### PR TITLE
fix(preprocess): 修复HandleInputEvent旧YAML复用

### DIFF
--- a/ida_preprocessor_scripts/find-ILoopMode_HandleInputEvent.py
+++ b/ida_preprocessor_scripts/find-ILoopMode_HandleInputEvent.py
@@ -66,6 +66,44 @@ def _read_func_va(yaml_path):
     return None
 
 
+def _read_vfunc_offset(yaml_path):
+    """Return vfunc_offset as int from a function YAML, or None on failure."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            vfunc_offset = data.get("vfunc_offset")
+            if vfunc_offset is not None:
+                return int(str(vfunc_offset), 0)
+    except Exception:
+        pass
+    return None
+
+
+def _resolve_old_vfunc_offset(old_yaml_map, output_path, expected_filename):
+    """Resolve previous-gamever vfunc_offset from supported old_yaml_map shapes."""
+    if not old_yaml_map:
+        return None
+
+    for key in (output_path, expected_filename, TARGET_FUNC_NAME):
+        if key not in old_yaml_map:
+            continue
+        old_entry = old_yaml_map[key]
+        if isinstance(old_entry, dict):
+            vfunc_offset = old_entry.get("vfunc_offset")
+            if vfunc_offset is not None:
+                try:
+                    return int(str(vfunc_offset), 0)
+                except (ValueError, TypeError):
+                    continue
+        elif isinstance(old_entry, str) and os.path.exists(old_entry):
+            vfunc_offset = _read_vfunc_offset(old_entry)
+            if vfunc_offset is not None:
+                return vfunc_offset
+
+    return None
+
+
 async def preprocess_skill(
     session,
     skill_name,
@@ -94,23 +132,24 @@ async def preprocess_skill(
     output_path = matching_outputs[0]
 
     # Reuse previous gamever result if available
-    if TARGET_FUNC_NAME in old_yaml_map:
-        old_data = old_yaml_map[TARGET_FUNC_NAME]
-        vfunc_offset_raw = old_data.get("vfunc_offset")
-        if vfunc_offset_raw is not None:
-            try:
-                vfunc_offset = int(str(vfunc_offset_raw), 0)
-                if debug:
-                    print(f"    Preprocess: reusing old vfunc_offset={hex(vfunc_offset)} for {TARGET_FUNC_NAME}")
-                write_func_yaml(output_path, {
-                    "func_name": TARGET_FUNC_NAME,
-                    "vtable_name": VTABLE_CLASS,
-                    "vfunc_offset": hex(vfunc_offset),
-                    "vfunc_index": vfunc_offset // 8,
-                })
-                return True
-            except (ValueError, TypeError):
-                pass
+    vfunc_offset = _resolve_old_vfunc_offset(
+        old_yaml_map,
+        output_path,
+        expected_filename,
+    )
+    if vfunc_offset is not None:
+        if debug:
+            print(
+                "    Preprocess: reusing old "
+                f"vfunc_offset={hex(vfunc_offset)} for {TARGET_FUNC_NAME}"
+            )
+        write_func_yaml(output_path, {
+            "func_name": TARGET_FUNC_NAME,
+            "vtable_name": VTABLE_CLASS,
+            "vfunc_offset": hex(vfunc_offset),
+            "vfunc_index": vfunc_offset // 8,
+        })
+        return True
 
     # Read predecessor func_va from its output YAML
     predecessor_yaml = os.path.join(new_binary_dir, f"{PREDECESSOR_STEM}.{platform}.yaml")

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -79,6 +79,10 @@ CBASEFILTER_INPUTTESTACTIVATOR_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CBaseFilter_InputTestActivator.py"
 )
+ILOOPMODE_HANDLEINPUTEVENT_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/"
+    "find-ILoopMode_HandleInputEvent.py"
+)
 ON_EVENT_MAP_CALLBACKS_CLIENT_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CLoopModeGame_OnEventMapCallbacks-client.py"
@@ -904,6 +908,97 @@ class TestFindCBaseFilterInputTestActivator(unittest.IsolatedAsyncioTestCase):
         )
         write_func_yaml.assert_called_once_with(output_path, reuse_result)
         fallback.assert_not_awaited()
+
+
+class TestFindILoopModeHandleInputEvent(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_skill_tolerates_missing_old_yaml_map(
+        self,
+    ) -> None:
+        module = _load_module(
+            ILOOPMODE_HANDLEINPUTEVENT_SCRIPT_PATH,
+            "find_ILoopMode_HandleInputEvent",
+        )
+        session = AsyncMock()
+        session.call_tool.return_value = _py_eval_payload({"vfunc_offset": 0x28})
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            module,
+            "write_func_yaml",
+        ) as write_func_yaml:
+            predecessor_yaml = (
+                Path(tmpdir)
+                / "CLoopTypeClientServerService_HandleInputEvent.linux.yaml"
+            )
+            predecessor_yaml.write_text("func_va: 0x180123450\n", encoding="utf-8")
+            output_path = str(Path(tmpdir) / "ILoopMode_HandleInputEvent.linux.yaml")
+
+            result = await module.preprocess_skill(
+                session=session,
+                skill_name="skill",
+                expected_outputs=[output_path],
+                old_yaml_map=None,
+                new_binary_dir=tmpdir,
+                platform="linux",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        session.call_tool.assert_awaited_once()
+        write_func_yaml.assert_called_once_with(
+            output_path,
+            {
+                "func_name": "ILoopMode_HandleInputEvent",
+                "vtable_name": "ILoopMode",
+                "vfunc_offset": "0x28",
+                "vfunc_index": 5,
+            },
+        )
+
+    async def test_preprocess_skill_reuses_old_yaml_via_output_path_key(
+        self,
+    ) -> None:
+        module = _load_module(
+            ILOOPMODE_HANDLEINPUTEVENT_SCRIPT_PATH,
+            "find_ILoopMode_HandleInputEvent",
+        )
+        session = AsyncMock()
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.object(
+            module,
+            "write_func_yaml",
+        ) as write_func_yaml:
+            output_path = str(Path(tmpdir) / "ILoopMode_HandleInputEvent.linux.yaml")
+            old_yaml_path = str(
+                Path(tmpdir) / "old.ILoopMode_HandleInputEvent.linux.yaml"
+            )
+            Path(old_yaml_path).write_text(
+                "vfunc_offset: 0x30\n",
+                encoding="utf-8",
+            )
+
+            result = await module.preprocess_skill(
+                session=session,
+                skill_name="skill",
+                expected_outputs=[output_path],
+                old_yaml_map={output_path: old_yaml_path},
+                new_binary_dir=tmpdir,
+                platform="linux",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        session.call_tool.assert_not_awaited()
+        write_func_yaml.assert_called_once_with(
+            output_path,
+            {
+                "func_name": "ILoopMode_HandleInputEvent",
+                "vtable_name": "ILoopMode",
+                "vfunc_offset": "0x30",
+                "vfunc_index": 6,
+            },
+        )
 
 
 class TestFindCLoopModeGameOnEventMapCallbacksClient(


### PR DESCRIPTION
## Summary
- 修复 `find-ILoopMode_HandleInputEvent` 在 `old_yaml_map=None` 时对空值做成员判断导致的预处理崩溃
- 修复旧 YAML 复用契约，支持按 `output_path -> old_yaml_path` 读取旧 `vfunc_offset`，并兼容旧的字典形态
- 新增回归测试，覆盖空旧映射和按输出路径复用旧 YAML 两个场景

## Test Plan
- [x] `python -m unittest tests.test_ida_preprocessor_scripts.TestFindILoopModeHandleInputEvent`
