### PR TITLE
Fix CNetworkMessages_FindNetworkMessage:

### DIFF
--- a/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkMessage.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_FindNetworkMessage.py
@@ -48,6 +48,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vtable_name",
             "vfunc_offset",
             "vfunc_index",
+            "func_sig_allow_across_function_boundary:true",
         ],
     ),
 ]


### PR DESCRIPTION
    Preprocess: common_funcs after excludes = ['0x3bc640']
    Preprocess: failed to generate a unique function-head signature for 0x3bc640
    Preprocess: CNetworkMessages_FindNetworkMessage matched CNetworkMessages vtable index 13 (offset 0x68)
    Preprocess: missing desired field func_sig for CNetworkMessages_FindNetworkMessage