### PR TITLE
fix(preprocess): 修复InputTestActivator旧YAML复用

### DIFF
--- a/ida_preprocessor_scripts/find-CBaseFilter_InputTestActivator.py
+++ b/ida_preprocessor_scripts/find-CBaseFilter_InputTestActivator.py
@@ -198,7 +198,11 @@ async def preprocess_skill(
                 output_path = p
                 break
         if output_path:
-            old_yaml_path = old_yaml_map.get(output_filename)
+            old_yaml_path = None
+            if old_yaml_map:
+                old_yaml_path = old_yaml_map.get(output_path)
+                if old_yaml_path is None:
+                    old_yaml_path = old_yaml_map.get(output_filename)
             if old_yaml_path and os.path.exists(old_yaml_path):
                 reuse_result = await preprocess_func_sig_via_mcp(
                     session=session,

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -810,6 +810,101 @@ class TestFindCBaseFilterInputTestActivator(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIn("if func_start == candidate:", py_code)
 
+    async def test_preprocess_skill_linux_tolerates_missing_old_yaml_map(
+        self,
+    ) -> None:
+        module = _load_module(
+            CBASEFILTER_INPUTTESTACTIVATOR_SCRIPT_PATH,
+            "find_CBaseFilter_InputTestActivator",
+        )
+        fallback = AsyncMock(return_value=True)
+        reuse = AsyncMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            module,
+            "_linux_resolve_via_string_xref",
+            fallback,
+        ), patch.object(module, "preprocess_func_sig_via_mcp", reuse):
+            output_path = str(
+                Path(tmpdir) / "CBaseFilter_InputTestActivator.linux.yaml"
+            )
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=[output_path],
+                old_yaml_map=None,
+                new_binary_dir=tmpdir,
+                platform="linux",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        reuse.assert_not_awaited()
+        fallback.assert_awaited_once_with(
+            "session",
+            [output_path],
+            "linux",
+            0x180000000,
+            debug=True,
+        )
+
+    async def test_preprocess_skill_linux_reuses_old_yaml_via_output_path_key(
+        self,
+    ) -> None:
+        module = _load_module(
+            CBASEFILTER_INPUTTESTACTIVATOR_SCRIPT_PATH,
+            "find_CBaseFilter_InputTestActivator",
+        )
+        reuse_result = {
+            "func_name": "CBaseFilter_InputTestActivator",
+            "func_va": "0x180123450",
+            "func_rva": "0x123450",
+            "func_size": "0x90",
+            "func_sig": "48 89 5C 24 ? 57 48 83 EC ?",
+        }
+        reuse = AsyncMock(return_value=reuse_result)
+        fallback = AsyncMock(return_value=False)
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            module,
+            "preprocess_func_sig_via_mcp",
+            reuse,
+        ), patch.object(module, "_linux_resolve_via_string_xref", fallback), patch.object(
+            module,
+            "write_func_yaml",
+        ) as write_func_yaml, patch.object(module.os.path, "exists", return_value=True):
+            output_path = str(
+                Path(tmpdir) / "CBaseFilter_InputTestActivator.linux.yaml"
+            )
+            old_path = str(
+                Path(tmpdir) / "old.CBaseFilter_InputTestActivator.linux.yaml"
+            )
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=[output_path],
+                old_yaml_map={output_path: old_path},
+                new_binary_dir=tmpdir,
+                platform="linux",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        reuse.assert_awaited_once_with(
+            session="session",
+            new_path=output_path,
+            old_path=old_path,
+            image_base=0x180000000,
+            new_binary_dir=tmpdir,
+            platform="linux",
+            func_name="CBaseFilter_InputTestActivator",
+            debug=True,
+        )
+        write_func_yaml.assert_called_once_with(output_path, reuse_result)
+        fallback.assert_not_awaited()
+
 
 class TestFindCLoopModeGameOnEventMapCallbacksClient(
     unittest.IsolatedAsyncioTestCase


### PR DESCRIPTION
## Summary
- 修复 `find-CBaseFilter_InputTestActivator` 在 `old_yaml_map=None` 时直接调用 `.get()` 导致的预处理崩溃
- 修复 Linux 签名复用路径的映射键读取，优先按 `output_path` 匹配旧 YAML，并兼容旧的文件名键
- 新增回归测试，覆盖空旧映射与按输出路径命中旧 YAML 两种场景

## Test Plan
- [x] `python -m unittest tests.test_ida_preprocessor_scripts.TestFindCBaseFilterInputTestActivator`
