### PR TITLE
fix(ci): 修复发布包排除规则

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -131,21 +131,29 @@ jobs:
         shell: pwsh
         working-directory: ${{ github.workspace }}
         run: |
-          7z a "gamedata-$($env:GAMEVER).7z" "bin\$($env:GAMEVER)" "dist" "hl2sdk_cs2" -r `
-          "-x!*.dll" `
-          "-x!*.so" `
-          "-x!*.i64" `
-          "-x!*.id0" `
-          "-x!*.id1" `
-          "-x!*.id2" `
-          "-x!*.nam" `
-          "-x!*.til" `
-          "-x!.git" `
-          "-x!.git-blame-ignore-revs" `
-          "-x!.gitmodules"
-          "-x!__pycache__"
-          "-x!gamedata.py"
-          "-x!config.yaml"
+          $archiveArgs = @(
+            "a"
+            "gamedata-$($env:GAMEVER).7z"
+            "bin\$($env:GAMEVER)"
+            "dist"
+            "hl2sdk_cs2"
+            "-r"
+            "-x!*.dll"
+            "-x!*.so"
+            "-x!*.i64"
+            "-x!*.id0"
+            "-x!*.id1"
+            "-x!*.id2"
+            "-x!*.nam"
+            "-x!*.til"
+            "-x!.git"
+            "-x!.git-blame-ignore-revs"
+            "-x!.gitmodules"
+            "-xr!__pycache__"
+            "-xr!gamedata.py"
+            "-xr!config.yaml"
+          )
+          & 7z @archiveArgs
 
       - name: Create release
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
- Replace fragile PowerShell line continuations in the release archive step with an explicit argument array.
- Use recursive 7z excludes for __pycache__, gamedata.py, and config.yaml so nested generated files are excluded reliably.

## Verification
- Ran git diff --check on .github/workflows/build-on-self-runner.yml.
- Checked the workflow text contains & 7z @archiveArgs and the expected recursive exclude arguments.
- Did not run tests or builds per repository instruction unless explicitly requested.