### PR TITLE
feat(llm-decompile): 增加参考YAML生成与LLM预处理

### DIFF
--- a/.claude/skills/generate-reference-yaml/SKILL.md
+++ b/.claude/skills/generate-reference-yaml/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: generate-reference-yaml
+description: Generate reference YAML via project CLI into ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml
+disable-model-invocation: true
+---
+
+# Generate Reference YAML
+
+Use this skill as the unified backend entrypoint through project CLI.
+
+Do not call IDA API directly in this skill. Always run `generate_reference_yaml.py`.
+
+## Required parameters
+
+- `gamever`
+- `module`
+- `platform`
+- `func_name`
+
+## Command examples
+
+### 1) Attach to existing MCP
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -mcp_host 127.0.0.1 -mcp_port 13337
+```
+
+### 2) Auto-start `idalib-mcp` with binary
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -auto_start_mcp -binary bin/14141/engine/engine2.dll
+```
+
+## Output path
+
+- `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+
+## Manual checks after generation
+
+1. `func_va` is credible for current binary/version.
+2. `disasm_code` is non-empty and matches target function semantics.
+3. `procedure` matches expected semantics when available; it can be an empty string when Hex-Rays is unavailable.
+4. `func_name` only confirms the output file targets your requested canonical name; it does not prove address resolution correctness.
+
+## `LLM_DECOMPILE` path wiring
+
+- Generated file path in repository:
+  - `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+- In target `find-*.py`, when `LLM_DECOMPILE` uses relative paths, write:
+  - `references/<module>/<func_name>.<platform>.yaml`
+- Example tuple:
+  - `("CNetworkMessages_FindNetworkGroup", "prompt/call_llm_decompile.md", "references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml")`

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ Example outputs:
 - `vcall_finder/14141/g_pNetworkMessages/networksystem/windows/sub_140123450.yaml`
 - `vcall_finder/14141/g_pNetworkMessages.txt`
 
+#### 2.5 Prepare reference YAML for `LLM_DECOMPILE`
+
+Reference YAML path:
+
+- `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+
+Preparation steps:
+
+1. Confirm the target function already has a current-version YAML with `func_va`, or can be resolved in IDA by symbol name/alias from `config.yaml`.
+2. Run standalone CLI:
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -mcp_host 127.0.0.1 -mcp_port 13337
+```
+
+Auto-start `idalib-mcp` example:
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -auto_start_mcp -binary bin/14141/engine/engine2.dll
+```
+
+3. Check generated YAML:
+   - `func_va` is credible
+   - `disasm_code` is non-empty and matches target function semantics
+   - `procedure` matches expected semantics when available (it can be an empty string when Hex-Rays is unavailable)
+   - `func_name` only confirms the output file targets your requested canonical name; it does not prove address resolution correctness
+4. Wire it in target `find-*.py` `LLM_DECOMPILE`:
+   - Generated file path in repository:
+     - `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+   - If `LLM_DECOMPILE` uses relative path, write:
+     - `references/<module>/<func_name>.<platform>.yaml`
+   - Example tuple:
+     - `("CNetworkMessages_FindNetworkGroup", "prompt/call_llm_decompile.md", "references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml")`
+
 #### 3. Convert yaml(s) to gamedata json / txt
 
 ```bash

--- a/README_CN.md
+++ b/README_CN.md
@@ -77,6 +77,40 @@ uv run ida_analyze_bin.py -gamever=14141 -platform=windows,linux -vcall_finder=*
 - `vcall_finder/14141/g_pNetworkMessages/networksystem/windows/sub_140123450.yaml`
 - `vcall_finder/14141/g_pNetworkMessages.txt`
 
+#### 2.5 准备 `LLM_DECOMPILE` 的 reference YAML
+
+reference YAML 存放路径：
+
+- `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+
+准备步骤：
+
+1. 确认目标函数已有当前版本 YAML 且包含 `func_va`，或可通过 `config.yaml` 的 symbol name/alias 在 IDA 中定位。
+2. 运行独立 CLI：
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -mcp_host 127.0.0.1 -mcp_port 13337
+```
+
+自动启动 `idalib-mcp` 示例：
+
+```bash
+uv run generate_reference_yaml.py -gamever 14141 -module engine -platform windows -func_name CNetworkGameClient_RecordEntityBandwidth -auto_start_mcp -binary bin/14141/engine/engine2.dll
+```
+
+3. 检查生成文件：
+   - `func_va` 可信
+   - `disasm_code` 非空，且与目标函数语义匹配
+   - `procedure` 在可用时应与预期语义一致（Hex-Rays 不可用时允许为空字符串）
+   - `func_name` 仅用于确认输出文件对应你请求的规范名，不能单独证明地址解析正确
+4. 在目标 `find-*.py` 脚本里接入 `LLM_DECOMPILE`：
+   - 生成文件在仓库中的路径：
+     - `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+   - 若 `LLM_DECOMPILE` 使用相对路径，应写成：
+     - `references/<module>/<func_name>.<platform>.yaml`
+   - tuple 示例：
+     - `("CNetworkMessages_FindNetworkGroup", "prompt/call_llm_decompile.md", "references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml")`
+
 #### 3. 将 yaml(s) 转换为 gamedata json / txt
 
 ```bash

--- a/docs/superpowers/plans/2026-04-09-llm-decompile.md
+++ b/docs/superpowers/plans/2026-04-09-llm-decompile.md
@@ -1,0 +1,967 @@
+# LLM Decompile Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为预处理链路增加 `call_llm_decompile` 回退能力，统一 `llm_*` CLI 配置，复用 `vcall_finder` 的底层 LLM 调用骨架，并先接入 `find-CNetworkMessages_FindNetworkGroup.py` 作为首个真实样例。
+
+**Architecture:** 先在主入口中把 `vcall_finder_*` 配置统一替换为 `llm_*`，并抽出新的 `ida_llm_utils.py` 承载公共 OpenAI 调用骨架，再将 `ida_vcall_finder.py` 切到共享 helper。随后扩展 `ida_skill_preprocessor.py` 与 `ida_analyze_util.py`，让脚本可以声明 `LLM_DECOMPILE`，并把 `found_call`、`found_vcall`、`found_gv`、`found_struct_offset` 直接转换成当前版本 YAML。最后接入 `find-CNetworkMessages_FindNetworkGroup.py`、新增 prompt 文件，并用现有 `unittest` 风格补齐参数解析、helper、预处理与脚本回归测试。
+
+**Tech Stack:** Python 3.10, `argparse`, `unittest`, `unittest.mock`, `PyYAML`, OpenAI Python SDK, MCP `py_eval`
+
+---
+
+## File Map
+
+- `ida_analyze_bin.py`
+  - 把 `DEFAULT_VCALL_FINDER_MODEL` 改为 `DEFAULT_LLM_MODEL`
+  - 删除 `-vcall_finder_model` / `-vcall_finder_apikey` / `-vcall_finder_baseurl`
+  - 新增 `-llm_model` / `-llm_apikey` / `-llm_baseurl`
+  - 将统一 LLM 配置传给 `preprocess_single_skill_via_mcp(...)` 与 `aggregate_vcall_results_for_object(...)`
+- `ida_llm_utils.py`
+  - 新增共享 LLM helper
+  - 承载 `create_openai_client(...)`、统一 response 文本提取、chat completion 调用、debug 输出
+- `ida_vcall_finder.py`
+  - 删除本地 `create_openai_client(...)`
+  - 删除本地通用 chat completion 骨架
+  - 改为复用 `ida_llm_utils.py`
+  - 保留 `render_vcall_prompt(...)` 与 `parse_llm_vcall_response(...)`
+- `ida_skill_preprocessor.py`
+  - 扩展 `preprocess_single_skill_via_mcp(...)` 签名
+  - 仅当脚本 `preprocess_skill(...)` 声明 `llm_config` 参数时才下传
+- `ida_analyze_util.py`
+  - 扩展 `preprocess_common_skill(...)` 参数
+  - 增加 `call_llm_decompile(...)`
+  - 增加 `parse_llm_decompile_response(...)`
+  - 增加当前版 detail 导出 helper
+  - 扩展 `preprocess_func_sig_via_mcp(...)` 以支持 `found_call` / `found_vcall` 直生
+  - 新增 `preprocess_gen_struct_offset_sig_via_mcp(...)`
+- `ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py`
+  - 增加 `LLM_DECOMPILE`
+  - 增加可选 `llm_config` 参数
+  - 传入 `llm_decompile_specs` 与 `llm_config`
+- `ida_preprocessor_scripts/prompt/call_llm_decompile.md`
+  - 新增 prompt 模板文件
+  - 内容迁移自 `docs/call_llm_decompile_prompt.md`
+- `tests/test_ida_analyze_bin.py`
+  - 增加 `llm_*` 参数解析与旧参数报错测试
+- `tests/test_ida_vcall_finder.py`
+  - 增加对共享 helper 的接线回归测试
+- `tests/test_ida_preprocessor_scripts.py`
+  - 增加 `find-CNetworkMessages_FindNetworkGroup.py` 对 `LLM_DECOMPILE` 与 `llm_config` 的转发测试
+- `tests/test_ida_analyze_util.py`
+  - 增加 `parse_llm_decompile_response(...)` 测试
+  - 增加 `found_call` / `found_vcall` / `found_gv` / `found_struct_offset` 直生测试
+- `tests/test_ida_llm_utils.py`
+  - 新增共享 helper 测试
+- `docs/superpowers/specs/2026-04-09-llm-decompile-design.md`
+  - 只作为核对依据，不改内容
+
+## Task 1: 先锁定 CLI 与共享 LLM helper 测试
+
+**Files:**
+- Create: `tests/test_ida_llm_utils.py`
+- Modify: `tests/test_ida_analyze_bin.py`
+- Modify: `ida_analyze_bin.py:65`
+- Modify: `ida_vcall_finder.py:243`
+
+- [x] **Step 1: 为共享 helper 写失败测试**
+
+```python
+import types
+import unittest
+from unittest.mock import patch
+
+import ida_llm_utils
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content):
+        self.message = _FakeMessage(content)
+
+
+class _FakeResponse:
+    def __init__(self, content):
+        self.choices = [_FakeChoice(content)]
+
+
+class TestIdaLlmUtils(unittest.TestCase):
+    def test_create_openai_client_requires_api_key(self) -> None:
+        with self.assertRaises(RuntimeError):
+            ida_llm_utils.create_openai_client(
+                api_key=None,
+                base_url=None,
+                api_key_required_message="-llm_apikey is required when LLM workflow is enabled",
+            )
+
+    def test_extract_message_text_supports_string_content(self) -> None:
+        response = _FakeResponse("```yaml\\nfound_vcall: []\\n```")
+        self.assertEqual(
+            "```yaml\\nfound_vcall: []\\n```",
+            ida_llm_utils.extract_first_message_text(response),
+        )
+
+    def test_extract_message_text_rejects_empty_choices(self) -> None:
+        response = types.SimpleNamespace(choices=[])
+        with self.assertRaises(ValueError):
+            ida_llm_utils.extract_first_message_text(response)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [x] **Step 2: 为 `llm_*` 参数写失败测试**
+
+```python
+class TestParseArgsLlmOptions(unittest.TestCase):
+    def test_parse_args_accepts_llm_options(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "ida_analyze_bin.py",
+                "-gamever=14141",
+                "-llm_model=gpt-4o",
+                "-llm_apikey=test-key",
+                "-llm_baseurl=https://api.example.com/v1",
+            ],
+        ):
+            args = ida_analyze_bin.parse_args()
+
+        self.assertEqual("gpt-4o", args.llm_model)
+        self.assertEqual("test-key", args.llm_apikey)
+        self.assertEqual("https://api.example.com/v1", args.llm_baseurl)
+
+    def test_parse_args_rejects_legacy_vcall_finder_llm_options(self) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "ida_analyze_bin.py",
+                "-gamever=14141",
+                "-vcall_finder_model=gpt-4o",
+            ],
+        ), self.assertRaises(SystemExit):
+            ida_analyze_bin.parse_args()
+```
+
+- [x] **Step 3: 运行新增测试，确认当前会失败**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_llm_utils tests.test_ida_analyze_bin -v
+```
+
+Expected: FAIL，因为 `ida_llm_utils.py` 不存在，且 `parse_args()` 还未提供 `llm_*`。
+
+- [ ] **Step 4: 提交失败测试**
+
+```bash
+git add tests/test_ida_llm_utils.py tests/test_ida_analyze_bin.py
+git commit -m "test(llm): 增加统一配置与共享辅助测试"
+```
+
+## Task 2: 实现统一 `llm_*` 配置并抽出共享 helper
+
+**Files:**
+- Create: `ida_llm_utils.py`
+- Modify: `ida_analyze_bin.py:31-70`
+- Modify: `ida_analyze_bin.py:388-405`
+- Modify: `ida_analyze_bin.py:1116`
+- Modify: `ida_analyze_bin.py:1331-1337`
+- Modify: `ida_vcall_finder.py:12-15`
+- Modify: `ida_vcall_finder.py:243-292`
+- Test: `tests/test_ida_llm_utils.py`
+- Test: `tests/test_ida_analyze_bin.py`
+
+- [x] **Step 1: 在主入口中统一常量与 CLI 参数**
+
+```python
+DEFAULT_LLM_MODEL = "gpt-4o"
+
+parser.add_argument(
+    "-llm_model",
+    default=DEFAULT_LLM_MODEL,
+    help=f"OpenAI-compatible model for LLM workflows (default: {DEFAULT_LLM_MODEL})",
+)
+parser.add_argument(
+    "-llm_apikey",
+    default=None,
+    help="OpenAI-compatible API key used by LLM workflows",
+)
+parser.add_argument(
+    "-llm_baseurl",
+    default=None,
+    help="Optional OpenAI-compatible base URL used by LLM workflows",
+)
+```
+
+- [x] **Step 2: 新增共享 helper 模块**
+
+```python
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from openai import OpenAI
+
+
+def require_nonempty_text(value: Any, name: str) -> str:
+    text = "" if value is None else str(value).strip()
+    if not text:
+        raise ValueError(f"{name} cannot be empty")
+    return text
+
+
+def create_openai_client(api_key, base_url=None, *, api_key_required_message: str) -> OpenAI:
+    if api_key is None or not str(api_key).strip():
+        raise RuntimeError(api_key_required_message)
+
+    client_kwargs = {"api_key": require_nonempty_text(api_key, "api_key")}
+    if base_url is not None:
+        client_kwargs["base_url"] = require_nonempty_text(base_url, "base_url")
+    return OpenAI(**client_kwargs)
+
+
+def extract_first_message_text(response: Any) -> str:
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        raise ValueError("OpenAI response missing choices")
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    return content if isinstance(content, str) else str(content)
+
+
+def call_llm_text(client, *, model, messages, temperature=0.1):
+    return extract_first_message_text(
+        client.chat.completions.create(
+            model=require_nonempty_text(model, "model"),
+            messages=messages,
+            temperature=temperature,
+        )
+    )
+```
+
+- [x] **Step 3: 让 `ida_vcall_finder.py` 复用共享 helper**
+
+```python
+from ida_llm_utils import call_llm_text, create_openai_client
+
+
+def call_openai_for_vcalls(client, detail, model, *, debug=False, request_label=""):
+    if debug:
+        _print_vcall_debug(
+            f"LLM request start {request_label} model='{model}'".rstrip(),
+            debug,
+        )
+
+    started_at = time.monotonic()
+    content = call_llm_text(
+        client,
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a reverse engineering expert."},
+            {"role": "user", "content": render_vcall_prompt(detail)},
+        ],
+        temperature=0.1,
+    )
+    found_vcall = parse_llm_vcall_response(content)["found_vcall"]
+    if debug:
+        elapsed_seconds = time.monotonic() - started_at
+        _print_vcall_debug(
+            "LLM request done "
+            f"{request_label} elapsed={elapsed_seconds:.2f}s "
+            f"response_chars={len(content)} found_vcall={len(found_vcall)}",
+            debug,
+        )
+    return found_vcall
+```
+
+- [x] **Step 4: 主流程改为向预处理与聚合都传统一配置**
+
+```python
+preprocess_ok = asyncio.run(
+    preprocess_single_skill_via_mcp(
+        host,
+        port,
+        skill_name,
+        expected_outputs,
+        old_yaml_map,
+        binary_dir,
+        platform,
+        llm_model=args.llm_model,
+        llm_apikey=args.llm_apikey,
+        llm_baseurl=args.llm_baseurl,
+        debug=debug,
+    )
+)
+
+stats = aggregate_vcall_results_for_object(
+    base_dir="vcall_finder",
+    gamever=gamever,
+    object_name=object_name,
+    model=args.llm_model,
+    api_key=args.llm_apikey,
+    base_url=args.llm_baseurl,
+    debug=debug,
+)
+```
+
+- [x] **Step 5: 运行测试，确认共享 helper 与参数解析通过**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_llm_utils tests.test_ida_analyze_bin tests.test_ida_vcall_finder -v
+```
+
+Expected: PASS，新参数解析通过，旧参数继续报错，`vcall_finder` 测试不再依赖本地 `OpenAI` 构造逻辑。
+
+- [ ] **Step 6: 提交共享配置与 helper**
+
+```bash
+git add ida_analyze_bin.py ida_llm_utils.py ida_vcall_finder.py tests/test_ida_llm_utils.py tests/test_ida_analyze_bin.py tests/test_ida_vcall_finder.py
+git commit -m "feat(llm): 统一预处理与聚合配置"
+```
+
+## Task 3: 让脚本调度层支持 `llm_config`
+
+**Files:**
+- Modify: `ida_skill_preprocessor.py:30-147`
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+- Test: `tests/test_ida_preprocessor_scripts.py`
+
+- [x] **Step 1: 为脚本转发 `llm_config` 写失败测试**
+
+```python
+FIND_NETWORK_GROUP_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py"
+)
+
+
+class TestFindCNetworkMessagesFindNetworkGroup(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_skill_forwards_llm_specs_and_config(self) -> None:
+        module = _load_module(
+            FIND_NETWORK_GROUP_SCRIPT_PATH,
+            "find_CNetworkMessages_FindNetworkGroup",
+        )
+        mock_preprocess_common_skill = AsyncMock(return_value=True)
+        llm_config = {"model": "gpt-4o", "api_key": "k", "base_url": "https://api.example.com/v1"}
+
+        with patch.object(module, "preprocess_common_skill", mock_preprocess_common_skill):
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"k": "v"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                llm_config=llm_config,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_preprocess_common_skill.assert_awaited_once()
+        self.assertEqual(llm_config, mock_preprocess_common_skill.await_args.kwargs["llm_config"])
+        self.assertIn("llm_decompile_specs", mock_preprocess_common_skill.await_args.kwargs)
+```
+
+- [x] **Step 2: 扩展 `preprocess_single_skill_via_mcp(...)`，按脚本签名传递 `llm_config`**
+
+```python
+async def preprocess_single_skill_via_mcp(
+    host,
+    port,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    llm_model=None,
+    llm_apikey=None,
+    llm_baseurl=None,
+    debug=False,
+):
+    preprocess_func = _get_preprocess_entry(skill_name, debug=debug)
+    if preprocess_func is None:
+        return False
+
+    server_url = f"http://{host}:{port}/mcp"
+    llm_config = {
+        "model": llm_model,
+        "api_key": llm_apikey,
+        "base_url": llm_baseurl,
+    }
+    call_kwargs = dict(
+        skill_name=skill_name,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        debug=debug,
+    )
+    if "llm_config" in inspect.signature(preprocess_func).parameters:
+        call_kwargs["llm_config"] = llm_config
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=httpx.Timeout(30.0, read=300.0),
+        trust_env=False,
+    ) as http_client:
+        async with streamable_http_client(server_url, http_client=http_client) as (read_stream, write_stream, _):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                ib_result = await session.call_tool(
+                    name="py_eval",
+                    arguments={"code": "hex(idaapi.get_imagebase())"},
+                )
+                ib_data = parse_mcp_result(ib_result)
+                image_base = int(ib_data.get("result", "0x0"), 16) if isinstance(ib_data, dict) else int(str(ib_data), 16)
+                call_kwargs["session"] = session
+                call_kwargs["image_base"] = image_base
+                result = preprocess_func(**call_kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return bool(result)
+```
+
+- [x] **Step 3: 运行脚本转发测试**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_preprocessor_scripts -v
+```
+
+Expected: PASS，现有脚本继续工作，`find-CNetworkMessages_FindNetworkGroup.py` 可选择性接收 `llm_config`。
+
+- [ ] **Step 4: 提交调度层改动**
+
+```bash
+git add ida_skill_preprocessor.py tests/test_ida_preprocessor_scripts.py
+git commit -m "feat(preprocess): 下传统一 llm 配置"
+```
+
+## Task 4: 先写 `ida_analyze_util.py` 的 LLM decompile 失败测试
+
+**Files:**
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `ida_analyze_util.py:461-520`
+- Modify: `ida_analyze_util.py:2825-3265`
+
+- [x] **Step 1: 为响应解析写失败测试**
+
+```python
+class TestParseLlmDecompileResponse(unittest.TestCase):
+    def test_parse_llm_decompile_response_normalizes_all_sections(self) -> None:
+        payload = """
+```yaml
+found_vcall:
+  - insn_va: '0x180777700'
+    insn_disasm: call    [rax+68h]
+    vfunc_offset: '0x68'
+    func_name: ILoopMode_OnLoopActivate
+found_call:
+  - insn_va: '0x180888800'
+    insn_disasm: call    sub_180999900
+    func_name: CLoopModeGame_RegisterEventMapInternal
+found_gv:
+  - insn_va: '0x180444400'
+    insn_disasm: mov rcx, cs:qword_180666600
+    gv_name: s_GameEventManager
+found_struct_offset:
+  - insn_va: '0x1801BA12A'
+    insn_disasm: mov rcx, [r14+58h]
+    offset: '0x58'
+    struct_name: CGameResourceService
+    member_name: m_pEntitySystem
+```
+"""
+        parsed = ida_analyze_util.parse_llm_decompile_response(payload)
+        self.assertEqual("0x68", parsed["found_vcall"][0]["vfunc_offset"])
+        self.assertEqual(
+            "CLoopModeGame_RegisterEventMapInternal",
+            parsed["found_call"][0]["func_name"],
+        )
+        self.assertEqual("CGameResourceService", parsed["found_struct_offset"][0]["struct_name"])
+```
+
+- [x] **Step 2: 为 `found_vcall` / `found_gv` / `found_struct_offset` 直生写失败测试**
+
+```python
+class TestApplyLlmDecompileResults(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_common_skill_uses_found_vcall_to_generate_func_yaml(self) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "preprocess_func_sig_via_mcp",
+            AsyncMock(side_effect=[None, {
+                "func_name": "CNetworkMessages_FindNetworkGroup",
+                "func_va": "0x180010780",
+                "func_rva": "0x10780",
+                "func_size": "0x40",
+                "func_sig": "AA BB CC DD",
+                "vtable_name": "CNetworkMessages",
+                "vfunc_offset": "0x78",
+                "vfunc_index": 15,
+            }]),
+        ), patch.object(
+            ida_analyze_util,
+            "call_llm_decompile",
+            AsyncMock(return_value={
+                "found_vcall": [{
+                    "insn_va": "0x180020000",
+                    "insn_disasm": "call    [rax+78h]",
+                    "vfunc_offset": "0x78",
+                    "func_name": "CNetworkMessages_FindNetworkGroup",
+                }],
+                "found_call": [],
+                "found_gv": [],
+                "found_struct_offset": [],
+            }),
+        ), patch.object(
+            ida_analyze_util,
+            "write_func_yaml",
+        ) as mock_write_func_yaml, patch.object(
+            ida_analyze_util,
+            "_rename_func_in_ida",
+            AsyncMock(return_value=None),
+        ):
+            result = await ida_analyze_util.preprocess_common_skill(
+                session="session",
+                expected_outputs=["/tmp/CNetworkMessages_FindNetworkGroup.windows.yaml"],
+                old_yaml_map={"/tmp/CNetworkMessages_FindNetworkGroup.windows.yaml": "/tmp/old.yaml"},
+                new_binary_dir="/tmp",
+                platform="windows",
+                image_base=0x180000000,
+                func_names=["CNetworkMessages_FindNetworkGroup"],
+                func_vtable_relations=[("CNetworkMessages_FindNetworkGroup", "CNetworkMessages", True)],
+                llm_decompile_specs=[("CNetworkMessages_FindNetworkGroup", "prompt/call_llm_decompile.md", "references/CNetworkMessages_FindNetworkGroup.reference.yaml")],
+                llm_config={"model": "gpt-4o", "api_key": "k", "base_url": None},
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        written_payload = mock_write_func_yaml.call_args.args[1]
+        self.assertEqual("0x78", written_payload["vfunc_offset"])
+```
+
+- [x] **Step 3: 运行测试确认当前失败**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_analyze_util -v
+```
+
+Expected: FAIL，因为 `parse_llm_decompile_response(...)`、`call_llm_decompile(...)` 和直生路径还不存在。
+
+- [ ] **Step 4: 提交失败测试**
+
+```bash
+git add tests/test_ida_analyze_util.py
+git commit -m "test(preprocess): 增加 llm 反编译回退测试"
+```
+
+## Task 5: 实现 `call_llm_decompile`、四类直生与 struct-offset 生成
+
+**Files:**
+- Modify: `ida_analyze_util.py:461-843`
+- Modify: `ida_analyze_util.py:1147-1275`
+- Modify: `ida_analyze_util.py:1835-2095`
+- Modify: `ida_analyze_util.py:2825-3265`
+- Test: `tests/test_ida_analyze_util.py`
+
+- [x] **Step 1: 给 `preprocess_func_sig_via_mcp(...)` 增加直接地址与 vfunc 偏移入口**
+
+```python
+async def preprocess_func_sig_via_mcp(
+    session,
+    new_path,
+    old_path,
+    image_base,
+    new_binary_dir,
+    platform,
+    func_name=None,
+    debug=False,
+    mangled_class_names=None,
+    direct_func_va=None,
+    direct_vtable_class=None,
+    direct_vfunc_offset=None,
+):
+    if direct_func_va is not None:
+        generated = await preprocess_gen_func_sig_via_mcp(
+            session=session,
+            func_va=direct_func_va,
+            image_base=image_base,
+            debug=debug,
+        )
+        if generated is None:
+            return None
+        new_data = {"func_name": func_name, **generated}
+        if direct_vtable_class is not None and direct_vfunc_offset is not None:
+            offset_value = int(str(direct_vfunc_offset), 0)
+            new_data["vtable_name"] = direct_vtable_class
+            new_data["vfunc_offset"] = hex(offset_value)
+            new_data["vfunc_index"] = offset_value // 8
+        return new_data
+    if yaml is None:
+        if debug:
+            print("    Preprocess: PyYAML is required for func_sig preprocessing")
+        return None
+
+    if not old_path or not os.path.exists(old_path):
+        if debug:
+            print(f"    Preprocess: no old YAML for {os.path.basename(new_path)}")
+        return None
+
+    with open(old_path, "r", encoding="utf-8") as handle:
+        old_data = yaml.safe_load(handle)
+    if not old_data or not isinstance(old_data, dict):
+        return None
+    # 其余旧版 `func_sig` / `vfunc_sig` 复用逻辑保持原样
+```
+
+- [x] **Step 2: 增加 `parse_llm_decompile_response(...)` 与 `call_llm_decompile(...)`**
+
+```python
+def _parse_yaml_mapping_from_response(response_text: str | None) -> dict[str, object]:
+    text = (response_text or "").strip()
+    if not text:
+        return {}
+    matches = re.findall(r"```(?:yaml|yml)?\s*(.*?)```", text, re.IGNORECASE | re.DOTALL)
+    candidates = matches or [text]
+    for candidate in candidates:
+        try:
+            parsed = yaml.load(candidate.strip(), Loader=yaml.BaseLoader)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+        if parsed is None:
+            return {}
+    return {}
+
+
+def _normalize_llm_entries(entries, required_keys):
+    normalized = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        item = {key: str(entry.get(key, "")).strip() for key in required_keys}
+        if all(item.values()):
+            normalized.append(item)
+    return normalized
+
+
+def _collect_symbol_names(reference_detail, target_detail):
+    names = set()
+    for payload in (reference_detail, target_detail):
+        if isinstance(payload, dict):
+            for key in ("func_name", "gv_name", "struct_name", "member_name"):
+                value = str(payload.get(key, "")).strip()
+                if value:
+                    names.add(value)
+    return names
+
+
+def parse_llm_decompile_response(response_text: str | None) -> dict[str, list[dict[str, str]]]:
+    parsed = _parse_yaml_mapping_from_response(response_text)
+    return {
+        "found_vcall": _normalize_llm_entries(parsed.get("found_vcall", []), ("insn_va", "insn_disasm", "vfunc_offset", "func_name")),
+        "found_call": _normalize_llm_entries(parsed.get("found_call", []), ("insn_va", "insn_disasm", "func_name")),
+        "found_gv": _normalize_llm_entries(parsed.get("found_gv", []), ("insn_va", "insn_disasm", "gv_name")),
+        "found_struct_offset": _normalize_llm_entries(parsed.get("found_struct_offset", []), ("insn_va", "insn_disasm", "offset", "struct_name", "member_name")),
+    }
+
+
+def call_llm_decompile(client, target_detail, reference_detail, prompt_text, model, *, debug=False, request_label=""):
+    content = call_llm_text(
+        client,
+        model=model,
+        messages=[
+            {"role": "system", "content": "You are a reverse engineering expert."},
+            {"role": "user", "content": prompt_text.format(
+                symbol_name_list=", ".join(sorted(_collect_symbol_names(reference_detail, target_detail))),
+                disasm_for_reference=reference_detail.get("disasm_code", ""),
+                procedure_for_reference=reference_detail.get("procedure", ""),
+                disasm_code=target_detail.get("disasm_code", ""),
+                procedure=target_detail.get("procedure", ""),
+            )},
+        ],
+        temperature=0.1,
+    )
+    return parse_llm_decompile_response(content)
+```
+
+- [x] **Step 3: 新增 `preprocess_gen_struct_offset_sig_via_mcp(...)`**
+
+```python
+async def _generate_instruction_signature(
+    session,
+    *,
+    inst_va,
+    func_va,
+    image_base,
+    debug=False,
+):
+    # 将 `preprocess_gen_gv_sig_via_mcp()` 中“从已知指令位置收集指令字节并搜索最短唯一签名”的逻辑提取到这里，
+    # 返回统一结构：{"sig": "...", "sig_disp": 0}
+    return await _generate_signature_from_known_instruction(
+        session=session,
+        inst_va=inst_va,
+        func_va=func_va,
+        image_base=image_base,
+        debug=debug,
+    )
+
+
+async def preprocess_gen_struct_offset_sig_via_mcp(
+    session,
+    struct_name,
+    member_name,
+    offset,
+    image_base,
+    access_inst_va=None,
+    access_func_va=None,
+    member_size=None,
+    debug=False,
+):
+    generated = await _generate_instruction_signature(
+        session=session,
+        inst_va=access_inst_va,
+        func_va=access_func_va,
+        image_base=image_base,
+        debug=debug,
+    )
+    if generated is None:
+        return None
+    payload = {
+        "struct_name": str(struct_name),
+        "member_name": str(member_name),
+        "offset": hex(int(str(offset), 0)),
+        "offset_sig": generated["sig"],
+        "offset_sig_disp": generated["sig_disp"],
+    }
+    if member_size is not None:
+        payload["size"] = int(member_size)
+    return payload
+```
+
+- [x] **Step 4: 在 `preprocess_common_skill(...)` 中接入 LLM 回退与四类直生**
+
+```python
+if func_data is None and func_name in llm_decompile_map and llm_config and llm_config.get("api_key"):
+    decompile_result = await _run_llm_decompile_for_target(
+        session=session,
+        func_name=func_name,
+        target_output=target_output,
+        llm_spec=llm_decompile_map[func_name],
+        llm_config=llm_config,
+        image_base=image_base,
+        platform=platform,
+        debug=debug,
+    )
+    func_data = await _apply_llm_decompile_results(
+        session=session,
+        func_name=func_name,
+        target_output=target_output,
+        expected_outputs=expected_outputs,
+        matched_func_outputs=matched_func_outputs,
+        matched_gv_outputs=matched_gv_outputs,
+        matched_struct_outputs=matched_struct_outputs,
+        decompile_result=decompile_result,
+        vtable_relations_map=vtable_relations_map,
+        image_base=image_base,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        debug=debug,
+    )
+```
+
+- [x] **Step 5: 运行 util 测试，确认四类直生通过**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_analyze_util -v
+```
+
+Expected: PASS，`found_vcall` 能直生 `CNetworkMessages_FindNetworkGroup` 的 vfunc YAML，`found_gv` 与 `found_struct_offset` 路径具备当前版生成能力。
+
+- [ ] **Step 6: 提交 util 实现**
+
+```bash
+git add ida_analyze_util.py tests/test_ida_analyze_util.py
+git commit -m "feat(preprocess): 增加 llm 反编译回退"
+```
+
+## Task 6: 接入 `find-CNetworkMessages_FindNetworkGroup.py` 与 prompt 文件
+
+**Files:**
+- Create: `ida_preprocessor_scripts/prompt/call_llm_decompile.md`
+- Modify: `ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py`
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+- Check: `.claude/skills/find-CNetworkMessages_FindNetworkGroup/SKILL.md`
+
+- [x] **Step 1: 新增 prompt 文件**
+
+```markdown
+You are a reverse engineering expert. I have disassembly outputs and procedure code of the same function.
+
+This is the function for reference:
+
+**Disassembly for Reference**
+
+```c
+{disasm_for_reference}
+```
+
+**Procedure code for Reference**
+
+```c
+{procedure_for_reference}
+```
+
+This is the function you need to reverse-engineering:
+
+**Disassembly to reverse-engineering**
+
+```c
+{disasm_code}
+```
+
+**Procedure code to reverse-engineering**
+
+```c
+{procedure}
+```
+
+Please collect all references for "{symbol_name_list}" in the function you need to reverse-engineering and output those references as YAML.
+`found_vcall` is for indirect call to virtual function.
+`found_call` is for direct call to regular function.
+`found_gv` is for reference to global variable.
+`found_struct_offset` is for reference to struct offset.
+
+If nothing found, output an empty YAML.
+```
+
+- [x] **Step 2: 在 `find-CNetworkMessages_FindNetworkGroup.py` 中声明 `LLM_DECOMPILE`**
+
+```python
+LLM_DECOMPILE = [
+    (
+        "CNetworkMessages_FindNetworkGroup",
+        "prompt/call_llm_decompile.md",
+        "references/CNetworkMessages_FindNetworkGroup.from-CNetworkGameClient_RecordEntityBandwidth.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CNetworkMessages_FindNetworkGroup", "CNetworkMessages", True),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        debug=debug,
+    )
+```
+
+- [x] **Step 3: 运行脚本测试，确认新样例配置通过**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_ida_preprocessor_scripts -v
+```
+
+Expected: PASS，脚本能把 `LLM_DECOMPILE`、`func_vtable_relations` 与 `llm_config` 一起传给 `preprocess_common_skill(...)`。
+
+- [ ] **Step 4: 提交首个样例接入**
+
+```bash
+git add ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py ida_preprocessor_scripts/prompt/call_llm_decompile.md tests/test_ida_preprocessor_scripts.py
+git commit -m "feat(skill): 接入 FindNetworkGroup 反编译回退"
+```
+
+## Task 7: 运行定向回归并更新计划状态
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-09-llm-decompile.md`
+- Check: `tests/test_ida_analyze_bin.py`
+- Check: `tests/test_ida_llm_utils.py`
+- Check: `tests/test_ida_vcall_finder.py`
+- Check: `tests/test_ida_preprocessor_scripts.py`
+- Check: `tests/test_ida_analyze_util.py`
+
+- [x] **Step 1: 运行全部定向测试**
+
+Run:
+
+```bash
+uv run python -m unittest \
+  tests.test_ida_analyze_bin \
+  tests.test_ida_llm_utils \
+  tests.test_ida_vcall_finder \
+  tests.test_ida_preprocessor_scripts \
+  tests.test_ida_analyze_util \
+  -v
+```
+
+Observed: Ran 50 tests in 0.047s, OK.
+
+- [x] **Step 2: 记录手动验收说明**
+
+- 本次代码不自动生成 `ida_preprocessor_scripts/references/CNetworkMessages_FindNetworkGroup.from-CNetworkGameClient_RecordEntityBandwidth.yaml`
+- 该样本 YAML 由用户在实现完成后手动准备
+- 用户使用真实 IDA 数据验证 `CNetworkMessages_FindNetworkGroup.{platform}.yaml` 是否能由 `found_vcall` 直生
+
+- [x] **Step 3: 更新计划勾选状态并整理交付说明**
+
+- [x] Task 1
+- [x] Task 2
+- [x] Task 3
+- [x] Task 4
+- [x] Task 5
+- [x] Task 6
+- [x] Task 7
+
+- [ ] **Step 4: 提交最终收尾**
+
+```bash
+git add docs/superpowers/plans/2026-04-09-llm-decompile.md
+git commit -m "docs(plan): 完成 llm 反编译实施计划"
+```
+
+## Self-Review
+
+- **Spec coverage:** 本计划覆盖了 spec 中的四大块：统一 `llm_*` CLI、共享 LLM helper、`call_llm_decompile` 与四类直生、`find-CNetworkMessages_FindNetworkGroup.py` 首个真实样例接入与人工验收说明。
+- **Placeholder scan:** 计划中没有 `TODO` / `TBD` / “后续实现”一类占位语句；所有测试、命令、文件路径与代码草案均已写明。
+- **Type consistency:** 统一使用 `llm_config = {"model", "api_key", "base_url"}`；统一使用 `LLM_DECOMPILE = [(func_name, prompt_path, reference_yaml_path)]`；`preprocess_func_sig_via_mcp(...)` 的新增参数名固定为 `direct_func_va`、`direct_vtable_class`、`direct_vfunc_offset`。

--- a/docs/superpowers/plans/2026-04-09-reference-yaml-generator.md
+++ b/docs/superpowers/plans/2026-04-09-reference-yaml-generator.md
@@ -1,0 +1,1061 @@
+# Reference YAML Generator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为仓库新增 `generate_reference_yaml.py` 独立 CLI，并配套 project-level SKILL，使其能够从现有 `bin/<gamever>/<module>/<func_name>.<platform>.yaml` 或 `config.yaml` + IDA MCP 自动生成 `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`。
+
+**Architecture:** 先在 `tests/test_generate_reference_yaml.py` 中用现有 `unittest` 风格锁定纯 helper、函数地址解析、MCP 导出与 attach/auto-start 两种连接模式；实现上把首版 CLI 保持在单文件 `generate_reference_yaml.py`，内部拆成“路径/配置解析”“函数地址解析”“MCP 会话适配”“reference YAML 导出与落盘”四层小函数，避免首版扩散到多模块。最后新增 `.claude/skills/generate-reference-yaml/SKILL.md` 与 README/README_CN 文档，把 reference YAML 准备步骤、命令行入口和 SKILL 触发方式统一到同一条后端路径。
+
+**Tech Stack:** Python 3.10, `argparse`, `asyncio`, `unittest`, `unittest.mock`, `httpx`, MCP `streamable_http_client`, `PyYAML`, `uv run idalib-mcp`
+
+---
+
+## File Structure
+
+- `generate_reference_yaml.py`
+  - 新增仓库根目录 CLI。
+  - 承载参数解析、路径规范化、旧 YAML 优先解析、`config.yaml` alias 收集、MCP 会话管理、reference YAML 导出与落盘。
+- `tests/test_generate_reference_yaml.py`
+  - 新增定向测试文件。
+  - 覆盖纯 helper、解析优先级、歧义错误、导出 payload、attach/auto-start 会话编排。
+- `.claude/skills/generate-reference-yaml/SKILL.md`
+  - 新增 project-level SKILL。
+  - 只调用 `uv run generate_reference_yaml.py ...`，不直接编排 IDA API。
+- `README.md`
+  - 增加英文版 “Generate reference YAML” 使用章节。
+- `README_CN.md`
+  - 增加中文版 “生成 reference YAML” 使用章节。
+
+## Validation Notes
+
+- 纯 helper / 异步解析 / 会话编排都走现有 `unittest`：
+  - `uv run python -m unittest tests.test_generate_reference_yaml -v`
+- CLI 语法与导入最小验证：
+  - `uv run python -m py_compile generate_reference_yaml.py`
+- 手动验收场景聚焦：
+  - `CNetworkGameClient_RecordEntityBandwidth`
+  - 输出应落到 `ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml`
+
+## Task 1: 先锁定纯 helper 与 CLI 参数约束
+
+**Files:**
+- Create: `tests/test_generate_reference_yaml.py`
+- Create: `generate_reference_yaml.py`
+
+- [ ] **Step 1: 先写失败测试，锁定路径、旧 YAML 优先级、`config.yaml` alias 收集与参数约束**
+
+```python
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+import generate_reference_yaml
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+class TestReferenceYamlPureHelpers(unittest.TestCase):
+    def test_build_reference_output_path_puts_module_and_platform_in_path(self) -> None:
+        path = generate_reference_yaml.build_reference_output_path(
+            repo_root=Path("/repo"),
+            module="engine",
+            func_name="CNetworkMessages_FindNetworkGroup",
+            platform="windows",
+        )
+
+        self.assertEqual(
+            Path(
+                "/repo/ida_preprocessor_scripts/references/engine/"
+                "CNetworkMessages_FindNetworkGroup.windows.yaml"
+            ),
+            path,
+        )
+
+    def test_load_existing_func_va_prefers_bin_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root / "bin" / "14141" / "engine" / "Foo.windows.yaml",
+                {
+                    "func_name": "Foo",
+                    "func_va": "0x180123450",
+                },
+            )
+
+            self.assertEqual(
+                "0x180123450",
+                generate_reference_yaml.load_existing_func_va(
+                    repo_root=repo_root,
+                    gamever="14141",
+                    module="engine",
+                    func_name="Foo",
+                    platform="windows",
+                ),
+            )
+
+    def test_load_symbol_aliases_collects_name_then_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "config.yaml").write_text(
+                """
+modules:
+  - name: engine
+    symbols:
+      - name: CNetworkGameClient_RecordEntityBandwidth
+        category: func
+        alias:
+          - CNetworkGameClient::RecordEntityBandwidth
+          - RecordEntityBandwidth
+""".strip(),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                [
+                    "CNetworkGameClient_RecordEntityBandwidth",
+                    "CNetworkGameClient::RecordEntityBandwidth",
+                    "RecordEntityBandwidth",
+                ],
+                generate_reference_yaml.load_symbol_aliases(
+                    repo_root=repo_root,
+                    module="engine",
+                    func_name="CNetworkGameClient_RecordEntityBandwidth",
+                ),
+            )
+
+    def test_parse_args_rejects_auto_start_without_binary(self) -> None:
+        with self.assertRaises(SystemExit):
+            generate_reference_yaml.parse_args(
+                [
+                    "-gamever",
+                    "14141",
+                    "-module",
+                    "engine",
+                    "-platform",
+                    "windows",
+                    "-func_name",
+                    "CNetworkGameClient_RecordEntityBandwidth",
+                    "-auto_start_mcp",
+                ]
+            )
+```
+
+- [ ] **Step 2: 运行测试，确认当前失败**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_generate_reference_yaml -v
+```
+
+Expected: FAIL，因为 `generate_reference_yaml.py` 还不存在，且上述 helper 与参数约束尚未实现。
+
+- [ ] **Step 3: 写最小可测 helper 层与 CLI 参数解析**
+
+```python
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import yaml
+
+
+class ReferenceGenerationError(RuntimeError):
+    pass
+
+
+class LiteralDumper(yaml.SafeDumper):
+    pass
+
+
+def _literal_str_representer(dumper, value):
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+LiteralDumper.add_representer(str, _literal_str_representer)
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Generate minimal reference YAML from IDA MCP."
+    )
+    parser.add_argument("-gamever", required=True)
+    parser.add_argument("-module", required=True)
+    parser.add_argument("-platform", choices=["windows", "linux"], required=True)
+    parser.add_argument("-func_name", required=True)
+    parser.add_argument("-mcp_host", default="127.0.0.1")
+    parser.add_argument("-mcp_port", type=int, default=13337)
+    parser.add_argument("-binary", default=None)
+    parser.add_argument("-auto_start_mcp", action="store_true")
+    parser.add_argument("-ida_args", default="")
+    parser.add_argument("-debug", action="store_true")
+    args = parser.parse_args(argv)
+    if args.auto_start_mcp and not args.binary:
+        parser.error("-auto_start_mcp requires -binary")
+    if args.binary and not args.auto_start_mcp:
+        parser.error("-binary requires -auto_start_mcp")
+    return args
+
+
+def load_yaml_mapping(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if parsed is None:
+        return {}
+    if not isinstance(parsed, dict):
+        raise ReferenceGenerationError(
+            f"YAML root must be mapping: {path}"
+        )
+    return parsed
+
+
+def build_reference_output_path(*, repo_root: Path, module: str, func_name: str, platform: str) -> Path:
+    return (
+        Path(repo_root)
+        / "ida_preprocessor_scripts"
+        / "references"
+        / module
+        / f"{func_name}.{platform}.yaml"
+    )
+
+
+def build_existing_yaml_path(*, repo_root: Path, gamever: str, module: str, func_name: str, platform: str) -> Path:
+    return Path(repo_root) / "bin" / gamever / module / f"{func_name}.{platform}.yaml"
+
+
+def load_existing_func_va(*, repo_root: Path, gamever: str, module: str, func_name: str, platform: str) -> str | None:
+    data = load_yaml_mapping(
+        build_existing_yaml_path(
+            repo_root=repo_root,
+            gamever=gamever,
+            module=module,
+            func_name=func_name,
+            platform=platform,
+        )
+    )
+    func_va = str(data.get("func_va", "")).strip()
+    return func_va or None
+
+
+def load_symbol_aliases(*, repo_root: Path, module: str, func_name: str) -> list[str]:
+    config_data = load_yaml_mapping(Path(repo_root) / "config.yaml")
+    modules = config_data.get("modules", [])
+    for module_data in modules:
+        if not isinstance(module_data, dict) or module_data.get("name") != module:
+            continue
+        for symbol_data in module_data.get("symbols", []):
+            if not isinstance(symbol_data, dict) or symbol_data.get("name") != func_name:
+                continue
+            names = [func_name]
+            names.extend(str(alias).strip() for alias in symbol_data.get("alias", []) if str(alias).strip())
+            return names
+    raise ReferenceGenerationError(
+        f"symbol not found in config.yaml: module={module}, func_name={func_name}"
+    )
+```
+
+- [ ] **Step 4: 重跑纯 helper 测试，确认通过**
+
+Run:
+
+```bash
+uv run python -m unittest tests.test_generate_reference_yaml.TestReferenceYamlPureHelpers -v
+```
+
+Expected: PASS，路径、旧 YAML 优先级、`config.yaml` alias 收集与 `-auto_start_mcp/-binary` 配对约束全部通过。
+
+- [ ] **Step 5: 提交当前 helper 骨架**
+
+```bash
+git add generate_reference_yaml.py tests/test_generate_reference_yaml.py
+git commit -m "test(reference): 增加 reference yaml CLI 基础测试"
+```
+
+## Task 2: 实现函数地址解析与 reference payload 导出
+
+**Files:**
+- Modify: `generate_reference_yaml.py`
+- Modify: `tests/test_generate_reference_yaml.py`
+
+- [ ] **Step 1: 先补失败测试，锁定“旧 YAML 优先、IDA alias fallback、歧义报错、伪代码可空”**
+
+```python
+import json
+from unittest.mock import AsyncMock
+
+
+class _FakeTextContent:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeCallToolResult:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.content = [_FakeTextContent(json.dumps(payload))]
+
+
+def _py_eval_payload(payload: object) -> _FakeCallToolResult:
+    return _FakeCallToolResult(
+        {
+            "result": json.dumps(payload),
+            "stdout": "",
+            "stderr": "",
+        }
+    )
+
+
+class TestResolveFuncVa(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_func_va_uses_existing_yaml_before_ida_lookup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root / "bin" / "14141" / "engine" / "Foo.windows.yaml",
+                {"func_name": "Foo", "func_va": "0x180123450"},
+            )
+            session = AsyncMock()
+
+            func_va = await generate_reference_yaml.resolve_func_va(
+                session=session,
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                platform="windows",
+                func_name="Foo",
+                debug=False,
+            )
+
+            self.assertEqual("0x180123450", func_va)
+            session.call_tool.assert_not_awaited()
+
+    async def test_resolve_func_va_falls_back_to_config_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "config.yaml").write_text(
+                """
+modules:
+  - name: engine
+    symbols:
+      - name: CNetworkGameClient_RecordEntityBandwidth
+        category: func
+        alias:
+          - CNetworkGameClient::RecordEntityBandwidth
+          - RecordEntityBandwidth
+""".strip(),
+                encoding="utf-8",
+            )
+            session = AsyncMock()
+            session.call_tool.return_value = _py_eval_payload(
+                [
+                    {
+                        "query": "RecordEntityBandwidth",
+                        "func_name": "CNetworkGameClient_RecordEntityBandwidth",
+                        "func_va": "0x180123450",
+                    }
+                ]
+            )
+
+            func_va = await generate_reference_yaml.resolve_func_va(
+                session=session,
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                platform="windows",
+                func_name="CNetworkGameClient_RecordEntityBandwidth",
+                debug=False,
+            )
+
+            self.assertEqual("0x180123450", func_va)
+
+    async def test_resolve_func_va_raises_on_ambiguous_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            (repo_root / "config.yaml").write_text(
+                """
+modules:
+  - name: engine
+    symbols:
+      - name: Foo
+        category: func
+        alias:
+          - FooAlias
+""".strip(),
+                encoding="utf-8",
+            )
+            session = AsyncMock()
+            session.call_tool.return_value = _py_eval_payload(
+                [
+                    {"query": "Foo", "func_name": "Foo", "func_va": "0x180100000"},
+                    {"query": "FooAlias", "func_name": "Foo_impl", "func_va": "0x180200000"},
+                ]
+            )
+
+            with self.assertRaisesRegex(
+                generate_reference_yaml.ReferenceGenerationError,
+                "ambiguous",
+            ):
+                await generate_reference_yaml.resolve_func_va(
+                    session=session,
+                    repo_root=repo_root,
+                    gamever="14141",
+                    module="engine",
+                    platform="windows",
+                    func_name="Foo",
+                    debug=False,
+                )
+
+
+class TestExportReferencePayload(unittest.IsolatedAsyncioTestCase):
+    async def test_export_reference_payload_keeps_empty_procedure_when_hexrays_missing(self) -> None:
+        session = AsyncMock()
+        session.call_tool.return_value = _py_eval_payload(
+            {
+                "func_name": "CNetworkGameClient_RecordEntityBandwidth",
+                "func_va": "0x180123450",
+                "disasm_code": "text:0000000180123450 mov eax, 1",
+                "procedure": "",
+            }
+        )
+
+        payload = await generate_reference_yaml.export_reference_payload_via_mcp(
+            session=session,
+            func_name="CNetworkGameClient_RecordEntityBandwidth",
+            func_va="0x180123450",
+            debug=False,
+        )
+
+        self.assertEqual("CNetworkGameClient_RecordEntityBandwidth", payload["func_name"])
+        self.assertEqual("0x180123450", payload["func_va"])
+        self.assertEqual("", payload["procedure"])
+        self.assertIn("mov eax, 1", payload["disasm_code"])
+```
+
+- [ ] **Step 2: 运行解析/导出测试，确认当前失败**
+
+Run:
+
+```bash
+uv run python -m unittest \
+  tests.test_generate_reference_yaml.TestResolveFuncVa \
+  tests.test_generate_reference_yaml.TestExportReferencePayload \
+  -v
+```
+
+Expected: FAIL，因为 `resolve_func_va(...)`、`find_function_addr_by_names(...)`、`export_reference_payload_via_mcp(...)` 还未实现。
+
+- [ ] **Step 3: 实现解析顺序、IDA alias 搜索与最小 reference payload 导出**
+
+```python
+import json
+
+from ida_analyze_util import parse_mcp_result
+
+
+async def find_function_addr_by_names(session, candidate_names, *, debug=False) -> str:
+    py_code = (
+        "import idaapi, ida_funcs, ida_name, json\n"
+        f"candidate_names = {json.dumps(list(candidate_names), ensure_ascii=False)}\n"
+        "matches = []\n"
+        "seen = set()\n"
+        "for candidate in candidate_names:\n"
+        "    if not candidate:\n"
+        "        continue\n"
+        "    ea = ida_name.get_name_ea(idaapi.BADADDR, candidate)\n"
+        "    if ea == idaapi.BADADDR:\n"
+        "        continue\n"
+        "    func = ida_funcs.get_func(ea)\n"
+        "    if func is None:\n"
+        "        continue\n"
+        "    start_ea = int(func.start_ea)\n"
+        "    if start_ea in seen:\n"
+        "        continue\n"
+        "    seen.add(start_ea)\n"
+        "    matches.append({\n"
+        "        'query': candidate,\n"
+        "        'func_name': ida_funcs.get_func_name(start_ea) or f'sub_{start_ea:X}',\n"
+        "        'func_va': hex(start_ea),\n"
+        "    })\n"
+        "result = json.dumps(matches)\n"
+    )
+    result = await session.call_tool(name="py_eval", arguments={"code": py_code})
+    payload = parse_mcp_result(result)
+    result_text = payload.get("result", "") if isinstance(payload, dict) else ""
+    matches = json.loads(result_text) if result_text else []
+    if not matches:
+        raise ReferenceGenerationError("unable to locate function address via IDA")
+    if len(matches) != 1:
+        raise ReferenceGenerationError(f"ambiguous function matches: {matches}")
+    return str(matches[0]["func_va"])
+
+
+async def resolve_func_va(
+    *,
+    session,
+    repo_root: Path,
+    gamever: str,
+    module: str,
+    platform: str,
+    func_name: str,
+    debug: bool,
+) -> str:
+    existing = load_existing_func_va(
+        repo_root=repo_root,
+        gamever=gamever,
+        module=module,
+        func_name=func_name,
+        platform=platform,
+    )
+    if existing:
+        return existing
+    candidate_names = load_symbol_aliases(
+        repo_root=repo_root,
+        module=module,
+        func_name=func_name,
+    )
+    return await find_function_addr_by_names(
+        session,
+        candidate_names,
+        debug=debug,
+    )
+
+
+async def export_reference_payload_via_mcp(session, *, func_name: str, func_va: str, debug=False) -> dict[str, str]:
+    func_va_int = int(str(func_va), 0)
+    py_code = (
+        "import ida_funcs, ida_lines, ida_segment, idautils, idc, json\n"
+        "try:\n"
+        "    import ida_hexrays\n"
+        "except Exception:\n"
+        "    ida_hexrays = None\n"
+        f"func_ea = {func_va_int}\n"
+        f"expected_name = {func_name!r}\n"
+        "def get_disasm(start_ea):\n"
+        "    func = ida_funcs.get_func(start_ea)\n"
+        "    if func is None:\n"
+        "        return ''\n"
+        "    lines = []\n"
+        "    for ea in idautils.FuncItems(func.start_ea):\n"
+        "        if ea < func.start_ea or ea >= func.end_ea:\n"
+        "            continue\n"
+        "        seg = ida_segment.getseg(ea)\n"
+        "        seg_name = ida_segment.get_segm_name(seg) if seg else ''\n"
+        "        address_text = f'{seg_name}:{ea:016X}' if seg_name else f'{ea:016X}'\n"
+        "        disasm_line = idc.generate_disasm_line(ea, 0) or ''\n"
+        "        lines.append(f\"{address_text}                 {ida_lines.tag_remove(disasm_line)}\")\n"
+        "    return '\\n'.join(lines)\n"
+        "def get_pseudocode(start_ea):\n"
+        "    if ida_hexrays is None:\n"
+        "        return ''\n"
+        "    try:\n"
+        "        if not ida_hexrays.init_hexrays_plugin():\n"
+        "            return ''\n"
+        "        cfunc = ida_hexrays.decompile(start_ea)\n"
+        "    except Exception:\n"
+        "        return ''\n"
+        "    if not cfunc:\n"
+        "        return ''\n"
+        "    return '\\n'.join(ida_lines.tag_remove(line.line) for line in cfunc.get_pseudocode())\n"
+        "func = ida_funcs.get_func(func_ea)\n"
+        "if func is None:\n"
+        "    result = json.dumps(None)\n"
+        "else:\n"
+        "    func_start = int(func.start_ea)\n"
+        "    result = json.dumps({\n"
+        "        'func_name': expected_name,\n"
+        "        'func_va': hex(func_start),\n"
+        "        'disasm_code': get_disasm(func_start),\n"
+        "        'procedure': get_pseudocode(func_start),\n"
+        "    })\n"
+    )
+    result = await session.call_tool(name="py_eval", arguments={"code": py_code})
+    payload = parse_mcp_result(result)
+    result_text = payload.get("result", "") if isinstance(payload, dict) else ""
+    exported = json.loads(result_text) if result_text else None
+    if not isinstance(exported, dict):
+        raise ReferenceGenerationError(f"failed to export reference payload for {func_name}")
+    return {
+        "func_name": str(exported.get("func_name") or func_name),
+        "func_va": str(exported.get("func_va") or func_va),
+        "disasm_code": str(exported.get("disasm_code", "") or ""),
+        "procedure": str(exported.get("procedure", "") or ""),
+    }
+
+
+def write_reference_yaml(path: Path, payload: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.dump(
+            payload,
+            Dumper=LiteralDumper,
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+```
+
+- [ ] **Step 4: 重跑解析/导出测试，确认通过**
+
+Run:
+
+```bash
+uv run python -m unittest \
+  tests.test_generate_reference_yaml.TestResolveFuncVa \
+  tests.test_generate_reference_yaml.TestExportReferencePayload \
+  -v
+```
+
+Expected: PASS，解析顺序固定为“旧 YAML `func_va` 优先，其次 `config.yaml` + IDA alias 搜索”，并且导出的 YAML payload 保持最小 schema 与空 `procedure` 兼容。
+
+- [ ] **Step 5: 提交解析与导出实现**
+
+```bash
+git add generate_reference_yaml.py tests/test_generate_reference_yaml.py
+git commit -m "feat(reference): 实现地址解析与导出"
+```
+
+## Task 3: 接入 attach/auto-start MCP 两种模式并打通 CLI 主流程
+
+**Files:**
+- Modify: `generate_reference_yaml.py`
+- Modify: `tests/test_generate_reference_yaml.py`
+
+- [ ] **Step 1: 先补失败测试，锁定 attach 模式、auto-start 模式与主流程编排**
+
+```python
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+class _FakeStreamableHttpClient:
+    async def __aenter__(self):
+        return ("read-stream", "write-stream", None)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeClientSession:
+    def __init__(self, read_stream, write_stream):
+        self.read_stream = read_stream
+        self.write_stream = write_stream
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def initialize(self):
+        return None
+
+
+class TestMcpSessionModes(unittest.IsolatedAsyncioTestCase):
+    @patch.object(generate_reference_yaml, "check_mcp_health", AsyncMock(return_value=True))
+    @patch.object(generate_reference_yaml, "httpx")
+    @patch.object(generate_reference_yaml, "streamable_http_client", return_value=_FakeStreamableHttpClient())
+    @patch.object(generate_reference_yaml, "ClientSession", _FakeClientSession)
+    async def test_attach_existing_mcp_session_checks_health_first(
+        self,
+        _mock_streamable,
+        mock_httpx,
+        mock_health,
+    ) -> None:
+        mock_httpx.AsyncClient = _FakeAsyncClient
+
+        async with generate_reference_yaml.attach_existing_mcp_session(
+            host="127.0.0.1",
+            port=13337,
+            debug=False,
+        ) as session:
+            self.assertIsInstance(session, _FakeClientSession)
+
+        mock_health.assert_awaited_once_with("127.0.0.1", 13337)
+
+    @patch.object(generate_reference_yaml, "quit_ida_gracefully")
+    @patch.object(generate_reference_yaml, "start_idalib_mcp", return_value=object())
+    @patch.object(generate_reference_yaml, "httpx")
+    @patch.object(generate_reference_yaml, "streamable_http_client", return_value=_FakeStreamableHttpClient())
+    @patch.object(generate_reference_yaml, "ClientSession", _FakeClientSession)
+    async def test_autostart_mcp_session_starts_and_quits_process(
+        self,
+        _mock_streamable,
+        mock_httpx,
+        mock_start,
+        mock_quit,
+    ) -> None:
+        mock_httpx.AsyncClient = _FakeAsyncClient
+
+        async with generate_reference_yaml.autostart_mcp_session(
+            binary_path="bin/14141/engine/engine2.dll",
+            host="127.0.0.1",
+            port=13337,
+            ida_args="",
+            debug=False,
+        ) as session:
+            self.assertIsInstance(session, _FakeClientSession)
+
+        mock_start.assert_called_once()
+        mock_quit.assert_called_once()
+
+
+class TestRunReferenceGeneration(unittest.IsolatedAsyncioTestCase):
+    async def test_run_reference_generation_uses_attach_mode_by_default(self) -> None:
+        args = SimpleNamespace(
+            gamever="14141",
+            module="engine",
+            platform="windows",
+            func_name="Foo",
+            mcp_host="127.0.0.1",
+            mcp_port=13337,
+            binary=None,
+            auto_start_mcp=False,
+            ida_args="",
+            debug=False,
+        )
+
+        fake_session = AsyncMock()
+
+        @asynccontextmanager
+        async def _fake_attach(*args, **kwargs):
+            yield fake_session
+
+        with (
+            patch.object(generate_reference_yaml, "attach_existing_mcp_session", _fake_attach),
+            patch.object(generate_reference_yaml, "resolve_func_va", AsyncMock(return_value="0x180123450")),
+            patch.object(
+                generate_reference_yaml,
+                "export_reference_payload_via_mcp",
+                AsyncMock(
+                    return_value={
+                        "func_name": "Foo",
+                        "func_va": "0x180123450",
+                        "disasm_code": "mov eax, 1",
+                        "procedure": "",
+                    }
+                ),
+            ),
+        ):
+            with tempfile.TemporaryDirectory() as temp_dir:
+                output_path = await generate_reference_yaml.run_reference_generation(
+                    args,
+                    repo_root=Path(temp_dir),
+                )
+
+        self.assertEqual(
+            Path(temp_dir)
+            / "ida_preprocessor_scripts"
+            / "references"
+            / "engine"
+            / "Foo.windows.yaml",
+            output_path,
+        )
+```
+
+- [ ] **Step 2: 运行会话编排测试，确认当前失败**
+
+Run:
+
+```bash
+uv run python -m unittest \
+  tests.test_generate_reference_yaml.TestMcpSessionModes \
+  tests.test_generate_reference_yaml.TestRunReferenceGeneration \
+  -v
+```
+
+Expected: FAIL，因为 attach/auto-start 会话管理器和 `run_reference_generation(...)` 还未实现。
+
+- [ ] **Step 3: 实现 MCP 会话适配、主流程编排与 CLI 入口**
+
+```python
+import asyncio
+import httpx
+from contextlib import asynccontextmanager
+
+from ida_analyze_bin import check_mcp_health, quit_ida_gracefully, start_idalib_mcp
+
+try:
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+except ImportError:
+    ClientSession = None
+    streamable_http_client = None
+
+
+@asynccontextmanager
+async def _open_mcp_session(host: str, port: int):
+    server_url = f"http://{host}:{port}/mcp"
+    async with httpx.AsyncClient(
+        follow_redirects=True,
+        timeout=httpx.Timeout(30.0, read=300.0),
+        trust_env=False,
+    ) as http_client:
+        async with streamable_http_client(server_url, http_client=http_client) as (
+            read_stream,
+            write_stream,
+            _,
+        ):
+            async with ClientSession(read_stream, write_stream) as session:
+                await session.initialize()
+                yield session
+
+
+@asynccontextmanager
+async def attach_existing_mcp_session(*, host: str, port: int, debug: bool):
+    healthy = await check_mcp_health(host, port)
+    if not healthy:
+        raise ReferenceGenerationError(
+            f"MCP server is not reachable at {host}:{port}"
+        )
+    async with _open_mcp_session(host, port) as session:
+        yield session
+
+
+@asynccontextmanager
+async def autostart_mcp_session(*, binary_path: str, host: str, port: int, ida_args: str, debug: bool):
+    process = start_idalib_mcp(binary_path, host, port, ida_args, debug)
+    if process is None:
+        raise ReferenceGenerationError(f"failed to start idalib-mcp for {binary_path}")
+    try:
+        async with _open_mcp_session(host, port) as session:
+            yield session
+    finally:
+        quit_ida_gracefully(process, host, port, debug=debug)
+
+
+async def run_reference_generation(args, *, repo_root: Path | None = None) -> Path:
+    repo_root = Path(repo_root or Path(__file__).resolve().parent)
+    session_manager = (
+        autostart_mcp_session(
+            binary_path=args.binary,
+            host=args.mcp_host,
+            port=args.mcp_port,
+            ida_args=args.ida_args,
+            debug=args.debug,
+        )
+        if args.auto_start_mcp
+        else attach_existing_mcp_session(
+            host=args.mcp_host,
+            port=args.mcp_port,
+            debug=args.debug,
+        )
+    )
+    async with session_manager as session:
+        func_va = await resolve_func_va(
+            session=session,
+            repo_root=repo_root,
+            gamever=args.gamever,
+            module=args.module,
+            platform=args.platform,
+            func_name=args.func_name,
+            debug=args.debug,
+        )
+        payload = await export_reference_payload_via_mcp(
+            session=session,
+            func_name=args.func_name,
+            func_va=func_va,
+            debug=args.debug,
+        )
+        output_path = build_reference_output_path(
+            repo_root=repo_root,
+            module=args.module,
+            func_name=args.func_name,
+            platform=args.platform,
+        )
+        write_reference_yaml(output_path, payload)
+        return output_path
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    try:
+        output_path = asyncio.run(run_reference_generation(args))
+    except ReferenceGenerationError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+    print(f"Generated reference YAML: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: 重跑整套 `generate_reference_yaml` 定向测试并做语法检查**
+
+Run:
+
+```bash
+uv run python -m py_compile generate_reference_yaml.py && \
+uv run python -m unittest tests.test_generate_reference_yaml -v
+```
+
+Expected: PASS，attach/auto-start 两种模式、解析优先级、reference payload 导出与主流程编排全部通过。
+
+- [ ] **Step 5: 提交 CLI 主流程实现**
+
+```bash
+git add generate_reference_yaml.py tests/test_generate_reference_yaml.py
+git commit -m "feat(reference): 增加 reference yaml 生成 CLI"
+```
+
+## Task 4: 补 project-level SKILL 与 README 准备步骤文档
+
+**Files:**
+- Create: `.claude/skills/generate-reference-yaml/SKILL.md`
+- Modify: `README.md`
+- Modify: `README_CN.md`
+
+- [ ] **Step 1: 新建 project-level SKILL，只保留 CLI 触发与人工检查指引**
+
+````markdown
+---
+name: generate-reference-yaml
+description: |
+  Generate minimal reference YAML for LLM_DECOMPILE inputs by calling the project CLI.
+  Use this skill when you need `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`.
+  Trigger: generate reference yaml, reference yaml, LLM_DECOMPILE reference
+disable-model-invocation: true
+---
+
+# Generate Reference YAML
+
+Use the project CLI as the single backend. Do not call IDA APIs directly from this SKILL.
+
+## Required parameters
+
+- `gamever`
+- `module`
+- `platform`
+- `func_name`
+
+## Attach to existing MCP
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever <gamever> \
+  -module <module> \
+  -platform <platform> \
+  -func_name <func_name> \
+  -mcp_host 127.0.0.1 \
+  -mcp_port 13337
+```
+
+## Auto-start `idalib-mcp`
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever <gamever> \
+  -module <module> \
+  -platform <platform> \
+  -func_name <func_name> \
+  -auto_start_mcp \
+  -binary bin/<gamever>/<module>/<binary_name>
+```
+
+## After generation
+
+1. Verify `func_name`, `func_va`, `disasm_code`, `procedure`
+2. Update the target `find-*.py` script `LLM_DECOMPILE` reference path
+3. Continue the unfinished reverse-engineering task
+````
+
+- [ ] **Step 2: 在 README/README_CN 新增“reference YAML 准备步骤”与命令示例**
+
+````markdown
+## Generate reference YAML for `LLM_DECOMPILE`
+
+Reference YAML is stored under:
+
+```text
+ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml
+```
+
+Preparation flow:
+
+1. Confirm the target function already has current-version YAML with `func_va`, or can be found by `config.yaml` symbol name / alias in IDA.
+2. Run:
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever 14141 \
+  -module engine \
+  -platform windows \
+  -func_name CNetworkGameClient_RecordEntityBandwidth \
+  -mcp_host 127.0.0.1 \
+  -mcp_port 13337
+```
+
+3. Check the generated file:
+   - `func_name` is correct
+   - `func_va` is trusted
+   - `disasm_code` is not empty
+   - `procedure` is acceptable, empty string is allowed when Hex-Rays is unavailable
+4. Reference the path from `LLM_DECOMPILE` in the target `find-*.py` script.
+````
+
+- [ ] **Step 3: 跑最终定向验证，并记录真实 IDA 手动验收动作**
+
+Run:
+
+```bash
+uv run python -m py_compile generate_reference_yaml.py && \
+uv run python -m unittest tests.test_generate_reference_yaml -v
+```
+
+Manual acceptance:
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever 14141 \
+  -module engine \
+  -platform windows \
+  -func_name CNetworkGameClient_RecordEntityBandwidth \
+  -mcp_host 127.0.0.1 \
+  -mcp_port 13337
+```
+
+Expected:
+
+- 生成 `ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml`
+- YAML 只有 `func_name`、`func_va`、`disasm_code`、`procedure`
+- `disasm_code` 非空
+- `procedure` 允许为空字符串，但字段必须存在
+
+- [ ] **Step 4: 提交 SKILL 与文档**
+
+```bash
+git add \
+  .claude/skills/generate-reference-yaml/SKILL.md \
+  README.md \
+  README_CN.md
+git commit -m "docs(reference): 增加 reference yaml 生成说明"
+```
+
+## Self-Review
+
+- **Spec coverage:** 本计划覆盖了 `docs/superpowers/specs/2026-04-09-reference-yaml-generator-design.md` 的全部核心要求：独立 CLI、attach/auto-start 双模式、旧 YAML `func_va` 优先、`config.yaml` + alias fallback、最小 reference schema、路径包含 `module/platform`、project-level SKILL、README/README_CN 的 reference YAML 准备步骤与首个真实验收场景。
+- **Placeholder scan:** 计划正文中没有 `TBD`、`TODO`、`implement later`、`similar to` 等占位语；每个任务都给出了明确文件路径、测试命令、期望结果与关键代码骨架。
+- **Type consistency:** 计划中统一使用 `ReferenceGenerationError`、`build_reference_output_path(...)`、`load_existing_func_va(...)`、`load_symbol_aliases(...)`、`resolve_func_va(...)`、`export_reference_payload_via_mcp(...)`、`attach_existing_mcp_session(...)`、`autostart_mcp_session(...)`、`run_reference_generation(...)` 这一组函数名，后续执行时不得改名漂移。

--- a/docs/superpowers/specs/2026-04-09-reference-yaml-generator-design.md
+++ b/docs/superpowers/specs/2026-04-09-reference-yaml-generator-design.md
@@ -1,0 +1,415 @@
+# reference YAML 自动生成 CLI 设计
+
+## 背景
+
+当前 `call_llm_decompile` 的接线已经支持从 prompt 模板与 reference YAML 读取参考函数上下文，但 reference YAML 仍需要人工在 IDA 中导出并放到 `ida_preprocessor_scripts/references/...`。
+
+对于 `CNetworkMessages_FindNetworkGroup` 这类场景，人工流程的核心工作其实很固定：
+
+1. 根据参考函数名定位目标函数地址
+2. 在 IDA 中导出该函数的反汇编与伪代码
+3. 按固定 schema 写成 reference YAML
+4. 放入 `ida_preprocessor_scripts/references/<module>/<func>.<platform>.yaml`
+
+因此本次希望新增一个 project-level 的独立 CLI，把这条流程自动化；同时再提供一个轻量 SKILL 作为统一触发入口，让人和 agent 都走同一条实现路径。
+
+## 目标
+
+- 新增一个独立 CLI，用于自动生成 reference YAML。
+- CLI 同时支持：
+  - 连接已运行的 `ida-pro-mcp` / `idalib-mcp`
+  - 自动启动 `idalib-mcp` 后执行导出
+- CLI 的主输入是 `func_name`，而不是手工输入地址。
+- 默认先从现有 `bin/<gamever>/<module>/<func>.<platform>.yaml` 读取 `func_va`；读不到时，再用 `config.yaml` 中的 symbol name / alias 到 IDA 搜索。
+- reference YAML 采用最小 schema，仅包含：
+  - `func_name`
+  - `func_va`
+  - `disasm_code`
+  - `procedure`
+- `module` 与 `platform` 不写入 YAML，而是体现在输出路径与文件名中，例如：
+  - `ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml`
+- 新增一个 project-level SKILL，内部只调用该 CLI，不复制导出逻辑。
+- 首版按“通用框架 + `func` 首版实现”落地，后续可扩展到 `vfunc` 或其他 reference 类型。
+
+## 非目标
+
+- 本次不直接把该 CLI 接入 `ida_analyze_bin.py` 主流程。
+- 本次不一次性实现 `vfunc`、`vcall_finder detail`、struct/member 等所有 reference 类型。
+- 本次不替代已有 `call_llm_decompile` 逻辑，只负责补齐其 reference 产物来源。
+- 本次不要求 reference YAML 自动注册到 `config.yaml`。
+- 本次不要求生成 reference YAML 后立即执行真实 LLM fallback 验证。
+
+## 方案比较
+
+### 方案 1：最薄 CLI
+
+只做一个小脚本，输入 `func_name/module/platform/gamever`，导出 reference YAML。
+
+优点：
+
+- 实现最快
+- 首版最小
+
+缺点：
+
+- 未来扩展到 `vfunc` / 其他 reference 类型时，容易继续堆条件分支
+- 与 project-level SKILL 的协作边界不够明确
+
+### 方案 2：通用框架 + `func` 首版实现
+
+新增独立 CLI，但内部拆为“目标解析”“MCP 会话适配”“IDA 导出”“YAML 写入”几个小单元；首版只实现 `func` reference 导出。
+
+优点：
+
+- 满足当前需求的同时，为后续扩展预留清晰边界
+- 适合作为 project-level SKILL 的统一后端
+- 更容易测试和复用
+
+缺点：
+
+- 首版实现量略高于最薄 CLI
+
+### 方案 3：直接做成 SKILL
+
+把 reference 导出逻辑写入一个 SKILL，由 SKILL 直接连接 IDA 并落盘。
+
+优点：
+
+- 入口简单
+
+缺点：
+
+- 不符合“独立命令行工具”的目标
+- 人工与自动化会变成两套入口
+- 不利于后续在 shell / CI / 其他 agent 工作流中复用
+
+## 选定方案
+
+采用方案 2：实现一个独立 CLI，并提供一个 project-level SKILL 作为该 CLI 的统一触发器。
+
+这是满足当前需求与未来扩展需求的最小充分方案。
+
+## 详细设计
+
+### 1. CLI 入口
+
+建议新增独立脚本：
+
+- `generate_reference_yaml.py`
+
+建议命令形态：
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever 14141 \
+  -module engine \
+  -platform windows \
+  -func_name CNetworkGameClient_RecordEntityBandwidth
+```
+
+两种运行模式：
+
+#### 1.1 连接现有 MCP
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever 14141 \
+  -module engine \
+  -platform windows \
+  -func_name CNetworkGameClient_RecordEntityBandwidth \
+  -mcp_host 127.0.0.1 \
+  -mcp_port 13337
+```
+
+#### 1.2 自动启动 `idalib-mcp`
+
+```bash
+uv run generate_reference_yaml.py \
+  -gamever 14141 \
+  -module engine \
+  -platform windows \
+  -func_name CNetworkGameClient_RecordEntityBandwidth \
+  -binary bin/14141/engine/engine2.dll \
+  -auto_start_mcp
+```
+
+规则：
+
+- `-auto_start_mcp` 与 `-binary` 成对出现
+- 未指定 `-auto_start_mcp` 时，默认连接已存在的 MCP 服务
+- 两种模式共享同一套解析与导出逻辑
+
+### 2. 内部结构
+
+建议拆成以下逻辑单元，但首版可先放在一个文件中，后续再提炼：
+
+#### 2.1 `ReferenceTargetResolver`
+
+职责：
+
+- 根据 `func_name/module/platform/gamever` 解析目标函数地址
+
+解析顺序：
+
+1. 先读：
+   - `bin/<gamever>/<module>/<func_name>.<platform>.yaml`
+2. 若该 YAML 存在且包含 `func_va`，直接使用
+3. 若不存在或缺失 `func_va`，读取 `config.yaml`
+   - 找到对应 `symbol`
+   - 收集 `name` 与 `alias`
+4. 使用这些候选名字在 IDA 中搜索函数
+
+失败策略：
+
+- 如果 YAML 与 IDA 搜索都失败，则 CLI 返回非零并输出明确错误
+
+#### 2.2 `McpSessionAdapter`
+
+职责：
+
+- 统一封装“连接已有 MCP”和“自动启动 MCP”
+
+能力：
+
+- 复用现有仓库中的 MCP 连接模式
+- 自动启动模式下复用 `ida_analyze_bin.py` 里的 `idalib-mcp` 启动参数习惯
+- 失败时统一做 graceful cleanup
+
+#### 2.3 `IdaReferenceExporter`
+
+职责：
+
+- 给定 `func_va`
+- 通过 MCP 从 IDA 导出：
+  - `disasm_code`
+  - `procedure`
+
+首版要求：
+
+- 必须拿到反汇编文本
+- 伪代码若 Hex-Rays 不可用，可允许为空字符串，但字段仍保留
+
+建议优先复用仓库中已有“函数导出反汇编/伪代码”的 py_eval 组织方式，避免再造一套不一致的导出格式。
+
+#### 2.4 `ReferenceYamlWriter`
+
+职责：
+
+- 生成最小 reference YAML
+- 负责输出路径规范化与落盘
+
+### 3. 输出 schema 与路径
+
+reference YAML 最小 schema：
+
+```yaml
+func_name: CNetworkGameClient_RecordEntityBandwidth
+func_va: 0x180123450
+disasm_code: |
+  ...
+procedure: |
+  ...
+```
+
+不额外写入：
+
+- `module`
+- `platform`
+- `generated_at`
+- `generated_by`
+
+原因：
+
+- 这些信息已经体现在路径与文件名中
+- 当前 `call_llm_decompile` 实际只需要函数内容与名字
+- 保持 reference 产物最小化更利于人工检查
+
+默认输出路径：
+
+```text
+ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml
+```
+
+例如：
+
+```text
+ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml
+```
+
+### 4. 函数名解析规则
+
+CLI 主输入为：
+
+- `func_name`
+
+规则：
+
+- `func_name` 是规范名，不要求用户自己提供 alias
+- 解析地址时，优先读现有 YAML
+- 现有 YAML 不可用时，再用 `config.yaml` 中该符号的 `name + alias` 到 IDA 搜索
+
+这样可以最大化复用现有仓库资产，同时避免每次都依赖 IDA 名字匹配。
+
+### 5. IDA 搜索策略
+
+当需要 fallback 到 IDA 搜索时：
+
+1. 先按 `func_name`
+2. 再按 `alias` 列表逐个尝试
+3. 若匹配到多个候选：
+   - 输出歧义错误
+   - 列出候选地址
+   - 返回失败，不自动猜测
+
+不做的事情：
+
+- 不做模糊搜索后自动择优
+- 不根据字符串 xref 再做复杂启发式推断
+
+原因：
+
+- CLI 的职责是“导出 reference”，不是重新实现符号定位框架
+- 当前项目已有 `config.yaml` 与旧 YAML 作为更稳定的来源
+
+### 6. 与 `call_llm_decompile` 的协作
+
+该 CLI 不直接调用 LLM。
+
+它只负责生成可被 `call_llm_decompile` 使用的 reference YAML。
+
+因此正向链路为：
+
+1. 用户或 SKILL 运行 CLI
+2. CLI 生成：
+   - `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+3. `LLM_DECOMPILE` spec 引用该 YAML
+4. `preprocess_common_skill(...)` 在运行 LLM fallback 时读取该 reference YAML
+
+### 7. project-level SKILL 设计
+
+建议新增一个 project-level SKILL，例如：
+
+- `generate-reference-yaml`
+
+其职责非常单一：
+
+- 接收用户给定的 `gamever/module/platform/func_name`
+- 调用 `uv run generate_reference_yaml.py ...`
+- 不直接与 IDA API 或 MCP 对话
+
+这样可保证：
+
+- 命令行与 SKILL 共用一条后端逻辑
+- 避免 shell 路径与 prompt 路径分叉
+
+### 8. 首个目标场景
+
+首版应优先支持：
+
+- `CNetworkGameClient_RecordEntityBandwidth`
+
+因为它正是当前 `CNetworkMessages_FindNetworkGroup` 的 reference 来源。
+
+示例输出目标：
+
+```text
+ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml
+ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.linux.yaml
+```
+
+### 9. reference YAML 准备步骤
+
+面向最终用户，推荐准备步骤如下：
+
+1. 先确认目标函数已有当前版本 YAML，或可通过 `config.yaml` alias 在 IDA 中搜索到
+2. 运行独立 CLI，输入：
+   - `gamever`
+   - `module`
+   - `platform`
+   - `func_name`
+3. CLI 导出 reference YAML 到：
+   - `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
+4. 在对应 `find-*.py` 脚本中，把该路径写入 `LLM_DECOMPILE`
+5. 人工检查该 YAML：
+   - `func_name` 是否正确
+   - `func_va` 是否可信
+   - `disasm_code` 是否非空
+   - `procedure` 是否符合预期
+6. 再执行实际的 LLM fallback 流程
+
+### 10. 失败与降级策略
+
+#### 10.1 现有 YAML 不存在
+
+- 不直接失败
+- 转入 `config.yaml + IDA 搜索`
+
+#### 10.2 `config.yaml` 找不到对应 symbol
+
+- 失败
+- 输出明确错误
+
+#### 10.3 IDA 搜索结果为空
+
+- 失败
+- 输出“无法定位函数地址”
+
+#### 10.4 IDA 搜索结果多于一个
+
+- 失败
+- 输出候选列表
+
+#### 10.5 反汇编导出成功、伪代码导出失败
+
+- reference YAML 仍可写出
+- `procedure` 写空字符串
+
+#### 10.6 自动启动 MCP 失败
+
+- 返回非零
+- 不写出半成品 YAML
+
+### 11. 测试与验证
+
+首版建议覆盖以下层次：
+
+#### 单元测试
+
+- YAML 路径生成
+- 现有 YAML 优先解析 `func_va`
+- `config.yaml` alias 收集
+- 歧义 / 缺失错误处理
+
+#### 集成级测试
+
+- mock MCP 会话，验证导出 payload
+- 验证最小 schema 落盘
+- 验证 auto-start 与 attach 两种模式的参数分流
+
+#### 手动验证
+
+以 `CNetworkGameClient_RecordEntityBandwidth` 为例：
+
+1. 连接实际 IDA 会话
+2. 运行 CLI
+3. 检查生成文件是否位于：
+   - `ida_preprocessor_scripts/references/engine/CNetworkGameClient_RecordEntityBandwidth.windows.yaml`
+4. 打开 YAML，检查反汇编与伪代码是否可信
+
+## 建议落地文件
+
+首版建议至少涉及：
+
+- Create: `generate_reference_yaml.py`
+- Create: `.claude/skills/generate-reference-yaml/SKILL.md`
+- Modify: `README.md`
+- Modify: `README_CN.md`
+- Modify: `tests/...`（按最终实现拆分）
+
+如为降低首版复杂度，也可先不新增 SKILL，先完成 CLI 与测试，再在第二步补 SKILL；但从用户目标看，CLI 与 SKILL 最终都应具备。
+
+## 结论
+
+本需求适合做成一个独立 CLI，并由 project-level SKILL 统一触发。
+
+首版采用“通用框架 + `func` 首版实现”，既能尽快覆盖 `CNetworkGameClient_RecordEntityBandwidth` 的 reference YAML 自动化生成，又不会把后续 `vfunc` / 其他 reference 类型的扩展路径堵死。

--- a/generate_reference_yaml.py
+++ b/generate_reference_yaml.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+from collections.abc import Mapping, Sequence
+from contextlib import AsyncExitStack, asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    import httpx
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamable_http_client
+except ImportError:
+    httpx = None
+    ClientSession = None
+    streamable_http_client = None
+
+from ida_analyze_util import parse_mcp_result
+
+
+class ReferenceGenerationError(RuntimeError):
+    pass
+
+
+class LiteralDumper(yaml.SafeDumper):
+    pass
+
+
+def _literal_str_representer(dumper: yaml.Dumper, value: str) -> yaml.Node:
+    style = "|" if "\n" in value else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", value, style=style)
+
+
+LiteralDumper.add_representer(str, _literal_str_representer)
+
+
+def _normalize_non_empty_text(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _normalize_address_text(value: Any, *, require_string: bool = False) -> str | None:
+    if require_string:
+        text = _normalize_non_empty_text(value)
+        if text is None:
+            return None
+        try:
+            int(text, 0)
+        except (TypeError, ValueError):
+            return None
+        return text
+
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            int(text, 0)
+        except (TypeError, ValueError):
+            return None
+        return text
+
+    if isinstance(value, int):
+        return hex(value)
+
+    return None
+
+
+def _validate_reference_yaml_payload(payload: Mapping[str, Any]) -> dict[str, str]:
+    func_name = _normalize_non_empty_text(payload.get("func_name"))
+    func_va = _normalize_address_text(payload.get("func_va"))
+    disasm_code = _normalize_non_empty_text(payload.get("disasm_code"))
+    procedure_raw = payload.get("procedure", "")
+
+    if func_name is None or func_va is None or disasm_code is None:
+        raise ReferenceGenerationError("invalid reference YAML payload")
+
+    if procedure_raw is None:
+        procedure = ""
+    elif isinstance(procedure_raw, str):
+        procedure = procedure_raw
+    else:
+        raise ReferenceGenerationError("invalid reference YAML payload")
+
+    return {
+        "func_name": func_name,
+        "func_va": func_va,
+        "disasm_code": disasm_code,
+        "procedure": procedure,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate reference YAML for IDA preprocess scripts")
+    parser.add_argument("-gamever", required=True, help="Game version (required)")
+    parser.add_argument("-module", required=True, help="Module name (required)")
+    parser.add_argument(
+        "-platform",
+        required=True,
+        choices=["windows", "linux"],
+        help="Target platform (windows|linux)",
+    )
+    parser.add_argument("-func_name", required=True, help="Function name (required)")
+    parser.add_argument("-mcp_host", default="127.0.0.1", help="MCP host")
+    parser.add_argument("-mcp_port", type=int, default=13337, help="MCP port")
+    parser.add_argument("-ida_args", default="", help="Additional arguments for idalib-mcp")
+    parser.add_argument("-debug", action="store_true", help="Enable debug output")
+    parser.add_argument("-binary", default=None, help="Binary path for auto-start MCP mode")
+    parser.add_argument(
+        "-auto_start_mcp",
+        action="store_true",
+        help="Start IDA MCP automatically; must be used with -binary",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.auto_start_mcp and not args.binary:
+        parser.error("-auto_start_mcp requires -binary")
+    if args.binary and not args.auto_start_mcp:
+        parser.error("-binary requires -auto_start_mcp")
+
+    return args
+
+
+def load_yaml_mapping(path: str | Path) -> dict[str, Any]:
+    yaml_path = Path(path)
+    if not yaml_path.exists():
+        return {}
+
+    try:
+        data = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ReferenceGenerationError(f"Failed to parse YAML: {yaml_path}") from exc
+
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise ReferenceGenerationError(f"YAML root must be a mapping: {yaml_path}")
+
+    return dict(data)
+
+
+def build_reference_output_path(
+    repo_root: str | Path,
+    module: str,
+    func_name: str,
+    platform: str,
+) -> Path:
+    return (
+        Path(repo_root)
+        / "ida_preprocessor_scripts"
+        / "references"
+        / module
+        / f"{func_name}.{platform}.yaml"
+    )
+
+
+def build_existing_yaml_path(
+    repo_root: str | Path,
+    gamever: str,
+    module: str,
+    func_name: str,
+    platform: str,
+) -> Path:
+    return Path(repo_root) / "bin" / gamever / module / f"{func_name}.{platform}.yaml"
+
+
+def load_existing_func_va(
+    repo_root: str | Path,
+    gamever: str,
+    module: str,
+    func_name: str,
+    platform: str,
+) -> str | None:
+    existing_yaml_path = build_existing_yaml_path(repo_root, gamever, module, func_name, platform)
+    existing_yaml_map = load_yaml_mapping(existing_yaml_path)
+    if not existing_yaml_map:
+        return None
+
+    func_va = existing_yaml_map.get("func_va")
+    return _normalize_address_text(func_va)
+
+
+def load_symbol_aliases(
+    repo_root: str | Path,
+    module: str,
+    func_name: str,
+) -> list[str]:
+    config_path = Path(repo_root) / "config.yaml"
+    config_map = load_yaml_mapping(config_path)
+    modules = config_map.get("modules")
+    if not isinstance(modules, list):
+        raise ReferenceGenerationError("config.yaml missing 'modules' list")
+
+    for module_entry in modules:
+        if not isinstance(module_entry, Mapping):
+            continue
+        module_name = str(module_entry.get("name", "")).strip()
+        if module_name != module:
+            continue
+
+        symbols = module_entry.get("symbols")
+        if not isinstance(symbols, list):
+            raise ReferenceGenerationError(f"module '{module}' missing 'symbols' list")
+
+        for symbol_entry in symbols:
+            if not isinstance(symbol_entry, Mapping):
+                continue
+            symbol_name = str(symbol_entry.get("name", "")).strip()
+            if symbol_name != func_name:
+                continue
+
+            ordered_aliases: list[str] = []
+            seen: set[str] = set()
+
+            def _append_alias(raw: Any) -> None:
+                text = str(raw).strip()
+                if not text or text in seen:
+                    return
+                seen.add(text)
+                ordered_aliases.append(text)
+
+            _append_alias(symbol_name)
+            raw_alias = symbol_entry.get("alias")
+            if isinstance(raw_alias, list):
+                for alias in raw_alias:
+                    _append_alias(alias)
+            elif raw_alias is not None:
+                _append_alias(raw_alias)
+
+            if not ordered_aliases:
+                raise ReferenceGenerationError(
+                    f"symbol '{func_name}' in module '{module}' has no usable alias values"
+                )
+            return ordered_aliases
+
+        raise ReferenceGenerationError(
+            f"symbol '{func_name}' not found in module '{module}' within config.yaml"
+        )
+
+    raise ReferenceGenerationError(f"module '{module}' not found in config.yaml")
+
+
+def _parse_py_eval_json_result(
+    eval_result: Any,
+    *,
+    debug: bool = False,
+) -> Any:
+    parsed = parse_mcp_result(eval_result)
+    if not isinstance(parsed, dict):
+        raise ReferenceGenerationError("invalid py_eval response from IDA")
+
+    stderr_text = str(parsed.get("stderr", "")).strip()
+    if stderr_text and debug:
+        print(f"py_eval stderr: {stderr_text}")
+
+    result_str = parsed.get("result", "")
+    if not result_str:
+        raise ReferenceGenerationError("missing py_eval result from IDA")
+
+    try:
+        return json.loads(result_str)
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise ReferenceGenerationError("invalid py_eval JSON payload from IDA") from exc
+
+
+async def find_function_addr_by_names(
+    session: Any,
+    candidate_names: Sequence[str],
+    *,
+    debug: bool = False,
+) -> str:
+    ordered_candidates: list[str] = []
+    seen_candidates: set[str] = set()
+    for raw_name in candidate_names:
+        text = str(raw_name).strip()
+        if not text or text in seen_candidates:
+            continue
+        seen_candidates.add(text)
+        ordered_candidates.append(text)
+
+    if not ordered_candidates:
+        raise ReferenceGenerationError("unable to locate function address via IDA")
+
+    py_code = (
+        "import ida_funcs, ida_name, idaapi, json\n"
+        f"candidate_names = {json.dumps(ordered_candidates)}\n"
+        "matches = []\n"
+        "seen_addrs = set()\n"
+        "for candidate_name in candidate_names:\n"
+        "    ea = ida_name.get_name_ea(idaapi.BADADDR, candidate_name)\n"
+        "    if ea == idaapi.BADADDR:\n"
+        "        continue\n"
+        "    func = ida_funcs.get_func(ea)\n"
+        "    if func is None:\n"
+        "        continue\n"
+        "    func_start = int(func.start_ea)\n"
+        "    func_va = hex(func_start)\n"
+        "    if func_va in seen_addrs:\n"
+        "        continue\n"
+        "    seen_addrs.add(func_va)\n"
+        "    matches.append({'name': candidate_name, 'func_va': func_va})\n"
+        "result = json.dumps(matches)\n"
+    )
+
+    try:
+        eval_result = await session.call_tool(
+            name="py_eval",
+            arguments={"code": py_code},
+        )
+        match_payload = _parse_py_eval_json_result(eval_result, debug=debug)
+    except ReferenceGenerationError:
+        raise
+    except Exception as exc:
+        raise ReferenceGenerationError("unable to locate function address via IDA") from exc
+
+    if not isinstance(match_payload, list):
+        raise ReferenceGenerationError("unable to locate function address via IDA")
+
+    resolved_matches: list[str] = []
+    seen_func_vas: set[str] = set()
+    for item in match_payload:
+        if not isinstance(item, Mapping):
+            continue
+        func_va = _normalize_address_text(item.get("func_va"))
+        if func_va is None or func_va in seen_func_vas:
+            continue
+        seen_func_vas.add(func_va)
+        resolved_matches.append(func_va)
+
+    if not resolved_matches:
+        raise ReferenceGenerationError("unable to locate function address via IDA")
+    if len(resolved_matches) > 1:
+        raise ReferenceGenerationError(
+            f"ambiguous function address matches returned via IDA: {resolved_matches!r}"
+        )
+    return resolved_matches[0]
+
+
+async def resolve_func_va(
+    session: Any,
+    *,
+    repo_root: str | Path,
+    gamever: str,
+    module: str,
+    platform: str,
+    func_name: str,
+    debug: bool,
+) -> str:
+    existing_func_va = load_existing_func_va(
+        repo_root=repo_root,
+        gamever=gamever,
+        module=module,
+        func_name=func_name,
+        platform=platform,
+    )
+    if existing_func_va:
+        return existing_func_va
+
+    candidate_names = load_symbol_aliases(
+        repo_root=repo_root,
+        module=module,
+        func_name=func_name,
+    )
+    return await find_function_addr_by_names(
+        session,
+        candidate_names,
+        debug=debug,
+    )
+
+
+async def export_reference_payload_via_mcp(
+    session: Any,
+    *,
+    func_name: str,
+    func_va: str,
+    debug: bool = False,
+) -> dict[str, str]:
+    normalized_input_func_va = _normalize_address_text(func_va)
+    if normalized_input_func_va is None:
+        raise ReferenceGenerationError("unable to export reference payload via IDA")
+
+    func_va_int = int(normalized_input_func_va, 0)
+    py_code = (
+        "import ida_funcs, ida_lines, ida_segment, idautils, idc, json\n"
+        "try:\n"
+        "    import ida_hexrays\n"
+        "except Exception:\n"
+        "    ida_hexrays = None\n"
+        f"func_ea = {func_va_int}\n"
+        "def get_disasm(start_ea):\n"
+        "    func = ida_funcs.get_func(start_ea)\n"
+        "    if func is None:\n"
+        "        return ''\n"
+        "    lines = []\n"
+        "    for ea in idautils.FuncItems(func.start_ea):\n"
+        "        if ea < func.start_ea or ea >= func.end_ea:\n"
+        "            continue\n"
+        "        seg = ida_segment.getseg(ea)\n"
+        "        seg_name = ida_segment.get_segm_name(seg) if seg else ''\n"
+        "        address_text = f'{seg_name}:{ea:016X}' if seg_name else f'{ea:016X}'\n"
+        "        disasm_line = idc.generate_disasm_line(ea, 0) or ''\n"
+        "        lines.append(f\"{address_text}                 {ida_lines.tag_remove(disasm_line)}\")\n"
+        "    return '\\n'.join(lines)\n"
+        "def get_pseudocode(start_ea):\n"
+        "    if ida_hexrays is None:\n"
+        "        return ''\n"
+        "    try:\n"
+        "        if not ida_hexrays.init_hexrays_plugin():\n"
+        "            return ''\n"
+        "        cfunc = ida_hexrays.decompile(start_ea)\n"
+        "    except Exception:\n"
+        "        return ''\n"
+        "    if not cfunc:\n"
+        "        return ''\n"
+        "    return '\\n'.join(ida_lines.tag_remove(line.line) for line in cfunc.get_pseudocode())\n"
+        "func = ida_funcs.get_func(func_ea)\n"
+        "if func is None:\n"
+        "    raise ValueError(f'Function not found: {hex(func_ea)}')\n"
+        "func_start = int(func.start_ea)\n"
+        "result = json.dumps({\n"
+        "    'func_name': ida_funcs.get_func_name(func_start) or f'sub_{func_start:X}',\n"
+        "    'func_va': hex(func_start),\n"
+        "    'disasm_code': get_disasm(func_start),\n"
+        "    'procedure': get_pseudocode(func_start),\n"
+        "})\n"
+    )
+
+    try:
+        eval_result = await session.call_tool(
+            name="py_eval",
+            arguments={"code": py_code},
+        )
+        exported_payload = _parse_py_eval_json_result(eval_result, debug=debug)
+    except ReferenceGenerationError:
+        raise
+    except Exception as exc:
+        raise ReferenceGenerationError("unable to export reference payload via IDA") from exc
+
+    if not isinstance(exported_payload, Mapping):
+        raise ReferenceGenerationError("unable to export reference payload via IDA")
+
+    resolved_func_va = _normalize_address_text(exported_payload.get("func_va"))
+    disasm_code = _normalize_non_empty_text(exported_payload.get("disasm_code"))
+    procedure = exported_payload.get("procedure", "")
+    if resolved_func_va is None or disasm_code is None:
+        raise ReferenceGenerationError("unable to export reference payload via IDA")
+
+    if procedure is None:
+        normalized_procedure = ""
+    elif isinstance(procedure, str):
+        normalized_procedure = procedure
+    else:
+        raise ReferenceGenerationError("unable to export reference payload via IDA")
+
+    return {
+        "func_name": func_name,
+        "func_va": resolved_func_va,
+        "disasm_code": disasm_code,
+        "procedure": normalized_procedure,
+    }
+
+
+def write_reference_yaml(path: str | Path, payload: Mapping[str, Any]) -> None:
+    minimal_payload = _validate_reference_yaml_payload(payload)
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        yaml.dump(
+            minimal_payload,
+            Dumper=LiteralDumper,
+            sort_keys=False,
+            allow_unicode=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+async def check_mcp_health(host: str, port: int) -> bool:
+    ida_analyze_bin = _load_ida_analyze_bin()
+    return await ida_analyze_bin.check_mcp_health(host, port)
+
+
+def _load_ida_analyze_bin() -> Any:
+    try:
+        return importlib.import_module("ida_analyze_bin")
+    except (ImportError, SystemExit) as exc:
+        raise ReferenceGenerationError("failed to import ida_analyze_bin helpers") from exc
+
+
+def start_idalib_mcp(
+    binary_path: str,
+    host: str,
+    port: int,
+    ida_args: str,
+    debug: bool,
+) -> Any:
+    ida_analyze_bin = _load_ida_analyze_bin()
+    return ida_analyze_bin.start_idalib_mcp(binary_path, host, port, ida_args, debug)
+
+
+def quit_ida_gracefully(
+    process: Any,
+    host: str,
+    port: int,
+    *,
+    debug: bool,
+) -> None:
+    ida_analyze_bin = _load_ida_analyze_bin()
+    ida_analyze_bin.quit_ida_gracefully(process, host, port, debug=debug)
+
+
+@asynccontextmanager
+async def _open_mcp_session(host: str, port: int):
+    if httpx is None or ClientSession is None or streamable_http_client is None:
+        raise ReferenceGenerationError("MCP client dependencies are unavailable")
+
+    server_url = f"http://{host}:{port}/mcp"
+
+    async with AsyncExitStack() as stack:
+        try:
+            http_client = await stack.enter_async_context(
+                httpx.AsyncClient(
+                    follow_redirects=True,
+                    timeout=httpx.Timeout(30.0, read=300.0),
+                    trust_env=False,
+                )
+            )
+            read_stream, write_stream, _ = await stack.enter_async_context(
+                streamable_http_client(server_url, http_client=http_client)
+            )
+            session = await stack.enter_async_context(ClientSession(read_stream, write_stream))
+            await session.initialize()
+        except Exception as exc:
+            raise ReferenceGenerationError(f"unable to open MCP session at {host}:{port}") from exc
+
+        yield session
+
+
+@asynccontextmanager
+async def attach_existing_mcp_session(host: str, port: int, debug: bool):
+    del debug
+    healthy = await check_mcp_health(host, port)
+    if not healthy:
+        raise ReferenceGenerationError(f"MCP server is not reachable at {host}:{port}")
+
+    async with _open_mcp_session(host, port) as session:
+        yield session
+
+
+@asynccontextmanager
+async def autostart_mcp_session(
+    binary_path: str,
+    host: str,
+    port: int,
+    ida_args: str,
+    debug: bool,
+):
+    process = start_idalib_mcp(binary_path, host, port, ida_args, debug)
+    if process is None:
+        raise ReferenceGenerationError(f"failed to start idalib-mcp for {binary_path}")
+
+    try:
+        async with _open_mcp_session(host, port) as session:
+            yield session
+    finally:
+        quit_ida_gracefully(process, host, port, debug=debug)
+
+
+async def run_reference_generation(
+    args: argparse.Namespace,
+    repo_root: str | Path | None = None,
+) -> Path:
+    resolved_repo_root = Path(repo_root) if repo_root is not None else Path(__file__).resolve().parent
+
+    if args.auto_start_mcp:
+        session_manager = autostart_mcp_session(
+            binary_path=args.binary,
+            host=args.mcp_host,
+            port=args.mcp_port,
+            ida_args=args.ida_args,
+            debug=args.debug,
+        )
+    else:
+        session_manager = attach_existing_mcp_session(
+            host=args.mcp_host,
+            port=args.mcp_port,
+            debug=args.debug,
+        )
+
+    async with session_manager as session:
+        func_va = await resolve_func_va(
+            session,
+            repo_root=resolved_repo_root,
+            gamever=args.gamever,
+            module=args.module,
+            platform=args.platform,
+            func_name=args.func_name,
+            debug=args.debug,
+        )
+        payload = await export_reference_payload_via_mcp(
+            session,
+            func_name=args.func_name,
+            func_va=func_va,
+            debug=args.debug,
+        )
+        output_path = build_reference_output_path(
+            resolved_repo_root,
+            args.module,
+            args.func_name,
+            args.platform,
+        )
+        write_reference_yaml(output_path, payload)
+        return output_path
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        output_path = asyncio.run(run_reference_generation(args))
+    except ReferenceGenerationError as exc:
+        print(f"ERROR: {exc}")
+        return 1
+
+    print(f"Generated reference YAML: {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -29,6 +29,7 @@ Output:
 """
 
 import argparse
+import inspect
 import json
 import os
 import re
@@ -62,7 +63,7 @@ DEFAULT_BIN_DIR = "bin"
 DEFAULT_PLATFORM = "windows,linux"
 DEFAULT_MODULES = "*"
 DEFAULT_AGENT = "claude"
-DEFAULT_VCALL_FINDER_MODEL = "gpt-4o"
+DEFAULT_LLM_MODEL = "gpt-4o"
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 13337
 MCP_STARTUP_TIMEOUT = 1200  # seconds to wait for MCP server
@@ -390,19 +391,19 @@ def parse_args():
         help="vcall_finder object selector: '*' for all, or comma-separated object names"
     )
     parser.add_argument(
-        "-vcall_finder_model",
-        default=DEFAULT_VCALL_FINDER_MODEL,
-        help=f"OpenAI-compatible model for vcall_finder workflow (default: {DEFAULT_VCALL_FINDER_MODEL})"
+        "-llm_model",
+        default=DEFAULT_LLM_MODEL,
+        help=f"OpenAI-compatible model for preprocessing and vcall_finder workflow (default: {DEFAULT_LLM_MODEL})"
     )
     parser.add_argument(
-        "-vcall_finder_apikey",
+        "-llm_apikey",
         default=None,
-        help="OpenAI-compatible API key used only by vcall_finder aggregation"
+        help="OpenAI-compatible API key used by preprocessing and vcall_finder aggregation"
     )
     parser.add_argument(
-        "-vcall_finder_baseurl",
+        "-llm_baseurl",
         default=None,
-        help="Optional OpenAI-compatible base URL used only by vcall_finder aggregation"
+        help="Optional OpenAI-compatible base URL used by preprocessing and vcall_finder aggregation"
     )
     parser.add_argument(
         "-ida_args",
@@ -454,6 +455,50 @@ def parse_args():
         args.oldgamever = None
 
     return args
+
+
+def _run_preprocess_single_skill_via_mcp(
+    *,
+    host,
+    port,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    debug,
+    llm_model,
+    llm_apikey,
+    llm_baseurl,
+):
+    preprocess_kwargs = {
+        "host": host,
+        "port": port,
+        "skill_name": skill_name,
+        "expected_outputs": expected_outputs,
+        "old_yaml_map": old_yaml_map,
+        "new_binary_dir": new_binary_dir,
+        "platform": platform,
+        "debug": debug,
+        "llm_model": llm_model,
+        "llm_apikey": llm_apikey,
+        "llm_baseurl": llm_baseurl,
+    }
+
+    try:
+        return asyncio.run(preprocess_single_skill_via_mcp(**preprocess_kwargs))
+    except TypeError as exc:
+        signature = inspect.signature(preprocess_single_skill_via_mcp)
+        if any(name in signature.parameters for name in ("llm_model", "llm_apikey", "llm_baseurl")):
+            raise
+        if "unexpected keyword argument" not in str(exc):
+            raise
+
+        fallback_kwargs = dict(preprocess_kwargs)
+        fallback_kwargs.pop("llm_model", None)
+        fallback_kwargs.pop("llm_apikey", None)
+        fallback_kwargs.pop("llm_baseurl", None)
+        return asyncio.run(preprocess_single_skill_via_mcp(**fallback_kwargs))
 
 
 def parse_config(config_path):
@@ -1000,6 +1045,9 @@ def process_binary(
     module_name=None,
     vcall_targets=None,
     vcall_output_dir="vcall_finder",
+    llm_model=DEFAULT_LLM_MODEL,
+    llm_apikey=None,
+    llm_baseurl=None,
 ):
     """
     Process a single binary file.
@@ -1112,11 +1160,18 @@ def process_binary(
                     old_yaml_map[new_path] = old_path
 
             try:
-                preprocess_ok = asyncio.run(
-                    preprocess_single_skill_via_mcp(
-                        host, port, skill_name, expected_outputs, old_yaml_map,
-                        binary_dir, platform, debug
-                    )
+                preprocess_ok = _run_preprocess_single_skill_via_mcp(
+                    host=host,
+                    port=port,
+                    skill_name=skill_name,
+                    expected_outputs=expected_outputs,
+                    old_yaml_map=old_yaml_map,
+                    new_binary_dir=binary_dir,
+                    platform=platform,
+                    debug=debug,
+                    llm_model=llm_model,
+                    llm_apikey=llm_apikey,
+                    llm_baseurl=llm_baseurl,
                 )
             except Exception as e:
                 if debug:
@@ -1318,6 +1373,9 @@ def main():
                 gamever=gamever,
                 module_name=module_name,
                 vcall_targets=vcall_targets,
+                llm_model=args.llm_model,
+                llm_apikey=args.llm_apikey,
+                llm_baseurl=args.llm_baseurl,
             )
             total_success += success
             total_fail += fail
@@ -1332,9 +1390,9 @@ def main():
                     base_dir="vcall_finder",
                     gamever=gamever,
                     object_name=object_name,
-                    model=args.vcall_finder_model,
-                    api_key=args.vcall_finder_apikey,
-                    base_url=args.vcall_finder_baseurl,
+                    model=args.llm_model,
+                    api_key=args.llm_apikey,
+                    base_url=args.llm_baseurl,
                     debug=debug,
                 )
                 aggregation_status = stats["status"]

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import re
 import textwrap
 from pathlib import Path
 
@@ -10,6 +11,12 @@ try:
     import yaml
 except ImportError:
     yaml = None
+
+try:
+    from ida_llm_utils import call_llm_text, create_openai_client
+except Exception:
+    call_llm_text = None
+    create_openai_client = None
 
 
 # Combined vtable lookup + entry reading script for IDA py_eval.
@@ -387,6 +394,307 @@ def write_struct_offset_yaml(path, data):
             allow_unicode=False,
         )
 
+
+def _empty_llm_decompile_result():
+    return {
+        "found_vcall": [],
+        "found_call": [],
+        "found_gv": [],
+        "found_struct_offset": [],
+    }
+
+
+def _get_preprocessor_scripts_dir():
+    return Path(__file__).resolve().parent / "ida_preprocessor_scripts"
+
+
+def _build_llm_decompile_specs_map(llm_decompile_specs, debug=False):
+    specs_map = {}
+    for spec in llm_decompile_specs or []:
+        if not isinstance(spec, (tuple, list)) or len(spec) != 3:
+            if debug:
+                print(f"    Preprocess: invalid llm_decompile spec: {spec}")
+            return None
+
+        func_name, prompt_path, reference_yaml_path = spec
+        if not isinstance(func_name, str) or not func_name:
+            if debug:
+                print(f"    Preprocess: invalid llm_decompile target: {func_name}")
+            return None
+        if not isinstance(prompt_path, str) or not prompt_path:
+            if debug:
+                print(
+                    "    Preprocess: invalid llm_decompile prompt path for "
+                    f"{func_name}: {prompt_path!r}"
+                )
+            return None
+        if not isinstance(reference_yaml_path, str) or not reference_yaml_path:
+            if debug:
+                print(
+                    "    Preprocess: invalid llm_decompile reference path for "
+                    f"{func_name}: {reference_yaml_path!r}"
+                )
+            return None
+        if func_name in specs_map:
+            if debug:
+                print(f"    Preprocess: duplicated llm_decompile target: {func_name}")
+            return None
+
+        specs_map[func_name] = {
+            "prompt_path": prompt_path,
+            "reference_yaml_path": reference_yaml_path,
+        }
+
+    return specs_map
+
+
+def _parse_yaml_mapping(text):
+    if yaml is None:
+        return None
+    try:
+        parsed = yaml.load(text, Loader=yaml.BaseLoader)
+    except yaml.YAMLError:
+        return None
+    if parsed is None:
+        return {}
+    if isinstance(parsed, dict):
+        return parsed
+    return None
+
+
+def _normalize_llm_entries(entries, required_keys):
+    if isinstance(entries, (str, bytes, bytearray)) or not isinstance(entries, (list, tuple)):
+        return []
+
+    normalized = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        item = {}
+        valid = True
+        for key in required_keys:
+            value = str(entry.get(key, "")).strip()
+            if not value:
+                valid = False
+                break
+            item[key] = value
+        if valid:
+            normalized.append(item)
+    return normalized
+
+
+def parse_llm_decompile_response(response_text):
+    response_text = str(response_text or "").strip()
+    if not response_text:
+        return _empty_llm_decompile_result()
+
+    candidates = []
+    for match in re.finditer(
+        r"```(?:yaml|yml)[ \t]*\n?(.*?)```",
+        response_text,
+        re.IGNORECASE | re.DOTALL,
+    ):
+        candidates.append(match.group(1).strip())
+    if not candidates:
+        for match in re.finditer(r"```[ \t]*\n(.*?)```", response_text, re.DOTALL):
+            candidates.append(match.group(1).strip())
+    if not candidates:
+        candidates.append(response_text)
+
+    parsed = None
+    for candidate in candidates:
+        if not candidate:
+            continue
+        parsed = _parse_yaml_mapping(candidate)
+        if parsed is not None:
+            break
+
+    if not isinstance(parsed, dict):
+        return _empty_llm_decompile_result()
+
+    return {
+        "found_vcall": _normalize_llm_entries(
+            parsed.get("found_vcall", []),
+            ("insn_va", "insn_disasm", "vfunc_offset", "func_name"),
+        ),
+        "found_call": _normalize_llm_entries(
+            parsed.get("found_call", []),
+            ("insn_va", "insn_disasm", "func_name"),
+        ),
+        "found_gv": _normalize_llm_entries(
+            parsed.get("found_gv", []),
+            ("insn_va", "insn_disasm", "gv_name"),
+        ),
+        "found_struct_offset": _normalize_llm_entries(
+            parsed.get("found_struct_offset", []),
+            ("insn_va", "insn_disasm", "offset", "struct_name", "member_name"),
+        ),
+    }
+
+
+def _prepare_llm_decompile_request(
+    func_name,
+    llm_decompile_specs_map,
+    llm_config,
+    debug=False,
+):
+    llm_spec = (llm_decompile_specs_map or {}).get(func_name)
+    if llm_spec is None:
+        return None
+
+    if yaml is None:
+        if debug:
+            print("    Preprocess: PyYAML is required for llm_decompile fallback")
+        return None
+
+    if not isinstance(llm_config, dict):
+        if debug:
+            print(f"    Preprocess: llm_config missing or invalid for {func_name}")
+        return None
+
+    model = str(llm_config.get("model", "")).strip()
+    if not model:
+        if debug:
+            print(f"    Preprocess: llm_config.model missing for {func_name}")
+        return None
+
+    if not callable(create_openai_client):
+        if debug:
+            print(f"    Preprocess: create_openai_client unavailable for {func_name}")
+        return None
+
+    scripts_dir = _get_preprocessor_scripts_dir()
+    prompt_path = Path(llm_spec["prompt_path"])
+    reference_yaml_path = Path(llm_spec["reference_yaml_path"])
+    if not prompt_path.is_absolute():
+        prompt_path = scripts_dir / prompt_path
+    if not reference_yaml_path.is_absolute():
+        reference_yaml_path = scripts_dir / reference_yaml_path
+
+    if not prompt_path.is_file():
+        if debug:
+            print(
+                f"    Preprocess: llm_decompile prompt missing for {func_name}: "
+                f"{prompt_path}"
+            )
+        return None
+
+    if not reference_yaml_path.is_file():
+        if debug:
+            print(
+                f"    Preprocess: llm_decompile reference missing for {func_name}: "
+                f"{reference_yaml_path}"
+            )
+        return None
+
+    try:
+        prompt_template = prompt_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        if debug:
+            print(
+                f"    Preprocess: failed to read llm_decompile prompt for "
+                f"{func_name}: {exc}"
+            )
+        return None
+
+    try:
+        with open(reference_yaml_path, "r", encoding="utf-8") as handle:
+            reference_data = yaml.safe_load(handle) or {}
+    except Exception as exc:
+        if debug:
+            print(
+                f"    Preprocess: failed to read llm_decompile reference for "
+                f"{func_name}: {exc}"
+            )
+        return None
+
+    if not isinstance(reference_data, dict):
+        if debug:
+            print(
+                f"    Preprocess: invalid llm_decompile reference payload for "
+                f"{func_name}"
+            )
+        return None
+
+    try:
+        client = create_openai_client(
+            llm_config.get("api_key"),
+            llm_config.get("base_url"),
+            api_key_required_message=(
+                "llm_config.api_key is required for llm_decompile fallback"
+            ),
+        )
+    except Exception as exc:
+        if debug:
+            print(
+                f"    Preprocess: llm_decompile client unavailable for "
+                f"{func_name}: {exc}"
+            )
+        return None
+
+    return {
+        "client": client,
+        "model": model,
+        "prompt_template": prompt_template,
+        "disasm_for_reference": str(reference_data.get("disasm_code", "") or ""),
+        "procedure_for_reference": str(reference_data.get("procedure", "") or ""),
+    }
+
+
+async def call_llm_decompile(
+    client,
+    model,
+    symbol_name_list,
+    disasm_code,
+    procedure,
+    disasm_for_reference="",
+    procedure_for_reference="",
+    prompt_template=None,
+):
+    if not callable(call_llm_text):
+        return _empty_llm_decompile_result()
+
+    if isinstance(symbol_name_list, (list, tuple, set)):
+        symbol_name_text = ", ".join(
+            str(item).strip() for item in symbol_name_list if str(item).strip()
+        )
+    else:
+        symbol_name_text = str(symbol_name_list or "").strip()
+
+    if prompt_template is not None:
+        try:
+            prompt = str(prompt_template).format(
+                symbol_name_list=symbol_name_text,
+                disasm_for_reference=str(disasm_for_reference or ""),
+                procedure_for_reference=str(procedure_for_reference or ""),
+                disasm_code=str(disasm_code or ""),
+                procedure=str(procedure or ""),
+            )
+        except Exception:
+            return _empty_llm_decompile_result()
+    else:
+        prompt = (
+            "You are a reverse engineering expert.\n\n"
+            f"Reference disassembly:\n{disasm_for_reference}\n\n"
+            f"Reference procedure:\n{procedure_for_reference}\n\n"
+            f"Target disassembly:\n{disasm_code}\n\n"
+            f"Target procedure:\n{procedure}\n\n"
+            f"Please collect all references for \"{symbol_name_text}\" and output YAML."
+        )
+    try:
+        content = call_llm_text(
+            client=client,
+            model=str(model).strip(),
+            messages=[
+                {"role": "system", "content": "You are a reverse engineering expert."},
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.1,
+        )
+    except Exception:
+        return _empty_llm_decompile_result()
+    return parse_llm_decompile_response(content)
+
 async def preprocess_vtable_via_mcp(
     session,
     class_name,
@@ -468,6 +776,9 @@ async def preprocess_func_sig_via_mcp(
     func_name=None,
     debug=False,
     mangled_class_names=None,
+    direct_func_va=None,
+    direct_vtable_class=None,
+    direct_vfunc_offset=None,
 ):
     """
     Preprocess a function output by reusing old-version signature metadata.
@@ -500,6 +811,31 @@ async def preprocess_func_sig_via_mcp(
             print("    Preprocess: PyYAML is required for func_sig preprocessing")
         return None
 
+    normalized_mangled_class_names = _normalize_mangled_class_names(
+        mangled_class_names,
+        debug=debug,
+    )
+    if normalized_mangled_class_names is None:
+        return None
+
+    if (
+        direct_func_va is not None
+        or direct_vtable_class is not None
+        or direct_vfunc_offset is not None
+    ):
+        return await _preprocess_direct_func_sig_via_mcp(
+            session=session,
+            new_path=new_path,
+            image_base=image_base,
+            platform=platform,
+            func_name=func_name,
+            direct_func_va=direct_func_va,
+            direct_vtable_class=direct_vtable_class,
+            direct_vfunc_offset=direct_vfunc_offset,
+            normalized_mangled_class_names=normalized_mangled_class_names,
+            debug=debug,
+        )
+
     # Check if old YAML exists
     if not old_path or not os.path.exists(old_path):
         if debug:
@@ -514,13 +850,6 @@ async def preprocess_func_sig_via_mcp(
         return None
 
     if not old_data or not isinstance(old_data, dict):
-        return None
-
-    normalized_mangled_class_names = _normalize_mangled_class_names(
-        mangled_class_names,
-        debug=debug,
-    )
-    if normalized_mangled_class_names is None:
         return None
 
     def _parse_int_field(value, field_name):
@@ -2579,6 +2908,301 @@ async def _get_func_basic_info_via_mcp(session, func_va, image_base, debug=False
     }
 
 
+async def _preprocess_direct_func_sig_via_mcp(
+    session,
+    new_path,
+    image_base,
+    platform,
+    func_name=None,
+    direct_func_va=None,
+    direct_vtable_class=None,
+    direct_vfunc_offset=None,
+    normalized_mangled_class_names=None,
+    debug=False,
+):
+    resolved_func_va = None
+    vfunc_index = None
+    vfunc_offset = None
+    vtable_name = None
+
+    if func_name is None:
+        func_name = os.path.basename(new_path).rsplit(".", 2)[0]
+
+    if direct_func_va is not None:
+        try:
+            resolved_func_va = _parse_int_value(direct_func_va)
+        except Exception:
+            return None
+
+    if direct_vtable_class is not None:
+        vtable_data = await preprocess_vtable_via_mcp(
+            session=session,
+            class_name=direct_vtable_class,
+            image_base=image_base,
+            platform=platform,
+            debug=debug,
+            symbol_aliases=_get_mangled_class_aliases(
+                normalized_mangled_class_names,
+                direct_vtable_class,
+            ),
+        )
+        if not isinstance(vtable_data, dict):
+            return None
+
+        if direct_vfunc_offset is None:
+            return None
+
+        try:
+            offset_value = _parse_int_value(direct_vfunc_offset)
+        except Exception:
+            return None
+        if offset_value < 0 or offset_value % 8 != 0:
+            return None
+
+        vfunc_index = offset_value // 8
+        try:
+            raw_entry = vtable_data.get("vtable_entries", {}).get(vfunc_index)
+            resolved_from_vtable = _parse_int_value(raw_entry)
+        except Exception:
+            return None
+
+        if resolved_func_va is not None and resolved_func_va != resolved_from_vtable:
+            return None
+
+        resolved_func_va = resolved_from_vtable
+        vfunc_offset = hex(offset_value)
+        vtable_name = direct_vtable_class
+
+    if resolved_func_va is None:
+        return None
+
+    payload = {
+        "func_name": func_name,
+        "func_va": hex(resolved_func_va),
+        "func_rva": hex(resolved_func_va - image_base),
+    }
+
+    if hasattr(session, "call_tool"):
+        basic_data = await _get_func_basic_info_via_mcp(
+            session=session,
+            func_va=resolved_func_va,
+            image_base=image_base,
+            debug=debug,
+        )
+        if isinstance(basic_data, dict):
+            payload.update(basic_data)
+
+        gen_data = await preprocess_gen_func_sig_via_mcp(
+            session=session,
+            func_va=resolved_func_va,
+            image_base=image_base,
+            debug=debug,
+        )
+        if isinstance(gen_data, dict) and gen_data.get("func_sig"):
+            payload["func_sig"] = gen_data["func_sig"]
+
+    if vtable_name is not None:
+        payload["vtable_name"] = vtable_name
+    if vfunc_offset is not None:
+        payload["vfunc_offset"] = vfunc_offset
+    if vfunc_index is not None:
+        payload["vfunc_index"] = vfunc_index
+
+    return payload
+
+
+async def preprocess_gen_struct_offset_sig_via_mcp(
+    session,
+    struct_name,
+    member_name,
+    offset,
+    offset_inst_va,
+    image_base,
+    min_sig_bytes=8,
+    max_sig_bytes=96,
+    max_instructions=64,
+    extra_wildcard_offsets=None,
+    debug=False,
+):
+    _ = image_base
+
+    try:
+        offset_value = _parse_int_value(offset)
+        offset_inst_va_int = _parse_int_value(offset_inst_va)
+        min_sig_bytes = max(1, int(min_sig_bytes))
+        max_sig_bytes = max(1, int(max_sig_bytes))
+        max_instructions = max(1, int(max_instructions))
+    except Exception:
+        return None
+
+    extra_wildcards = set()
+    for item in extra_wildcard_offsets or []:
+        try:
+            parsed = _parse_int_value(item)
+        except Exception:
+            continue
+        if parsed >= 0:
+            extra_wildcards.add(parsed)
+
+    py_code = (
+        "import idaapi, ida_bytes, idautils, ida_ua, json\n"
+        f"target_inst = {offset_inst_va_int}\n"
+        f"max_sig_bytes = {max_sig_bytes}\n"
+        f"max_instructions = {max_instructions}\n"
+        "func = idaapi.get_func(target_inst)\n"
+        "if not func:\n"
+        "    result = json.dumps([])\n"
+        "else:\n"
+        "    cursor = target_inst\n"
+        "    total = 0\n"
+        "    insts = []\n"
+        "    while cursor < func.end_ea and len(insts) < max_instructions and total < max_sig_bytes:\n"
+        "        insn = idautils.DecodeInstruction(cursor)\n"
+        "        if not insn or insn.size <= 0:\n"
+        "            break\n"
+        "        raw = ida_bytes.get_bytes(cursor, insn.size)\n"
+        "        if not raw:\n"
+        "            break\n"
+        "        wild = set()\n"
+        "        for op in insn.ops:\n"
+        "            op_type = int(op.type)\n"
+        "            if op_type == int(idaapi.o_void):\n"
+        "                continue\n"
+        "            offb = int(getattr(op, 'offb', 0))\n"
+        "            offo = int(getattr(op, 'offo', 0))\n"
+        "            dtype_size = ida_ua.get_dtype_size(getattr(op, 'dtype', getattr(op, 'dtyp', 0)))\n"
+        "            if dtype_size <= 0:\n"
+        "                dtype_size = 4\n"
+        "            if op_type in (int(idaapi.o_imm), int(idaapi.o_displ), int(idaapi.o_mem), int(idaapi.o_near), int(idaapi.o_far)):\n"
+        "                if offb > 0 and offb < insn.size:\n"
+        "                    for idx in range(offb, min(insn.size, offb + dtype_size)):\n"
+        "                        wild.add(idx)\n"
+        "                if offo > 0 and offo < insn.size:\n"
+        "                    for idx in range(offo, min(insn.size, offo + dtype_size)):\n"
+        "                        wild.add(idx)\n"
+        "        b0 = raw[0]\n"
+        "        if b0 in (0xE8, 0xE9, 0xEB):\n"
+        "            for idx in range(1, insn.size):\n"
+        "                wild.add(idx)\n"
+        "        elif b0 == 0x0F and insn.size >= 2 and (raw[1] & 0xF0) == 0x80:\n"
+        "            for idx in range(2, insn.size):\n"
+        "                wild.add(idx)\n"
+        "        elif 0x70 <= b0 <= 0x7F:\n"
+        "            for idx in range(1, insn.size):\n"
+        "                wild.add(idx)\n"
+        "        insts.append({'size': insn.size, 'bytes': raw.hex(), 'wild': sorted(wild)})\n"
+        "        cursor += insn.size\n"
+        "        total += insn.size\n"
+        "    result = json.dumps([{'offset_inst_va': hex(target_inst), 'insts': insts}] if insts else [])\n"
+    )
+    try:
+        result = await session.call_tool(
+            name="py_eval",
+            arguments={"code": py_code},
+        )
+        result_data = parse_mcp_result(result)
+    except Exception:
+        return None
+
+    candidate_infos = None
+    if isinstance(result_data, dict):
+        result_str = result_data.get("result", "")
+        if result_str:
+            try:
+                candidate_infos = json.loads(result_str)
+            except (json.JSONDecodeError, TypeError):
+                candidate_infos = None
+
+    if not isinstance(candidate_infos, list) or not candidate_infos:
+        return None
+
+    for candidate in candidate_infos:
+        try:
+            inst_va = _parse_int_value(candidate.get("offset_inst_va"))
+            insts = candidate.get("insts", [])
+        except Exception:
+            continue
+        if inst_va != offset_inst_va_int or not isinstance(insts, list) or not insts:
+            continue
+
+        sig_tokens = []
+        inst_boundaries = []
+        malformed = False
+        for inst in insts:
+            try:
+                inst_size = int(inst.get("size", 0))
+                inst_hex = str(inst.get("bytes", ""))
+                inst_wild = {int(item) for item in inst.get("wild", [])}
+            except Exception:
+                malformed = True
+                break
+            if inst_size <= 0 or len(inst_hex) != inst_size * 2:
+                malformed = True
+                break
+
+            inst_bytes = [
+                int(inst_hex[idx:idx + 2], 16)
+                for idx in range(0, len(inst_hex), 2)
+            ]
+            base_offset = len(sig_tokens)
+            for rel_idx, value in enumerate(inst_bytes):
+                abs_offset = base_offset + rel_idx
+                if rel_idx in inst_wild or abs_offset in extra_wildcards:
+                    sig_tokens.append("??")
+                else:
+                    sig_tokens.append(f"{value:02X}")
+            inst_boundaries.append(len(sig_tokens))
+
+        if malformed:
+            continue
+
+        for prefix_len in inst_boundaries:
+            if prefix_len < min_sig_bytes:
+                continue
+            prefix_tokens = sig_tokens[:prefix_len]
+            if all(token == "??" for token in prefix_tokens):
+                continue
+
+            candidate_sig = " ".join(prefix_tokens)
+            try:
+                fb_result = await session.call_tool(
+                    name="find_bytes",
+                    arguments={"patterns": [candidate_sig], "limit": 2},
+                )
+                fb_data = parse_mcp_result(fb_result)
+            except Exception:
+                return None
+
+            if not isinstance(fb_data, list) or not fb_data:
+                continue
+            entry = fb_data[0]
+            matches = entry.get("matches", [])
+            match_count = entry.get("n", len(matches))
+            if match_count != 1 or not matches:
+                continue
+
+            try:
+                match_addr = _parse_int_value(matches[0])
+            except Exception:
+                continue
+            if match_addr != offset_inst_va_int:
+                continue
+
+            return {
+                "struct_name": struct_name,
+                "member_name": member_name,
+                "offset": hex(offset_value),
+                "offset_sig": candidate_sig,
+            }
+
+    if debug:
+        print(
+            "    Preprocess: failed to generate struct offset sig for "
+            f"{struct_name}.{member_name}"
+        )
+    return None
+
+
 async def preprocess_func_xrefs_via_mcp(
     session,
     func_name,
@@ -2837,6 +3461,8 @@ async def preprocess_common_skill(
     inherit_vfuncs=None,
     func_xrefs=None,
     func_vtable_relations=None,
+    llm_decompile_specs=None,
+    llm_config=None,
     mangled_class_names=None,
     debug=False,
 ):
@@ -2906,6 +3532,9 @@ async def preprocess_common_skill(
         func_vtable_relations: List of (func_name, vtable_class,
             generate_vfunc_offset) tuples for enriching function YAML with
             vtable metadata (may be empty/None).
+        llm_decompile_specs: Optional LLM decompile spec tuples of
+            (func_name, prompt_path, reference_yaml_path).
+        llm_config: Optional LLM config dict for llm_decompile fallback.
         debug: Enable debug output.
 
     Returns:
@@ -2919,11 +3548,18 @@ async def preprocess_common_skill(
     inherit_vfuncs = inherit_vfuncs or []
     func_xrefs = func_xrefs or []
     func_vtable_relations = func_vtable_relations or []
+    llm_decompile_specs = llm_decompile_specs or []
     normalized_mangled_class_names = _normalize_mangled_class_names(
         mangled_class_names,
         debug=debug,
     )
     if normalized_mangled_class_names is None:
+        return False
+    llm_decompile_specs_map = _build_llm_decompile_specs_map(
+        llm_decompile_specs,
+        debug=debug,
+    )
+    if llm_decompile_specs_map is None:
         return False
 
     func_xrefs_map = {}
@@ -3205,6 +3841,51 @@ async def preprocess_common_skill(
                 vtable_class=xref_vtable_class,
                 debug=debug,
             )
+
+        if (
+            func_data is None
+            and func_name in vtable_relations_map
+            and func_name in llm_decompile_specs_map
+        ):
+            vtable_class = vtable_relations_map[func_name][0]
+            llm_request = _prepare_llm_decompile_request(
+                func_name,
+                llm_decompile_specs_map,
+                llm_config,
+                debug=debug,
+            )
+            if llm_request is None:
+                llm_result = _empty_llm_decompile_result()
+            else:
+                try:
+                    llm_result = await call_llm_decompile(
+                        client=llm_request["client"],
+                        model=llm_request["model"],
+                        symbol_name_list=[func_name],
+                        disasm_code="",
+                        procedure="",
+                        disasm_for_reference=llm_request["disasm_for_reference"],
+                        procedure_for_reference=llm_request["procedure_for_reference"],
+                        prompt_template=llm_request["prompt_template"],
+                    )
+                except Exception:
+                    llm_result = _empty_llm_decompile_result()
+            for entry in llm_result.get("found_vcall", []):
+                if entry.get("func_name") != func_name:
+                    continue
+                func_data = await _preprocess_direct_func_sig_via_mcp(
+                    session=session,
+                    new_path=target_output,
+                    image_base=image_base,
+                    platform=platform,
+                    func_name=func_name,
+                    direct_vtable_class=vtable_class,
+                    direct_vfunc_offset=entry.get("vfunc_offset"),
+                    normalized_mangled_class_names=normalized_mangled_class_names,
+                    debug=debug,
+                )
+                if func_data is not None:
+                    break
 
         if func_data is None:
             if debug:

--- a/ida_llm_utils.py
+++ b/ida_llm_utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from openai import OpenAI
+
+
+def require_nonempty_text(value: Any, name: str) -> str:
+    if value is None:
+        raise ValueError(f"{name} cannot be empty")
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{name} cannot be empty")
+    return text
+
+
+def create_openai_client(api_key, base_url=None, *, api_key_required_message):
+    if api_key is None or not str(api_key).strip():
+        raise RuntimeError(api_key_required_message)
+
+    client_kwargs = {
+        "api_key": require_nonempty_text(api_key, "api_key"),
+    }
+    if base_url is not None:
+        client_kwargs["base_url"] = require_nonempty_text(base_url, "base_url")
+
+    return OpenAI(**client_kwargs)
+
+
+def extract_first_message_text(response) -> str:
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        raise ValueError("OpenAI response missing choices")
+
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", "") if message is not None else ""
+    if isinstance(content, str):
+        return content
+
+    if isinstance(content, Sequence) and not isinstance(content, (str, bytes, bytearray)):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, Mapping):
+                text = part.get("text")
+            else:
+                text = getattr(part, "text", None)
+            if text:
+                parts.append(str(text))
+        return "".join(parts)
+
+    text = getattr(content, "text", None)
+    if text is not None:
+        return str(text)
+    return str(content)
+
+
+def call_llm_text(client, *, model, messages, temperature=0.1) -> str:
+    response = client.chat.completions.create(
+        model=require_nonempty_text(model, "model"),
+        messages=messages,
+        temperature=temperature,
+    )
+    return extract_first_message_text(response)

--- a/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py
@@ -7,10 +7,22 @@ TARGET_FUNCTION_NAMES = [
     "CNetworkMessages_FindNetworkGroup",
 ]
 
+LLM_DECOMPILE = [
+    (
+        "CNetworkMessages_FindNetworkGroup",
+        "prompt/call_llm_decompile.md",
+        "references/CNetworkMessages_FindNetworkGroup.from-CNetworkGameClient_RecordEntityBandwidth.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CNetworkMessages_FindNetworkGroup", "CNetworkMessages", True),
+]
+
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, image_base, debug=False,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
     """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
     return await preprocess_common_skill(
@@ -21,5 +33,8 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/prompt/call_llm_decompile.md
+++ b/ida_preprocessor_scripts/prompt/call_llm_decompile.md
@@ -1,0 +1,65 @@
+You are a reverse engineering expert. I have disassembly outputs and procedure code of the same function.
+
+This is the function for reference:
+
+**Disassembly for Reference**
+
+```c
+{disasm_for_reference}
+```
+
+**Procedure code for Reference**
+
+```c
+{procedure_for_reference}
+```
+
+This is the function you need to reverse-engineering:
+
+**Disassembly to reverse-engineering**
+
+```c
+{disasm_code}
+```
+
+**Procedure code to reverse-engineering**
+
+```c
+{procedure}
+```
+
+Please collect all references for "{symbol_name_list}" in the function you need to reverse-engineering and output those references as YAML.
+`found_vcall` is for indirect call to virtual function.
+`found_call` is for direct call to regular function.
+`found_gv` is for reference to global variable.
+`found_struct_offset` is for reference to struct offset.
+
+Example:
+
+```yaml
+found_vcall:
+  - insn_va: '0x180777700'
+    insn_disasm: call    [rax+68h]
+    vfunc_offset: '0x68'
+    func_name: ILoopMode_OnLoopActivate
+  - insn_va: '0x180777778'
+    insn_disasm: call    [rax+88h]
+    vfunc_offset: '0x88'
+    func_name: ILoopMode_OnLoopDeactivate
+found_call:
+  - insn_va: '0x180888800'
+    insn_disasm: call    sub_180999900
+    func_name: CLoopModeGame_RegisterEventMapInternal
+found_gv:
+  - insn_va: '0x180444400'
+    insn_disasm: mov     rcx, cs:qword_180666600
+    gv_name: s_GameEventManager
+found_struct_offset:
+  - insn_va: '0x1801BA12A'
+    insn_disasm: mov     rcx, [r14+58h]
+    offset: '0x58'
+    struct_name: CGameResourceService
+    member_name: m_pEntitySystem
+```
+
+If nothing found, output an empty YAML.

--- a/ida_skill_preprocessor.py
+++ b/ida_skill_preprocessor.py
@@ -72,7 +72,9 @@ def _get_preprocess_entry(skill_name, debug=False):
 
 async def preprocess_single_skill_via_mcp(
     host, port, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, debug=False
+    new_binary_dir, platform,
+    llm_model=None, llm_apikey=None, llm_baseurl=None,
+    debug=False,
 ):
     """
     Attempt to pre-process a single skill via IDA MCP and skill script dispatch.
@@ -89,6 +91,9 @@ async def preprocess_single_skill_via_mcp(
         old_yaml_map: dict mapping new_yaml_path -> old_yaml_path
         new_binary_dir: directory for new version YAML outputs
         platform: "windows" or "linux"
+        llm_model: optional OpenAI-compatible model name for scripts that support LLM
+        llm_apikey: optional OpenAI-compatible API key for scripts that support LLM
+        llm_baseurl: optional OpenAI-compatible base URL for scripts that support LLM
         debug: enable debug output
 
     Returns:
@@ -122,16 +127,25 @@ async def preprocess_single_skill_via_mcp(
                         image_base = int(str(ib_data), 16) if ib_data else 0
 
                     try:
-                        result = preprocess_func(
-                            session=session,
-                            skill_name=skill_name,
-                            expected_outputs=expected_outputs,
-                            old_yaml_map=old_yaml_map,
-                            new_binary_dir=new_binary_dir,
-                            platform=platform,
-                            image_base=image_base,
-                            debug=debug,
-                        )
+                        llm_config = {
+                            "model": llm_model,
+                            "api_key": llm_apikey,
+                            "base_url": llm_baseurl,
+                        }
+                        preprocess_kwargs = {
+                            "session": session,
+                            "skill_name": skill_name,
+                            "expected_outputs": expected_outputs,
+                            "old_yaml_map": old_yaml_map,
+                            "new_binary_dir": new_binary_dir,
+                            "platform": platform,
+                            "image_base": image_base,
+                            "debug": debug,
+                        }
+                        if "llm_config" in inspect.signature(preprocess_func).parameters:
+                            preprocess_kwargs["llm_config"] = llm_config
+
+                        result = preprocess_func(**preprocess_kwargs)
                         if inspect.isawaitable(result):
                             result = await result
                         return bool(result)

--- a/ida_vcall_finder.py
+++ b/ida_vcall_finder.py
@@ -11,7 +11,7 @@ from typing import Any
 
 import yaml
 from ida_analyze_util import build_remote_text_export_py_eval, parse_mcp_result
-from openai import OpenAI
+from ida_llm_utils import call_llm_text, create_openai_client, require_nonempty_text
 
 
 VCALL_FINDER_DIRNAME = "vcall_finder"
@@ -58,6 +58,8 @@ def _literal_str_representer(dumper, value):
 
 
 LiteralDumper.add_representer(str, _literal_str_representer)
+
+_require_nonempty_text = require_nonempty_text
 
 
 def _require_mapping(value: Any, name: str) -> Mapping[str, Any]:
@@ -240,19 +242,6 @@ def parse_llm_vcall_response(response_text: str | None) -> dict[str, list[dict[s
     return {"found_vcall": normalize_found_vcalls(parsed.get("found_vcall", []))}
 
 
-def create_openai_client(api_key, base_url=None):
-    if api_key is None or not str(api_key).strip():
-        raise RuntimeError("-vcall_finder_apikey is required when -vcall_finder is enabled")
-
-    resolved_api_key = _require_nonempty_text(api_key, "api_key")
-
-    client_kwargs = {"api_key": resolved_api_key}
-    if base_url is not None:
-        client_kwargs["base_url"] = _require_nonempty_text(base_url, "base_url")
-
-    return OpenAI(**client_kwargs)
-
-
 def call_openai_for_vcalls(client, detail, model, *, debug=False, request_label=""):
     model = _require_nonempty_text(model, "model")
     if debug:
@@ -262,23 +251,15 @@ def call_openai_for_vcalls(client, detail, model, *, debug=False, request_label=
         )
 
     started_at = time.monotonic()
-    response = client.chat.completions.create(
+    content = call_llm_text(
         model=model,
+        client=client,
         messages=[
             {"role": "system", "content": "You are a reverse engineering expert."},
             {"role": "user", "content": render_vcall_prompt(detail)},
         ],
         temperature=0.1,
     )
-    choices = getattr(response, "choices", None) or []
-    if not choices:
-        raise ValueError("OpenAI response missing choices")
-
-    message = getattr(choices[0], "message", None)
-    content = getattr(message, "content", "") if message is not None else ""
-    if not isinstance(content, str):
-        content = str(content)
-
     found_vcall = parse_llm_vcall_response(content)["found_vcall"]
     if debug:
         elapsed_seconds = time.monotonic() - started_at
@@ -522,15 +503,6 @@ def _write_yaml_mapping(path: str | Path, payload: Mapping[str, Any]) -> None:
         )
 
 
-def _require_nonempty_text(value: Any, name: str) -> str:
-    if value is None:
-        raise ValueError(f"{name} cannot be empty")
-    text = str(value).strip()
-    if not text:
-        raise ValueError(f"{name} cannot be empty")
-    return text
-
-
 def _print_vcall_debug(message: str, debug: bool) -> None:
     if not debug:
         return
@@ -555,6 +527,7 @@ def _get_or_create_llm_client(
         llm_client = create_openai_client(
             api_key=api_key,
             base_url=base_url,
+            api_key_required_message="-llm_apikey is required when -vcall_finder is enabled",
         )
         client_ref["client"] = llm_client
     return llm_client

--- a/tests/test_generate_reference_yaml.py
+++ b/tests/test_generate_reference_yaml.py
@@ -1,0 +1,1384 @@
+import json
+import tempfile
+import unittest
+from argparse import Namespace
+from contextlib import asynccontextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import yaml
+
+import generate_reference_yaml
+
+
+class _FakeTextContent:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeCallToolResult:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.content = [_FakeTextContent(json.dumps(payload))]
+
+
+def _py_eval_payload(payload: object) -> _FakeCallToolResult:
+    return _FakeCallToolResult(
+        {
+            "result": json.dumps(payload),
+            "stdout": "",
+            "stderr": "",
+        }
+    )
+
+
+def _raw_py_eval_payload(result: object, *, stderr: str = "") -> _FakeCallToolResult:
+    return _FakeCallToolResult(
+        {
+            "result": result,
+            "stdout": "",
+            "stderr": stderr,
+        }
+    )
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+class _FakeStreamableHttpClient:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    @asynccontextmanager
+    async def __call__(self, url: str, *, http_client: object):
+        self.calls.append({"url": url, "http_client": http_client})
+        yield ("read_stream", "write_stream", None)
+
+
+class _FakeAsyncClient:
+    instances: list["_FakeAsyncClient"] = []
+
+    def __init__(self, **kwargs: object) -> None:
+        self.kwargs = kwargs
+        self.entered = False
+        self.exited = False
+        type(self).instances.append(self)
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        self.entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.exited = True
+
+
+class _FakeClientSession:
+    instances: list["_FakeClientSession"] = []
+
+    def __init__(self, read_stream: object, write_stream: object) -> None:
+        self.read_stream = read_stream
+        self.write_stream = write_stream
+        self.initialized = False
+        self.closed = False
+        type(self).instances.append(self)
+
+    async def __aenter__(self) -> "_FakeClientSession":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self.closed = True
+
+    async def initialize(self) -> None:
+        self.initialized = True
+
+
+class _FakeClientSessionInitFailure(_FakeClientSession):
+    async def initialize(self) -> None:
+        raise RuntimeError("initialize failed")
+
+
+def _make_fake_httpx() -> SimpleNamespace:
+    _FakeAsyncClient.instances.clear()
+    return SimpleNamespace(
+        AsyncClient=_FakeAsyncClient,
+        Timeout=lambda *args, **kwargs: {"args": args, "kwargs": kwargs},
+    )
+
+
+def _base_args(**overrides: object) -> Namespace:
+    payload = {
+        "gamever": "14141",
+        "module": "engine",
+        "platform": "windows",
+        "func_name": "CNetworkMessages_FindNetworkGroup",
+        "mcp_host": "127.0.0.1",
+        "mcp_port": 13337,
+        "ida_args": "--headless",
+        "debug": False,
+        "binary": None,
+        "auto_start_mcp": False,
+    }
+    payload.update(overrides)
+    return Namespace(**payload)
+
+
+class TestReferenceYamlPureHelpers(unittest.TestCase):
+    def test_build_reference_output_path_includes_module_and_platform(self) -> None:
+        repo_root = Path("/repo")
+
+        output_path = generate_reference_yaml.build_reference_output_path(
+            repo_root=repo_root,
+            module="engine",
+            func_name="CNetworkMessages_FindNetworkGroup",
+            platform="windows",
+        )
+
+        self.assertEqual(
+            Path(
+                "/repo/ida_preprocessor_scripts/references/engine/"
+                "CNetworkMessages_FindNetworkGroup.windows.yaml"
+            ),
+            output_path,
+        )
+
+    def test_build_existing_yaml_path_uses_bin_gamever_module_func_platform(self) -> None:
+        repo_root = Path("/repo")
+
+        existing_yaml_path = generate_reference_yaml.build_existing_yaml_path(
+            repo_root=repo_root,
+            gamever="14141",
+            module="engine",
+            func_name="CNetworkMessages_FindNetworkGroup",
+            platform="windows",
+        )
+
+        self.assertEqual(
+            Path("/repo/bin/14141/engine/CNetworkMessages_FindNetworkGroup.windows.yaml"),
+            existing_yaml_path,
+        )
+
+    def test_load_yaml_mapping_returns_empty_for_missing_and_empty_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            tmp_path = Path(temp_dir)
+            missing_path = tmp_path / "missing.yaml"
+            empty_yaml_path = tmp_path / "empty.yaml"
+            empty_yaml_path.write_text("", encoding="utf-8")
+
+            self.assertEqual({}, generate_reference_yaml.load_yaml_mapping(missing_path))
+            self.assertEqual({}, generate_reference_yaml.load_yaml_mapping(empty_yaml_path))
+
+    def test_load_yaml_mapping_rejects_non_mapping_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yaml_path = Path(temp_dir) / "invalid.yaml"
+            yaml_path.write_text("- item\n", encoding="utf-8")
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_yaml_mapping(yaml_path)
+
+    def test_load_yaml_mapping_raises_for_yaml_syntax_error(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yaml_path = Path(temp_dir) / "invalid_syntax.yaml"
+            yaml_path.write_text("broken: [1, 2\n", encoding="utf-8")
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_yaml_mapping(yaml_path)
+
+    def test_load_existing_func_va_reads_from_bin_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            yaml_path = (
+                repo_root
+                / "bin"
+                / "14141"
+                / "engine"
+                / "CNetworkMessages_FindNetworkGroup.windows.yaml"
+            )
+            _write_yaml(yaml_path, {"func_va": "0x180123456"})
+
+            func_va = generate_reference_yaml.load_existing_func_va(
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                platform="windows",
+            )
+
+            self.assertEqual("0x180123456", func_va)
+
+    def test_load_existing_func_va_accepts_unquoted_yaml_integer_value(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            yaml_path = (
+                repo_root
+                / "bin"
+                / "14141"
+                / "engine"
+                / "CNetworkMessages_FindNetworkGroup.windows.yaml"
+            )
+            _write_yaml(yaml_path, {"func_va": 0x180123450})
+
+            func_va = generate_reference_yaml.load_existing_func_va(
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                platform="windows",
+            )
+
+            self.assertEqual("0x180123450", func_va)
+
+    def test_load_existing_func_va_returns_none_for_missing_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            func_va = generate_reference_yaml.load_existing_func_va(
+                repo_root=Path(temp_dir),
+                gamever="14141",
+                module="engine",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                platform="windows",
+            )
+
+            self.assertIsNone(func_va)
+
+    def test_load_existing_func_va_returns_none_for_unparseable_value(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            yaml_path = (
+                repo_root
+                / "bin"
+                / "14141"
+                / "engine"
+                / "CNetworkMessages_FindNetworkGroup.windows.yaml"
+            )
+            _write_yaml(yaml_path, {"func_va": "not-an-address"})
+
+            func_va = generate_reference_yaml.load_existing_func_va(
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                platform="windows",
+            )
+
+            self.assertIsNone(func_va)
+
+    def test_load_symbol_aliases_collects_name_then_alias(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            config_path = repo_root / "config.yaml"
+            _write_yaml(
+                config_path,
+                {
+                    "modules": [
+                        {
+                            "name": "engine",
+                            "symbols": [
+                                {
+                                    "name": "CNetworkMessages_FindNetworkGroup",
+                                    "alias": [
+                                        "FindNetworkGroupAliasA",
+                                        "FindNetworkGroupAliasB",
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            )
+
+            aliases = generate_reference_yaml.load_symbol_aliases(
+                repo_root=repo_root,
+                module="engine",
+                func_name="CNetworkMessages_FindNetworkGroup",
+            )
+
+            self.assertEqual(
+                [
+                    "CNetworkMessages_FindNetworkGroup",
+                    "FindNetworkGroupAliasA",
+                    "FindNetworkGroupAliasB",
+                ],
+                aliases,
+            )
+
+    def test_load_symbol_aliases_raises_when_symbol_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            config_path = repo_root / "config.yaml"
+            _write_yaml(
+                config_path,
+                {
+                    "modules": [
+                        {
+                            "name": "engine",
+                            "symbols": [{"name": "OtherFunc", "alias": "OtherAlias"}],
+                        }
+                    ]
+                },
+            )
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_symbol_aliases(
+                    repo_root=repo_root,
+                    module="engine",
+                    func_name="CNetworkMessages_FindNetworkGroup",
+                )
+
+    def test_load_symbol_aliases_raises_when_config_missing_or_modules_not_list(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_symbol_aliases(
+                    repo_root=repo_root,
+                    module="engine",
+                    func_name="CNetworkMessages_FindNetworkGroup",
+                )
+
+            _write_yaml(repo_root / "config.yaml", {"modules": {"name": "engine"}})
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_symbol_aliases(
+                    repo_root=repo_root,
+                    module="engine",
+                    func_name="CNetworkMessages_FindNetworkGroup",
+                )
+
+    def test_load_symbol_aliases_raises_when_target_module_symbols_not_list(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root / "config.yaml",
+                {
+                    "modules": [
+                        {
+                            "name": "engine",
+                            "symbols": {"name": "CNetworkMessages_FindNetworkGroup"},
+                        }
+                    ]
+                },
+            )
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.load_symbol_aliases(
+                    repo_root=repo_root,
+                    module="engine",
+                    func_name="CNetworkMessages_FindNetworkGroup",
+                )
+
+    def test_parse_args_requires_core_inputs(self) -> None:
+        base_args = [
+            "-gamever",
+            "14141",
+            "-module",
+            "engine",
+            "-platform",
+            "windows",
+            "-func_name",
+            "CNetworkMessages_FindNetworkGroup",
+        ]
+
+        required_flags = ["-gamever", "-module", "-platform", "-func_name"]
+        for flag in required_flags:
+            with self.subTest(flag=flag):
+                missing_args = list(base_args)
+                index = missing_args.index(flag)
+                del missing_args[index : index + 2]
+                with self.assertRaises(SystemExit):
+                    generate_reference_yaml.parse_args(missing_args)
+
+    def test_parse_args_requires_binary_with_auto_start_mcp(self) -> None:
+        with self.assertRaises(SystemExit):
+            generate_reference_yaml.parse_args(
+                [
+                    "-gamever",
+                    "14141",
+                    "-module",
+                    "engine",
+                    "-platform",
+                    "windows",
+                    "-func_name",
+                    "CNetworkMessages_FindNetworkGroup",
+                    "-auto_start_mcp",
+                ]
+            )
+
+    def test_parse_args_requires_auto_start_mcp_with_binary(self) -> None:
+        with self.assertRaises(SystemExit):
+            generate_reference_yaml.parse_args(
+                [
+                    "-gamever",
+                    "14141",
+                    "-module",
+                    "engine",
+                    "-platform",
+                    "windows",
+                    "-func_name",
+                    "CNetworkMessages_FindNetworkGroup",
+                    "-binary",
+                    "/tmp/server.dll",
+                ]
+            )
+
+    def test_parse_args_accepts_pair_required_inputs_and_defaults(self) -> None:
+        args = generate_reference_yaml.parse_args(
+            [
+                "-gamever",
+                "14141",
+                "-module",
+                "engine",
+                "-platform",
+                "linux",
+                "-func_name",
+                "CNetworkMessages_FindNetworkGroup",
+                "-auto_start_mcp",
+                "-binary",
+                "/tmp/server.so",
+            ]
+        )
+
+        self.assertEqual("14141", args.gamever)
+        self.assertEqual("engine", args.module)
+        self.assertEqual("linux", args.platform)
+        self.assertEqual("CNetworkMessages_FindNetworkGroup", args.func_name)
+        self.assertTrue(args.auto_start_mcp)
+        self.assertEqual("/tmp/server.so", args.binary)
+        self.assertEqual("127.0.0.1", args.mcp_host)
+        self.assertEqual(13337, args.mcp_port)
+        self.assertEqual("", args.ida_args)
+        self.assertFalse(args.debug)
+
+
+class TestResolveFuncVa(unittest.IsolatedAsyncioTestCase):
+    async def test_resolve_func_va_uses_existing_yaml_before_ida_lookup(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root
+                / "bin"
+                / "14141"
+                / "engine"
+                / "CNetworkMessages_FindNetworkGroup.windows.yaml",
+                {"func_va": "0x180123450"},
+            )
+            session = AsyncMock()
+
+            func_va = await generate_reference_yaml.resolve_func_va(
+                session=session,
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                platform="windows",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                debug=False,
+            )
+
+            self.assertEqual("0x180123450", func_va)
+            session.call_tool.assert_not_called()
+
+    async def test_resolve_func_va_falls_back_to_config_aliases(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root / "config.yaml",
+                {
+                    "modules": [
+                        {
+                            "name": "engine",
+                            "symbols": [
+                                {
+                                    "name": "CNetworkMessages_FindNetworkGroup",
+                                    "alias": ["FindNetworkGroupAlias"],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            )
+            session = AsyncMock()
+            session.call_tool.return_value = _py_eval_payload(
+                [
+                    {
+                        "name": "FindNetworkGroupAlias",
+                        "func_va": "0x180123456",
+                    }
+                ]
+            )
+
+            func_va = await generate_reference_yaml.resolve_func_va(
+                session=session,
+                repo_root=repo_root,
+                gamever="14141",
+                module="engine",
+                platform="windows",
+                func_name="CNetworkMessages_FindNetworkGroup",
+                debug=False,
+            )
+
+            self.assertEqual("0x180123456", func_va)
+            session.call_tool.assert_awaited_once()
+            py_code = session.call_tool.await_args.kwargs["arguments"]["code"]
+            self.assertIn("CNetworkMessages_FindNetworkGroup", py_code)
+            self.assertIn("FindNetworkGroupAlias", py_code)
+
+    async def test_resolve_func_va_raises_on_ambiguous_matches(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            repo_root = Path(temp_dir)
+            _write_yaml(
+                repo_root / "config.yaml",
+                {
+                    "modules": [
+                        {
+                            "name": "engine",
+                            "symbols": [
+                                {
+                                    "name": "CNetworkMessages_FindNetworkGroup",
+                                    "alias": ["FindNetworkGroupAlias"],
+                                }
+                            ],
+                        }
+                    ]
+                },
+            )
+            session = AsyncMock()
+            session.call_tool.return_value = _py_eval_payload(
+                [
+                    {
+                        "name": "CNetworkMessages_FindNetworkGroup",
+                        "func_va": "0x180123450",
+                    },
+                    {
+                        "name": "FindNetworkGroupAlias",
+                        "func_va": "0x180123456",
+                    },
+                ]
+            )
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                await generate_reference_yaml.resolve_func_va(
+                    session=session,
+                    repo_root=repo_root,
+                    gamever="14141",
+                    module="engine",
+                    platform="windows",
+                    func_name="CNetworkMessages_FindNetworkGroup",
+                    debug=False,
+                )
+
+            self.assertEqual(
+                "ambiguous function address matches returned via IDA: "
+                "['0x180123450', '0x180123456']",
+                str(ctx.exception),
+            )
+
+
+class TestFindFunctionAddrByNames(unittest.IsolatedAsyncioTestCase):
+    async def test_find_function_addr_by_names_raises_with_candidate_address_list(
+        self,
+    ) -> None:
+        session = AsyncMock()
+        session.call_tool.return_value = _py_eval_payload(
+            [
+                {
+                    "name": "CNetworkMessages_FindNetworkGroup",
+                    "func_va": "0x180123450",
+                },
+                {
+                    "name": "FindNetworkGroupAlias",
+                    "func_va": "0x180123456",
+                },
+            ]
+        )
+
+        with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+            await generate_reference_yaml.find_function_addr_by_names(
+                session,
+                [
+                    "CNetworkMessages_FindNetworkGroup",
+                    "FindNetworkGroupAlias",
+                ],
+                debug=False,
+            )
+
+        self.assertEqual(
+            "ambiguous function address matches returned via IDA: "
+            "['0x180123450', '0x180123456']",
+            str(ctx.exception),
+        )
+
+    async def test_find_function_addr_by_names_ignores_invalid_func_va_entries(self) -> None:
+        session = AsyncMock()
+        session.call_tool.return_value = _py_eval_payload(
+            [
+                {
+                    "name": "BrokenAlias",
+                    "func_va": None,
+                },
+                {
+                    "name": "FindNetworkGroupAlias",
+                    "func_va": "0x180123456",
+                },
+            ]
+        )
+
+        func_va = await generate_reference_yaml.find_function_addr_by_names(
+            session,
+            [
+                "BrokenAlias",
+                "FindNetworkGroupAlias",
+            ],
+            debug=False,
+        )
+
+        self.assertEqual("0x180123456", func_va)
+
+
+class TestParsePyEvalJsonResult(unittest.TestCase):
+    def test_parse_py_eval_json_result_raises_when_result_missing_or_empty(self) -> None:
+        for payload in (
+            {"stdout": "", "stderr": ""},
+            {"result": "", "stdout": "", "stderr": ""},
+        ):
+            with self.subTest(payload=payload):
+                with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                    generate_reference_yaml._parse_py_eval_json_result(
+                        _FakeCallToolResult(payload),
+                    )
+
+                self.assertEqual("missing py_eval result from IDA", str(ctx.exception))
+
+    def test_parse_py_eval_json_result_raises_when_result_not_json(self) -> None:
+        with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+            generate_reference_yaml._parse_py_eval_json_result(
+                _raw_py_eval_payload("not-json"),
+            )
+
+        self.assertEqual("invalid py_eval JSON payload from IDA", str(ctx.exception))
+
+
+class TestExportReferencePayload(unittest.IsolatedAsyncioTestCase):
+    async def test_export_reference_payload_keeps_empty_procedure_when_hexrays_missing(
+        self,
+    ) -> None:
+        session = AsyncMock()
+        session.call_tool.return_value = _py_eval_payload(
+            {
+                "func_name": "sub_180123450",
+                "func_va": "0x180123450",
+                "disasm_code": "text:180123450 push rbp",
+                "procedure": "",
+                "extra_field": "ignored",
+            }
+        )
+
+        payload = await generate_reference_yaml.export_reference_payload_via_mcp(
+            session=session,
+            func_name="CNetworkMessages_FindNetworkGroup",
+            func_va="0x180123450",
+            debug=False,
+        )
+
+        self.assertEqual(
+            {
+                "func_name": "CNetworkMessages_FindNetworkGroup",
+                "func_va": "0x180123450",
+                "disasm_code": "text:180123450 push rbp",
+                "procedure": "",
+            },
+            payload,
+        )
+        session.call_tool.assert_awaited_once()
+
+    async def test_export_reference_payload_raises_when_func_va_is_none_or_invalid(self) -> None:
+        for exported in (
+            {
+                "func_name": "sub_180123450",
+                "func_va": None,
+                "disasm_code": "text:180123450 push rbp",
+                "procedure": "",
+            },
+            {
+                "func_name": "sub_180123450",
+                "func_va": "bad-va",
+                "disasm_code": "text:180123450 push rbp",
+                "procedure": "",
+            },
+        ):
+            with self.subTest(exported=exported):
+                session = AsyncMock()
+                session.call_tool.return_value = _py_eval_payload(exported)
+
+                with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                    await generate_reference_yaml.export_reference_payload_via_mcp(
+                        session=session,
+                        func_name="CNetworkMessages_FindNetworkGroup",
+                        func_va="0x180123450",
+                        debug=False,
+                    )
+
+                self.assertEqual(
+                    "unable to export reference payload via IDA",
+                    str(ctx.exception),
+                )
+
+    async def test_export_reference_payload_raises_when_disasm_code_empty_or_none(self) -> None:
+        for exported in (
+            {
+                "func_name": "sub_180123450",
+                "func_va": "0x180123450",
+                "disasm_code": "",
+                "procedure": "",
+            },
+            {
+                "func_name": "sub_180123450",
+                "func_va": "0x180123450",
+                "disasm_code": None,
+                "procedure": "",
+            },
+        ):
+            with self.subTest(exported=exported):
+                session = AsyncMock()
+                session.call_tool.return_value = _py_eval_payload(exported)
+
+                with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                    await generate_reference_yaml.export_reference_payload_via_mcp(
+                        session=session,
+                        func_name="CNetworkMessages_FindNetworkGroup",
+                        func_va="0x180123450",
+                        debug=False,
+                    )
+
+                self.assertEqual(
+                    "unable to export reference payload via IDA",
+                    str(ctx.exception),
+                )
+
+
+class TestWriteReferenceYaml(unittest.TestCase):
+    def test_write_reference_yaml_writes_minimal_schema_only(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "refs" / "func.yaml"
+
+            generate_reference_yaml.write_reference_yaml(
+                output_path,
+                {
+                    "func_name": "CNetworkMessages_FindNetworkGroup",
+                    "func_va": "0x180123450",
+                    "disasm_code": "text:180123450 push rbp",
+                    "procedure": "",
+                    "extra_field": "ignored",
+                },
+            )
+
+            written = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                {
+                    "func_name": "CNetworkMessages_FindNetworkGroup",
+                    "func_va": "0x180123450",
+                    "disasm_code": "text:180123450 push rbp",
+                    "procedure": "",
+                },
+                written,
+            )
+
+    def test_write_reference_yaml_raises_for_missing_required_field_without_writing_file(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "refs" / "func.yaml"
+
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError):
+                generate_reference_yaml.write_reference_yaml(
+                    output_path,
+                    {
+                        "func_name": "CNetworkMessages_FindNetworkGroup",
+                        "func_va": "0x180123450",
+                        "procedure": "",
+                    },
+                )
+
+            self.assertFalse(output_path.exists())
+
+
+class TestMcpSessionModes(unittest.IsolatedAsyncioTestCase):
+    async def test_open_mcp_session_raises_reference_generation_error_when_open_fails(self) -> None:
+        @asynccontextmanager
+        async def _failing_streamable_http_client(url: str, *, http_client: object):
+            raise RuntimeError("open failed")
+            yield ("read_stream", "write_stream", None)
+
+        with (
+            patch.object(generate_reference_yaml, "httpx", _make_fake_httpx(), create=True),
+            patch.object(
+                generate_reference_yaml,
+                "streamable_http_client",
+                _failing_streamable_http_client,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "ClientSession",
+                _FakeClientSession,
+                create=True,
+            ),
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                async with generate_reference_yaml._open_mcp_session("127.0.0.1", 13337):
+                    self.fail("_open_mcp_session should not yield on open failure")
+
+        self.assertEqual(
+            "unable to open MCP session at 127.0.0.1:13337",
+            str(ctx.exception),
+        )
+
+    async def test_open_mcp_session_raises_reference_generation_error_when_initialize_fails(
+        self,
+    ) -> None:
+        fake_stream_client = _FakeStreamableHttpClient()
+
+        with (
+            patch.object(generate_reference_yaml, "httpx", _make_fake_httpx(), create=True),
+            patch.object(
+                generate_reference_yaml,
+                "streamable_http_client",
+                fake_stream_client,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "ClientSession",
+                _FakeClientSessionInitFailure,
+                create=True,
+            ),
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                async with generate_reference_yaml._open_mcp_session("127.0.0.1", 13337):
+                    self.fail("_open_mcp_session should not yield on initialize failure")
+
+        self.assertEqual(
+            "unable to open MCP session at 127.0.0.1:13337",
+            str(ctx.exception),
+        )
+
+    async def test_attach_existing_mcp_session_checks_health_first(self) -> None:
+        _FakeClientSession.instances.clear()
+        fake_stream_client = _FakeStreamableHttpClient()
+        call_order: list[str] = []
+
+        async def _fake_check_mcp_health(host: str, port: int) -> bool:
+            call_order.append(f"health:{host}:{port}")
+            return True
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "check_mcp_health",
+                AsyncMock(side_effect=_fake_check_mcp_health),
+                create=True,
+            ) as check_health,
+            patch.object(generate_reference_yaml, "httpx", _make_fake_httpx(), create=True),
+            patch.object(
+                generate_reference_yaml,
+                "streamable_http_client",
+                fake_stream_client,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "ClientSession",
+                _FakeClientSession,
+                create=True,
+            ),
+        ):
+            async with generate_reference_yaml.attach_existing_mcp_session(
+                host="127.0.0.1",
+                port=13337,
+                debug=True,
+            ) as session:
+                self.assertIsInstance(session, _FakeClientSession)
+                call_order.append("session-opened")
+
+        self.assertEqual(["health:127.0.0.1:13337", "session-opened"], call_order)
+        check_health.assert_awaited_once_with("127.0.0.1", 13337)
+        self.assertEqual("http://127.0.0.1:13337/mcp", fake_stream_client.calls[0]["url"])
+        self.assertEqual(
+            {
+                "args": (30.0,),
+                "kwargs": {"read": 300.0},
+            },
+            _FakeAsyncClient.instances[0].kwargs["timeout"],
+        )
+        self.assertTrue(_FakeAsyncClient.instances[0].kwargs["follow_redirects"])
+        self.assertFalse(_FakeAsyncClient.instances[0].kwargs["trust_env"])
+        self.assertTrue(_FakeClientSession.instances[0].initialized)
+
+    async def test_attach_existing_mcp_session_raises_when_health_check_fails(self) -> None:
+        with patch.object(
+            generate_reference_yaml,
+            "check_mcp_health",
+            AsyncMock(return_value=False),
+            create=True,
+        ) as check_health:
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                async with generate_reference_yaml.attach_existing_mcp_session(
+                    host="127.0.0.1",
+                    port=13337,
+                    debug=False,
+                ):
+                    self.fail("attach_existing_mcp_session should not yield when health check fails")
+
+        self.assertEqual(
+            "MCP server is not reachable at 127.0.0.1:13337",
+            str(ctx.exception),
+        )
+        check_health.assert_awaited_once_with("127.0.0.1", 13337)
+
+    async def test_autostart_mcp_session_starts_and_quits_process(self) -> None:
+        _FakeClientSession.instances.clear()
+        fake_stream_client = _FakeStreamableHttpClient()
+        process = MagicMock(name="fake_process")
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "start_idalib_mcp",
+                return_value=process,
+                create=True,
+            ) as start_idalib_mcp,
+            patch.object(
+                generate_reference_yaml,
+                "quit_ida_gracefully",
+                create=True,
+            ) as quit_ida_gracefully,
+            patch.object(generate_reference_yaml, "httpx", _make_fake_httpx(), create=True),
+            patch.object(
+                generate_reference_yaml,
+                "streamable_http_client",
+                fake_stream_client,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "ClientSession",
+                _FakeClientSession,
+                create=True,
+            ),
+        ):
+            async with generate_reference_yaml.autostart_mcp_session(
+                binary_path="/tmp/server.dll",
+                host="127.0.0.1",
+                port=13337,
+                ida_args="--headless",
+                debug=True,
+            ) as session:
+                self.assertIsInstance(session, _FakeClientSession)
+
+        start_idalib_mcp.assert_called_once_with(
+            "/tmp/server.dll",
+            "127.0.0.1",
+            13337,
+            "--headless",
+            True,
+        )
+        quit_ida_gracefully.assert_called_once_with(
+            process,
+            "127.0.0.1",
+            13337,
+            debug=True,
+        )
+        self.assertEqual("http://127.0.0.1:13337/mcp", fake_stream_client.calls[0]["url"])
+        self.assertTrue(_FakeClientSession.instances[0].initialized)
+
+    async def test_autostart_mcp_session_raises_when_start_returns_none(self) -> None:
+        with patch.object(
+            generate_reference_yaml,
+            "start_idalib_mcp",
+            return_value=None,
+            create=True,
+        ) as start_idalib_mcp:
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                async with generate_reference_yaml.autostart_mcp_session(
+                    binary_path="/tmp/server.dll",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="--headless",
+                    debug=False,
+                ):
+                    self.fail("autostart_mcp_session should not yield when process start fails")
+
+        self.assertEqual(
+            "failed to start idalib-mcp for /tmp/server.dll",
+            str(ctx.exception),
+        )
+        start_idalib_mcp.assert_called_once_with(
+            "/tmp/server.dll",
+            "127.0.0.1",
+            13337,
+            "--headless",
+            False,
+        )
+
+    async def test_autostart_mcp_session_quits_process_when_session_body_raises(self) -> None:
+        _FakeClientSession.instances.clear()
+        fake_stream_client = _FakeStreamableHttpClient()
+        process = MagicMock(name="fake_process")
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "start_idalib_mcp",
+                return_value=process,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "quit_ida_gracefully",
+                create=True,
+            ) as quit_ida_gracefully,
+            patch.object(generate_reference_yaml, "httpx", _make_fake_httpx(), create=True),
+            patch.object(
+                generate_reference_yaml,
+                "streamable_http_client",
+                fake_stream_client,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "ClientSession",
+                _FakeClientSession,
+                create=True,
+            ),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                async with generate_reference_yaml.autostart_mcp_session(
+                    binary_path="/tmp/server.dll",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="--headless",
+                    debug=True,
+                ):
+                    raise RuntimeError("boom")
+
+        self.assertEqual("boom", str(ctx.exception))
+        quit_ida_gracefully.assert_called_once_with(
+            process,
+            "127.0.0.1",
+            13337,
+            debug=True,
+        )
+
+    async def test_autostart_mcp_session_quits_process_when_open_session_fails(self) -> None:
+        process = MagicMock(name="fake_process")
+
+        @asynccontextmanager
+        async def _failing_open_mcp_session(host: str, port: int):
+            raise generate_reference_yaml.ReferenceGenerationError(
+                f"unable to open MCP session at {host}:{port}"
+            )
+            yield None
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "start_idalib_mcp",
+                return_value=process,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "_open_mcp_session",
+                side_effect=_failing_open_mcp_session,
+                create=True,
+            ) as open_mcp_session,
+            patch.object(
+                generate_reference_yaml,
+                "quit_ida_gracefully",
+                create=True,
+            ) as quit_ida_gracefully,
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                async with generate_reference_yaml.autostart_mcp_session(
+                    binary_path="/tmp/server.dll",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="--headless",
+                    debug=False,
+                ):
+                    self.fail("autostart_mcp_session should not yield when open session fails")
+
+        self.assertEqual(
+            "unable to open MCP session at 127.0.0.1:13337",
+            str(ctx.exception),
+        )
+        open_mcp_session.assert_called_once_with("127.0.0.1", 13337)
+        quit_ida_gracefully.assert_called_once_with(
+            process,
+            "127.0.0.1",
+            13337,
+            debug=False,
+        )
+
+
+class TestIdaAnalyzeBinWrappers(unittest.IsolatedAsyncioTestCase):
+    async def test_check_mcp_health_wraps_system_exit_as_reference_generation_error(self) -> None:
+        with patch.object(
+            generate_reference_yaml.importlib,
+            "import_module",
+            side_effect=SystemExit(2),
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                await generate_reference_yaml.check_mcp_health("127.0.0.1", 13337)
+
+        self.assertEqual("failed to import ida_analyze_bin helpers", str(ctx.exception))
+
+    async def test_start_idalib_mcp_wraps_system_exit_as_reference_generation_error(self) -> None:
+        with patch.object(
+            generate_reference_yaml.importlib,
+            "import_module",
+            side_effect=SystemExit(2),
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                generate_reference_yaml.start_idalib_mcp(
+                    "/tmp/server.dll",
+                    "127.0.0.1",
+                    13337,
+                    "--headless",
+                    False,
+                )
+
+        self.assertEqual("failed to import ida_analyze_bin helpers", str(ctx.exception))
+
+    async def test_quit_ida_gracefully_wraps_system_exit_as_reference_generation_error(self) -> None:
+        with patch.object(
+            generate_reference_yaml.importlib,
+            "import_module",
+            side_effect=SystemExit(2),
+        ):
+            with self.assertRaises(generate_reference_yaml.ReferenceGenerationError) as ctx:
+                generate_reference_yaml.quit_ida_gracefully(
+                    MagicMock(name="fake_process"),
+                    "127.0.0.1",
+                    13337,
+                    debug=False,
+                )
+
+        self.assertEqual("failed to import ida_analyze_bin helpers", str(ctx.exception))
+
+
+class TestRunReferenceGeneration(unittest.IsolatedAsyncioTestCase):
+    async def test_run_reference_generation_uses_attach_mode_by_default(self) -> None:
+        fake_session = object()
+        output_path = Path("/repo/out/reference.yaml")
+        exported_payload = {
+            "func_name": "CNetworkMessages_FindNetworkGroup",
+            "func_va": "0x180123450",
+            "disasm_code": "text:180123450 push rbp",
+            "procedure": "",
+        }
+        call_order: list[str] = []
+
+        @asynccontextmanager
+        async def _fake_attach_existing_mcp_session(**kwargs):
+            self.assertEqual({"host": "127.0.0.1", "port": 13337, "debug": False}, kwargs)
+            yield fake_session
+
+        async def _fake_resolve_func_va(*args, **kwargs):
+            call_order.append("resolve_func_va")
+            self.assertIs(args[0], fake_session)
+            return "0x180123450"
+
+        async def _fake_export_reference_payload_via_mcp(*args, **kwargs):
+            call_order.append("export_reference_payload_via_mcp")
+            self.assertIs(args[0], fake_session)
+            self.assertEqual("0x180123450", kwargs["func_va"])
+            return exported_payload
+
+        def _fake_build_reference_output_path(*args):
+            call_order.append("build_reference_output_path")
+            return output_path
+
+        def _fake_write_reference_yaml(*args):
+            call_order.append("write_reference_yaml")
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "attach_existing_mcp_session",
+                _fake_attach_existing_mcp_session,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "autostart_mcp_session",
+                create=True,
+            ) as autostart_mcp_session,
+            patch.object(
+                generate_reference_yaml,
+                "resolve_func_va",
+                AsyncMock(side_effect=_fake_resolve_func_va),
+                create=True,
+            ) as resolve_func_va,
+            patch.object(
+                generate_reference_yaml,
+                "export_reference_payload_via_mcp",
+                AsyncMock(side_effect=_fake_export_reference_payload_via_mcp),
+                create=True,
+            ) as export_reference_payload_via_mcp,
+            patch.object(
+                generate_reference_yaml,
+                "build_reference_output_path",
+                side_effect=_fake_build_reference_output_path,
+            ) as build_reference_output_path,
+            patch.object(
+                generate_reference_yaml,
+                "write_reference_yaml",
+                side_effect=_fake_write_reference_yaml,
+            ) as write_reference_yaml,
+        ):
+            result = await generate_reference_yaml.run_reference_generation(
+                _base_args(),
+                repo_root=Path("/repo"),
+            )
+
+        self.assertEqual(output_path, result)
+        self.assertEqual(
+            [
+                "resolve_func_va",
+                "export_reference_payload_via_mcp",
+                "build_reference_output_path",
+                "write_reference_yaml",
+            ],
+            call_order,
+        )
+        autostart_mcp_session.assert_not_called()
+        resolve_func_va.assert_awaited_once_with(
+            fake_session,
+            repo_root=Path("/repo"),
+            gamever="14141",
+            module="engine",
+            platform="windows",
+            func_name="CNetworkMessages_FindNetworkGroup",
+            debug=False,
+        )
+        export_reference_payload_via_mcp.assert_awaited_once_with(
+            fake_session,
+            func_name="CNetworkMessages_FindNetworkGroup",
+            func_va="0x180123450",
+            debug=False,
+        )
+        build_reference_output_path.assert_called_once_with(
+            Path("/repo"),
+            "engine",
+            "CNetworkMessages_FindNetworkGroup",
+            "windows",
+        )
+        write_reference_yaml.assert_called_once_with(output_path, exported_payload)
+
+    async def test_run_reference_generation_uses_autostart_mode_when_enabled(self) -> None:
+        fake_session = object()
+        output_path = Path("/repo/out/reference.yaml")
+
+        @asynccontextmanager
+        async def _fake_autostart_mcp_session(**kwargs):
+            self.assertEqual(
+                {
+                    "binary_path": "/tmp/server.dll",
+                    "host": "127.0.0.1",
+                    "port": 13337,
+                    "ida_args": "--headless",
+                    "debug": True,
+                },
+                kwargs,
+            )
+            yield fake_session
+
+        with (
+            patch.object(
+                generate_reference_yaml,
+                "attach_existing_mcp_session",
+                create=True,
+            ) as attach_existing_mcp_session,
+            patch.object(
+                generate_reference_yaml,
+                "autostart_mcp_session",
+                _fake_autostart_mcp_session,
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "resolve_func_va",
+                AsyncMock(return_value="0x180123450"),
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "export_reference_payload_via_mcp",
+                AsyncMock(
+                    return_value={
+                        "func_name": "CNetworkMessages_FindNetworkGroup",
+                        "func_va": "0x180123450",
+                        "disasm_code": "text:180123450 push rbp",
+                        "procedure": "",
+                    }
+                ),
+                create=True,
+            ),
+            patch.object(
+                generate_reference_yaml,
+                "build_reference_output_path",
+                return_value=output_path,
+            ),
+            patch.object(generate_reference_yaml, "write_reference_yaml"),
+        ):
+            result = await generate_reference_yaml.run_reference_generation(
+                _base_args(
+                    auto_start_mcp=True,
+                    binary="/tmp/server.dll",
+                    debug=True,
+                ),
+                repo_root=Path("/repo"),
+            )
+
+        self.assertEqual(output_path, result)
+        attach_existing_mcp_session.assert_not_called()
+
+
+class TestMain(unittest.TestCase):
+    def test_main_returns_zero_and_prints_generated_path(self) -> None:
+        args = _base_args()
+        output_path = Path("/tmp/reference.yaml")
+
+        def _fake_asyncio_run(coro):
+            coro.close()
+            return output_path
+
+        fake_asyncio = SimpleNamespace(run=MagicMock(side_effect=_fake_asyncio_run))
+
+        with (
+            patch.object(generate_reference_yaml, "parse_args", return_value=args),
+            patch.object(generate_reference_yaml, "asyncio", fake_asyncio, create=True),
+            patch("builtins.print") as fake_print,
+        ):
+            exit_code = generate_reference_yaml.main(["--ignored"])
+
+        self.assertEqual(0, exit_code)
+        fake_print.assert_called_once_with(f"Generated reference YAML: {output_path}")
+
+    def test_main_returns_one_and_prints_error_message(self) -> None:
+        args = _base_args()
+
+        def _fake_asyncio_run(coro):
+            coro.close()
+            raise generate_reference_yaml.ReferenceGenerationError("boom")
+
+        fake_asyncio = SimpleNamespace(run=MagicMock(side_effect=_fake_asyncio_run))
+
+        with (
+            patch.object(generate_reference_yaml, "parse_args", return_value=args),
+            patch.object(generate_reference_yaml, "asyncio", fake_asyncio, create=True),
+            patch("builtins.print") as fake_print,
+        ):
+            exit_code = generate_reference_yaml.main(["--ignored"])
+
+        self.assertEqual(1, exit_code)
+        fake_print.assert_called_once_with("ERROR: boom")

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -1,7 +1,8 @@
 import io
 import unittest
 from pathlib import Path
-from unittest.mock import call, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call, patch
 
 import ida_analyze_bin
 
@@ -312,6 +313,162 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         expected_prompt = 'Run SKILL: .claude/skills/find-IGameSystem_vtable/SKILL.md'
         self.assertEqual(expected_prompt, ''.join(first_process.stdin.writes))
         self.assertEqual(expected_prompt, ''.join(second_process.stdin.writes))
+
+
+class TestParseArgsLlmOptions(unittest.TestCase):
+    @patch.object(ida_analyze_bin, "resolve_oldgamever", return_value="14140")
+    def test_parse_args_accepts_llm_options(
+        self,
+        _mock_resolve_oldgamever,
+    ) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "ida_analyze_bin.py",
+                "-gamever",
+                "14141",
+                "-llm_model",
+                "gpt-4.1-mini",
+                "-llm_apikey",
+                "test-api-key",
+                "-llm_baseurl",
+                "https://example.invalid/v1",
+            ],
+        ):
+            args = ida_analyze_bin.parse_args()
+
+        self.assertEqual("gpt-4.1-mini", args.llm_model)
+        self.assertEqual("test-api-key", args.llm_apikey)
+        self.assertEqual("https://example.invalid/v1", args.llm_baseurl)
+
+    @patch.object(ida_analyze_bin, "resolve_oldgamever", return_value="14140")
+    def test_parse_args_rejects_legacy_vcall_finder_model(
+        self,
+        _mock_resolve_oldgamever,
+    ) -> None:
+        with patch(
+            "sys.argv",
+            [
+                "ida_analyze_bin.py",
+                "-gamever",
+                "14141",
+                "-vcall_finder_model",
+                "gpt-4o",
+            ],
+        ), patch("sys.stderr", new_callable=io.StringIO) as fake_stderr:
+            with self.assertRaises(SystemExit) as exc:
+                ida_analyze_bin.parse_args()
+
+        self.assertEqual(2, exc.exception.code)
+        self.assertIn("-vcall_finder_model", fake_stderr.getvalue())
+
+
+class TestProcessBinaryLlmWiring(unittest.TestCase):
+    @patch("ida_analyze_bin.os.path.exists", return_value=False)
+    @patch.object(ida_analyze_bin, "run_skill", return_value=False)
+    @patch.object(
+        ida_analyze_bin,
+        "preprocess_single_skill_via_mcp",
+        new_callable=AsyncMock,
+        return_value=False,
+    )
+    @patch.object(ida_analyze_bin, "ensure_mcp_available")
+    @patch.object(ida_analyze_bin, "start_idalib_mcp")
+    @patch.object(ida_analyze_bin, "quit_ida_gracefully")
+    def test_process_binary_passes_unified_llm_options_to_preprocess(
+        self,
+        _mock_quit_ida,
+        mock_start_idalib_mcp,
+        mock_ensure_mcp_available,
+        mock_preprocess,
+        _mock_run_skill,
+        _mock_exists,
+    ) -> None:
+        fake_process = object()
+        mock_start_idalib_mcp.return_value = fake_process
+        mock_ensure_mcp_available.return_value = (fake_process, True)
+
+        ida_analyze_bin.process_binary(
+            binary_path="/tmp/bin/14141/networksystem/networksystem.dll",
+            skills=[
+                {
+                    "name": "find-IGameSystem_vtable",
+                    "expected_output": ["IGameSystem_vtable.{platform}.yaml"],
+                    "expected_input": [],
+                }
+            ],
+            agent="codex",
+            host="127.0.0.1",
+            port=13337,
+            ida_args="",
+            platform="windows",
+            debug=False,
+            max_retries=1,
+            llm_model="gpt-4.1-mini",
+            llm_apikey="test-api-key",
+            llm_baseurl="https://example.invalid/v1",
+        )
+
+        self.assertEqual("gpt-4.1-mini", mock_preprocess.await_args.kwargs["llm_model"])
+        self.assertEqual("test-api-key", mock_preprocess.await_args.kwargs["llm_apikey"])
+        self.assertEqual(
+            "https://example.invalid/v1",
+            mock_preprocess.await_args.kwargs["llm_baseurl"],
+        )
+
+
+class TestMainLlmWiring(unittest.TestCase):
+    @patch.object(ida_analyze_bin, "aggregate_vcall_results_for_object")
+    @patch.object(ida_analyze_bin, "process_binary", return_value=(0, 0, 0))
+    @patch.object(ida_analyze_bin, "parse_config")
+    @patch("ida_analyze_bin.os.path.exists", return_value=True)
+    @patch.object(ida_analyze_bin, "parse_args")
+    def test_main_passes_unified_llm_options_to_vcall_aggregation(
+        self,
+        mock_parse_args,
+        _mock_exists,
+        mock_parse_config,
+        _mock_process_binary,
+        mock_aggregate,
+    ) -> None:
+        mock_parse_args.return_value = SimpleNamespace(
+            configyaml="config.yaml",
+            bindir="bin",
+            gamever="14141",
+            oldgamever=None,
+            platforms=["windows"],
+            module_filter=None,
+            modules="*",
+            agent="codex",
+            ida_args="",
+            debug=False,
+            maxretry=3,
+            vcall_finder_filter={"all": True},
+            llm_model="gpt-4.1-mini",
+            llm_apikey="test-api-key",
+            llm_baseurl="https://example.invalid/v1",
+        )
+        mock_parse_config.return_value = [
+            {
+                "name": "networksystem",
+                "skills": [],
+                "vcall_finder_objects": ["g_pNetworkMessages"],
+                "path_windows": "game/bin/win64/networksystem.dll",
+            }
+        ]
+        mock_aggregate.return_value = {"status": "success", "processed": 1, "failed": 0}
+
+        ida_analyze_bin.main()
+
+        mock_aggregate.assert_called_once_with(
+            base_dir="vcall_finder",
+            gamever="14141",
+            object_name="g_pNetworkMessages",
+            model="gpt-4.1-mini",
+            api_key="test-api-key",
+            base_url="https://example.invalid/v1",
+            debug=False,
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -446,5 +446,468 @@ class TestVtableAliasSupport(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("0x8", written_payload["vfunc_offset"])
 
 
+class TestLlmDecompileSupport(unittest.IsolatedAsyncioTestCase):
+    def test_parse_llm_decompile_response_normalizes_all_sections(self) -> None:
+        response_text = """
+```yaml
+found_vcall:
+  - insn_va: 0x180777700
+    insn_disasm: " call    [rax+68h] "
+    vfunc_offset: 0x68
+    func_name: " ILoopMode_OnLoopActivate "
+  - invalid: true
+found_call:
+  - insn_va: 0x180888800
+    insn_disasm: " call    sub_180999900 "
+    func_name: " CLoopModeGame_RegisterEventMapInternal "
+  - insn_disasm: call    sub_missing
+found_gv:
+  - insn_va: 0x180444400
+    insn_disasm: " mov     rcx, cs:qword_180666600 "
+    gv_name: " s_GameEventManager "
+  - insn_va: 0x180000001
+found_struct_offset:
+  - insn_va: 0x1801BA12A
+    insn_disasm: " mov     rcx, [r14+58h] "
+    offset: 0x58
+    struct_name: " CGameResourceService "
+    member_name: " m_pEntitySystem "
+  - member_name: only_member
+```
+""".strip()
+
+        parsed = ida_analyze_util.parse_llm_decompile_response(response_text)
+
+        self.assertEqual(
+            {
+                "found_vcall": [
+                    {
+                        "insn_va": "0x180777700",
+                        "insn_disasm": "call    [rax+68h]",
+                        "vfunc_offset": "0x68",
+                        "func_name": "ILoopMode_OnLoopActivate",
+                    }
+                ],
+                "found_call": [
+                    {
+                        "insn_va": "0x180888800",
+                        "insn_disasm": "call    sub_180999900",
+                        "func_name": "CLoopModeGame_RegisterEventMapInternal",
+                    }
+                ],
+                "found_gv": [
+                    {
+                        "insn_va": "0x180444400",
+                        "insn_disasm": "mov     rcx, cs:qword_180666600",
+                        "gv_name": "s_GameEventManager",
+                    }
+                ],
+                "found_struct_offset": [
+                    {
+                        "insn_va": "0x1801BA12A",
+                        "insn_disasm": "mov     rcx, [r14+58h]",
+                        "offset": "0x58",
+                        "struct_name": "CGameResourceService",
+                        "member_name": "m_pEntitySystem",
+                    }
+                ],
+            },
+            parsed,
+        )
+
+    async def test_call_llm_decompile_uses_shared_llm_helper_and_parses_yaml(
+        self,
+    ) -> None:
+        response_text = """
+```yaml
+found_vcall:
+  - insn_va: 0x180777700
+    insn_disasm: " call    [rax+68h] "
+    vfunc_offset: 0x68
+    func_name: " ILoopMode_OnLoopActivate "
+found_call: []
+found_gv: []
+found_struct_offset: []
+```
+""".strip()
+
+        with patch.object(
+            ida_analyze_util,
+            "call_llm_text",
+            return_value=response_text,
+            create=True,
+        ) as mock_call_llm_text:
+            parsed = await ida_analyze_util.call_llm_decompile(
+                client=object(),
+                model="gpt-4.1-mini",
+                symbol_name_list=["ILoopMode_OnLoopActivate"],
+                disasm_code="call    [rax+68h]",
+                procedure="(*v1->lpVtbl->OnLoopActivate)(v1);",
+            )
+
+        self.assertEqual(
+            {
+                "found_vcall": [
+                    {
+                        "insn_va": "0x180777700",
+                        "insn_disasm": "call    [rax+68h]",
+                        "vfunc_offset": "0x68",
+                        "func_name": "ILoopMode_OnLoopActivate",
+                    }
+                ],
+                "found_call": [],
+                "found_gv": [],
+                "found_struct_offset": [],
+            },
+            parsed,
+        )
+        mock_call_llm_text.assert_called_once()
+        self.assertEqual("gpt-4.1-mini", mock_call_llm_text.call_args.kwargs["model"])
+        self.assertEqual(0.1, mock_call_llm_text.call_args.kwargs["temperature"])
+
+    async def test_call_llm_decompile_fails_closed_when_shared_helper_raises(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "call_llm_text",
+            side_effect=RuntimeError("llm unavailable"),
+            create=True,
+        ):
+            parsed = await ida_analyze_util.call_llm_decompile(
+                client=object(),
+                model="gpt-4.1-mini",
+                symbol_name_list=["ILoopMode_OnLoopActivate"],
+                disasm_code="call    [rax+68h]",
+                procedure="(*v1->lpVtbl->OnLoopActivate)(v1);",
+            )
+
+        self.assertEqual(
+            {
+                "found_vcall": [],
+                "found_call": [],
+                "found_gv": [],
+                "found_struct_offset": [],
+            },
+            parsed,
+        )
+
+    async def test_preprocess_func_sig_via_mcp_supports_direct_vtable_generation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            session = AsyncMock()
+            session.call_tool.return_value = _py_eval_payload(
+                {
+                    "func_va": "0x180123450",
+                    "func_size": "0x40",
+                }
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "preprocess_vtable_via_mcp",
+                AsyncMock(
+                    return_value={
+                        "vtable_class": "CLoopModeGame",
+                        "vtable_symbol": "??_7CLoopModeGame@@6B@",
+                        "vtable_va": "0x180001000",
+                        "vtable_rva": "0x1000",
+                        "vtable_size": "0x90",
+                        "vtable_numvfunc": 32,
+                        "vtable_entries": {13: "0x180123450"},
+                    }
+                ),
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_gen_func_sig_via_mcp",
+                AsyncMock(
+                    return_value={
+                        "func_va": "0x180123450",
+                        "func_rva": "0x123450",
+                        "func_size": "0x40",
+                        "func_sig": "48 89 ??",
+                    }
+                ),
+            ):
+                result = await ida_analyze_util.preprocess_func_sig_via_mcp(
+                    session=session,
+                    new_path=f"{temp_dir}/CLoopModeGame_OnLoopActivate.windows.yaml",
+                    old_path=None,
+                    image_base=0x180000000,
+                    new_binary_dir=temp_dir,
+                    platform="windows",
+                    func_name="CLoopModeGame_OnLoopActivate",
+                    direct_vtable_class="CLoopModeGame",
+                    direct_vfunc_offset="0x68",
+                    debug=False,
+                )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual("CLoopModeGame_OnLoopActivate", result["func_name"])
+        self.assertEqual("0x180123450", result["func_va"])
+        self.assertEqual("48 89 ??", result["func_sig"])
+        self.assertEqual("CLoopModeGame", result["vtable_name"])
+        self.assertEqual("0x68", result["vfunc_offset"])
+        self.assertEqual(13, result["vfunc_index"])
+
+    async def test_preprocess_gen_struct_offset_sig_via_mcp_generates_current_version_sig(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                self.assertIn("DecodeInstruction", arguments["code"])
+                self.assertIn("ida_bytes.get_bytes", arguments["code"])
+                return _py_eval_payload(
+                    [
+                        {
+                            "offset_inst_va": "0x1801BA12A",
+                            "insts": [
+                                {
+                                    "size": 4,
+                                    "bytes": "498b4e58",
+                                    "wild": [3],
+                                },
+                                {
+                                    "size": 3,
+                                    "bytes": "4885c9",
+                                    "wild": [],
+                                },
+                            ],
+                        }
+                    ]
+                )
+            if name == "find_bytes":
+                self.assertEqual(
+                    ["49 8B 4E ??"],
+                    arguments["patterns"],
+                )
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": ["0x1801BA12A"],
+                            "n": 1,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_struct_offset_sig_via_mcp(
+            session=session,
+            struct_name="CGameResourceService",
+            member_name="m_pEntitySystem",
+            offset="0x58",
+            offset_inst_va="0x1801BA12A",
+            image_base=0x180000000,
+            min_sig_bytes=4,
+            debug=False,
+        )
+
+        self.assertEqual(
+            {
+                "struct_name": "CGameResourceService",
+                "member_name": "m_pEntitySystem",
+                "offset": "0x58",
+                "offset_sig": "49 8B 4E ??",
+            },
+            result,
+        )
+
+    async def test_preprocess_common_skill_uses_llm_decompile_vcall_fallback_for_func_yaml(
+        self,
+    ) -> None:
+        func_name = "CLoopModeGame_OnLoopActivate"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+        normalized_payload = {
+            "found_vcall": [
+                {
+                    "insn_va": "0x180777700",
+                    "insn_disasm": "call    [rax+68h]",
+                    "vfunc_offset": "0x68",
+                    "func_name": func_name,
+                }
+            ],
+            "found_call": [],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            prompt_text = (
+                "ref={disasm_for_reference}|{procedure_for_reference}|"
+                "target={disasm_code}|{procedure}|symbols={symbol_name_list}"
+            )
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                prompt_text,
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "disasm_code": "mov rax, [rcx]",
+                    "procedure": "return this->vfptr[13](this);",
+                },
+            )
+            fake_client = object()
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=fake_client,
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ) as mock_call_llm_decompile, patch.object(
+                ida_analyze_util,
+                "preprocess_vtable_via_mcp",
+                AsyncMock(
+                    return_value={
+                        "vtable_class": "CLoopModeGame",
+                        "vtable_symbol": "??_7CLoopModeGame@@6B@",
+                        "vtable_va": "0x180001000",
+                        "vtable_rva": "0x1000",
+                        "vtable_size": "0x90",
+                        "vtable_numvfunc": 32,
+                        "vtable_entries": {13: "0x180123450"},
+                    }
+                ),
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    func_vtable_relations=[(func_name, "CLoopModeGame", True)],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        )
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        mock_call_llm_decompile.assert_awaited_once()
+        self.assertIs(fake_client, mock_call_llm_decompile.call_args.kwargs["client"])
+        self.assertEqual(
+            "gpt-4.1-mini",
+            mock_call_llm_decompile.call_args.kwargs["model"],
+        )
+        self.assertEqual(
+            prompt_text,
+            mock_call_llm_decompile.call_args.kwargs["prompt_template"],
+        )
+        self.assertEqual(
+            "mov rax, [rcx]",
+            mock_call_llm_decompile.call_args.kwargs["disasm_for_reference"],
+        )
+        self.assertEqual(
+            "return this->vfptr[13](this);",
+            mock_call_llm_decompile.call_args.kwargs["procedure_for_reference"],
+        )
+        mock_write_func_yaml.assert_called_once()
+        written_payload = mock_write_func_yaml.call_args.args[1]
+        self.assertEqual(func_name, written_payload["func_name"])
+        self.assertEqual("0x68", written_payload["vfunc_offset"])
+        self.assertEqual(13, written_payload["vfunc_index"])
+
+    async def test_preprocess_common_skill_llm_fallback_skips_missing_reference_yaml(
+        self,
+    ) -> None:
+        func_name = "CLoopModeGame_OnLoopActivate"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                create=True,
+            ) as mock_create_openai_client, patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+            ) as mock_call_llm_decompile, patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml:
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    func_vtable_relations=[(func_name, "CLoopModeGame", True)],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/missing.yaml",
+                        )
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertFalse(result)
+        mock_create_openai_client.assert_not_called()
+        mock_call_llm_decompile.assert_not_awaited()
+        mock_write_func_yaml.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ida_llm_utils.py
+++ b/tests/test_ida_llm_utils.py
@@ -1,0 +1,112 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import ida_llm_utils
+
+
+class TestRequireNonemptyText(unittest.TestCase):
+    def test_require_nonempty_text_returns_stripped_text(self) -> None:
+        self.assertEqual("hello", ida_llm_utils.require_nonempty_text("  hello  ", "value"))
+
+    def test_require_nonempty_text_raises_value_error_for_blank_text(self) -> None:
+        with self.assertRaises(ValueError):
+            ida_llm_utils.require_nonempty_text("   ", "value")
+
+
+class TestCreateOpenAiClient(unittest.TestCase):
+    def test_create_openai_client_raises_runtime_error_when_api_key_missing(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "LLM API key required"):
+            ida_llm_utils.create_openai_client(
+                None,
+                api_key_required_message="LLM API key required",
+            )
+
+    @patch("ida_llm_utils.OpenAI")
+    def test_create_openai_client_uses_trimmed_api_key_and_base_url(self, mock_openai) -> None:
+        mock_client = object()
+        mock_openai.return_value = mock_client
+
+        client = ida_llm_utils.create_openai_client(
+            "  test-api-key  ",
+            "  https://example.invalid/v1  ",
+            api_key_required_message="unused",
+        )
+
+        self.assertIs(mock_client, client)
+        mock_openai.assert_called_once_with(
+            api_key="test-api-key",
+            base_url="https://example.invalid/v1",
+        )
+
+
+class TestExtractFirstMessageText(unittest.TestCase):
+    def test_extract_first_message_text_supports_string_content(self) -> None:
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="hello from llm"),
+                )
+            ]
+        )
+
+        self.assertEqual("hello from llm", ida_llm_utils.extract_first_message_text(response))
+
+    def test_extract_first_message_text_supports_text_parts(self) -> None:
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=[
+                            SimpleNamespace(text="hello "),
+                            {"text": "from "},
+                            SimpleNamespace(text="parts"),
+                        ]
+                    ),
+                )
+            ]
+        )
+
+        self.assertEqual("hello from parts", ida_llm_utils.extract_first_message_text(response))
+
+    def test_extract_first_message_text_raises_value_error_on_empty_choices(self) -> None:
+        response = SimpleNamespace(choices=[])
+
+        with self.assertRaises(ValueError):
+            ida_llm_utils.extract_first_message_text(response)
+
+
+class TestCallLlmText(unittest.TestCase):
+    def test_call_llm_text_invokes_chat_completions_and_returns_first_message_text(self) -> None:
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="found_vcall:\n  []"),
+                )
+            ]
+        )
+        create = MagicMock(return_value=response)
+        client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=create),
+            )
+        )
+        messages = [{"role": "user", "content": "hello"}]
+
+        text = ida_llm_utils.call_llm_text(
+            client,
+            model="  gpt-4o-mini  ",
+            messages=messages,
+            temperature=0.25,
+        )
+
+        self.assertEqual("found_vcall:\n  []", text)
+        create.assert_called_once_with(
+            model="gpt-4o-mini",
+            messages=messages,
+            temperature=0.25,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -3,6 +3,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import ida_skill_preprocessor
+
 
 FLATTENED_SERIALIZERS_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
@@ -20,6 +22,47 @@ REALLOCATING_FACTORY_DEALLOCATE_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl.py"
 )
+FIND_NETWORK_GROUP_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/"
+    "find-CNetworkMessages_FindNetworkGroup.py"
+)
+
+
+class _FakeStreamableHttpClient:
+    async def __aenter__(self):
+        return ("read-stream", "write-stream", None)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeClientSession:
+    def __init__(self, read_stream, write_stream):
+        self.read_stream = read_stream
+        self.write_stream = write_stream
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def initialize(self):
+        return None
+
+    async def call_tool(self, name, arguments):
+        return {"name": name, "arguments": arguments}
 
 
 def _load_module(script_path: Path, module_name: str):
@@ -215,6 +258,189 @@ class TestFindCGameSystemReallocatingFactoryCSpawnGroupMgrGameSystemDeallocateIm
             platform="windows",
             image_base=0x180000000,
             inherit_vfuncs=expected_inherit_vfuncs,
+            debug=True,
+        )
+
+
+class TestPreprocessSingleSkillViaMcp(unittest.IsolatedAsyncioTestCase):
+    async def test_forwards_llm_config_when_script_accepts_it(self) -> None:
+        received = {}
+
+        async def fake_preprocess_skill(
+            session, skill_name, expected_outputs, old_yaml_map,
+            new_binary_dir, platform, image_base, llm_config, debug=False,
+        ):
+            received["args"] = {
+                "session": session,
+                "skill_name": skill_name,
+                "expected_outputs": expected_outputs,
+                "old_yaml_map": old_yaml_map,
+                "new_binary_dir": new_binary_dir,
+                "platform": platform,
+                "image_base": image_base,
+                "llm_config": llm_config,
+                "debug": debug,
+            }
+            return True
+
+        with patch.object(
+            ida_skill_preprocessor,
+            "_get_preprocess_entry",
+            return_value=fake_preprocess_skill,
+        ), patch.object(
+            ida_skill_preprocessor.httpx,
+            "AsyncClient",
+            _FakeAsyncClient,
+        ), patch.object(
+            ida_skill_preprocessor,
+            "streamable_http_client",
+            return_value=_FakeStreamableHttpClient(),
+        ), patch.object(
+            ida_skill_preprocessor,
+            "ClientSession",
+            _FakeClientSession,
+        ), patch.object(
+            ida_skill_preprocessor,
+            "parse_mcp_result",
+            return_value={"result": "0x180000000"},
+        ):
+            result = await ida_skill_preprocessor.preprocess_single_skill_via_mcp(
+                host="127.0.0.1",
+                port=13337,
+                skill_name="find-CNetworkMessages_FindNetworkGroup",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"out.yaml": "old.yaml"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                llm_model="gpt-4.1-mini",
+                llm_apikey="test-api-key",
+                llm_baseurl="https://example.invalid/v1",
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            {
+                "model": "gpt-4.1-mini",
+                "api_key": "test-api-key",
+                "base_url": "https://example.invalid/v1",
+            },
+            received["args"]["llm_config"],
+        )
+        self.assertEqual(0x180000000, received["args"]["image_base"])
+        self.assertTrue(received["args"]["debug"])
+
+    async def test_skips_llm_config_when_script_does_not_accept_it(self) -> None:
+        received = {}
+
+        async def fake_preprocess_skill(
+            session, skill_name, expected_outputs, old_yaml_map,
+            new_binary_dir, platform, image_base, debug=False,
+        ):
+            received["args"] = {
+                "session": session,
+                "skill_name": skill_name,
+                "expected_outputs": expected_outputs,
+                "old_yaml_map": old_yaml_map,
+                "new_binary_dir": new_binary_dir,
+                "platform": platform,
+                "image_base": image_base,
+                "debug": debug,
+            }
+            return True
+
+        with patch.object(
+            ida_skill_preprocessor,
+            "_get_preprocess_entry",
+            return_value=fake_preprocess_skill,
+        ), patch.object(
+            ida_skill_preprocessor.httpx,
+            "AsyncClient",
+            _FakeAsyncClient,
+        ), patch.object(
+            ida_skill_preprocessor,
+            "streamable_http_client",
+            return_value=_FakeStreamableHttpClient(),
+        ), patch.object(
+            ida_skill_preprocessor,
+            "ClientSession",
+            _FakeClientSession,
+        ), patch.object(
+            ida_skill_preprocessor,
+            "parse_mcp_result",
+            return_value={"result": "0x180000000"},
+        ):
+            result = await ida_skill_preprocessor.preprocess_single_skill_via_mcp(
+                host="127.0.0.1",
+                port=13337,
+                skill_name="find-CNetworkMessages_FindNetworkGroup",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"out.yaml": "old.yaml"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                llm_model="gpt-4.1-mini",
+                llm_apikey="test-api-key",
+                llm_baseurl="https://example.invalid/v1",
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(0x180000000, received["args"]["image_base"])
+        self.assertTrue(received["args"]["debug"])
+
+
+class TestFindCNetworkMessagesFindNetworkGroup(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_skill_forwards_llm_and_vtable_wiring(self) -> None:
+        module = _load_module(
+            FIND_NETWORK_GROUP_SCRIPT_PATH,
+            "find_CNetworkMessages_FindNetworkGroup",
+        )
+        mock_preprocess_common_skill = AsyncMock(return_value=True)
+        expected_llm_decompile_specs = [
+            (
+                "CNetworkMessages_FindNetworkGroup",
+                "prompt/call_llm_decompile.md",
+                "references/CNetworkMessages_FindNetworkGroup.from-CNetworkGameClient_RecordEntityBandwidth.yaml",
+            )
+        ]
+        expected_func_vtable_relations = [
+            ("CNetworkMessages_FindNetworkGroup", "CNetworkMessages", True)
+        ]
+        llm_config = {
+            "model": "gpt-4.1-mini",
+            "api_key": "test-api-key",
+            "base_url": "https://example.invalid/v1",
+        }
+
+        with patch.object(
+            module,
+            "preprocess_common_skill",
+            mock_preprocess_common_skill,
+        ):
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"k": "v"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                llm_config=llm_config,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_preprocess_common_skill.assert_awaited_once_with(
+            session="session",
+            expected_outputs=["out.yaml"],
+            old_yaml_map={"k": "v"},
+            new_binary_dir="bin_dir",
+            platform="windows",
+            image_base=0x180000000,
+            func_names=["CNetworkMessages_FindNetworkGroup"],
+            func_vtable_relations=expected_func_vtable_relations,
+            llm_decompile_specs=expected_llm_decompile_specs,
+            llm_config=llm_config,
             debug=True,
         )
 

--- a/tests/test_ida_vcall_finder.py
+++ b/tests/test_ida_vcall_finder.py
@@ -2,7 +2,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import ida_vcall_finder
 
@@ -132,6 +132,129 @@ class TestExportObjectXrefDetailsViaMcp(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(0, summary["exported_functions"])
             self.assertEqual(1, summary["failed_functions"])
             self.assertEqual(0, summary["skipped_functions"])
+
+
+class TestCallOpenAiForVcalls(unittest.TestCase):
+    @patch("ida_vcall_finder.call_llm_text")
+    def test_call_openai_for_vcalls_uses_shared_llm_helper(self, mock_call_llm_text) -> None:
+        mock_call_llm_text.return_value = """
+```yaml
+found_vcall:
+  - insn_va: 0x12345678
+    insn_disasm: call    [rax+68h]
+    vfunc_offset: 0x68
+```
+""".strip()
+
+        found_vcall = ida_vcall_finder.call_openai_for_vcalls(
+            object(),
+            {
+                "object_name": "g_pNetworkMessages",
+                "module": "networksystem",
+                "platform": "linux",
+                "func_name": "sub_2000",
+                "func_va": "0x2000",
+                "disasm_code": "call    [rax+68h]",
+                "procedure": "obj->vfptr[13](obj);",
+            },
+            "gpt-4.1-mini",
+        )
+
+        self.assertEqual(
+            [
+                {
+                    "insn_va": "0x12345678",
+                    "insn_disasm": "call    [rax+68h]",
+                    "vfunc_offset": "0x68",
+                }
+            ],
+            found_vcall,
+        )
+        mock_call_llm_text.assert_called_once()
+        self.assertEqual("gpt-4.1-mini", mock_call_llm_text.call_args.kwargs["model"])
+        self.assertEqual(0.1, mock_call_llm_text.call_args.kwargs["temperature"])
+        self.assertEqual(
+            "You are a reverse engineering expert.",
+            mock_call_llm_text.call_args.kwargs["messages"][0]["content"],
+        )
+        self.assertIn(
+            "g_pNetworkMessages",
+            mock_call_llm_text.call_args.kwargs["messages"][1]["content"],
+        )
+
+
+class TestAggregateVcallResultsForObject(unittest.TestCase):
+    @patch("ida_vcall_finder.call_llm_text")
+    @patch("ida_vcall_finder.create_openai_client")
+    def test_aggregate_vcall_results_for_object_uses_shared_client_factory(
+        self,
+        mock_create_openai_client,
+        mock_call_llm_text,
+    ) -> None:
+        mock_create_openai_client.return_value = object()
+        mock_call_llm_text.return_value = """
+found_vcall:
+  - insn_va: 0x12345678
+    insn_disasm: call    [rax+68h]
+    vfunc_offset: 0x68
+""".strip()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            detail_path = ida_vcall_finder.build_vcall_detail_path(
+                temp_dir,
+                "14141b",
+                "g_pNetworkMessages",
+                "networksystem",
+                "linux",
+                "sub_2000",
+            )
+            ida_vcall_finder.write_vcall_detail_yaml(
+                detail_path,
+                {
+                    "object_name": "g_pNetworkMessages",
+                    "module": "networksystem",
+                    "platform": "linux",
+                    "func_name": "sub_2000",
+                    "func_va": "0x2000",
+                    "disasm_code": "call    [rax+68h]",
+                    "procedure": "obj->vfptr[13](obj);",
+                },
+            )
+
+            stats = ida_vcall_finder.aggregate_vcall_results_for_object(
+                base_dir=temp_dir,
+                gamever="14141b",
+                object_name="g_pNetworkMessages",
+                model="gpt-4.1-mini",
+                api_key="test-api-key",
+                base_url="https://example.invalid/v1",
+                debug=False,
+            )
+
+            self.assertEqual({"status": "success", "processed": 1, "failed": 0}, stats)
+            mock_create_openai_client.assert_called_once_with(
+                api_key="test-api-key",
+                base_url="https://example.invalid/v1",
+                api_key_required_message="-llm_apikey is required when -vcall_finder is enabled",
+            )
+            saved_detail = ida_vcall_finder.load_yaml_file(detail_path)
+            self.assertEqual(
+                [
+                    {
+                        "insn_va": "0x12345678",
+                        "insn_disasm": "call    [rax+68h]",
+                        "vfunc_offset": "0x68",
+                    }
+                ],
+                saved_detail["found_vcall"],
+            )
+            summary_text = ida_vcall_finder.build_vcall_summary_path(
+                temp_dir,
+                "14141b",
+                "g_pNetworkMessages",
+            ).read_text(encoding="utf-8")
+            self.assertIn("insn_va: '0x12345678'", summary_text)
+            self.assertIn("func_name: sub_2000", summary_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 统一 `ida_analyze_bin.py`、`ida_analyze_util.py`、`ida_vcall_finder.py` 与 `ida_skill_preprocessor.py` 的 LLM 入口，补充 `ida_llm_utils.py` 与 `LLM_DECOMPILE` prompt wiring
- 新增独立 CLI `generate_reference_yaml.py`、project-level skill 与中英文说明，用于生成 `ida_preprocessor_scripts/references/<module>/<func_name>.<platform>.yaml`
- 补充 reference YAML generator 设计/执行文档，并为 LLM wiring、路径校验、reference YAML 导出新增定向测试

## Test Plan
- [x] `uv run python -m py_compile generate_reference_yaml.py ida_llm_utils.py ida_analyze_bin.py ida_analyze_util.py ida_skill_preprocessor.py ida_vcall_finder.py ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkGroup.py`
- [x] `uv run python -m unittest tests.test_generate_reference_yaml tests.test_ida_llm_utils tests.test_ida_analyze_util tests.test_ida_analyze_bin tests.test_ida_preprocessor_scripts tests.test_ida_vcall_finder -v`
- [ ] Live IDA/MCP smoke（需要本地启动 `idalib-mcp` 和目标 binary，本次未在 CLI 环境执行）
