### PR TITLE
feat(ida): 支持 llm_decompile 解析 found_funcptr

### DIFF
--- a/docs/call_llm_decompile_prompt.md
+++ b/docs/call_llm_decompile_prompt.md
@@ -31,6 +31,7 @@ This is the function you need to reverse-engineering:
 Please collect all references to "{symbol_name_list}" in the function you need to reverse-engineering and output those references as YAML.
 `found_vcall` is for indirect call to virtual function.
 `found_call` is for direct call to regular non-virtual function.
+`found_funcptr` is for reference to function pointer. the `insn_disasm` and `insn_va` must be the instruction that loads or references the function pointer target address, not a later use-site such as `call reg`.
 `found_gv` is for reference to global variable.
 `found_struct_offset` is for reference to struct offset.
 
@@ -53,6 +54,10 @@ found_call:
   - insn_va: '0x180888880'
     insn_disasm: call    sub_180555500
     func_name: CLoopModeGame_SetGameSystemState
+found_funcptr:
+  - insn_va: '0x180666600'                # Must load/reference the function pointer target address
+    insn_disasm: lea     rdx, sub_15BC910 # Must load/reference the function pointer target address
+    funcptr_name: CLoopModeGame_OnClientPollNetworking
 found_gv:
   - insn_va: '0x180444400'
     insn_disasm: mov     rcx, cs:qword_180666600

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -605,6 +605,7 @@ def _empty_llm_decompile_result():
     return {
         "found_vcall": [],
         "found_call": [],
+        "found_funcptr": [],
         "found_gv": [],
         "found_struct_offset": [],
     }
@@ -1306,6 +1307,77 @@ async def _resolve_direct_call_target_via_mcp(session, insn_va, debug=False):
     return resolved_matches[0]
 
 
+async def _resolve_direct_funcptr_target_via_mcp(session, insn_va, debug=False):
+    try:
+        insn_va_int = _parse_int_value(insn_va)
+    except Exception:
+        return None
+
+    py_code = (
+        "import ida_funcs, idautils, json\n"
+        f"insn_ea = {insn_va_int}\n"
+        "matches = []\n"
+        "seen_addrs = set()\n"
+        "for target_ea in idautils.DataRefsFrom(insn_ea):\n"
+        "    func = ida_funcs.get_func(target_ea)\n"
+        "    if func is None:\n"
+        "        continue\n"
+        "    func_start = int(func.start_ea)\n"
+        "    func_va = hex(func_start)\n"
+        "    if func_va in seen_addrs:\n"
+        "        continue\n"
+        "    seen_addrs.add(func_va)\n"
+        "    matches.append({'func_va': func_va})\n"
+        "result = json.dumps(matches)\n"
+    )
+
+    try:
+        eval_result = await session.call_tool(
+            name="py_eval",
+            arguments={"code": py_code},
+        )
+    except Exception as exc:
+        if debug:
+            print(
+                "    Preprocess: py_eval error while resolving direct funcptr target: "
+                f"{exc}"
+            )
+        return None
+
+    match_payload = _parse_py_eval_json_result(
+        eval_result,
+        debug=debug,
+        context="llm_decompile direct funcptr target lookup",
+    )
+    if not isinstance(match_payload, list):
+        return None
+
+    resolved_matches = []
+    seen_func_vas = set()
+    for item in match_payload:
+        if not isinstance(item, dict):
+            continue
+        func_va = str(item.get("func_va", "")).strip()
+        if not func_va or func_va in seen_func_vas:
+            continue
+        try:
+            int(func_va, 0)
+        except (TypeError, ValueError):
+            continue
+        seen_func_vas.add(func_va)
+        resolved_matches.append(func_va)
+
+    if len(resolved_matches) != 1:
+        if debug:
+            print(
+                "    Preprocess: llm_decompile direct funcptr target lookup returned "
+                f"{len(resolved_matches)} matches: {resolved_matches}"
+            )
+        return None
+
+    return resolved_matches[0]
+
+
 async def _resolve_direct_gv_target_via_mcp(session, insn_va, debug=False):
     try:
         insn_va_int = _parse_int_value(insn_va)
@@ -1448,6 +1520,10 @@ def parse_llm_decompile_response(response_text):
         "found_call": _normalize_llm_entries(
             parsed.get("found_call", []),
             ("insn_va", "insn_disasm", "func_name"),
+        ),
+        "found_funcptr": _normalize_llm_entries(
+            parsed.get("found_funcptr", []),
+            ("insn_va", "insn_disasm", "funcptr_name"),
         ),
         "found_gv": _normalize_llm_entries(
             parsed.get("found_gv", []),
@@ -6147,6 +6223,7 @@ async def preprocess_common_skill(
         desired_fields = desired_field_spec["desired_output_fields"]
         generation_options = desired_field_spec["generation_options"]
         desired_fields_set = set(desired_fields)
+        can_use_direct_func_fallback = "vfunc_sig" not in desired_fields_set
 
         if func_name not in fast_path_attempted:
             fast_path_results[func_name] = await _try_preprocess_func_without_llm(
@@ -6213,29 +6290,54 @@ async def preprocess_common_skill(
                     llm_result = _empty_llm_decompile_result()
                 for symbol_name in llm_symbol_name_list:
                     llm_result_by_symbol_name[symbol_name] = llm_result
-            for entry in llm_result.get("found_call", []):
-                if entry.get("func_name") != func_name:
-                    continue
-                direct_func_va = await _resolve_direct_call_target_via_mcp(
-                    session,
-                    entry.get("insn_va"),
-                    debug=debug,
-                )
-                if direct_func_va is None:
-                    continue
-                func_data = await _preprocess_direct_func_sig_via_mcp(
-                    session=session,
-                    new_path=target_output,
-                    image_base=image_base,
-                    platform=platform,
-                    func_name=func_name,
-                    direct_func_va=direct_func_va,
-                    require_func_sig="func_sig" in desired_fields_set,
-                    normalized_mangled_class_names=normalized_mangled_class_names,
-                    debug=debug,
-                )
-                if func_data is not None:
-                    break
+            if can_use_direct_func_fallback:
+                for entry in llm_result.get("found_call", []):
+                    if entry.get("func_name") != func_name:
+                        continue
+                    direct_func_va = await _resolve_direct_call_target_via_mcp(
+                        session,
+                        entry.get("insn_va"),
+                        debug=debug,
+                    )
+                    if direct_func_va is None:
+                        continue
+                    func_data = await _preprocess_direct_func_sig_via_mcp(
+                        session=session,
+                        new_path=target_output,
+                        image_base=image_base,
+                        platform=platform,
+                        func_name=func_name,
+                        direct_func_va=direct_func_va,
+                        require_func_sig="func_sig" in desired_fields_set,
+                        normalized_mangled_class_names=normalized_mangled_class_names,
+                        debug=debug,
+                    )
+                    if func_data is not None:
+                        break
+            if func_data is None and can_use_direct_func_fallback:
+                for entry in llm_result.get("found_funcptr", []):
+                    if entry.get("funcptr_name") != func_name:
+                        continue
+                    direct_func_va = await _resolve_direct_funcptr_target_via_mcp(
+                        session,
+                        entry.get("insn_va"),
+                        debug=debug,
+                    )
+                    if direct_func_va is None:
+                        continue
+                    func_data = await _preprocess_direct_func_sig_via_mcp(
+                        session=session,
+                        new_path=target_output,
+                        image_base=image_base,
+                        platform=platform,
+                        func_name=func_name,
+                        direct_func_va=direct_func_va,
+                        require_func_sig="func_sig" in desired_fields_set,
+                        normalized_mangled_class_names=normalized_mangled_class_names,
+                        debug=debug,
+                    )
+                    if func_data is not None:
+                        break
             vtable_class = None
             if func_data is None and func_name in vtable_relations_map:
                 vtable_class = vtable_relations_map[func_name]

--- a/ida_preprocessor_scripts/prompt/call_llm_decompile.md
+++ b/ida_preprocessor_scripts/prompt/call_llm_decompile.md
@@ -31,6 +31,7 @@ This is the function you need to reverse-engineering:
 Please collect all references to "{symbol_name_list}" in the function you need to reverse-engineering and output those references as YAML.
 `found_vcall` is for indirect call to virtual function. the `insn_disasm` and `insn_va` must be the instruction with displacement offset.
 `found_call` is for direct call to regular non-virtual function.
+`found_funcptr` is for reference to function pointer. the `insn_disasm` and `insn_va` must be the instruction that loads or references the function pointer target address, not a later use-site such as `call reg`.
 `found_gv` is for reference to global variable.
 `found_struct_offset` is for reference to struct offset. the `insn_disasm` and `insn_va` must be the instruction with displacement offset.
 
@@ -53,6 +54,10 @@ found_call:
   - insn_va: '0x180888880'
     insn_disasm: call    sub_180555500
     func_name: CLoopModeGame_SetGameSystemState
+found_funcptr:
+  - insn_va: '0x180666600'                # Must load/reference the function pointer target address
+    insn_disasm: lea     rdx, sub_15BC910 # Must load/reference the function pointer target address
+    funcptr_name: CLoopModeGame_OnClientPollNetworking
 found_gv:
   - insn_va: '0x180444400'
     insn_disasm: mov     rcx, cs:qword_180666600

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -1340,6 +1340,32 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
 
 
 class TestLlmDecompileSupport(unittest.IsolatedAsyncioTestCase):
+    def test_parse_llm_decompile_response_normalizes_found_funcptr(self) -> None:
+        response_text = """
+```yaml
+found_funcptr:
+  - insn_va: 0x180666600
+    insn_disasm: " lea     rdx, sub_15BC910 "
+    funcptr_name: " CLoopModeGame_OnClientPollNetworking "
+  - insn_va: 0x180666601
+```
+""".strip()
+
+        parsed = ida_analyze_util.parse_llm_decompile_response(response_text)
+
+        self.assertEqual(
+            [
+                {
+                    "insn_va": "0x180666600",
+                    "insn_disasm": "lea     rdx, sub_15BC910",
+                    "funcptr_name": "CLoopModeGame_OnClientPollNetworking",
+                }
+            ],
+            parsed["found_funcptr"],
+        )
+        self.assertEqual([], parsed["found_call"])
+        self.assertEqual([], parsed["found_vcall"])
+
     def test_parse_llm_decompile_response_normalizes_all_sections(self) -> None:
         response_text = """
 ```yaml
@@ -1389,6 +1415,7 @@ found_struct_offset:
                         "func_name": "CLoopModeGame_RegisterEventMapInternal",
                     }
                 ],
+                "found_funcptr": [],
                 "found_gv": [
                     {
                         "insn_va": "0x180444400",
@@ -1451,6 +1478,7 @@ found_struct_offset: []
                     }
                 ],
                 "found_call": [],
+                "found_funcptr": [],
                 "found_gv": [],
                 "found_struct_offset": [],
             },
@@ -1491,6 +1519,7 @@ found_struct_offset: []
             {
                 "found_vcall": [],
                 "found_call": [],
+                "found_funcptr": [],
                 "found_gv": [],
                 "found_struct_offset": [],
             },
@@ -1520,6 +1549,7 @@ found_struct_offset: []
             {
                 "found_vcall": [],
                 "found_call": [],
+                "found_funcptr": [],
                 "found_gv": [],
                 "found_struct_offset": [],
             },
@@ -3320,6 +3350,686 @@ found_struct_offset: []
         self.assertEqual(func_name, written_payload["func_name"])
         self.assertEqual("0x180123450", written_payload["func_va"])
         self.assertNotIn("vtable_name", written_payload)
+
+    async def test_preprocess_common_skill_uses_found_funcptr_to_generate_func_yaml(
+        self,
+    ) -> None:
+        func_name = "CLoopModeGame_OnClientPollNetworking"
+        output_paths = [f"/tmp/{func_name}.windows.yaml"]
+        target_detail_payload = {
+            "func_name": "CLoopModeGame_RegisterEventMapInternal",
+            "func_va": "0x180555500",
+            "disasm_code": "lea     rdx, sub_15BC910",
+            "procedure": "v40 = sub_15BC910;",
+        }
+        normalized_payload = {
+            "found_vcall": [],
+            "found_call": [],
+            "found_funcptr": [
+                {
+                    "insn_va": "0x180666600",
+                    "insn_disasm": "lea     rdx, sub_15BC910",
+                    "funcptr_name": func_name,
+                }
+            ],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+
+        async def _fake_preprocess_direct_func_sig_via_mcp(**kwargs):
+            return {
+                "func_name": kwargs["func_name"],
+                "func_va": str(kwargs["direct_func_va"]).strip().lower(),
+            }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "func_name": target_detail_payload["func_name"],
+                    "disasm_code": target_detail_payload["disasm_code"],
+                    "procedure": target_detail_payload["procedure"],
+                },
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=object(),
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "_load_llm_decompile_target_detail_via_mcp",
+                AsyncMock(return_value=target_detail_payload),
+            ), patch.object(
+                ida_analyze_util,
+                "_resolve_direct_funcptr_target_via_mcp",
+                AsyncMock(return_value="0x180123450"),
+                create=True,
+            ) as mock_resolve_direct_funcptr_target, patch.object(
+                ida_analyze_util,
+                "_preprocess_direct_func_sig_via_mcp",
+                AsyncMock(side_effect=_fake_preprocess_direct_func_sig_via_mcp),
+            ), patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=output_paths,
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    generate_yaml_desired_fields=[
+                        (func_name, ["func_name", "func_va"]),
+                    ],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        ),
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        mock_resolve_direct_funcptr_target.assert_awaited_once_with(
+            "session",
+            "0x180666600",
+            debug=True,
+        )
+        self.assertEqual("0x180123450", mock_write_func_yaml.call_args.args[1]["func_va"])
+
+    async def test_preprocess_common_skill_prefers_found_call_over_found_funcptr(
+        self,
+    ) -> None:
+        func_name = "CLoopModeGame_OnClientPollNetworking"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+        target_detail_payload = {
+            "func_name": "CLoopModeGame_RegisterEventMapInternal",
+            "func_va": "0x180555500",
+            "disasm_code": "call    sub_180111111\nlea     rdx, sub_15BC910",
+            "procedure": "sub_180111111(); v40 = sub_15BC910;",
+        }
+        normalized_payload = {
+            "found_vcall": [],
+            "found_call": [
+                {
+                    "insn_va": "0x180777700",
+                    "insn_disasm": "call    sub_180111111",
+                    "func_name": func_name,
+                }
+            ],
+            "found_funcptr": [
+                {
+                    "insn_va": "0x180666600",
+                    "insn_disasm": "lea     rdx, sub_15BC910",
+                    "funcptr_name": func_name,
+                }
+            ],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+
+        async def _fake_preprocess_direct_func_sig_via_mcp(**kwargs):
+            return {
+                "func_name": kwargs["func_name"],
+                "func_va": str(kwargs["direct_func_va"]).strip().lower(),
+            }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "func_name": target_detail_payload["func_name"],
+                    "disasm_code": target_detail_payload["disasm_code"],
+                    "procedure": target_detail_payload["procedure"],
+                },
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=object(),
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "_load_llm_decompile_target_detail_via_mcp",
+                AsyncMock(return_value=target_detail_payload),
+            ), patch.object(
+                ida_analyze_util,
+                "_resolve_direct_call_target_via_mcp",
+                AsyncMock(return_value="0x180111111"),
+                create=True,
+            ) as mock_resolve_direct_call_target, patch.object(
+                ida_analyze_util,
+                "_resolve_direct_funcptr_target_via_mcp",
+                AsyncMock(return_value="0x180222222"),
+                create=True,
+            ) as mock_resolve_direct_funcptr_target, patch.object(
+                ida_analyze_util,
+                "_preprocess_direct_func_sig_via_mcp",
+                AsyncMock(side_effect=_fake_preprocess_direct_func_sig_via_mcp),
+            ), patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    generate_yaml_desired_fields=[
+                        (func_name, ["func_name", "func_va"]),
+                    ],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        ),
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        mock_resolve_direct_call_target.assert_awaited_once_with(
+            "session",
+            "0x180777700",
+            debug=True,
+        )
+        mock_resolve_direct_funcptr_target.assert_not_awaited()
+        mock_write_func_yaml.assert_called_once()
+        self.assertEqual("0x180111111", mock_write_func_yaml.call_args.args[1]["func_va"])
+
+    async def test_preprocess_common_skill_skips_found_funcptr_when_resolver_is_non_unique(
+        self,
+    ) -> None:
+        func_name = "CLoopModeGame_OnClientPollNetworking"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+        target_detail_payload = {
+            "func_name": "CLoopModeGame_RegisterEventMapInternal",
+            "func_va": "0x180555500",
+            "disasm_code": "lea     rdx, sub_15BC910",
+            "procedure": "v40 = sub_15BC910;",
+        }
+        normalized_payload = {
+            "found_vcall": [],
+            "found_call": [],
+            "found_funcptr": [
+                {
+                    "insn_va": "0x180666600",
+                    "insn_disasm": "lea     rdx, sub_15BC910",
+                    "funcptr_name": func_name,
+                }
+            ],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "func_name": target_detail_payload["func_name"],
+                    "disasm_code": target_detail_payload["disasm_code"],
+                    "procedure": target_detail_payload["procedure"],
+                },
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=object(),
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "_load_llm_decompile_target_detail_via_mcp",
+                AsyncMock(return_value=target_detail_payload),
+            ), patch.object(
+                ida_analyze_util,
+                "_resolve_direct_funcptr_target_via_mcp",
+                AsyncMock(return_value=None),
+                create=True,
+            ) as mock_resolve_direct_funcptr_target, patch.object(
+                ida_analyze_util,
+                "_preprocess_direct_func_sig_via_mcp",
+                AsyncMock(),
+            ) as mock_preprocess_direct_func_sig_via_mcp, patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    generate_yaml_desired_fields=[
+                        (func_name, ["func_name", "func_va"]),
+                    ],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        ),
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertFalse(result)
+        mock_resolve_direct_funcptr_target.assert_awaited_once_with(
+            "session",
+            "0x180666600",
+            debug=True,
+        )
+        mock_preprocess_direct_func_sig_via_mcp.assert_not_awaited()
+        mock_write_func_yaml.assert_not_called()
+
+    async def test_preprocess_common_skill_skips_found_funcptr_when_vfunc_sig_required(
+        self,
+    ) -> None:
+        func_name = "CBaseEntity_GetHammerUniqueId"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+        target_detail_payload = {
+            "func_name": "CBaseEntity_Spawn",
+            "func_va": "0x180555500",
+            "disasm_code": "lea     rdx, sub_15BC910\ncall    qword ptr [rax+370h]",
+            "procedure": "v40 = sub_15BC910; return this->vfptr[110](this);",
+        }
+        normalized_payload = {
+            "found_vcall": [
+                {
+                    "insn_va": "0x18016742cf",
+                    "insn_disasm": "call    qword ptr [rax+370h]",
+                    "vfunc_offset": "0x370",
+                    "func_name": func_name,
+                }
+            ],
+            "found_call": [],
+            "found_funcptr": [
+                {
+                    "insn_va": "0x180666600",
+                    "insn_disasm": "lea     rdx, sub_15BC910",
+                    "funcptr_name": func_name,
+                }
+            ],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+
+        async def _fake_preprocess_direct_func_sig_via_mcp(**kwargs):
+            if kwargs.get("direct_vcall_inst_va"):
+                return {
+                    "func_name": kwargs["func_name"],
+                    "func_va": "0x1809b8db0",
+                    "vfunc_sig": "FF 90 70 03 00 00",
+                    "vfunc_sig_max_match": 10,
+                    "vfunc_offset": "0x370",
+                    "vfunc_index": 110,
+                }
+            if kwargs.get("direct_func_va"):
+                return {
+                    "func_name": kwargs["func_name"],
+                    "func_va": str(kwargs["direct_func_va"]).strip().lower(),
+                }
+            return None
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "func_name": target_detail_payload["func_name"],
+                    "disasm_code": target_detail_payload["disasm_code"],
+                    "procedure": target_detail_payload["procedure"],
+                },
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=object(),
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "_load_llm_decompile_target_detail_via_mcp",
+                AsyncMock(return_value=target_detail_payload),
+            ), patch.object(
+                ida_analyze_util,
+                "_resolve_direct_funcptr_target_via_mcp",
+                AsyncMock(return_value="0x180123450"),
+                create=True,
+            ) as mock_resolve_direct_funcptr_target, patch.object(
+                ida_analyze_util,
+                "_preprocess_direct_func_sig_via_mcp",
+                AsyncMock(side_effect=_fake_preprocess_direct_func_sig_via_mcp),
+            ) as mock_preprocess_direct_func_sig_via_mcp, patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    func_vtable_relations=[(func_name, "CBaseEntity")],
+                    generate_yaml_desired_fields=[
+                        (
+                            func_name,
+                            [
+                                "func_name",
+                                "func_va",
+                                "vfunc_sig",
+                                "vfunc_sig_max_match:10",
+                                "vtable_name",
+                                "vfunc_offset",
+                                "vfunc_index",
+                            ],
+                        )
+                    ],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        ),
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        mock_resolve_direct_funcptr_target.assert_not_awaited()
+        mock_preprocess_direct_func_sig_via_mcp.assert_awaited_once()
+        preprocess_kwargs = mock_preprocess_direct_func_sig_via_mcp.await_args.kwargs
+        self.assertEqual("0x18016742cf", preprocess_kwargs["direct_vcall_inst_va"])
+        self.assertEqual("0x370", preprocess_kwargs["direct_vfunc_offset"])
+        self.assertNotIn("direct_func_va", preprocess_kwargs)
+        mock_write_func_yaml.assert_called_once()
+        written_payload = mock_write_func_yaml.call_args.args[1]
+        self.assertEqual(func_name, written_payload["func_name"])
+        self.assertEqual("FF 90 70 03 00 00", written_payload["vfunc_sig"])
+        self.assertEqual(10, written_payload["vfunc_sig_max_match"])
+        self.assertEqual("CBaseEntity", written_payload["vtable_name"])
+
+    async def test_preprocess_common_skill_skips_found_call_when_vfunc_sig_required(
+        self,
+    ) -> None:
+        func_name = "CBaseEntity_GetHammerUniqueId"
+        output_path = f"/tmp/{func_name}.windows.yaml"
+        target_detail_payload = {
+            "func_name": "CBaseEntity_Spawn",
+            "func_va": "0x180555500",
+            "disasm_code": "call    sub_180111111\ncall    qword ptr [rax+370h]",
+            "procedure": "sub_180111111(); return this->vfptr[110](this);",
+        }
+        normalized_payload = {
+            "found_vcall": [
+                {
+                    "insn_va": "0x18016742cf",
+                    "insn_disasm": "call    qword ptr [rax+370h]",
+                    "vfunc_offset": "0x370",
+                    "func_name": func_name,
+                }
+            ],
+            "found_call": [
+                {
+                    "insn_va": "0x180777700",
+                    "insn_disasm": "call    sub_180111111",
+                    "func_name": func_name,
+                }
+            ],
+            "found_funcptr": [],
+            "found_gv": [],
+            "found_struct_offset": [],
+        }
+
+        async def _fake_preprocess_direct_func_sig_via_mcp(**kwargs):
+            if kwargs.get("direct_vcall_inst_va"):
+                return {
+                    "func_name": kwargs["func_name"],
+                    "func_va": "0x1809b8db0",
+                    "vfunc_sig": "FF 90 70 03 00 00",
+                    "vfunc_sig_max_match": 10,
+                    "vfunc_offset": "0x370",
+                    "vfunc_index": 110,
+                }
+            if kwargs.get("direct_func_va"):
+                return {
+                    "func_name": kwargs["func_name"],
+                    "func_va": str(kwargs["direct_func_va"]).strip().lower(),
+                }
+            return None
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            preprocessor_dir = Path(temp_dir) / "ida_preprocessor_scripts"
+            (preprocessor_dir / "prompt").mkdir(parents=True, exist_ok=True)
+            (preprocessor_dir / "prompt" / "call_llm_decompile.md").write_text(
+                "{symbol_name_list}",
+                encoding="utf-8",
+            )
+            _write_yaml(
+                preprocessor_dir / "references" / "reference.yaml",
+                {
+                    "func_name": target_detail_payload["func_name"],
+                    "disasm_code": target_detail_payload["disasm_code"],
+                    "procedure": target_detail_payload["procedure"],
+                },
+            )
+
+            with patch.object(
+                ida_analyze_util,
+                "_get_preprocessor_scripts_dir",
+                return_value=preprocessor_dir,
+            ), patch.object(
+                ida_analyze_util,
+                "create_openai_client",
+                return_value=object(),
+                create=True,
+            ), patch.object(
+                ida_analyze_util,
+                "preprocess_func_sig_via_mcp",
+                AsyncMock(return_value=None),
+            ), patch.object(
+                ida_analyze_util,
+                "_load_llm_decompile_target_detail_via_mcp",
+                AsyncMock(return_value=target_detail_payload),
+            ), patch.object(
+                ida_analyze_util,
+                "_resolve_direct_call_target_via_mcp",
+                AsyncMock(return_value="0x180111111"),
+                create=True,
+            ) as mock_resolve_direct_call_target, patch.object(
+                ida_analyze_util,
+                "_preprocess_direct_func_sig_via_mcp",
+                AsyncMock(side_effect=_fake_preprocess_direct_func_sig_via_mcp),
+            ) as mock_preprocess_direct_func_sig_via_mcp, patch.object(
+                ida_analyze_util,
+                "call_llm_decompile",
+                create=True,
+                new_callable=AsyncMock,
+                return_value=normalized_payload,
+            ), patch.object(
+                ida_analyze_util,
+                "write_func_yaml",
+            ) as mock_write_func_yaml, patch.object(
+                ida_analyze_util,
+                "_rename_func_in_ida",
+                AsyncMock(return_value=None),
+            ):
+                result = await ida_analyze_util.preprocess_common_skill(
+                    session="session",
+                    expected_outputs=[output_path],
+                    old_yaml_map={},
+                    new_binary_dir="/tmp",
+                    platform="windows",
+                    image_base=0x180000000,
+                    func_names=[func_name],
+                    func_vtable_relations=[(func_name, "CBaseEntity")],
+                    generate_yaml_desired_fields=[
+                        (
+                            func_name,
+                            [
+                                "func_name",
+                                "func_va",
+                                "vfunc_sig",
+                                "vfunc_sig_max_match:10",
+                                "vtable_name",
+                                "vfunc_offset",
+                                "vfunc_index",
+                            ],
+                        )
+                    ],
+                    llm_decompile_specs=[
+                        (
+                            func_name,
+                            "prompt/call_llm_decompile.md",
+                            "references/reference.yaml",
+                        ),
+                    ],
+                    llm_config={
+                        "model": "gpt-4.1-mini",
+                        "api_key": "test-api-key",
+                    },
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        mock_resolve_direct_call_target.assert_not_awaited()
+        mock_preprocess_direct_func_sig_via_mcp.assert_awaited_once()
+        preprocess_kwargs = mock_preprocess_direct_func_sig_via_mcp.await_args.kwargs
+        self.assertEqual("0x18016742cf", preprocess_kwargs["direct_vcall_inst_va"])
+        self.assertEqual("0x370", preprocess_kwargs["direct_vfunc_offset"])
+        self.assertNotIn("direct_func_va", preprocess_kwargs)
+        mock_write_func_yaml.assert_called_once()
+        written_payload = mock_write_func_yaml.call_args.args[1]
+        self.assertEqual(func_name, written_payload["func_name"])
+        self.assertEqual("FF 90 70 03 00 00", written_payload["vfunc_sig"])
+        self.assertEqual(10, written_payload["vfunc_sig_max_match"])
+        self.assertEqual("CBaseEntity", written_payload["vtable_name"])
 
     async def test_preprocess_common_skill_generates_vfunc_sig_from_vcall_even_when_vtable_available(
         self,


### PR DESCRIPTION
## Summary
- 扩展 `llm_decompile` schema、parser 和 fallback 控制流，支持 `found_funcptr`
- 新增 direct funcptr resolver，并收紧 `vfunc_sig` 场景下的优先级语义
- 同步真实 prompt、公开文档与定向回归测试

## Test Plan
- [x] `uv run --with pytest python -m pytest -v tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_parse_llm_decompile_response_normalizes_found_funcptr tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_preprocess_common_skill_uses_found_funcptr_to_generate_func_yaml tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_preprocess_common_skill_prefers_found_call_over_found_funcptr tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_preprocess_common_skill_skips_found_funcptr_when_resolver_is_non_unique tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_preprocess_common_skill_skips_found_funcptr_when_vfunc_sig_required tests/test_ida_analyze_util.py::TestLlmDecompileSupport::test_preprocess_common_skill_skips_found_call_when_vfunc_sig_required` (6 passed)
- [x] `git diff --check`