### PR TITLE
fix(preprocess): 支持vfunc签名多匹配上限

### DIFF
--- a/docs/superpowers/plans/2026-04-10-vfunc-sig-max-match.md
+++ b/docs/superpowers/plans/2026-04-10-vfunc-sig-max-match.md
@@ -1,0 +1,1046 @@
+# Vfunc Sig Max Match Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `vfunc_sig` 增加 `vfunc_sig_max_match` 契约与 YAML 持久化能力，让 slot-only 生成和旧 YAML 复用都支持“最多 N 个匹配”。
+
+**Architecture:** 先用 `unittest` 锁定三类行为：字段契约能把 `"vfunc_sig_max_match:10"` 解析成输出字段和生成选项、`preprocess_gen_vfunc_sig_via_mcp(...)` 能在 `<= N` 个命中时提前收敛、`preprocess_func_sig_via_mcp(...)` 能读取旧 YAML 中的 `vfunc_sig_max_match` 放宽 `vfunc_sig` 复用匹配条件。随后在 `ida_analyze_util.py` 中补齐 directive 规范化、字段顺序、slot-only 参数透传、`vfunc_sig` 限制匹配 helper 与 YAML 组装逻辑，最后回归目标脚本与相关定向测试。
+
+**Tech Stack:** Python 3、`unittest`、`unittest.mock`、`tempfile`、`pathlib`、`yaml.safe_dump`
+
+---
+
+## File Structure
+
+- Modify: `ida_analyze_util.py`
+  - 扩展 `_normalize_generate_yaml_desired_fields(...)` 以区分 `desired_output_fields` 与 `generation_options`
+  - 在 `func` 字段顺序与合法字段集合中加入 `vfunc_sig_max_match`
+  - 调整 `_assemble_symbol_payload(...)` 只消费规范化后的输出字段
+  - 为 slot-only fallback 增加 `vfunc_sig_max_match` 透传
+  - 为 `preprocess_gen_vfunc_sig_via_mcp(...)` 增加 `max_match_count`
+  - 为 `preprocess_func_sig_via_mcp(...)` 增加仅限 `vfunc_sig` 路径使用的受限匹配 helper
+- Modify: `tests/test_ida_analyze_util.py`
+  - 新增 directive 解析、非法契约、slot-only 透传、多匹配生成、旧 YAML 复用等回归测试
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+  - 为 `find-INetworkMessages_GetLoggingChannel-windows.py` 增加转发 `"vfunc_sig_max_match:10"` 的断言
+- Modify: `ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py`
+  - 若当前分支尚未保留用户改动，则补齐 `"vfunc_sig_max_match:10"`
+- Create: `docs/superpowers/plans/2026-04-10-vfunc-sig-max-match.md`
+  - 当前实现计划文档
+
+**仓库约束：**
+
+- 实施时先跑定向 `unittest`，不要先跑全量 build
+- `git commit` 消息遵循仓库约定：`<type>(scope): <中文动词开头摘要>`
+- 该计划只放宽 `vfunc_sig`，不能顺手改松 `func_sig`、`gv_sig`、`patch_sig`
+
+## Task 1: 锁定字段契约与 YAML 输出行为
+
+**Files:**
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `ida_analyze_util.py`
+
+- [ ] **Step 1: 先写 directive 解析与非法契约的 failing tests**
+
+在 `tests/test_ida_analyze_util.py` 的 `TestGenerateYamlDesiredFieldsContract` 中追加以下测试：
+
+```python
+    def test_normalize_generate_yaml_desired_fields_parses_vfunc_sig_max_match_directive(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "INetworkMessages_GetLoggingChannel",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:10",
+                        "vfunc_offset",
+                        "vfunc_index",
+                        "vtable_name",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertEqual(
+            {
+                "INetworkMessages_GetLoggingChannel": {
+                    "desired_output_fields": [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match",
+                        "vfunc_offset",
+                        "vfunc_index",
+                        "vtable_name",
+                    ],
+                    "generation_options": {
+                        "vfunc_sig_max_match": 10,
+                    },
+                }
+            },
+            result,
+        )
+
+    def test_normalize_generate_yaml_desired_fields_rejects_vfunc_sig_max_match_without_vfunc_sig(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [("Foo", ["func_name", "vfunc_sig_max_match:10"])],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    def test_normalize_generate_yaml_desired_fields_rejects_invalid_vfunc_sig_max_match_value(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [("Foo", ["func_name", "vfunc_sig", "vfunc_sig_max_match:abc"])],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+```
+
+- [ ] **Step 2: 运行新增测试，确认当前实现失败**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestGenerateYamlDesiredFieldsContract.test_normalize_generate_yaml_desired_fields_parses_vfunc_sig_max_match_directive \
+  tests.test_ida_analyze_util.TestGenerateYamlDesiredFieldsContract.test_normalize_generate_yaml_desired_fields_rejects_vfunc_sig_max_match_without_vfunc_sig \
+  tests.test_ida_analyze_util.TestGenerateYamlDesiredFieldsContract.test_normalize_generate_yaml_desired_fields_rejects_invalid_vfunc_sig_max_match_value \
+  -v
+```
+
+Expected:
+
+```text
+FAIL: ...parses_vfunc_sig_max_match_directive
+```
+
+并且当前 `_normalize_generate_yaml_desired_fields(...)` 仍返回旧的 `dict[str, list[str]]` 结构。
+
+- [ ] **Step 3: 实现 directive 规范化、合法字段与 payload 组装调整**
+
+在 `ida_analyze_util.py` 中按下面的形态修改三个位置：
+
+```python
+FUNC_YAML_ORDER = [
+    "func_name",
+    "func_va",
+    "func_rva",
+    "func_size",
+    "func_sig",
+    "vtable_name",
+    "vfunc_offset",
+    "vfunc_index",
+    "vfunc_sig",
+    "vfunc_sig_max_match",
+]
+```
+
+```python
+def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=False):
+    if not generate_yaml_desired_fields:
+        if debug:
+            print("    Preprocess: missing generate_yaml_desired_fields")
+        return None
+
+    normalized = {}
+    for spec in generate_yaml_desired_fields:
+        if not isinstance(spec, (tuple, list)) or len(spec) != 2:
+            if debug:
+                print(f"    Preprocess: invalid desired-fields spec: {spec}")
+            return None
+
+        symbol_name, desired_fields = spec
+        if not isinstance(symbol_name, str) or not symbol_name:
+            if debug:
+                print(f"    Preprocess: invalid desired-fields symbol: {symbol_name}")
+            return None
+        if symbol_name in normalized:
+            if debug:
+                print(f"    Preprocess: duplicated desired-fields symbol: {symbol_name}")
+            return None
+        if not isinstance(desired_fields, (tuple, list)) or not desired_fields:
+            if debug:
+                print(f"    Preprocess: empty desired-fields for {symbol_name}")
+            return None
+
+        desired_output_fields = []
+        generation_options = {}
+        seen_directives = set()
+        for raw_field in desired_fields:
+            if not isinstance(raw_field, str) or not raw_field:
+                if debug:
+                    print(f"    Preprocess: invalid desired field list for {symbol_name}")
+                return None
+
+            if raw_field.startswith("vfunc_sig_max_match:"):
+                if "vfunc_sig_max_match" in seen_directives:
+                    if debug:
+                        print(
+                            f"    Preprocess: duplicated vfunc_sig_max_match for {symbol_name}"
+                        )
+                    return None
+                value_text = raw_field.split(":", 1)[1].strip()
+                try:
+                    value = int(value_text, 10)
+                except Exception:
+                    if debug:
+                        print(
+                            f"    Preprocess: invalid vfunc_sig_max_match for {symbol_name}: {raw_field}"
+                        )
+                    return None
+                if value <= 0:
+                    if debug:
+                        print(
+                            f"    Preprocess: vfunc_sig_max_match must be > 0 for {symbol_name}"
+                        )
+                    return None
+                desired_output_fields.append("vfunc_sig_max_match")
+                generation_options["vfunc_sig_max_match"] = value
+                seen_directives.add("vfunc_sig_max_match")
+                continue
+
+            desired_output_fields.append(raw_field)
+
+        if "vfunc_sig_max_match" in generation_options and "vfunc_sig" not in desired_output_fields:
+            if debug:
+                print(
+                    f"    Preprocess: vfunc_sig_max_match requires vfunc_sig for {symbol_name}"
+                )
+            return None
+
+        normalized[symbol_name] = {
+            "desired_output_fields": desired_output_fields,
+            "generation_options": generation_options,
+        }
+
+    return normalized
+```
+
+```python
+def _assemble_symbol_payload(symbol_name, target_kind, candidate_data, desired_fields_map, debug=False):
+    desired_fields_entry = desired_fields_map.get(symbol_name)
+    if desired_fields_entry is None:
+        if debug:
+            print(f"    Preprocess: missing desired-fields entry for {symbol_name}")
+        return None
+
+    desired_fields = desired_fields_entry["desired_output_fields"]
+    payload = {}
+    for field_name in desired_fields:
+        if field_name not in candidate_data:
+            if debug:
+                print(
+                    f"    Preprocess: missing desired field {field_name} "
+                    f"for {symbol_name}"
+                )
+            return None
+        payload[field_name] = candidate_data[field_name]
+
+    ordered_keys = TARGET_KIND_TO_FIELD_ORDER[target_kind]
+    return _build_ordered_yaml_payload(payload, ordered_keys)
+```
+
+- [ ] **Step 4: 回跑契约测试并补一个 payload 持久化断言**
+
+把下面这个测试也加到 `TestGenerateYamlDesiredFieldsContract`：
+
+```python
+    async def test_preprocess_common_skill_writes_vfunc_sig_max_match_field(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "preprocess_func_sig_via_mcp",
+            AsyncMock(
+                return_value={
+                    "func_name": "Foo",
+                    "vfunc_sig": "FF 90 78 00 00 00",
+                    "vfunc_sig_max_match": 10,
+                    "vtable_name": "Bar",
+                    "vfunc_offset": "0x78",
+                    "vfunc_index": 15,
+                }
+            ),
+        ), patch.object(
+            ida_analyze_util,
+            "write_func_yaml",
+        ) as mock_write_func_yaml, patch.object(
+            ida_analyze_util,
+            "_rename_func_in_ida",
+            AsyncMock(return_value=None),
+        ):
+            result = await ida_analyze_util.preprocess_common_skill(
+                session="session",
+                expected_outputs=["/tmp/Foo.windows.yaml"],
+                old_yaml_map={},
+                new_binary_dir="/tmp",
+                platform="windows",
+                image_base=0x180000000,
+                func_names=["Foo"],
+                generate_yaml_desired_fields=[
+                    (
+                        "Foo",
+                        [
+                            "func_name",
+                            "vfunc_sig",
+                            "vfunc_sig_max_match:10",
+                            "vtable_name",
+                            "vfunc_offset",
+                            "vfunc_index",
+                        ],
+                    )
+                ],
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            {
+                "func_name": "Foo",
+                "vtable_name": "Bar",
+                "vfunc_offset": "0x78",
+                "vfunc_index": 15,
+                "vfunc_sig": "FF 90 78 00 00 00",
+                "vfunc_sig_max_match": 10,
+            },
+            mock_write_func_yaml.call_args.args[1],
+        )
+```
+
+Run:
+
+```bash
+python -m unittest tests.test_ida_analyze_util.TestGenerateYamlDesiredFieldsContract -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: 提交契约与 payload 调整**
+
+```bash
+git add ida_analyze_util.py tests/test_ida_analyze_util.py
+git commit -m "test(preprocess): 补齐vfunc多匹配契约测试"
+```
+
+## Task 2: 锁定 `preprocess_gen_vfunc_sig_via_mcp(...)` 的多匹配收敛行为
+
+**Files:**
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `ida_analyze_util.py`
+
+- [ ] **Step 1: 先写 `<= N` 成功与 `> N` 继续扩展的 failing tests**
+
+在 `tests/test_ida_analyze_util.py` 的 `test_preprocess_gen_vfunc_sig_via_mcp_generates_current_version_sig` 后面追加：
+
+```python
+    async def test_preprocess_gen_vfunc_sig_via_mcp_accepts_match_count_within_limit(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                return _py_eval_payload(
+                    {
+                        "vfunc_sig_va": "0x18004abc3",
+                        "vfunc_inst_length": 6,
+                        "vfunc_disp_offset": 2,
+                        "vfunc_disp_size": 4,
+                        "insts": [
+                            {
+                                "ea": "0x18004abc3",
+                                "size": 6,
+                                "bytes": "ff9078000000",
+                                "wild": [],
+                            },
+                            {
+                                "ea": "0x18004abc9",
+                                "size": 3,
+                                "bytes": "4885c0",
+                                "wild": [],
+                            },
+                        ],
+                    }
+                )
+            if name == "find_bytes":
+                self.assertEqual(11, arguments["limit"])
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": ["0x18004abc3", "0x18004abd0"],
+                            "n": 2,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_vfunc_sig_via_mcp(
+            session=session,
+            inst_va="0x18004ABC3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=True,
+        )
+
+        self.assertEqual("FF 90 78 00 00 00", result["vfunc_sig"])
+        self.assertEqual(10, result["vfunc_sig_max_match"])
+
+    async def test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_count_over_limit(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                return _py_eval_payload(
+                    {
+                        "vfunc_sig_va": "0x18004abc3",
+                        "vfunc_inst_length": 6,
+                        "vfunc_disp_offset": 2,
+                        "vfunc_disp_size": 4,
+                        "insts": [
+                            {
+                                "ea": "0x18004abc3",
+                                "size": 6,
+                                "bytes": "ff9078000000",
+                                "wild": [],
+                            },
+                            {
+                                "ea": "0x18004abc9",
+                                "size": 3,
+                                "bytes": "4885c0",
+                                "wild": [],
+                            },
+                        ],
+                    }
+                )
+            if name == "find_bytes":
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": [
+                                "0x18004abc3",
+                                "0x18004abd0",
+                                "0x18004abe0",
+                            ],
+                            "n": 11,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_vfunc_sig_via_mcp(
+            session=session,
+            inst_va="0x18004ABC3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+```
+
+- [ ] **Step 2: 运行这两条测试，确认当前实现仍按唯一匹配失败**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_accepts_match_count_within_limit \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_count_over_limit \
+  -v
+```
+
+Expected:
+
+```text
+FAIL: ...accepts_match_count_within_limit
+```
+
+- [ ] **Step 3: 实现 `max_match_count` 参数与 `limit = N + 1` 逻辑**
+
+在 `ida_analyze_util.py` 的 `preprocess_gen_vfunc_sig_via_mcp(...)` 中按下面形态修改：
+
+```python
+async def preprocess_gen_vfunc_sig_via_mcp(
+    session,
+    inst_va,
+    vfunc_offset,
+    min_sig_bytes=6,
+    max_sig_bytes=96,
+    max_instructions=64,
+    max_match_count=1,
+    extra_wildcard_offsets=None,
+    debug=False,
+):
+    try:
+        max_match_count = max(1, int(max_match_count))
+    except Exception:
+        if debug:
+            print("    Preprocess: invalid max_match_count for vfunc_sig")
+        return None
+```
+
+并把 `find_bytes` 调用和判定改成：
+
+```python
+            fb_result = await session.call_tool(
+                name="find_bytes",
+                arguments={
+                    "patterns": [candidate_sig],
+                    "limit": max_match_count + 1,
+                },
+            )
+```
+
+```python
+        matches = entry.get("matches", [])
+        match_count = entry.get("n", len(matches))
+
+        if match_count < 1 or match_count > max_match_count:
+            continue
+
+        normalized_matches = {str(match).lower() for match in matches}
+        if hex(inst_va_int).lower() not in normalized_matches:
+            continue
+
+        best_sig = candidate_sig
+        best_sig_len = prefix_len
+        break
+```
+
+返回值补齐：
+
+```python
+    return {
+        "vfunc_sig": best_sig,
+        "vfunc_sig_va": hex(inst_va_int),
+        "vfunc_sig_disp": 0,
+        "vfunc_inst_length": first_len,
+        "vfunc_disp_offset": disp_off,
+        "vfunc_disp_size": disp_size,
+        "vfunc_offset": hex(vfunc_offset_int),
+        "vfunc_sig_max_match": max_match_count,
+    }
+```
+
+- [ ] **Step 4: 回跑 `vfunc_sig` 生成测试**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_generates_current_version_sig \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_accepts_match_count_within_limit \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_count_over_limit \
+  -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: 提交 `vfunc_sig` 生成器改动**
+
+```bash
+git add ida_analyze_util.py tests/test_ida_analyze_util.py
+git commit -m "fix(preprocess): 支持vfunc签名多匹配收敛"
+```
+
+## Task 3: 打通 slot-only fallback 与目标脚本转发
+
+**Files:**
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+- Modify: `ida_analyze_util.py`
+- Modify: `ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py`
+
+- [ ] **Step 1: 先写 slot-only 透传与脚本转发的 failing tests**
+
+在 `tests/test_ida_analyze_util.py` 的 slot-only 测试旁追加：
+
+```python
+        mock_preprocess_gen_vfunc_sig.assert_awaited_once_with(
+            session=session,
+            inst_va="0x18004abc3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=True,
+        )
+        self.assertEqual(10, written_payload["vfunc_sig_max_match"])
+```
+
+同时在 `tests/test_ida_preprocessor_scripts.py` 新增：
+
+```python
+class TestFindINetworkMessagesGetLoggingChannelWindows(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_skill_forwards_vfunc_sig_max_match_directive(self) -> None:
+        module = _load_module(
+            "ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py",
+            "find_INetworkMessages_GetLoggingChannel_windows",
+        )
+        mock_preprocess_common_skill = AsyncMock(return_value=True)
+        llm_config = {
+            "model": "gpt-4.1-mini",
+            "api_key": "test-api-key",
+        }
+
+        with patch.object(module, "preprocess_common_skill", mock_preprocess_common_skill):
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"k": "v"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                llm_config=llm_config,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_preprocess_common_skill.assert_awaited_once_with(
+            session="session",
+            expected_outputs=["out.yaml"],
+            old_yaml_map={"k": "v"},
+            new_binary_dir="bin_dir",
+            platform="windows",
+            image_base=0x180000000,
+            func_names=["INetworkMessages_GetLoggingChannel"],
+            func_vtable_relations=[
+                ("INetworkMessages_GetLoggingChannel", "INetworkMessages")
+            ],
+            llm_decompile_specs=[
+                (
+                    "INetworkMessages_GetLoggingChannel",
+                    "prompt/call_llm_decompile.md",
+                    "references/server/CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes.{platform}.yaml",
+                )
+            ],
+            generate_yaml_desired_fields=[
+                (
+                    "INetworkMessages_GetLoggingChannel",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:10",
+                        "vfunc_offset",
+                        "vfunc_index",
+                        "vtable_name",
+                    ],
+                )
+            ],
+            llm_config=llm_config,
+            debug=True,
+        )
+```
+
+- [ ] **Step 2: 运行两组测试，确认当前透传尚未打通**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_uses_slot_only_fallback_when_vtable_unavailable \
+  tests.test_ida_preprocessor_scripts.TestFindINetworkMessagesGetLoggingChannelWindows.test_preprocess_skill_forwards_vfunc_sig_max_match_directive \
+  -v
+```
+
+Expected:
+
+```text
+FAIL: expected await not found
+```
+
+因为当前 `preprocess_gen_vfunc_sig_via_mcp(...)` 还没有收到 `max_match_count=10`。
+
+- [ ] **Step 3: 在公共层与 helper 中透传 `vfunc_sig_max_match`**
+
+在 `ida_analyze_util.py` 中调整：
+
+```python
+async def _build_enriched_slot_only_vfunc_payload_via_mcp(
+    session,
+    func_name,
+    llm_result,
+    *,
+    vtable_name=None,
+    require_vfunc_sig=False,
+    require_vtable_name=False,
+    vfunc_sig_max_match=1,
+    debug=False,
+):
+```
+
+并在生成成功后补齐：
+
+```python
+        payload["vfunc_sig"] = str(vfunc_sig)
+        payload["vfunc_sig_max_match"] = int(
+            sig_data.get("vfunc_sig_max_match", vfunc_sig_max_match)
+        )
+```
+
+`preprocess_common_skill(...)` 中读取规范化结果并透传：
+
+```python
+        desired_fields_entry = desired_fields_map.get(func_name)
+        desired_fields = desired_fields_entry["desired_output_fields"]
+        generation_options = desired_fields_entry["generation_options"]
+        desired_fields_set = set(desired_fields)
+```
+
+```python
+                func_data = await _build_enriched_slot_only_vfunc_payload_via_mcp(
+                    session=session,
+                    func_name=func_name,
+                    llm_result=llm_result,
+                    vtable_name=fallback_vtable_name,
+                    require_vfunc_sig="vfunc_sig" in desired_fields_set,
+                    require_vtable_name="vtable_name" in desired_fields_set,
+                    vfunc_sig_max_match=generation_options.get("vfunc_sig_max_match", 1),
+                    debug=debug,
+                )
+```
+
+如果目标脚本里还没有该 directive，则保持为：
+
+```python
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_max_match:10",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+```
+
+- [ ] **Step 4: 回跑 slot-only 与脚本转发测试**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_uses_slot_only_fallback_when_vtable_unavailable \
+  tests.test_ida_preprocessor_scripts.TestFindINetworkMessagesGetLoggingChannelWindows.test_preprocess_skill_forwards_vfunc_sig_max_match_directive \
+  -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: 提交 slot-only 透传改动**
+
+```bash
+git add \
+  ida_analyze_util.py \
+  tests/test_ida_analyze_util.py \
+  tests/test_ida_preprocessor_scripts.py \
+  ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py
+git commit -m "fix(preprocess): 透传vfunc多匹配上限"
+```
+
+## Task 4: 打通旧 YAML 的 `vfunc_sig` 复用路径
+
+**Files:**
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `ida_analyze_util.py`
+
+- [ ] **Step 1: 先写旧 YAML 复用的 failing tests**
+
+在 `tests/test_ida_analyze_util.py` 中追加一个新测试类：
+
+```python
+class TestPreprocessFuncSigViaMcpVfuncSigMaxMatch(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_func_sig_via_mcp_allows_vfunc_sig_match_count_within_limit(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            old_path = Path(temp_dir) / "old.yaml"
+            new_path = Path(temp_dir) / "new.yaml"
+            vtable_path = Path(temp_dir) / "INetworkMessages_vtable.windows.yaml"
+            old_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "func_name": "INetworkMessages_GetLoggingChannel",
+                        "vfunc_sig": "FF 90 20 01 00 00",
+                        "vfunc_sig_max_match": 10,
+                        "vtable_name": "INetworkMessages",
+                        "vfunc_offset": "0x120",
+                        "vfunc_index": 36,
+                        "func_va": "0x180111111",
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+            vtable_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "vtable_class": "INetworkMessages",
+                        "vtable_entries": {36: "0x180222222"},
+                    },
+                    sort_keys=False,
+                ),
+                encoding="utf-8",
+            )
+
+            async def _fake_call_tool(*, name, arguments):
+                if name == "find_bytes":
+                    return _FakeCallToolResult(
+                        [
+                            {
+                                "matches": ["0x1805f0173", "0x1805f01ad"],
+                                "n": 2,
+                            }
+                        ]
+                    )
+                if name == "py_eval":
+                    return _py_eval_payload(
+                        {"func_va": "0x180222222", "func_size": "0x40"}
+                    )
+                raise AssertionError(f"unexpected MCP tool: {name}")
+
+            session.call_tool.side_effect = _fake_call_tool
+
+            result = await ida_analyze_util.preprocess_func_sig_via_mcp(
+                session=session,
+                new_path=str(new_path),
+                old_path=str(old_path),
+                image_base=0x180000000,
+                new_binary_dir=temp_dir,
+                platform="windows",
+                func_name="INetworkMessages_GetLoggingChannel",
+                debug=True,
+            )
+
+        self.assertEqual(10, result["vfunc_sig_max_match"])
+        self.assertEqual("FF 90 20 01 00 00", result["vfunc_sig"])
+        self.assertEqual(36, result["vfunc_index"])
+```
+
+- [ ] **Step 2: 运行旧 YAML 复用测试，确认当前实现仍然要求唯一匹配**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestPreprocessFuncSigViaMcpVfuncSigMaxMatch \
+  -v
+```
+
+Expected:
+
+```text
+FAIL: ...matched 2 (need 1)
+```
+
+- [ ] **Step 3: 新增仅限 `vfunc_sig` 使用的受限匹配 helper，并写回字段**
+
+在 `ida_analyze_util.py` 的 `preprocess_func_sig_via_mcp(...)` 内保留 `_find_unique_match(...)` 不动，新增：
+
+```python
+    async def _find_match_with_limit(signature, label, max_match_count):
+        try:
+            max_match_count = max(1, int(max_match_count))
+        except Exception:
+            if debug:
+                print(f"    Preprocess: invalid max match count for {label}")
+            return None
+
+        try:
+            fb_result = await session.call_tool(
+                name="find_bytes",
+                arguments={
+                    "patterns": [signature],
+                    "limit": max_match_count + 1,
+                },
+            )
+            fb_data = parse_mcp_result(fb_result)
+        except Exception as e:
+            if debug:
+                print(f"    Preprocess: find_bytes error: {e}")
+            return None
+
+        if not isinstance(fb_data, list) or len(fb_data) == 0:
+            return None
+
+        entry = fb_data[0]
+        if not isinstance(entry, dict):
+            return None
+
+        matches = entry.get("matches", [])
+        match_count = entry.get("n", len(matches))
+        if match_count < 1 or match_count > max_match_count:
+            if debug:
+                print(
+                    f"    Preprocess: {label} matched {match_count} "
+                    f"(need <= {max_match_count})"
+                )
+            return None
+
+        return matches[0]
+```
+
+在 `vfunc_sig` fallback 分支读取旧 YAML：
+
+```python
+        vfunc_sig_max_match = old_data.get("vfunc_sig_max_match", 1)
+        try:
+            vfunc_sig_max_match = _parse_int_field(
+                vfunc_sig_max_match,
+                "vfunc_sig_max_match",
+            )
+        except Exception:
+            if debug:
+                print(
+                    "    Preprocess: invalid vfunc_sig_max_match in "
+                    f"{os.path.basename(old_path)}"
+                )
+            return None
+        if vfunc_sig_max_match <= 0:
+            if debug:
+                print(
+                    "    Preprocess: vfunc_sig_max_match must be > 0 in "
+                    f"{os.path.basename(old_path)}"
+                )
+            return None
+```
+
+把匹配调用改成：
+
+```python
+        vfunc_match_addr = await _find_match_with_limit(
+            vfunc_sig,
+            f"{os.path.basename(old_path)} vfunc_sig",
+            vfunc_sig_max_match,
+        )
+```
+
+并在两个 `used_vfunc_fallback` 返回分支都补上：
+
+```python
+        new_data["vfunc_sig_max_match"] = vfunc_sig_max_match
+```
+
+- [ ] **Step 4: 回跑旧 YAML 复用与 slot-only 相关测试**
+
+Run:
+
+```bash
+python -m unittest \
+  tests.test_ida_analyze_util.TestPreprocessFuncSigViaMcpVfuncSigMaxMatch \
+  tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_fails_when_slot_only_vfunc_sig_generation_fails \
+  -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: 提交旧 YAML 复用改动**
+
+```bash
+git add ida_analyze_util.py tests/test_ida_analyze_util.py
+git commit -m "fix(preprocess): 复用vfunc多匹配上限"
+```
+
+## Task 5: 跑最终定向回归并整理交付说明
+
+**Files:**
+- Modify: `ida_analyze_util.py`
+- Modify: `tests/test_ida_analyze_util.py`
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+- Modify: `ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py`
+
+- [ ] **Step 1: 跑 `ida_analyze_util` 相关定向回归**
+
+Run:
+
+```bash
+python -m unittest tests.test_ida_analyze_util -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 2: 跑脚本转发回归**
+
+Run:
+
+```bash
+python -m unittest tests.test_ida_preprocessor_scripts -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 3: 人工检查最终目标脚本与字段顺序**
+
+Run:
+
+```bash
+rg -n "vfunc_sig_max_match|FUNC_YAML_ORDER|_normalize_generate_yaml_desired_fields|_find_match_with_limit" \
+  ida_analyze_util.py \
+  ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py
+```
+
+Expected:
+
+```text
+ida_analyze_util.py: ... "vfunc_sig_max_match"
+ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py: ... "vfunc_sig_max_match:10"
+```
+
+- [ ] **Step 4: 整理最终变更摘要**
+
+在提交说明或交付说明中明确写出：
+
+```text
+1. vfunc_sig 生成支持 <= N 个匹配
+2. 旧 YAML 复用支持读取 vfunc_sig_max_match
+3. 最终 YAML 会持久化 vfunc_sig_max_match
+4. 未声明该字段的旧路径仍保持唯一匹配
+```
+
+- [ ] **Step 5: 提交最终回归通过的实现**
+
+```bash
+git add \
+  ida_analyze_util.py \
+  tests/test_ida_analyze_util.py \
+  tests/test_ida_preprocessor_scripts.py \
+  ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py
+git commit -m "fix(preprocess): 支持vfunc签名多匹配上限"
+```

--- a/docs/superpowers/specs/2026-04-10-vfunc-sig-max-match-design.md
+++ b/docs/superpowers/specs/2026-04-10-vfunc-sig-max-match-design.md
@@ -1,0 +1,435 @@
+# `vfunc_sig_max_match` 设计
+
+## 背景
+
+当前仓库中，`GENERATE_YAML_DESIRED_FIELDS` 被设计为每个 symbol 的唯一 YAML 输出契约，`preprocess_common_skill(...)` 会严格按该契约校验字段并生成 YAML。
+
+但现有 `vfunc_sig` 生成与复用逻辑都默认要求签名字节模式必须唯一匹配：
+
+- `preprocess_gen_vfunc_sig_via_mcp(...)` 只有在 `find_bytes` 命中数等于 `1` 时才接受签名
+- `preprocess_func_sig_via_mcp(...)` 在旧 YAML 走 `vfunc_sig` fallback 时，也要求旧 `vfunc_sig` 在新二进制里唯一匹配
+
+这对某些模板化实例函数并不合适。以 `INetworkMessages_GetLoggingChannel` 为例，LLM fallback 能稳定找到多个语义等价的 `vcall` 指令，它们共享同一模板形态与同一 `vfunc_offset`，但当前实现会因为命中数大于 `1` 而持续扩展签名，最终失败。
+
+用户要求新增：
+
+```python
+"vfunc_sig_max_match:10"
+```
+
+其语义是：
+
+- 生成 `vfunc_sig` 时，允许最多 `10` 个匹配，不再强求唯一
+- 当匹配数已经降到 `<= 10` 时，停止继续扩展 signature bytes
+- 最终 YAML 需要持久化：
+
+```yaml
+vfunc_sig_max_match: 10
+```
+
+- 后续 `preprocess_func_sig_via_mcp(...)` 复用旧 YAML 中的 `vfunc_sig` 时，也要按该上限放宽匹配条件
+
+## 目标
+
+- 支持在 `GENERATE_YAML_DESIRED_FIELDS` 中声明 `"vfunc_sig_max_match:N"`
+- 将该声明规范化为最终 YAML 字段 `vfunc_sig_max_match: N`
+- 让 slot-only vfunc 的 `vfunc_sig` 生成逻辑支持“最多 N 个匹配”
+- 让旧 YAML 复用 `vfunc_sig` 的 fallback 路径也支持“最多 N 个匹配”
+- 保持未声明 `vfunc_sig_max_match` 的现有脚本行为完全不变
+
+## 非目标
+
+- 本次不放宽 `func_sig`、`gv_sig`、`patch_sig`、`offset_sig` 的唯一匹配语义
+- 本次不改变 `FUNC_VTABLE_RELATIONS`、`FUNC_XREFS`、`LLM_DECOMPILE` 的结构
+- 本次不引入新的 YAML 契约入口，仍以 `GENERATE_YAML_DESIRED_FIELDS` 为唯一声明入口
+- 本次不修改与 `vfunc_sig` 无关的 writer 顺序与字段语义
+
+## 方案比较
+
+### 方案 A：把 `vfunc_sig_max_match:N` 作为字段契约 directive，并持久化为 YAML 字段
+
+示例：
+
+```python
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "INetworkMessages_GetLoggingChannel",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_max_match:10",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+```
+
+优点：
+
+- 与用户给出的目标写法完全一致
+- 继续保持 `GENERATE_YAML_DESIRED_FIELDS` 作为唯一契约入口
+- 既能表达生成控制，又能自然落地为最终 YAML 字段
+
+缺点：
+
+- 公共层需要区分“真实输出字段”和“带参数 directive”
+
+### 方案 B：把 `vfunc_sig_max_match` 作为普通字段单独声明
+
+示例：
+
+```python
+["func_name", "vfunc_sig", "vfunc_sig_max_match", ...]
+```
+
+优点：
+
+- 字段名更接近普通 YAML key
+
+缺点：
+
+- 无法直接表达数值
+- 需要在脚本别处额外放参数，语义分散
+
+### 方案 C：增加独立配置入口
+
+示例：
+
+```python
+VFUNC_SIG_MATCH_LIMITS = [
+    ("INetworkMessages_GetLoggingChannel", 10),
+]
+```
+
+优点：
+
+- 类型边界最清晰
+
+缺点：
+
+- 打破 `GENERATE_YAML_DESIRED_FIELDS` 作为唯一契约入口的设计
+- 增加维护成本，不符合本次最短路径
+
+## 选定方案
+
+采用方案 A。
+
+`"vfunc_sig_max_match:10"` 保留在 `GENERATE_YAML_DESIRED_FIELDS` 中作为带参数 directive。公共层解析后：
+
+- 参与最终 YAML 输出的真实字段为 `vfunc_sig_max_match`
+- 参与生成期与复用期控制的选项值为 `10`
+
+这样既满足用户希望的脚本写法，也让 YAML 持久化后的复用链路具备完整语义。
+
+## 详细设计
+
+### 1. 字段契约模型
+
+`_normalize_generate_yaml_desired_fields(...)` 需要从当前“仅返回字段列表”的模型升级为“字段列表 + 生成选项”的模型。
+
+每个 symbol 的规范化结果建议包含两部分：
+
+- `desired_output_fields`
+- `generation_options`
+
+其中：
+
+- 普通字段如 `"func_name"`、`"vfunc_sig"` 进入 `desired_output_fields`
+- directive `"vfunc_sig_max_match:10"` 被解析为：
+  - 输出字段 `vfunc_sig_max_match`
+  - 生成选项 `{"vfunc_sig_max_match": 10}`
+
+建议规范化后的内部结构为：
+
+```python
+{
+    "INetworkMessages_GetLoggingChannel": {
+        "desired_output_fields": [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_max_match",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+        "generation_options": {
+            "vfunc_sig_max_match": 10,
+        },
+    }
+}
+```
+
+### 2. 合法字段与稳定顺序
+
+`func/vfunc` 类型的合法字段集合新增：
+
+- `vfunc_sig_max_match`
+
+稳定顺序建议更新为：
+
+1. `func_name`
+2. `func_va`
+3. `func_rva`
+4. `func_size`
+5. `func_sig`
+6. `vtable_name`
+7. `vfunc_offset`
+8. `vfunc_index`
+9. `vfunc_sig`
+10. `vfunc_sig_max_match`
+
+这样可保持现有顺序基本不变，并把 `vfunc_sig_max_match` 作为 `vfunc_sig` 的附属元数据放在其后。
+
+### 3. 契约校验规则
+
+新增以下校验：
+
+- `vfunc_sig_max_match:N` 中的 `N` 必须是正整数
+- 同一 symbol 不允许声明多个 `vfunc_sig_max_match:*`
+- 如果声明了 `vfunc_sig_max_match:*`，同一 symbol 必须同时声明 `vfunc_sig`
+- `vfunc_sig_max_match` 只允许出现在 `func/vfunc` 类型 symbol 中
+
+以下情况直接失败：
+
+- `"vfunc_sig_max_match:abc"`
+- `"vfunc_sig_max_match:0"`
+- `"vfunc_sig_max_match:-1"`
+- 同一个 symbol 同时出现 `"vfunc_sig_max_match:10"` 与 `"vfunc_sig_max_match:20"`
+- 存在 `"vfunc_sig_max_match:10"` 但没有 `vfunc_sig`
+
+未声明 `vfunc_sig_max_match` 时，默认值为 `1`，完全保持现有行为。
+
+### 4. payload 组装
+
+`_assemble_symbol_payload(...)` 不应再直接迭代原始字段字符串列表，而应只处理规范化后的 `desired_output_fields`。
+
+当某个 symbol 声明了 `vfunc_sig_max_match:N` 时，`candidate_data` 中必须出现：
+
+```python
+"vfunc_sig_max_match": N
+```
+
+最终写出的 YAML 形态应为：
+
+```yaml
+func_name: INetworkMessages_GetLoggingChannel
+vtable_name: INetworkMessages
+vfunc_offset: '0x120'
+vfunc_index: 36
+vfunc_sig: FF 90 20 01 00 00 ...
+vfunc_sig_max_match: 10
+```
+
+### 5. `vfunc_sig` 生成路径
+
+slot-only vfunc LLM fallback 路径如下：
+
+```python
+preprocess_common_skill(...)
+-> _build_enriched_slot_only_vfunc_payload_via_mcp(...)
+-> preprocess_gen_vfunc_sig_via_mcp(...)
+```
+
+这条链路需要支持把 `vfunc_sig_max_match` 逐层透传。
+
+建议在 `_build_enriched_slot_only_vfunc_payload_via_mcp(...)` 中新增参数：
+
+```python
+vfunc_sig_max_match=1
+```
+
+在 `preprocess_gen_vfunc_sig_via_mcp(...)` 中新增参数：
+
+```python
+max_match_count=1
+```
+
+成功条件从当前的：
+
+- `match_count == 1`
+
+改为：
+
+- `1 <= match_count <= max_match_count`
+- 且当前目标 `inst_va` 必须位于返回的 matches 中
+
+一旦满足该条件，就停止继续扩展 signature bytes。
+
+### 6. `find_bytes` 的调用方式
+
+为了区分“命中数已经不超过 N”与“实际命中数大于 N 但被截断”，`preprocess_gen_vfunc_sig_via_mcp(...)` 在测试候选签名时，不应继续固定使用：
+
+```python
+limit = 2
+```
+
+而应改为：
+
+```python
+limit = max_match_count + 1
+```
+
+例如：
+
+- `N = 1` 时，`limit = 2`，行为与当前完全一致
+- `N = 10` 时，`limit = 11`
+
+判定逻辑：
+
+- 若 `match_count > N`，继续扩展
+- 若 `1 <= match_count <= N` 且命中列表包含目标 `inst_va`，则接受该签名
+
+### 7. 旧 YAML 复用路径
+
+`preprocess_func_sig_via_mcp(...)` 当前内部 helper `_find_unique_match(...)` 被同时用于：
+
+- `func_sig`
+- `vfunc_sig`
+
+本次不建议直接放宽 `_find_unique_match(...)`，否则会把其它签名类型的“必须唯一匹配”语义一起改松。
+
+建议新增一个仅供 `vfunc_sig` 使用的受限匹配 helper，例如：
+
+```python
+_find_match_with_limit(signature, label, max_match_count)
+```
+
+语义：
+
+- `func_sig` 仍走 `_find_unique_match(...)`
+- `vfunc_sig` fallback 读取旧 YAML 中的 `vfunc_sig_max_match`
+- 若不存在该字段，则默认按 `1` 处理
+- 若存在，则允许 `match_count <= vfunc_sig_max_match`
+
+返回值仍然可以是一个代表性匹配地址，用于日志输出；真正定位函数地址的逻辑仍然依赖：
+
+- `vtable_name`
+- `vfunc_index`
+
+也就是说，多匹配只意味着“该 `vfunc_sig` 仍然有效”，并不意味着用它直接反推出唯一函数。
+
+### 8. slot-only YAML 的复用语义
+
+对没有 `func_va` 的 slot-only vfunc YAML：
+
+- 复用 `vfunc_sig` 时允许最多 `N` 个匹配
+- 但最终仍然只沿用：
+  - `vtable_name`
+  - `vfunc_offset`
+  - `vfunc_index`
+  - `vfunc_sig`
+  - `vfunc_sig_max_match`
+
+不会因为 `vfunc_sig` 存在多个命中而尝试从这些命中地址中选具体函数地址。
+
+### 9. 目标脚本形态
+
+`ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py` 的目标形态保持为：
+
+```python
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "INetworkMessages_GetLoggingChannel",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_max_match:10",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+```
+
+无需再引入新的独立配置入口。
+
+## 测试设计
+
+### 1. 契约解析测试
+
+在 `tests/test_ida_analyze_util.py` 中新增或调整以下测试：
+
+- 解析 `"vfunc_sig_max_match:10"` 成功
+- 输出字段中包含 `vfunc_sig_max_match`
+- 生成选项中记录整数值 `10`
+- 非法值、重复声明、缺少 `vfunc_sig` 时失败
+
+### 2. `vfunc_sig` 生成测试
+
+为 `preprocess_gen_vfunc_sig_via_mcp(...)` 增加测试：
+
+- `max_match_count=1` 时保持唯一匹配逻辑
+- `max_match_count=10` 且 `match_count=2` 时成功
+- `max_match_count=10` 且 `match_count=10` 时成功
+- `max_match_count=10` 且 `match_count=11` 时继续扩展，不应提前成功
+- 命中结果若不包含目标 `inst_va`，即使 `match_count <= N` 也失败
+
+### 3. slot-only fallback 测试
+
+扩展现有 slot-only vfunc 测试，验证：
+
+- `preprocess_common_skill(...)` 会把 `vfunc_sig_max_match` 透传到 `preprocess_gen_vfunc_sig_via_mcp(...)`
+- 最终写出的 payload 包含：
+  - `func_name`
+  - `vfunc_sig`
+  - `vfunc_sig_max_match`
+  - `vtable_name`
+  - `vfunc_offset`
+  - `vfunc_index`
+
+### 4. 旧 YAML 复用测试
+
+为 `preprocess_func_sig_via_mcp(...)` 增加测试：
+
+- 旧 YAML 带 `vfunc_sig_max_match: 10` 时，`vfunc_sig` 多匹配仍可成功进入 fallback
+- 旧 YAML 不带该字段时，仍要求唯一匹配
+- 旧 YAML 带非法 `vfunc_sig_max_match` 时失败
+
+### 5. 目标脚本测试
+
+在 `tests/test_ida_preprocessor_scripts.py` 中，为 `find-INetworkMessages_GetLoggingChannel-windows.py` 增加断言：
+
+- 转发给 `preprocess_common_skill(...)` 的 `generate_yaml_desired_fields` 中包含：
+
+```python
+"vfunc_sig_max_match:10"
+```
+
+## 风险与权衡
+
+### 风险 1：directive 与真实字段混用后增加解析复杂度
+
+应对：
+
+- 只为当前确有需求的 `vfunc_sig_max_match` 增加一类 directive
+- 不把任意 `name:value` 都当作通用机制无限扩张
+
+### 风险 2：误把多匹配语义扩散到其它签名类型
+
+应对：
+
+- 不修改 `_find_unique_match(...)` 的语义
+- 只在 `vfunc_sig` 路径引入受限匹配 helper
+
+### 风险 3：匹配计数被 `find_bytes limit` 截断导致误判
+
+应对：
+
+- 统一使用 `limit = N + 1`
+- 只有在确认 `match_count <= N` 时才接受
+
+## 验收标准
+
+- `GENERATE_YAML_DESIRED_FIELDS` 中的 `"vfunc_sig_max_match:10"` 不再被视为非法字段
+- 最终 YAML 会持久化 `vfunc_sig_max_match: 10`
+- `preprocess_gen_vfunc_sig_via_mcp(...)` 在匹配数降到 `<= N` 时停止扩展
+- `preprocess_func_sig_via_mcp(...)` 读取旧 YAML 后，会按 `vfunc_sig_max_match` 放宽 `vfunc_sig` 复用匹配条件
+- 未声明 `vfunc_sig_max_match` 的所有现有脚本行为保持不变
+
+## 实施边界
+
+- 本次只覆盖 `vfunc_sig_max_match`
+- 若未来需要类似 `func_sig_max_match`、`gv_sig_max_match` 等能力，应重新单独设计，而不是在本次实现中顺手泛化

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -232,12 +232,64 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
                 print(f"    Preprocess: empty desired-fields for {symbol_name}")
             return None
 
-        desired_field_list = list(desired_fields)
-        if any(not isinstance(field_name, str) or not field_name for field_name in desired_field_list):
+        desired_output_fields = []
+        generation_options = {}
+        for field_name in desired_fields:
+            if not isinstance(field_name, str) or not field_name:
+                if debug:
+                    print(f"    Preprocess: invalid desired field list for {symbol_name}")
+                return None
+
+            if field_name == "vfunc_sig_max_match":
+                if debug:
+                    print(
+                        f"    Preprocess: bare vfunc_sig_max_match field is "
+                        f"not allowed for {symbol_name}"
+                    )
+                return None
+
+            if field_name.startswith("vfunc_sig_max_match:"):
+                if "vfunc_sig_max_match" in generation_options:
+                    if debug:
+                        print(
+                            f"    Preprocess: duplicated vfunc_sig_max_match "
+                            f"directive for {symbol_name}"
+                        )
+                    return None
+                max_match_text = field_name.split(":", 1)[1]
+                try:
+                    max_match = int(max_match_text)
+                except ValueError:
+                    if debug:
+                        print(
+                            f"    Preprocess: invalid vfunc_sig_max_match "
+                            f"value for {symbol_name}: {max_match_text}"
+                        )
+                    return None
+                if max_match <= 0:
+                    if debug:
+                        print(
+                            f"    Preprocess: invalid vfunc_sig_max_match "
+                            f"value for {symbol_name}: {max_match_text}"
+                        )
+                    return None
+                desired_output_fields.append("vfunc_sig_max_match")
+                generation_options["vfunc_sig_max_match"] = max_match
+                continue
+
+            desired_output_fields.append(field_name)
+
+        if "vfunc_sig_max_match" in generation_options and "vfunc_sig" not in desired_output_fields:
             if debug:
-                print(f"    Preprocess: invalid desired field list for {symbol_name}")
+                print(
+                    f"    Preprocess: vfunc_sig_max_match requires vfunc_sig "
+                    f"for {symbol_name}"
+                )
             return None
-        normalized[symbol_name] = desired_field_list
+        normalized[symbol_name] = {
+            "desired_output_fields": desired_output_fields,
+            "generation_options": generation_options,
+        }
 
     return normalized
 
@@ -374,6 +426,7 @@ FUNC_YAML_ORDER = [
     "vfunc_offset",
     "vfunc_index",
     "vfunc_sig",
+    "vfunc_sig_max_match",
 ]
 GV_YAML_ORDER = [
     "gv_name",
@@ -437,11 +490,12 @@ def _build_ordered_yaml_payload(data, ordered_keys):
 
 
 def _assemble_symbol_payload(symbol_name, target_kind, candidate_data, desired_fields_map, debug=False):
-    desired_fields = desired_fields_map.get(symbol_name)
-    if desired_fields is None:
+    desired_field_spec = desired_fields_map.get(symbol_name)
+    if desired_field_spec is None:
         if debug:
             print(f"    Preprocess: missing desired-fields entry for {symbol_name}")
         return None
+    desired_fields = desired_field_spec["desired_output_fields"]
 
     payload = {}
     for field_name in desired_fields:
@@ -804,6 +858,7 @@ async def _build_enriched_slot_only_vfunc_payload_via_mcp(
     llm_result,
     *,
     vtable_name=None,
+    vfunc_sig_max_match=1,
     require_vfunc_sig=False,
     require_vtable_name=False,
     debug=False,
@@ -856,6 +911,7 @@ async def _build_enriched_slot_only_vfunc_payload_via_mcp(
             session=session,
             inst_va=inst_va,
             vfunc_offset=slot_only_info["vfunc_offset"],
+            max_match_count=vfunc_sig_max_match,
             debug=debug,
         )
         if not isinstance(sig_data, dict):
@@ -864,6 +920,9 @@ async def _build_enriched_slot_only_vfunc_payload_via_mcp(
         if not vfunc_sig:
             continue
         payload["vfunc_sig"] = str(vfunc_sig)
+        payload["vfunc_sig_max_match"] = int(
+            sig_data.get("vfunc_sig_max_match", vfunc_sig_max_match)
+        )
         if sig_data.get("vfunc_sig_disp") not in (None, 0, "0", "0x0"):
             payload["vfunc_sig_disp"] = sig_data["vfunc_sig_disp"]
         return payload
@@ -1793,6 +1852,18 @@ async def preprocess_func_sig_via_mcp(
             return int(raw, 0)
         return int(value)
 
+    def _parse_strict_int_field(value, field_name):
+        if isinstance(value, bool):
+            raise ValueError(f"invalid {field_name}")
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                raise ValueError(f"empty {field_name}")
+            return int(raw, 0)
+        raise ValueError(f"invalid {field_name}")
+
     async def _find_unique_match(signature, label):
         try:
             fb_result = await session.call_tool(
@@ -1817,6 +1888,51 @@ async def preprocess_func_sig_via_mcp(
         if match_count != 1:
             if debug:
                 print(f"    Preprocess: {label} matched {match_count} (need 1)")
+            return None
+
+        return matches[0]
+
+    async def _find_match_with_limit(signature, label, max_match_count):
+        try:
+            max_match_count = _parse_strict_int_field(
+                max_match_count,
+                "max_match_count",
+            )
+        except Exception:
+            return None
+
+        if max_match_count <= 0:
+            return None
+
+        try:
+            fb_result = await session.call_tool(
+                name="find_bytes",
+                arguments={
+                    "patterns": [signature],
+                    "limit": max_match_count + 1,
+                }
+            )
+            fb_data = parse_mcp_result(fb_result)
+        except Exception as e:
+            if debug:
+                print(f"    Preprocess: find_bytes error: {e}")
+            return None
+
+        if not isinstance(fb_data, list) or len(fb_data) == 0:
+            return None
+
+        entry = fb_data[0]
+        if not isinstance(entry, dict):
+            return None
+
+        matches = entry.get("matches", [])
+        match_count = entry.get("n", len(matches))
+        if match_count < 1 or match_count > max_match_count:
+            if debug:
+                print(
+                    f"    Preprocess: {label} matched {match_count} "
+                    f"(need 1..{max_match_count})"
+                )
             return None
 
         return matches[0]
@@ -1909,6 +2025,7 @@ async def preprocess_func_sig_via_mcp(
     vfunc_index = None
     vfunc_offset = None
     vfunc_match_addr = None
+    vfunc_sig_max_match = 1
 
     if func_sig:
         match_addr = await _find_unique_match(
@@ -1932,6 +2049,26 @@ async def preprocess_func_sig_via_mcp(
             if debug:
                 print(
                     "    Preprocess: no vtable_name for vfunc fallback in "
+                    f"{os.path.basename(old_path)}"
+                )
+            return None
+
+        try:
+            vfunc_sig_max_match = _parse_strict_int_field(
+                old_data.get("vfunc_sig_max_match", 1),
+                "vfunc_sig_max_match",
+            )
+        except Exception:
+            if debug:
+                print(
+                    "    Preprocess: invalid vfunc_sig_max_match in "
+                    f"{os.path.basename(old_path)}"
+                )
+            return None
+        if vfunc_sig_max_match <= 0:
+            if debug:
+                print(
+                    "    Preprocess: invalid vfunc_sig_max_match in "
                     f"{os.path.basename(old_path)}"
                 )
             return None
@@ -1976,8 +2113,10 @@ async def preprocess_func_sig_via_mcp(
                 )
             return None
 
-        vfunc_match_addr = await _find_unique_match(
-            vfunc_sig, f"{os.path.basename(old_path)} vfunc_sig"
+        vfunc_match_addr = await _find_match_with_limit(
+            vfunc_sig,
+            f"{os.path.basename(old_path)} vfunc_sig",
+            vfunc_sig_max_match,
         )
         if vfunc_match_addr is None:
             return None
@@ -1995,6 +2134,7 @@ async def preprocess_func_sig_via_mcp(
             new_data = {
                 "func_name": func_name,
                 "vfunc_sig": vfunc_sig,
+                "vfunc_sig_max_match": vfunc_sig_max_match,
                 "vtable_name": vtable_name,
                 "vfunc_offset": hex(vfunc_offset),
                 "vfunc_index": vfunc_index,
@@ -2065,6 +2205,7 @@ async def preprocess_func_sig_via_mcp(
     # vfunc fallback path: reuse old index/offset and regenerate func_sig from vtable-resolved function.
     if used_vfunc_fallback:
         new_data["vfunc_sig"] = vfunc_sig
+        new_data["vfunc_sig_max_match"] = vfunc_sig_max_match
         new_data["vtable_name"] = vtable_name
         new_data["vfunc_offset"] = hex(vfunc_offset)
         new_data["vfunc_index"] = vfunc_index
@@ -2535,6 +2676,7 @@ async def preprocess_gen_vfunc_sig_via_mcp(
     session,
     inst_va,
     vfunc_offset,
+    max_match_count=1,
     min_sig_bytes=6,
     max_sig_bytes=96,
     max_instructions=64,
@@ -2554,6 +2696,8 @@ async def preprocess_gen_vfunc_sig_via_mcp(
         inst_va: Virtual-call instruction address (int or hex string).
         vfunc_offset: Expected vtable slot displacement encoded by the target
             instruction (int or hex string).
+        max_match_count: Maximum acceptable number of signature matches while
+            still accepting the signature, as long as it contains `inst_va`.
         min_sig_bytes: Minimum signature prefix length to try.
         max_sig_bytes: Maximum bytes collected from signature start.
         max_instructions: Max instructions collected from signature start.
@@ -2598,9 +2742,15 @@ async def preprocess_gen_vfunc_sig_via_mcp(
         min_sig_bytes = max(1, int(min_sig_bytes))
         max_sig_bytes = max(1, int(max_sig_bytes))
         max_instructions = max(1, int(max_instructions))
+        max_match_count = int(max_match_count)
     except Exception:
         if debug:
             print("    Preprocess: invalid vfunc signature generation limits")
+        return None
+
+    if max_match_count <= 0:
+        if debug:
+            print("    Preprocess: invalid max_match_count for vfunc_sig")
         return None
 
     extra_wildcard_set = set()
@@ -2840,7 +2990,10 @@ async def preprocess_gen_vfunc_sig_via_mcp(
         try:
             fb_result = await session.call_tool(
                 name="find_bytes",
-                arguments={"patterns": [candidate_sig], "limit": 2},
+                arguments={
+                    "patterns": [candidate_sig],
+                    "limit": max_match_count + 1,
+                },
             )
             fb_data = parse_mcp_result(fb_result)
         except Exception as e:
@@ -2858,15 +3011,17 @@ async def preprocess_gen_vfunc_sig_via_mcp(
         matches = entry.get("matches", [])
         match_count = entry.get("n", len(matches))
 
-        if match_count != 1 or not matches:
+        if match_count < 1 or match_count > max_match_count or not matches:
             continue
 
+        match_addrs = set()
         try:
-            match_addr = _parse_addr(matches[0])
+            for match in matches:
+                match_addrs.add(_parse_addr(match))
         except Exception:
             continue
 
-        if match_addr != inst_va_int:
+        if inst_va_int not in match_addrs:
             continue
 
         best_sig = candidate_sig
@@ -2895,6 +3050,7 @@ async def preprocess_gen_vfunc_sig_via_mcp(
         "vfunc_disp_offset": disp_off,
         "vfunc_disp_size": disp_size,
         "vfunc_offset": hex(vfunc_offset_int),
+        "vfunc_sig_max_match": max_match_count,
     }
 
 
@@ -5374,12 +5530,13 @@ async def preprocess_common_skill(
     if target_kind_map is None:
         return False
 
-    for symbol_name, desired_fields in desired_fields_map.items():
+    for symbol_name, desired_field_spec in desired_fields_map.items():
         target_kind = target_kind_map.get(symbol_name)
         if target_kind is None:
             if debug:
                 print(f"    Preprocess: unknown desired-fields symbol: {symbol_name}")
             return False
+        desired_fields = desired_field_spec["desired_output_fields"]
         allowed_fields = TARGET_KIND_TO_FIELD_SET[target_kind]
         invalid_fields = [
             field_name for field_name in desired_fields
@@ -5764,11 +5921,13 @@ async def preprocess_common_skill(
     for func_name in all_func_names:
         target_output = matched_func_outputs[func_name]
         old_path = (old_yaml_map or {}).get(target_output)
-        desired_fields = desired_fields_map.get(func_name)
-        if desired_fields is None:
+        desired_field_spec = desired_fields_map.get(func_name)
+        if desired_field_spec is None:
             if debug:
                 print(f"    Preprocess: missing desired-fields entry for {func_name}")
             return False
+        desired_fields = desired_field_spec["desired_output_fields"]
+        generation_options = desired_field_spec["generation_options"]
         desired_fields_set = set(desired_fields)
 
         if func_name not in fast_path_attempted:
@@ -5887,6 +6046,7 @@ async def preprocess_common_skill(
                     func_name=func_name,
                     llm_result=llm_result,
                     vtable_name=fallback_vtable_name,
+                    vfunc_sig_max_match=generation_options.get("vfunc_sig_max_match", 1),
                     require_vfunc_sig="vfunc_sig" in desired_fields_set,
                     require_vtable_name="vtable_name" in desired_fields_set,
                     debug=debug,

--- a/ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py
+++ b/ida_preprocessor_scripts/find-INetworkMessages_GetLoggingChannel-windows.py
@@ -28,6 +28,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         [
             "func_name",
             "vfunc_sig",
+            "vfunc_sig_max_match:10",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -506,6 +506,153 @@ class TestGenerateYamlDesiredFieldsContract(unittest.IsolatedAsyncioTestCase):
         mock_preprocess_func_sig.assert_not_awaited()
         mock_write_func_yaml.assert_not_called()
 
+    async def test_normalize_generate_yaml_desired_fields_parses_vfunc_sig_max_match_directive(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:10",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertEqual(
+            {
+                "Foo": {
+                    "desired_output_fields": [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match",
+                    ],
+                    "generation_options": {
+                        "vfunc_sig_max_match": 10,
+                    },
+                }
+            },
+            result,
+        )
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_vfunc_sig_max_match_without_vfunc_sig(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig_max_match:10",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_invalid_vfunc_sig_max_match_value(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:abc",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_bare_vfunc_sig_max_match_field(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_duplicate_vfunc_sig_max_match_directive(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:10",
+                        "vfunc_sig_max_match:12",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_zero_vfunc_sig_max_match_value(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:0",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_normalize_generate_yaml_desired_fields_rejects_negative_vfunc_sig_max_match_value(
+        self,
+    ) -> None:
+        result = ida_analyze_util._normalize_generate_yaml_desired_fields(
+            [
+                (
+                    "Foo",
+                    [
+                        "func_name",
+                        "vfunc_sig",
+                        "vfunc_sig_max_match:-1",
+                    ],
+                )
+            ],
+            debug=True,
+        )
+
+        self.assertIsNone(result)
+
     async def test_preprocess_common_skill_rejects_missing_desired_fields_before_any_write(
         self,
     ) -> None:
@@ -637,6 +784,67 @@ class TestGenerateYamlDesiredFieldsContract(unittest.IsolatedAsyncioTestCase):
                 "vfunc_index": 1,
             },
             mock_write_func_yaml.call_args.args[1],
+        )
+
+    async def test_preprocess_common_skill_writes_vfunc_sig_max_match_field(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "preprocess_func_sig_via_mcp",
+            AsyncMock(
+                return_value={
+                    "func_name": "Foo",
+                    "func_va": "0x180004000",
+                    "func_sig": "AA BB",
+                    "vfunc_sig": "48 89 5C 24 ? ? 57",
+                    "vfunc_sig_max_match": 10,
+                    "vtable_name": "Bar",
+                }
+            ),
+        ), patch.object(
+            ida_analyze_util,
+            "write_func_yaml",
+        ) as mock_write_func_yaml, patch.object(
+            ida_analyze_util,
+            "_rename_func_in_ida",
+            AsyncMock(return_value=None),
+        ):
+            result = await ida_analyze_util.preprocess_common_skill(
+                session="session",
+                expected_outputs=["/tmp/Foo.windows.yaml"],
+                old_yaml_map={},
+                new_binary_dir="/tmp",
+                platform="windows",
+                image_base=0x180000000,
+                func_names=["Foo"],
+                generate_yaml_desired_fields=[
+                    (
+                        "Foo",
+                        [
+                            "vfunc_sig_max_match:10",
+                            "func_name",
+                            "vfunc_sig",
+                        ],
+                    )
+                ],
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_write_func_yaml.assert_called_once()
+        written_payload = mock_write_func_yaml.call_args.args[1]
+        self.assertEqual(
+            ["func_name", "vfunc_sig", "vfunc_sig_max_match"],
+            list(written_payload.keys()),
+        )
+        self.assertEqual(
+            {
+                "func_name": "Foo",
+                "vfunc_sig": "48 89 5C 24 ? ? 57",
+                "vfunc_sig_max_match": 10,
+            },
+            written_payload,
         )
 
     async def test_preprocess_common_skill_rejects_missing_requested_func_field(
@@ -1499,9 +1707,155 @@ found_struct_offset: []
                 "vfunc_disp_offset": 2,
                 "vfunc_disp_size": 4,
                 "vfunc_offset": "0x78",
+                "vfunc_sig_max_match": 1,
             },
             result,
         )
+
+    async def test_preprocess_gen_vfunc_sig_via_mcp_accepts_match_count_within_limit(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                return _py_eval_payload(
+                    {
+                        "vfunc_sig_va": "0x18004abc3",
+                        "vfunc_inst_length": 6,
+                        "vfunc_disp_offset": 2,
+                        "vfunc_disp_size": 4,
+                        "insts": [
+                            {
+                                "ea": "0x18004abc3",
+                                "size": 6,
+                                "bytes": "ff9078000000",
+                                "wild": [],
+                            },
+                        ],
+                    }
+                )
+            if name == "find_bytes":
+                self.assertEqual(["FF 90 78 00 00 00"], arguments["patterns"])
+                self.assertEqual(11, arguments["limit"])
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": ["0x18004abc3", "0x18010abc3"],
+                            "n": 2,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_vfunc_sig_via_mcp(
+            session=session,
+            inst_va="0x18004ABC3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=False,
+        )
+
+        self.assertEqual("FF 90 78 00 00 00", result["vfunc_sig"])
+        self.assertEqual(10, result["vfunc_sig_max_match"])
+
+    async def test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_count_over_limit(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                return _py_eval_payload(
+                    {
+                        "vfunc_sig_va": "0x18004abc3",
+                        "vfunc_inst_length": 6,
+                        "vfunc_disp_offset": 2,
+                        "vfunc_disp_size": 4,
+                        "insts": [
+                            {
+                                "ea": "0x18004abc3",
+                                "size": 6,
+                                "bytes": "ff9078000000",
+                                "wild": [],
+                            },
+                        ],
+                    }
+                )
+            if name == "find_bytes":
+                self.assertEqual(["FF 90 78 00 00 00"], arguments["patterns"])
+                self.assertEqual(11, arguments["limit"])
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": ["0x18004abc3"],
+                            "n": 11,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_vfunc_sig_via_mcp(
+            session=session,
+            inst_va="0x18004ABC3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=False,
+        )
+
+        self.assertIsNone(result)
+
+    async def test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_set_without_target_inst(
+        self,
+    ) -> None:
+        session = AsyncMock()
+
+        def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+            if name == "py_eval":
+                return _py_eval_payload(
+                    {
+                        "vfunc_sig_va": "0x18004abc3",
+                        "vfunc_inst_length": 6,
+                        "vfunc_disp_offset": 2,
+                        "vfunc_disp_size": 4,
+                        "insts": [
+                            {
+                                "ea": "0x18004abc3",
+                                "size": 6,
+                                "bytes": "ff9078000000",
+                                "wild": [],
+                            },
+                        ],
+                    }
+                )
+            if name == "find_bytes":
+                self.assertEqual(["FF 90 78 00 00 00"], arguments["patterns"])
+                self.assertEqual(11, arguments["limit"])
+                return _FakeCallToolResult(
+                    [
+                        {
+                            "matches": ["0x18010abc3", "0x18020abc3"],
+                            "n": 2,
+                        }
+                    ]
+                )
+            raise AssertionError(f"unexpected MCP tool: {name}")
+
+        session.call_tool.side_effect = _fake_call_tool
+
+        result = await ida_analyze_util.preprocess_gen_vfunc_sig_via_mcp(
+            session=session,
+            inst_va="0x18004ABC3",
+            vfunc_offset="0x78",
+            max_match_count=10,
+            debug=False,
+        )
+
+        self.assertIsNone(result)
 
     async def test_preprocess_common_skill_uses_llm_decompile_vcall_fallback_for_func_yaml(
         self,
@@ -2995,6 +3349,7 @@ found_struct_offset: []
                             [
                                 "func_name",
                                 "vfunc_sig",
+                                "vfunc_sig_max_match:10",
                                 "vtable_name",
                                 "vfunc_offset",
                                 "vfunc_index",
@@ -3020,12 +3375,14 @@ found_struct_offset: []
             session=session,
             inst_va="0x18004abc3",
             vfunc_offset="0x78",
+            max_match_count=10,
             debug=True,
         )
         mock_write_func_yaml.assert_called_once()
         written_payload = mock_write_func_yaml.call_args.args[1]
         self.assertEqual(func_name, written_payload["func_name"])
         self.assertEqual("FF 90 78 00 00 00 48 8B C8", written_payload["vfunc_sig"])
+        self.assertEqual(10, written_payload["vfunc_sig_max_match"])
         self.assertEqual("CNetworkMessages", written_payload["vtable_name"])
         self.assertEqual("0x78", written_payload["vfunc_offset"])
         self.assertEqual(15, written_payload["vfunc_index"])
@@ -3177,17 +3534,167 @@ found_struct_offset: []
                     session=session,
                     inst_va="0x1d859bf",
                     vfunc_offset="0xa8",
+                    max_match_count=1,
                     debug=True,
                 ),
                 call(
                     session=session,
                     inst_va="0x1d85a10",
                     vfunc_offset="0xa8",
+                    max_match_count=1,
                     debug=True,
                 ),
             ]
         )
         mock_write_func_yaml.assert_not_called()
+
+
+class TestPreprocessFuncSigViaMcpVfuncSigMaxMatch(unittest.IsolatedAsyncioTestCase):
+    async def _preprocess_with_vfunc_sig_max_match(self, max_match_count):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            old_path = Path(temp_dir) / "INetworkMessages_GetLoggingChannel.windows.yaml"
+            new_path = Path(temp_dir) / "INetworkMessages_GetLoggingChannel.new.windows.yaml"
+
+            _write_yaml(
+                old_path,
+                {
+                    "func_name": "INetworkMessages_GetLoggingChannel",
+                    "vfunc_sig": "FF 90 20 01 00 00",
+                    "vfunc_sig_max_match": max_match_count,
+                    "vtable_name": "INetworkMessages",
+                    "vfunc_offset": "0x120",
+                    "vfunc_index": 36,
+                    "func_va": "0x180111111",
+                },
+            )
+            _write_yaml(
+                Path(temp_dir) / "INetworkMessages_vtable.windows.yaml",
+                {
+                    "vtable_entries": {
+                        36: "0x180222222",
+                    }
+                },
+            )
+
+            session = AsyncMock()
+
+            async def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+                if name == "find_bytes":
+                    return _FakeCallToolResult(
+                        [
+                            {
+                                "matches": ["0x180012340"],
+                                "n": 1,
+                            }
+                        ]
+                    )
+                if name == "py_eval":
+                    return _py_eval_payload(
+                        {
+                            "func_va": "0x180222222",
+                            "func_size": "0x40",
+                        }
+                    )
+                raise AssertionError(f"unexpected MCP tool: {name}")
+
+            session.call_tool.side_effect = _fake_call_tool
+
+            result = await ida_analyze_util.preprocess_func_sig_via_mcp(
+                session=session,
+                new_path=str(new_path),
+                old_path=str(old_path),
+                image_base=0x180000000,
+                new_binary_dir=temp_dir,
+                platform="windows",
+                debug=True,
+            )
+
+        return result, session
+
+    async def test_preprocess_func_sig_via_mcp_allows_vfunc_sig_match_count_within_limit(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            old_path = Path(temp_dir) / "INetworkMessages_GetLoggingChannel.windows.yaml"
+            new_path = Path(temp_dir) / "INetworkMessages_GetLoggingChannel.new.windows.yaml"
+
+            _write_yaml(
+                old_path,
+                {
+                    "func_name": "INetworkMessages_GetLoggingChannel",
+                    "vfunc_sig": "FF 90 20 01 00 00",
+                    "vfunc_sig_max_match": 10,
+                    "vtable_name": "INetworkMessages",
+                    "vfunc_offset": "0x120",
+                    "vfunc_index": 36,
+                    "func_va": "0x180111111",
+                },
+            )
+            _write_yaml(
+                Path(temp_dir) / "INetworkMessages_vtable.windows.yaml",
+                {
+                    "vtable_entries": {
+                        36: "0x180222222",
+                    }
+                },
+            )
+
+            session = AsyncMock()
+
+            async def _fake_call_tool(*, name: str, arguments: dict[str, object]):
+                if name == "find_bytes":
+                    self.assertEqual(
+                        ["FF 90 20 01 00 00"],
+                        arguments["patterns"],
+                    )
+                    return _FakeCallToolResult(
+                        [
+                            {
+                                "matches": ["0x180012340", "0x180056780"],
+                                "n": 2,
+                            }
+                        ]
+                    )
+                if name == "py_eval":
+                    return _py_eval_payload(
+                        {
+                            "func_va": "0x180222222",
+                            "func_size": "0x40",
+                        }
+                    )
+                raise AssertionError(f"unexpected MCP tool: {name}")
+
+            session.call_tool.side_effect = _fake_call_tool
+
+            result = await ida_analyze_util.preprocess_func_sig_via_mcp(
+                session=session,
+                new_path=str(new_path),
+                old_path=str(old_path),
+                image_base=0x180000000,
+                new_binary_dir=temp_dir,
+                platform="windows",
+                debug=True,
+            )
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(10, result["vfunc_sig_max_match"])
+        self.assertEqual("FF 90 20 01 00 00", result["vfunc_sig"])
+        self.assertEqual(36, result["vfunc_index"])
+
+    async def test_preprocess_func_sig_via_mcp_rejects_invalid_vfunc_sig_max_match(
+        self,
+    ) -> None:
+        invalid_values = [True, 1.5, 0, "abc"]
+
+        for invalid_value in invalid_values:
+            with self.subTest(vfunc_sig_max_match=invalid_value):
+                result, session = await self._preprocess_with_vfunc_sig_max_match(
+                    invalid_value,
+                )
+
+                self.assertIsNone(result)
+                session.call_tool.assert_not_awaited()
 
 
 if __name__ == "__main__":

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -18,6 +18,10 @@ I_SET_IS_FOR_SERVER_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-INetworkMessages_SetIsForServer.py"
 )
+I_GET_LOGGING_CHANNEL_WINDOWS_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/"
+    "find-INetworkMessages_GetLoggingChannel-windows.py"
+)
 NETWORK_GROUP_STATS_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CNetworkMessages_GetNetworkGroupCount-AND-"
@@ -920,6 +924,80 @@ class TestFindCBaseEntityCollisionRulesChanged(unittest.IsolatedAsyncioTestCase)
             platform="windows",
             image_base=0x180000000,
             func_names=["CBaseEntity_CollisionRulesChanged"],
+            generate_yaml_desired_fields=expected_generate_yaml_desired_fields,
+            debug=True,
+        )
+
+
+class TestFindINetworkMessagesGetLoggingChannelWindows(
+    unittest.IsolatedAsyncioTestCase
+):
+    async def test_preprocess_skill_forwards_vfunc_sig_max_match_directive(
+        self,
+    ) -> None:
+        module = _load_module(
+            I_GET_LOGGING_CHANNEL_WINDOWS_SCRIPT_PATH,
+            "find_INetworkMessages_GetLoggingChannel_windows",
+        )
+        mock_preprocess_common_skill = AsyncMock(return_value=True)
+        llm_config = {"model": "gpt-4.1-mini", "api_key": "test-api-key"}
+        expected_llm_decompile_specs = [
+            (
+                "INetworkMessages_GetLoggingChannel",
+                "prompt/call_llm_decompile.md",
+                (
+                    "references/server/"
+                    "CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes."
+                    "{platform}.yaml"
+                ),
+            )
+        ]
+        expected_func_vtable_relations = [
+            ("INetworkMessages_GetLoggingChannel", "INetworkMessages")
+        ]
+        expected_generate_yaml_desired_fields = [
+            (
+                "INetworkMessages_GetLoggingChannel",
+                [
+                    "func_name",
+                    "vfunc_sig",
+                    "vfunc_sig_max_match:10",
+                    "vfunc_offset",
+                    "vfunc_index",
+                    "vtable_name",
+                ],
+            )
+        ]
+
+        with patch.object(
+            module,
+            "preprocess_common_skill",
+            mock_preprocess_common_skill,
+        ):
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"k": "v"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                llm_config=llm_config,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_preprocess_common_skill.assert_awaited_once_with(
+            session="session",
+            expected_outputs=["out.yaml"],
+            old_yaml_map={"k": "v"},
+            new_binary_dir="bin_dir",
+            platform="windows",
+            image_base=0x180000000,
+            func_names=["INetworkMessages_GetLoggingChannel"],
+            func_vtable_relations=expected_func_vtable_relations,
+            llm_decompile_specs=expected_llm_decompile_specs,
+            llm_config=llm_config,
             generate_yaml_desired_fields=expected_generate_yaml_desired_fields,
             debug=True,
         )


### PR DESCRIPTION
## Summary
- add `vfunc_sig_max_match` directive parsing and func YAML persistence
- allow generated and slot-only `vfunc_sig` paths to accept `<= N` matches and persist the bound
- reuse `vfunc_sig_max_match` from old YAML in the `vfunc_sig` fallback path and cover the flow with regression tests

## Test Plan
- `python -m unittest tests.test_ida_analyze_util.TestGenerateYamlDesiredFieldsContract tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_generates_current_version_sig tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_accepts_match_count_within_limit tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_count_over_limit tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_vfunc_sig_via_mcp_rejects_match_set_without_target_inst tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_uses_slot_only_fallback_when_vtable_unavailable tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_fails_when_slot_only_vfunc_sig_generation_fails tests.test_ida_analyze_util.TestPreprocessFuncSigViaMcpVfuncSigMaxMatch tests.test_ida_preprocessor_scripts.TestFindINetworkMessagesGetLoggingChannelWindows -v`
- broader module suites still show pre-existing baseline failures unrelated to this patch:
  - `tests.test_ida_analyze_util.TestLlmDecompileSupport.test_call_llm_decompile_uses_shared_llm_helper_and_parses_yaml`
  - `tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_gen_struct_offset_sig_via_mcp_generates_current_version_sig`
  - several existing failures in `tests.test_ida_preprocessor_scripts`
