### PR TITLE
refactor(func-xrefs): 增加exclude_strings并统一六元组契约

### DIFF
--- a/.serena/memories/preprocess_common_skill_func_xrefs.md
+++ b/.serena/memories/preprocess_common_skill_func_xrefs.md
@@ -1,24 +1,20 @@
 # preprocess_common_skill func_xrefs
 
 ## Summary
-- `preprocess_common_skill` 只接受统一的 `func_xrefs`；旧的 `func_xref_strings` 已经移除。
-- 当前 `func_xrefs` 还能与 `func_vtable_relations` 联动，为同名函数追加 vtable-entry 候选集约束。
+- `preprocess_common_skill` 只接受统一的 `func_xrefs`
+- `func_xrefs` 现固定为六元组：
+  `(func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)`
+- `exclude_strings_list` 与 `xref_strings_list` 一样使用子串匹配
 
 ## Contract
-- `func_xrefs` 条目格式：`(func_name, xref_strings_list, xref_funcs_list, exclude_funcs_list)`
-- `xref_strings_list` 与 `xref_funcs_list` 不能同时为空
-- 三个列表字段都必须只包含非空字符串
-- `exclude_funcs_list` 在正向候选集求交之后、唯一性校验之前做差集过滤
-
-## Dependency resolution
-- `xref_funcs_list` 与 `exclude_funcs_list` 只会从 `new_binary_dir` 下的当前版本 YAML 读取地址
-- YAML 路径模式：`{func_name}.{platform}.yaml`
-- 必需字段：`func_va`
-- xref 依赖解析不会读取 `old_yaml_map`
-- 当同一函数也出现在 `func_vtable_relations` 中时，`preprocess_common_skill` 会把对应的 `vtable_class` 传给 `preprocess_func_xrefs_via_mcp`，让候选函数额外受 vtable entries 约束
+- `xref_strings_list`、`xref_signatures_list`、`xref_funcs_list` 不能同时为空
+- `exclude_funcs_list` 与 `exclude_strings_list` 可为空
+- 旧 5 元组不再支持，命中后应直接视为非法配置
 
 ## Operational notes
-- `config.yaml` 中的 skill 顺序必须保证依赖 YAML 已在执行 `func_xrefs` 脚本前生成
-- `func_xrefs` 当前支持纯字符串、纯函数、字符串+函数联合求交，以及求交后的排除过滤
-- 只出现在 `func_xrefs`、不在 `func_names` 里的函数，也会被并入正常的 func 处理流水线并写出标准函数 YAML
-- `CNetworkGameClient_ProcessPacketEntities` 仍依赖 `CNetworkGameClient_ProcessPacketEntitiesInternal.{platform}.yaml`
+- `exclude_funcs_list` 在正向交集后按 `func_va` 做差集
+- `exclude_strings_list` 在正向交集后，按字符串 xref 所属函数集合并集做差集
+- `exclude_strings_list` 若某个字符串没有命中任何函数，不视为失败，只视为空排除集
+- `find-CBaseEntity_SetStateChanged.py` 的 Linux 路径使用
+  `CNetworkTransmitComponent::StateChanged(%s) @%s:%d`
+  作为内联 vcall 排除字符串

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -4315,9 +4315,9 @@ def _parse_int_value(value):
 
 
 def _parse_func_start_set_from_py_eval(eval_data, debug=False):
-    """Parse py_eval JSON payload and return function-start address set."""
+    """Parse py_eval JSON payload, or return None on invalid payload."""
     if not isinstance(eval_data, dict):
-        return set()
+        return None
 
     stderr_text = eval_data.get("stderr", "")
     if stderr_text and debug:
@@ -4326,15 +4326,15 @@ def _parse_func_start_set_from_py_eval(eval_data, debug=False):
 
     result_str = eval_data.get("result", "")
     if not result_str:
-        return set()
+        return None
 
     try:
         parsed = json.loads(result_str)
     except (json.JSONDecodeError, TypeError):
-        return set()
+        return None
 
     if not isinstance(parsed, list):
-        return set()
+        return None
 
     func_starts = set()
     for item in parsed:
@@ -4350,7 +4350,7 @@ async def _collect_xref_func_starts_for_string(session, xref_string, debug=False
     Collect function-start addresses that reference the given string literal.
 
     Returns:
-        Set[int]: Function start addresses.
+        Set[int]: Function start addresses, or None on collection failure.
     """
     if not isinstance(xref_string, str) or not xref_string:
         return set()
@@ -4377,7 +4377,7 @@ async def _collect_xref_func_starts_for_string(session, xref_string, debug=False
     except Exception as e:
         if debug:
             print(f"    Preprocess: py_eval error for xref string search: {e}")
-        return set()
+        return None
 
     return _parse_func_start_set_from_py_eval(eval_data, debug=debug)
 
@@ -4387,7 +4387,7 @@ async def _collect_xref_func_starts_for_ea(session, target_ea, debug=False):
     Collect function-start addresses that reference the specified target address.
 
     Returns:
-        Set[int]: Function start addresses.
+        Set[int]: Function start addresses, or None on py_eval failure.
     """
     try:
         target_ea_int = _parse_int_value(target_ea)
@@ -4414,7 +4414,7 @@ async def _collect_xref_func_starts_for_ea(session, target_ea, debug=False):
     except Exception as e:
         if debug:
             print(f"    Preprocess: py_eval error for xref ea search: {e}")
-        return set()
+        return None
 
     return _parse_func_start_set_from_py_eval(eval_data, debug=debug)
 
@@ -4426,7 +4426,7 @@ async def _collect_xref_func_starts_for_signature(
     Collect function-start addresses that contain bytes matched by a signature.
 
     Returns:
-        Set[int]: Function start addresses.
+        Set[int]: Function start addresses, or None on py_eval failure.
     """
     if not isinstance(xref_signature, str) or not xref_signature:
         return set()
@@ -4478,7 +4478,7 @@ async def _collect_xref_func_starts_for_signature(
     except Exception as e:
         if debug:
             print(f"    Preprocess: py_eval error for xref signature search: {e}")
-        return set()
+        return None
 
     return _parse_func_start_set_from_py_eval(eval_data, debug=debug)
 
@@ -4984,6 +4984,7 @@ async def preprocess_func_xrefs_via_mcp(
     xref_signatures,
     xref_funcs,
     exclude_funcs,
+    exclude_strings,
     new_binary_dir,
     platform,
     image_base,
@@ -5001,6 +5002,13 @@ async def preprocess_func_xrefs_via_mcp(
     ``func_va`` values are loaded from current-version YAML files in
     ``new_binary_dir`` and removed from the intersection result before
     enforcing the uniqueness check.
+
+    ``exclude_strings`` uses the same substring matching semantics as
+    ``xref_strings``. For each configured string, collect the containing
+    function-start set from its xrefs, union these sets, and subtract the
+    result from the already-intersected positive candidate set. Empty
+    exclude-string matches are treated as an empty exclusion set rather
+    than a hard failure.
 
     When ``vtable_class`` is given, the vtable YAML file
     ``{vtable_class}_vtable.{platform}.yaml`` is loaded from
@@ -5071,6 +5079,11 @@ async def preprocess_func_xrefs_via_mcp(
         addr_set = await _collect_xref_func_starts_for_string(
             session=session, xref_string=xref_string, debug=debug
         )
+        if addr_set is None:
+            if debug:
+                short = str(xref_string)[:80]
+                print(f"    Preprocess: failed to collect string xref: {short}")
+            return None
         if not addr_set:
             if debug:
                 short = str(xref_string)[:80]
@@ -5164,11 +5177,50 @@ async def preprocess_func_xrefs_via_mcp(
     for addr_set in candidate_sets[1:]:
         common_funcs = common_funcs & addr_set
 
-    if excluded_func_addrs:
-        common_funcs -= excluded_func_addrs
+    excluded_string_func_addrs = set()
+    for excluded_string in (exclude_strings or []):
+        addr_set = await _collect_xref_func_starts_for_string(
+            session=session,
+            xref_string=excluded_string,
+            debug=debug,
+        )
+        if addr_set is None:
+            if debug:
+                short = str(excluded_string)[:80]
+                print(
+                    f"    Preprocess: failed to collect exclude string xref: {short}"
+                )
+            return None
+        if debug:
+            short = str(excluded_string)[:80]
+            print(
+                f"    Preprocess: exclude string xref '{short}' matched "
+                f"{len(addr_set)} function(s)"
+            )
+        excluded_string_func_addrs |= set(addr_set)
+
+    if debug and excluded_string_func_addrs:
+        print(
+            "    Preprocess: excluded_string_func_addrs = "
+            f"{[hex(a) for a in sorted(excluded_string_func_addrs)]}"
+        )
 
     if debug:
-        print(f"    Preprocess: common_funcs = {[hex(a) for a in common_funcs]}")
+        print(
+            "    Preprocess: common_funcs before excludes = "
+            f"{[hex(a) for a in sorted(common_funcs)]}"
+        )
+
+    if excluded_func_addrs:
+        common_funcs -= excluded_func_addrs
+    if excluded_string_func_addrs:
+        common_funcs -= excluded_string_func_addrs
+
+    if debug:
+        print(
+            "    Preprocess: common_funcs after excludes = "
+            f"{[hex(a) for a in sorted(common_funcs)]}"
+        )
 
     if len(common_funcs) != 1:
         if debug:
@@ -5282,6 +5334,7 @@ async def _try_preprocess_func_without_llm(
             xref_signatures=xref_spec["xref_signatures"],
             xref_funcs=xref_spec["xref_funcs"],
             exclude_funcs=xref_spec["exclude_funcs"],
+            exclude_strings=xref_spec["exclude_strings"],
             new_binary_dir=new_binary_dir,
             platform=platform,
             image_base=image_base,
@@ -5390,7 +5443,7 @@ async def preprocess_common_skill(
     - ``func_xrefs``: locate functions via unified xref fallback through
       ``preprocess_func_xrefs_via_mcp``. Each element is a tuple of
       ``(func_name, xref_strings_list, xref_signatures_list, xref_funcs_list,``
-      ``exclude_funcs_list)``. ``xref_strings`` provides string
+      ``exclude_funcs_list, exclude_strings_list)``. ``xref_strings`` provides string
       cross-reference constraints, ``xref_signatures`` provides byte-pattern
       constraints mapped to containing function starts, and ``xref_funcs``
       provides dependency function names whose addresses are read only from
@@ -5423,7 +5476,7 @@ async def preprocess_common_skill(
         inherit_vfuncs: List of inherited vfunc specs (may be empty/None).
         func_xrefs: List of
             (func_name, xref_strings_list, xref_signatures_list,
-            xref_funcs_list, exclude_funcs_list) tuples for unified
+            xref_funcs_list, exclude_funcs_list, exclude_strings_list) tuples for unified
             xref-based function lookup (may be empty/None). Dependency and
             exclude function addresses are read only from current-version
             YAML files.
@@ -5469,7 +5522,7 @@ async def preprocess_common_skill(
 
     func_xrefs_map = {}
     for spec in func_xrefs:
-        if not isinstance(spec, (tuple, list)) or len(spec) != 5:
+        if not isinstance(spec, (tuple, list)) or len(spec) != 6:
             if debug:
                 print(f"    Preprocess: invalid func_xrefs spec: {spec}")
             return False
@@ -5480,6 +5533,7 @@ async def preprocess_common_skill(
             xref_signatures,
             xref_funcs,
             exclude_funcs,
+            exclude_strings,
         ) = spec
         if not isinstance(func_name, str) or not func_name:
             if debug:
@@ -5523,10 +5577,19 @@ async def preprocess_common_skill(
                 )
             return False
 
+        if not isinstance(exclude_strings, (tuple, list)):
+            if debug:
+                print(
+                    f"    Preprocess: invalid exclude_strings type for "
+                    f"{func_name}: {type(exclude_strings).__name__}"
+                )
+            return False
+
         xref_strings = list(xref_strings)
         xref_signatures = list(xref_signatures)
         xref_funcs = list(xref_funcs)
         exclude_funcs = list(exclude_funcs)
+        exclude_strings = list(exclude_strings)
         if any(not isinstance(item, str) or not item for item in xref_strings):
             if debug:
                 print(f"    Preprocess: invalid xref_strings values for {func_name}")
@@ -5549,6 +5612,13 @@ async def preprocess_common_skill(
                 print(f"    Preprocess: invalid exclude_funcs values for {func_name}")
             return False
 
+        if any(not isinstance(item, str) or not item for item in exclude_strings):
+            if debug:
+                print(
+                    f"    Preprocess: invalid exclude_strings values for {func_name}"
+                )
+            return False
+
         if not xref_strings and not xref_signatures and not xref_funcs:
             if debug:
                 print(f"    Preprocess: empty func_xrefs spec for {func_name}")
@@ -5559,6 +5629,7 @@ async def preprocess_common_skill(
             "xref_signatures": xref_signatures,
             "xref_funcs": xref_funcs,
             "exclude_funcs": exclude_funcs,
+            "exclude_strings": exclude_strings,
         }
 
     target_kind_map = _build_target_kind_map(

--- a/ida_preprocessor_scripts/find-CBaseEntity_SetStateChanged.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_SetStateChanged.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS_WINDOWS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CBaseEntity_SetStateChanged",
         [
@@ -17,17 +17,21 @@ FUNC_XREFS_WINDOWS = [
         [],
         ["CNetworkTransmitComponent_StateChanged"],
         [],
+        [],
     ),
 ]
 
 FUNC_XREFS_LINUX = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CBaseEntity_SetStateChanged",
         [],
         [],
         ["CNetworkTransmitComponent_StateChanged"],
         [],
+        [
+            "CNetworkTransmitComponent::StateChanged(%s) @%s:%d",
+        ]
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CBaseEntity_Spawn.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_Spawn.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CBaseEntity_Spawn",
         [
@@ -19,6 +19,7 @@ FUNC_XREFS = [
         ],
         [],
         ["CGameSceneNode_PostSpawnKeyValues", "CBaseEntity_SpawnRadius"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CBaseEntity_SpawnRadius.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_SpawnRadius.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS_WINDOWS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CBaseEntity_SpawnRadius",
         [
@@ -20,11 +20,12 @@ FUNC_XREFS_WINDOWS = [
         ],
         [],
         [],
+        [],
     ),
 ]
 
 FUNC_XREFS_LINUX = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CBaseEntity_SpawnRadius",
         [
@@ -34,6 +35,7 @@ FUNC_XREFS_LINUX = [
         [
             "20 59 41 31"
         ],
+        [],
         [],
         [],
     ),

--- a/ida_preprocessor_scripts/find-CDemoRecorder_ParseMessage.py
+++ b/ida_preprocessor_scripts/find-CDemoRecorder_ParseMessage.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CDemoRecorder_ParseMessage",
         [
             "CDemoRecorder::ParseMessage: Failed to serialize message",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CDemoRecorder_WriteSpawnGroups.py
+++ b/ida_preprocessor_scripts/find-CDemoRecorder_WriteSpawnGroups.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CDemoRecorder_WriteSpawnGroups",
         [
             "CDemoRecorder::WriteSpawnGroups()",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CEntitySystem_Activate.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Activate.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CEntitySystem_Activate",
         [
             "EntitySystem - Class Tables",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CGameSceneNode_PostSpawnKeyValues.py
+++ b/ida_preprocessor_scripts/find-CGameSceneNode_PostSpawnKeyValues.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CGameSceneNode_PostSpawnKeyValues",
         [
@@ -16,6 +16,7 @@ FUNC_XREFS = [
             "hammerUniqueId",
             "parentname"
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CLoopModeGame_LoopShutdown-linux.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_LoopShutdown-linux.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_LoopShutdown",
         [],
         [],
         ["CLoopModeGame_Shutdown"],
         ["CLoopModeGame_SetWorldSession", "CLoopModeGame_ReceivedServerInfo"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CLoopModeGame_LoopShutdown-windows.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_LoopShutdown-windows.py
@@ -9,13 +9,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_LoopShutdown",
         ["--CLoopModeGame::SetWorldSession"],
         [],
         ["CLoopModeGame_SetGameSystemState", "IGameSystem_DestroyAllGameSystems"],
         ["CLoopModeGame_ReceivedServerInfo", "CLoopModeGame_SetWorldSession"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CLoopModeGame_ReceivedServerInfo.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_ReceivedServerInfo.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_ReceivedServerInfo",
         [
             "CLoopModeGame::ReceivedServerInfo restarting loopmode game systems from",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CLoopModeGame_RegisterEventMap.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_RegisterEventMap.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_RegisterEventMap",
         [],
         [],
         ["CLoopModeGame_RegisterEventMapInternal"],
+        [],
         [],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CLoopModeGame_SetGameSystemState.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_SetGameSystemState.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_SetGameSystemState",
         [
@@ -17,6 +17,7 @@ FUNC_XREFS = [
         [],
         [],
         ["CLoopModeGame_ReceivedServerInfo"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CLoopModeGame_SetWorldSession.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_SetWorldSession.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_SetWorldSession",
         [
             "--CLoopModeGame::SetWorldSession",
             "++CLoopModeGame::SetWorldSession",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CLoopModeGame_Shutdown-linux.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_Shutdown-linux.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopModeGame_Shutdown",
         ["--CLoopModeGame::SetWorldSession"],
         [],
         ["CLoopModeGame_SetGameSystemState", "IGameSystem_DestroyAllGameSystems"],
         ["CLoopModeGame_SetWorldSession"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CLoopTypeClientServerService_OnLoopActivate.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeClientServerService_OnLoopActivate.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopTypeClientServerService_OnLoopActivate",
         [
             "ClientServerEngineLoop",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CLoopTypeClientServer_BuildAndActivateLoopTypes.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeClientServer_BuildAndActivateLoopTypes.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CLoopTypeClientServer_BuildAndActivateLoopTypes",
         [
@@ -16,6 +16,7 @@ FUNC_XREFS = [
             "remoteconnect",
             "sourcetvrelay",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetChan_ParseMessagesDemo.py
+++ b/ida_preprocessor_scripts/find-CNetChan_ParseMessagesDemo.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetChan_ParseMessagesDemo",
         [
             "%8.3f: %s: ParseMessagesDemo UNRELIABLE %d bytes",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetChan_ParseMessagesDemoInternal.py
+++ b/ida_preprocessor_scripts/find-CNetChan_ParseMessagesDemoInternal.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetChan_ParseMessagesDemoInternal",
         [
             "Encountered message with an invalid network category! [net message %s]",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetChan_ProcessMessages.py
+++ b/ida_preprocessor_scripts/find-CNetChan_ProcessMessages.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetChan_ProcessMessages",
         [
             "NetChan %s ProcessMessages has taken more than %dms to process %d messages.",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntities-linux.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntities-linux.py
@@ -9,13 +9,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_ProcessPacketEntities",
         [
             "InternalProcessPacketEntities",
             "%s [%s from %d to %d - %d entities]",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntities-windows.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntities-windows.py
@@ -9,7 +9,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_ProcessPacketEntities",
         [
@@ -19,6 +19,7 @@ FUNC_XREFS = [
         [
             "CNetworkGameClient_ProcessPacketEntitiesInternal",
         ],
+        [],
         [],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntitiesInternal-windows.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessPacketEntitiesInternal-windows.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_ProcessPacketEntitiesInternal",
         [
             "CL:  ProcessPacketEntities: frame window too big (>=%i)",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_RecordEntityBandwidth.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_RecordEntityBandwidth.py
@@ -9,7 +9,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_RecordEntityBandwidth",
         [
@@ -21,6 +21,7 @@ FUNC_XREFS = [
         [
             "CNetworkServerService_Init",
         ],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_SendMove.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_SendMove.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_SendMove",
         [
             "CL:  CNetworkGameClient::SendMove Transmit Suppressed waiting for levelload",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_SendMovePacket.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_SendMovePacket.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkGameClient_SendMovePacket",
         [
             "Failed to serialize one usercommand?",
             "SendMovePacket overflowed trying to send %d commands, will try using %d!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_AllocateAndCopyConstructNetMessageAbstract",
         [
             "CNetworkMessages::AllocateAndCopyConstructNetMessageAbstract unable to allocate unknown message type!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_AssociateNetMessageGroupIdWithChannelCategory",
         [
             "AssociateNetMessageGroupIdWithChannelCategory: Trying to use an unregistered netchannel category!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_AssociateNetMessageWithChannelCategoryAbstract",
         [
             "AssociateNetMessageWithChannelCategoryAbstract: Passed in an invalid net message handle!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_ComputeOrderForPriority.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_ComputeOrderForPriority.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_ComputeOrderForPriority",
         [
             "Network field tried to use a priority that has not been registered!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_ConfirmAllMessageHandlersInstalled.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_ConfirmAllMessageHandlersInstalled.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_ConfirmAllMessageHandlersInstalled",
         [
             "Error installing message handlers into a net channel: missing handlers in channel %s!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_DeallocateNetMessageAbstract.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_DeallocateNetMessageAbstract.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_DeallocateNetMessageAbstract",
         [
             "CNetworkMessages::DeallocateUnserializedMessage unable to deallocate unknown message type!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkMessage.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkMessage.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS_WINDOWS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_FindNetworkMessage",
         [
@@ -20,11 +20,12 @@ FUNC_XREFS_WINDOWS = [
         ],
         [],
         ["CNetworkMessages_FindNetworkMessagePartial", "CNetworkMessages_ConfirmAllMessageHandlersInstalled"],
+        [],
     ),
 ]
 
 FUNC_XREFS_LINUX = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_FindNetworkMessage",
         [
@@ -36,6 +37,7 @@ FUNC_XREFS_LINUX = [
         ],
         [],
         ["CNetworkMessages_FindNetworkMessagePartial", "CNetworkMessages_ConfirmAllMessageHandlersInstalled"],
+        [],
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-CNetworkMessages_FindOrCreateNetMessage.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_FindOrCreateNetMessage.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_FindOrCreateNetMessage",
         [
             "CNetworkMessages::FindOrCreateNetMessage: Message %s is expected to have already been registered!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_RegisterFieldChangeCallbackPriority.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_RegisterFieldChangeCallbackPriority.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_RegisterFieldChangeCallbackPriority",
         [
             "Cannot use priority equal to NETWORK_FIELD_CHANGE_DEFAULT_PRIORITY!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkArrayFieldSerializer.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkArrayFieldSerializer.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_RegisterNetworkArrayFieldSerializer",
         [
             "Error: Duplicate network array field serializer registered (%s)!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkCategory.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkCategory.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_RegisterNetworkCategory",
         [
             "INetworkSystem::RegisterNetworkCategory: Attempted to register category %u twice",
             "INetworkSystem::RegisterNetworkCategory: all categories must have ids between 0-31!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_RegisterNetworkFieldChangeCallbackInternal",
         [
             "Error: Duplicate network field change callback registered (%s)",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkFieldSerializer.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_RegisterNetworkFieldSerializer.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_RegisterNetworkFieldSerializer",
         [
             "Error: Duplicate network field serializer registered (%s)",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_SerializeInternal.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_SerializeInternal.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_SerializeInternal",
         [
             "CNetworkMessages::Serialize attempted to serialize a non-serializeable message [%s]!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_SerializeMessageInternal.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_SerializeMessageInternal.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_SerializeMessageInternal",
         [
             "WriteToBuffer Message %s is not initialized! Probably missing required fields!",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_UnserializeFromStream.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_UnserializeFromStream.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_UnserializeFromStream",
         [
             "Error parsing message type %d (%s)",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkMessages_UnserializeMessageInternal.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_UnserializeMessageInternal.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkMessages_UnserializeMessageInternal",
         [
             "size_exceeded_max",
             "netmessage",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkServerService_Init.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_Init.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkServerService_Init",
         [
@@ -17,6 +17,7 @@ FUNC_XREFS = [
             "Local Player",
             "Other Players",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkSystem_SendNetworkStats.py
+++ b/ida_preprocessor_scripts/find-CNetworkSystem_SendNetworkStats.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkSystem_SendNetworkStats",
         [
             "Stack depth limit hit (%d)",
             "groupnames",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkTransmitComponent_StateChanged.py
+++ b/ida_preprocessor_scripts/find-CNetworkTransmitComponent_StateChanged.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkTransmitComponent_StateChanged",
         [
             "%d %s [%d] offset(s) %s are culled",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.py
+++ b/ida_preprocessor_scripts/find-CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.py
@@ -8,13 +8,14 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes",
         [
             "m_vecRenderAttributes",
             "%s was not composed of trivial POD-type fields",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-CSceneEntity_GetScriptDesc.py
+++ b/ida_preprocessor_scripts/find-CSceneEntity_GetScriptDesc.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CSceneEntity_GetScriptDesc",
         [],
         [],
         ["GetCSceneEntityScriptDesc"],
+        [],
         [],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CSteamworksGameStats_OnReceivedSessionID.py
+++ b/ida_preprocessor_scripts/find-CSteamworksGameStats_OnReceivedSessionID.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "CSteamworksGameStats_OnReceivedSessionID",
         [
             "Steamworks Stats: %s Received %s session id: %llu",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-GetCSceneEntityScriptDesc.py
+++ b/ida_preprocessor_scripts/find-GetCSceneEntityScriptDesc.py
@@ -8,12 +8,13 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "GetCSceneEntityScriptDesc",
         [
             "Choreographed scene which controls animation and/or dialog on one or more actors.",
         ],
+        [],
         [],
         [],
         [],

--- a/ida_preprocessor_scripts/find-RegisterSchemaTypeOverride_CEntityHandle.py
+++ b/ida_preprocessor_scripts/find-RegisterSchemaTypeOverride_CEntityHandle.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = [
 ]
 
 FUNC_XREFS = [
-    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list)
+    # (func_name, xref_strings_list, xref_signatures_list, xref_funcs_list, exclude_funcs_list, exclude_strings_list)
     (
         "RegisterSchemaTypeOverride_CEntityHandle",
         [
@@ -16,6 +16,7 @@ FUNC_XREFS = [
             "ehandle",
         ],
         ["A8 99 30 96"],
+        [],
         [],
         [],
     ),

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -1106,6 +1106,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
                 xref_signatures=["C7 44 24 40 64 FF FF FF"],
                 xref_funcs=[],
                 exclude_funcs=[],
+                exclude_strings=[],
                 new_binary_dir="bin_dir",
                 platform="windows",
                 image_base=0x180000000,
@@ -1157,6 +1158,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
                 xref_signatures=["C7 44 24 40 64 FF FF FF"],
                 xref_funcs=[],
                 exclude_funcs=[],
+                exclude_strings=[],
                 new_binary_dir="bin_dir",
                 platform="windows",
                 image_base=0x180000000,
@@ -1208,6 +1210,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
                         ["C7 44 24 40 64 FF FF FF"],
                         [],
                         [],
+                        [],
                     )
                 ],
                 generate_yaml_desired_fields=[
@@ -1233,7 +1236,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
         )
         mock_write_func_yaml.assert_called_once()
 
-    async def test_preprocess_common_skill_rejects_legacy_four_item_func_xrefs(
+    async def test_preprocess_common_skill_rejects_legacy_five_item_func_xrefs(
         self,
     ) -> None:
         result = await ida_analyze_util.preprocess_common_skill(
@@ -1248,6 +1251,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
                 (
                     "LoggingChannel_Init",
                     ["Networking"],
+                    [],
                     [],
                     [],
                 )
@@ -1277,6 +1281,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
             func_xrefs=[
                 (
                     "LoggingChannel_Init",
+                    [],
                     [],
                     [],
                     [],
@@ -2813,6 +2818,7 @@ found_struct_offset: []
                             [],
                             [first_func_name],
                             [],
+                            [],
                         ),
                     ],
                     generate_yaml_desired_fields=[
@@ -2984,6 +2990,7 @@ found_struct_offset: []
                             ["dummy-string"],
                             [],
                             [first_func_name],
+                            [],
                             [],
                         ),
                     ],

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -22,6 +22,10 @@ I_GET_LOGGING_CHANNEL_WINDOWS_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-INetworkMessages_GetLoggingChannel-windows.py"
 )
+I_GET_LOGGING_CHANNEL_LINUX_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/"
+    "find-INetworkMessages_GetLoggingChannel-linux.py"
+)
 NETWORK_GROUP_STATS_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CNetworkMessages_GetNetworkGroupCount-AND-"
@@ -39,14 +43,6 @@ REALLOCATING_FACTORY_DEALLOCATE_SCRIPT_PATH = Path(
 FIND_NETWORK_GROUP_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CNetworkMessages_FindNetworkGroup.py"
-)
-LOGGING_CHANNEL_INIT_WINDOWS_SCRIPT_PATH = Path(
-    "ida_preprocessor_scripts/"
-    "find-LoggingChannel_Init-windows.py"
-)
-LOGGING_CHANNEL_INIT_LINUX_SCRIPT_PATH = Path(
-    "ida_preprocessor_scripts/"
-    "find-LoggingChannel_Init-linux.py"
 )
 CNETWORK_SERVER_SERVICE_INIT_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
@@ -1003,78 +999,43 @@ class TestFindINetworkMessagesGetLoggingChannelWindows(
         )
 
 
-class TestFindLoggingChannelInit(unittest.IsolatedAsyncioTestCase):
-    async def test_windows_script_forwards_five_tuple_func_xrefs(self) -> None:
+class TestFindINetworkMessagesGetLoggingChannelLinux(
+    unittest.IsolatedAsyncioTestCase
+):
+    async def test_preprocess_skill_forwards_linux_llm_decompile_spec(
+        self,
+    ) -> None:
         module = _load_module(
-            LOGGING_CHANNEL_INIT_WINDOWS_SCRIPT_PATH,
-            "find_LoggingChannel_Init_windows",
+            I_GET_LOGGING_CHANNEL_LINUX_SCRIPT_PATH,
+            "find_INetworkMessages_GetLoggingChannel_linux",
         )
         mock_preprocess_common_skill = AsyncMock(return_value=True)
+        llm_config = {"model": "gpt-4.1-mini", "api_key": "test-api-key"}
+        expected_llm_decompile_specs = [
+            (
+                "INetworkMessages_GetLoggingChannel",
+                "prompt/call_llm_decompile.md",
+                (
+                    "references/server/"
+                    "CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes."
+                    "{platform}.yaml"
+                ),
+            )
+        ]
+        expected_func_vtable_relations = [
+            ("INetworkMessages_GetLoggingChannel", "INetworkMessages")
+        ]
         expected_generate_yaml_desired_fields = [
             (
-                "LoggingChannel_Init",
-                ["func_name", "func_va", "func_rva", "func_size", "func_sig"],
-            )
-        ]
-        expected_func_xrefs = [
-            (
-                "LoggingChannel_Init",
-                ["Networking"],
-                ["C7 44 24 40 64 FF FF FF"],
-                [],
-                [],
-            )
-        ]
-
-        with patch.object(
-            module,
-            "preprocess_common_skill",
-            mock_preprocess_common_skill,
-        ):
-            result = await module.preprocess_skill(
-                session="session",
-                skill_name="skill",
-                expected_outputs=["out.yaml"],
-                old_yaml_map={"k": "v"},
-                new_binary_dir="bin_dir",
-                platform="windows",
-                image_base=0x180000000,
-                debug=True,
-            )
-
-        self.assertTrue(result)
-        mock_preprocess_common_skill.assert_awaited_once_with(
-            session="session",
-            expected_outputs=["out.yaml"],
-            old_yaml_map={"k": "v"},
-            new_binary_dir="bin_dir",
-            platform="windows",
-            image_base=0x180000000,
-            func_names=["LoggingChannel_Init"],
-            func_xrefs=expected_func_xrefs,
-            generate_yaml_desired_fields=expected_generate_yaml_desired_fields,
-            debug=True,
-        )
-
-    async def test_linux_script_forwards_five_tuple_func_xrefs(self) -> None:
-        module = _load_module(
-            LOGGING_CHANNEL_INIT_LINUX_SCRIPT_PATH,
-            "find_LoggingChannel_Init_linux",
-        )
-        mock_preprocess_common_skill = AsyncMock(return_value=True)
-        expected_generate_yaml_desired_fields = [
-            (
-                "LoggingChannel_Init",
-                ["func_name", "func_va", "func_rva", "func_size", "func_sig"],
-            )
-        ]
-        expected_func_xrefs = [
-            (
-                "LoggingChannel_Init",
-                ["Networking"],
-                ["41 B8 64 FF FF FF"],
-                [],
-                [],
+                "INetworkMessages_GetLoggingChannel",
+                [
+                    "func_name",
+                    "vfunc_sig",
+                    "vfunc_sig_max_match:10",
+                    "vfunc_offset",
+                    "vfunc_index",
+                    "vtable_name",
+                ],
             )
         ]
 
@@ -1091,6 +1052,7 @@ class TestFindLoggingChannelInit(unittest.IsolatedAsyncioTestCase):
                 new_binary_dir="bin_dir",
                 platform="linux",
                 image_base=0x180000000,
+                llm_config=llm_config,
                 debug=True,
             )
 
@@ -1102,15 +1064,17 @@ class TestFindLoggingChannelInit(unittest.IsolatedAsyncioTestCase):
             new_binary_dir="bin_dir",
             platform="linux",
             image_base=0x180000000,
-            func_names=["LoggingChannel_Init"],
-            func_xrefs=expected_func_xrefs,
+            func_names=["INetworkMessages_GetLoggingChannel"],
+            func_vtable_relations=expected_func_vtable_relations,
+            llm_decompile_specs=expected_llm_decompile_specs,
+            llm_config=llm_config,
             generate_yaml_desired_fields=expected_generate_yaml_desired_fields,
             debug=True,
         )
 
 
 class TestFindCNetworkServerServiceInit(unittest.IsolatedAsyncioTestCase):
-    async def test_script_forwards_five_tuple_func_xrefs(self) -> None:
+    async def test_script_forwards_six_tuple_func_xrefs(self) -> None:
         module = _load_module(
             CNETWORK_SERVER_SERVICE_INIT_SCRIPT_PATH,
             "find_CNetworkServerService_Init",
@@ -1125,6 +1089,7 @@ class TestFindCNetworkServerServiceInit(unittest.IsolatedAsyncioTestCase):
                     "Local Player",
                     "Other Players",
                 ],
+                [],
                 [],
                 [],
                 [],


### PR DESCRIPTION
## Summary
- 为共享 `func_xrefs` 管线增加 `exclude_strings_list` 负向过滤，并在采集失败时避免静默放行
- 将 `ida_preprocessor_scripts/` 下全部 `FUNC_XREFS*` 统一迁移到固定六元组，保留 Linux `CBaseEntity_SetStateChanged` 特例
- 同步 `.serena`/Serena memory 与直接受影响测试到六元组契约

## Test Plan
- [x] `uv run python - <<'PY' ...` 全仓静态校验通过，结果为 `validated 53 FUNC_XREFS assignments`
- [x] `python -m py_compile ida_analyze_util.py $(rg -l "^FUNC_XREFS(_WINDOWS|_LINUX)?\\s*=\" ida_preprocessor_scripts -g '*.py' | sort)`
- [x] `python -m unittest tests.test_ida_analyze_util.TestFuncXrefsSignatureSupport tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_llm_batch_skips_future_targets_with_unready_xref_dependencies tests.test_ida_analyze_util.TestLlmDecompileSupport.test_preprocess_common_skill_llm_batch_issues_second_request_for_symbol_not_covered_in_first_batch tests.test_ida_preprocessor_scripts.TestFindINetworkMessagesGetLoggingChannelWindows tests.test_ida_preprocessor_scripts.TestFindINetworkMessagesGetLoggingChannelLinux tests.test_ida_preprocessor_scripts.TestFindCNetworkServerServiceInit`
- [ ] `python -m unittest tests.test_ida_analyze_util tests.test_ida_preprocessor_scripts` 仍存在既有非本次范围失败（2 failures, 6 errors）
