### PR TITLE
Add forward declarations to fix INetworkMessages cpp_test build after hl2sdk_cs2 update

### DIFF
--- a/cpp_tests/inetworkmessages.cpp
+++ b/cpp_tests/inetworkmessages.cpp
@@ -9,6 +9,11 @@
 #define INETCHANNEL_H
 enum NetChannelBufType_t : int8 {};
 
+// Forward declarations for types added to inetworkserializer.h in hl2sdk_cs2 update
+class CPlayerBitVec;
+typedef void *(*SchemaClassManipulatorFn_t)(int, void *);
+typedef void *(*SchemaCollectionManipulatorFn_t)(int, void *, int, int);
+
 #include <networksystem/inetworkmessages.h>
 
 INetworkMessages * networkmessages();


### PR DESCRIPTION
The submodule update added CPlayerBitVec, SchemaCollectionManipulatorFn_t, and SchemaClassManipulatorFn_t references to inetworkserializer.h without the corresponding includes. Added forward declarations in the test file.