### PR TITLE
Add entity lifecycle and I/O preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3109,6 +3109,13 @@ modules:
         expected_input:
           - CGameSceneNode_PostDataUpdate.{platform}.yaml
 
+      - name: find-CEntitySystem_OnEntityParentChanged
+        expected_output:
+          - CEntitySystem_OnEntityParentChanged.{platform}.yaml
+        expected_input:
+          - CGameSceneNode_OnParentChanged.{platform}.yaml
+          - CEntitySystem_vtable.{platform}.yaml
+
       - name: find-CPointTeleportAPI_TeleportEntityInternal
         expected_output:
           - CPointTeleportAPI_TeleportEntityInternal.{platform}.yaml
@@ -4334,6 +4341,11 @@ modules:
         category: vfunc
         alias:
           - CEntitySystem::OnAddEntity
+
+      - name: CEntitySystem_OnEntityParentChanged
+        category: vfunc
+        alias:
+          - CEntitySystem::OnEntityParentChanged
 
       - name: CEntitySystem_PrecacheEntity
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -3096,6 +3096,13 @@ modules:
         expected_input:
           - CSkeletonInstance_vtable.{platform}.yaml
 
+      - name: find-CGameSceneNode_PostDataUpdate
+        expected_output:
+          - CGameSceneNode_PostDataUpdate.{platform}.yaml
+        expected_input:
+          - CSkeletonInstance_PostDataUpdate.{platform}.yaml
+          - CGameSceneNode_vtable.{platform}.yaml
+
       - name: find-CPointTeleportAPI_TeleportEntityInternal
         expected_output:
           - CPointTeleportAPI_TeleportEntityInternal.{platform}.yaml
@@ -4865,6 +4872,11 @@ modules:
         category: vfunc
         alias:
           - CSkeletonInstance::PostDataUpdate
+
+      - name: CGameSceneNode_PostDataUpdate
+        category: vfunc
+        alias:
+          - CGameSceneNode::PostDataUpdate
 
       - name: CPointTeleportAPI_TeleportEntityInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2784,6 +2784,13 @@ modules:
         expected_output:
           - EntInfo_CommandHandler.{platform}.yaml
 
+      - name: find-CEntitySystem_RemoveEntityImmediate-AND-ClientPrintToController
+        expected_output:
+          - CEntitySystem_RemoveEntityImmediate.{platform}.yaml
+          - ClientPrintToController.{platform}.yaml
+        expected_input:
+          - EntInfo_CommandHandler.{platform}.yaml
+
       - name: find-CBasePlayerPawn_CommitSuicide
         expected_output:
           - CBasePlayerPawn_CommitSuicide.{platform}.yaml
@@ -5020,6 +5027,16 @@ modules:
         category: func
         alias:
           - CC_Ent_Info
+
+      - name: CEntitySystem_RemoveEntityImmediate
+        category: func
+        alias:
+          - CEntitySystem::RemoveEntityImmediate
+
+      - name: ClientPrintToController
+        category: func
+        alias:
+          - ClientPrint
 
       - name: g_pCSBotManager
         category: gv

--- a/config.yaml
+++ b/config.yaml
@@ -2906,6 +2906,12 @@ modules:
         expected_input:
           - CEntFireOutputAutoCompletionFunctor_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_FindOutputsByName
+        expected_output:
+          - CEntityInstance_FindOutputsByName.{platform}.yaml
+        expected_input:
+          - CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml
+
       - name: find-CEntityIOOutput_FireOutputInternal
         expected_output:
           - CEntityIOOutput_FireOutputInternal.{platform}.yaml
@@ -4639,6 +4645,11 @@ modules:
         category: vfunc
         alias:
           - CEntFireOutputAutoCompletionFunctor::FireOutput
+
+      - name: CEntityInstance_FindOutputsByName
+        category: func
+        alias:
+          - CEntityInstance::FindOutputsByName
 
       - name: CEntityIOOutput_FireOutputInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2780,6 +2780,10 @@ modules:
         expected_output:
           - BotKill_CommandHandler.{platform}.yaml
 
+      - name: find-EntInfo_CommandHandler
+        expected_output:
+          - EntInfo_CommandHandler.{platform}.yaml
+
       - name: find-CBasePlayerPawn_CommitSuicide
         expected_output:
           - CBasePlayerPawn_CommitSuicide.{platform}.yaml
@@ -5011,6 +5015,11 @@ modules:
         category: func
         alias:
           - CCSBotManager::BotKillCommand
+
+      - name: EntInfo_CommandHandler
+        category: func
+        alias:
+          - CC_Ent_Info
 
       - name: g_pCSBotManager
         category: gv

--- a/config.yaml
+++ b/config.yaml
@@ -2912,6 +2912,13 @@ modules:
         expected_input:
           - CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml
 
+      - name: find-CEntityInstance_ScriptEntityIO
+        expected_output:
+          - CEntityInstance_ScriptEntityIO.{platform}.yaml
+        expected_input:
+          - CEntityInstance_FindOutputsByName.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CEntityIOOutput_FireOutputInternal
         expected_output:
           - CEntityIOOutput_FireOutputInternal.{platform}.yaml
@@ -4650,6 +4657,11 @@ modules:
         category: func
         alias:
           - CEntityInstance::FindOutputsByName
+
+      - name: CEntityInstance_ScriptEntityIO
+        category: vfunc
+        alias:
+          - CEntityInstance::ScriptEntityIO
 
       - name: CEntityIOOutput_FireOutputInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -3103,6 +3103,12 @@ modules:
           - CSkeletonInstance_PostDataUpdate.{platform}.yaml
           - CGameSceneNode_vtable.{platform}.yaml
 
+      - name: find-CGameSceneNode_OnParentChanged
+        expected_output:
+          - CGameSceneNode_OnParentChanged.{platform}.yaml
+        expected_input:
+          - CGameSceneNode_PostDataUpdate.{platform}.yaml
+
       - name: find-CPointTeleportAPI_TeleportEntityInternal
         expected_output:
           - CPointTeleportAPI_TeleportEntityInternal.{platform}.yaml
@@ -4877,6 +4883,11 @@ modules:
         category: vfunc
         alias:
           - CGameSceneNode::PostDataUpdate
+
+      - name: CGameSceneNode_OnParentChanged
+        category: func
+        alias:
+          - CGameSceneNode::OnParentChanged
 
       - name: CPointTeleportAPI_TeleportEntityInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2798,9 +2798,9 @@ modules:
         expected_input:
           - CEntitySystem_RemoveEntityImmediate.{platform}.yaml
 
-      - name: find-CEntityInstance_OnRemoveEntity
+      - name: find-CEntitySystem_OnRemoveEntity
         expected_output:
-          - CEntityInstance_OnRemoveEntity.{platform}.yaml
+          - CEntitySystem_OnRemoveEntity.{platform}.yaml
         expected_input:
           - CEntitySystem_NotifyRemoveEntity.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
@@ -5148,10 +5148,10 @@ modules:
         alias:
           - CEntityInstance::AddedToEntityDatabase
 
-      - name: CEntityInstance_OnRemoveEntity
+      - name: CEntitySystem_OnRemoveEntity
         category: vfunc
         alias:
-          - CEntityInstance::OnRemoveEntity
+          - CEntitySystem::OnRemoveEntity
 
       - name: CEntityComponentHelperT_Free
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2956,6 +2956,13 @@ modules:
         expected_input:
           - CGameEntitySystem_Activate.{platform}.yaml
 
+      - name: find-CGameSceneNode_AcquireParent
+        expected_output:
+          - CGameSceneNode_AcquireParent.{platform}.yaml
+        expected_input:
+          - CBodyGameSystem_ProcessSpawnGroupSceneNodes.{platform}.yaml
+          - CGameSceneNode_vtable.{platform}.yaml
+
       - name: find-IGameSystem_OnBuildGameSessionManifest
         expected_output:
           - IGameSystem_OnBuildGameSessionManifest.{platform}.yaml
@@ -4817,6 +4824,11 @@ modules:
         member: m_skeletonInstance
         alias:
           - CBaseAnimGraph::m_skeletonInstance
+
+      - name: CGameSceneNode_AcquireParent
+        category: vfunc
+        alias:
+          - CGameSceneNode::AcquireParent
 
       - name: CGameSceneNode_GetSkeletonInstance
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -3086,6 +3086,16 @@ modules:
           - CBaseAnimGraph_GetAnimationController.{platform}.yaml
           - CGameSceneNode_vtable.{platform}.yaml
 
+      - name: find-CSkeletonInstance_vtable
+        expected_output:
+          - CSkeletonInstance_vtable.{platform}.yaml
+
+      - name: find-CSkeletonInstance_PostDataUpdate
+        expected_output:
+          - CSkeletonInstance_PostDataUpdate.{platform}.yaml
+        expected_input:
+          - CSkeletonInstance_vtable.{platform}.yaml
+
       - name: find-CPointTeleportAPI_TeleportEntityInternal
         expected_output:
           - CPointTeleportAPI_TeleportEntityInternal.{platform}.yaml
@@ -4847,6 +4857,14 @@ modules:
 
       - name: CSkeletonInstance
         category: struct
+
+      - name: CSkeletonInstance_vtable
+        category: vtable
+
+      - name: CSkeletonInstance_PostDataUpdate
+        category: vfunc
+        alias:
+          - CSkeletonInstance::PostDataUpdate
 
       - name: CPointTeleportAPI_TeleportEntityInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2798,6 +2798,13 @@ modules:
         expected_input:
           - CEntitySystem_RemoveEntityImmediate.{platform}.yaml
 
+      - name: find-CEntityInstance_OnRemoveEntity
+        expected_output:
+          - CEntityInstance_OnRemoveEntity.{platform}.yaml
+        expected_input:
+          - CEntitySystem_NotifyRemoveEntity.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CBasePlayerPawn_CommitSuicide
         expected_output:
           - CBasePlayerPawn_CommitSuicide.{platform}.yaml
@@ -5140,6 +5147,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::AddedToEntityDatabase
+
+      - name: CEntityInstance_OnRemoveEntity
+        category: vfunc
+        alias:
+          - CEntityInstance::OnRemoveEntity
 
       - name: CEntityComponentHelperT_Free
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -1916,6 +1916,8 @@ modules:
     vcall_finder:
       - g_pNetworkMessages
       - g_pFlattenedSerializers
+      - g_pEntitySystem
+      - g_pGameEntitySystem
 
     skills:
       - name: find-CSource2Server_vtable
@@ -2946,6 +2948,13 @@ modules:
           - CGameEntitySystem_Activate.{platform}.yaml
         expected_input:
           - CGameEntitySystem_vtable.{platform}.yaml
+
+      - name: find-CBodyGameSystem_ProcessSpawnGroupSceneNodes-AND-CGameEntitySystem_CheckGlobalState
+        expected_output:
+          - CBodyGameSystem_ProcessSpawnGroupSceneNodes.{platform}.yaml
+          - CGameEntitySystem_CheckGlobalState.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_Activate.{platform}.yaml
 
       - name: find-IGameSystem_OnBuildGameSessionManifest
         expected_output:
@@ -4622,6 +4631,16 @@ modules:
         category: vfunc
         alias:
           - CGameEntitySystem::Activate
+
+      - name: CBodyGameSystem_ProcessSpawnGroupSceneNodes
+        category: func
+        alias:
+          - CBodyGameSystem::ProcessSpawnGroupSceneNodes
+
+      - name: CGameEntitySystem_CheckGlobalState
+        category: func
+        alias:
+          - CGameEntitySystem::CheckGlobalState
 
       - name: IGameSystem_OnBuildGameSessionManifest
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2172,6 +2172,10 @@ modules:
         expected_output:
           - CSmokeGrenadeProjectile_Create.{platform}.yaml
 
+      - name: find-SV_Kill_SmokeGrenade_CommandHandler
+        expected_output:
+          - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+
       - name: find-CBaseModelEntity_SetModel-AND-CBaseEntity_SetGravityScale
         expected_output:
           - CBaseModelEntity_SetModel.{platform}.yaml
@@ -3872,6 +3876,9 @@ modules:
         category: func
         alias:
           - CSmokeGrenadeProjectile::Create
+
+      - name: SV_Kill_SmokeGrenade_CommandHandler
+        category: func
 
       - name: CBaseModelEntity_SetModel
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -3456,6 +3456,12 @@ modules:
           - CEntityInstance_vtable.{platform}.yaml
           - CBasePlayerController_Connect.{platform}.yaml
 
+      - name: find-CEntityInstance_UpdateOnRemove
+        expected_output:
+          - CEntityInstance_UpdateOnRemove.{platform}.yaml
+        expected_input:
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CScriptedSequence_SynchronizeSequence
         expected_output:
           - CScriptedSequence_SynchronizeSequence.{platform}.yaml
@@ -5221,6 +5227,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::Connect
+
+      - name: CEntityInstance_UpdateOnRemove
+        category: vfunc
+        alias:
+          - CEntityInstance::UpdateOnRemove
 
       - name: CEntityInstance_Disconnect
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2176,6 +2176,12 @@ modules:
         expected_output:
           - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
 
+      - name: find-CEntitySystem_RemoveEntity
+        expected_output:
+          - CEntitySystem_RemoveEntity.{platform}.yaml
+        expected_input:
+          - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+
       - name: find-CBaseModelEntity_SetModel-AND-CBaseEntity_SetGravityScale
         expected_output:
           - CBaseModelEntity_SetModel.{platform}.yaml
@@ -3879,6 +3885,11 @@ modules:
 
       - name: SV_Kill_SmokeGrenade_CommandHandler
         category: func
+
+      - name: CEntitySystem_RemoveEntity
+        category: func
+        alias:
+          - CEntitySystem::RemoveEntity
 
       - name: CBaseModelEntity_SetModel
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2645,6 +2645,12 @@ modules:
         expected_output:
           - NetworkStateChanged.{platform}.yaml
 
+      - name: find-CCSPlayerPawnBase_OnSetDormant
+        expected_output:
+          - CCSPlayerPawnBase_OnSetDormant.{platform}.yaml
+        expected_input:
+          - CCSPlayerPawnBase_vtable.{platform}.yaml
+
       - name: find-CCSPlayerPawnBase_CheckForIdle
         platform: windows
         expected_output:
@@ -4206,6 +4212,11 @@ modules:
         category: func
         alias:
           - CCSPlayerController::SwitchTeam
+
+      - name: CCSPlayerPawnBase_OnSetDormant
+        category: vfunc
+        alias:
+          - CCSPlayerPawnBase::OnSetDormant
 
       - name: CCSPlayerPawnBase_CheckForIdle
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2791,6 +2791,13 @@ modules:
         expected_input:
           - EntInfo_CommandHandler.{platform}.yaml
 
+      - name: find-CEntitySystem_NotifyRemoveEntity-AND-CEntitySystem_DestroyEntityInternal
+        expected_output:
+          - CEntitySystem_NotifyRemoveEntity.{platform}.yaml
+          - CEntitySystem_DestroyEntityInternal.{platform}.yaml
+        expected_input:
+          - CEntitySystem_RemoveEntityImmediate.{platform}.yaml
+
       - name: find-CBasePlayerPawn_CommitSuicide
         expected_output:
           - CBasePlayerPawn_CommitSuicide.{platform}.yaml
@@ -5032,6 +5039,16 @@ modules:
         category: func
         alias:
           - CEntitySystem::RemoveEntityImmediate
+
+      - name: CEntitySystem_NotifyRemoveEntity
+        category: func
+        alias:
+          - CEntitySystem::NotifyRemoveEntity
+
+      - name: CEntitySystem_DestroyEntityInternal
+        category: func
+        alias:
+          - CEntitySystem::DestroyEntityInternal
 
       - name: ClientPrintToController
         category: func

--- a/docs/superpowers/plans/2026-04-27-centitysystem-removeentity-preprocessor-implementation.md
+++ b/docs/superpowers/plans/2026-04-27-centitysystem-removeentity-preprocessor-implementation.md
@@ -1,0 +1,775 @@
+# CEntitySystem_RemoveEntity Preprocessor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `find-CEntitySystem_RemoveEntity` 预处理脚本，并通过可复用工具类从 `SV_Kill_SmokeGrenade_CommandHandler` 内定位唯一直接 `call` / 尾调用 `jmp` 目标。
+
+**Architecture:** 实现分三层：`_direct_branch_target_common.py` 负责读取源 YAML、扫描 IDA 函数内直接分支、按 `GENERATE_YAML_DESIRED_FIELDS` 写出目标 YAML；`find-CEntitySystem_RemoveEntity.py` 只声明源函数、目标函数和字段契约；`config.yaml` 把新 skill 接入现有预处理链。公共 helper 只支持直接 `call imm` / `jmp imm`，并在候选数量不是 1 时 fail-fast。
+
+**Tech Stack:** Python 3、IDA MCP `py_eval`、PyYAML、`ida_analyze_util.write_func_yaml`、`ida_analyze_util.preprocess_gen_func_sig_via_mcp`
+
+---
+
+## File Structure
+
+- Create: `ida_preprocessor_scripts/_direct_branch_target_common.py`
+  - 公共 helper 与 `DirectBranchTargetLocator` 工具类
+  - 负责 `py_eval` 扫描、唯一目标校验、函数信息查询、字段契约写出和 best-effort rename
+- Create: `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+  - 薄封装预处理脚本
+  - 声明 `SOURCE_FUNCTION_NAME`、`TARGET_FUNCTION_NAMES`、`GENERATE_YAML_DESIRED_FIELDS`
+- Modify: `config.yaml`
+  - 在 `find-SV_Kill_SmokeGrenade_CommandHandler` 附近新增 `find-CEntitySystem_RemoveEntity`
+  - 在 symbol metadata 中新增 `CEntitySystem_RemoveEntity`
+- Create: `docs/superpowers/plans/2026-04-27-centitysystem-removeentity-preprocessor-implementation.md`
+  - 当前实施计划文档
+
+## Execution Constraints
+
+- 不修改已有公共 helper 行为。
+- 不运行完整 build 或完整 test。
+- 定向验证只使用 `python -m py_compile` 和轻量静态 YAML 检查。
+- YAML 输出字段必须完全由 `GENERATE_YAML_DESIRED_FIELDS` 决定。
+- 所有预处理失败路径返回 `False`，不向上层抛出异常。
+
+### Task 1: 新增直接分支目标公共 helper
+
+**Files:**
+- Create: `ida_preprocessor_scripts/_direct_branch_target_common.py`
+
+- [ ] **Step 1: 创建 `_direct_branch_target_common.py`**
+
+Create `ida_preprocessor_scripts/_direct_branch_target_common.py` with this full content:
+
+```python
+#!/usr/bin/env python3
+"""Shared preprocess helpers for direct branch target skills."""
+
+import json
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import (
+    parse_mcp_result,
+    preprocess_gen_func_sig_via_mcp,
+    write_func_yaml,
+)
+
+
+_SUPPORTED_FIELDS = {
+    "func_name",
+    "func_sig",
+    "func_va",
+    "func_rva",
+    "func_size",
+}
+
+
+_DIRECT_BRANCH_TARGET_PY_EVAL = """import idaapi, idautils, idc, json
+func_addr = __FUNC_ADDR__
+allowed_mnemonics = set(__ALLOWED_MNEMONICS__)
+result_obj = None
+if not idaapi.get_func(func_addr):
+    idaapi.add_func(func_addr)
+func = idaapi.get_func(func_addr)
+
+def _func_start_for_target(target_ea):
+    target_func = idaapi.get_func(target_ea)
+    if not target_func:
+        idaapi.add_func(target_ea)
+        target_func = idaapi.get_func(target_ea)
+    if not target_func:
+        return None
+    return int(target_func.start_ea)
+
+if func:
+    targets = []
+    seen = set()
+    for head in idautils.Heads(func.start_ea, func.end_ea):
+        mnem = idc.print_insn_mnem(head).lower()
+        if mnem not in allowed_mnemonics:
+            continue
+        insn = idaapi.insn_t()
+        if not idaapi.decode_insn(insn, head):
+            continue
+        op = insn.ops[0]
+        if op.type not in (idaapi.o_near, idaapi.o_far):
+            continue
+        refs = []
+        for target_ea in idautils.CodeRefsFrom(head, False):
+            target_start = _func_start_for_target(target_ea)
+            if target_start is not None:
+                refs.append(target_start)
+        refs = sorted(set(refs))
+        if len(refs) != 1:
+            continue
+        target_start = refs[0]
+        if target_start in seen:
+            continue
+        seen.add(target_start)
+        targets.append({
+            "source_ea": hex(head),
+            "source_mnemonic": mnem,
+            "target_va": hex(target_start),
+        })
+    result_obj = {
+        "source_func_va": hex(func.start_ea),
+        "source_func_size": hex(func.end_ea - func.start_ea),
+        "targets": targets,
+    }
+result = json.dumps(result_obj)
+"""
+
+
+def _debug(debug, message):
+    if debug:
+        print(f"    Preprocess: {message}")
+
+
+def _read_yaml(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+def _parse_int(value):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("empty integer string")
+        return int(raw, 0)
+    return int(value)
+
+
+def _normalize_requested_fields(generate_yaml_desired_fields, target_name, debug=False):
+    if not generate_yaml_desired_fields:
+        _debug(debug, "missing generate_yaml_desired_fields")
+        return None
+
+    desired_map = {}
+    try:
+        for symbol_name, fields in generate_yaml_desired_fields:
+            desired_map[str(symbol_name)] = list(fields)
+    except Exception:
+        _debug(debug, "invalid generate_yaml_desired_fields")
+        return None
+
+    fields = desired_map.get(target_name)
+    if not fields:
+        _debug(debug, f"missing desired fields for {target_name}")
+        return None
+
+    normalized = []
+    seen = set()
+    for field in fields:
+        field_name = str(field)
+        if field_name not in _SUPPORTED_FIELDS:
+            _debug(debug, f"unsupported requested field for {target_name}: {field_name}")
+            return None
+        if field_name in seen:
+            _debug(debug, f"duplicate requested field for {target_name}: {field_name}")
+            return None
+        seen.add(field_name)
+        normalized.append(field_name)
+
+    return normalized
+
+
+def _resolve_output_path(expected_outputs, target_name, platform, debug=False):
+    filename = f"{target_name}.{platform}.yaml"
+    matches = [
+        path for path in expected_outputs if os.path.basename(path) == filename
+    ]
+    if len(matches) != 1:
+        _debug(debug, f"expected exactly one output for {filename}")
+        return None
+    return matches[0]
+
+
+async def _call_py_eval_json(session, code, debug=False, error_label="py_eval"):
+    try:
+        result = await session.call_tool(name="py_eval", arguments={"code": code})
+        result_data = parse_mcp_result(result)
+    except Exception:
+        _debug(debug, f"{error_label} error")
+        return None
+
+    raw = None
+    if isinstance(result_data, dict):
+        stderr_text = result_data.get("stderr", "")
+        if stderr_text and debug:
+            print("    Preprocess: py_eval stderr:")
+            print(str(stderr_text).strip())
+        raw = result_data.get("result", "")
+    elif result_data is not None:
+        raw = str(result_data)
+
+    if not raw:
+        return None
+
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        _debug(debug, f"invalid JSON result from {error_label}")
+        return None
+
+
+def _build_direct_branch_target_py_eval(func_va, allowed_mnemonics):
+    normalized = [str(item).lower() for item in allowed_mnemonics]
+    return (
+        _DIRECT_BRANCH_TARGET_PY_EVAL
+        .replace("__FUNC_ADDR__", str(func_va))
+        .replace("__ALLOWED_MNEMONICS__", json.dumps(normalized))
+    )
+
+
+async def _rename_func_best_effort(session, func_va, func_name, debug=False):
+    if not func_va or not func_name:
+        return
+    try:
+        await session.call_tool(
+            name="rename",
+            arguments={
+                "batch": {
+                    "func": {"addr": str(func_va), "name": str(func_name)}
+                }
+            },
+        )
+    except Exception:
+        _debug(debug, f"failed to rename {func_name} (non-fatal)")
+
+
+class DirectBranchTargetLocator:
+    """Locate one direct call/jmp target inside a known source function."""
+
+    def __init__(self, session, debug=False):
+        self.session = session
+        self.debug = debug
+
+    async def collect_targets(self, source_func_va, allowed_mnemonics=("call", "jmp")):
+        code = _build_direct_branch_target_py_eval(
+            func_va=source_func_va,
+            allowed_mnemonics=allowed_mnemonics,
+        )
+        parsed = await _call_py_eval_json(
+            session=self.session,
+            code=code,
+            debug=self.debug,
+            error_label="py_eval collecting direct branch targets",
+        )
+        if not isinstance(parsed, dict):
+            _debug(self.debug, "failed to collect direct branch targets")
+            return None
+
+        raw_targets = parsed.get("targets")
+        if not isinstance(raw_targets, list):
+            _debug(self.debug, "direct branch target result missing targets list")
+            return None
+
+        targets = []
+        seen = set()
+        for item in raw_targets:
+            if not isinstance(item, dict):
+                _debug(self.debug, "invalid direct branch target entry")
+                return None
+            target_va = item.get("target_va")
+            try:
+                target_va_int = _parse_int(target_va)
+            except Exception:
+                _debug(self.debug, f"invalid target_va: {target_va}")
+                return None
+            if target_va_int in seen:
+                continue
+            seen.add(target_va_int)
+            targets.append(
+                {
+                    "source_ea": str(item.get("source_ea", "")),
+                    "source_mnemonic": str(item.get("source_mnemonic", "")),
+                    "target_va": hex(target_va_int),
+                }
+            )
+
+        return targets
+
+    async def query_func_info(self, target_va):
+        try:
+            target_va_int = _parse_int(target_va)
+        except Exception:
+            _debug(self.debug, f"invalid target func_va: {target_va}")
+            return None
+
+        code = (
+            "import idaapi, json\n"
+            f"target_ea = {target_va_int}\n"
+            "func = idaapi.get_func(target_ea)\n"
+            "if func and func.start_ea == target_ea:\n"
+            "    result = json.dumps({\n"
+            "        'func_va': hex(func.start_ea),\n"
+            "        'func_size': hex(func.end_ea - func.start_ea),\n"
+            "    })\n"
+            "else:\n"
+            "    result = json.dumps(None)\n"
+        )
+        parsed = await _call_py_eval_json(
+            session=self.session,
+            code=code,
+            debug=self.debug,
+            error_label="py_eval querying direct branch target function info",
+        )
+        return parsed if isinstance(parsed, dict) else None
+
+    async def rename_func_best_effort(self, func_va, func_name):
+        await _rename_func_best_effort(
+            session=self.session,
+            func_va=func_va,
+            func_name=func_name,
+            debug=self.debug,
+        )
+
+
+async def _build_requested_payload(
+    session,
+    target_name,
+    requested_fields,
+    func_info,
+    image_base,
+    debug=False,
+):
+    try:
+        func_va = str(func_info["func_va"])
+        func_va_int = _parse_int(func_va)
+        func_size = str(func_info["func_size"])
+    except Exception:
+        _debug(debug, f"incomplete function info for {target_name}")
+        return None
+
+    available = {
+        "func_name": target_name,
+        "func_va": func_va,
+        "func_size": func_size,
+    }
+
+    if "func_rva" in requested_fields:
+        available["func_rva"] = hex(func_va_int - image_base)
+
+    if "func_sig" in requested_fields:
+        sig_info = await preprocess_gen_func_sig_via_mcp(
+            session=session,
+            func_va=func_va,
+            image_base=image_base,
+            debug=debug,
+        )
+        if not isinstance(sig_info, dict) or not sig_info.get("func_sig"):
+            _debug(debug, f"failed to generate func_sig for {target_name}")
+            return None
+        available["func_sig"] = sig_info["func_sig"]
+        if "func_rva" in requested_fields and sig_info.get("func_rva"):
+            available["func_rva"] = sig_info["func_rva"]
+        if "func_size" in requested_fields and sig_info.get("func_size"):
+            available["func_size"] = sig_info["func_size"]
+
+    payload = {}
+    for field in requested_fields:
+        if field not in available:
+            _debug(debug, f"requested field is not available for {target_name}: {field}")
+            return None
+        payload[field] = available[field]
+
+    return payload
+
+
+async def preprocess_direct_branch_target_skill(
+    session,
+    expected_outputs,
+    new_binary_dir,
+    platform,
+    image_base,
+    source_yaml_stem,
+    target_name,
+    generate_yaml_desired_fields,
+    rename_to=None,
+    allowed_mnemonics=("call", "jmp"),
+    expected_target_count=1,
+    debug=False,
+):
+    if yaml is None:
+        _debug(debug, "PyYAML is required")
+        return False
+
+    if expected_target_count != 1:
+        _debug(debug, "expected_target_count must be 1")
+        return False
+
+    requested_fields = _normalize_requested_fields(
+        generate_yaml_desired_fields,
+        target_name,
+        debug=debug,
+    )
+    if requested_fields is None:
+        return False
+
+    output_path = _resolve_output_path(
+        expected_outputs,
+        target_name,
+        platform,
+        debug=debug,
+    )
+    if output_path is None:
+        return False
+
+    source_path = os.path.join(
+        new_binary_dir,
+        f"{source_yaml_stem}.{platform}.yaml",
+    )
+    source_yaml = _read_yaml(source_path)
+    if not isinstance(source_yaml, dict) or not source_yaml.get("func_va"):
+        _debug(debug, f"failed to read source function YAML: {source_path}")
+        return False
+
+    source_func_va = str(source_yaml["func_va"])
+    locator = DirectBranchTargetLocator(session=session, debug=debug)
+    targets = await locator.collect_targets(
+        source_func_va=source_func_va,
+        allowed_mnemonics=allowed_mnemonics,
+    )
+    if not isinstance(targets, list) or len(targets) != expected_target_count:
+        count = len(targets) if isinstance(targets, list) else "N/A"
+        _debug(
+            debug,
+            f"expected {expected_target_count} direct branch target, got {count}",
+        )
+        return False
+
+    target_va = targets[0]["target_va"]
+    func_info = await locator.query_func_info(target_va)
+    if not isinstance(func_info, dict):
+        _debug(debug, f"failed to query function info for {target_name}")
+        return False
+
+    payload = await _build_requested_payload(
+        session=session,
+        target_name=target_name,
+        requested_fields=requested_fields,
+        func_info=func_info,
+        image_base=image_base,
+        debug=debug,
+    )
+    if payload is None:
+        return False
+
+    write_func_yaml(output_path, payload)
+
+    await locator.rename_func_best_effort(
+        func_va=target_va,
+        func_name=rename_to,
+    )
+
+    if debug:
+        print(
+            "    Preprocess: "
+            f"written {os.path.basename(output_path)} from direct branch target {target_va}"
+        )
+
+    return True
+```
+
+- [ ] **Step 2: 编译检查公共 helper**
+
+Run:
+
+```bash
+python -m py_compile ida_preprocessor_scripts/_direct_branch_target_common.py
+```
+
+Expected:
+
+```text
+no output, exit code 0
+```
+
+### Task 2: 新增 `find-CEntitySystem_RemoveEntity.py`
+
+**Files:**
+- Create: `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+
+- [ ] **Step 1: 创建薄封装脚本**
+
+Create `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py` with this full content:
+
+```python
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RemoveEntity skill."""
+
+from ida_preprocessor_scripts._direct_branch_target_common import (
+    preprocess_direct_branch_target_skill,
+)
+
+
+SOURCE_FUNCTION_NAME = "SV_Kill_SmokeGrenade_CommandHandler"
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RemoveEntity",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_RemoveEntity",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_direct_branch_target_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        source_yaml_stem=SOURCE_FUNCTION_NAME,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        debug=debug,
+    )
+```
+
+- [ ] **Step 2: 编译检查两个新增 Python 文件**
+
+Run:
+
+```bash
+python -m py_compile ida_preprocessor_scripts/_direct_branch_target_common.py ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py
+```
+
+Expected:
+
+```text
+no output, exit code 0
+```
+
+### Task 3: 接入 `config.yaml`
+
+**Files:**
+- Modify: `config.yaml`
+
+- [ ] **Step 1: 在 skill 列表中新增 `find-CEntitySystem_RemoveEntity`**
+
+Find this existing block near the server projectile commands:
+
+```yaml
+      - name: find-SV_Kill_SmokeGrenade_CommandHandler
+        expected_output:
+          - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+```
+
+Change it to:
+
+```yaml
+      - name: find-SV_Kill_SmokeGrenade_CommandHandler
+        expected_output:
+          - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+
+      - name: find-CEntitySystem_RemoveEntity
+        expected_output:
+          - CEntitySystem_RemoveEntity.{platform}.yaml
+        expected_input:
+          - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+```
+
+- [ ] **Step 2: 在 symbol metadata 中新增 `CEntitySystem_RemoveEntity`**
+
+Find this existing block:
+
+```yaml
+      - name: SV_Kill_SmokeGrenade_CommandHandler
+        category: func
+
+      - name: CBaseModelEntity_SetModel
+        category: func
+        alias:
+          - CBaseModelEntity::SetModel
+```
+
+Change it to:
+
+```yaml
+      - name: SV_Kill_SmokeGrenade_CommandHandler
+        category: func
+
+      - name: CEntitySystem_RemoveEntity
+        category: func
+        alias:
+          - CEntitySystem::RemoveEntity
+
+      - name: CBaseModelEntity_SetModel
+        category: func
+        alias:
+          - CBaseModelEntity::SetModel
+```
+
+- [ ] **Step 3: 静态检查新增配置项**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+text = Path("config.yaml").read_text(encoding="utf-8")
+required = [
+    "find-CEntitySystem_RemoveEntity",
+    "CEntitySystem_RemoveEntity.{platform}.yaml",
+    "SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml",
+    "CEntitySystem::RemoveEntity",
+]
+missing = [item for item in required if item not in text]
+if missing:
+    raise SystemExit(f"missing config entries: {missing}")
+print("config entries present")
+PY
+```
+
+Expected:
+
+```text
+config entries present
+```
+
+### Task 4: 定向验证与收尾检查
+
+**Files:**
+- Verify: `ida_preprocessor_scripts/_direct_branch_target_common.py`
+- Verify: `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+- Verify: `config.yaml`
+
+- [ ] **Step 1: 运行 Python 编译检查**
+
+Run:
+
+```bash
+python -m py_compile ida_preprocessor_scripts/_direct_branch_target_common.py ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py
+```
+
+Expected:
+
+```text
+no output, exit code 0
+```
+
+- [ ] **Step 2: 检查字段契约没有被脚本绕过**
+
+Run:
+
+```bash
+python - <<'PY'
+from pathlib import Path
+
+common = Path("ida_preprocessor_scripts/_direct_branch_target_common.py").read_text(encoding="utf-8")
+script = Path("ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py").read_text(encoding="utf-8")
+
+if "generate_yaml_desired_fields" not in common:
+    raise SystemExit("common helper does not accept generate_yaml_desired_fields")
+if "_build_requested_payload" not in common:
+    raise SystemExit("common helper does not centralize requested payload building")
+if "GENERATE_YAML_DESIRED_FIELDS" not in script:
+    raise SystemExit("skill script does not declare GENERATE_YAML_DESIRED_FIELDS")
+if "func_sig" not in script:
+    raise SystemExit("skill script does not request func_sig")
+
+print("field contract checks passed")
+PY
+```
+
+Expected:
+
+```text
+field contract checks passed
+```
+
+- [ ] **Step 3: 查看最终 diff**
+
+Run:
+
+```bash
+git diff -- ida_preprocessor_scripts/_direct_branch_target_common.py ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py config.yaml
+```
+
+Expected:
+
+```text
+diff shows only the new helper, the new skill script, and the two config.yaml insertions described in this plan
+```
+
+- [ ] **Step 4: 暂不运行完整测试或构建**
+
+Do not run full test suites or build commands unless the user explicitly requests them. Record in the final implementation response that only targeted compile/static checks were run.
+
+### Task 5: 提交实施改动
+
+**Files:**
+- Commit: `ida_preprocessor_scripts/_direct_branch_target_common.py`
+- Commit: `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+- Commit: `config.yaml`
+
+- [ ] **Step 1: 检查工作区中本任务相关文件**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected:
+
+```text
+new helper, new skill script, config.yaml changes, and this plan file may appear; unrelated pre-existing changes must not be reverted
+```
+
+- [ ] **Step 2: 提交实现文件**
+
+Run:
+
+```bash
+git add ida_preprocessor_scripts/_direct_branch_target_common.py ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py config.yaml
+git commit -m "feat(preprocessor): 新增 RemoveEntity 定位脚本"
+```
+
+Expected:
+
+```text
+commit succeeds
+```
+
+Do not commit unrelated files.
+
+## Self-Review Notes
+
+- Spec coverage: tasks cover the shared helper, concrete script, `config.yaml` skill wiring, symbol metadata, field-contract behavior, and targeted verification.
+- Scope check: this is one bounded preprocessor addition, not multiple independent subsystems.
+- Placeholder scan: this plan contains no deferred implementation placeholders.
+- Type consistency: the helper entry is named `preprocess_direct_branch_target_skill`, the script imports that exact name, and `GENERATE_YAML_DESIRED_FIELDS` is passed through unchanged.

--- a/docs/superpowers/specs/2026-04-27-centitysystem-removeentity-preprocessor-design.md
+++ b/docs/superpowers/specs/2026-04-27-centitysystem-removeentity-preprocessor-design.md
@@ -1,0 +1,273 @@
+# CEntitySystem_RemoveEntity 预处理脚本设计
+
+## 背景
+
+仓库中已经存在 `find-SV_Kill_SmokeGrenade_CommandHandler.py`，可以通过 `RegisterConCommand` 注册信息定位 `SV_Kill_SmokeGrenade_CommandHandler`。
+
+在 Windows 与 Linux 样本中，该 handler 的主体逻辑都非常集中：遍历 smoke grenade 链表，并在循环内直接调用 `CEntitySystem_RemoveEntity`。Windows 使用 `call imm`，Linux 样本也使用直接 `call imm`；同类优化场景还可能把最后一次调用变成尾调用 `jmp imm`。
+
+因此，本次需要新增一个预处理脚本，从已知的 `SV_Kill_SmokeGrenade_CommandHandler` 函数体内定位唯一存在的直接分支目标，并将其作为 `CEntitySystem_RemoveEntity` 写出。与此同时，这类“从一个已知函数内抽取唯一直接 `call` / 尾调用 `jmp` 目标”的逻辑具有复用价值，应封装成独立工具类，供后续预处理脚本调用。
+
+## 目标
+
+- 新增共享模块 `ida_preprocessor_scripts/_direct_branch_target_common.py`
+- 在共享模块中封装 `DirectBranchTargetLocator` 工具类
+- 支持从指定源函数 YAML 读取 `func_va`
+- 支持在源函数体内定位唯一直接 `call imm` 或直接 `jmp imm` 的目标函数
+- 新增 `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+- 新增 `config.yaml` skill 配置，使 `find-CEntitySystem_RemoveEntity` 依赖 `SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml`
+- 新增 `CEntitySystem_RemoveEntity` symbol metadata
+- 输出 YAML 字段必须完全由调用脚本声明的 `GENERATE_YAML_DESIRED_FIELDS` 决定，公共工具类不得硬编码固定字段集合
+- 成功时写出普通函数 YAML，失败时返回 `False` 交由上层 Agent 流程回退
+
+## 非目标
+
+- 本次不改造 `preprocess_common_skill`
+- 本次不把间接调用、vtable 调用、寄存器跳转或内存操作数调用纳入定位范围
+- 本次不根据参数寄存器模式识别 `g_pEntitySystem` 或待删除实体参数
+- 本次不新增调试型扩展字段到最终 YAML
+- 本次不运行完整构建或完整测试流程
+
+## 方案比较
+
+### 方案 1：新增直接分支目标公共工具类
+
+新增 `_direct_branch_target_common.py`，把源 YAML 读取、IDA 函数扫描、唯一目标校验、目标函数信息查询、按字段契约写 YAML 等逻辑集中封装。具体 skill 脚本只声明源函数、目标函数和输出字段。
+
+优点：
+
+- 符合当前需求中的工具类要求
+- 复用边界清晰，后续类似脚本不用复制 `py_eval` 与 YAML 写出逻辑
+- 与 `_igamesystem_dispatch_common.py` 这类共享模块风格一致
+
+缺点：
+
+- 初次实现比单脚本略多一些结构代码
+
+### 方案 2：只在 `find-CEntitySystem_RemoveEntity.py` 中写专用逻辑
+
+优点：
+
+- 实现路径最短
+
+缺点：
+
+- 后续类似需求会产生重复代码
+- 唯一性校验、字段契约和错误处理容易漂移
+- 不满足本次希望封装为工具类的要求
+
+### 方案 3：扩展 `_registerconcommand.py`
+
+优点：
+
+- 可以少建一个公共模块
+
+缺点：
+
+- `_registerconcommand.py` 的职责是从控制台命令注册信息中提取 handler
+- 本次问题是从已知函数内提取直接分支目标，职责不同
+- 扩展进去会降低模块边界清晰度
+
+## 选定方案
+
+采用方案 1：新增直接分支目标公共工具类。
+
+这是满足当前需求的最小充分方案，同时保留后续复用能力。
+
+## 详细设计
+
+### 1. 公共模块与工具类
+
+新增模块：
+
+- `ida_preprocessor_scripts/_direct_branch_target_common.py`
+
+核心类：
+
+```python
+class DirectBranchTargetLocator:
+    """Locate one direct call/jmp target inside a known source function."""
+```
+
+建议高层入口，以下只规定调用契约，具体实现步骤见后文定位流程：
+
+```python
+async def preprocess_direct_branch_target_skill(
+    session,
+    expected_outputs,
+    new_binary_dir,
+    platform,
+    image_base,
+    source_yaml_stem,
+    target_name,
+    generate_yaml_desired_fields,
+    rename_to=None,
+    allowed_mnemonics=("call", "jmp"),
+    expected_target_count=1,
+    debug=False,
+):
+    """Locate the direct branch target and write the requested YAML fields."""
+```
+
+接口约束：
+
+- `source_yaml_stem` 指向已生成的源函数 YAML stem
+- `target_name` 用于匹配输出文件名与最终 `func_name`
+- `generate_yaml_desired_fields` 是输出字段契约的唯一来源
+- `allowed_mnemonics` 默认只允许 `call` 与 `jmp`
+- `expected_target_count` 本次固定使用 1，非 1 可先拒绝，避免提前泛化
+
+### 2. 具体调用脚本
+
+新增：
+
+- `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+
+脚本只声明常量并调用公共入口：
+
+```python
+SOURCE_FUNCTION_NAME = "SV_Kill_SmokeGrenade_CommandHandler"
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RemoveEntity",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_RemoveEntity",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+```
+
+`preprocess_skill` 调用 `preprocess_direct_branch_target_skill`，传入：
+
+- `source_yaml_stem=SOURCE_FUNCTION_NAME`
+- `target_name=TARGET_FUNCTION_NAMES[0]`
+- `rename_to=TARGET_FUNCTION_NAMES[0]`
+- `generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS`
+
+### 3. 定位流程
+
+公共工具类按以下顺序执行：
+
+1. 从 `new_binary_dir/{source_yaml_stem}.{platform}.yaml` 读取源函数 YAML
+2. 校验源 YAML 为 dict 且包含 `func_va`
+3. 从 `expected_outputs` 中匹配唯一的 `{target_name}.{platform}.yaml`
+4. 通过 `py_eval` 在 IDA 中解析源函数边界
+5. 遍历 `idautils.Heads(func.start_ea, func.end_ea)`
+6. 仅处理 mnemonic 在 `allowed_mnemonics` 中的指令
+7. 使用 `idautils.CodeRefsFrom(ea, False)` 解析直接代码引用
+8. 将目标地址归一到所属 IDA function start
+9. 对目标函数 start 去重
+10. 要求去重后的目标函数数量等于 `expected_target_count`
+11. 查询目标函数 `func_va` 与 `func_size`
+12. 根据 `GENERATE_YAML_DESIRED_FIELDS` 构造 payload
+13. 写出目标 YAML
+14. best-effort rename 目标函数
+
+### 4. 直接分支判定
+
+接受：
+
+- `call imm`
+- 直接尾调用 `jmp imm`
+
+不接受：
+
+- `call rax`
+- `jmp rax`
+- `call [reg+disp]`
+- `jmp [reg+disp]`
+- vtable dispatch
+- thunk 链的跨函数递归展开
+
+判定方式以 IDA 代码引用为准，而不是只看文本操作数。若某条 `call` 或 `jmp` 没有直接代码引用，则不计入候选。
+
+### 5. YAML 字段生成
+
+公共工具类必须先解析 `generate_yaml_desired_fields`，只允许为当前 `target_name` 生成声明过的字段。
+
+字段来源：
+
+- `func_name`：`target_name`
+- `func_va`：IDA 查询到的目标函数 start
+- `func_rva`：`func_va - image_base`
+- `func_size`：IDA function boundary
+- `func_sig`：仅当 `GENERATE_YAML_DESIRED_FIELDS` 为当前目标声明该字段时，调用 `preprocess_gen_func_sig_via_mcp` 生成
+
+如果声明了工具类无法提供的字段，应返回 `False` 并在 `debug=True` 时打印原因。公共工具类不得因为自己默认习惯而额外写出未声明字段。
+
+### 6. `config.yaml` 接入
+
+新增 skill 配置，位置放在 `find-SV_Kill_SmokeGrenade_CommandHandler` 附近：
+
+```yaml
+- name: find-CEntitySystem_RemoveEntity
+  expected_output:
+    - CEntitySystem_RemoveEntity.{platform}.yaml
+  expected_input:
+    - SV_Kill_SmokeGrenade_CommandHandler.{platform}.yaml
+```
+
+新增 symbol metadata：
+
+```yaml
+- name: CEntitySystem_RemoveEntity
+  category: func
+  alias:
+    - CEntitySystem::RemoveEntity
+```
+
+### 7. 错误处理
+
+以下情况返回 `False`：
+
+- `PyYAML` 不可用
+- 源 YAML 缺失或格式不正确
+- 源 YAML 缺少 `func_va`
+- 目标输出路径不唯一
+- `generate_yaml_desired_fields` 未包含当前 `target_name`
+- 源函数边界无法在 IDA 中解析
+- 直接 `call` / `jmp` 目标去重后数量不是 1
+- 目标函数边界无法解析
+- 请求了 `func_sig` 但签名生成失败
+- 请求了未知字段
+
+所有异常都应被公共入口收敛为 `False`，保持预处理失败后可回退。
+
+## 验证方式
+
+不主动运行完整构建或测试。
+
+实施后应做定向验证：
+
+- `python -m py_compile ida_preprocessor_scripts/_direct_branch_target_common.py ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+- 静态检查 `config.yaml` 中新增 skill 的 `expected_input`、`expected_output` 与 symbol metadata 名称一致
+
+真实 IDA MCP 验证需要在有 IDA 会话的环境中触发对应预处理流程，预期结果是：
+
+- `SV_Kill_SmokeGrenade_CommandHandler` 内唯一直接分支目标被解析为 `CEntitySystem_RemoveEntity`
+- 写出 `CEntitySystem_RemoveEntity.{platform}.yaml`
+- YAML 字段只包含 `GENERATE_YAML_DESIRED_FIELDS` 声明的字段
+
+## 风险与权衡
+
+- 如果未来 `SV_Kill_SmokeGrenade_CommandHandler` 内新增其他直接 `call` 或直接 `jmp`，本脚本会失败。这是有意的 fail-fast 设计，避免误判。
+- 如果目标函数通过 thunk 间接跳转，本次不会递归展开 thunk。这样可以保持工具类语义简单，并避免误跨到不相关函数。
+- `func_sig` 生成依赖现有 `preprocess_gen_func_sig_via_mcp`，若目标函数过短或签名不唯一，预处理会失败并回退。
+
+## 实施边界
+
+本次实施只触及：
+
+- `ida_preprocessor_scripts/_direct_branch_target_common.py`
+- `ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py`
+- `config.yaml`
+
+不修改其他预处理脚本，不修改已有公共 helper 的行为。

--- a/ida_preprocessor_scripts/_direct_branch_target_common.py
+++ b/ida_preprocessor_scripts/_direct_branch_target_common.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Shared preprocess helpers for direct branch target skills."""
+
+import json
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import (
+    parse_mcp_result,
+    preprocess_gen_func_sig_via_mcp,
+    write_func_yaml,
+)
+
+
+_SUPPORTED_FIELDS = {
+    "func_name",
+    "func_sig",
+    "func_va",
+    "func_rva",
+    "func_size",
+}
+
+
+_DIRECT_BRANCH_TARGET_PY_EVAL = """import idaapi, idautils, idc, json
+func_addr = __FUNC_ADDR__
+allowed_mnemonics = set(__ALLOWED_MNEMONICS__)
+result_obj = None
+if not idaapi.get_func(func_addr):
+    idaapi.add_func(func_addr)
+func = idaapi.get_func(func_addr)
+
+def _func_start_for_target(target_ea):
+    target_func = idaapi.get_func(target_ea)
+    if not target_func:
+        idaapi.add_func(target_ea)
+        target_func = idaapi.get_func(target_ea)
+    if not target_func:
+        return None
+    return int(target_func.start_ea)
+
+if func:
+    targets = []
+    seen = set()
+    for head in idautils.Heads(func.start_ea, func.end_ea):
+        mnem = idc.print_insn_mnem(head).lower()
+        if mnem not in allowed_mnemonics:
+            continue
+        insn = idaapi.insn_t()
+        if not idaapi.decode_insn(insn, head):
+            continue
+        op = insn.ops[0]
+        if op.type not in (idaapi.o_near, idaapi.o_far):
+            continue
+        refs = []
+        for target_ea in idautils.CodeRefsFrom(head, False):
+            target_start = _func_start_for_target(target_ea)
+            if target_start is not None:
+                refs.append(target_start)
+        refs = sorted(set(refs))
+        if len(refs) != 1:
+            continue
+        target_start = refs[0]
+        if target_start in seen:
+            continue
+        seen.add(target_start)
+        targets.append({
+            "source_ea": hex(head),
+            "source_mnemonic": mnem,
+            "target_va": hex(target_start),
+        })
+    result_obj = {
+        "source_func_va": hex(func.start_ea),
+        "source_func_size": hex(func.end_ea - func.start_ea),
+        "targets": targets,
+    }
+result = json.dumps(result_obj)
+"""
+
+
+def _debug(debug, message):
+    if debug:
+        print(f"    Preprocess: {message}")
+
+
+def _read_yaml(path):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except Exception:
+        return None
+
+
+def _parse_int(value):
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        raw = value.strip()
+        if not raw:
+            raise ValueError("empty integer string")
+        return int(raw, 0)
+    return int(value)
+
+
+def _normalize_requested_fields(generate_yaml_desired_fields, target_name, debug=False):
+    if not generate_yaml_desired_fields:
+        _debug(debug, "missing generate_yaml_desired_fields")
+        return None
+
+    desired_map = {}
+    try:
+        for symbol_name, fields in generate_yaml_desired_fields:
+            desired_map[str(symbol_name)] = list(fields)
+    except Exception:
+        _debug(debug, "invalid generate_yaml_desired_fields")
+        return None
+
+    fields = desired_map.get(target_name)
+    if not fields:
+        _debug(debug, f"missing desired fields for {target_name}")
+        return None
+
+    normalized = []
+    seen = set()
+    for field in fields:
+        field_name = str(field)
+        if field_name not in _SUPPORTED_FIELDS:
+            _debug(debug, f"unsupported requested field for {target_name}: {field_name}")
+            return None
+        if field_name in seen:
+            _debug(debug, f"duplicate requested field for {target_name}: {field_name}")
+            return None
+        seen.add(field_name)
+        normalized.append(field_name)
+
+    return normalized
+
+
+def _resolve_output_path(expected_outputs, target_name, platform, debug=False):
+    filename = f"{target_name}.{platform}.yaml"
+    matches = [
+        path for path in expected_outputs if os.path.basename(path) == filename
+    ]
+    if len(matches) != 1:
+        _debug(debug, f"expected exactly one output for {filename}")
+        return None
+    return matches[0]
+
+
+async def _call_py_eval_json(session, code, debug=False, error_label="py_eval"):
+    try:
+        result = await session.call_tool(name="py_eval", arguments={"code": code})
+        result_data = parse_mcp_result(result)
+    except Exception:
+        _debug(debug, f"{error_label} error")
+        return None
+
+    raw = None
+    if isinstance(result_data, dict):
+        stderr_text = result_data.get("stderr", "")
+        if stderr_text and debug:
+            print("    Preprocess: py_eval stderr:")
+            print(str(stderr_text).strip())
+        raw = result_data.get("result", "")
+    elif result_data is not None:
+        raw = str(result_data)
+
+    if not raw:
+        return None
+
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        _debug(debug, f"invalid JSON result from {error_label}")
+        return None
+
+
+def _build_direct_branch_target_py_eval(func_va, allowed_mnemonics):
+    normalized = [str(item).lower() for item in allowed_mnemonics]
+    return (
+        _DIRECT_BRANCH_TARGET_PY_EVAL
+        .replace("__FUNC_ADDR__", str(func_va))
+        .replace("__ALLOWED_MNEMONICS__", json.dumps(normalized))
+    )
+
+
+async def _rename_func_best_effort(session, func_va, func_name, debug=False):
+    if not func_va or not func_name:
+        return
+    try:
+        await session.call_tool(
+            name="rename",
+            arguments={
+                "batch": {
+                    "func": {"addr": str(func_va), "name": str(func_name)}
+                }
+            },
+        )
+    except Exception:
+        _debug(debug, f"failed to rename {func_name} (non-fatal)")
+
+
+class DirectBranchTargetLocator:
+    """Locate one direct call/jmp target inside a known source function."""
+
+    def __init__(self, session, debug=False):
+        self.session = session
+        self.debug = debug
+
+    async def collect_targets(self, source_func_va, allowed_mnemonics=("call", "jmp")):
+        code = _build_direct_branch_target_py_eval(
+            func_va=source_func_va,
+            allowed_mnemonics=allowed_mnemonics,
+        )
+        parsed = await _call_py_eval_json(
+            session=self.session,
+            code=code,
+            debug=self.debug,
+            error_label="py_eval collecting direct branch targets",
+        )
+        if not isinstance(parsed, dict):
+            _debug(self.debug, "failed to collect direct branch targets")
+            return None
+
+        raw_targets = parsed.get("targets")
+        if not isinstance(raw_targets, list):
+            _debug(self.debug, "direct branch target result missing targets list")
+            return None
+
+        targets = []
+        seen = set()
+        for item in raw_targets:
+            if not isinstance(item, dict):
+                _debug(self.debug, "invalid direct branch target entry")
+                return None
+            target_va = item.get("target_va")
+            try:
+                target_va_int = _parse_int(target_va)
+            except Exception:
+                _debug(self.debug, f"invalid target_va: {target_va}")
+                return None
+            if target_va_int in seen:
+                continue
+            seen.add(target_va_int)
+            targets.append(
+                {
+                    "source_ea": str(item.get("source_ea", "")),
+                    "source_mnemonic": str(item.get("source_mnemonic", "")),
+                    "target_va": hex(target_va_int),
+                }
+            )
+
+        return targets
+
+    async def query_func_info(self, target_va):
+        try:
+            target_va_int = _parse_int(target_va)
+        except Exception:
+            _debug(self.debug, f"invalid target func_va: {target_va}")
+            return None
+
+        code = (
+            "import idaapi, json\n"
+            f"target_ea = {target_va_int}\n"
+            "func = idaapi.get_func(target_ea)\n"
+            "if func and func.start_ea == target_ea:\n"
+            "    result = json.dumps({\n"
+            "        'func_va': hex(func.start_ea),\n"
+            "        'func_size': hex(func.end_ea - func.start_ea),\n"
+            "    })\n"
+            "else:\n"
+            "    result = json.dumps(None)\n"
+        )
+        parsed = await _call_py_eval_json(
+            session=self.session,
+            code=code,
+            debug=self.debug,
+            error_label="py_eval querying direct branch target function info",
+        )
+        return parsed if isinstance(parsed, dict) else None
+
+    async def rename_func_best_effort(self, func_va, func_name):
+        await _rename_func_best_effort(
+            session=self.session,
+            func_va=func_va,
+            func_name=func_name,
+            debug=self.debug,
+        )
+
+
+async def _build_requested_payload(
+    session,
+    target_name,
+    requested_fields,
+    func_info,
+    image_base,
+    debug=False,
+):
+    try:
+        func_va = str(func_info["func_va"])
+        func_va_int = _parse_int(func_va)
+        func_size = str(func_info["func_size"])
+    except Exception:
+        _debug(debug, f"incomplete function info for {target_name}")
+        return None
+
+    available = {
+        "func_name": target_name,
+        "func_va": func_va,
+        "func_size": func_size,
+    }
+
+    if "func_rva" in requested_fields:
+        available["func_rva"] = hex(func_va_int - image_base)
+
+    if "func_sig" in requested_fields:
+        sig_info = await preprocess_gen_func_sig_via_mcp(
+            session=session,
+            func_va=func_va,
+            image_base=image_base,
+            debug=debug,
+        )
+        if not isinstance(sig_info, dict) or not sig_info.get("func_sig"):
+            _debug(debug, f"failed to generate func_sig for {target_name}")
+            return None
+        available["func_sig"] = sig_info["func_sig"]
+        if "func_rva" in requested_fields and sig_info.get("func_rva"):
+            available["func_rva"] = sig_info["func_rva"]
+        if "func_size" in requested_fields and sig_info.get("func_size"):
+            available["func_size"] = sig_info["func_size"]
+
+    payload = {}
+    for field in requested_fields:
+        if field not in available:
+            _debug(debug, f"requested field is not available for {target_name}: {field}")
+            return None
+        payload[field] = available[field]
+
+    return payload
+
+
+async def preprocess_direct_branch_target_skill(
+    session,
+    expected_outputs,
+    new_binary_dir,
+    platform,
+    image_base,
+    source_yaml_stem,
+    target_name,
+    generate_yaml_desired_fields,
+    rename_to=None,
+    allowed_mnemonics=("call", "jmp"),
+    expected_target_count=1,
+    debug=False,
+):
+    if yaml is None:
+        _debug(debug, "PyYAML is required")
+        return False
+
+    if expected_target_count != 1:
+        _debug(debug, "expected_target_count must be 1")
+        return False
+
+    requested_fields = _normalize_requested_fields(
+        generate_yaml_desired_fields,
+        target_name,
+        debug=debug,
+    )
+    if requested_fields is None:
+        return False
+
+    output_path = _resolve_output_path(
+        expected_outputs,
+        target_name,
+        platform,
+        debug=debug,
+    )
+    if output_path is None:
+        return False
+
+    source_path = os.path.join(
+        new_binary_dir,
+        f"{source_yaml_stem}.{platform}.yaml",
+    )
+    source_yaml = _read_yaml(source_path)
+    if not isinstance(source_yaml, dict) or not source_yaml.get("func_va"):
+        _debug(debug, f"failed to read source function YAML: {source_path}")
+        return False
+
+    source_func_va = str(source_yaml["func_va"])
+    locator = DirectBranchTargetLocator(session=session, debug=debug)
+    targets = await locator.collect_targets(
+        source_func_va=source_func_va,
+        allowed_mnemonics=allowed_mnemonics,
+    )
+    if not isinstance(targets, list) or len(targets) != expected_target_count:
+        count = len(targets) if isinstance(targets, list) else "N/A"
+        _debug(
+            debug,
+            f"expected {expected_target_count} direct branch target, got {count}",
+        )
+        return False
+
+    target_va = targets[0]["target_va"]
+    func_info = await locator.query_func_info(target_va)
+    if not isinstance(func_info, dict):
+        _debug(debug, f"failed to query function info for {target_name}")
+        return False
+
+    payload = await _build_requested_payload(
+        session=session,
+        target_name=target_name,
+        requested_fields=requested_fields,
+        func_info=func_info,
+        image_base=image_base,
+        debug=debug,
+    )
+    if payload is None:
+        return False
+
+    write_func_yaml(output_path, payload)
+
+    await locator.rename_func_best_effort(
+        func_va=target_va,
+        func_name=rename_to,
+    )
+
+    if debug:
+        print(
+            "    Preprocess: "
+            f"written {os.path.basename(output_path)} from direct branch target {target_va}"
+        )
+
+    return True

--- a/ida_preprocessor_scripts/find-CBodyGameSystem_ProcessSpawnGroupSceneNodes-AND-CGameEntitySystem_CheckGlobalState.py
+++ b/ida_preprocessor_scripts/find-CBodyGameSystem_ProcessSpawnGroupSceneNodes-AND-CGameEntitySystem_CheckGlobalState.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBodyGameSystem_ProcessSpawnGroupSceneNodes-AND-CGameEntitySystem_CheckGlobalState skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBodyGameSystem_ProcessSpawnGroupSceneNodes",
+    "CGameEntitySystem_CheckGlobalState",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CBodyGameSystem_ProcessSpawnGroupSceneNodes",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_Activate.{platform}.yaml",
+    ),
+    (
+        "CGameEntitySystem_CheckGlobalState",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_Activate.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBodyGameSystem_ProcessSpawnGroupSceneNodes",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CGameEntitySystem_CheckGlobalState",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CCSPlayerPawnBase_OnSetDormant.py
+++ b/ida_preprocessor_scripts/find-CCSPlayerPawnBase_OnSetDormant.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CCSPlayerPawnBase_OnSetDormant skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CCSPlayerPawnBase_OnSetDormant",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CCSPlayerPawnBase_OnSetDormant",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": ["41 B9 FF B6 BC A7"],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CCSPlayerPawnBase_OnSetDormant",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": ["B9 FF B6 BC A7"],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CCSPlayerPawnBase_OnSetDormant", "CCSPlayerPawnBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CCSPlayerPawnBase_OnSetDormant",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_FindOutputsByName.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_FindOutputsByName.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_FindOutputsByName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_FindOutputsByName",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntityInstance_FindOutputsByName",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntityInstance_FindOutputsByName",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_OnRemoveEntity.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_OnRemoveEntity.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_OnRemoveEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_OnRemoveEntity",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_OnRemoveEntity",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_NotifyRemoveEntity.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_OnRemoveEntity", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_OnRemoveEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target virtual function and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_ScriptEntityIO.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_ScriptEntityIO.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_ScriptEntityIO skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_ScriptEntityIO",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntityInstance_ScriptEntityIO",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityInstance_FindOutputsByName.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEntityInstance_ScriptEntityIO", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntityInstance_ScriptEntityIO",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_UpdateOnRemove.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_UpdateOnRemove.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_UpdateOnRemove skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_UpdateOnRemove",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntityInstance_UpdateOnRemove",
+        "xref_strings": ["FULLMATCH:UpdateOnRemove"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_UpdateOnRemove", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_UpdateOnRemove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_NotifyRemoveEntity-AND-CEntitySystem_DestroyEntityInternal.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_NotifyRemoveEntity-AND-CEntitySystem_DestroyEntityInternal.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_NotifyRemoveEntity-AND-CEntitySystem_DestroyEntityInternal skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_NotifyRemoveEntity",
+    "CEntitySystem_DestroyEntityInternal",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_NotifyRemoveEntity",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RemoveEntityImmediate.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_DestroyEntityInternal",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RemoveEntityImmediate.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_NotifyRemoveEntity",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CEntitySystem_DestroyEntityInternal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_OnEntityParentChanged.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_OnEntityParentChanged.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_OnEntityParentChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_OnEntityParentChanged",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_OnEntityParentChanged",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameSceneNode_OnParentChanged.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySystem_OnEntityParentChanged", "CEntitySystem"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_OnEntityParentChanged",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_OnRemoveEntity.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_OnRemoveEntity.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CEntityInstance_OnRemoveEntity skill."""
+"""Preprocess script for find-CEntitySystem_OnRemoveEntity skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CEntityInstance_OnRemoveEntity",
+    "CEntitySystem_OnRemoveEntity",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
-        "CEntityInstance_OnRemoveEntity",
+        "CEntitySystem_OnRemoveEntity",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_NotifyRemoveEntity.{platform}.yaml",
     ),
@@ -18,13 +18,13 @@ LLM_DECOMPILE = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CEntityInstance_OnRemoveEntity", "CEntityInstance"),
+    ("CEntitySystem_OnRemoveEntity", "CEntityInstance"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CEntityInstance_OnRemoveEntity",
+        "CEntitySystem_OnRemoveEntity",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntity.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RemoveEntity skill."""
+
+from ida_preprocessor_scripts._direct_branch_target_common import (
+    preprocess_direct_branch_target_skill,
+)
+
+
+SOURCE_FUNCTION_NAME = "SV_Kill_SmokeGrenade_CommandHandler"
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RemoveEntity",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_RemoveEntity",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_direct_branch_target_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        source_yaml_stem=SOURCE_FUNCTION_NAME,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntityImmediate-AND-ClientPrintToController.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntityImmediate-AND-ClientPrintToController.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RemoveEntityImmediate-AND-ClientPrintToController skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RemoveEntityImmediate",
+    "ClientPrintToController",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_RemoveEntityImmediate",
+        "prompt/call_llm_decompile.md",
+        "references/server/EntInfo_CommandHandler.{platform}.yaml",
+    ),
+    (
+        "ClientPrintToController",
+        "prompt/call_llm_decompile.md",
+        "references/server/EntInfo_CommandHandler.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_RemoveEntityImmediate",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "ClientPrintToController",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSceneNode_AcquireParent.py
+++ b/ida_preprocessor_scripts/find-CGameSceneNode_AcquireParent.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSceneNode_AcquireParent skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameSceneNode_AcquireParent",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameSceneNode_AcquireParent",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBodyGameSystem_ProcessSpawnGroupSceneNodes.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameSceneNode_AcquireParent", "CGameSceneNode"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSceneNode_AcquireParent",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target virtual function and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSceneNode_OnParentChanged.py
+++ b/ida_preprocessor_scripts/find-CGameSceneNode_OnParentChanged.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSceneNode_OnParentChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameSceneNode_OnParentChanged",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameSceneNode_OnParentChanged",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameSceneNode_PostDataUpdate.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSceneNode_OnParentChanged",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSceneNode_PostDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CGameSceneNode_PostDataUpdate.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSceneNode_PostDataUpdate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameSceneNode_PostDataUpdate",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameSceneNode_PostDataUpdate",
+        "prompt/call_llm_decompile.md",
+        "references/server/CSkeletonInstance_PostDataUpdate.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameSceneNode_PostDataUpdate", "CGameSceneNode"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSceneNode_PostDataUpdate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSceneNode_PostDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CGameSceneNode_PostDataUpdate.py
@@ -3,22 +3,9 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CGameSceneNode_PostDataUpdate",
-]
-
-LLM_DECOMPILE = [
-    # (symbol_name, path_to_prompt, path_to_reference)
-    (
-        "CGameSceneNode_PostDataUpdate",
-        "prompt/call_llm_decompile.md",
-        "references/server/CSkeletonInstance_PostDataUpdate.{platform}.yaml",
-    ),
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
-    ("CGameSceneNode_PostDataUpdate", "CGameSceneNode"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CGameSceneNode_PostDataUpdate", "CGameSceneNode", "CSkeletonInstance_PostDataUpdate", True),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -31,18 +18,26 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_rva",
             "func_size",
             "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
 
 async def preprocess_skill(
-    session, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -50,10 +45,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSkeletonInstance_PostDataUpdate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSkeletonInstance_PostDataUpdate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSkeletonInstance_PostDataUpdate",
+        "xref_strings": [
+            "!IsFlagSet( type, DATA_UPDATE_TYPE_CREATED )",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSkeletonInstance_PostDataUpdate", "CSkeletonInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSkeletonInstance_PostDataUpdate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSkeletonInstance_vtable.py
+++ b/ida_preprocessor_scripts/find-CSkeletonInstance_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSkeletonInstance_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CSkeletonInstance"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSkeletonInstance",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CSkeletonInstance vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-EntInfo_CommandHandler.py
+++ b/ida_preprocessor_scripts/find-EntInfo_CommandHandler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-EntInfo_CommandHandler skill."""
+
+from ida_preprocessor_scripts._registerconcommand import (
+    preprocess_registerconcommand_skill,
+)
+
+
+TARGET_FUNCTION_NAMES = [
+    "EntInfo_CommandHandler",
+]
+
+COMMAND_NAME = "ent_info"
+HELP_STRING = "Usage:\n   ent_info <class name>\n"
+SEARCH_WINDOW_BEFORE_CALL = 96
+SEARCH_WINDOW_AFTER_XREF = 96
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "EntInfo_CommandHandler",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_registerconcommand_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        command_name=COMMAND_NAME,
+        help_string=HELP_STRING,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        search_window_before_call=SEARCH_WINDOW_BEFORE_CALL,
+        search_window_after_xref=SEARCH_WINDOW_AFTER_XREF,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SV_Kill_SmokeGrenade_CommandHandler.py
+++ b/ida_preprocessor_scripts/find-SV_Kill_SmokeGrenade_CommandHandler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SV_Kill_SmokeGrenade_CommandHandler skill."""
+
+from ida_preprocessor_scripts._registerconcommand import (
+    preprocess_registerconcommand_skill,
+)
+
+
+TARGET_FUNCTION_NAMES = [
+    "SV_Kill_SmokeGrenade_CommandHandler",
+]
+
+COMMAND_NAME = "sv_kill_smokegrenade"
+HELP_STRING = "kill all smoke grenades"
+SEARCH_WINDOW_BEFORE_CALL = 96
+SEARCH_WINDOW_AFTER_XREF = 96
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "SV_Kill_SmokeGrenade_CommandHandler",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_registerconcommand_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        command_name=COMMAND_NAME,
+        help_string=HELP_STRING,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        search_window_before_call=SEARCH_WINDOW_BEFORE_CALL,
+        search_window_after_xref=SEARCH_WINDOW_AFTER_XREF,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBodyGameSystem_ProcessSpawnGroupSceneNodes.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBodyGameSystem_ProcessSpawnGroupSceneNodes.linux.yaml
@@ -1,0 +1,461 @@
+func_name: CBodyGameSystem_ProcessSpawnGroupSceneNodes
+func_va: '0xde8300'
+disasm_code: |-
+  .text:0000000000DE8300                 mov     rax, 8000000000000200h
+  .text:0000000000DE830A                 push    rbp
+  .text:0000000000DE830B                 mov     rbp, rsp
+  .text:0000000000DE830E                 push    r15
+  .text:0000000000DE8310                 push    r14
+  .text:0000000000DE8312                 lea     r14, [rbp+var_1038]
+  .text:0000000000DE8319                 push    r13
+  .text:0000000000DE831B                 push    r12
+  .text:0000000000DE831D                 push    rbx
+  .text:0000000000DE831E                 sub     rsp, 1088h
+  .text:0000000000DE8325                 mov     [rbp+var_10A8], rdi
+  .text:0000000000DE832C                 mov     [rbp+var_1040], rax
+  .text:0000000000DE8333                 mov     [rbp+var_1048], r14
+  .text:0000000000DE833A                 mov     [rbp+var_1050], 0
+  .text:0000000000DE8344                 test    edx, edx
+  .text:0000000000DE8346                 jle     loc_DE8679
+  .text:0000000000DE834C                 movsxd  rdx, edx
+  .text:0000000000DE834F                 mov     rax, rcx
+  .text:0000000000DE8352                 xor     ebx, ebx
+  .text:0000000000DE8354                 mov     [rbp+var_1094], esi
+  .text:0000000000DE835A                 lea     rdx, [rdx+rdx*2]
+  .text:0000000000DE835E                 mov     [rbp+var_10A0], r14
+  .text:0000000000DE8365                 lea     r13, [rcx+rdx*8]
+  .text:0000000000DE8369                 mov     [rbp+var_1090], r13
+  .text:0000000000DE8370                 mov     rdx, [rax]
+  .text:0000000000DE8373                 mov     rcx, [rdx]
+  .text:0000000000DE8376                 test    rcx, rcx
+  .text:0000000000DE8379                 jz      loc_DE8547
+  .text:0000000000DE837F                 mov     rdx, [rdx+8]
+  .text:0000000000DE8383                 lea     rsi, xmmword_256BC80
+  .text:0000000000DE838A                 mov     rdx, [rdx+80h]
+  .text:0000000000DE8391                 movsxd  rsi, dword ptr [rsi+20h]
+  .text:0000000000DE8395                 movzx   edx, word ptr [rdx+rsi*2]
+  .text:0000000000DE8399                 cmp     dx, 0FFFFh
+  .text:0000000000DE839D                 jz      loc_DE8547
+  .text:0000000000DE83A3                 mov     r10, [rcx+rdx]
+  .text:0000000000DE83A7                 test    r10, r10
+  .text:0000000000DE83AA                 jz      loc_DE8547
+  .text:0000000000DE83B0                 movsxd  r9, dword ptr [r10+10h]
+  .text:0000000000DE83B4                 test    r9d, r9d
+  .text:0000000000DE83B7                 jle     loc_DE8547
+  .text:0000000000DE83BD                 xor     r15d, r15d
+  .text:0000000000DE83C0                 mov     r13, r10
+  .text:0000000000DE83C3                 mov     [rbp+var_1088], rax
+  .text:0000000000DE83CA                 lea     r12, ds:0[r9*8]
+  .text:0000000000DE83D2                 mov     r14, r15
+  .text:0000000000DE83D5                 mov     r15, r12
+  .text:0000000000DE83D8                 jmp     short loc_DE842A
+  .text:0000000000DE8400                 mov     rdx, [rbp+var_1048]
+  .text:0000000000DE8407                 mov     eax, ebx
+  .text:0000000000DE8409                 add     eax, 1
+  .text:0000000000DE840C                 add     r14, 8
+  .text:0000000000DE8410                 mov     [rbp+var_1050], eax
+  .text:0000000000DE8416                 mov     [rdx+rbx*8], r9
+  .text:0000000000DE841A                 movsxd  rbx, [rbp+var_1050]
+  .text:0000000000DE8421                 cmp     r14, r15
+  .text:0000000000DE8424                 jz      loc_DE8540
+  .text:0000000000DE842A                 mov     rax, [r13+18h]
+  .text:0000000000DE842E                 mov     r9, [rax+r14]
+  .text:0000000000DE8432                 cmp     dword ptr [rbp+var_1040], ebx
+  .text:0000000000DE8438                 jnz     short loc_DE8400
+  .text:0000000000DE843A                 mov     esi, dword ptr [rbp+var_1040+4]
+  .text:0000000000DE8440                 cmp     esi, 3FFFFFFFh
+  .text:0000000000DE8446                 jbe     short loc_DE8456
+  .text:0000000000DE8448                 mov     eax, esi
+  .text:0000000000DE844A                 and     eax, 0C0000000h
+  .text:0000000000DE844F                 cmp     eax, 80000000h
+  .text:0000000000DE8454                 jnz     short loc_DE8400
+  .text:0000000000DE8456                 ; _QWORD
+  .text:0000000000DE8456                 mov     edi, ebx; _QWORD
+  .text:0000000000DE8458                 cmp     ebx, 7FFFFFFFh
+  .text:0000000000DE845E                 jz      loc_DE8690
+  .text:0000000000DE8464                 ; _QWORD
+  .text:0000000000DE8464                 lea     edx, [rdi+1]; _QWORD
+  .text:0000000000DE8467                 ; _QWORD
+  .text:0000000000DE8467                 and     esi, 3FFFFFFFh; _QWORD
+  .text:0000000000DE846D                 ; _QWORD
+  .text:0000000000DE846D                 mov     ecx, 8; _QWORD
+  .text:0000000000DE8472                 mov     [rbp+var_1080], r9
+  .text:0000000000DE8479                 mov     dword ptr [rbp+var_1078], edx
+  .text:0000000000DE847F                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000000DE8484                 mov     edx, dword ptr [rbp+var_1078]
+  .text:0000000000DE848A                 mov     r9, [rbp+var_1080]
+  .text:0000000000DE8491                 mov     r12d, eax
+  .text:0000000000DE8494                 cmp     edx, eax
+  .text:0000000000DE8496                 jg      loc_DE8520
+  .text:0000000000DE849C                 movsxd  rcx, dword ptr [rbp+var_1040]
+  .text:0000000000DE84A3                 movsxd  rdx, r12d
+  .text:0000000000DE84A6                 xor     esi, esi
+  .text:0000000000DE84A8                 mov     [rbp+var_1078], r9
+  .text:0000000000DE84AF                 ; _QWORD
+  .text:0000000000DE84AF                 shl     rdx, 3; _QWORD
+  .text:0000000000DE84B3                 ; _QWORD
+  .text:0000000000DE84B3                 mov     rdi, [rbp+var_1048]; _QWORD
+  .text:0000000000DE84BA                 ; _QWORD
+  .text:0000000000DE84BA                 shl     rcx, 3; _QWORD
+  .text:0000000000DE84BE                 cmp     dword ptr [rbp+var_1040+4], 3FFFFFFFh
+  .text:0000000000DE84C8                 ; _QWORD
+  .text:0000000000DE84C8                 setbe   sil; _QWORD
+  .text:0000000000DE84CC                 call    _UtlVectorMemory_Alloc
+  .text:0000000000DE84D1                 mov     r9, [rbp+var_1078]
+  .text:0000000000DE84D8                 mov     rdx, rax
+  .text:0000000000DE84DB                 mov     [rbp+var_1048], rax
+  .text:0000000000DE84E2                 mov     eax, dword ptr [rbp+var_1040+4]
+  .text:0000000000DE84E8                 cmp     eax, 3FFFFFFFh
+  .text:0000000000DE84ED                 jbe     short loc_DE84FA
+  .text:0000000000DE84EF                 and     eax, 3FFFFFFFh
+  .text:0000000000DE84F4                 mov     dword ptr [rbp+var_1040+4], eax
+  .text:0000000000DE84FA                 mov     eax, [rbp+var_1050]
+  .text:0000000000DE8500                 mov     dword ptr [rbp+var_1040], r12d
+  .text:0000000000DE8507                 jmp     loc_DE8409
+  .text:0000000000DE8520                 add     r12d, edx
+  .text:0000000000DE8523                 mov     eax, r12d
+  .text:0000000000DE8526                 shr     eax, 1Fh
+  .text:0000000000DE8529                 add     r12d, eax
+  .text:0000000000DE852C                 sar     r12d, 1
+  .text:0000000000DE852F                 cmp     edx, r12d
+  .text:0000000000DE8532                 jg      short loc_DE8520
+  .text:0000000000DE8534                 jmp     loc_DE849C
+  .text:0000000000DE8540                 mov     rax, [rbp+var_1088]
+  .text:0000000000DE8547                 mov     rdi, [rbp+var_1090]
+  .text:0000000000DE854E                 add     rax, 18h
+  .text:0000000000DE8552                 cmp     rax, rdi
+  .text:0000000000DE8555                 jnz     loc_DE8370
+  .text:0000000000DE855B                 mov     r15d, [rbp+var_1094]
+  .text:0000000000DE8562                 mov     r14, [rbp+var_10A0]
+  .text:0000000000DE8569                 test    ebx, ebx
+  .text:0000000000DE856B                 jz      loc_DE86ED
+  .text:0000000000DE8571                 test    r15d, r15d
+  .text:0000000000DE8574                 jz      loc_DE86BE
+  .text:0000000000DE857A                 movsxd  r13, ebx
+  .text:0000000000DE857D                 shl     r13, 3
+  .text:0000000000DE8581                 lea     rax, [r13+1Fh]
+  .text:0000000000DE8585                 and     rax, 0FFFFFFFFFFFFFFF0h
+  .text:0000000000DE8589                 add     rax, 10h
+  .text:0000000000DE858D                 sub     rsp, rax
+  .text:0000000000DE8590                 mov     [rbp+var_1060], ebx
+  .text:0000000000DE8596                 mov     [rbp+var_105C], 40000000h
+  .text:0000000000DE85A0                 lea     rdx, [rsp+10B0h+var_10A8+7]
+  .text:0000000000DE85A5                 mov     [rbp+var_1070], 0
+  .text:0000000000DE85AF                 and     rdx, 0FFFFFFFFFFFFFFF0h
+  .text:0000000000DE85B3                 add     rdx, 10h
+  .text:0000000000DE85B7                 mov     [rbp+var_1068], rdx
+  .text:0000000000DE85BE                 test    ebx, ebx
+  .text:0000000000DE85C0                 jle     loc_DE876A
+  .text:0000000000DE85C6                 lea     r12, [rbp+var_1070]
+  .text:0000000000DE85CD                 xor     ebx, ebx
+  .text:0000000000DE85CF                 nop
+  .text:0000000000DE85D0                 mov     rax, [rbp+var_1048]
+  .text:0000000000DE85D7                 mov     rsi, r12
+  .text:0000000000DE85DA                 mov     rdi, [rax+rbx]
+  .text:0000000000DE85DE                 add     rbx, 8
+  .text:0000000000DE85E2                 mov     rax, [rdi]
+  .text:0000000000DE85E5                 ; 0xA8 = 168LL = CGameSceneNode_AcquireParent
+  .text:0000000000DE85E5                 call    qword ptr [rax+0A8h]; 0xA8 = 168LL = CGameSceneNode_AcquireParent
+  .text:0000000000DE85EB                 cmp     r13, rbx
+  .text:0000000000DE85EE                 jnz     short loc_DE85D0
+  .text:0000000000DE85F0                 mov     esi, [rbp+var_1070]
+  .text:0000000000DE85F6                 mov     rdx, [rbp+var_1068]
+  .text:0000000000DE85FD                 mov     rdi, [rbp+var_10A8]
+  .text:0000000000DE8604                 call    sub_DE7EC0
+  .text:0000000000DE8609                 cmp     [rbp+var_105C], 3FFFFFFFh
+  .text:0000000000DE8613                 mov     [rbp+var_1070], 0
+  .text:0000000000DE861D                 ja      short loc_DE863B
+  .text:0000000000DE861F                 mov     rsi, [rbp+var_1068]
+  .text:0000000000DE8626                 test    rsi, rsi
+  .text:0000000000DE8629                 jz      short loc_DE863B
+  .text:0000000000DE862B                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000DE8632                 mov     rdi, [rax]
+  .text:0000000000DE8635                 mov     rax, [rdi]
+  .text:0000000000DE8638                 call    qword ptr [rax+20h]
+  .text:0000000000DE863B                 mov     [rbp+var_1050], 0
+  .text:0000000000DE8645                 mov     edx, dword ptr [rbp+var_1040]
+  .text:0000000000DE864B                 mov     eax, dword ptr [rbp+var_1040+4]
+  .text:0000000000DE8651                 test    edx, edx
+  .text:0000000000DE8653                 js      loc_DE8746
+  .text:0000000000DE8659                 mov     rsi, [rbp+var_1048]
+  .text:0000000000DE8660                 cmp     rsi, r14
+  .text:0000000000DE8663                 jz      loc_DE875A
+  .text:0000000000DE8669                 test    rsi, rsi
+  .text:0000000000DE866C                 jz      short loc_DE8679
+  .text:0000000000DE866E                 cmp     eax, 3FFFFFFFh
+  .text:0000000000DE8673                 jbe     loc_DE8727
+  .text:0000000000DE8679                 lea     rsp, [rbp-28h]
+  .text:0000000000DE867D                 pop     rbx
+  .text:0000000000DE867E                 pop     r12
+  .text:0000000000DE8680                 pop     r13
+  .text:0000000000DE8682                 pop     r14
+  .text:0000000000DE8684                 pop     r15
+  .text:0000000000DE8686                 pop     rbp
+  .text:0000000000DE8687                 retn
+  .text:0000000000DE8690                 ; _QWORD
+  .text:0000000000DE8690                 mov     esi, 1; _QWORD
+  .text:0000000000DE8695                 ; _QWORD
+  .text:0000000000DE8695                 mov     edi, 7FFFFFFFh; _QWORD
+  .text:0000000000DE869A                 mov     [rbp+var_1078], r9
+  .text:0000000000DE86A1                 call    _UtlVectorMemory_FailedAllocation
+  .text:0000000000DE86A6                 mov     edi, dword ptr [rbp+var_1040]
+  .text:0000000000DE86AC                 mov     esi, dword ptr [rbp+var_1040+4]
+  .text:0000000000DE86B2                 mov     r9, [rbp+var_1078]
+  .text:0000000000DE86B9                 jmp     loc_DE8464
+  .text:0000000000DE86BE                 test    ebx, ebx
+  .text:0000000000DE86C0                 jle     short loc_DE86ED
+  .text:0000000000DE86C2                 lea     r12, ds:0[rbx*8]
+  .text:0000000000DE86CA                 xor     ebx, ebx
+  .text:0000000000DE86CC                 nop     dword ptr [rax+00h]
+  .text:0000000000DE86D0                 mov     rax, [rbp+var_1048]
+  .text:0000000000DE86D7                 mov     rdi, [rax+rbx]
+  .text:0000000000DE86DB                 add     rbx, 8
+  .text:0000000000DE86DF                 mov     rax, [rdi]
+  .text:0000000000DE86E2                 call    qword ptr [rax+0A0h]
+  .text:0000000000DE86E8                 cmp     rbx, r12
+  .text:0000000000DE86EB                 jnz     short loc_DE86D0
+  .text:0000000000DE86ED                 mov     [rbp+var_1050], 0
+  .text:0000000000DE86F7                 mov     edx, dword ptr [rbp+var_1040]
+  .text:0000000000DE86FD                 mov     eax, dword ptr [rbp+var_1040+4]
+  .text:0000000000DE8703                 test    edx, edx
+  .text:0000000000DE8705                 js      short loc_DE8746
+  .text:0000000000DE8707                 mov     rsi, [rbp+var_1048]
+  .text:0000000000DE870E                 cmp     rsi, r14
+  .text:0000000000DE8711                 jz      short loc_DE875A
+  .text:0000000000DE8713                 cmp     eax, 3FFFFFFFh
+  .text:0000000000DE8718                 ja      loc_DE8679
+  .text:0000000000DE871E                 test    rsi, rsi
+  .text:0000000000DE8721                 jz      loc_DE8679
+  .text:0000000000DE8727                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000DE872E                 mov     rdi, [rax]
+  .text:0000000000DE8731                 mov     rax, [rdi]
+  .text:0000000000DE8734                 call    qword ptr [rax+20h]
+  .text:0000000000DE8737                 lea     rsp, [rbp-28h]
+  .text:0000000000DE873B                 pop     rbx
+  .text:0000000000DE873C                 pop     r12
+  .text:0000000000DE873E                 pop     r13
+  .text:0000000000DE8740                 pop     r14
+  .text:0000000000DE8742                 pop     r15
+  .text:0000000000DE8744                 pop     rbp
+  .text:0000000000DE8745                 retn
+  .text:0000000000DE8746                 cmp     eax, 3FFFFFFFh
+  .text:0000000000DE874B                 ja      loc_DE8679
+  .text:0000000000DE8751                 mov     rsi, [rbp+var_1048]
+  .text:0000000000DE8758                 jmp     short loc_DE871E
+  .text:0000000000DE875A                 cmp     eax, 3FFFFFFFh
+  .text:0000000000DE875F                 ja      loc_DE8679
+  .text:0000000000DE8765                 mov     rsi, r14
+  .text:0000000000DE8768                 jmp     short loc_DE8727
+  .text:0000000000DE876A                 xor     esi, esi
+  .text:0000000000DE876C                 jmp     loc_DE85FD
+procedure: |-
+  unsigned __int64 __fastcall CBodyGameSystem_ProcessSpawnGroupSceneNodes(__int64 a1, int a2, int a3, __int64 **a4)
+  {
+    unsigned __int64 result; // rax
+    __int64 **v5; // rax
+    __int64 v6; // rbx
+    __int64 v7; // rcx
+    __int64 v8; // rdx
+    __int64 v9; // r10
+    __int64 v10; // r9
+    __int64 v11; // r13
+    __int64 v12; // r14
+    __int64 v13; // r15
+    _BYTE *v14; // rdx
+    int v15; // eax
+    __int64 v16; // r9
+    int v17; // esi
+    __int64 v18; // rdi
+    int v19; // eax
+    int v20; // edx
+    int i; // r12d
+    __int64 v22; // rax
+    _BYTE *v23; // r14
+    __int64 v24; // r13
+    void *v25; // rsp
+    _BYTE **v26; // rdx
+    __int64 v27; // rbx
+    __int64 v28; // rdi
+    __int64 v29; // rsi
+    __int64 v30; // r12
+    __int64 v31; // rbx
+    __int64 v32; // rdi
+    _BYTE *v33; // rsi
+    _BYTE *v35; // [rsp+10h] [rbp-10A0h] BYREF
+    int v36; // [rsp+1Ch] [rbp-1094h]
+    __int64 **v37; // [rsp+20h] [rbp-1090h]
+    __int64 **v38; // [rsp+28h] [rbp-1088h]
+    __int64 v39; // [rsp+30h] [rbp-1080h]
+    __int64 v40; // [rsp+38h] [rbp-1078h]
+    unsigned int v41; // [rsp+40h] [rbp-1070h] BYREF
+    _QWORD *v42; // [rsp+48h] [rbp-1068h]
+    int v43; // [rsp+50h] [rbp-1060h]
+    unsigned int v44; // [rsp+54h] [rbp-105Ch]
+    int v45; // [rsp+60h] [rbp-1050h]
+    _BYTE *v46; // [rsp+68h] [rbp-1048h]
+    unsigned __int64 v47; // [rsp+70h] [rbp-1040h]
+    _BYTE v48[4152]; // [rsp+78h] [rbp-1038h] BYREF
+
+    result = 0x8000000000000200LL;
+    v47 = 0x8000000000000200LL;
+    v46 = v48;
+    v45 = 0;
+    if ( a3 > 0 )
+    {
+      v5 = a4;
+      v6 = 0;
+      v36 = a2;
+      v35 = v48;
+      v37 = &a4[3 * a3];
+      do
+      {
+        v7 = **v5;
+        if ( v7 )
+        {
+          v8 = *(unsigned __int16 *)(*(_QWORD *)((*v5)[1] + 128) + 2LL * (int)qword_256BCA0);
+          if ( (_WORD)v8 != 0xFFFF )
+          {
+            v9 = *(_QWORD *)(v7 + v8);
+            if ( v9 )
+            {
+              v10 = *(int *)(v9 + 16);
+              if ( (int)v10 > 0 )
+              {
+                v11 = *(_QWORD *)(v7 + v8);
+                v38 = v5;
+                v12 = 0;
+                v13 = 8 * v10;
+                do
+                {
+                  v16 = *(_QWORD *)(*(_QWORD *)(v11 + 24) + v12);
+                  if ( (_DWORD)v47 == (_DWORD)v6
+                    && ((v17 = HIDWORD(v47), HIDWORD(v47) <= 0x3FFFFFFF) || (HIDWORD(v47) & 0xC0000000) == 0x80000000) )
+                  {
+                    v18 = (unsigned int)v6;
+                    if ( (_DWORD)v6 == 0x7FFFFFFF )
+                    {
+                      v40 = *(_QWORD *)(*(_QWORD *)(v11 + 24) + v12);
+                      UtlVectorMemory_FailedAllocation(0x7FFFFFFF, 1);
+                      v18 = (unsigned int)v47;
+                      v17 = HIDWORD(v47);
+                      v16 = v40;
+                    }
+                    v39 = v16;
+                    v19 = UtlVectorMemory_CalcNewAllocationCount(v18, v17 & 0x3FFFFFFF, (unsigned int)(v18 + 1), 8);
+                    v20 = v18 + 1;
+                    for ( i = v19; v20 > i; i = (v20 + i) / 2 )
+                      ;
+                    v40 = v39;
+                    v22 = UtlVectorMemory_Alloc(v46, HIDWORD(v47) <= 0x3FFFFFFF, 8LL * i, 8LL * (int)v47);
+                    v16 = v39;
+                    v14 = (_BYTE *)v22;
+                    v46 = (_BYTE *)v22;
+                    if ( HIDWORD(v47) > 0x3FFFFFFF )
+                      HIDWORD(v47) &= 0x3FFFFFFFu;
+                    v15 = v45;
+                    LODWORD(v47) = i;
+                  }
+                  else
+                  {
+                    v14 = v46;
+                    v15 = v6;
+                  }
+                  v12 += 8;
+                  v45 = v15 + 1;
+                  *(_QWORD *)&v14[8 * v6] = v16;
+                  v6 = v45;
+                }
+                while ( v12 != v13 );
+                v5 = v38;
+              }
+            }
+          }
+        }
+        v5 += 3;
+      }
+      while ( v5 != v37 );
+      v23 = v35;
+      if ( (_DWORD)v6 )
+      {
+        if ( v36 )
+        {
+          v24 = 8LL * (int)v6;
+          v25 = alloca(((v24 + 31) & 0xFFFFFFFFFFFFFFF0LL) + 16);
+          v43 = v6;
+          v44 = 0x40000000;
+          v41 = 0;
+          v26 = &v35;
+          v42 = &v35;
+          if ( (int)v6 <= 0 )
+          {
+            v29 = 0;
+          }
+          else
+          {
+            v27 = 0;
+            do
+            {
+              v28 = *(_QWORD *)&v46[v27];
+              v27 += 8;
+              (*(void (__fastcall **)(__int64, unsigned int *))(*(_QWORD *)v28 + 168LL))(v28, &v41);// 0xA8 = 168LL = CGameSceneNode_AcquireParent
+            }
+            while ( v24 != v27 );
+            v29 = v41;
+            v26 = (_BYTE **)v42;
+          }
+          sub_DE7EC0(a1, v29, v26);
+          v41 = 0;
+          if ( v44 <= 0x3FFFFFFF && v42 )
+            (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+          v45 = 0;
+          result = HIDWORD(v47);
+          if ( (v47 & 0x80000000) == 0LL )
+          {
+            if ( v46 != v23 )
+            {
+              if ( !v46 || HIDWORD(v47) > 0x3FFFFFFF )
+                return result;
+              return (*(__int64 (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+            }
+  LABEL_47:
+            if ( (unsigned int)result > 0x3FFFFFFF )
+              return result;
+            return (*(__int64 (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+          }
+          goto LABEL_45;
+        }
+        if ( (int)v6 > 0 )
+        {
+          v30 = 8 * v6;
+          v31 = 0;
+          do
+          {
+            v32 = *(_QWORD *)&v46[v31];
+            v31 += 8;
+            (*(void (__fastcall **)(__int64))(*(_QWORD *)v32 + 160LL))(v32);
+          }
+          while ( v31 != v30 );
+        }
+      }
+      v45 = 0;
+      result = HIDWORD(v47);
+      if ( (v47 & 0x80000000) == 0LL )
+      {
+        v33 = v46;
+        if ( v46 == v35 )
+          goto LABEL_47;
+        if ( HIDWORD(v47) > 0x3FFFFFFF )
+          return result;
+  LABEL_43:
+        if ( !v33 )
+          return result;
+        return (*(__int64 (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+      }
+  LABEL_45:
+      if ( (unsigned int)result > 0x3FFFFFFF )
+        return result;
+      v33 = v46;
+      goto LABEL_43;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CBodyGameSystem_ProcessSpawnGroupSceneNodes.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBodyGameSystem_ProcessSpawnGroupSceneNodes.windows.yaml
@@ -1,0 +1,498 @@
+func_name: CBodyGameSystem_ProcessSpawnGroupSceneNodes
+func_va: '0x1805395d0'
+disasm_code: |-
+  .text:00000001805395D0                 mov     [rsp-8+arg_18], r9
+  .text:00000001805395D5                 mov     [rsp-8+arg_8], edx
+  .text:00000001805395D9                 mov     [rsp-8+arg_0], rcx
+  .text:00000001805395DE                 push    rbp
+  .text:00000001805395DF                 push    rsi
+  .text:00000001805395E0                 push    rdi
+  .text:00000001805395E1                 push    r12
+  .text:00000001805395E3                 push    r13
+  .text:00000001805395E5                 push    r14
+  .text:00000001805395E7                 push    r15
+  .text:00000001805395E9                 mov     eax, 1060h
+  .text:00000001805395EE                 call    __alloca_probe
+  .text:00000001805395F3                 sub     rsp, rax
+  .text:00000001805395F6                 lea     rbp, [rsp+20h]
+  .text:00000001805395FB                 xor     r12d, r12d
+  .text:00000001805395FE                 mov     [rbp+1070h+arg_10], rbx
+  .text:0000000180539605                 mov     r14, rcx
+  .text:0000000180539608                 movsxd  rbx, r8d
+  .text:000000018053960B                 lea     rcx, [rbp+1070h+var_1048]
+  .text:000000018053960F                 mov     [rbp+1070h+var_1048], r12
+  .text:0000000180539613                 mov     [rbp+1070h+var_103C], 80000000h
+  .text:000000018053961A                 mov     r10d, 200h
+  .text:0000000180539620                 mov     [rbp+1070h+var_1040], r10d
+  .text:0000000180539624                 mov     rax, r9
+  .text:0000000180539627                 mov     esi, edx
+  .text:0000000180539629                 test    cl, 7
+  .text:000000018053962C                 jz      short loc_18053963E
+  .text:000000018053962E                 call    sub_1814DD520
+  .text:0000000180539633                 mov     r10d, [rbp+1070h+var_1040]
+  .text:0000000180539637                 mov     rax, [rbp+1070h+arg_18]
+  .text:000000018053963E                 mov     [rbp+1070h+var_1058], rbx
+  .text:0000000180539642                 lea     r8, [rbp+1070h+var_1038]
+  .text:0000000180539646                 mov     [rbp+1070h+var_1048], r8
+  .text:000000018053964A                 mov     edx, r12d
+  .text:000000018053964D                 mov     [rbp+1070h+var_1050], edx
+  .text:0000000180539650                 test    ebx, ebx
+  .text:0000000180539652                 jle     loc_1805397E2
+  .text:0000000180539658                 mov     ebx, 0FFFFh
+  .text:000000018053965D                 nop     dword ptr [rax]
+  .text:0000000180539660                 mov     rax, [rax]
+  .text:0000000180539663                 mov     r9, [rax]
+  .text:0000000180539666                 test    r9, r9
+  .text:0000000180539669                 jnz     loc_180539701
+  .text:000000018053966F                 mov     r15, r12
+  .text:0000000180539672                 mov     eax, r12d
+  .text:0000000180539675                 movsxd  r13, eax
+  .text:0000000180539678                 mov     rsi, r12
+  .text:000000018053967B                 test    eax, eax
+  .text:000000018053967D                 jle     loc_1805397B8
+  .text:0000000180539683                 nop     dword ptr [rax+00h]
+  .text:0000000180539687                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180539690                 mov     rax, [r15+18h]
+  .text:0000000180539694                 movsxd  r14, edx
+  .text:0000000180539697                 mov     r12, [rax+rsi*8]
+  .text:000000018053969B                 cmp     r14d, r10d
+  .text:000000018053969E                 jnz     loc_180539790
+  .text:00000001805396A4                 test    [rbp+1070h+var_103C], 40000000h
+  .text:00000001805396AB                 jnz     loc_180539790
+  .text:00000001805396B1                 cmp     r10d, 7FFFFFFEh
+  .text:00000001805396B8                 jle     short loc_1805396CC
+  .text:00000001805396BA                 mov     edx, 1
+  .text:00000001805396BF                 mov     ecx, r10d
+  .text:00000001805396C2                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:00000001805396C8                 mov     r10d, [rbp+1070h+var_1040]
+  .text:00000001805396CC                 mov     edx, [rbp+1070h+var_103C]
+  .text:00000001805396CF                 lea     edi, [r10+1]
+  .text:00000001805396D3                 and     edx, 3FFFFFFFh
+  .text:00000001805396D9                 mov     r8d, edi
+  .text:00000001805396DC                 mov     r9d, 8
+  .text:00000001805396E2                 mov     ecx, r10d
+  .text:00000001805396E5                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001805396EB                 mov     ebx, eax
+  .text:00000001805396ED                 cmp     eax, edi
+  .text:00000001805396EF                 jge     short loc_18053974E
+  .text:00000001805396F1                 test    eax, eax
+  .text:00000001805396F3                 jnz     short loc_180539740
+  .text:00000001805396F5                 cmp     edi, 0FFFFFFFFh
+  .text:00000001805396F8                 jg      short loc_180539740
+  .text:00000001805396FA                 mov     ebx, 0FFFFFFFFh
+  .text:00000001805396FF                 jmp     short loc_18053974E
+  .text:0000000180539701                 mov     rax, [rax+8]
+  .text:0000000180539705                 movsxd  rcx, cs:dword_181B69BE0
+  .text:000000018053970C                 mov     rax, [rax+80h]
+  .text:0000000180539713                 movzx   r11d, word ptr [rax+rcx*2]
+  .text:0000000180539718                 cmp     r11w, bx
+  .text:000000018053971C                 jz      short loc_180539724
+  .text:000000018053971E                 mov     r15, [r11+r9]
+  .text:0000000180539722                 jmp     short loc_180539727
+  .text:0000000180539724                 mov     r15, r12
+  .text:0000000180539727                 test    r15, r15
+  .text:000000018053972A                 jz      loc_180539672
+  .text:0000000180539730                 mov     eax, [r15+10h]
+  .text:0000000180539734                 jmp     loc_180539675
+  .text:0000000180539740                 lea     eax, [rbx+rdi]
+  .text:0000000180539743                 cdq
+  .text:0000000180539744                 sub     eax, edx
+  .text:0000000180539746                 sar     eax, 1
+  .text:0000000180539748                 mov     ebx, eax
+  .text:000000018053974A                 cmp     eax, edi
+  .text:000000018053974C                 jl      short loc_180539740
+  .text:000000018053974E                 movsxd  r9, [rbp+1070h+var_1040]
+  .text:0000000180539752                 mov     rcx, [rbp+1070h+var_1048]
+  .text:0000000180539756                 shl     r9, 3
+  .text:000000018053975A                 test    [rbp+1070h+var_103C], 0C0000000h
+  .text:0000000180539761                 movsxd  r8, ebx
+  .text:0000000180539764                 setz    dl
+  .text:0000000180539767                 shl     r8, 3
+  .text:000000018053976B                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180539771                 mov     r8, rax
+  .text:0000000180539774                 mov     [rbp+1070h+var_1048], rax
+  .text:0000000180539778                 mov     eax, [rbp+1070h+var_103C]
+  .text:000000018053977B                 test    eax, 0C0000000h
+  .text:0000000180539780                 jz      short loc_18053978A
+  .text:0000000180539782                 and     eax, 3FFFFFFFh
+  .text:0000000180539787                 mov     [rbp+1070h+var_103C], eax
+  .text:000000018053978A                 mov     edx, [rbp+1070h+var_1050]
+  .text:000000018053978D                 mov     [rbp+1070h+var_1040], ebx
+  .text:0000000180539790                 inc     edx
+  .text:0000000180539792                 inc     rsi
+  .text:0000000180539795                 mov     [rbp+1070h+var_1050], edx
+  .text:0000000180539798                 mov     [r8+r14*8], r12
+  .text:000000018053979C                 mov     r10d, [rbp+1070h+var_1040]
+  .text:00000001805397A0                 mov     r8, [rbp+1070h+var_1048]
+  .text:00000001805397A4                 mov     edx, [rbp+1070h+var_1050]
+  .text:00000001805397A7                 cmp     rsi, r13
+  .text:00000001805397AA                 jl      loc_180539690
+  .text:00000001805397B0                 xor     r12d, r12d
+  .text:00000001805397B3                 mov     ebx, 0FFFFh
+  .text:00000001805397B8                 mov     rax, [rbp+1070h+arg_18]
+  .text:00000001805397BF                 add     rax, 18h
+  .text:00000001805397C3                 sub     [rbp+1070h+var_1058], 1
+  .text:00000001805397C8                 mov     [rbp+1070h+arg_18], rax
+  .text:00000001805397CF                 jnz     loc_180539660
+  .text:00000001805397D5                 mov     esi, [rbp+1070h+arg_8]
+  .text:00000001805397DB                 mov     r14, [rbp+1070h+arg_0]
+  .text:00000001805397E2                 test    edx, edx
+  .text:00000001805397E4                 jz      loc_180539907
+  .text:00000001805397EA                 movsxd  rdi, edx
+  .text:00000001805397ED                 test    esi, esi
+  .text:00000001805397EF                 jnz     short loc_18053981E
+  .text:00000001805397F1                 test    edx, edx
+  .text:00000001805397F3                 jle     loc_180539907
+  .text:00000001805397F9                 mov     rbx, r12
+  .text:00000001805397FC                 nop     dword ptr [rax+00h]
+  .text:0000000180539800                 mov     rcx, [r8+rbx*8]
+  .text:0000000180539804                 mov     rax, [rcx]
+  .text:0000000180539807                 ; 0x98 = 152LL = CGameSceneNode_AcquireParent
+  .text:0000000180539807                 call    qword ptr [rax+98h]; 0x98 = 152LL = CGameSceneNode_AcquireParent
+  .text:000000018053980D                 mov     r8, [rbp+1070h+var_1048]
+  .text:0000000180539811                 inc     rbx
+  .text:0000000180539814                 cmp     rbx, rdi
+  .text:0000000180539817                 jl      short loc_180539800
+  .text:0000000180539819                 jmp     loc_180539903
+  .text:000000018053981E                 lea     rax, ds:1Fh[rdi*8]
+  .text:0000000180539826                 and     rax, 0FFFFFFFFFFFFFFF0h
+  .text:000000018053982A                 lea     rcx, [rax+0Fh]
+  .text:000000018053982E                 cmp     rcx, rax
+  .text:0000000180539831                 ja      short loc_18053983D
+  .text:0000000180539833                 mov     rcx, 0FFFFFFFFFFFFFF0h
+  .text:000000018053983D                 and     rcx, 0FFFFFFFFFFFFFFF0h
+  .text:0000000180539841                 mov     rax, rcx
+  .text:0000000180539844                 call    __alloca_probe
+  .text:0000000180539849                 sub     rsp, rcx
+  .text:000000018053984C                 mov     [rbp+1070h+var_1060], edx
+  .text:000000018053984F                 mov     edx, r12d
+  .text:0000000180539852                 mov     [rbp+1070h+var_105C], 40000000h
+  .text:0000000180539859                 mov     [rbp+1070h+var_1070], edx
+  .text:000000018053985C                 lea     rax, [rsp+1090h+var_1070]
+  .text:0000000180539861                 add     rax, 10h
+  .text:0000000180539865                 and     rax, 0FFFFFFFFFFFFFFF0h
+  .text:0000000180539869                 mov     [rbp+1070h+var_1068], rax
+  .text:000000018053986D                 test    rdi, rdi
+  .text:0000000180539870                 jle     short loc_18053989B
+  .text:0000000180539872                 mov     rbx, r12
+  .text:0000000180539875                 mov     rcx, [r8+rbx*8]
+  .text:0000000180539879                 lea     rdx, [rbp+1070h+var_1070]
+  .text:000000018053987D                 mov     rax, [rcx]
+  .text:0000000180539880                 call    qword ptr [rax+0A0h]
+  .text:0000000180539886                 inc     rbx
+  .text:0000000180539889                 cmp     rbx, rdi
+  .text:000000018053988C                 jge     short loc_180539894
+  .text:000000018053988E                 mov     r8, [rbp+1070h+var_1048]
+  .text:0000000180539892                 jmp     short loc_180539875
+  .text:0000000180539894                 mov     rax, [rbp+1070h+var_1068]
+  .text:0000000180539898                 mov     edx, [rbp+1070h+var_1070]
+  .text:000000018053989B                 mov     r8, rax
+  .text:000000018053989E                 mov     rcx, r14
+  .text:00000001805398A1                 call    sub_180510870
+  .text:00000001805398A6                 mov     eax, [rbp+1070h+var_105C]
+  .text:00000001805398A9                 mov     rdx, [rbp+1070h+var_1068]
+  .text:00000001805398AD                 mov     [rbp+1070h+var_1070], r12d
+  .text:00000001805398B1                 test    eax, 0C0000000h
+  .text:00000001805398B6                 jnz     short loc_1805398FF
+  .text:00000001805398B8                 test    rdx, rdx
+  .text:00000001805398BB                 jz      short loc_1805398D7
+  .text:00000001805398BD                 mov     rax, cs:g_pMemAlloc
+  .text:00000001805398C4                 mov     rcx, [rax]
+  .text:00000001805398C7                 mov     rax, [rcx]
+  .text:00000001805398CA                 call    qword ptr [rax+18h]
+  .text:00000001805398CD                 mov     eax, [rbp+1070h+var_105C]
+  .text:00000001805398D0                 mov     rdx, r12
+  .text:00000001805398D3                 mov     [rbp+1070h+var_1068], rdx
+  .text:00000001805398D7                 mov     [rbp+1070h+var_1060], r12d
+  .text:00000001805398DB                 test    eax, 0C0000000h
+  .text:00000001805398E0                 jnz     short loc_1805398FF
+  .text:00000001805398E2                 test    rdx, rdx
+  .text:00000001805398E5                 jz      short loc_1805398FB
+  .text:00000001805398E7                 mov     rax, cs:g_pMemAlloc
+  .text:00000001805398EE                 mov     rcx, [rax]
+  .text:00000001805398F1                 mov     rax, [rcx]
+  .text:00000001805398F4                 call    qword ptr [rax+18h]
+  .text:00000001805398F7                 mov     [rbp+1070h+var_1068], r12
+  .text:00000001805398FB                 mov     [rbp+1070h+var_1060], r12d
+  .text:00000001805398FF                 mov     r8, [rbp+1070h+var_1048]
+  .text:0000000180539903                 mov     r10d, [rbp+1070h+var_1040]
+  .text:0000000180539907                 mov     [rbp+1070h+var_1050], r12d
+  .text:000000018053990B                 test    r10d, r10d
+  .text:000000018053990E                 js      short loc_180539958
+  .text:0000000180539910                 lea     rax, [rbp+1070h+var_1038]
+  .text:0000000180539914                 cmp     r8, rax
+  .text:0000000180539917                 jz      short loc_180539958
+  .text:0000000180539919                 test    r8, r8
+  .text:000000018053991C                 jz      short loc_18053993A
+  .text:000000018053991E                 test    [rbp+1070h+var_103C], 0C0000000h
+  .text:0000000180539925                 jnz     short loc_18053993A
+  .text:0000000180539927                 mov     rax, cs:g_pMemAlloc
+  .text:000000018053992E                 mov     rdx, r8
+  .text:0000000180539931                 mov     rcx, [rax]
+  .text:0000000180539934                 mov     rax, [rcx]
+  .text:0000000180539937                 call    qword ptr [rax+18h]
+  .text:000000018053993A                 mov     eax, [rbp+1070h+var_103C]
+  .text:000000018053993D                 lea     r8, [rbp+1070h+var_1038]
+  .text:0000000180539941                 and     eax, 3FFFFFFFh
+  .text:0000000180539946                 mov     [rbp+1070h+var_1048], r8
+  .text:000000018053994A                 bts     eax, 1Fh
+  .text:000000018053994E                 mov     [rbp+1070h+var_1040], 200h
+  .text:0000000180539955                 mov     [rbp+1070h+var_103C], eax
+  .text:0000000180539958                 test    [rbp+1070h+var_103C], 0C0000000h
+  .text:000000018053995F                 jnz     short loc_180539979
+  .text:0000000180539961                 test    r8, r8
+  .text:0000000180539964                 jz      short loc_180539979
+  .text:0000000180539966                 mov     rax, cs:g_pMemAlloc
+  .text:000000018053996D                 mov     rdx, r8
+  .text:0000000180539970                 mov     rcx, [rax]
+  .text:0000000180539973                 mov     rax, [rcx]
+  .text:0000000180539976                 call    qword ptr [rax+18h]
+  .text:0000000180539979                 mov     rbx, [rbp+1070h+arg_10]
+  .text:0000000180539980                 lea     rsp, [rbp+1040h]
+  .text:0000000180539987                 pop     r15
+  .text:0000000180539989                 pop     r14
+  .text:000000018053998B                 pop     r13
+  .text:000000018053998D                 pop     r12
+  .text:000000018053998F                 pop     rdi
+  .text:0000000180539990                 pop     rsi
+  .text:0000000180539991                 pop     rbp
+  .text:0000000180539992                 retn
+procedure: |-
+  int __fastcall CBodyGameSystem_ProcessSpawnGroupSceneNodes(__int64 a1, int a2, int a3, _QWORD **a4)
+  {
+    __int64 v4; // r14
+    __int64 v5; // rbx
+    int v6; // r10d
+    __int64 v7; // rax
+    int v8; // esi
+    __int64 v9; // r8
+    int v10; // edx
+    _QWORD *v11; // rax
+    __int64 v12; // r15
+    int v13; // eax
+    __int64 v14; // r13
+    __int64 i; // rsi
+    __int64 v16; // r14
+    __int64 v17; // r12
+    int v18; // edi
+    int v19; // eax
+    __int64 v20; // rdx
+    int v21; // ebx
+    __int64 v22; // r11
+    bool v23; // zf
+    __int64 v24; // rdi
+    __int64 v25; // rbx
+    unsigned __int64 v26; // rax
+    __int64 v27; // rcx
+    unsigned __int64 v28; // rcx
+    void *v29; // rsp
+    void *v30; // rsp
+    unsigned int v31; // edx
+    int *v32; // rax
+    __int64 v33; // rbx
+    int *v34; // rdx
+    unsigned int v36; // [rsp+20h] [rbp+0h] BYREF
+    int *v37; // [rsp+28h] [rbp+8h]
+    int v38; // [rsp+30h] [rbp+10h] BYREF
+    int v39; // [rsp+34h] [rbp+14h]
+    __int64 v40; // [rsp+38h] [rbp+18h]
+    int v41; // [rsp+40h] [rbp+20h]
+    _BYTE *v42; // [rsp+48h] [rbp+28h] BYREF
+    int v43; // [rsp+50h] [rbp+30h]
+    unsigned int v44; // [rsp+54h] [rbp+34h]
+    _BYTE v45[4152]; // [rsp+58h] [rbp+38h] BYREF
+    _QWORD **v48; // [rsp+10B8h] [rbp+1098h]
+
+    v48 = a4;
+    v4 = a1;
+    v5 = a3;
+    v42 = nullptr;
+    v44 = 0x80000000;
+    v6 = 512;
+    v43 = 512;
+    v7 = (__int64)a4;
+    v8 = a2;
+    if ( ((unsigned __int8)&v42 & 7) != 0 )
+    {
+      sub_1814DD520();
+      v6 = v43;
+      v7 = (__int64)v48;
+    }
+    v40 = v5;
+    v9 = (__int64)v45;
+    v42 = v45;
+    v10 = 0;
+    v41 = 0;
+    if ( (int)v5 > 0 )
+    {
+      while ( 1 )
+      {
+        v11 = *(_QWORD **)v7;
+        if ( *v11 )
+        {
+          v22 = *(unsigned __int16 *)(*(_QWORD *)(v11[1] + 128LL) + 2LL * dword_181B69BE0);
+          if ( (_WORD)v22 == 0xFFFF )
+            v12 = 0;
+          else
+            v12 = *(_QWORD *)(v22 + *v11);
+          if ( v12 )
+          {
+            v13 = *(_DWORD *)(v12 + 16);
+            goto LABEL_7;
+          }
+        }
+        else
+        {
+          v12 = 0;
+        }
+        v13 = 0;
+  LABEL_7:
+        v14 = v13;
+        for ( i = 0; i < v14; v10 = v41 )
+        {
+          v16 = v10;
+          v17 = *(_QWORD *)(*(_QWORD *)(v12 + 24) + 8 * i);
+          if ( v10 == v6 && (v44 & 0x40000000) == 0 )
+          {
+            if ( v6 == 0x7FFFFFFF )
+            {
+              UtlVectorMemory_FailedAllocation(0x7FFFFFFF, 1);
+              v6 = v43;
+            }
+            v18 = v6 + 1;
+            v19 = UtlVectorMemory_CalcNewAllocationCount((unsigned int)v6, v44 & 0x3FFFFFFF, (unsigned int)(v6 + 1), 8);
+            v21 = v19;
+            if ( v19 < v18 )
+            {
+              if ( v19 || v18 > -1 )
+              {
+                do
+                {
+                  v20 = (unsigned int)((v21 + v18) >> 31);
+                  v21 = (v21 + v18) / 2;
+                }
+                while ( v21 < v18 );
+              }
+              else
+              {
+                v21 = -1;
+              }
+            }
+            LOBYTE(v20) = (v44 & 0xC0000000) == 0;
+            v9 = UtlVectorMemory_Alloc(v42, v20, 8LL * v21, 8LL * v43);
+            v42 = (_BYTE *)v9;
+            if ( (v44 & 0xC0000000) != 0 )
+              v44 &= 0x3FFFFFFFu;
+            v10 = v41;
+            v43 = v21;
+          }
+          ++i;
+          v41 = v10 + 1;
+          *(_QWORD *)(v9 + 8 * v16) = v17;
+          v6 = v43;
+          v9 = (__int64)v42;
+        }
+        v7 = (__int64)(v48 + 3);
+        v23 = v40-- == 1;
+        v48 += 3;
+        if ( v23 )
+        {
+          v8 = a2;
+          v4 = a1;
+          break;
+        }
+      }
+    }
+    if ( v10 )
+    {
+      v24 = v10;
+      if ( v8 )
+      {
+        v26 = (8LL * v10 + 31) & 0xFFFFFFFFFFFFFFF0uLL;
+        v27 = v26 + 15;
+        if ( v26 + 15 < v26 )
+          v27 = 0xFFFFFFFFFFFFFF0LL;
+        v28 = v27 & 0xFFFFFFFFFFFFFFF0uLL;
+        v29 = alloca(v28);
+        v30 = alloca(v28);
+        v38 = v10;
+        v31 = 0;
+        v39 = 0x40000000;
+        v36 = 0;
+        v32 = &v38;
+        v37 = &v38;
+        if ( v24 > 0 )
+        {
+          v33 = 0;
+          while ( 1 )
+          {
+            (*(void (__fastcall **)(_QWORD, unsigned int *))(**(_QWORD **)(v9 + 8 * v33) + 160LL))(
+              *(_QWORD *)(v9 + 8 * v33),
+              &v36);
+            if ( ++v33 >= v24 )
+              break;
+            v9 = (__int64)v42;
+          }
+          v32 = v37;
+          v31 = v36;
+        }
+        sub_180510870(v4, v31, v32);
+        LODWORD(v7) = v39;
+        v34 = v37;
+        v36 = 0;
+        if ( (v39 & 0xC0000000) == 0 )
+        {
+          if ( v37 )
+          {
+            (*(void (__fastcall **)(_QWORD, int *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v37);
+            LODWORD(v7) = v39;
+            v34 = nullptr;
+            v37 = nullptr;
+          }
+          v38 = 0;
+          if ( (v7 & 0xC0000000) == 0 )
+          {
+            if ( v34 )
+            {
+              LODWORD(v7) = (*(__int64 (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+              v37 = nullptr;
+            }
+            v38 = 0;
+          }
+        }
+        v9 = (__int64)v42;
+        goto LABEL_49;
+      }
+      if ( v10 > 0 )
+      {
+        v25 = 0;
+        do
+        {
+          LODWORD(v7) = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)(v9 + 8 * v25) + 152LL))(*(_QWORD *)(v9 + 8 * v25));// 0x98 = 152LL = CGameSceneNode_AcquireParent
+          v9 = (__int64)v42;
+          ++v25;
+        }
+        while ( v25 < v24 );
+  LABEL_49:
+        v6 = v43;
+      }
+    }
+    v41 = 0;
+    if ( v6 >= 0 )
+    {
+      v7 = (__int64)v45;
+      if ( (_BYTE *)v9 != v45 )
+      {
+        if ( v9 && (v44 & 0xC0000000) == 0 )
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v9);
+        v9 = (__int64)v45;
+        v42 = v45;
+        LODWORD(v7) = v44 & 0x3FFFFFFF | 0x80000000;
+        v43 = 512;
+        v44 = v7;
+      }
+    }
+    if ( (v44 & 0xC0000000) == 0 && v9 )
+      LODWORD(v7) = (*(int (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v9);
+    return v7;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntFireOutputAutoCompletionFunctor_FireOutput.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntFireOutputAutoCompletionFunctor_FireOutput.linux.yaml
@@ -46,7 +46,7 @@ disasm_code: |-
   .text:000000000161FCF6                 mov     [rbp+var_68], 0
   .text:000000000161FCFE                 mov     qword ptr [rbp-60h], 0
   .text:000000000161FD06                 mov     rdi, [rax+10h]
-  .text:000000000161FD0A                 call    sub_1D58AE0
+  .text:000000000161FD0A                 call    CEntityInstance_FindOutputsByName
   .text:000000000161FD0F                 mov     eax, dword ptr [rbp+var_70]
   .text:000000000161FD12                 test    eax, eax
   .text:000000000161FD14                 jle     loc_161FDB0
@@ -134,7 +134,7 @@ procedure: |-
     v11 = 0;
     v17 = 0;
     v18 = 0;
-    sub_1D58AE0(*(_QWORD *)(v14 + 16), a4, &v16);
+    CEntityInstance_FindOutputsByName(*(_QWORD *)(v14 + 16), a4, &v16);
     if ( (int)v16 <= 0 )
     {
       result = sub_97F3E0("Couldn't find output named '%s' on entity '%s'.\n", a4, a3);

--- a/ida_preprocessor_scripts/references/server/CEntFireOutputAutoCompletionFunctor_FireOutput.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntFireOutputAutoCompletionFunctor_FireOutput.windows.yaml
@@ -38,7 +38,7 @@ disasm_code: |-
   .text:0000000180BDFA9A                 mov     rdx, rsi
   .text:0000000180BDFA9D                 mov     [rbp+3Fh+var_70], r12d
   .text:0000000180BDFAA1                 mov     rcx, [r14+10h]
-  .text:0000000180BDFAA5                 call    sub_1811A5000
+  .text:0000000180BDFAA5                 call    CEntityInstance_FindOutputsByName
   .text:0000000180BDFAAA                 mov     eax, [rbp+3Fh+var_70]
   .text:0000000180BDFAAD                 test    eax, eax
   .text:0000000180BDFAAF                 jg      short loc_180BDFB2A
@@ -152,7 +152,7 @@ procedure: |-
       v16 = 0;
       v17 = 0;
       v15 = 0;
-      sub_1811A5000(*(_QWORD *)(v10 + 16), a3, &v15);
+      CEntityInstance_FindOutputsByName(*(_QWORD *)(v10 + 16), a3, &v15);
       if ( v15 > 0 )
       {
         v13 = 0;

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_FindOutputsByName.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_FindOutputsByName.linux.yaml
@@ -1,0 +1,127 @@
+func_name: CEntityInstance_FindOutputsByName
+func_va: '0x1e44ae0'
+disasm_code: |-
+  .text:0000000001E44AE0                 push    rbp
+  .text:0000000001E44AE1                 mov     rbp, rsp
+  .text:0000000001E44AE4                 push    r15
+  .text:0000000001E44AE6                 push    r14
+  .text:0000000001E44AE8                 push    r13
+  .text:0000000001E44AEA                 mov     r13, rsi
+  .text:0000000001E44AED                 push    r12
+  .text:0000000001E44AEF                 mov     r12, rdx
+  .text:0000000001E44AF2                 push    rbx
+  .text:0000000001E44AF3                 mov     rbx, rdi
+  .text:0000000001E44AF6                 sub     rsp, 8
+  .text:0000000001E44AFA                 mov     rdx, [rdi]
+  .text:0000000001E44AFD                 mov     rdi, [rdi+8]
+  .text:0000000001E44B01                 call    sub_1E3D5A0
+  .text:0000000001E44B06                 test    rax, rax
+  .text:0000000001E44B09                 jz      short loc_1E44B30
+  .text:0000000001E44B0B                 movsxd  r15, dword ptr [r12]
+  .text:0000000001E44B0F                 mov     r14, rax
+  .text:0000000001E44B12                 mov     eax, r15d
+  .text:0000000001E44B15                 cmp     r15d, [r12+10h]
+  .text:0000000001E44B1A                 jz      loc_1E44BC0
+  .text:0000000001E44B20                 add     eax, 1
+  .text:0000000001E44B23                 mov     [r12], eax
+  .text:0000000001E44B27                 mov     rax, [r12+8]
+  .text:0000000001E44B2C                 mov     [rax+r15*8], r14
+  .text:0000000001E44B30                 mov     rdi, [rbx]
+  .text:0000000001E44B33                 lea     rdx, CEntitySystem_OnRemoveEntity
+  .text:0000000001E44B3A                 mov     rax, [rdi]
+  .text:0000000001E44B3D                 mov     rax, [rax+88h]   ; 0x88 = CEntityInstance_ScriptEntityIO
+  .text:0000000001E44B44                 cmp     rax, rdx
+  .text:0000000001E44B47                 jnz     short loc_1E44B90
+  .text:0000000001E44B49                 mov     rax, [rbx+8]
+  .text:0000000001E44B4D                 lea     rdx, xmmword_27BA840
+  .text:0000000001E44B54                 mov     rax, [rax+80h]
+  .text:0000000001E44B5B                 movsxd  rdx, dword ptr [rdx+20h]
+  .text:0000000001E44B5F                 movzx   eax, word ptr [rax+rdx*2]
+  .text:0000000001E44B63                 cmp     ax, 0FFFFh
+  .text:0000000001E44B67                 jz      short loc_1E44BAD
+  .text:0000000001E44B69                 mov     rdi, [rdi+rax]
+  .text:0000000001E44B6D                 test    rdi, rdi
+  .text:0000000001E44B70                 jz      short loc_1E44BAD
+  .text:0000000001E44B72                 add     rsp, 8
+  .text:0000000001E44B76                 mov     rdx, r12
+  .text:0000000001E44B79                 mov     rsi, r13
+  .text:0000000001E44B7C                 pop     rbx
+  .text:0000000001E44B7D                 pop     r12
+  .text:0000000001E44B7F                 pop     r13
+  .text:0000000001E44B81                 pop     r14
+  .text:0000000001E44B83                 pop     r15
+  .text:0000000001E44B85                 pop     rbp
+  .text:0000000001E44B86                 jmp     sub_1E7A000
+  .text:0000000001E44B90                 call    rax
+  .text:0000000001E44B92                 mov     rdi, rax
+  .text:0000000001E44B95                 test    rax, rax
+  .text:0000000001E44B98                 jz      short loc_1E44BA5
+  .text:0000000001E44B9A                 mov     rdx, r12
+  .text:0000000001E44B9D                 mov     rsi, r13
+  .text:0000000001E44BA0                 call    sub_1E32820
+  .text:0000000001E44BA5                 mov     rdi, [rbx]
+  .text:0000000001E44BA8                 test    rdi, rdi
+  .text:0000000001E44BAB                 jnz     short loc_1E44B49
+  .text:0000000001E44BAD                 add     rsp, 8
+  .text:0000000001E44BB1                 pop     rbx
+  .text:0000000001E44BB2                 pop     r12
+  .text:0000000001E44BB4                 pop     r13
+  .text:0000000001E44BB6                 pop     r14
+  .text:0000000001E44BB8                 pop     r15
+  .text:0000000001E44BBA                 pop     rbp
+  .text:0000000001E44BBB                 retn
+  .text:0000000001E44BC0                 lea     rdi, [r12+8]
+  .text:0000000001E44BC5                 mov     esi, 1
+  .text:0000000001E44BCA                 call    sub_1E449C0
+  .text:0000000001E44BCF                 mov     eax, [r12]
+  .text:0000000001E44BD3                 jmp     loc_1E44B20
+procedure: |-
+  __int64 __fastcall CEntityInstance_FindOutputsByName(__int64 *a1, __int64 a2, int *a3)
+  {
+    __int64 v5; // rax
+    __int64 v6; // r15
+    __int64 v7; // r14
+    int v8; // eax
+    __int64 v9; // rdi
+    __int64 (__fastcall *v10)(); // rax
+    __int64 result; // rax
+    __int64 v12; // rdi
+    __int64 v13; // rcx
+    __int64 v14; // r8
+    __int64 v15; // r9
+
+    v5 = sub_1E3D5A0(a1[1], a2, *a1);
+    if ( v5 )
+    {
+      v6 = *a3;
+      v7 = v5;
+      v8 = v6;
+      if ( (_DWORD)v6 == a3[4] )
+      {
+        sub_1E449C0(a3 + 2, 1);
+        v8 = *a3;
+      }
+      *a3 = v8 + 1;
+      *(_QWORD *)(*((_QWORD *)a3 + 1) + 8 * v6) = v7;
+    }
+    v9 = *a1;
+    v10 = *(__int64 (__fastcall **)())(*(_QWORD *)*a1 + 136LL);// 0x88 = 136LL = CEntityInstance_ScriptEntityIO
+    if ( v10 == CEntitySystem_OnRemoveEntity )
+      goto LABEL_6;
+    result = v10();
+    if ( result )
+      result = sub_1E32820(result, a2, a3, v13, v14, v15);
+    v9 = *a1;
+    if ( *a1 )
+    {
+  LABEL_6:
+      result = *(unsigned __int16 *)(*(_QWORD *)(a1[1] + 128) + 2LL * (int)qword_27BA860);
+      if ( (_WORD)result != 0xFFFF )
+      {
+        v12 = *(_QWORD *)(v9 + result);
+        if ( v12 )
+          return sub_1E7A000(v12, a2, a3);
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_FindOutputsByName.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_FindOutputsByName.windows.yaml
@@ -1,0 +1,181 @@
+func_name: CEntityInstance_FindOutputsByName
+func_va: '0x18120e4f0'
+disasm_code: |-
+  .text:000000018120E4F0                 push    rbx
+  .text:000000018120E4F2                 push    rbp
+  .text:000000018120E4F3                 push    r14
+  .text:000000018120E4F5                 sub     rsp, 20h
+  .text:000000018120E4F9                 mov     rbx, r8
+  .text:000000018120E4FC                 mov     [rsp+38h+arg_10], r12
+  .text:000000018120E501                 mov     r8, [rcx]
+  .text:000000018120E504                 mov     r14, rcx
+  .text:000000018120E507                 mov     rcx, [rcx+8]
+  .text:000000018120E50B                 mov     rbp, rdx
+  .text:000000018120E50E                 call    sub_1811DD6B0
+  .text:000000018120E513                 mov     r12, rax
+  .text:000000018120E516                 test    rax, rax
+  .text:000000018120E519                 jz      loc_18120E5F5
+  .text:000000018120E51F                 mov     [rsp+38h+arg_18], r15
+  .text:000000018120E524                 movsxd  r15, dword ptr [rbx]
+  .text:000000018120E527                 cmp     r15d, [rbx+10h]
+  .text:000000018120E52B                 jnz     loc_18120E5E6
+  .text:000000018120E531                 test    dword ptr [rbx+14h], 40000000h
+  .text:000000018120E538                 jnz     loc_18120E5E6
+  .text:000000018120E53E                 mov     ecx, [rbx+10h]
+  .text:000000018120E541                 mov     [rsp+38h+arg_0], rsi
+  .text:000000018120E546                 mov     [rsp+38h+arg_8], rdi
+  .text:000000018120E54B                 cmp     ecx, 7FFFFFFEh
+  .text:000000018120E551                 jle     short loc_18120E55E
+  .text:000000018120E553                 mov     edx, 1
+  .text:000000018120E558                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:000000018120E55E                 mov     ecx, [rbx+10h]
+  .text:000000018120E561                 mov     r9d, 8
+  .text:000000018120E567                 mov     edx, [rbx+14h]
+  .text:000000018120E56A                 and     edx, 3FFFFFFFh
+  .text:000000018120E570                 lea     esi, [rcx+1]
+  .text:000000018120E573                 mov     r8d, esi
+  .text:000000018120E576                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:000000018120E57C                 mov     edi, eax
+  .text:000000018120E57E                 cmp     eax, esi
+  .text:000000018120E580                 jge     short loc_18120E5A0
+  .text:000000018120E582                 test    eax, eax
+  .text:000000018120E584                 jnz     short loc_18120E592
+  .text:000000018120E586                 cmp     esi, 0FFFFFFFFh
+  .text:000000018120E589                 jg      short loc_18120E592
+  .text:000000018120E58B                 mov     edi, 0FFFFFFFFh
+  .text:000000018120E590                 jmp     short loc_18120E5A0
+  .text:000000018120E592                 lea     eax, [rdi+rsi]
+  .text:000000018120E595                 cdq
+  .text:000000018120E596                 sub     eax, edx
+  .text:000000018120E598                 sar     eax, 1
+  .text:000000018120E59A                 mov     edi, eax
+  .text:000000018120E59C                 cmp     eax, esi
+  .text:000000018120E59E                 jl      short loc_18120E592
+  .text:000000018120E5A0                 movsxd  r9, dword ptr [rbx+10h]
+  .text:000000018120E5A4                 mov     rcx, [rbx+8]
+  .text:000000018120E5A8                 shl     r9, 3
+  .text:000000018120E5AC                 test    dword ptr [rbx+14h], 0C0000000h
+  .text:000000018120E5B3                 movsxd  r8, edi
+  .text:000000018120E5B6                 setz    dl
+  .text:000000018120E5B9                 shl     r8, 3
+  .text:000000018120E5BD                 call    cs:UtlVectorMemory_Alloc
+  .text:000000018120E5C3                 mov     rsi, [rsp+38h+arg_0]
+  .text:000000018120E5C8                 mov     [rbx+8], rax
+  .text:000000018120E5CC                 mov     eax, [rbx+14h]
+  .text:000000018120E5CF                 test    eax, 0C0000000h
+  .text:000000018120E5D4                 jz      short loc_18120E5DE
+  .text:000000018120E5D6                 and     eax, 3FFFFFFFh
+  .text:000000018120E5DB                 mov     [rbx+14h], eax
+  .text:000000018120E5DE                 mov     [rbx+10h], edi
+  .text:000000018120E5E1                 mov     rdi, [rsp+38h+arg_8]
+  .text:000000018120E5E6                 inc     dword ptr [rbx]
+  .text:000000018120E5E8                 mov     rax, [rbx+8]
+  .text:000000018120E5EC                 mov     [rax+r15*8], r12
+  .text:000000018120E5F0                 mov     r15, [rsp+38h+arg_18]
+  .text:000000018120E5F5                 mov     rcx, [r14]
+  .text:000000018120E5F8                 mov     rax, [rcx]
+  .text:000000018120E5FB                 ; 0x80 = 128LL = CEntityInstance_ScriptEntityIO
+  .text:000000018120E5FB                 call    qword ptr [rax+80h]; 0x80 = 128LL = CEntityInstance_ScriptEntityIO
+  .text:000000018120E601                 mov     r12, [rsp+38h+arg_10]
+  .text:000000018120E606                 test    rax, rax
+  .text:000000018120E609                 jz      short loc_18120E619
+  .text:000000018120E60B                 mov     r8, rbx
+  .text:000000018120E60E                 mov     rdx, rbp
+  .text:000000018120E611                 mov     rcx, rax
+  .text:000000018120E614                 call    sub_181212B00
+  .text:000000018120E619                 mov     r8, [r14]
+  .text:000000018120E61C                 test    r8, r8
+  .text:000000018120E61F                 jz      short loc_18120E661
+  .text:000000018120E621                 mov     rax, [r14+8]
+  .text:000000018120E625                 movsxd  rdx, cs:dword_181CAD0D0
+  .text:000000018120E62C                 mov     rcx, [rax+80h]
+  .text:000000018120E633                 movzx   eax, word ptr [rcx+rdx*2]
+  .text:000000018120E637                 mov     ecx, 0FFFFh
+  .text:000000018120E63C                 cmp     ax, cx
+  .text:000000018120E63F                 jz      short loc_18120E647
+  .text:000000018120E641                 mov     rcx, [rax+r8]
+  .text:000000018120E645                 jmp     short loc_18120E649
+  .text:000000018120E647                 xor     ecx, ecx
+  .text:000000018120E649                 test    rcx, rcx
+  .text:000000018120E64C                 jz      short loc_18120E661
+  .text:000000018120E64E                 mov     r8, rbx
+  .text:000000018120E651                 mov     rdx, rbp
+  .text:000000018120E654                 add     rsp, 20h
+  .text:000000018120E658                 pop     r14
+  .text:000000018120E65A                 pop     rbp
+  .text:000000018120E65B                 pop     rbx
+  .text:000000018120E65C                 jmp     sub_181218CD0
+  .text:000000018120E661                 add     rsp, 20h
+  .text:000000018120E665                 pop     r14
+  .text:000000018120E667                 pop     rbp
+  .text:000000018120E668                 pop     rbx
+  .text:000000018120E669                 retn
+procedure: |-
+  void __fastcall CEntityInstance_FindOutputByName(__int64 a1, __int64 a2, int *a3)
+  {
+    __int64 v6; // r12
+    __int64 v7; // r15
+    __int64 v8; // rcx
+    __int64 v9; // rcx
+    int v10; // esi
+    int v11; // eax
+    __int64 v12; // rdx
+    int v13; // edi
+    int v14; // eax
+    __int64 pScriptEntityIO; // rax
+    __int64 v16; // rax
+    __int64 v17; // rcx
+
+    v6 = sub_1811DD6B0(*(_QWORD *)(a1 + 8), a2, *(_QWORD *)a1);
+    if ( v6 )
+    {
+      v7 = *a3;
+      if ( (_DWORD)v7 == a3[4] && (a3[5] & 0x40000000) == 0 )
+      {
+        v8 = (unsigned int)a3[4];
+        if ( (_DWORD)v8 == 0x7FFFFFFF )
+          UtlVectorMemory_FailedAllocation(v8, 1);
+        v9 = (unsigned int)a3[4];
+        v10 = v9 + 1;
+        v11 = UtlVectorMemory_CalcNewAllocationCount(v9, a3[5] & 0x3FFFFFFF, (unsigned int)(v9 + 1), 8);
+        v13 = v11;
+        if ( v11 < v10 )
+        {
+          if ( v11 || v10 > -1 )
+          {
+            do
+            {
+              v12 = (unsigned int)((v13 + v10) >> 31);
+              v13 = (v13 + v10) / 2;
+            }
+            while ( v13 < v10 );
+          }
+          else
+          {
+            v13 = -1;
+          }
+        }
+        LOBYTE(v12) = (a3[5] & 0xC0000000) == 0;
+        *((_QWORD *)a3 + 1) = UtlVectorMemory_Alloc(*((_QWORD *)a3 + 1), v12, 8LL * v13, 8LL * a3[4]);
+        v14 = a3[5];
+        if ( (v14 & 0xC0000000) != 0 )
+          a3[5] = v14 & 0x3FFFFFFF;
+        a3[4] = v13;
+      }
+      ++*a3;
+      *(_QWORD *)(*((_QWORD *)a3 + 1) + 8 * v7) = v6;
+    }
+    pScriptEntityIO = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)a1 + 128LL))(*(_QWORD *)a1);// 0x80 = 128LL = CEntityInstance_ScriptEntityIO
+    if ( pScriptEntityIO )
+      sub_181212B00(pScriptEntityIO, a2, a3);
+    if ( *(_QWORD *)a1 )
+    {
+      v16 = *(unsigned __int16 *)(*(_QWORD *)(*(_QWORD *)(a1 + 8) + 128LL) + 2LL * dword_181CAD0D0);
+      if ( (_WORD)v16 == 0xFFFF )
+        v17 = 0;
+      else
+        v17 = *(_QWORD *)(v16 + *(_QWORD *)a1);
+      if ( v17 )
+        sub_181218CD0(v17, a2, a3);
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.linux.yaml
@@ -12,7 +12,7 @@ disasm_code: |-
   .text:0000000001E63048                 mov     rbx, rsi
   .text:0000000001E6304B                 sub     rsp, 18h
   .text:0000000001E6304F                 mov     rdx, [rdi]
-  .text:0000000001E63052                 mov     rcx, [rdx+88h] ; 0x88 = 136LL = CEntityInstance_OnRemoveEntity
+  .text:0000000001E63052                 mov     rcx, [rdx+88h] ; 0x88 = 136LL = CEntitySystem_OnRemoveEntity
   .text:0000000001E63059                 mov     edx, [rsi+10h]
   .text:0000000001E6305C                 shr     edx, 0Fh
   .text:0000000001E6305F                 sub     edx, eax
@@ -51,7 +51,7 @@ procedure: |-
     result = *(unsigned int *)(a2 + 48);
     if ( (result & 0x4800) == 0 )
     {
-      v3 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 136LL);// 0x88 = 136LL = CEntityInstance_OnRemoveEntity
+      v3 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 136LL);// 0x88 = 136LL = CEntitySystem_OnRemoveEntity
       if ( *(_DWORD *)(a2 + 16) == -1 )
         v4 = 0x7FFF;
       else

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.linux.yaml
@@ -1,0 +1,66 @@
+func_name: CEntitySystem_NotifyRemoveEntity
+func_va: '0x1e63030'
+disasm_code: |-
+  .text:0000000001E63030                 mov     eax, [rsi+30h]
+  .text:0000000001E63033                 test    ah, 48h
+  .text:0000000001E63036                 jz      short loc_1E63040
+  .text:0000000001E63038                 retn
+  .text:0000000001E63040                 push    rbp
+  .text:0000000001E63041                 and     eax, 1
+  .text:0000000001E63044                 mov     rbp, rsp
+  .text:0000000001E63047                 push    rbx
+  .text:0000000001E63048                 mov     rbx, rsi
+  .text:0000000001E6304B                 sub     rsp, 18h
+  .text:0000000001E6304F                 mov     rdx, [rdi]
+  .text:0000000001E63052                 mov     rcx, [rdx+88h] ; 0x88 = 136LL = CEntityInstance_OnRemoveEntity
+  .text:0000000001E63059                 mov     edx, [rsi+10h]
+  .text:0000000001E6305C                 shr     edx, 0Fh
+  .text:0000000001E6305F                 sub     edx, eax
+  .text:0000000001E63061                 cmp     dword ptr [rsi+10h], 0FFFFFFFFh
+  .text:0000000001E63065                 jz      short loc_1E630B0
+  .text:0000000001E63067                 movzx   eax, word ptr [rsi+10h]
+  .text:0000000001E6306B                 and     ax, 7FFFh
+  .text:0000000001E6306F                 movzx   eax, ax
+  .text:0000000001E63072                 shl     edx, 0Fh
+  .text:0000000001E63075                 or      edx, eax
+  .text:0000000001E63077                 lea     rax, nullsub_1672
+  .text:0000000001E6307E                 cmp     rcx, rax
+  .text:0000000001E63081                 jnz     short loc_1E630A0
+  .text:0000000001E63083                 mov     rsi, rbx
+  .text:0000000001E63086                 call    sub_1E62E30
+  .text:0000000001E6308B                 mov     rdi, [rbx+8]
+  .text:0000000001E6308F                 mov     rsi, rbx
+  .text:0000000001E63092                 mov     rbx, [rbp-8]
+  .text:0000000001E63096                 leave
+  .text:0000000001E63097                 jmp     sub_1E3BFF0
+  .text:0000000001E630A0                 mov     [rbp-18h], rdi
+  .text:0000000001E630A4                 mov     rsi, [rbx]
+  .text:0000000001E630A7                 call    rcx
+  .text:0000000001E630A9                 mov     rdi, [rbp-18h]
+  .text:0000000001E630AD                 jmp     short loc_1E63083
+  .text:0000000001E630B0                 mov     eax, 7FFFh
+  .text:0000000001E630B5                 jmp     short loc_1E6306F
+procedure: |-
+  __int64 __fastcall CEntitySystem_NotifyRemoveEntity(__int64 a1, __int64 a2)
+  {
+    __int64 result; // rax
+    __int64 (__fastcall *v3)(); // rcx
+    unsigned __int16 v4; // ax
+    __int64 v5; // rdx
+
+    result = *(unsigned int *)(a2 + 48);
+    if ( (result & 0x4800) == 0 )
+    {
+      v3 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 136LL);// 0x88 = 136LL = CEntityInstance_OnRemoveEntity
+      if ( *(_DWORD *)(a2 + 16) == -1 )
+        v4 = 0x7FFF;
+      else
+        v4 = *(_WORD *)(a2 + 16) & 0x7FFF;
+      v5 = v4 | (((*(_DWORD *)(a2 + 16) >> 15) - (*(_DWORD *)(a2 + 48) & 1u)) << 15);
+      if ( v3 != nullsub_1672 )
+        ((void (__fastcall *)(__int64, _QWORD, __int64))v3)(a1, *(_QWORD *)a2, v5);
+      sub_1E62E30(a1, a2, v5);
+      return sub_1E3BFF0(*(_QWORD *)(a2 + 8), a2);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.windows.yaml
@@ -28,7 +28,7 @@ disasm_code: |-
   .text:00000001811F2FDC                 cmovnz  ecx, eax
   .text:00000001811F2FDF                 or      r8d, ecx
   .text:00000001811F2FE2                 mov     rcx, rdi
-  .text:00000001811F2FE5                 call    qword ptr [r9+80h] ; 0x80 = 128LL = CEntityInstance_OnRemoveEntity
+  .text:00000001811F2FE5                 call    qword ptr [r9+80h] ; 0x80 = 128LL = CEntitySystem_OnRemoveEntity
   .text:00000001811F2FEC                 mov     rdx, rbx
   .text:00000001811F2FEF                 mov     rcx, rdi
   .text:00000001811F2FF2                 call    sub_1811F4440
@@ -56,7 +56,7 @@ procedure: |-
       if ( v5 != -1 )
         v7 = v5 & 0x7FFF;
       (*(void (__fastcall **)(__int64 *, _QWORD, _QWORD))(v6
-                                                        + 128))(// 0x80 = 128LL = CEntityInstance_OnRemoveEntity
+                                                        + 128))(// 0x80 = 128LL = CEntitySystem_OnRemoveEntity
         a1,
         *(_QWORD *)a2,
         v7 | (((v5 >> 15) - (v2 & 1)) << 15));

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_NotifyRemoveEntity.windows.yaml
@@ -1,0 +1,66 @@
+func_name: CEntitySystem_NotifyRemoveEntity
+func_va: '0x1811f2f90'
+disasm_code: |-
+  .text:00000001811F2F90                 mov     [rsp+arg_0], rbx
+  .text:00000001811F2F95                 push    rdi
+  .text:00000001811F2F96                 sub     rsp, 20h
+  .text:00000001811F2F9A                 mov     r10d, [rdx+30h]
+  .text:00000001811F2F9E                 mov     rbx, rdx
+  .text:00000001811F2FA1                 mov     rdi, rcx
+  .text:00000001811F2FA4                 bt      r10d, 0Bh
+  .text:00000001811F2FA9                 jb      short loc_1811F3003
+  .text:00000001811F2FAB                 mov     eax, r10d
+  .text:00000001811F2FAE                 shr     eax, 0Eh
+  .text:00000001811F2FB1                 test    al, 1
+  .text:00000001811F2FB3                 jnz     short loc_1811F3003
+  .text:00000001811F2FB5                 mov     edx, [rdx+10h]
+  .text:00000001811F2FB8                 and     r10d, 1
+  .text:00000001811F2FBC                 mov     r9, [rcx]
+  .text:00000001811F2FBF                 mov     r8d, edx
+  .text:00000001811F2FC2                 shr     r8d, 0Fh
+  .text:00000001811F2FC6                 mov     eax, edx
+  .text:00000001811F2FC8                 sub     r8d, r10d
+  .text:00000001811F2FCB                 mov     ecx, 7FFFh
+  .text:00000001811F2FD0                 and     eax, ecx
+  .text:00000001811F2FD2                 shl     r8d, 0Fh
+  .text:00000001811F2FD6                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811F2FD9                 mov     rdx, [rbx]
+  .text:00000001811F2FDC                 cmovnz  ecx, eax
+  .text:00000001811F2FDF                 or      r8d, ecx
+  .text:00000001811F2FE2                 mov     rcx, rdi
+  .text:00000001811F2FE5                 call    qword ptr [r9+80h] ; 0x80 = 128LL = CEntityInstance_OnRemoveEntity
+  .text:00000001811F2FEC                 mov     rdx, rbx
+  .text:00000001811F2FEF                 mov     rcx, rdi
+  .text:00000001811F2FF2                 call    sub_1811F4440
+  .text:00000001811F2FF7                 mov     rcx, [rbx+8]
+  .text:00000001811F2FFB                 mov     rdx, rbx
+  .text:00000001811F2FFE                 call    sub_1811DECA0
+  .text:00000001811F3003                 mov     rbx, [rsp+28h+arg_0]
+  .text:00000001811F3008                 add     rsp, 20h
+  .text:00000001811F300C                 pop     rdi
+  .text:00000001811F300D                 retn
+procedure: |-
+  void __fastcall CEntitySystem_NotifyRemoveEntity(__int64 *a1, __int64 a2)
+  {
+    int v2; // r10d
+    unsigned int v5; // edx
+    __int64 v6; // r9
+    int v7; // ecx
+
+    v2 = *(_DWORD *)(a2 + 48);
+    if ( (v2 & 0x800) == 0 && (v2 & 0x4000) == 0 )
+    {
+      v5 = *(_DWORD *)(a2 + 16);
+      v6 = *a1;
+      v7 = 0x7FFF;
+      if ( v5 != -1 )
+        v7 = v5 & 0x7FFF;
+      (*(void (__fastcall **)(__int64 *, _QWORD, _QWORD))(v6
+                                                        + 128))(// 0x80 = 128LL = CEntityInstance_OnRemoveEntity
+        a1,
+        *(_QWORD *)a2,
+        v7 | (((v5 >> 15) - (v2 & 1)) << 15));
+      sub_1811F4440((__int64)a1, a2);
+      sub_1811DECA0(*(_QWORD *)(a2 + 8), a2);
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RemoveEntityImmediate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RemoveEntityImmediate.linux.yaml
@@ -1,0 +1,280 @@
+func_name: CEntitySystem_RemoveEntityImmediate
+func_va: '0x1e64150'
+disasm_code: |-
+  .text:0000000001E64150                 test    rsi, rsi
+  .text:0000000001E64153                 jz      locret_1E64300
+  .text:0000000001E64159                 push    rbp
+  .text:0000000001E6415A                 mov     rbp, rsp
+  .text:0000000001E6415D                 push    r15
+  .text:0000000001E6415F                 push    r14
+  .text:0000000001E64161                 push    r13
+  .text:0000000001E64163                 push    r12
+  .text:0000000001E64165                 mov     r12, rdi
+  .text:0000000001E64168                 push    rbx
+  .text:0000000001E64169                 mov     rbx, rsi
+  .text:0000000001E6416C                 sub     rsp, 18h
+  .text:0000000001E64170                 mov     eax, [rsi+30h]
+  .text:0000000001E64173                 test    ah, 8
+  .text:0000000001E64176                 jnz     loc_1E642C8
+  .text:0000000001E6417C                 test    ah, 2
+  .text:0000000001E6417F                 jnz     loc_1E6429A
+  .text:0000000001E64185                 mov     ecx, [rdi+0BC8h]
+  .text:0000000001E6418B                 test    ecx, ecx
+  .text:0000000001E6418D                 jg      loc_1E642B0
+  .text:0000000001E64193                 add     dword ptr [rdi+0BCCh], 1
+  .text:0000000001E6419A                 mov     eax, [rsi+30h]
+  .text:0000000001E6419D                 mov     r14, [rsi]
+  .text:0000000001E641A0                 mov     edx, eax
+  .text:0000000001E641A2                 or      edx, 10h
+  .text:0000000001E641A5                 mov     [rsi+30h], edx
+  .text:0000000001E641A8                 test    r14, r14
+  .text:0000000001E641AB                 jz      loc_1E64260
+  .text:0000000001E641B1                 and     eax, 4
+  .text:0000000001E641B4                 mov     r13d, eax
+  .text:0000000001E641B7                 jnz     loc_1E64255
+  .text:0000000001E641BD                 mov     rax, [rdi]
+  .text:0000000001E641C0                 lea     rdx, sub_1E4F560
+  .text:0000000001E641C7                 mov     [rbp-38h], rsi
+  .text:0000000001E641CB                 mov     rax, [rax+0C0h]
+  .text:0000000001E641D2                 cmp     rax, rdx
+  .text:0000000001E641D5                 jnz     loc_1E643B8
+  .text:0000000001E641DB                 lea     r15, g_pResourceSystem
+  .text:0000000001E641E2                 mov     rdi, [r15]
+  .text:0000000001E641E5                 test    rdi, rdi
+  .text:0000000001E641E8                 jz      loc_1E64340
+  .text:0000000001E641EE                 mov     rax, [rdi]
+  .text:0000000001E641F1                 call    qword ptr [rax+1E8h]
+  .text:0000000001E641F7                 mov     rdi, rax
+  .text:0000000001E641FA                 mov     rax, [rax]
+  .text:0000000001E641FD                 call    qword ptr [rax+28h]
+  .text:0000000001E64200                 mov     rdx, [rbp-38h]
+  .text:0000000001E64204                 test    al, al
+  .text:0000000001E64206                 jnz     loc_1E64358
+  .text:0000000001E6420C                 mov     byte ptr [r12+0BDCh], 0
+  .text:0000000001E64215                 lea     rax, byte_27BA2E9
+  .text:0000000001E6421C                 mov     rdi, [rdx]
+  .text:0000000001E6421F                 mov     byte ptr [rax], 0
+  .text:0000000001E64222                 mov     rax, [rdi]
+  .text:0000000001E64225                 call    qword ptr [rax+78h]
+  .text:0000000001E64228                 cmp     byte ptr [r12+0BDCh], 0
+  .text:0000000001E64231                 jz      short loc_1E64255
+  .text:0000000001E64233                 mov     rdi, [r15]
+  .text:0000000001E64236                 mov     rax, [rdi]
+  .text:0000000001E64239                 call    qword ptr [rax+1E8h]
+  .text:0000000001E6423F                 mov     ecx, 2
+  .text:0000000001E64244                 mov     edx, 17h
+  .text:0000000001E64249                 mov     esi, r13d
+  .text:0000000001E6424C                 mov     rdi, rax
+  .text:0000000001E6424F                 mov     rax, [rax]
+  .text:0000000001E64252                 call    qword ptr [rax+18h]
+  .text:0000000001E64255                 mov     rsi, rbx
+  .text:0000000001E64258                 mov     rdi, r12
+  .text:0000000001E6425B                 call    CEntitySystem_NotifyRemoveEntity
+  .text:0000000001E64260                 mov     rdi, r14
+  .text:0000000001E64263                 call    CEntitySystem_DestroyEntityInternal
+  .text:0000000001E64268                 xor     esi, esi
+  .text:0000000001E6426A                 mov     rdi, rbx
+  .text:0000000001E6426D                 call    sub_1E446E0
+  .text:0000000001E64272                 lea     rdi, [r12+10h]
+  .text:0000000001E64277                 mov     edx, 1
+  .text:0000000001E6427C                 mov     rsi, rbx
+  .text:0000000001E6427F                 call    sub_1E51E80
+  .text:0000000001E64284                 sub     dword ptr [r12+0BCCh], 1
+  .text:0000000001E6428D                 jnz     short loc_1E6429A
+  .text:0000000001E6428F                 cmp     byte ptr [r12+0BDBh], 0
+  .text:0000000001E64298                 jnz     short loc_1E64308
+  .text:0000000001E6429A                 add     rsp, 18h
+  .text:0000000001E6429E                 pop     rbx
+  .text:0000000001E6429F                 pop     r12
+  .text:0000000001E642A1                 pop     r13
+  .text:0000000001E642A3                 pop     r14
+  .text:0000000001E642A5                 pop     r15
+  .text:0000000001E642A7                 pop     rbp
+  .text:0000000001E642A8                 retn
+  .text:0000000001E642B0                 add     rsp, 18h
+  .text:0000000001E642B4                 pop     rbx
+  .text:0000000001E642B5                 pop     r12
+  .text:0000000001E642B7                 pop     r13
+  .text:0000000001E642B9                 pop     r14
+  .text:0000000001E642BB                 pop     r15
+  .text:0000000001E642BD                 pop     rbp
+  .text:0000000001E642BE                 jmp     sub_1E643E0
+  .text:0000000001E642C8                 mov     rdi, [rsi]
+  .text:0000000001E642CB                 call    CEntitySystem_DestroyEntityInternal
+  .text:0000000001E642D0                 mov     rdi, rbx
+  .text:0000000001E642D3                 xor     esi, esi
+  .text:0000000001E642D5                 call    sub_1E446E0
+  .text:0000000001E642DA                 add     rsp, 18h
+  .text:0000000001E642DE                 mov     rsi, rbx
+  .text:0000000001E642E1                 mov     edx, 1
+  .text:0000000001E642E6                 pop     rbx
+  .text:0000000001E642E7                 lea     rdi, [r12+10h]
+  .text:0000000001E642EC                 pop     r12
+  .text:0000000001E642EE                 pop     r13
+  .text:0000000001E642F0                 pop     r14
+  .text:0000000001E642F2                 pop     r15
+  .text:0000000001E642F4                 pop     rbp
+  .text:0000000001E642F5                 jmp     sub_1E51E80
+  .text:0000000001E64300                 retn
+  .text:0000000001E64308                 mov     edx, [r12+0BC4h]
+  .text:0000000001E64310                 test    edx, edx
+  .text:0000000001E64312                 jnz     short loc_1E6429A
+  .text:0000000001E64314                 mov     eax, [r12+0BC0h]
+  .text:0000000001E6431C                 test    eax, eax
+  .text:0000000001E6431E                 jnz     loc_1E643C8
+  .text:0000000001E64324                 add     rsp, 18h
+  .text:0000000001E64328                 mov     rdi, r12
+  .text:0000000001E6432B                 xor     esi, esi
+  .text:0000000001E6432D                 pop     rbx
+  .text:0000000001E6432E                 pop     r12
+  .text:0000000001E64330                 pop     r13
+  .text:0000000001E64332                 pop     r14
+  .text:0000000001E64334                 pop     r15
+  .text:0000000001E64336                 pop     rbp
+  .text:0000000001E64337                 jmp     CEntitySystem_PurgeRemovedEntities
+  .text:0000000001E64340                 mov     byte ptr [r12+0BDCh], 0
+  .text:0000000001E64349                 mov     rdx, rsi
+  .text:0000000001E6434C                 jmp     loc_1E64215
+  .text:0000000001E64358                 mov     byte ptr [r12+0BDCh], 1
+  .text:0000000001E64361                 mov     eax, [rdx+10h]
+  .text:0000000001E64364                 mov     ecx, [rdx+30h]
+  .text:0000000001E64367                 shr     eax, 0Fh
+  .text:0000000001E6436A                 and     ecx, 1
+  .text:0000000001E6436D                 sub     eax, ecx
+  .text:0000000001E6436F                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001E64373                 jz      short loc_1E643D6
+  .text:0000000001E64375                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000001E64379                 and     dx, 7FFFh
+  .text:0000000001E6437E                 mov     rdi, [r15]
+  .text:0000000001E64381                 movzx   edx, dx
+  .text:0000000001E64384                 shl     eax, 0Fh
+  .text:0000000001E64387                 or      eax, edx
+  .text:0000000001E64389                 mov     r13d, eax
+  .text:0000000001E6438C                 mov     rax, [rdi]
+  .text:0000000001E6438F                 call    qword ptr [rax+1E8h]
+  .text:0000000001E64395                 mov     edx, 17h
+  .text:0000000001E6439A                 mov     ecx, 1
+  .text:0000000001E6439F                 mov     esi, r13d
+  .text:0000000001E643A2                 mov     rdi, rax
+  .text:0000000001E643A5                 mov     rax, [rax]
+  .text:0000000001E643A8                 call    qword ptr [rax+18h]
+  .text:0000000001E643AB                 mov     rdx, [rbp-38h]
+  .text:0000000001E643AF                 jmp     loc_1E64215
+  .text:0000000001E643B8                 lea     rdx, [rbp-38h]
+  .text:0000000001E643BC                 mov     esi, 1
+  .text:0000000001E643C1                 call    rax
+  .text:0000000001E643C3                 jmp     loc_1E64255
+  .text:0000000001E643C8                 mov     byte ptr [r12+0BD8h], 1
+  .text:0000000001E643D1                 jmp     loc_1E6429A
+  .text:0000000001E643D6                 mov     edx, 7FFFh
+  .text:0000000001E643DB                 jmp     short loc_1E6437E
+procedure: |-
+  void __fastcall CEntitySystem_RemoveEntityImmediate(__int64 *a1, unsigned __int64 a2)
+  {
+    int v3; // eax
+    int v4; // eax
+    __int64 v5; // r14
+    unsigned int v6; // r13d
+    __int64 v7; // rax
+    __int64 (__fastcall *v8)(__int64, int, __int64 **); // rax
+    __int64 v9; // rax
+    char v10; // al
+    unsigned __int64 v11; // rdx
+    __int64 v12; // rdi
+    __int64 v13; // rax
+    bool v14; // zf
+    int v15; // eax
+    unsigned __int16 v16; // dx
+    __int64 v17; // rax
+    unsigned __int64 v18; // [rsp-40h] [rbp-40h] BYREF
+
+    if ( a2 )
+    {
+      v3 = *(_DWORD *)(a2 + 48);
+      if ( (v3 & 0x800) != 0 )
+      {
+        CEntitySystem_DestroyEntityInternal(*(_QWORD *)a2);
+        sub_1E446E0(a2);
+        sub_1E51E80((__int64)(a1 + 2), a2, 1);
+      }
+      else if ( (v3 & 0x200) == 0 )
+      {
+        if ( *((int *)a1 + 754) > 0 )
+        {
+          sub_1E643E0();
+        }
+        else
+        {
+          ++*((_DWORD *)a1 + 755);
+          v4 = *(_DWORD *)(a2 + 48);
+          v5 = *(_QWORD *)a2;
+          *(_DWORD *)(a2 + 48) = v4 | 0x10;
+          if ( v5 )
+          {
+            v6 = v4 & 4;
+            if ( (v4 & 4) == 0 )
+            {
+              v7 = *a1;
+              v18 = a2;
+              v8 = *(__int64 (__fastcall **)(__int64, int, __int64 **))(v7 + 192);
+              if ( v8 == sub_1E4F560 )
+              {
+                if ( g_pResourceSystem )
+                {
+                  v9 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pResourceSystem + 488LL))(g_pResourceSystem);
+                  v10 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v9 + 40LL))(v9);
+                  v11 = v18;
+                  if ( v10 )
+                  {
+                    *((_BYTE *)a1 + 3036) = 1;
+                    v15 = (*(_DWORD *)(v11 + 16) >> 15) - (*(_DWORD *)(v11 + 48) & 1);
+                    if ( *(_DWORD *)(v11 + 16) == -1 )
+                      v16 = 0x7FFF;
+                    else
+                      v16 = *(_WORD *)(v11 + 16) & 0x7FFF;
+                    v6 = v16 | (v15 << 15);
+                    v17 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pResourceSystem + 488LL))(g_pResourceSystem);
+                    (*(void (__fastcall **)(__int64, _QWORD, __int64, __int64))(*(_QWORD *)v17 + 24LL))(v17, v6, 23, 1);
+                    v11 = v18;
+                  }
+                  else
+                  {
+                    *((_BYTE *)a1 + 3036) = 0;
+                  }
+                }
+                else
+                {
+                  *((_BYTE *)a1 + 3036) = 0;
+                  v11 = a2;
+                }
+                v12 = *(_QWORD *)v11;
+                byte_27BA2E9 = 0;
+                (*(void (__fastcall **)(__int64))(*(_QWORD *)v12 + 120LL))(v12);
+                if ( *((_BYTE *)a1 + 3036) )
+                {
+                  v13 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pResourceSystem + 488LL))(g_pResourceSystem);
+                  (*(void (__fastcall **)(__int64, _QWORD, __int64, __int64))(*(_QWORD *)v13 + 24LL))(v13, v6, 23, 2);
+                }
+              }
+              else
+              {
+                v8((__int64)a1, 1, (__int64 **)&v18);
+              }
+            }
+            CEntitySystem_NotifyRemoveEntity((__int64)a1, a2);
+          }
+          CEntitySystem_DestroyEntityInternal(v5);
+          sub_1E446E0(a2);
+          sub_1E51E80((__int64)(a1 + 2), a2, 1);
+          v14 = (*((_DWORD *)a1 + 755))-- == 1;
+          if ( v14 && *((_BYTE *)a1 + 3035) && !*((_DWORD *)a1 + 753) )
+          {
+            if ( *((_DWORD *)a1 + 752) )
+              *((_BYTE *)a1 + 3032) = 1;
+            else
+              CEntitySystem_PurgeRemovedEntities((__int64)a1, 0);
+          }
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RemoveEntityImmediate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RemoveEntityImmediate.windows.yaml
@@ -1,0 +1,207 @@
+func_name: CEntitySystem_RemoveEntityImmediate
+func_va: '0x1811ea450'
+disasm_code: |-
+  .text:00000001811EA450                 test    rdx, rdx
+  .text:00000001811EA453                 jz      locret_1811EA604
+  .text:00000001811EA459                 push    rdi
+  .text:00000001811EA45A                 push    r14
+  .text:00000001811EA45C                 sub     rsp, 38h
+  .text:00000001811EA460                 mov     eax, [rdx+30h]
+  .text:00000001811EA463                 mov     r14, rdx
+  .text:00000001811EA466                 mov     [rsp+48h+arg_0], rbx
+  .text:00000001811EA46B                 mov     rdi, rcx
+  .text:00000001811EA46E                 bt      eax, 0Bh
+  .text:00000001811EA472                 jnb     loc_1811EA553
+  .text:00000001811EA478                 mov     [rsp+48h+arg_10], rbp
+  .text:00000001811EA47D                 mov     [rsp+48h+var_20], r12
+  .text:00000001811EA482                 mov     r12, [rdx]
+  .text:00000001811EA485                 mov     [rsp+48h+var_28], r15
+  .text:00000001811EA48A                 mov     r15, [r12+10h]
+  .text:00000001811EA48F                 mov     rbp, [r15+8]
+  .text:00000001811EA493                 mov     cs:byte_1820B0582, 0
+  .text:00000001811EA49A                 mov     rcx, [r15]
+  .text:00000001811EA49D                 mov     rax, [rcx]
+  .text:00000001811EA4A0                 call    qword ptr [rax+30h]
+  .text:00000001811EA4A3                 mov     eax, [rbp+70h]
+  .text:00000001811EA4A6                 shr     eax, 1
+  .text:00000001811EA4A8                 test    al, 1
+  .text:00000001811EA4AA                 jz      short loc_1811EA502
+  .text:00000001811EA4AC                 mov     eax, [rbp+90h]
+  .text:00000001811EA4B2                 sub     eax, 1
+  .text:00000001811EA4B5                 movsxd  rbx, eax
+  .text:00000001811EA4B8                 js      short loc_1811EA502
+  .text:00000001811EA4BA                 mov     [rsp+48h+var_18], rsi
+  .text:00000001811EA4BF                 mov     rsi, rbx
+  .text:00000001811EA4C2                 shl     rsi, 4
+  .text:00000001811EA4C6                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811EA4D0                 mov     rax, [rbp+98h]
+  .text:00000001811EA4D7                 mov     rcx, [rsi+rax+8]
+  .text:00000001811EA4DC                 test    byte ptr [rcx+8], 2
+  .text:00000001811EA4E0                 jz      short loc_1811EA4F3
+  .text:00000001811EA4E2                 mov     r8, [rsi+rax]
+  .text:00000001811EA4E6                 mov     rdx, r15
+  .text:00000001811EA4E9                 mov     r9, [rcx]
+  .text:00000001811EA4EC                 add     r8, r12
+  .text:00000001811EA4EF                 call    qword ptr [r9+28h]
+  .text:00000001811EA4F3                 sub     rsi, 10h
+  .text:00000001811EA4F7                 sub     rbx, 1
+  .text:00000001811EA4FB                 jns     short loc_1811EA4D0
+  .text:00000001811EA4FD                 mov     rsi, [rsp+48h+var_18]
+  .text:00000001811EA502                 mov     rdx, r12
+  .text:00000001811EA505                 mov     rcx, rbp
+  .text:00000001811EA508                 call    sub_1811DD630
+  .text:00000001811EA50D                 mov     rdx, r12
+  .text:00000001811EA510                 mov     rcx, rbp
+  .text:00000001811EA513                 call    sub_1811DDAB0
+  .text:00000001811EA518                 xor     edx, edx
+  .text:00000001811EA51A                 mov     qword ptr [r15], 0
+  .text:00000001811EA521                 mov     rcx, r14
+  .text:00000001811EA524                 call    sub_18120E670
+  .text:00000001811EA529                 lea     rcx, [rdi+10h]
+  .text:00000001811EA52D                 mov     r8b, 1
+  .text:00000001811EA530                 mov     rdx, r14
+  .text:00000001811EA533                 mov     r15, [rsp+48h+var_28]
+  .text:00000001811EA538                 mov     r12, [rsp+48h+var_20]
+  .text:00000001811EA53D                 mov     rbp, [rsp+48h+arg_10]
+  .text:00000001811EA542                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001811EA547                 add     rsp, 38h
+  .text:00000001811EA54B                 pop     r14
+  .text:00000001811EA54D                 pop     rdi
+  .text:00000001811EA54E                 jmp     sub_1811EE5A0
+  .text:00000001811EA553                 bt      eax, 9
+  .text:00000001811EA557                 jb      loc_1811EA5F8
+  .text:00000001811EA55D                 cmp     dword ptr [rcx+0BC8h], 0
+  .text:00000001811EA564                 jle     short loc_1811EA577
+  .text:00000001811EA566                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001811EA56B                 add     rsp, 38h
+  .text:00000001811EA56F                 pop     r14
+  .text:00000001811EA571                 pop     rdi
+  .text:00000001811EA572                 jmp     CEntitySystem_QueueRemoveEntity
+  .text:00000001811EA577                 inc     dword ptr [rcx+0BCCh]
+  .text:00000001811EA57D                 mov     eax, [rdx+30h]
+  .text:00000001811EA580                 mov     rbx, [rdx]
+  .text:00000001811EA583                 or      eax, 10h
+  .text:00000001811EA586                 mov     [rdx+30h], eax
+  .text:00000001811EA589                 test    rbx, rbx
+  .text:00000001811EA58C                 jz      short loc_1811EA5B5
+  .text:00000001811EA58E                 test    al, 4
+  .text:00000001811EA590                 jnz     short loc_1811EA5AA
+  .text:00000001811EA592                 mov     rax, [rcx]
+  .text:00000001811EA595                 lea     r8, [rsp+48h+arg_8]
+  .text:00000001811EA59A                 mov     edx, 1
+  .text:00000001811EA59F                 mov     [rsp+48h+arg_8], r14
+  .text:00000001811EA5A4                 call    qword ptr [rax+0B8h]
+  .text:00000001811EA5AA                 mov     rdx, r14
+  .text:00000001811EA5AD                 mov     rcx, rdi
+  .text:00000001811EA5B0                 call    CEntitySystem_NotifyRemoveEntity
+  .text:00000001811EA5B5                 xor     r8d, r8d
+  .text:00000001811EA5B8                 mov     rdx, rbx
+  .text:00000001811EA5BB                 mov     rcx, rdi
+  .text:00000001811EA5BE                 call    CEntitySystem_DestroyEntityInternal
+  .text:00000001811EA5C3                 xor     edx, edx
+  .text:00000001811EA5C5                 mov     rcx, r14
+  .text:00000001811EA5C8                 call    sub_18120E670
+  .text:00000001811EA5CD                 lea     rcx, [rdi+10h]
+  .text:00000001811EA5D1                 mov     r8b, 1
+  .text:00000001811EA5D4                 mov     rdx, r14
+  .text:00000001811EA5D7                 call    sub_1811EE5A0
+  .text:00000001811EA5DC                 sub     dword ptr [rdi+0BCCh], 1
+  .text:00000001811EA5E3                 jnz     short loc_1811EA5F8
+  .text:00000001811EA5E5                 cmp     byte ptr [rdi+0BDBh], 0
+  .text:00000001811EA5EC                 jz      short loc_1811EA5F8
+  .text:00000001811EA5EE                 xor     edx, edx
+  .text:00000001811EA5F0                 mov     rcx, rdi
+  .text:00000001811EA5F3                 call    CEntitySystem_PurgeRemovedEntities
+  .text:00000001811EA5F8                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001811EA5FD                 add     rsp, 38h
+  .text:00000001811EA601                 pop     r14
+  .text:00000001811EA603                 pop     rdi
+  .text:00000001811EA604                 retn
+procedure: |-
+  void __fastcall CEntitySystem_RemoveEntityImmediate(__int64 a1, __int64 a2)
+  {
+    int v2; // eax
+    __int64 v5; // r12
+    __int64 v6; // r15
+    __int64 v7; // rbp
+    int v8; // eax
+    __int64 v9; // rbx
+    __int64 v10; // rsi
+    __int64 v11; // rax
+    _BYTE *v12; // rcx
+    __int64 v13; // rbx
+    int v14; // eax
+    __int64 v15; // rax
+    bool v16; // zf
+    __int64 v17; // [rsp+58h] [rbp+10h] BYREF
+
+    if ( a2 )
+    {
+      v2 = *(_DWORD *)(a2 + 48);
+      if ( (v2 & 0x800) != 0 )
+      {
+        v5 = *(_QWORD *)a2;
+        v6 = *(_QWORD *)(*(_QWORD *)a2 + 16LL);
+        v7 = *(_QWORD *)(v6 + 8);
+        byte_1820B0582 = 0;
+        (*(void (__fastcall **)(_QWORD))(**(_QWORD **)v6 + 48LL))(*(_QWORD *)v6);
+        if ( (*(_DWORD *)(v7 + 112) & 2) != 0 )
+        {
+          v8 = *(_DWORD *)(v7 + 144) - 1;
+          v9 = v8;
+          if ( v8 >= 0 )
+          {
+            v10 = 16LL * v8;
+            do
+            {
+              v11 = *(_QWORD *)(v7 + 152);
+              v12 = *(_BYTE **)(v10 + v11 + 8);
+              if ( (v12[8] & 2) != 0 )
+                (*(void (__fastcall **)(_BYTE *, __int64, __int64))(*(_QWORD *)v12 + 40LL))(
+                  v12,
+                  v6,
+                  v5 + *(_QWORD *)(v10 + v11));
+              v10 -= 16;
+              --v9;
+            }
+            while ( v9 >= 0 );
+          }
+        }
+        sub_1811DD630(v7, v5);
+        sub_1811DDAB0(v7, v5);
+        *(_QWORD *)v6 = 0;
+        sub_18120E670(a2);
+        sub_1811EE5A0(a1 + 16, a2, 1);
+      }
+      else if ( (v2 & 0x200) == 0 )
+      {
+        if ( *(int *)(a1 + 3016) <= 0 )
+        {
+          ++*(_DWORD *)(a1 + 3020);
+          v13 = *(_QWORD *)a2;
+          v14 = *(_DWORD *)(a2 + 48) | 0x10;
+          *(_DWORD *)(a2 + 48) = v14;
+          if ( v13 )
+          {
+            if ( (v14 & 4) == 0 )
+            {
+              v15 = *(_QWORD *)a1;
+              v17 = a2;
+              (*(void (__fastcall **)(__int64, __int64, __int64 *))(v15 + 184))(a1, 1, &v17);// (numEntities, entities)?
+            }
+            CEntitySystem_NotifyRemoveEntity((__int64 *)a1, a2);
+          }
+          CEntitySystem_DestroyEntityInternal(a1, v13, 0);
+          sub_18120E670(a2);
+          sub_1811EE5A0(a1 + 16, a2, 1);
+          v16 = (*(_DWORD *)(a1 + 3020))-- == 1;
+          if ( v16 && *(_BYTE *)(a1 + 3035) )
+            CEntitySystem_PurgeRemovedEntities(a1, 0);
+        }
+        else
+        {
+          CEntitySystem_QueueRemoveEntity(a1, (_DWORD *)a2);
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_Activate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_Activate.linux.yaml
@@ -1,0 +1,239 @@
+func_name: CGameEntitySystem_Activate
+func_va: '0x1551c40'
+disasm_code: |-
+  .text:0000000001551C40                 push    rbp
+  .text:0000000001551C41                 mov     r8d, esi
+  .text:0000000001551C44                 mov     rbp, rsp
+  .text:0000000001551C47                 push    r15
+  .text:0000000001551C49                 push    r14
+  .text:0000000001551C4B                 push    r13
+  .text:0000000001551C4D                 push    r12
+  .text:0000000001551C4F                 push    rbx
+  .text:0000000001551C50                 mov     rbx, rdx
+  .text:0000000001551C53                 sub     rsp, 58h
+  .text:0000000001551C57                 test    esi, esi
+  .text:0000000001551C59                 jle     loc_1551DDE
+  .text:0000000001551C5F                 lea     rax, [rdx+16h]
+  .text:0000000001551C63                 movsxd  rdx, esi
+  .text:0000000001551C66                 mov     r13, rdi
+  .text:0000000001551C69                 lea     rdx, [rdx+rdx*2]
+  .text:0000000001551C6D                 xor     r15d, r15d
+  .text:0000000001551C70                 lea     rsi, [rax+rdx*8]
+  .text:0000000001551C74                 mov     edx, 0FFFFFFFFh
+  .text:0000000001551C79                 jmp     short loc_1551CA2
+  .text:0000000001551C80                 ; _QWORD
+  .text:0000000001551C80                 movsxd  rcx, r15d; _QWORD
+  .text:0000000001551C83                 add     r15d, 1
+  .text:0000000001551C87                 mov     [rbp+rcx*4+var_70], 1
+  .text:0000000001551C8F                 cmp     r15d, 10h
+  .text:0000000001551C93                 jg      loc_1551DFB
+  .text:0000000001551C99                 add     rax, 18h
+  .text:0000000001551C9D                 cmp     rsi, rax
+  .text:0000000001551CA0                 jz      short loc_1551CC0
+  .text:0000000001551CA2                 mov     ecx, edx
+  .text:0000000001551CA4                 ; _QWORD
+  .text:0000000001551CA4                 movzx   edx, byte ptr [rax]; _QWORD
+  .text:0000000001551CA7                 cmp     edx, ecx
+  .text:0000000001551CA9                 jnz     short loc_1551C80
+  .text:0000000001551CAB                 lea     ecx, [r15-1]
+  .text:0000000001551CAF                 add     rax, 18h
+  .text:0000000001551CB3                 movsxd  rcx, ecx
+  .text:0000000001551CB6                 add     [rbp+rcx*4+var_70], 1
+  .text:0000000001551CBB                 cmp     rsi, rax
+  .text:0000000001551CBE                 jnz     short loc_1551CA2
+  .text:0000000001551CC0                 lea     r14, g_pBodyGameSystem
+  .text:0000000001551CC7                 mov     rdx, rbx
+  .text:0000000001551CCA                 mov     esi, r8d
+  .text:0000000001551CCD                 mov     rdi, [r14]
+  .text:0000000001551CD0                 call    sub_DE8250
+  .text:0000000001551CD5                 test    r15d, r15d
+  .text:0000000001551CD8                 jz      loc_1551DCF
+  .text:0000000001551CDE                 lea     r12, [rbp+var_70]
+  .text:0000000001551CE2                 movsxd  r15, r15d
+  .text:0000000001551CE5                 lea     rax, [r12+r15*4]
+  .text:0000000001551CE9                 mov     [rbp+var_78], rax
+  .text:0000000001551CED                 nop     dword ptr [rax]
+  .text:0000000001551CF0                 mov     r15d, [r12]
+  .text:0000000001551CF4                 xor     esi, esi
+  .text:0000000001551CF6                 mov     rcx, rbx
+  .text:0000000001551CF9                 mov     rdi, [r14]
+  .text:0000000001551CFC                 mov     edx, r15d
+  .text:0000000001551CFF                 call    CBodyGameSystem_ProcessSpawnGroupSceneNodes
+  .text:0000000001551D04                 mov     rdx, rbx
+  .text:0000000001551D07                 mov     esi, r15d
+  .text:0000000001551D0A                 mov     rdi, r13
+  .text:0000000001551D0D                 call    CEntitySystem_Activate
+  .text:0000000001551D12                 mov     edx, r15d
+  .text:0000000001551D15                 sub     edx, 1
+  .text:0000000001551D18                 js      loc_1551DA8
+  .text:0000000001551D1E                 movsxd  rax, r15d
+  .text:0000000001551D21                 lea     rax, [rax+rax*2]
+  .text:0000000001551D25                 lea     rax, [rbx+rax*8-18h]
+  .text:0000000001551D2A                 jmp     short loc_1551D4C
+  .text:0000000001551D40                 sub     edx, 1
+  .text:0000000001551D43                 sub     rax, 18h
+  .text:0000000001551D47                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001551D4A                 jz      short loc_1551D90
+  .text:0000000001551D4C                 mov     rcx, [rax]
+  .text:0000000001551D4F                 cmp     qword ptr [rcx], 0
+  .text:0000000001551D53                 jnz     short loc_1551D40
+  .text:0000000001551D55                 lea     ecx, [r15-1]
+  .text:0000000001551D59                 cmp     ecx, edx
+  .text:0000000001551D5B                 jz      short loc_1551D78
+  .text:0000000001551D5D                 movsxd  r8, r15d
+  .text:0000000001551D60                 lea     rsi, [r8+r8*2]
+  .text:0000000001551D64                 lea     rsi, [rbx+rsi*8]
+  .text:0000000001551D68                 movdqu  xmm0, xmmword ptr [rsi-18h]
+  .text:0000000001551D6D                 movups  xmmword ptr [rax], xmm0
+  .text:0000000001551D70                 mov     rsi, [rsi-8]
+  .text:0000000001551D74                 mov     [rax+10h], rsi
+  .text:0000000001551D78                 sub     edx, 1
+  .text:0000000001551D7B                 mov     r15d, ecx
+  .text:0000000001551D7E                 sub     rax, 18h
+  .text:0000000001551D82                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001551D85                 jnz     short loc_1551D4C
+  .text:0000000001551D87                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001551D90                 test    r15d, r15d
+  .text:0000000001551D93                 jle     short loc_1551DA8
+  .text:0000000001551D95                 mov     rdi, [r14]
+  .text:0000000001551D98                 mov     rcx, rbx
+  .text:0000000001551D9B                 mov     edx, r15d
+  .text:0000000001551D9E                 mov     esi, 1
+  .text:0000000001551DA3                 call    CBodyGameSystem_ProcessSpawnGroupSceneNodes
+  .text:0000000001551DA8                 mov     rdx, rbx
+  .text:0000000001551DAB                 ; _QWORD
+  .text:0000000001551DAB                 mov     esi, r15d; _QWORD
+  .text:0000000001551DAE                 mov     rdi, r13
+  .text:0000000001551DB1                 call    CGameEntitySystem_CheckGlobalState
+  .text:0000000001551DB6                 ; _QWORD
+  .text:0000000001551DB6                 movsxd  r8, r15d; _QWORD
+  .text:0000000001551DB9                 add     r12, 4
+  .text:0000000001551DBD                 lea     rax, [r8+r8*2]
+  .text:0000000001551DC1                 lea     rbx, [rbx+rax*8]
+  .text:0000000001551DC5                 cmp     [rbp+var_78], r12
+  .text:0000000001551DC9                 jnz     loc_1551CF0
+  .text:0000000001551DCF                 add     rsp, 58h
+  .text:0000000001551DD3                 pop     rbx
+  .text:0000000001551DD4                 pop     r12
+  .text:0000000001551DD6                 pop     r13
+  .text:0000000001551DD8                 pop     r14
+  .text:0000000001551DDA                 pop     r15
+  .text:0000000001551DDC                 pop     rbp
+  .text:0000000001551DDD                 retn
+  .text:0000000001551DDE                 lea     rax, g_pBodyGameSystem
+  .text:0000000001551DE5                 mov     rdi, [rax]
+  .text:0000000001551DE8                 add     rsp, 58h
+  .text:0000000001551DEC                 pop     rbx
+  .text:0000000001551DED                 pop     r12
+  .text:0000000001551DEF                 pop     r13
+  .text:0000000001551DF1                 pop     r14
+  .text:0000000001551DF3                 pop     r15
+  .text:0000000001551DF5                 pop     rbp
+  .text:0000000001551DF6                 jmp     sub_DE8250
+  .text:0000000001551DFB                 lea     rdi, aMemoryTrashInS; "Memory trash in SortEntities.. overran "...
+  .text:0000000001551E02                 xor     eax, eax
+  .text:0000000001551E04                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_Activate(__int64 a1, __int64 a2, __int64 a3, __int64 a4)
+  {
+    __int64 v4; // r8
+    __int64 v5; // rbx
+    unsigned __int8 *v6; // rax
+    int v7; // r15d
+    __int64 v8; // rsi
+    __int64 v9; // rcx
+    int v10; // ecx
+    __int64 result; // rax
+    int *v12; // r12
+    int v13; // r15d
+    int v14; // edx
+    __int64 v15; // rax
+    __int64 v16; // rsi
+    int *v17; // [rsp+8h] [rbp-78h]
+    _DWORD v18[28]; // [rsp+10h] [rbp-70h] BYREF
+
+    v4 = (unsigned int)a2;
+    v5 = a3;
+    if ( (int)a2 <= 0 )
+      return sub_DE8250(g_pBodyGameSystem, a2, a3, a4, (unsigned int)a2);
+    v6 = (unsigned __int8 *)(a3 + 22);
+    v7 = 0;
+    v8 = a3 + 22 + 24LL * (int)a2;
+    LODWORD(a3) = -1;
+    do
+    {
+      while ( 1 )
+      {
+        v10 = a3;
+        a3 = *v6;
+        if ( (_DWORD)a3 != v10 )
+          break;
+        v6 += 24;
+        v9 = v7 - 1;
+        ++v18[v9];
+        if ( (unsigned __int8 *)v8 == v6 )
+          goto LABEL_7;
+      }
+      v9 = v7++;
+      v18[v9] = 1;
+      if ( v7 > 16 )
+      {
+        Plat_FatalError(
+          "Memory trash in SortEntities.. overran the number of entity islands supported!\n",
+          v8,
+          a3,
+          v9,
+          v4);
+        JUMPOUT(0x1551E09);
+      }
+      v6 += 24;
+    }
+    while ( (unsigned __int8 *)v8 != v6 );
+  LABEL_7:
+    result = sub_DE8250(g_pBodyGameSystem, (unsigned int)v4, v5, v9, v4);
+    if ( v7 )
+    {
+      v12 = v18;
+      v17 = &v18[v7];
+      do
+      {
+        v13 = *v12;
+        CBodyGameSystem_ProcessSpawnGroupSceneNodes(g_pBodyGameSystem, 0, (unsigned int)*v12, v5);
+        CEntitySystem_Activate(a1, (unsigned int)v13, v5);
+        v14 = v13 - 1;
+        if ( v13 - 1 >= 0 )
+        {
+          v15 = v5 + 24LL * v13 - 24;
+          do
+          {
+            while ( **(_QWORD **)v15 )
+            {
+              --v14;
+              v15 -= 24;
+              if ( v14 == -1 )
+                goto LABEL_16;
+            }
+            if ( v13 - 1 != v14 )
+            {
+              v16 = v5 + 24LL * v13;
+              *(__m128i *)v15 = _mm_loadu_si128((const __m128i *)(v16 - 24));
+              *(_QWORD *)(v15 + 16) = *(_QWORD *)(v16 - 8);
+            }
+            --v14;
+            --v13;
+            v15 -= 24;
+          }
+          while ( v14 != -1 );
+  LABEL_16:
+          if ( v13 > 0 )
+            CBodyGameSystem_ProcessSpawnGroupSceneNodes(g_pBodyGameSystem, 1, (unsigned int)v13, v5);
+        }
+        CGameEntitySystem_CheckGlobalState(a1, (unsigned int)v13, v5);
+        ++v12;
+        result = 3LL * v13;
+        v5 += 24LL * v13;
+      }
+      while ( v17 != v12 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_Activate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_Activate.windows.yaml
@@ -1,0 +1,214 @@
+func_name: CGameEntitySystem_Activate
+func_va: '0x180b84e20'
+disasm_code: |-
+  .text:0000000180B84E20                 mov     [rsp+arg_8], rbx
+  .text:0000000180B84E25                 mov     [rsp+arg_10], rsi
+  .text:0000000180B84E2A                 mov     [rsp+arg_18], rdi
+  .text:0000000180B84E2F                 push    r14
+  .text:0000000180B84E31                 sub     rsp, 60h
+  .text:0000000180B84E35                 xor     esi, esi
+  .text:0000000180B84E37                 movsxd  r11, edx
+  .text:0000000180B84E3A                 mov     rdi, r8
+  .text:0000000180B84E3D                 mov     r14, rcx
+  .text:0000000180B84E40                 mov     ebx, esi
+  .text:0000000180B84E42                 mov     r9d, 0FFFFFFFFh
+  .text:0000000180B84E48                 test    edx, edx
+  .text:0000000180B84E4A                 jle     short loc_180B84E90
+  .text:0000000180B84E4C                 lea     rax, [rsp+68h+var_48]
+  .text:0000000180B84E51                 mov     r8d, esi
+  .text:0000000180B84E54                 sub     rax, 4
+  .text:0000000180B84E58                 lea     rdx, [rdi+16h]
+  .text:0000000180B84E5C                 nop     dword ptr [rax+00h]
+  .text:0000000180B84E60                 movzx   ecx, byte ptr [rdx]
+  .text:0000000180B84E63                 cmp     r9d, ecx
+  .text:0000000180B84E66                 jnz     short loc_180B84E6C
+  .text:0000000180B84E68                 inc     dword ptr [rax]
+  .text:0000000180B84E6A                 jmp     short loc_180B84E84
+  .text:0000000180B84E6C                 add     rax, 4
+  .text:0000000180B84E70                 inc     ebx
+  .text:0000000180B84E72                 mov     r9d, ecx
+  .text:0000000180B84E75                 mov     dword ptr [rax], 1
+  .text:0000000180B84E7B                 cmp     ebx, 10h
+  .text:0000000180B84E7E                 ja      loc_180B84F9F
+  .text:0000000180B84E84                 inc     r8
+  .text:0000000180B84E87                 add     rdx, 18h
+  .text:0000000180B84E8B                 cmp     r8, r11
+  .text:0000000180B84E8E                 jl      short loc_180B84E60
+  .text:0000000180B84E90                 mov     rcx, cs:g_pBodyGameSystem
+  .text:0000000180B84E97                 mov     r8, rdi
+  .text:0000000180B84E9A                 mov     edx, r11d
+  .text:0000000180B84E9D                 mov     [rsp+68h+arg_0], rbp
+  .text:0000000180B84EA2                 call    sub_180539550
+  .text:0000000180B84EA7                 movsxd  rbp, ebx
+  .text:0000000180B84EAA                 test    ebx, ebx
+  .text:0000000180B84EAC                 jle     loc_180B84F83
+  .text:0000000180B84EB2                 nop     dword ptr [rax+00h]
+  .text:0000000180B84EB6                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180B84EC0                 movsxd  rbx, [rsp+rsi*4+68h+var_48]
+  .text:0000000180B84EC5                 mov     r9, rdi
+  .text:0000000180B84EC8                 mov     rcx, cs:g_pBodyGameSystem
+  .text:0000000180B84ECF                 mov     r8d, ebx
+  .text:0000000180B84ED2                 xor     edx, edx
+  .text:0000000180B84ED4                 call    CBodyGameSystem_ProcessSpawnGroupSceneNodes
+  .text:0000000180B84ED9                 mov     r8, rdi
+  .text:0000000180B84EDC                 mov     edx, ebx
+  .text:0000000180B84EDE                 mov     rcx, r14
+  .text:0000000180B84EE1                 call    CEntitySystem_Activate
+  .text:0000000180B84EE6                 lea     r9d, [rbx-1]
+  .text:0000000180B84EEA                 movsxd  r8, r9d
+  .text:0000000180B84EED                 test    r9d, r9d
+  .text:0000000180B84EF0                 js      short loc_180B84F44
+  .text:0000000180B84EF2                 lea     rdx, [rbx-1]
+  .text:0000000180B84EF6                 mov     r10d, r9d
+  .text:0000000180B84EF9                 lea     rdx, [rdx+rdx*2]
+  .text:0000000180B84EFD                 lea     rax, [r8+r8*2]
+  .text:0000000180B84F01                 lea     rdx, [rdi+rdx*8]
+  .text:0000000180B84F05                 lea     rax, [rdi+rax*8]
+  .text:0000000180B84F09                 nop     dword ptr [rax+00000000h]
+  .text:0000000180B84F10                 mov     rcx, [rax]
+  .text:0000000180B84F13                 cmp     qword ptr [rcx], 0
+  .text:0000000180B84F17                 jnz     short loc_180B84F37
+  .text:0000000180B84F19                 cmp     r9d, r10d
+  .text:0000000180B84F1C                 jz      short loc_180B84F2E
+  .text:0000000180B84F1E                 movups  xmm0, xmmword ptr [rdx]
+  .text:0000000180B84F21                 movups  xmmword ptr [rax], xmm0
+  .text:0000000180B84F24                 movsd   xmm1, qword ptr [rdx+10h]
+  .text:0000000180B84F29                 movsd   qword ptr [rax+10h], xmm1
+  .text:0000000180B84F2E                 dec     ebx
+  .text:0000000180B84F30                 dec     r10d
+  .text:0000000180B84F33                 sub     rdx, 18h
+  .text:0000000180B84F37                 dec     r9d
+  .text:0000000180B84F3A                 sub     rax, 18h
+  .text:0000000180B84F3E                 sub     r8, 1
+  .text:0000000180B84F42                 jns     short loc_180B84F10
+  .text:0000000180B84F44                 test    ebx, ebx
+  .text:0000000180B84F46                 jle     short loc_180B84F5F
+  .text:0000000180B84F48                 mov     rcx, cs:g_pBodyGameSystem
+  .text:0000000180B84F4F                 mov     r9, rdi
+  .text:0000000180B84F52                 mov     r8d, ebx
+  .text:0000000180B84F55                 mov     edx, 1
+  .text:0000000180B84F5A                 call    CBodyGameSystem_ProcessSpawnGroupSceneNodes
+  .text:0000000180B84F5F                 mov     r8, rdi
+  .text:0000000180B84F62                 mov     edx, ebx
+  .text:0000000180B84F64                 mov     rcx, r14
+  .text:0000000180B84F67                 call    CGameEntitySystem_CheckGlobalState
+  .text:0000000180B84F6C                 movsxd  rax, ebx
+  .text:0000000180B84F6F                 inc     rsi
+  .text:0000000180B84F72                 lea     rcx, [rax+rax*2]
+  .text:0000000180B84F76                 lea     rdi, [rdi+rcx*8]
+  .text:0000000180B84F7A                 cmp     rsi, rbp
+  .text:0000000180B84F7D                 jl      loc_180B84EC0
+  .text:0000000180B84F83                 mov     rbp, [rsp+68h+arg_0]
+  .text:0000000180B84F88                 lea     r11, [rsp+68h+var_8]
+  .text:0000000180B84F8D                 mov     rbx, [r11+18h]
+  .text:0000000180B84F91                 mov     rsi, [r11+20h]
+  .text:0000000180B84F95                 mov     rdi, [r11+28h]
+  .text:0000000180B84F99                 mov     rsp, r11
+  .text:0000000180B84F9C                 pop     r14
+  .text:0000000180B84F9E                 retn
+  .text:0000000180B84F9F                 lea     rcx, aMemoryTrashInS; "Memory trash in SortEntities.. overran "...
+  .text:0000000180B84FA6                 call    cs:Plat_FatalError
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_Activate(__int64 a1, int a2, __int64 **a3)
+  {
+    __int64 v3; // rsi
+    __int64 v4; // r11
+    int v7; // ebx
+    __int64 v8; // r9
+    __int64 v9; // r8
+    _DWORD *v10; // rax
+    unsigned __int8 *v11; // rdx
+    unsigned int v12; // ecx
+    __int64 result; // rax
+    __int64 v14; // rbp
+    __int64 v15; // rbx
+    int v16; // r9d
+    __int64 v17; // r8
+    int v18; // r10d
+    __int64 **v19; // rdx
+    __int64 **v20; // rax
+    _BYTE v21[96]; // [rsp+0h] [rbp-68h] BYREF
+
+    v3 = 0;
+    v4 = a2;
+    v7 = 0;
+    v8 = 0xFFFFFFFFLL;
+    if ( a2 > 0 )
+    {
+      v9 = 0;
+      v10 = &v21[28];
+      v11 = (unsigned __int8 *)a3 + 22;
+      do
+      {
+        v12 = *v11;
+        if ( (_DWORD)v8 == v12 )
+        {
+          ++*v10;
+        }
+        else
+        {
+          ++v10;
+          ++v7;
+          v8 = *v11;
+          *v10 = 1;
+          if ( (unsigned int)v7 > 0x10 )
+          {
+            Plat_FatalError(
+              "Memory trash in SortEntities.. overran the number of entity islands supported!\n",
+              v11,
+              v9,
+              v12);
+            JUMPOUT(0x180B84FACLL);
+          }
+        }
+        ++v9;
+        v11 += 24;
+      }
+      while ( v9 < v4 );
+    }
+    result = sub_180539550(g_pBodyGameSystem, (unsigned int)v4, a3, v8);
+    v14 = v7;
+    if ( v7 > 0 )
+    {
+      do
+      {
+        v15 = *(int *)&v21[4 * v3 + 32];
+        CBodyGameSystem_ProcessSpawnGroupSceneNodes(g_pBodyGameSystem, 0, *(_DWORD *)&v21[4 * v3 + 32], a3);
+        CEntitySystem_Activate(a1, (unsigned int)v15, a3);
+        v16 = v15 - 1;
+        v17 = (int)v15 - 1;
+        if ( (int)v15 - 1 >= 0 )
+        {
+          v18 = v15 - 1;
+          v19 = &a3[3 * v15 - 3];
+          v20 = &a3[3 * v16];
+          do
+          {
+            if ( !**v20 )
+            {
+              if ( v16 != v18 )
+              {
+                *(_OWORD *)v20 = *(_OWORD *)v19;
+                v20[2] = v19[2];
+              }
+              LODWORD(v15) = v15 - 1;
+              --v18;
+              v19 -= 3;
+            }
+            --v16;
+            v20 -= 3;
+            --v17;
+          }
+          while ( v17 >= 0 );
+        }
+        if ( (int)v15 > 0 )
+          CBodyGameSystem_ProcessSpawnGroupSceneNodes(g_pBodyGameSystem, 1, v15, a3);
+        CGameEntitySystem_CheckGlobalState(a1, v15, a3);
+        result = (int)v15;
+        ++v3;
+        a3 += 3 * (int)v15;
+      }
+      while ( v3 < v14 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameSceneNode_OnParentChanged.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameSceneNode_OnParentChanged.linux.yaml
@@ -1,0 +1,113 @@
+func_name: CGameSceneNode_OnParentChanged
+func_va: '0x155e2b0'
+disasm_code: |-
+  .text:000000000155E2B0                 push    rbp
+  .text:000000000155E2B1                 mov     rbp, rsp
+  .text:000000000155E2B4                 push    r14
+  .text:000000000155E2B6                 push    r13
+  .text:000000000155E2B8                 mov     r13, rsi
+  .text:000000000155E2BB                 push    r12
+  .text:000000000155E2BD                 push    rbx
+  .text:000000000155E2BE                 mov     r12, [rdi+30h]
+  .text:000000000155E2C2                 mov     rbx, rdi
+  .text:000000000155E2C5                 mov     rax, [r12]
+  .text:000000000155E2C9                 mov     rdi, r12
+  .text:000000000155E2CC                 call    qword ptr [rax+2A0h]
+  .text:000000000155E2D2                 cmp     qword ptr [rbx+38h], 0
+  .text:000000000155E2D7                 jz      short loc_155E302
+  .text:000000000155E2D9                 mov     rax, [r12]
+  .text:000000000155E2DD                 lea     r14, sub_9A4FC0
+  .text:000000000155E2E4                 mov     rax, [rax+218h]
+  .text:000000000155E2EB                 cmp     rax, r14
+  .text:000000000155E2EE                 jnz     short loc_155E358
+  .text:000000000155E2F0                 mov     rdi, [r12+6B8h]
+  .text:000000000155E2F8                 test    rdi, rdi
+  .text:000000000155E2FB                 jz      short loc_155E302
+  .text:000000000155E2FD                 call    sub_16A6450
+  .text:000000000155E302                 mov     rdi, rbx
+  .text:000000000155E305                 call    sub_155E1F0
+  .text:000000000155E30A                 lea     rax, g_pEntitySystem
+  .text:000000000155E311                 mov     rdx, [rbx+38h]
+  .text:000000000155E315                 mov     rdi, [rax]
+  .text:000000000155E318                 mov     rax, [rdi]
+  .text:000000000155E31B                 ; 0x78 = 120LL = CEntitySystem_OnEntityParentChanged
+  .text:000000000155E31B                 mov     rax, [rax+78h]; 0x78 = 120LL = CEntitySystem_OnEntityParentChanged
+  .text:000000000155E31F                 test    rdx, rdx
+  .text:000000000155E322                 jz      short loc_155E328
+  .text:000000000155E324                 mov     rdx, [rdx+30h]
+  .text:000000000155E328                 mov     rsi, [rbx+30h]
+  .text:000000000155E32C                 call    rax
+  .text:000000000155E32E                 mov     rax, [r12]
+  .text:000000000155E332                 mov     rax, [rax+470h]
+  .text:000000000155E339                 test    r13, r13
+  .text:000000000155E33C                 jz      short loc_155E342
+  .text:000000000155E33E                 mov     r13, [r13+30h]
+  .text:000000000155E342                 pop     rbx
+  .text:000000000155E343                 mov     rsi, r13
+  .text:000000000155E346                 mov     rdi, r12
+  .text:000000000155E349                 pop     r12
+  .text:000000000155E34B                 pop     r13
+  .text:000000000155E34D                 pop     r14
+  .text:000000000155E34F                 pop     rbp
+  .text:000000000155E350                 jmp     rax
+  .text:000000000155E358                 mov     rdi, r12
+  .text:000000000155E35B                 call    rax
+  .text:000000000155E35D                 test    rax, rax
+  .text:000000000155E360                 jz      short loc_155E302
+  .text:000000000155E362                 mov     rax, [r12]
+  .text:000000000155E366                 mov     rax, [rax+218h]
+  .text:000000000155E36D                 cmp     rax, r14
+  .text:000000000155E370                 jz      short loc_155E37C
+  .text:000000000155E372                 mov     rdi, r12
+  .text:000000000155E375                 call    rax
+  .text:000000000155E377                 mov     rdi, rax
+  .text:000000000155E37A                 jmp     short loc_155E2FD
+  .text:000000000155E37C                 mov     rdi, [r12+6B8h]
+  .text:000000000155E384                 jmp     loc_155E2FD
+procedure: |-
+  __int64 __fastcall CGameSceneNode_OnParentChanged(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // r13
+    _QWORD *v3; // r12
+    __int64 (__fastcall *v5)(__int64); // rax
+    __int64 v6; // rdi
+    __int64 v7; // rdx
+    __int64 (__fastcall *v9)(__int64); // rax
+
+    v2 = a2;
+    v3 = *(_QWORD **)(a1 + 48);
+    (*(void (__fastcall **)(_QWORD *))(*v3 + 672LL))(v3);
+    if ( *(_QWORD *)(a1 + 56) )
+    {
+      v5 = *(__int64 (__fastcall **)(__int64))(*v3 + 536LL);
+      if ( v5 == sub_9A4FC0 )
+      {
+        v6 = v3[215];
+        if ( !v6 )
+          goto LABEL_5;
+        goto LABEL_4;
+      }
+      if ( v5((__int64)v3) )
+      {
+        v9 = *(__int64 (__fastcall **)(__int64))(*v3 + 536LL);
+        if ( v9 == sub_9A4FC0 )
+          v6 = v3[215];
+        else
+          v6 = v9((__int64)v3);
+  LABEL_4:
+        sub_16A6450(v6);
+      }
+    }
+  LABEL_5:
+    sub_155E1F0((_QWORD *)a1);
+    v7 = *(_QWORD *)(a1 + 56);
+    if ( v7 )
+      v7 = *(_QWORD *)(v7 + 48);
+    (*(void (__fastcall **)(_QWORD, _QWORD, __int64))(*(_QWORD *)g_pEntitySystem + 120LL))(// 0x78 = 120LL = CEntitySystem_OnEntityParentChanged
+      g_pEntitySystem,
+      *(_QWORD *)(a1 + 48),
+      v7);
+    if ( a2 )
+      v2 = *(_QWORD *)(a2 + 48);
+    return (*(__int64 (__fastcall **)(_QWORD *, __int64))(*v3 + 1136LL))(v3, v2);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameSceneNode_OnParentChanged.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameSceneNode_OnParentChanged.windows.yaml
@@ -1,0 +1,134 @@
+func_name: CGameSceneNode_OnParentChanged
+func_va: '0x180b8cae0'
+disasm_code: |-
+  .text:0000000180B8CAE0                 mov     [rsp+arg_0], rbx
+  .text:0000000180B8CAE5                 mov     [rsp+arg_8], rbp
+  .text:0000000180B8CAEA                 mov     [rsp+arg_10], rsi
+  .text:0000000180B8CAEF                 mov     [rsp+arg_18], rdi
+  .text:0000000180B8CAF4                 push    r14
+  .text:0000000180B8CAF6                 sub     rsp, 20h
+  .text:0000000180B8CAFA                 mov     rsi, [rcx+30h]
+  .text:0000000180B8CAFE                 mov     rdi, rcx
+  .text:0000000180B8CB01                 mov     rcx, rsi
+  .text:0000000180B8CB04                 mov     rbp, rdx
+  .text:0000000180B8CB07                 mov     rax, [rsi]
+  .text:0000000180B8CB0A                 call    qword ptr [rax+2A8h]
+  .text:0000000180B8CB10                 cmp     qword ptr [rdi+38h], 0
+  .text:0000000180B8CB15                 jz      short loc_180B8CB3C
+  .text:0000000180B8CB17                 mov     rax, [rsi]
+  .text:0000000180B8CB1A                 mov     rcx, rsi
+  .text:0000000180B8CB1D                 call    qword ptr [rax+220h]
+  .text:0000000180B8CB23                 test    rax, rax
+  .text:0000000180B8CB26                 jz      short loc_180B8CB3C
+  .text:0000000180B8CB28                 mov     rax, [rsi]
+  .text:0000000180B8CB2B                 mov     rcx, rsi
+  .text:0000000180B8CB2E                 call    qword ptr [rax+220h]
+  .text:0000000180B8CB34                 mov     rcx, rax
+  .text:0000000180B8CB37                 call    sub_180C45660
+  .text:0000000180B8CB3C                 mov     rax, [rdi]
+  .text:0000000180B8CB3F                 mov     rcx, rdi
+  .text:0000000180B8CB42                 mov     r14, [rdi+30h]
+  .text:0000000180B8CB46                 call    qword ptr [rax+50h]
+  .text:0000000180B8CB49                 test    rax, rax
+  .text:0000000180B8CB4C                 jz      short loc_180B8CB8A
+  .text:0000000180B8CB4E                 mov     rax, [r14]
+  .text:0000000180B8CB51                 mov     rcx, r14
+  .text:0000000180B8CB54                 call    qword ptr [rax+220h]
+  .text:0000000180B8CB5A                 test    rax, rax
+  .text:0000000180B8CB5D                 jz      short loc_180B8CB8A
+  .text:0000000180B8CB5F                 mov     rax, [rdi]
+  .text:0000000180B8CB62                 mov     rcx, rdi
+  .text:0000000180B8CB65                 call    qword ptr [rax+50h]
+  .text:0000000180B8CB68                 mov     rdx, [r14]
+  .text:0000000180B8CB6B                 mov     rcx, r14
+  .text:0000000180B8CB6E                 mov     rbx, rax
+  .text:0000000180B8CB71                 call    qword ptr [rdx+220h]
+  .text:0000000180B8CB77                 mov     rcx, rax
+  .text:0000000180B8CB7A                 call    sub_180C570B0
+  .text:0000000180B8CB7F                 mov     rdx, rax
+  .text:0000000180B8CB82                 mov     rcx, rbx
+  .text:0000000180B8CB85                 call    sub_180BF81D0
+  .text:0000000180B8CB8A                 mov     rbx, [rdi+40h]
+  .text:0000000180B8CB8E                 test    rbx, rbx
+  .text:0000000180B8CB91                 jz      short loc_180B8CBA4
+  .text:0000000180B8CB93                 mov     rcx, rbx
+  .text:0000000180B8CB96                 call    sub_180B8D300
+  .text:0000000180B8CB9B                 mov     rbx, [rbx+48h]
+  .text:0000000180B8CB9F                 test    rbx, rbx
+  .text:0000000180B8CBA2                 jnz     short loc_180B8CB93
+  .text:0000000180B8CBA4                 mov     r9, cs:g_pEntitySystem
+  .text:0000000180B8CBAB                 xor     ebx, ebx
+  .text:0000000180B8CBAD                 mov     rcx, [rdi+38h]
+  .text:0000000180B8CBB1                 mov     rax, [r9]
+  .text:0000000180B8CBB4                 test    rcx, rcx
+  .text:0000000180B8CBB7                 jz      short loc_180B8CBBF
+  .text:0000000180B8CBB9                 mov     r8, [rcx+30h]
+  .text:0000000180B8CBBD                 jmp     short loc_180B8CBC2
+  .text:0000000180B8CBBF                 mov     r8, rbx
+  .text:0000000180B8CBC2                 mov     rdx, [rdi+30h]
+  .text:0000000180B8CBC6                 mov     rcx, r9
+  .text:0000000180B8CBC9                 ; 0x70 = 112LL = CEntitySystem_OnEntityParentChanged
+  .text:0000000180B8CBC9                 call    qword ptr [rax+70h]; 0x70 = 112LL = CEntitySystem_OnEntityParentChanged
+  .text:0000000180B8CBCC                 mov     rax, [rsi]
+  .text:0000000180B8CBCF                 test    rbp, rbp
+  .text:0000000180B8CBD2                 jz      short loc_180B8CBD8
+  .text:0000000180B8CBD4                 mov     rbx, [rbp+30h]
+  .text:0000000180B8CBD8                 mov     rdx, rbx
+  .text:0000000180B8CBDB                 mov     rcx, rsi
+  .text:0000000180B8CBDE                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180B8CBE3                 mov     rbp, [rsp+28h+arg_8]
+  .text:0000000180B8CBE8                 mov     rsi, [rsp+28h+arg_10]
+  .text:0000000180B8CBED                 mov     rdi, [rsp+28h+arg_18]
+  .text:0000000180B8CBF2                 add     rsp, 20h
+  .text:0000000180B8CBF6                 pop     r14
+  .text:0000000180B8CBF8                 jmp     qword ptr [rax+478h]
+procedure: |-
+  // a1 = CGameSceneNode *
+  // a2 = CGameSceneNode *
+  __int64 __fastcall CGameSceneNode_OnParentChanged(__int64 a1, __int64 a2)
+  {
+    __int64 pCurrentEntity; // rsi
+    __int64 v5; // rax
+    __int64 v6; // rdx
+    __int64 pCurrentEntity_1; // r14
+    __int64 v8; // rbx
+    __int64 v9; // rax
+    __int64 v10; // rax
+    _QWORD *i; // rbx
+    __int64 pNewEntity; // rbx
+    __int64 v13; // rcx
+    __int64 pNewParent; // r8
+
+    pCurrentEntity = *(_QWORD *)(a1 + 48);
+    (*(void (__fastcall **)(__int64))(*(_QWORD *)pCurrentEntity + 680LL))(pCurrentEntity);
+    if ( *(_QWORD *)(a1 + 56) && (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)pCurrentEntity + 544LL))(pCurrentEntity) )
+    {
+      v5 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)pCurrentEntity + 544LL))(pCurrentEntity);
+      sub_180C45660(v5, v6);
+    }
+    pCurrentEntity_1 = *(_QWORD *)(a1 + 48);
+    if ( (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 80LL))(a1)
+      && (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)pCurrentEntity_1 + 544LL))(pCurrentEntity_1) )
+    {
+      v8 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 80LL))(a1);
+      v9 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)pCurrentEntity_1 + 544LL))(pCurrentEntity_1);
+      v10 = sub_180C570B0(v9);
+      sub_180BF81D0(v8, v10);
+    }
+    for ( i = *(_QWORD **)(a1 + 64); i; i = (_QWORD *)i[9] )
+      sub_180B8D300(i);
+    pNewEntity = 0;
+    v13 = *(_QWORD *)(a1 + 56);
+    if ( v13 )
+      pNewParent = *(_QWORD *)(v13 + 48);
+    else
+      pNewParent = 0;
+    (*(void (__fastcall **)(__int64, _QWORD, __int64))(*(_QWORD *)g_pEntitySystem
+                                                     + 112LL))(// 0x70 = 112LL = CEntitySystem_OnEntityParentChanged
+      g_pEntitySystem,
+      *(_QWORD *)(a1 + 48),
+      pNewParent);
+    if ( a2 )
+      pNewEntity = *(_QWORD *)(a2 + 48);
+    return (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)pCurrentEntity + 1144LL))(pCurrentEntity, pNewEntity);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameSceneNode_PostDataUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameSceneNode_PostDataUpdate.linux.yaml
@@ -1,0 +1,219 @@
+func_name: CGameSceneNode_PostDataUpdate
+func_va: '0x155e390'
+disasm_code: |-
+  .text:000000000155E390                 push    rbp
+  .text:000000000155E391                 mov     rbp, rsp
+  .text:000000000155E394                 push    r12
+  .text:000000000155E396                 push    rbx
+  .text:000000000155E397                 mov     rbx, rdi
+  .text:000000000155E39A                 sub     rsp, 10h
+  .text:000000000155E39E                 movzx   eax, byte ptr [rdi+0E9h]
+  .text:000000000155E3A5                 mov     edx, eax
+  .text:000000000155E3A7                 and     edx, 0FFFFFFDFh
+  .text:000000000155E3AA                 and     esi, 1
+  .text:000000000155E3AD                 mov     [rdi+0E9h], dl
+  .text:000000000155E3B3                 jnz     loc_155E4B0
+  .text:000000000155E3B9                 movzx   eax, byte ptr [rbx+0E9h]
+  .text:000000000155E3C0                 test    al, 1
+  .text:000000000155E3C2                 jnz     loc_155E4CB
+  .text:000000000155E3C8                 mov     ecx, eax
+  .text:000000000155E3CA                 mov     edx, eax
+  .text:000000000155E3CC                 shr     cl, 3
+  .text:000000000155E3CF                 shr     dl, 4
+  .text:000000000155E3D2                 and     ecx, 1
+  .text:000000000155E3D5                 and     edx, 1
+  .text:000000000155E3D8                 test    al, 4
+  .text:000000000155E3DA                 jnz     loc_155E510
+  .text:000000000155E3E0                 test    cl, cl
+  .text:000000000155E3E2                 jz      loc_155E580
+  .text:000000000155E3E8                 and     byte ptr [rbx+0E9h], 0F7h
+  .text:000000000155E3EF                 mov     r12d, 6
+  .text:000000000155E3F5                 mov     eax, 2
+  .text:000000000155E3FA                 test    dl, dl
+  .text:000000000155E3FC                 jz      loc_155E537
+  .text:000000000155E402                 and     byte ptr [rbx+0E9h], 0EFh
+  .text:000000000155E409                 cmp     byte ptr [rbx+0ECh], 0
+  .text:000000000155E410                 jnz     loc_155E547
+  .text:000000000155E416                 mov     rax, [rbx+80h]
+  .text:000000000155E41D                 lea     rdi, [rbx+0D4h]
+  .text:000000000155E424                 or      r12d, 100h
+  .text:000000000155E42B                 movss   xmm1, dword ptr [rbx+0C4h]
+  .text:000000000155E433                 movss   xmm0, dword ptr [rbx+88h]
+  .text:000000000155E43B                 movss   dword ptr [rbx+0E0h], xmm1
+  .text:000000000155E443                 mov     [rbx+0C8h], rax
+  .text:000000000155E44A                 mov     rax, [rbx+0B8h]
+  .text:000000000155E451                 movss   dword ptr [rbx+0D0h], xmm0
+  .text:000000000155E459                 movss   [rbp+var_14], xmm1
+  .text:000000000155E45E                 mov     [rbx+0D4h], rax
+  .text:000000000155E465                 mov     eax, [rbx+0C0h]
+  .text:000000000155E46B                 mov     [rbx+0DCh], eax
+  .text:000000000155E471                 call    sub_1BD5830
+  .text:000000000155E476                 movss   xmm2, dword ptr [rbx+0D0h]
+  .text:000000000155E47E                 movss   xmm1, [rbp+var_14]
+  .text:000000000155E483                 movaps  xmmword ptr [rbx+20h], xmm0
+  .text:000000000155E487                 movss   xmm0, dword ptr [rbx+0C8h]
+  .text:000000000155E48F                 insertps xmm0, dword ptr [rbx+0CCh], 10h
+  .text:000000000155E499                 unpcklps xmm2, xmm1
+  .text:000000000155E49C                 movlhps xmm0, xmm2
+  .text:000000000155E49F                 movaps  xmmword ptr [rbx+10h], xmm0
+  .text:000000000155E4A3                 jmp     loc_155E547
+  .text:000000000155E4B0                 lea     rdi, [rdi+70h]
+  .text:000000000155E4B4                 and     eax, 0FFFFFFC3h
+  .text:000000000155E4B7                 or      eax, 1Ch
+  .text:000000000155E4BA                 mov     [rdi+79h], al
+  .text:000000000155E4BD                 call    sub_155CA10
+  .text:000000000155E4C2                 test    rax, rax
+  .text:000000000155E4C5                 jz      loc_155E3B9
+  .text:000000000155E4CB                 mov     rax, [rbx]
+  .text:000000000155E4CE                 mov     esi, 1
+  .text:000000000155E4D3                 mov     rdi, rbx
+  .text:000000000155E4D6                 mov     r12, [rbx+38h]
+  .text:000000000155E4DA                 and     byte ptr [rbx+0E9h], 0FEh
+  .text:000000000155E4E1                 call    qword ptr [rax+90h]
+  .text:000000000155E4E7                 mov     rax, [rbx]
+  .text:000000000155E4EA                 mov     esi, 1
+  .text:000000000155E4EF                 mov     rdi, rbx
+  .text:000000000155E4F2                 call    qword ptr [rax+98h]
+  .text:000000000155E4F8                 mov     rsi, r12
+  .text:000000000155E4FB                 mov     rdi, rbx
+  .text:000000000155E4FE                 call    CGameSceneNode_OnParentChanged
+  .text:000000000155E503                 movzx   eax, byte ptr [rbx+0E9h]
+  .text:000000000155E50A                 jmp     loc_155E3C8
+  .text:000000000155E510                 and     eax, 0FFFFFFFBh
+  .text:000000000155E513                 mov     [rbx+0E9h], al
+  .text:000000000155E519                 test    cl, cl
+  .text:000000000155E51B                 jz      short loc_155E560
+  .text:000000000155E51D                 and     byte ptr [rbx+0E9h], 0F7h
+  .text:000000000155E524                 mov     r12d, 7
+  .text:000000000155E52A                 mov     eax, 3
+  .text:000000000155E52F                 test    dl, dl
+  .text:000000000155E531                 jnz     loc_155E402
+  .text:000000000155E537                 mov     r12d, eax
+  .text:000000000155E53A                 cmp     byte ptr [rbx+0ECh], 0
+  .text:000000000155E541                 jz      loc_155E416
+  .text:000000000155E547                 mov     rax, [rbx]
+  .text:000000000155E54A                 mov     esi, r12d
+  .text:000000000155E54D                 mov     rdi, rbx
+  .text:000000000155E550                 mov     rax, [rax+60h]
+  .text:000000000155E554                 add     rsp, 10h
+  .text:000000000155E558                 pop     rbx
+  .text:000000000155E559                 pop     r12
+  .text:000000000155E55B                 pop     rbp
+  .text:000000000155E55C                 jmp     rax
+  .text:000000000155E560                 mov     r12d, 1
+  .text:000000000155E566                 test    dl, dl
+  .text:000000000155E568                 jz      short loc_155E53A
+  .text:000000000155E56A                 and     byte ptr [rbx+0E9h], 0EFh
+  .text:000000000155E571                 mov     r12d, 5
+  .text:000000000155E577                 jmp     loc_155E409
+  .text:000000000155E580                 test    dl, dl
+  .text:000000000155E582                 jz      short loc_155E5A0
+  .text:000000000155E584                 and     byte ptr [rbx+0E9h], 0EFh
+  .text:000000000155E58B                 mov     r12d, 4
+  .text:000000000155E591                 jmp     loc_155E409
+  .text:000000000155E5A0                 add     rsp, 10h
+  .text:000000000155E5A4                 pop     rbx
+  .text:000000000155E5A5                 pop     r12
+  .text:000000000155E5A7                 pop     rbp
+  .text:000000000155E5A8                 retn
+procedure: |-
+  __int64 __fastcall CGameSceneNode_PostDataUpdate(__int64 *a1, char a2)
+  {
+    char v3; // al
+    __int64 v4; // rsi
+    __int64 result; // rax
+    bool v6; // dl
+    unsigned int v7; // r12d
+    int v8; // eax
+    __int64 v9; // rax
+    unsigned int v10; // xmm1_4
+    __int128 v11; // xmm0
+    __int64 v12; // rax
+    __m128 v13; // xmm2
+    __int64 v14; // rdi
+    __int64 v15; // rax
+    __int64 v16; // r12
+
+    v3 = *((_BYTE *)a1 + 233);
+    v4 = a2 & 1;
+    *((_BYTE *)a1 + 233) = v3 & 0xDF;
+    if ( (_DWORD)v4 && (v14 = (__int64)(a1 + 14), *(_BYTE *)(v14 + 121) = v3 & 0xC3 | 0x1C, sub_155CA10(v14))
+      || (result = *((unsigned __int8 *)a1 + 233), (result & 1) != 0) )
+    {
+      v15 = *a1;
+      v16 = a1[7];
+      *((_BYTE *)a1 + 233) &= ~1u;
+      (*(void (__fastcall **)(__int64 *, __int64))(v15 + 144))(a1, 1);
+      (*(void (__fastcall **)(__int64 *, __int64))(*a1 + 152))(a1, 1);
+      v4 = v16;
+      CGameSceneNode_OnParentChanged((__int64)a1, v16);
+      result = *((unsigned __int8 *)a1 + 233);
+    }
+    v6 = (result & 0x10) != 0;
+    if ( (result & 4) != 0 )
+    {
+      *((_BYTE *)a1 + 233) = result & 0xFB;
+      if ( (result & 8) != 0 )
+      {
+        *((_BYTE *)a1 + 233) &= ~8u;
+        v7 = 7;
+        v8 = 3;
+        if ( v6 )
+          goto LABEL_6;
+  LABEL_13:
+        v7 = v8;
+        goto LABEL_14;
+      }
+      v7 = 1;
+      if ( (result & 0x10) == 0 )
+      {
+  LABEL_14:
+        if ( *((_BYTE *)a1 + 236) )
+          return (*(__int64 (__fastcall **)(__int64 *, _QWORD))(*a1 + 96))(a1, v7);
+        goto LABEL_8;
+      }
+      *((_BYTE *)a1 + 233) &= ~0x10u;
+      v7 = 5;
+  LABEL_7:
+      if ( *((_BYTE *)a1 + 236) )
+        return (*(__int64 (__fastcall **)(__int64 *, _QWORD))(*a1 + 96))(a1, v7);
+  LABEL_8:
+      v9 = a1[16];
+      v7 |= 0x100u;
+      v10 = *((_DWORD *)a1 + 49);
+      v11 = *((unsigned int *)a1 + 34);
+      *((_DWORD *)a1 + 56) = v10;
+      a1[25] = v9;
+      v12 = a1[23];
+      *((_DWORD *)a1 + 52) = v11;
+      *(__int64 *)((char *)a1 + 212) = v12;
+      *((_DWORD *)a1 + 55) = *((_DWORD *)a1 + 48);
+      *(double *)&v11 = sub_1BD5830((char *)a1 + 212, v4);
+      v13 = (__m128)*((unsigned int *)a1 + 52);
+      *((_OWORD *)a1 + 2) = v11;
+      *((__m128 *)a1 + 1) = _mm_movelh_ps(
+                              _mm_insert_ps((__m128)*((unsigned int *)a1 + 50), (__m128)*((unsigned int *)a1 + 51), 16),
+                              _mm_unpacklo_ps(v13, (__m128)v10));
+      return (*(__int64 (__fastcall **)(__int64 *, _QWORD))(*a1 + 96))(a1, v7);
+    }
+    if ( (result & 8) != 0 )
+    {
+      *((_BYTE *)a1 + 233) &= ~8u;
+      v7 = 6;
+      v8 = 2;
+      if ( v6 )
+      {
+  LABEL_6:
+        *((_BYTE *)a1 + 233) &= ~0x10u;
+        goto LABEL_7;
+      }
+      goto LABEL_13;
+    }
+    if ( (result & 0x10) != 0 )
+    {
+      *((_BYTE *)a1 + 233) &= ~0x10u;
+      v7 = 4;
+      goto LABEL_7;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameSceneNode_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameSceneNode_PostDataUpdate.windows.yaml
@@ -1,0 +1,237 @@
+func_name: CGameSceneNode_PostDataUpdate
+func_va: '0x180b6ade0'
+disasm_code: |-
+  .text:0000000180B6ADE0                 mov     [rsp+arg_8], rsi
+  .text:0000000180B6ADE5                 push    rdi
+  .text:0000000180B6ADE6                 sub     rsp, 30h
+  .text:0000000180B6ADEA                 movzx   eax, byte ptr [rcx+0E9h]
+  .text:0000000180B6ADF1                 xor     esi, esi
+  .text:0000000180B6ADF3                 and     al, 0DFh
+  .text:0000000180B6ADF5                 mov     rdi, rcx
+  .text:0000000180B6ADF8                 mov     [rcx+0E9h], al
+  .text:0000000180B6ADFE                 test    dl, 1
+  .text:0000000180B6AE01                 jz      loc_180B6AEBE
+  .text:0000000180B6AE07                 or      al, 1Ch
+  .text:0000000180B6AE09                 mov     [rcx+0E9h], al
+  .text:0000000180B6AE0F                 mov     ecx, [rcx+78h]
+  .text:0000000180B6AE12                 cmp     ecx, 0FFFFFFFFh
+  .text:0000000180B6AE15                 jz      loc_180B6AEBE
+  .text:0000000180B6AE1B                 mov     r8, cs:g_pGameEntitySystem_m_EntityList
+  .text:0000000180B6AE22                 test    r8, r8
+  .text:0000000180B6AE25                 jz      loc_180B6AEBE
+  .text:0000000180B6AE2B                 cmp     ecx, 0FFFFFFFEh
+  .text:0000000180B6AE2E                 jz      short loc_180B6AE5E
+  .text:0000000180B6AE30                 mov     eax, ecx
+  .text:0000000180B6AE32                 and     eax, 7FFFh
+  .text:0000000180B6AE37                 mov     edx, eax
+  .text:0000000180B6AE39                 shr     rax, 9
+  .text:0000000180B6AE3D                 mov     r9, [r8+rax*8]
+  .text:0000000180B6AE41                 test    r9, r9
+  .text:0000000180B6AE44                 jz      short loc_180B6AE5E
+  .text:0000000180B6AE46                 and     edx, 1FFh
+  .text:0000000180B6AE4C                 imul    rax, rdx, 70h ; 'p'
+  .text:0000000180B6AE50                 add     rax, r9
+  .text:0000000180B6AE53                 jz      short loc_180B6AE5E
+  .text:0000000180B6AE55                 cmp     [rax+10h], ecx
+  .text:0000000180B6AE58                 cmovnz  rax, rsi
+  .text:0000000180B6AE5C                 jmp     short loc_180B6AE61
+  .text:0000000180B6AE5E                 mov     rax, rsi
+  .text:0000000180B6AE61                 test    rax, rax
+  .text:0000000180B6AE64                 jz      short loc_180B6AEBE
+  .text:0000000180B6AE66                 mov     rcx, [rax]
+  .text:0000000180B6AE69                 test    rcx, rcx
+  .text:0000000180B6AE6C                 jz      short loc_180B6AEBE
+  .text:0000000180B6AE6E                 mov     rax, [rcx+10h]
+  .text:0000000180B6AE72                 mov     rdx, [rax]
+  .text:0000000180B6AE75                 test    rdx, rdx
+  .text:0000000180B6AE78                 jz      short loc_180B6AEBE
+  .text:0000000180B6AE7A                 mov     rax, [rax+8]
+  .text:0000000180B6AE7E                 movsxd  rcx, cs:dword_181B69BE0
+  .text:0000000180B6AE85                 mov     rax, [rax+80h]
+  .text:0000000180B6AE8C                 movzx   r8d, word ptr [rax+rcx*2]
+  .text:0000000180B6AE91                 mov     eax, 0FFFFh
+  .text:0000000180B6AE96                 cmp     r8w, ax
+  .text:0000000180B6AE9A                 jz      short loc_180B6AEA2
+  .text:0000000180B6AE9C                 mov     rcx, [r8+rdx]
+  .text:0000000180B6AEA0                 jmp     short loc_180B6AEA5
+  .text:0000000180B6AEA2                 mov     rcx, rsi
+  .text:0000000180B6AEA5                 test    rcx, rcx
+  .text:0000000180B6AEA8                 jz      short loc_180B6AEBE
+  .text:0000000180B6AEAA                 mov     edx, [rdi+7Ch]
+  .text:0000000180B6AEAD                 call    sub_1801C4550
+  .text:0000000180B6AEB2                 test    rax, rax
+  .text:0000000180B6AEB5                 jz      short loc_180B6AEBE
+  .text:0000000180B6AEB7                 or      byte ptr [rdi+0E9h], 1
+  .text:0000000180B6AEBE                 movzx   eax, byte ptr [rdi+0E9h]
+  .text:0000000180B6AEC5                 test    al, 1
+  .text:0000000180B6AEC7                 jz      short loc_180B6AF06
+  .text:0000000180B6AEC9                 and     al, 0FEh
+  .text:0000000180B6AECB                 mov     [rsp+38h+arg_0], rbx
+  .text:0000000180B6AED0                 mov     rbx, [rdi+38h]
+  .text:0000000180B6AED4                 mov     dl, 1
+  .text:0000000180B6AED6                 mov     [rdi+0E9h], al
+  .text:0000000180B6AEDC                 mov     rcx, rdi
+  .text:0000000180B6AEDF                 mov     rax, [rdi]
+  .text:0000000180B6AEE2                 call    qword ptr [rax+88h]
+  .text:0000000180B6AEE8                 mov     rax, [rdi]
+  .text:0000000180B6AEEB                 mov     dl, 1
+  .text:0000000180B6AEED                 mov     rcx, rdi
+  .text:0000000180B6AEF0                 call    qword ptr [rax+90h]
+  .text:0000000180B6AEF6                 mov     rdx, rbx
+  .text:0000000180B6AEF9                 mov     rcx, rdi
+  .text:0000000180B6AEFC                 call    CGameSceneNode_OnParentChanged; a1 = CGameSceneNode *
+  .text:0000000180B6AF01                 mov     rbx, [rsp+38h+arg_0]
+  .text:0000000180B6AF06                 movzx   eax, byte ptr [rdi+0E9h]
+  .text:0000000180B6AF0D                 test    al, 4
+  .text:0000000180B6AF0F                 jz      short loc_180B6AF1E
+  .text:0000000180B6AF11                 and     al, 0FBh
+  .text:0000000180B6AF13                 mov     esi, 1
+  .text:0000000180B6AF18                 mov     [rdi+0E9h], al
+  .text:0000000180B6AF1E                 test    al, 8
+  .text:0000000180B6AF20                 jz      short loc_180B6AF2D
+  .text:0000000180B6AF22                 or      esi, 2
+  .text:0000000180B6AF25                 and     al, 0F7h
+  .text:0000000180B6AF27                 mov     [rdi+0E9h], al
+  .text:0000000180B6AF2D                 test    al, 10h
+  .text:0000000180B6AF2F                 jz      short loc_180B6AF3C
+  .text:0000000180B6AF31                 or      esi, 4
+  .text:0000000180B6AF34                 and     al, 0EFh
+  .text:0000000180B6AF36                 mov     [rdi+0E9h], al
+  .text:0000000180B6AF3C                 test    esi, esi
+  .text:0000000180B6AF3E                 jz      short loc_180B6AFB5
+  .text:0000000180B6AF40                 cmp     byte ptr [rdi+0ECh], 0
+  .text:0000000180B6AF47                 jnz     short loc_180B6AFAA
+  .text:0000000180B6AF49                 lea     rdx, [rdi+80h]
+  .text:0000000180B6AF50                 lea     rcx, [rsp+38h+var_18]
+  .text:0000000180B6AF55                 call    sub_1801B2610
+  .text:0000000180B6AF5A                 movss   xmm3, dword ptr [rdi+0C4h]
+  .text:0000000180B6AF62                 lea     r8, [rdi+0C8h]
+  .text:0000000180B6AF69                 lea     rdx, [rdi+0D4h]
+  .text:0000000180B6AF70                 lea     rcx, [rdi+10h]
+  .text:0000000180B6AF74                 movsd   xmm0, qword ptr [rax]
+  .text:0000000180B6AF78                 movsd   qword ptr [r8], xmm0
+  .text:0000000180B6AF7D                 mov     eax, [rax+8]
+  .text:0000000180B6AF80                 mov     [r8+8], eax
+  .text:0000000180B6AF84                 movsd   xmm0, qword ptr [rdi+0B8h]
+  .text:0000000180B6AF8C                 movsd   qword ptr [rdx], xmm0
+  .text:0000000180B6AF90                 mov     eax, [rdi+0C0h]
+  .text:0000000180B6AF96                 movss   dword ptr [rdi+0E0h], xmm3
+  .text:0000000180B6AF9E                 mov     [rdx+8], eax
+  .text:0000000180B6AFA1                 call    sub_1803D9BF0
+  .text:0000000180B6AFA6                 bts     esi, 8
+  .text:0000000180B6AFAA                 mov     rax, [rdi]
+  .text:0000000180B6AFAD                 mov     edx, esi
+  .text:0000000180B6AFAF                 mov     rcx, rdi
+  .text:0000000180B6AFB2                 call    qword ptr [rax+58h]
+  .text:0000000180B6AFB5                 mov     rsi, [rsp+38h+arg_8]
+  .text:0000000180B6AFBA                 add     rsp, 30h
+  .text:0000000180B6AFBE                 pop     rdi
+  .text:0000000180B6AFBF                 retn
+procedure: |-
+  char __fastcall CGameSceneNode_PostDataUpdate(__int64 a1, unsigned __int64 a2)
+  {
+    unsigned int v2; // esi
+    char v3; // al
+    int v5; // ecx
+    __int64 v6; // r9
+    _DWORD *v7; // rax
+    unsigned __int64 *v8; // rax
+    __int64 v9; // r8
+    __int64 v10; // rcx
+    char v11; // al
+    __int64 v12; // rbx
+    __int64 v13; // rdx
+    char result; // al
+    _DWORD *v15; // rax
+    int v16; // xmm3_4
+    _DWORD v17[6]; // [rsp+20h] [rbp-18h] BYREF
+
+    v2 = 0;
+    v3 = *(_BYTE *)(a1 + 233) & 0xDF;
+    *(_BYTE *)(a1 + 233) = v3;
+    if ( (a2 & 1) != 0 )
+    {
+      *(_BYTE *)(a1 + 233) = v3 | 0x1C;
+      v5 = *(_DWORD *)(a1 + 120);
+      if ( v5 != -1 )
+      {
+        if ( g_pGameEntitySystem_m_EntityList )
+        {
+          if ( v5 != -2
+            && (a2 = v5 & 0x7FFF, (v6 = *(_QWORD *)(g_pGameEntitySystem_m_EntityList + 8 * (a2 >> 9))) != 0)
+            && (a2 &= 0x1FFu, (v7 = (_DWORD *)(v6 + 112 * a2)) != nullptr) )
+          {
+            if ( v7[4] != v5 )
+              v7 = nullptr;
+          }
+          else
+          {
+            v7 = nullptr;
+          }
+          if ( v7 )
+          {
+            if ( *(_QWORD *)v7 )
+            {
+              v8 = *(unsigned __int64 **)(*(_QWORD *)v7 + 16LL);
+              a2 = *v8;
+              if ( *v8 )
+              {
+                v9 = *(unsigned __int16 *)(*(_QWORD *)(v8[1] + 128) + 2LL * dword_181B69BE0);
+                v10 = (_WORD)v9 == 0xFFFF ? 0LL : *(_QWORD *)(v9 + a2);
+                if ( v10 && sub_1801C4550(v10, *(_DWORD *)(a1 + 124)) )
+                  *(_BYTE *)(a1 + 233) |= 1u;
+              }
+            }
+          }
+        }
+      }
+    }
+    v11 = *(_BYTE *)(a1 + 233);
+    if ( (v11 & 1) != 0 )
+    {
+      v12 = *(_QWORD *)(a1 + 56);
+      LOBYTE(a2) = 1;
+      *(_BYTE *)(a1 + 233) = v11 & 0xFE;
+      (*(void (__fastcall **)(__int64, unsigned __int64))(*(_QWORD *)a1 + 136LL))(a1, a2);
+      LOBYTE(v13) = 1;
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 144LL))(a1, v13);
+      CGameSceneNode_OnParentChanged(a1, v12);
+    }
+    result = *(_BYTE *)(a1 + 233);
+    if ( (result & 4) != 0 )
+    {
+      result &= ~4u;
+      v2 = 1;
+      *(_BYTE *)(a1 + 233) = result;
+    }
+    if ( (result & 8) != 0 )
+    {
+      v2 |= 2u;
+      result &= ~8u;
+      *(_BYTE *)(a1 + 233) = result;
+    }
+    if ( (result & 0x10) != 0 )
+    {
+      v2 |= 4u;
+      result &= ~0x10u;
+      *(_BYTE *)(a1 + 233) = result;
+    }
+    if ( v2 )
+    {
+      if ( !*(_BYTE *)(a1 + 236) )
+      {
+        v15 = sub_1801B2610(v17, (_DWORD *)(a1 + 128));
+        v16 = *(_DWORD *)(a1 + 196);
+        *(_QWORD *)(a1 + 200) = *(_QWORD *)v15;
+        *(_DWORD *)(a1 + 208) = v15[2];
+        *(_QWORD *)(a1 + 212) = *(_QWORD *)(a1 + 184);
+        LODWORD(v15) = *(_DWORD *)(a1 + 192);
+        *(_DWORD *)(a1 + 224) = v16;
+        *(_DWORD *)(a1 + 220) = (_DWORD)v15;
+        sub_1803D9BF0(a1 + 16);
+        v2 |= 0x100u;
+      }
+      return (*(char (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 88LL))(a1, v2);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CSkeletonInstance_PostDataUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSkeletonInstance_PostDataUpdate.linux.yaml
@@ -1,0 +1,1009 @@
+func_name: CSkeletonInstance_PostDataUpdate
+func_va: '0x165de70'
+disasm_code: |-
+  .text:000000000165DE00                 movq    xmm0, cs:off_23651E0; "../../game/shared/skeletoninstance.cpp"
+  .text:000000000165DE08                 lea     rax, aPostdataupdate; "PostDataUpdate"
+  .text:000000000165DE0F                 mov     dword ptr [rbp+var_138], 750h
+  .text:000000000165DE19                 ; _QWORD
+  .text:000000000165DE19                 lea     rdi, [rbp+var_150]; _QWORD
+  .text:000000000165DE20                 pinsrq  xmm0, rax, 1
+  .text:000000000165DE27                 lea     rax, aIsflagsetTypeD; "!IsFlagSet( type, DATA_UPDATE_TYPE_CREA"...
+  .text:000000000165DE2E                 movaps  xmmword ptr [rbp+var_150], xmm0
+  .text:000000000165DE35                 mov     [rbp+var_140], rax
+  .text:000000000165DE3C                 movzx   eax, byte ptr [rbp+var_138+4]
+  .text:000000000165DE43                 and     eax, 0FFFFFF80h
+  .text:000000000165DE46                 or      eax, 14h
+  .text:000000000165DE49                 mov     byte ptr [rbp+var_138+4], al
+  .text:000000000165DE4F                 call    __Z22Assert_ConditionFailedRK34_AssertCompileTimeConstantStruct_t; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const&)
+  .text:000000000165DE54                 test    al, al
+  .text:000000000165DE56                 jz      short loc_165DE59
+  .text:000000000165DE58                 ; Trap to Debugger
+  .text:000000000165DE58                 int     3; Trap to Debugger
+  .text:000000000165DE59                 xor     r12d, r12d
+  .text:000000000165DE5C                 jmp     loc_165E2B6
+  .text:000000000165DE70                 push    rbp
+  .text:000000000165DE71                 mov     eax, esi
+  .text:000000000165DE73                 mov     rbp, rsp
+  .text:000000000165DE76                 push    r15
+  .text:000000000165DE78                 push    r14
+  .text:000000000165DE7A                 mov     r14, rdx
+  .text:000000000165DE7D                 push    r13
+  .text:000000000165DE7F                 mov     r13d, esi
+  .text:000000000165DE82                 push    r12
+  .text:000000000165DE84                 push    rbx
+  .text:000000000165DE85                 mov     rbx, rdi
+  .text:000000000165DE88                 sub     rsp, 148h
+  .text:000000000165DE8F                 and     eax, 1
+  .text:000000000165DE92                 movzx   r12d, byte ptr [rdi+1E0h]
+  .text:000000000165DE9A                 mov     [rbp+var_15C], eax
+  .text:000000000165DEA0                 jnz     loc_165E160
+  .text:000000000165DEA6                 test    r12b, r12b
+  .text:000000000165DEA9                 jz      loc_165E120
+  .text:000000000165DEAF                 mov     r12, [rdi+40h]
+  .text:000000000165DEB3                 test    r12, r12
+  .text:000000000165DEB6                 jz      loc_165DF66
+  .text:000000000165DEBC                 nop     dword ptr [rax+00h]
+  .text:000000000165DEC0                 mov     rax, [r12+30h]
+  .text:000000000165DEC5                 mov     rdx, [rax+10h]
+  .text:000000000165DEC9                 mov     eax, [rdx+30h]
+  .text:000000000165DECC                 test    ah, 8
+  .text:000000000165DECF                 jnz     loc_165E150
+  .text:000000000165DED5                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:000000000165DED9                 jz      loc_165E768
+  .text:000000000165DEDF                 movzx   eax, word ptr [rdx+10h]
+  .text:000000000165DEE3                 and     ax, 7FFFh
+  .text:000000000165DEE7                 cmp     ax, 3FFFh
+  .text:000000000165DEEB                 setbe   al
+  .text:000000000165DEEE                 test    al, al
+  .text:000000000165DEF0                 jnz     short loc_165DF58
+  .text:000000000165DEF2                 cmp     byte ptr [r12+0ECh], 3
+  .text:000000000165DEFB                 jz      short loc_165DF58
+  .text:000000000165DEFD                 cmp     byte ptr [r12+0F4h], 0
+  .text:000000000165DF06                 jnz     short loc_165DF50
+  .text:000000000165DF08                 movss   xmm0, dword ptr [r12+110h]
+  .text:000000000165DF12                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165DF19                 jp      short loc_165DF50
+  .text:000000000165DF1B                 jnz     short loc_165DF50
+  .text:000000000165DF1D                 movss   xmm0, dword ptr [r12+114h]
+  .text:000000000165DF27                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165DF2E                 jp      short loc_165DF50
+  .text:000000000165DF30                 jnz     short loc_165DF50
+  .text:000000000165DF32                 movss   xmm0, dword ptr [r12+118h]
+  .text:000000000165DF3C                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165DF43                 jp      short loc_165DF50
+  .text:000000000165DF45                 jz      short loc_165DF58
+  .text:000000000165DF47                 nop     word ptr [rax+rax+00000000h]
+  .text:000000000165DF50                 mov     rdi, r12
+  .text:000000000165DF53                 call    sub_155DB30
+  .text:000000000165DF58                 mov     r12, [r12+48h]
+  .text:000000000165DF5D                 test    r12, r12
+  .text:000000000165DF60                 jnz     loc_165DEC0
+  .text:000000000165DF66                 cmp     byte ptr [rbx+0ECh], 1
+  .text:000000000165DF6D                 jz      loc_165E838
+  .text:000000000165DF73                 ; _QWORD
+  .text:000000000165DF73                 mov     edi, 260h; _QWORD
+  .text:000000000165DF78                 call    __Znwm; operator new(ulong)
+  .text:000000000165DF7D                 mov     rdi, rax
+  .text:000000000165DF80                 mov     r12, rax
+  .text:000000000165DF83                 call    sub_16426C0
+  .text:000000000165DF88                 lea     rax, [rbx+130h]
+  .text:000000000165DF8F                 mov     rdx, r12
+  .text:000000000165DF92                 mov     rsi, rbx
+  .text:000000000165DF95                 mov     rdi, rax
+  .text:000000000165DF98                 mov     [rbp+var_158], rax
+  .text:000000000165DF9F                 call    sub_1645540
+  .text:000000000165DFA4                 mov     rax, [rbx+1E8h]
+  .text:000000000165DFAB                 test    rax, rax
+  .text:000000000165DFAE                 jz      loc_165E778
+  .text:000000000165DFB4                 lock add dword ptr [rax+20h], 1
+  .text:000000000165DFB9                 mov     rsi, [rbx+1D0h]
+  .text:000000000165DFC0                 cmp     rax, rsi
+  .text:000000000165DFC3                 jz      loc_165E1E0
+  .text:000000000165DFC9                 xor     esi, esi
+  .text:000000000165DFCB                 mov     [rbp+var_168], rax
+  .text:000000000165DFD2                 pxor    xmm0, xmm0
+  .text:000000000165DFD6                 mov     [rbp+var_114], si
+  .text:000000000165DFDD                 mov     esi, 1
+  .text:000000000165DFE2                 lea     rdi, [rbp+var_140]
+  .text:000000000165DFE9                 movaps  [rbp+var_130], xmm0
+  .text:000000000165DFF0                 mov     [rbp+var_150], 1
+  .text:000000000165DFFB                 lea     r15, [rbp+var_150]
+  .text:000000000165E002                 mov     [rbp+var_150+8], 0
+  .text:000000000165E00D                 mov     [rbp+var_140], 0
+  .text:000000000165E018                 mov     [rbp+var_138], 0
+  .text:000000000165E023                 mov     [rbp+var_120], 0FFFFFFFFFFFFFFFFh
+  .text:000000000165E02E                 mov     [rbp+var_118], 0FFFFFFFFh
+  .text:000000000165E038                 call    sub_9B9580
+  .text:000000000165E03D                 mov     rdx, [rbp+var_140]
+  .text:000000000165E044                 mov     rsi, r15
+  .text:000000000165E047                 mov     rdi, [rbp+var_158]
+  .text:000000000165E04E                 add     dword ptr [rbp+var_150+8], 1
+  .text:000000000165E055                 mov     dword ptr [rdx], 0A0h
+  .text:000000000165E05B                 call    sub_1623180
+  .text:000000000165E060                 mov     rax, [rbp+var_168]
+  .text:000000000165E067                 mov     dword ptr [rbp+var_150+8], 0
+  .text:000000000165E071                 cmp     dword ptr [rbp+var_138+4], 3FFFFFFFh
+  .text:000000000165E07B                 ja      short loc_165E0A7
+  .text:000000000165E07D                 mov     rsi, [rbp+var_140]
+  .text:000000000165E084                 test    rsi, rsi
+  .text:000000000165E087                 jz      short loc_165E0A7
+  .text:000000000165E089                 mov     rdx, cs:g_pMemAlloc_ptr
+  .text:000000000165E090                 mov     [rbp+var_168], rax
+  .text:000000000165E097                 mov     rdi, [rdx]
+  .text:000000000165E09A                 mov     rdx, [rdi]
+  .text:000000000165E09D                 call    qword ptr [rdx+20h]
+  .text:000000000165E0A0                 mov     rax, [rbp+var_168]
+  .text:000000000165E0A7                 mov     rsi, [rbx+1D0h]
+  .text:000000000165E0AE                 test    rsi, rsi
+  .text:000000000165E0B1                 jz      short loc_165E0F0
+  .text:000000000165E0B3                 lea     rdx, qword_2742068
+  .text:000000000165E0BA                 cmp     qword ptr [rdx], 0
+  .text:000000000165E0BE                 jz      short loc_165E0F0
+  .text:000000000165E0C0                 lock sub dword ptr [rsi+20h], 1
+  .text:000000000165E0C5                 mov     rdi, [rdx]
+  .text:000000000165E0C8                 test    rdi, rdi
+  .text:000000000165E0CB                 jz      short loc_165E0F0
+  .text:000000000165E0CD                 mov     edx, [rsi+20h]
+  .text:000000000165E0D0                 test    edx, edx
+  .text:000000000165E0D2                 jnz     short loc_165E0F0
+  .text:000000000165E0D4                 mov     rdx, [rdi]
+  .text:000000000165E0D7                 mov     [rbp+var_168], rax
+  .text:000000000165E0DE                 call    qword ptr [rdx+10h]
+  .text:000000000165E0E1                 mov     rax, [rbp+var_168]
+  .text:000000000165E0E8                 nop     dword ptr [rax+rax+00000000h]
+  .text:000000000165E0F0                 mov     [rbx+1D0h], rax
+  .text:000000000165E0F7                 test    rax, rax
+  .text:000000000165E0FA                 jz      loc_165E786
+  .text:000000000165E100                 lock add dword ptr [rax+20h], 1
+  .text:000000000165E105                 lea     rdx, qword_2742068
+  .text:000000000165E10C                 cmp     qword ptr [rdx], 0
+  .text:000000000165E110                 jnz     loc_165E1ED
+  .text:000000000165E116                 jmp     loc_165E20A
+  .text:000000000165E120                 call    CGameSceneNode_PostDataUpdate
+  .text:000000000165E125                 movzx   eax, byte ptr [rbx+392h]
+  .text:000000000165E12C                 test    al, 1
+  .text:000000000165E12E                 jnz     loc_165E7E0
+  .text:000000000165E134                 add     rsp, 148h
+  .text:000000000165E13B                 pop     rbx
+  .text:000000000165E13C                 pop     r12
+  .text:000000000165E13E                 pop     r13
+  .text:000000000165E140                 pop     r14
+  .text:000000000165E142                 pop     r15
+  .text:000000000165E144                 pop     rbp
+  .text:000000000165E145                 retn
+  .text:000000000165E150                 shr     eax, 6
+  .text:000000000165E153                 and     eax, 1
+  .text:000000000165E156                 jmp     loc_165DEEE
+  .text:000000000165E160                 mov     rsi, [rdi+1D0h]
+  .text:000000000165E167                 call    sub_1636C40
+  .text:000000000165E16C                 lea     rax, [rbx+130h]
+  .text:000000000165E173                 mov     r15, rax
+  .text:000000000165E176                 mov     rdi, rax
+  .text:000000000165E179                 mov     [rbp+var_158], rax
+  .text:000000000165E180                 call    sub_1636E60
+  .text:000000000165E185                 mov     rdi, r15
+  .text:000000000165E188                 call    sub_1644580
+  .text:000000000165E18D                 mov     rdx, r14
+  .text:000000000165E190                 mov     esi, r13d
+  .text:000000000165E193                 mov     rdi, rbx
+  .text:000000000165E196                 call    CGameSceneNode_PostDataUpdate
+  .text:000000000165E19B                 test    r12b, r12b
+  .text:000000000165E19E                 jnz     loc_165DE00
+  .text:000000000165E1A4                 mov     rax, [rbx]
+  .text:000000000165E1A7                 lea     rdx, sub_165DBA0
+  .text:000000000165E1AE                 mov     esi, 70h ; 'p'
+  .text:000000000165E1B3                 mov     rdi, rbx
+  .text:000000000165E1B6                 mov     rax, [rax+60h]
+  .text:000000000165E1BA                 cmp     rax, rdx
+  .text:000000000165E1BD                 jnz     loc_165E888
+  .text:000000000165E1C3                 call    sub_15866F0
+  .text:000000000165E1C8                 mov     r12, [rbx+3A0h]
+  .text:000000000165E1CF                 test    r12, r12
+  .text:000000000165E1D2                 jz      loc_165E88F
+  .text:000000000165E1D8                 xor     r12d, r12d
+  .text:000000000165E1DB                 jmp     loc_165E5FA
+  .text:000000000165E1E0                 lea     rdx, qword_2742068
+  .text:000000000165E1E7                 cmp     qword ptr [rdx], 0
+  .text:000000000165E1EB                 jz      short loc_165E21A
+  .text:000000000165E1ED                 lock sub dword ptr [rax+20h], 1
+  .text:000000000165E1F2                 mov     rdi, [rdx]
+  .text:000000000165E1F5                 test    rdi, rdi
+  .text:000000000165E1F8                 jz      short loc_165E20A
+  .text:000000000165E1FA                 mov     edx, [rax+20h]
+  .text:000000000165E1FD                 test    edx, edx
+  .text:000000000165E1FF                 jnz     short loc_165E20A
+  .text:000000000165E201                 mov     rdx, [rdi]
+  .text:000000000165E204                 mov     rsi, rax
+  .text:000000000165E207                 call    qword ptr [rdx+10h]
+  .text:000000000165E20A                 mov     rsi, [rbx+1D0h]
+  .text:000000000165E211                 test    rsi, rsi
+  .text:000000000165E214                 jz      loc_165E786
+  .text:000000000165E21A                 mov     r15, [rsi]
+  .text:000000000165E21D                 mov     [rbx+1F0h], rsi
+  .text:000000000165E224                 test    r15, r15
+  .text:000000000165E227                 jz      loc_165E793
+  .text:000000000165E22D                 lea     rdi, [r15+130h]
+  .text:000000000165E234                 call    sub_1BE1500
+  .text:000000000165E239                 mov     rdi, r15
+  .text:000000000165E23C                 mov     [rbx+380h], ax
+  .text:000000000165E243                 call    sub_1BE47F0
+  .text:000000000165E248                 test    eax, eax
+  .text:000000000165E24A                 jle     loc_165E820
+  .text:000000000165E250                 mov     byte ptr [rbx+387h], 1
+  .text:000000000165E257                 mov     rdi, r15
+  .text:000000000165E25A                 call    sub_1BE2E10
+  .text:000000000165E25F                 mov     rsi, [rbx+1D0h]
+  .text:000000000165E266                 test    eax, eax
+  .text:000000000165E268                 setnle  al
+  .text:000000000165E26B                 mov     [rbx+388h], al
+  .text:000000000165E271                 mov     rdi, rbx
+  .text:000000000165E274                 call    sub_1636C40
+  .text:000000000165E279                 mov     rdi, [rbp+var_158]
+  .text:000000000165E280                 mov     qword ptr [rbx+1E8h], 0
+  .text:000000000165E28B                 mov     byte ptr [rbx+1E0h], 0
+  .text:000000000165E292                 call    sub_1644580
+  .text:000000000165E297                 cmp     dword ptr [rbx+78h], 0FFFFFFFFh
+  .text:000000000165E29B                 jz      loc_165E7C0
+  .text:000000000165E2A1                 or      byte ptr [rbx+0E9h], 1
+  .text:000000000165E2A8                 mov     rdx, r14
+  .text:000000000165E2AB                 mov     esi, r13d
+  .text:000000000165E2AE                 mov     rdi, rbx
+  .text:000000000165E2B1                 call    CGameSceneNode_PostDataUpdate
+  .text:000000000165E2B6                 cmp     byte ptr [rbx+0F4h], 0
+  .text:000000000165E2BD                 jnz     loc_165E660
+  .text:000000000165E2C3                 movss   xmm0, dword ptr [rbx+110h]
+  .text:000000000165E2CB                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165E2D2                 jp      loc_165E660
+  .text:000000000165E2D8                 jnz     loc_165E660
+  .text:000000000165E2DE                 movss   xmm0, dword ptr [rbx+114h]
+  .text:000000000165E2E6                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165E2ED                 jp      loc_165E660
+  .text:000000000165E2F3                 jnz     loc_165E660
+  .text:000000000165E2F9                 movss   xmm0, dword ptr [rbx+118h]
+  .text:000000000165E301                 ucomiss xmm0, dword ptr cs:y
+  .text:000000000165E308                 jp      loc_165E660
+  .text:000000000165E30E                 jnz     loc_165E660
+  .text:000000000165E314                 nop     dword ptr [rax+00h]
+  .text:000000000165E318                 mov     rdi, [rbp+var_158]
+  .text:000000000165E31F                 lea     rcx, [rbx+10h]
+  .text:000000000165E323                 mov     rdx, rbx
+  .text:000000000165E326                 mov     rsi, r12
+  .text:000000000165E329                 call    sub_1636A20
+  .text:000000000165E32E                 mov     rax, [rbx+3D0h]
+  .text:000000000165E335                 test    rax, rax
+  .text:000000000165E338                 jz      short loc_165E345
+  .text:000000000165E33A                 mov     qword ptr [rax+10C0h], 0
+  .text:000000000165E345                 mov     rdi, [rbx+3A0h]
+  .text:000000000165E34C                 test    rdi, rdi
+  .text:000000000165E34F                 jz      short loc_165E36B
+  .text:000000000165E351                 mov     rax, [rdi]
+  .text:000000000165E354                 mov     ecx, 0FFFFFFFFh
+  .text:000000000165E359                 mov     rdx, [rbx+1D0h]
+  .text:000000000165E360                 mov     rsi, [r12+0A0h]
+  .text:000000000165E368                 call    qword ptr [rax+58h]
+  .text:000000000165E36B                 mov     rdi, rbx
+  .text:000000000165E36E                 call    sub_155CE40
+  .text:000000000165E373                 cmp     qword ptr [rax+6B8h], 0
+  .text:000000000165E37B                 jz      short loc_165E3A0
+  .text:000000000165E37D                 mov     rdi, rbx
+  .text:000000000165E380                 call    sub_155CE40
+  .text:000000000165E385                 mov     rdx, [rbx+1D0h]
+  .text:000000000165E38C                 mov     rdi, rax
+  .text:000000000165E38F                 mov     rax, [rax]
+  .text:000000000165E392                 mov     rsi, [r12+0A0h]
+  .text:000000000165E39A                 call    qword ptr [rax+198h]
+  .text:000000000165E3A0                 lea     rax, qword_25EE530
+  .text:000000000165E3A7                 mov     rsi, rbx
+  .text:000000000165E3AA                 mov     rdi, [rax]
+  .text:000000000165E3AD                 call    sub_E05490
+  .text:000000000165E3B2                 cmp     qword ptr [r12+0E0h], 0
+  .text:000000000165E3BB                 jz      short loc_165E3C8
+  .text:000000000165E3BD                 mov     rsi, rbx
+  .text:000000000165E3C0                 mov     rdi, r12
+  .text:000000000165E3C3                 call    sub_1630C80
+  .text:000000000165E3C8                 mov     rdi, [r12+80h]
+  .text:000000000165E3D0                 test    rdi, rdi
+  .text:000000000165E3D3                 jz      short loc_165E3E6
+  .text:000000000165E3D5                 call    __ZdaPv; operator delete[](void *)
+  .text:000000000165E3DA                 mov     qword ptr [r12+80h], 0
+  .text:000000000165E3E6                 mov     rdi, [r12+88h]
+  .text:000000000165E3EE                 test    rdi, rdi
+  .text:000000000165E3F1                 jz      short loc_165E404
+  .text:000000000165E3F3                 call    __ZdaPv; operator delete[](void *)
+  .text:000000000165E3F8                 mov     qword ptr [r12+88h], 0
+  .text:000000000165E404                 lea     rdi, [r12+40h]
+  .text:000000000165E409                 mov     dword ptr [r12+98h], 0
+  .text:000000000165E415                 mov     qword ptr [r12+90h], 0
+  .text:000000000165E421                 call    sub_1BDF490
+  .text:000000000165E426                 lea     rdi, [r12+10h]
+  .text:000000000165E42B                 call    sub_1BDF490
+  .text:000000000165E430                 mov     rdi, [r12+0C8h]
+  .text:000000000165E438                 test    rdi, rdi
+  .text:000000000165E43B                 jz      short loc_165E44E
+  .text:000000000165E43D                 call    __ZdaPv; operator delete[](void *)
+  .text:000000000165E442                 mov     qword ptr [r12+0C8h], 0
+  .text:000000000165E44E                 mov     rax, [rbx]
+  .text:000000000165E451                 lea     rdx, sub_165DBA0
+  .text:000000000165E458                 mov     esi, 70h ; 'p'
+  .text:000000000165E45D                 mov     rdi, rbx
+  .text:000000000165E460                 mov     rax, [rax+60h]
+  .text:000000000165E464                 cmp     rax, rdx
+  .text:000000000165E467                 jnz     loc_165E810
+  .text:000000000165E46D                 call    sub_15866F0
+  .text:000000000165E472                 mov     rax, 8000000000000020h
+  .text:000000000165E47C                 mov     r13, [rbx+40h]
+  .text:000000000165E480                 mov     dword ptr [rbp+var_150], 0
+  .text:000000000165E48A                 mov     [rbp+var_140], rax
+  .text:000000000165E491                 lea     rax, [rbp+var_138]
+  .text:000000000165E498                 mov     [rbp+var_168], rax
+  .text:000000000165E49F                 mov     [rbp+var_150+8], rax
+  .text:000000000165E4A6                 test    r13, r13
+  .text:000000000165E4A9                 jnz     short loc_165E4D3
+  .text:000000000165E4AB                 jmp     loc_165E5E6
+  .text:000000000165E4B0                 lea     rax, g_pBodyGameSystem
+  .text:000000000165E4B7                 mov     rsi, r13
+  .text:000000000165E4BA                 or      byte ptr [r13+0E9h], 1
+  .text:000000000165E4C2                 mov     rdi, [rax]
+  .text:000000000165E4C5                 call    sub_DFFD70
+  .text:000000000165E4CA                 mov     r13, [r13+48h]
+  .text:000000000165E4CE                 test    r13, r13
+  .text:000000000165E4D1                 jz      short loc_165E54D
+  .text:000000000165E4D3                 cmp     byte ptr [r13+0ECh], 3
+  .text:000000000165E4DB                 jz      short loc_165E4CA
+  .text:000000000165E4DD                 mov     rax, [r13+30h]
+  .text:000000000165E4E1                 mov     rdx, [rax+10h]
+  .text:000000000165E4E5                 mov     eax, [rdx+30h]
+  .text:000000000165E4E8                 test    ah, 8
+  .text:000000000165E4EB                 jnz     loc_165E670
+  .text:000000000165E4F1                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:000000000165E4F5                 jz      loc_165E7B0
+  .text:000000000165E4FB                 movzx   eax, word ptr [rdx+10h]
+  .text:000000000165E4FF                 and     ax, 7FFFh
+  .text:000000000165E503                 cmp     ax, 3FFFh
+  .text:000000000165E507                 setbe   al
+  .text:000000000165E50A                 test    al, al
+  .text:000000000165E50C                 jnz     short loc_165E4B0
+  .text:000000000165E50E                 mov     r15d, dword ptr [rbp+var_150]
+  .text:000000000165E515                 mov     edx, r15d
+  .text:000000000165E518                 cmp     r15d, dword ptr [rbp+var_140]
+  .text:000000000165E51F                 jz      loc_165E680
+  .text:000000000165E525                 add     edx, 1
+  .text:000000000165E528                 movsxd  rax, r15d
+  .text:000000000165E52B                 mov     dword ptr [rbp+var_150], edx
+  .text:000000000165E531                 mov     rdx, [rbp+var_150+8]
+  .text:000000000165E538                 mov     [rdx+rax*8], r13
+  .text:000000000165E53C                 or      byte ptr [r13+0E9h], 1
+  .text:000000000165E544                 mov     r13, [r13+48h]
+  .text:000000000165E548                 test    r13, r13
+  .text:000000000165E54B                 jnz     short loc_165E4D3
+  .text:000000000165E54D                 movsxd  r13, dword ptr [rbp+var_150]
+  .text:000000000165E554                 test    r13d, r13d
+  .text:000000000165E557                 jle     short loc_165E594
+  .text:000000000165E559                 shl     r13, 3
+  .text:000000000165E55D                 xor     r15d, r15d
+  .text:000000000165E560                 mov     rdx, [rbp+var_150+8]
+  .text:000000000165E567                 mov     esi, 1
+  .text:000000000165E56C                 add     rdx, r15
+  .text:000000000165E56F                 add     r15, 8
+  .text:000000000165E573                 mov     rcx, [rdx]
+  .text:000000000165E576                 mov     byte ptr [rcx+0F4h], 0
+  .text:000000000165E57D                 mov     rcx, [rdx]
+  .text:000000000165E580                 and     byte ptr [rcx+0E9h], 0FEh
+  .text:000000000165E587                 mov     rdi, [rdx]
+  .text:000000000165E58A                 call    sub_155E140
+  .text:000000000165E58F                 cmp     r15, r13
+  .text:000000000165E592                 jnz     short loc_165E560
+  .text:000000000165E594                 mov     dword ptr [rbp+var_150], 0
+  .text:000000000165E59E                 mov     eax, dword ptr [rbp+var_140]
+  .text:000000000165E5A4                 mov     edx, dword ptr [rbp+var_140+4]
+  .text:000000000165E5AA                 test    eax, eax
+  .text:000000000165E5AC                 js      loc_165E740
+  .text:000000000165E5B2                 mov     rsi, [rbp+var_150+8]
+  .text:000000000165E5B9                 mov     rax, [rbp+var_168]
+  .text:000000000165E5C0                 cmp     rsi, rax
+  .text:000000000165E5C3                 jz      loc_165E870
+  .text:000000000165E5C9                 test    rsi, rsi
+  .text:000000000165E5CC                 jz      short loc_165E5E6
+  .text:000000000165E5CE                 cmp     edx, 3FFFFFFFh
+  .text:000000000165E5D4                 ja      short loc_165E5E6
+  .text:000000000165E5D6                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:000000000165E5DD                 mov     rdi, [rax]
+  .text:000000000165E5E0                 mov     rax, [rdi]
+  .text:000000000165E5E3                 call    qword ptr [rax+20h]
+  .text:000000000165E5E6                 mov     eax, [rbp+var_15C]
+  .text:000000000165E5EC                 test    eax, eax
+  .text:000000000165E5EE                 jz      short loc_165E61F
+  .text:000000000165E5F0                 cmp     qword ptr [rbx+3A0h], 0
+  .text:000000000165E5F8                 jz      short loc_165E61F
+  .text:000000000165E5FA                 movsxd  r13, dword ptr [r14]
+  .text:000000000165E5FD                 mov     eax, r13d
+  .text:000000000165E600                 cmp     r13d, [r14+10h]
+  .text:000000000165E604                 jz      loc_165E850
+  .text:000000000165E60A                 add     eax, 1
+  .text:000000000165E60D                 mov     [r14], eax
+  .text:000000000165E610                 mov     rax, [r14+8]
+  .text:000000000165E614                 mov     rdx, [rbx+3A0h]
+  .text:000000000165E61B                 mov     [rax+r13*8], rdx
+  .text:000000000165E61F                 movzx   eax, byte ptr [rbx+392h]
+  .text:000000000165E626                 test    al, 1
+  .text:000000000165E628                 jnz     short loc_165E6A0
+  .text:000000000165E62A                 test    r12, r12
+  .text:000000000165E62D                 jz      loc_165E134
+  .text:000000000165E633                 mov     rdi, r12
+  .text:000000000165E636                 call    sub_16343F0
+  .text:000000000165E63B                 add     rsp, 148h
+  .text:000000000165E642                 ; _QWORD
+  .text:000000000165E642                 mov     rdi, r12; _QWORD
+  .text:000000000165E645                 ; _QWORD
+  .text:000000000165E645                 mov     esi, 260h; _QWORD
+  .text:000000000165E64A                 pop     rbx
+  .text:000000000165E64B                 pop     r12
+  .text:000000000165E64D                 pop     r13
+  .text:000000000165E64F                 pop     r14
+  .text:000000000165E651                 pop     r15
+  .text:000000000165E653                 pop     rbp
+  .text:000000000165E654                 jmp     __ZdlPvm; operator delete(void *,ulong)
+  .text:000000000165E660                 mov     rdi, rbx
+  .text:000000000165E663                 call    sub_155DB30
+  .text:000000000165E668                 jmp     loc_165E318
+  .text:000000000165E670                 shr     eax, 6
+  .text:000000000165E673                 and     eax, 1
+  .text:000000000165E676                 jmp     loc_165E50A
+  .text:000000000165E680                 lea     rdi, [rbp+var_150+8]
+  .text:000000000165E687                 mov     esi, 1
+  .text:000000000165E68C                 call    sub_DFF3A0
+  .text:000000000165E691                 mov     edx, dword ptr [rbp+var_150]
+  .text:000000000165E697                 jmp     loc_165E525
+  .text:000000000165E6A0                 mov     rdi, [rbp+var_158]
+  .text:000000000165E6A7                 and     eax, 0FFFFFFFEh
+  .text:000000000165E6AA                 xor     esi, esi
+  .text:000000000165E6AC                 mov     [rbx+392h], al
+  .text:000000000165E6B2                 call    sub_1634CC0
+  .text:000000000165E6B7                 mov     rbx, [rbx+40h]
+  .text:000000000165E6BB                 test    rbx, rbx
+  .text:000000000165E6BE                 jnz     short loc_165E6FC
+  .text:000000000165E6C0                 jmp     loc_165E62A
+  .text:000000000165E6C8                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:000000000165E6CC                 jz      short loc_165E6DE
+  .text:000000000165E6CE                 movzx   edx, word ptr [rdx+10h]
+  .text:000000000165E6D2                 and     dx, 7FFFh
+  .text:000000000165E6D7                 cmp     dx, 3FFFh
+  .text:000000000165E6DC                 jbe     short loc_165E71F
+  .text:000000000165E6DE                 lea     rdi, [rax+130h]
+  .text:000000000165E6E5                 mov     esi, 1
+  .text:000000000165E6EA                 call    sub_1634CC0
+  .text:000000000165E6EF                 mov     rbx, [rbx+48h]
+  .text:000000000165E6F3                 test    rbx, rbx
+  .text:000000000165E6F6                 jz      loc_165E62A
+  .text:000000000165E6FC                 mov     rax, [rbx]
+  .text:000000000165E6FF                 mov     rdi, rbx
+  .text:000000000165E702                 call    qword ptr [rax+50h]
+  .text:000000000165E705                 test    rax, rax
+  .text:000000000165E708                 jz      short loc_165E6EF
+  .text:000000000165E70A                 mov     rdx, [rax+30h]
+  .text:000000000165E70E                 mov     rdx, [rdx+10h]
+  .text:000000000165E712                 mov     ecx, [rdx+30h]
+  .text:000000000165E715                 test    ch, 8
+  .text:000000000165E718                 jz      short loc_165E6C8
+  .text:000000000165E71A                 and     ecx, 40h
+  .text:000000000165E71D                 jz      short loc_165E6DE
+  .text:000000000165E71F                 or      byte ptr [rax+392h], 1
+  .text:000000000165E726                 mov     rsi, rbx
+  .text:000000000165E729                 lea     rax, g_pBodyGameSystem
+  .text:000000000165E730                 mov     rdi, [rax]
+  .text:000000000165E733                 call    sub_DFFD70
+  .text:000000000165E738                 jmp     short loc_165E6EF
+  .text:000000000165E740                 cmp     edx, 3FFFFFFFh
+  .text:000000000165E746                 ja      loc_165E5E6
+  .text:000000000165E74C                 mov     rsi, [rbp+var_150+8]
+  .text:000000000165E753                 test    rsi, rsi
+  .text:000000000165E756                 jnz     loc_165E5D6
+  .text:000000000165E75C                 jmp     loc_165E5E6
+  .text:000000000165E768                 mov     eax, 7FFFh
+  .text:000000000165E76D                 jmp     loc_165DEE7
+  .text:000000000165E778                 cmp     qword ptr [rbx+1D0h], 0
+  .text:000000000165E780                 jnz     loc_165DFC9
+  .text:000000000165E786                 mov     qword ptr [rbx+1F0h], 0
+  .text:000000000165E791                 xor     esi, esi
+  .text:000000000165E793                 xor     ecx, ecx
+  .text:000000000165E795                 mov     byte ptr [rbx+387h], 0
+  .text:000000000165E79C                 xor     eax, eax
+  .text:000000000165E79E                 mov     [rbx+380h], cx
+  .text:000000000165E7A5                 jmp     loc_165E26B
+  .text:000000000165E7B0                 mov     eax, 7FFFh
+  .text:000000000165E7B5                 jmp     loc_165E503
+  .text:000000000165E7C0                 mov     edx, [rbx+7Ch]
+  .text:000000000165E7C3                 test    edx, edx
+  .text:000000000165E7C5                 jnz     loc_165E2A1
+  .text:000000000165E7CB                 mov     rdx, r14
+  .text:000000000165E7CE                 mov     esi, r13d
+  .text:000000000165E7D1                 mov     rdi, rbx
+  .text:000000000165E7D4                 call    CGameSceneNode_PostDataUpdate
+  .text:000000000165E7D9                 jmp     loc_165E2B6
+  .text:000000000165E7E0                 and     eax, 0FFFFFFFEh
+  .text:000000000165E7E3                 xor     esi, esi
+  .text:000000000165E7E5                 xor     r12d, r12d
+  .text:000000000165E7E8                 mov     [rbx+392h], al
+  .text:000000000165E7EE                 lea     rdi, [rbx+130h]
+  .text:000000000165E7F5                 call    sub_1634CC0
+  .text:000000000165E7FA                 mov     rbx, [rbx+40h]
+  .text:000000000165E7FE                 test    rbx, rbx
+  .text:000000000165E801                 jnz     loc_165E6FC
+  .text:000000000165E807                 jmp     loc_165E134
+  .text:000000000165E810                 call    rax
+  .text:000000000165E812                 jmp     loc_165E472
+  .text:000000000165E820                 mov     rsi, [rbx+1D0h]
+  .text:000000000165E827                 mov     byte ptr [rbx+387h], 0
+  .text:000000000165E82E                 xor     eax, eax
+  .text:000000000165E830                 jmp     loc_165E26B
+  .text:000000000165E838                 mov     esi, 1
+  .text:000000000165E83D                 mov     rdi, rbx
+  .text:000000000165E840                 call    sub_155D6C0
+  .text:000000000165E845                 jmp     loc_165DF73
+  .text:000000000165E850                 lea     rdi, [r14+8]
+  .text:000000000165E854                 mov     esi, 1
+  .text:000000000165E859                 call    sub_1645F00
+  .text:000000000165E85E                 mov     eax, [r14]
+  .text:000000000165E861                 jmp     loc_165E60A
+  .text:000000000165E870                 cmp     edx, 3FFFFFFFh
+  .text:000000000165E876                 ja      loc_165E5E6
+  .text:000000000165E87C                 mov     rsi, rax
+  .text:000000000165E87F                 jmp     loc_165E5D6
+  .text:000000000165E888                 call    rax
+  .text:000000000165E88A                 jmp     loc_165E1C8
+  .text:000000000165E88F                 movzx   eax, byte ptr [rbx+392h]
+  .text:000000000165E896                 test    al, 1
+  .text:000000000165E898                 jz      loc_165E134
+  .text:000000000165E89E                 mov     rdi, [rbp+var_158]
+  .text:000000000165E8A5                 and     eax, 0FFFFFFFEh
+  .text:000000000165E8A8                 xor     esi, esi
+  .text:000000000165E8AA                 mov     [rbx+392h], al
+  .text:000000000165E8B0                 call    sub_1634CC0
+  .text:000000000165E8B5                 mov     rbx, [rbx+40h]
+  .text:000000000165E8B9                 test    rbx, rbx
+  .text:000000000165E8BC                 jnz     loc_165E6FC
+  .text:000000000165E8C2                 jmp     loc_165E134
+procedure: |-
+  void __fastcall CSkeletonInstance_PostDataUpdate(__int64 a1, unsigned __int64 a2, int *a3, __m128i inserted)
+  {
+    unsigned int v5; // r13d
+    char v7; // r12
+    __int64 i; // r12
+    __int64 v9; // rdx
+    unsigned int v10; // eax
+    int v11; // eax
+    __int64 v12; // r12
+    __int64 v13; // rax
+    __int64 *v14; // rsi
+    __int64 v15; // rsi
+    char v16; // al
+    __int64 (__fastcall *v17)(); // rax
+    __int64 v18; // r15
+    int v19; // eax
+    bool v20; // al
+    __int64 v21; // rax
+    __int64 v22; // rdi
+    __int64 v23; // rax
+    __int64 (__fastcall *v24)(); // rax
+    __int64 v25; // r13
+    __int64 v26; // rdx
+    unsigned int v27; // eax
+    int v28; // eax
+    __int32 v29; // r15d
+    __int32 v30; // edx
+    __int64 v31; // r13
+    __int64 v32; // r15
+    _QWORD *v33; // rdx
+    __int64 v34; // r13
+    int v35; // eax
+    char v36; // al
+    _QWORD *v37; // rbx
+    __int64 v38; // rdx
+    __int64 v39; // rax
+    int v40; // ecx
+    char v41; // al
+    __int64 v42; // [rsp+8h] [rbp-168h]
+    __int64 v43; // [rsp+8h] [rbp-168h]
+    int v44; // [rsp+14h] [rbp-15Ch]
+    __int64 v45; // [rsp+18h] [rbp-158h]
+    __m128i v46; // [rsp+20h] [rbp-150h] BYREF
+    char *v47; // [rsp+30h] [rbp-140h] BYREF
+    __int64 v48; // [rsp+38h] [rbp-138h] BYREF
+    __int128 v49; // [rsp+40h] [rbp-130h]
+    __int64 v50; // [rsp+50h] [rbp-120h]
+    int v51; // [rsp+58h] [rbp-118h]
+    __int16 v52; // [rsp+5Ch] [rbp-114h]
+
+    v5 = a2;
+    v7 = *(_BYTE *)(a1 + 480);
+    v44 = a2 & 1;
+    if ( (a2 & 1) == 0 )
+    {
+      if ( !v7 )
+      {
+        CGameSceneNode_PostDataUpdate(a1, a2);
+        v16 = *(_BYTE *)(a1 + 914);
+        if ( (v16 & 1) == 0 )
+          return;
+        v12 = 0;
+        *(_BYTE *)(a1 + 914) = v16 & 0xFE;
+        sub_1634CC0(a1 + 304, 0);
+        v37 = *(_QWORD **)(a1 + 64);
+        if ( !v37 )
+          return;
+        goto LABEL_106;
+      }
+      for ( i = *(_QWORD *)(a1 + 64); i; i = *(_QWORD *)(i + 72) )
+      {
+        v9 = *(_QWORD *)(*(_QWORD *)(i + 48) + 16LL);
+        v10 = *(_DWORD *)(v9 + 48);
+        if ( (v10 & 0x800) != 0 )
+        {
+          v11 = (v10 >> 6) & 1;
+        }
+        else
+        {
+          if ( *(_DWORD *)(v9 + 16) == -1 )
+            LOWORD(v11) = 0x7FFF;
+          else
+            LOWORD(v11) = *(_WORD *)(v9 + 16) & 0x7FFF;
+          LOBYTE(v11) = (unsigned __int16)v11 <= 0x3FFFu;
+        }
+        if ( !(_BYTE)v11
+          && *(_BYTE *)(i + 236) != 3
+          && (*(_BYTE *)(i + 244)
+           || *(float *)(i + 272) != 3.4028235e38
+           || *(float *)(i + 276) != 3.4028235e38
+           || *(float *)(i + 280) != 3.4028235e38) )
+        {
+          sub_155DB30(i, a2);
+        }
+      }
+      if ( *(_BYTE *)(a1 + 236) == 1 )
+        sub_155D6C0(a1, 1);
+      v12 = operator new(608);
+      sub_16426C0(v12);
+      v45 = a1 + 304;
+      sub_1645540(a1 + 304, a1, v12);
+      v13 = *(_QWORD *)(a1 + 488);
+      if ( v13 )
+      {
+        _InterlockedAdd((volatile signed __int32 *)(v13 + 32), 1u);
+        v14 = *(__int64 **)(a1 + 464);
+        if ( (__int64 *)v13 == v14 )
+        {
+          if ( !qword_2742068 )
+            goto LABEL_44;
+  LABEL_40:
+          _InterlockedSub((volatile signed __int32 *)(v13 + 32), 1u);
+          if ( qword_2742068 && !*(_DWORD *)(v13 + 32) )
+            (*(void (__fastcall **)(_QWORD *, __int64))(*qword_2742068 + 16LL))(qword_2742068, v13);
+  LABEL_43:
+          v14 = *(__int64 **)(a1 + 464);
+          if ( v14 )
+          {
+  LABEL_44:
+            v18 = *v14;
+            *(_QWORD *)(a1 + 496) = v14;
+            if ( v18 )
+            {
+              *(_WORD *)(a1 + 896) = sub_1BE1500(v18 + 304);
+              if ( (int)sub_1BE47F0(v18) <= 0 )
+              {
+                v14 = *(__int64 **)(a1 + 464);
+                *(_BYTE *)(a1 + 903) = 0;
+                v20 = 0;
+              }
+              else
+              {
+                *(_BYTE *)(a1 + 903) = 1;
+                v19 = sub_1BE2E10(v18);
+                v14 = *(__int64 **)(a1 + 464);
+                v20 = v19 > 0;
+              }
+  LABEL_47:
+              *(_BYTE *)(a1 + 904) = v20;
+              sub_1636C40(a1, (__int64)v14);
+              *(_QWORD *)(a1 + 488) = 0;
+              *(_BYTE *)(a1 + 480) = 0;
+              sub_1644580(v45);
+              if ( *(_DWORD *)(a1 + 120) != -1 || *(_DWORD *)(a1 + 124) )
+              {
+                *(_BYTE *)(a1 + 233) |= 1u;
+                a2 = v5;
+                CGameSceneNode_PostDataUpdate(a1, v5);
+              }
+              else
+              {
+                a2 = v5;
+                CGameSceneNode_PostDataUpdate(a1, v5);
+              }
+              goto LABEL_49;
+            }
+  LABEL_116:
+            *(_BYTE *)(a1 + 903) = 0;
+            v20 = 0;
+            *(_WORD *)(a1 + 896) = 0;
+            goto LABEL_47;
+          }
+  LABEL_115:
+          *(_QWORD *)(a1 + 496) = 0;
+          v14 = nullptr;
+          goto LABEL_116;
+        }
+      }
+      else if ( !*(_QWORD *)(a1 + 464) )
+      {
+        goto LABEL_115;
+      }
+      v42 = v13;
+      v52 = 0;
+      v49 = 0;
+      v46 = (__m128i)1uLL;
+      v47 = nullptr;
+      v48 = 0;
+      v50 = -1;
+      v51 = -1;
+      sub_9B9580(&v47, 1);
+      ++v46.m128i_i32[2];
+      *(_DWORD *)v47 = 160;
+      sub_1623180(v45, &v46);
+      v13 = v42;
+      v46.m128i_i32[2] = 0;
+      if ( HIDWORD(v48) <= 0x3FFFFFFF && v47 )
+      {
+        (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+        v13 = v42;
+      }
+      v15 = *(_QWORD *)(a1 + 464);
+      if ( v15 )
+      {
+        if ( qword_2742068 )
+        {
+          _InterlockedSub((volatile signed __int32 *)(v15 + 32), 1u);
+          if ( qword_2742068 )
+          {
+            if ( !*(_DWORD *)(v15 + 32) )
+            {
+              v43 = v13;
+              (*(void (__fastcall **)(_QWORD *))(*qword_2742068 + 16LL))(qword_2742068);
+              v13 = v43;
+            }
+          }
+        }
+      }
+      *(_QWORD *)(a1 + 464) = v13;
+      if ( !v13 )
+        goto LABEL_115;
+      _InterlockedAdd((volatile signed __int32 *)(v13 + 32), 1u);
+      if ( !qword_2742068 )
+        goto LABEL_43;
+      goto LABEL_40;
+    }
+    sub_1636C40(a1, *(_QWORD *)(a1 + 464));
+    v45 = a1 + 304;
+    sub_1636E60(a1 + 304);
+    sub_1644580(a1 + 304);
+    a2 = (unsigned int)a2;
+    CGameSceneNode_PostDataUpdate(a1, a2);
+    if ( !v7 )
+    {
+      v17 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 96LL);
+      if ( v17 == sub_165DBA0 )
+        sub_15866F0(a1, 112);
+      else
+        ((void (__fastcall *)(__int64, __int64, double))v17)(a1, 112, *(double *)inserted.m128i_i64);
+      v12 = *(_QWORD *)(a1 + 928);
+      if ( v12 )
+      {
+        v12 = 0;
+        goto LABEL_92;
+      }
+      v41 = *(_BYTE *)(a1 + 914);
+      if ( (v41 & 1) == 0 )
+        return;
+      *(_BYTE *)(a1 + 914) = v41 & 0xFE;
+      sub_1634CC0(v45, 0);
+      v37 = *(_QWORD **)(a1 + 64);
+      if ( !v37 )
+        return;
+      while ( 1 )
+      {
+  LABEL_106:
+        v39 = (*(__int64 (__fastcall **)(_QWORD *))(*v37 + 80LL))(v37);
+        if ( v39 )
+        {
+          v38 = *(_QWORD *)(*(_QWORD *)(v39 + 48) + 16LL);
+          v40 = *(_DWORD *)(v38 + 48);
+          if ( (v40 & 0x800) != 0 )
+          {
+            if ( (v40 & 0x40) != 0 )
+              goto LABEL_109;
+          }
+          else if ( *(_DWORD *)(v38 + 16) != -1 )
+          {
+            v38 = *(unsigned __int16 *)(v38 + 16);
+            LOWORD(v38) = v38 & 0x7FFF;
+            if ( (unsigned __int16)v38 <= 0x3FFFu )
+            {
+  LABEL_109:
+              *(_BYTE *)(v39 + 914) |= 1u;
+              sub_DFFD70(g_pBodyGameSystem, (__int64)v37, v38);
+              goto LABEL_105;
+            }
+          }
+          sub_1634CC0(v39 + 304, 1);
+        }
+  LABEL_105:
+        v37 = (_QWORD *)v37[9];
+        if ( !v37 )
+          goto LABEL_96;
+      }
+    }
+    LODWORD(v48) = 1872;
+    v46 = _mm_insert_epi64(_mm_loadl_epi64((const __m128i *)&off_23651E0), (signed __int64)"PostDataUpdate", 1);
+    v47 = "!IsFlagSet( type, DATA_UPDATE_TYPE_CREATED )";
+    BYTE4(v48) = BYTE4(v48) & 0x80 | 0x14;
+    if ( (unsigned __int8)Assert_ConditionFailed(&v46) )
+      __debugbreak();
+    v12 = 0;
+  LABEL_49:
+    if ( *(_BYTE *)(a1 + 244)
+      || *(float *)(a1 + 272) != 3.4028235e38
+      || *(float *)(a1 + 276) != 3.4028235e38
+      || *(float *)(a1 + 280) != 3.4028235e38 )
+    {
+      sub_155DB30(a1, a2);
+    }
+    sub_1636A20(v45, v12, a1);
+    v21 = *(_QWORD *)(a1 + 976);
+    if ( v21 )
+      *(_QWORD *)(v21 + 4288) = 0;
+    v22 = *(_QWORD *)(a1 + 928);
+    if ( v22 )
+      (*(void (__fastcall **)(__int64, _QWORD, _QWORD, __int64))(*(_QWORD *)v22 + 88LL))(
+        v22,
+        *(_QWORD *)(v12 + 160),
+        *(_QWORD *)(a1 + 464),
+        0xFFFFFFFFLL);
+    if ( *(_QWORD *)(sub_155CE40(a1) + 1720) )
+    {
+      v23 = sub_155CE40(a1);
+      (*(void (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)v23 + 408LL))(
+        v23,
+        *(_QWORD *)(v12 + 160),
+        *(_QWORD *)(a1 + 464));
+    }
+    sub_E05490(qword_25EE530, a1);
+    if ( *(_QWORD *)(v12 + 224) )
+      sub_1630C80(v12, a1);
+    if ( *(_QWORD *)(v12 + 128) )
+    {
+      operator delete[]();
+      *(_QWORD *)(v12 + 128) = 0;
+    }
+    if ( *(_QWORD *)(v12 + 136) )
+    {
+      operator delete[]();
+      *(_QWORD *)(v12 + 136) = 0;
+    }
+    *(_DWORD *)(v12 + 152) = 0;
+    *(_QWORD *)(v12 + 144) = 0;
+    sub_1BDF490(v12 + 64);
+    sub_1BDF490(v12 + 16);
+    if ( *(_QWORD *)(v12 + 200) )
+    {
+      operator delete[]();
+      *(_QWORD *)(v12 + 200) = 0;
+    }
+    v24 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 96LL);
+    if ( v24 == sub_165DBA0 )
+      sub_15866F0(a1, 112);
+    else
+      ((void (__fastcall *)(__int64, __int64))v24)(a1, 112);
+    v25 = *(_QWORD *)(a1 + 64);
+    v46.m128i_i32[0] = 0;
+    v47 = (char *)0x8000000000000020LL;
+    v46.m128i_i64[1] = (__int64)&v48;
+    if ( !v25 )
+      goto LABEL_90;
+    do
+    {
+      while ( 1 )
+      {
+        if ( *(_BYTE *)(v25 + 236) == 3 )
+          goto LABEL_72;
+        v26 = *(_QWORD *)(*(_QWORD *)(v25 + 48) + 16LL);
+        v27 = *(_DWORD *)(v26 + 48);
+        if ( (v27 & 0x800) != 0 )
+        {
+          v28 = (v27 >> 6) & 1;
+        }
+        else
+        {
+          LOWORD(v28) = *(_DWORD *)(v26 + 16) == -1 ? 0x7FFF : *(_WORD *)(v26 + 16) & 0x7FFF;
+          LOBYTE(v28) = (unsigned __int16)v28 <= 0x3FFFu;
+        }
+        if ( !(_BYTE)v28 )
+          break;
+        *(_BYTE *)(v25 + 233) |= 1u;
+        sub_DFFD70(g_pBodyGameSystem, v25, v26);
+  LABEL_72:
+        v25 = *(_QWORD *)(v25 + 72);
+        if ( !v25 )
+          goto LABEL_82;
+      }
+      v29 = v46.m128i_i32[0];
+      v30 = v46.m128i_i32[0];
+      if ( v46.m128i_i32[0] == (_DWORD)v47 )
+      {
+        sub_DFF3A0(&v46.m128i_u64[1], 1, v46.m128i_u32[0]);
+        v30 = v46.m128i_i32[0];
+      }
+      v46.m128i_i32[0] = v30 + 1;
+      *(_QWORD *)(v46.m128i_i64[1] + 8LL * v29) = v25;
+      *(_BYTE *)(v25 + 233) |= 1u;
+      v25 = *(_QWORD *)(v25 + 72);
+    }
+    while ( v25 );
+  LABEL_82:
+    if ( v46.m128i_i32[0] > 0 )
+    {
+      v31 = 8LL * v46.m128i_i32[0];
+      v32 = 0;
+      do
+      {
+        v33 = (_QWORD *)(v32 + v46.m128i_i64[1]);
+        v32 += 8;
+        *(_BYTE *)(*v33 + 244LL) = 0;
+        *(_BYTE *)(*v33 + 233LL) &= ~1u;
+        sub_155E140(*v33, 1);
+      }
+      while ( v32 != v31 );
+    }
+    v46.m128i_i32[0] = 0;
+    if ( (int)v47 < 0 )
+    {
+      if ( HIDWORD(v47) <= 0x3FFFFFFF && v46.m128i_i64[1] )
+  LABEL_89:
+        (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+    }
+    else if ( (__int64 *)v46.m128i_i64[1] == &v48 )
+    {
+      if ( HIDWORD(v47) <= 0x3FFFFFFF )
+        goto LABEL_89;
+    }
+    else if ( v46.m128i_i64[1] && HIDWORD(v47) <= 0x3FFFFFFF )
+    {
+      goto LABEL_89;
+    }
+  LABEL_90:
+    if ( v44 && *(_QWORD *)(a1 + 928) )
+    {
+  LABEL_92:
+      v34 = *a3;
+      v35 = v34;
+      if ( (_DWORD)v34 == a3[4] )
+      {
+        sub_1645F00(a3 + 2, 1);
+        v35 = *a3;
+      }
+      *a3 = v35 + 1;
+      *(_QWORD *)(*((_QWORD *)a3 + 1) + 8 * v34) = *(_QWORD *)(a1 + 928);
+    }
+    v36 = *(_BYTE *)(a1 + 914);
+    if ( (v36 & 1) != 0 )
+    {
+      *(_BYTE *)(a1 + 914) = v36 & 0xFE;
+      sub_1634CC0(v45, 0);
+      v37 = *(_QWORD **)(a1 + 64);
+      if ( v37 )
+        goto LABEL_106;
+    }
+  LABEL_96:
+    if ( v12 )
+    {
+      sub_16343F0(v12);
+      operator delete(v12, 608);
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CSkeletonInstance_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSkeletonInstance_PostDataUpdate.windows.yaml
@@ -1,0 +1,1030 @@
+func_name: CSkeletonInstance_PostDataUpdate
+func_va: '0x180c067e0'
+disasm_code: |-
+  .text:0000000180C067E0                 mov     [rsp-8+arg_18], rbx
+  .text:0000000180C067E5                 mov     [rsp-8+arg_10], r8
+  .text:0000000180C067EA                 push    rbp
+  .text:0000000180C067EB                 push    rsi
+  .text:0000000180C067EC                 push    rdi
+  .text:0000000180C067ED                 push    r12
+  .text:0000000180C067EF                 push    r13
+  .text:0000000180C067F1                 push    r14
+  .text:0000000180C067F3                 push    r15
+  .text:0000000180C067F5                 lea     rbp, [rsp-140h]
+  .text:0000000180C067FD                 sub     rsp, 240h
+  .text:0000000180C06804                 movzx   r12d, byte ptr [rcx+1E0h]
+  .text:0000000180C0680C                 xor     r14d, r14d
+  .text:0000000180C0680F                 movzx   r13d, dl
+  .text:0000000180C06813                 mov     [rbp+170h+arg_8], r12b
+  .text:0000000180C0681A                 mov     r15d, edx
+  .text:0000000180C0681D                 mov     rsi, rcx
+  .text:0000000180C06820                 mov     ebx, r14d
+  .text:0000000180C06823                 and     r13b, 1
+  .text:0000000180C06827                 jz      loc_180C068C0
+  .text:0000000180C0682D                 mov     rdx, [rcx+1D0h]
+  .text:0000000180C06834                 call    sub_180C0A780
+  .text:0000000180C06839                 mov     rax, [rsi+1D0h]
+  .text:0000000180C06840                 test    rax, rax
+  .text:0000000180C06843                 jz      short loc_180C06878
+  .text:0000000180C06845                 mov     rdi, [rax]
+  .text:0000000180C06848                 mov     [rsi+1F0h], rax
+  .text:0000000180C0684F                 test    rdi, rdi
+  .text:0000000180C06852                 jz      short loc_180C06883
+  .text:0000000180C06854                 lea     rcx, [rdi+130h]
+  .text:0000000180C0685B                 call    sub_181305AF0
+  .text:0000000180C06860                 mov     rcx, rdi
+  .text:0000000180C06863                 mov     [rsi+370h], ax
+  .text:0000000180C0686A                 call    sub_181303540
+  .text:0000000180C0686F                 test    eax, eax
+  .text:0000000180C06871                 setnle  cl
+  .text:0000000180C06874                 xor     eax, eax
+  .text:0000000180C06876                 jmp     short loc_180C0688E
+  .text:0000000180C06878                 xor     ecx, ecx
+  .text:0000000180C0687A                 mov     [rsi+1F0h], rax
+  .text:0000000180C06881                 mov     edi, ecx
+  .text:0000000180C06883                 xor     eax, eax
+  .text:0000000180C06885                 mov     [rsi+370h], ax
+  .text:0000000180C0688C                 mov     ecx, eax
+  .text:0000000180C0688E                 mov     [rsi+377h], cl
+  .text:0000000180C06894                 test    cl, cl
+  .text:0000000180C06896                 jz      short loc_180C068A7
+  .text:0000000180C06898                 mov     rcx, rdi
+  .text:0000000180C0689B                 call    sub_181305B00
+  .text:0000000180C068A0                 test    eax, eax
+  .text:0000000180C068A2                 setnle  cl
+  .text:0000000180C068A5                 jmp     short loc_180C068A9
+  .text:0000000180C068A7                 mov     ecx, eax
+  .text:0000000180C068A9                 mov     [rsi+378h], cl
+  .text:0000000180C068AF                 lea     rcx, [rsi+130h]
+  .text:0000000180C068B6                 call    sub_180C0ADD0
+  .text:0000000180C068BB                 jmp     loc_180C06A84
+  .text:0000000180C068C0                 test    r12b, r12b
+  .text:0000000180C068C3                 jz      loc_180C06A84
+  .text:0000000180C068C9                 mov     rbx, [rcx+40h]
+  .text:0000000180C068CD                 test    rbx, rbx
+  .text:0000000180C068D0                 jz      loc_180C06952
+  .text:0000000180C068D6                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180C068E0                 mov     rax, [rbx+30h]
+  .text:0000000180C068E4                 mov     rcx, [rax+10h]
+  .text:0000000180C068E8                 mov     eax, [rcx+30h]
+  .text:0000000180C068EB                 bt      eax, 0Bh
+  .text:0000000180C068EF                 jnb     short loc_180C068F8
+  .text:0000000180C068F1                 shr     eax, 6
+  .text:0000000180C068F4                 and     al, 1
+  .text:0000000180C068F6                 jmp     short loc_180C0691E
+  .text:0000000180C068F8                 test    rcx, rcx
+  .text:0000000180C068FB                 jz      short loc_180C0690C
+  .text:0000000180C068FD                 cmp     dword ptr [rcx+10h], 0FFFFFFFFh
+  .text:0000000180C06901                 mov     eax, 7FFFh
+  .text:0000000180C06906                 cmovnz  eax, [rcx+10h]
+  .text:0000000180C0690A                 jmp     short loc_180C06911
+  .text:0000000180C0690C                 mov     eax, 0FFFFFFFFh
+  .text:0000000180C06911                 and     eax, 7FFFh
+  .text:0000000180C06916                 cmp     eax, 4000h
+  .text:0000000180C0691B                 setb    al
+  .text:0000000180C0691E                 test    al, al
+  .text:0000000180C06920                 jnz     short loc_180C06949
+  .text:0000000180C06922                 cmp     byte ptr [rbx+0ECh], 3
+  .text:0000000180C06929                 jz      short loc_180C06949
+  .text:0000000180C0692B                 nop
+  .text:0000000180C0692C                 cmp     [rbx+0F4h], r14b
+  .text:0000000180C06933                 jnz     short loc_180C06941
+  .text:0000000180C06935                 mov     rcx, rbx
+  .text:0000000180C06938                 call    sub_1801BD270
+  .text:0000000180C0693D                 test    al, al
+  .text:0000000180C0693F                 jz      short loc_180C06949
+  .text:0000000180C06941                 mov     rcx, rbx
+  .text:0000000180C06944                 call    sub_180B42250
+  .text:0000000180C06949                 mov     rbx, [rbx+48h]
+  .text:0000000180C0694D                 test    rbx, rbx
+  .text:0000000180C06950                 jnz     short loc_180C068E0
+  .text:0000000180C06952                 cmp     byte ptr [rsi+0ECh], 1
+  .text:0000000180C06959                 jnz     short loc_180C06965
+  .text:0000000180C0695B                 mov     dl, 1
+  .text:0000000180C0695D                 mov     rcx, rsi
+  .text:0000000180C06960                 call    sub_180B4AD90
+  .text:0000000180C06965                 mov     ecx, 250h
+  .text:0000000180C0696A                 call    operator_new
+  .text:0000000180C0696F                 test    rax, rax
+  .text:0000000180C06972                 jz      short loc_180C06981
+  .text:0000000180C06974                 mov     rcx, rax
+  .text:0000000180C06977                 call    sub_180BF2A20
+  .text:0000000180C0697C                 mov     rbx, rax
+  .text:0000000180C0697F                 jmp     short loc_180C06984
+  .text:0000000180C06981                 mov     rbx, r14
+  .text:0000000180C06984                 mov     r8, rbx
+  .text:0000000180C06987                 lea     rcx, [rsi+130h]
+  .text:0000000180C0698E                 mov     rdx, rsi
+  .text:0000000180C06991                 call    sub_180BF8F80
+  .text:0000000180C06996                 mov     rdx, [rsi+1E8h]
+  .text:0000000180C0699D                 lea     rcx, [rsi+130h]
+  .text:0000000180C069A4                 call    sub_180C09C30
+  .text:0000000180C069A9                 mov     rdx, [rsi+1D0h]
+  .text:0000000180C069B0                 test    rdx, rdx
+  .text:0000000180C069B3                 jz      loc_180C06A4E
+  .text:0000000180C069B9                 mov     r8, [rdx+8]
+  .text:0000000180C069BD                 lea     rdi, byte_18159A988
+  .text:0000000180C069C4                 xor     r9d, r9d
+  .text:0000000180C069C7                 mov     eax, 0C00000C8h
+  .text:0000000180C069CC                 mov     [rbp+170h+var_FC], eax
+  .text:0000000180C069CF                 mov     ecx, r9d
+  .text:0000000180C069D2                 mov     [rbp+170h+var_F8], rcx
+  .text:0000000180C069D6                 mov     [rbp+170h+var_100], r9d
+  .text:0000000180C069DA                 test    r8, r8
+  .text:0000000180C069DD                 jz      short loc_180C06A09
+  .text:0000000180C069DF                 mov     rax, [r8]
+  .text:0000000180C069E2                 mov     r9d, 0FFFFFFFFh
+  .text:0000000180C069E8                 test    rax, rax
+  .text:0000000180C069EB                 mov     [rsp+270h+var_250], cl
+  .text:0000000180C069EF                 mov     r8, rdi
+  .text:0000000180C069F2                 lea     rcx, [rbp+170h+var_100]
+  .text:0000000180C069F6                 cmovnz  r8, rax
+  .text:0000000180C069FA                 xor     edx, edx
+  .text:0000000180C069FC                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:0000000180C06A02                 mov     rcx, [rbp+170h+var_F8]
+  .text:0000000180C06A06                 mov     eax, [rbp+170h+var_FC]
+  .text:0000000180C06A09                 bt      eax, 1Eh
+  .text:0000000180C06A0D                 jnb     short loc_180C06A15
+  .text:0000000180C06A0F                 lea     rdi, [rbp+170h+var_F8]
+  .text:0000000180C06A13                 jmp     short loc_180C06A1E
+  .text:0000000180C06A15                 test    eax, 3FFFFFFFh
+  .text:0000000180C06A1A                 cmova   rdi, rcx
+  .text:0000000180C06A1E                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180C06A25                 lea     rdx, [rbp+170h+arg_0]
+  .text:0000000180C06A2C                 mov     r8, rdi
+  .text:0000000180C06A2F                 call    sub_1811E5EF0
+  .text:0000000180C06A34                 xor     edx, edx
+  .text:0000000180C06A36                 mov     rcx, [rax]
+  .text:0000000180C06A39                 mov     [rsi+1D8h], rcx
+  .text:0000000180C06A40                 lea     rcx, [rbp+170h+var_100]
+  .text:0000000180C06A44                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180C06A4A                 xor     ecx, ecx
+  .text:0000000180C06A4C                 jmp     short loc_180C06A57
+  .text:0000000180C06A4E                 xor     ecx, ecx
+  .text:0000000180C06A50                 mov     [rsi+1D8h], rcx
+  .text:0000000180C06A57                 mov     [rsi+1E8h], rcx
+  .text:0000000180C06A5E                 lea     rcx, [rsi+130h]
+  .text:0000000180C06A65                 mov     [rsi+1E0h], r14b
+  .text:0000000180C06A6C                 call    sub_180C0ADD0
+  .text:0000000180C06A71                 cmp     dword ptr [rsi+78h], 0FFFFFFFFh
+  .text:0000000180C06A75                 jnz     short loc_180C06A7D
+  .text:0000000180C06A77                 cmp     [rsi+7Ch], r14d
+  .text:0000000180C06A7B                 jz      short loc_180C06A84
+  .text:0000000180C06A7D                 or      byte ptr [rsi+0E9h], 1
+  .text:0000000180C06A84                 mov     rdi, [rbp+170h+arg_10]
+  .text:0000000180C06A8B                 mov     edx, r15d
+  .text:0000000180C06A8E                 mov     r8, rdi
+  .text:0000000180C06A91                 mov     rcx, rsi
+  .text:0000000180C06A94                 call    CGameSceneNode_PostDataUpdate
+  .text:0000000180C06A99                 test    r12b, r12b
+  .text:0000000180C06A9C                 jz      loc_180C06E9A
+  .text:0000000180C06AA2                 test    r13b, r13b
+  .text:0000000180C06AA5                 jz      short loc_180C06AEB
+  .text:0000000180C06AA7                 lea     rax, aCBuildworkerCs_47; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180C06AAE                 mov     [rsp+270h+var_228], 750h
+  .text:0000000180C06AB6                 mov     [rsp+270h+var_240], rax
+  .text:0000000180C06ABB                 lea     rcx, [rsp+270h+var_240]
+  .text:0000000180C06AC0                 lea     rax, aCskeletoninsta_1; "CSkeletonInstance::PostDataUpdate"
+  .text:0000000180C06AC7                 mov     [rsp+270h+var_224], 14h
+  .text:0000000180C06ACF                 mov     [rsp+270h+var_238], rax
+  .text:0000000180C06AD4                 lea     rax, aIsflagsetTypeD; "!IsFlagSet( type, DATA_UPDATE_TYPE_CREA"...
+  .text:0000000180C06ADB                 mov     [rsp+270h+var_230], rax
+  .text:0000000180C06AE0                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@@Z; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &)
+  .text:0000000180C06AE6                 test    al, al
+  .text:0000000180C06AE8                 jz      short loc_180C06AEB
+  .text:0000000180C06AEA                 ; Trap to Debugger
+  .text:0000000180C06AEA                 int     3; Trap to Debugger
+  .text:0000000180C06AEB                 nop
+  .text:0000000180C06AEC                 cmp     byte ptr [rsi+0F4h], 0
+  .text:0000000180C06AF3                 jnz     short loc_180C06B01
+  .text:0000000180C06AF5                 mov     rcx, rsi
+  .text:0000000180C06AF8                 call    sub_1801BD270
+  .text:0000000180C06AFD                 test    al, al
+  .text:0000000180C06AFF                 jz      short loc_180C06B09
+  .text:0000000180C06B01                 mov     rcx, rsi
+  .text:0000000180C06B04                 call    sub_180B42250
+  .text:0000000180C06B09                 lea     r9, [rsi+10h]
+  .text:0000000180C06B0D                 mov     r8, rsi
+  .text:0000000180C06B10                 mov     rdx, rbx
+  .text:0000000180C06B13                 lea     rcx, [rsi+130h]
+  .text:0000000180C06B1A                 call    sub_180C0B160
+  .text:0000000180C06B1F                 mov     rax, [rsi+3C0h]
+  .text:0000000180C06B26                 test    rax, rax
+  .text:0000000180C06B29                 jz      short loc_180C06B36
+  .text:0000000180C06B2B                 mov     qword ptr [rax+10C0h], 0
+  .text:0000000180C06B36                 mov     rcx, [rsi+390h]
+  .text:0000000180C06B3D                 test    rcx, rcx
+  .text:0000000180C06B40                 jz      short loc_180C06B59
+  .text:0000000180C06B42                 mov     rax, [rcx]
+  .text:0000000180C06B45                 mov     r9b, 0FFh
+  .text:0000000180C06B48                 mov     r8, [rsi+1D0h]
+  .text:0000000180C06B4F                 mov     rdx, [rbx+0A0h]
+  .text:0000000180C06B56                 call    qword ptr [rax+58h]
+  .text:0000000180C06B59                 mov     rcx, rsi
+  .text:0000000180C06B5C                 call    sub_180B58100
+  .text:0000000180C06B61                 cmp     qword ptr [rax+3D8h], 0
+  .text:0000000180C06B69                 jz      short loc_180C06B8E
+  .text:0000000180C06B6B                 mov     rcx, rsi
+  .text:0000000180C06B6E                 call    sub_180B58100
+  .text:0000000180C06B73                 mov     r8, [rsi+1D0h]
+  .text:0000000180C06B7A                 mov     rcx, rax
+  .text:0000000180C06B7D                 mov     rdx, [rbx+0A0h]
+  .text:0000000180C06B84                 mov     r9, [rax]
+  .text:0000000180C06B87                 call    qword ptr [r9+1A0h]
+  .text:0000000180C06B8E                 mov     rdx, rsi
+  .text:0000000180C06B91                 mov     rcx, rbx
+  .text:0000000180C06B94                 call    sub_180BF7B10
+  .text:0000000180C06B99                 mov     rcx, [rbx+80h]
+  .text:0000000180C06BA0                 test    rcx, rcx
+  .text:0000000180C06BA3                 jz      short loc_180C06BB1
+  .text:0000000180C06BA5                 call    sub_180E75C10
+  .text:0000000180C06BAA                 mov     [rbx+80h], r14
+  .text:0000000180C06BB1                 mov     rcx, [rbx+88h]
+  .text:0000000180C06BB8                 test    rcx, rcx
+  .text:0000000180C06BBB                 jz      short loc_180C06BC9
+  .text:0000000180C06BBD                 call    sub_180E75C10
+  .text:0000000180C06BC2                 mov     [rbx+88h], r14
+  .text:0000000180C06BC9                 lea     rcx, [rbx+40h]
+  .text:0000000180C06BCD                 mov     qword ptr [rbx+94h], 0
+  .text:0000000180C06BD8                 mov     [rbx+90h], r14d
+  .text:0000000180C06BDF                 call    sub_181307C00
+  .text:0000000180C06BE4                 lea     rcx, [rbx+10h]
+  .text:0000000180C06BE8                 call    sub_181307C00
+  .text:0000000180C06BED                 mov     rcx, [rbx+0C8h]
+  .text:0000000180C06BF4                 test    rcx, rcx
+  .text:0000000180C06BF7                 jz      short loc_180C06C05
+  .text:0000000180C06BF9                 call    sub_180E75C10
+  .text:0000000180C06BFE                 mov     [rbx+0C8h], r14
+  .text:0000000180C06C05                 mov     rax, [rsi]
+  .text:0000000180C06C08                 mov     edx, 70h ; 'p'
+  .text:0000000180C06C0D                 mov     rcx, rsi
+  .text:0000000180C06C10                 call    qword ptr [rax+58h]
+  .text:0000000180C06C13                 lea     rax, [rsp+270h+var_218]
+  .text:0000000180C06C18                 mov     [rsp+270h+var_218], r14
+  .text:0000000180C06C1D                 mov     [rsp+270h+var_20C], 80000000h
+  .text:0000000180C06C25                 mov     r10d, 20h ; ' '
+  .text:0000000180C06C2B                 mov     [rsp+270h+var_210], r10d
+  .text:0000000180C06C30                 test    al, 7
+  .text:0000000180C06C32                 jz      short loc_180C06C3E
+  .text:0000000180C06C34                 call    sub_1814DD520
+  .text:0000000180C06C39                 mov     r10d, [rsp+270h+var_210]
+  .text:0000000180C06C3E                 mov     r15, [rsi+40h]
+  .text:0000000180C06C42                 lea     rdx, [rsp+270h+var_208]
+  .text:0000000180C06C47                 mov     [rsp+270h+var_218], rdx
+  .text:0000000180C06C4C                 mov     [rsp+270h+var_220], r14d
+  .text:0000000180C06C51                 test    r15, r15
+  .text:0000000180C06C54                 jz      loc_180C06DC5
+  .text:0000000180C06C5A                 nop     word ptr [rax+rax+00h]
+  .text:0000000180C06C60                 cmp     byte ptr [r15+0ECh], 3
+  .text:0000000180C06C68                 jz      loc_180C06DB0
+  .text:0000000180C06C6E                 mov     rax, [r15+30h]
+  .text:0000000180C06C72                 mov     rcx, [rax+10h]
+  .text:0000000180C06C76                 mov     eax, [rcx+30h]
+  .text:0000000180C06C79                 bt      eax, 0Bh
+  .text:0000000180C06C7D                 jnb     short loc_180C06C86
+  .text:0000000180C06C7F                 shr     eax, 6
+  .text:0000000180C06C82                 and     al, 1
+  .text:0000000180C06C84                 jmp     short loc_180C06CAC
+  .text:0000000180C06C86                 test    rcx, rcx
+  .text:0000000180C06C89                 jz      short loc_180C06C9A
+  .text:0000000180C06C8B                 cmp     dword ptr [rcx+10h], 0FFFFFFFFh
+  .text:0000000180C06C8F                 mov     eax, 7FFFh
+  .text:0000000180C06C94                 cmovnz  eax, [rcx+10h]
+  .text:0000000180C06C98                 jmp     short loc_180C06C9F
+  .text:0000000180C06C9A                 mov     eax, 0FFFFFFFFh
+  .text:0000000180C06C9F                 and     eax, 7FFFh
+  .text:0000000180C06CA4                 cmp     eax, 4000h
+  .text:0000000180C06CA9                 setb    al
+  .text:0000000180C06CAC                 test    al, al
+  .text:0000000180C06CAE                 jz      short loc_180C06CCC
+  .text:0000000180C06CB0                 or      byte ptr [r15+0E9h], 1
+  .text:0000000180C06CB8                 mov     rdx, r15
+  .text:0000000180C06CBB                 mov     rcx, cs:g_pBodyGameSystem
+  .text:0000000180C06CC2                 call    sub_18052DD40
+  .text:0000000180C06CC7                 jmp     loc_180C06DA6
+  .text:0000000180C06CCC                 movsxd  r12, [rsp+270h+var_220]
+  .text:0000000180C06CD1                 cmp     r12d, r10d
+  .text:0000000180C06CD4                 jnz     loc_180C06D96
+  .text:0000000180C06CDA                 test    [rsp+270h+var_20C], 40000000h
+  .text:0000000180C06CE2                 jnz     loc_180C06D96
+  .text:0000000180C06CE8                 cmp     r10d, 7FFFFFFEh
+  .text:0000000180C06CEF                 jle     short loc_180C06D04
+  .text:0000000180C06CF1                 mov     edx, 1
+  .text:0000000180C06CF6                 mov     ecx, r10d
+  .text:0000000180C06CF9                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180C06CFF                 mov     r10d, [rsp+270h+var_210]
+  .text:0000000180C06D04                 mov     edx, [rsp+270h+var_20C]
+  .text:0000000180C06D08                 lea     r14d, [r10+1]
+  .text:0000000180C06D0C                 and     edx, 3FFFFFFFh
+  .text:0000000180C06D12                 mov     r8d, r14d
+  .text:0000000180C06D15                 mov     r9d, 8
+  .text:0000000180C06D1B                 mov     ecx, r10d
+  .text:0000000180C06D1E                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180C06D24                 mov     edi, eax
+  .text:0000000180C06D26                 cmp     eax, r14d
+  .text:0000000180C06D29                 jge     short loc_180C06D50
+  .text:0000000180C06D2B                 test    eax, eax
+  .text:0000000180C06D2D                 jnz     short loc_180C06D40
+  .text:0000000180C06D2F                 cmp     r14d, 0FFFFFFFFh
+  .text:0000000180C06D33                 jg      short loc_180C06D40
+  .text:0000000180C06D35                 mov     edi, 0FFFFFFFFh
+  .text:0000000180C06D3A                 jmp     short loc_180C06D50
+  .text:0000000180C06D40                 lea     eax, [rdi+r14]
+  .text:0000000180C06D44                 cdq
+  .text:0000000180C06D45                 sub     eax, edx
+  .text:0000000180C06D47                 sar     eax, 1
+  .text:0000000180C06D49                 mov     edi, eax
+  .text:0000000180C06D4B                 cmp     eax, r14d
+  .text:0000000180C06D4E                 jl      short loc_180C06D40
+  .text:0000000180C06D50                 movsxd  r9, [rsp+270h+var_210]
+  .text:0000000180C06D55                 mov     rcx, [rsp+270h+var_218]
+  .text:0000000180C06D5A                 shl     r9, 3
+  .text:0000000180C06D5E                 test    [rsp+270h+var_20C], 0C0000000h
+  .text:0000000180C06D66                 movsxd  r8, edi
+  .text:0000000180C06D69                 setz    dl
+  .text:0000000180C06D6C                 shl     r8, 3
+  .text:0000000180C06D70                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180C06D76                 mov     rdx, rax
+  .text:0000000180C06D79                 mov     [rsp+270h+var_218], rax
+  .text:0000000180C06D7E                 mov     eax, [rsp+270h+var_20C]
+  .text:0000000180C06D82                 test    eax, 0C0000000h
+  .text:0000000180C06D87                 jz      short loc_180C06D92
+  .text:0000000180C06D89                 and     eax, 3FFFFFFFh
+  .text:0000000180C06D8E                 mov     [rsp+270h+var_20C], eax
+  .text:0000000180C06D92                 mov     [rsp+270h+var_210], edi
+  .text:0000000180C06D96                 inc     [rsp+270h+var_220]
+  .text:0000000180C06D9A                 mov     [rdx+r12*8], r15
+  .text:0000000180C06D9E                 or      byte ptr [r15+0E9h], 1
+  .text:0000000180C06DA6                 mov     rdx, [rsp+270h+var_218]
+  .text:0000000180C06DAB                 mov     r10d, [rsp+270h+var_210]
+  .text:0000000180C06DB0                 mov     r15, [r15+48h]
+  .text:0000000180C06DB4                 test    r15, r15
+  .text:0000000180C06DB7                 jnz     loc_180C06C60
+  .text:0000000180C06DBD                 movzx   r12d, [rbp+170h+arg_8]
+  .text:0000000180C06DC5                 movsxd  r14, [rsp+270h+var_220]
+  .text:0000000180C06DCA                 test    r14, r14
+  .text:0000000180C06DCD                 jle     short loc_180C06E1D
+  .text:0000000180C06DCF                 xor     ecx, ecx
+  .text:0000000180C06DD1                 mov     edi, ecx
+  .text:0000000180C06DD3                 nop     dword ptr [rax+00h]
+  .text:0000000180C06DD7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180C06DE0                 mov     rax, [rdx+rdi*8]
+  .text:0000000180C06DE4                 mov     byte ptr [rax+0F4h], 0
+  .text:0000000180C06DEB                 mov     rax, [rsp+270h+var_218]
+  .text:0000000180C06DF0                 mov     rdx, [rax+rdi*8]
+  .text:0000000180C06DF4                 and     byte ptr [rdx+0E9h], 0FEh
+  .text:0000000180C06DFB                 mov     dl, 1
+  .text:0000000180C06DFD                 mov     rcx, [rsp+270h+var_218]
+  .text:0000000180C06E02                 mov     rcx, [rcx+rdi*8]
+  .text:0000000180C06E06                 call    sub_180B689C0
+  .text:0000000180C06E0B                 mov     rdx, [rsp+270h+var_218]
+  .text:0000000180C06E10                 inc     rdi
+  .text:0000000180C06E13                 cmp     rdi, r14
+  .text:0000000180C06E16                 jl      short loc_180C06DE0
+  .text:0000000180C06E18                 mov     r10d, [rsp+270h+var_210]
+  .text:0000000180C06E1D                 xor     eax, eax
+  .text:0000000180C06E1F                 mov     [rsp+270h+var_220], eax
+  .text:0000000180C06E23                 test    r10d, r10d
+  .text:0000000180C06E26                 js      short loc_180C06E74
+  .text:0000000180C06E28                 lea     rax, [rsp+270h+var_208]
+  .text:0000000180C06E2D                 cmp     rdx, rax
+  .text:0000000180C06E30                 jz      short loc_180C06E74
+  .text:0000000180C06E32                 test    rdx, rdx
+  .text:0000000180C06E35                 jz      short loc_180C06E51
+  .text:0000000180C06E37                 test    [rsp+270h+var_20C], 0C0000000h
+  .text:0000000180C06E3F                 jnz     short loc_180C06E51
+  .text:0000000180C06E41                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C06E48                 mov     rcx, [rax]
+  .text:0000000180C06E4B                 mov     rax, [rcx]
+  .text:0000000180C06E4E                 call    qword ptr [rax+18h]
+  .text:0000000180C06E51                 mov     eax, [rsp+270h+var_20C]
+  .text:0000000180C06E55                 lea     rdx, [rsp+270h+var_208]
+  .text:0000000180C06E5A                 and     eax, 3FFFFFFFh
+  .text:0000000180C06E5F                 mov     [rsp+270h+var_218], rdx
+  .text:0000000180C06E64                 bts     eax, 1Fh
+  .text:0000000180C06E68                 mov     [rsp+270h+var_210], 20h ; ' '
+  .text:0000000180C06E70                 mov     [rsp+270h+var_20C], eax
+  .text:0000000180C06E74                 test    [rsp+270h+var_20C], 0C0000000h
+  .text:0000000180C06E7C                 jnz     short loc_180C06E93
+  .text:0000000180C06E7E                 test    rdx, rdx
+  .text:0000000180C06E81                 jz      short loc_180C06E93
+  .text:0000000180C06E83                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C06E8A                 mov     rcx, [rax]
+  .text:0000000180C06E8D                 mov     rax, [rcx]
+  .text:0000000180C06E90                 call    qword ptr [rax+18h]
+  .text:0000000180C06E93                 mov     rdi, [rbp+170h+arg_10]
+  .text:0000000180C06E9A                 test    r13b, r13b
+  .text:0000000180C06E9D                 jz      short loc_180C06EC7
+  .text:0000000180C06E9F                 test    r12b, r12b
+  .text:0000000180C06EA2                 jnz     short loc_180C06EB2
+  .text:0000000180C06EA4                 mov     rax, [rsi]
+  .text:0000000180C06EA7                 mov     edx, 70h ; 'p'
+  .text:0000000180C06EAC                 mov     rcx, rsi
+  .text:0000000180C06EAF                 call    qword ptr [rax+58h]
+  .text:0000000180C06EB2                 lea     rdx, [rsi+390h]
+  .text:0000000180C06EB9                 cmp     qword ptr [rdx], 0
+  .text:0000000180C06EBD                 jz      short loc_180C06EC7
+  .text:0000000180C06EBF                 mov     rcx, rdi
+  .text:0000000180C06EC2                 call    sub_180BF4880
+  .text:0000000180C06EC7                 movzx   eax, byte ptr [rsi+382h]
+  .text:0000000180C06ECE                 test    al, 1
+  .text:0000000180C06ED0                 jz      loc_180C07068
+  .text:0000000180C06ED6                 and     al, 0FEh
+  .text:0000000180C06ED8                 mov     [rsi+382h], al
+  .text:0000000180C06EDE                 mov     rdi, [rsi+210h]
+  .text:0000000180C06EE5                 test    rdi, rdi
+  .text:0000000180C06EE8                 jz      loc_180C06FD5
+  .text:0000000180C06EEE                 mov     rcx, [rsi+38h]
+  .text:0000000180C06EF2                 test    rcx, rcx
+  .text:0000000180C06EF5                 jz      short loc_180C06F68
+  .text:0000000180C06EF7                 mov     rax, [rcx]
+  .text:0000000180C06EFA                 call    qword ptr [rax+50h]
+  .text:0000000180C06EFD                 test    rax, rax
+  .text:0000000180C06F00                 jz      short loc_180C06F68
+  .text:0000000180C06F02                 cmp     qword ptr [rax+210h], 0
+  .text:0000000180C06F0A                 jz      short loc_180C06F74
+  .text:0000000180C06F0C                 lea     rcx, [rax+130h]
+  .text:0000000180C06F13                 call    sub_180BF82B0
+  .text:0000000180C06F18                 cmp     eax, 1
+  .text:0000000180C06F1B                 jnz     short loc_180C06F74
+  .text:0000000180C06F1D                 cmp     byte ptr [rsi+0ECh], 3
+  .text:0000000180C06F24                 jnz     short loc_180C06F74
+  .text:0000000180C06F26                 mov     rax, [rdi]
+  .text:0000000180C06F29                 mov     edx, 1
+  .text:0000000180C06F2E                 mov     rcx, rdi
+  .text:0000000180C06F31                 call    qword ptr [rax+30h]
+  .text:0000000180C06F34                 test    eax, 0FFFFFFFBh
+  .text:0000000180C06F39                 jz      short loc_180C06FB7
+  .text:0000000180C06F3B                 mov     rax, [rdi]
+  .text:0000000180C06F3E                 xor     edx, edx
+  .text:0000000180C06F40                 mov     rcx, rdi
+  .text:0000000180C06F43                 call    qword ptr [rax+0C0h]
+  .text:0000000180C06F49                 mov     rcx, rax
+  .text:0000000180C06F4C                 mov     rdx, [rax]
+  .text:0000000180C06F4F                 call    qword ptr [rdx+20h]
+  .text:0000000180C06F52                 cmp     eax, 2
+  .text:0000000180C06F55                 jz      short loc_180C06FB7
+  .text:0000000180C06F57                 mov     rcx, cs:qword_181E13168
+  .text:0000000180C06F5E                 mov     rdx, rsi
+  .text:0000000180C06F61                 call    sub_1805114D0
+  .text:0000000180C06F66                 jmp     short loc_180C06FC6
+  .text:0000000180C06F68                 movsx   eax, byte ptr [rsi+372h]
+  .text:0000000180C06F6F                 cmp     eax, 3
+  .text:0000000180C06F72                 jnz     short loc_180C06F93
+  .text:0000000180C06F74                 mov     rcx, cs:qword_181E13168
+  .text:0000000180C06F7B                 mov     rdx, rsi
+  .text:0000000180C06F7E                 call    sub_1805114D0
+  .text:0000000180C06F83                 mov     rax, [rdi]
+  .text:0000000180C06F86                 mov     edx, 3
+  .text:0000000180C06F8B                 mov     rcx, rdi
+  .text:0000000180C06F8E                 call    qword ptr [rax+30h]
+  .text:0000000180C06F91                 jmp     short loc_180C06FC6
+  .text:0000000180C06F93                 cmp     eax, 2
+  .text:0000000180C06F96                 jnz     short loc_180C06F26
+  .text:0000000180C06F98                 mov     rcx, cs:qword_181E13168
+  .text:0000000180C06F9F                 mov     rdx, rsi
+  .text:0000000180C06FA2                 call    sub_1805114D0
+  .text:0000000180C06FA7                 mov     rax, [rdi]
+  .text:0000000180C06FAA                 mov     edx, 2
+  .text:0000000180C06FAF                 mov     rcx, rdi
+  .text:0000000180C06FB2                 call    qword ptr [rax+30h]
+  .text:0000000180C06FB5                 jmp     short loc_180C06FC6
+  .text:0000000180C06FB7                 mov     rcx, cs:qword_181E13168
+  .text:0000000180C06FBE                 mov     rdx, rsi
+  .text:0000000180C06FC1                 call    sub_18050FD90
+  .text:0000000180C06FC6                 mov     rcx, cs:qword_181E13168
+  .text:0000000180C06FCD                 mov     rdx, rsi
+  .text:0000000180C06FD0                 call    sub_180525000
+  .text:0000000180C06FD5                 mov     rdi, [rsi+40h]
+  .text:0000000180C06FD9                 test    rdi, rdi
+  .text:0000000180C06FDC                 jz      loc_180C07068
+  .text:0000000180C06FE2                 mov     rax, [rdi]
+  .text:0000000180C06FE5                 mov     rcx, rdi
+  .text:0000000180C06FE8                 call    qword ptr [rax+50h]
+  .text:0000000180C06FEB                 mov     rdx, rax
+  .text:0000000180C06FEE                 test    rax, rax
+  .text:0000000180C06FF1                 jz      short loc_180C0705B
+  .text:0000000180C06FF3                 mov     rcx, [rax+30h]
+  .text:0000000180C06FF7                 mov     rcx, [rcx+10h]
+  .text:0000000180C06FFB                 mov     eax, [rcx+30h]
+  .text:0000000180C06FFE                 bt      eax, 0Bh
+  .text:0000000180C07002                 jnb     short loc_180C0700B
+  .text:0000000180C07004                 shr     eax, 6
+  .text:0000000180C07007                 and     al, 1
+  .text:0000000180C07009                 jmp     short loc_180C07031
+  .text:0000000180C0700B                 test    rcx, rcx
+  .text:0000000180C0700E                 jz      short loc_180C0701F
+  .text:0000000180C07010                 cmp     dword ptr [rcx+10h], 0FFFFFFFFh
+  .text:0000000180C07014                 mov     eax, 7FFFh
+  .text:0000000180C07019                 cmovnz  eax, [rcx+10h]
+  .text:0000000180C0701D                 jmp     short loc_180C07024
+  .text:0000000180C0701F                 mov     eax, 0FFFFFFFFh
+  .text:0000000180C07024                 and     eax, 7FFFh
+  .text:0000000180C07029                 cmp     eax, 4000h
+  .text:0000000180C0702E                 setb    al
+  .text:0000000180C07031                 test    al, al
+  .text:0000000180C07033                 jz      short loc_180C0704D
+  .text:0000000180C07035                 or      byte ptr [rdx+382h], 1
+  .text:0000000180C0703C                 mov     rdx, rdi
+  .text:0000000180C0703F                 mov     rcx, cs:g_pBodyGameSystem
+  .text:0000000180C07046                 call    sub_18052DD40
+  .text:0000000180C0704B                 jmp     short loc_180C0705B
+  .text:0000000180C0704D                 lea     rcx, [rdx+130h]
+  .text:0000000180C07054                 mov     dl, 1
+  .text:0000000180C07056                 call    sub_180C0E790
+  .text:0000000180C0705B                 mov     rdi, [rdi+48h]
+  .text:0000000180C0705F                 test    rdi, rdi
+  .text:0000000180C07062                 jnz     loc_180C06FE2
+  .text:0000000180C07068                 test    rbx, rbx
+  .text:0000000180C0706B                 jz      short loc_180C07082
+  .text:0000000180C0706D                 mov     rcx, rbx
+  .text:0000000180C07070                 call    sub_180BF3610
+  .text:0000000180C07075                 mov     edx, 250h
+  .text:0000000180C0707A                 mov     rcx, rbx
+  .text:0000000180C0707D                 call    sub_180E75BB0
+  .text:0000000180C07082                 mov     rbx, [rsp+270h+arg_18]
+  .text:0000000180C0708A                 add     rsp, 240h
+  .text:0000000180C07091                 pop     r15
+  .text:0000000180C07093                 pop     r14
+  .text:0000000180C07095                 pop     r13
+  .text:0000000180C07097                 pop     r12
+  .text:0000000180C07099                 pop     rdi
+  .text:0000000180C0709A                 pop     rsi
+  .text:0000000180C0709B                 pop     rbp
+  .text:0000000180C0709C                 retn
+procedure: |-
+  char __fastcall CSkeletonInstance_PostDataUpdate(__int64 a1, __int64 a2, __int64 a3)
+  {
+    char v3; // r12
+    unsigned int v4; // r15d
+    __int64 v6; // rbx
+    char v7; // r13
+    __int64 *v8; // rax
+    __int64 v9; // rdi
+    bool v10; // cl
+    bool v11; // cl
+    __int64 i; // rbx
+    __int64 v13; // rcx
+    bool v14; // al
+    int v15; // eax
+    __int64 v16; // rax
+    __int64 v17; // rdx
+    const char **v18; // r8
+    char *v19; // rdi
+    int v20; // eax
+    char *v21; // rcx
+    const char *v22; // rax
+    bool v23; // zf
+    const char *v24; // r8
+    __int64 v25; // rdi
+    __int64 v26; // r9
+    __int64 v27; // rax
+    __int64 v28; // rcx
+    __int64 v29; // rax
+    __int64 v30; // rcx
+    __int64 v31; // rcx
+    __int64 v32; // rcx
+    int v33; // r10d
+    __int64 v34; // r15
+    _BYTE *v35; // rdx
+    __int64 v36; // rcx
+    bool v37; // al
+    int v38; // eax
+    __int64 v39; // r12
+    int v40; // r14d
+    int v41; // eax
+    __int64 v42; // rdx
+    int v43; // edi
+    __int64 v44; // r14
+    __int64 v45; // rdi
+    __int64 v46; // rdx
+    __int64 v47; // rax
+    __int64 v48; // rdi
+    __int64 v49; // rcx
+    __int64 v50; // rax
+    __int64 v51; // rax
+    int v52; // eax
+    _QWORD *j; // rdi
+    __int64 v54; // rdx
+    __int64 v55; // rcx
+    bool v56; // al
+    int v57; // eax
+    __int64 v58; // rcx
+    _QWORD v60[3]; // [rsp+30h] [rbp-D0h] BYREF
+    int v61; // [rsp+48h] [rbp-B8h]
+    int v62; // [rsp+4Ch] [rbp-B4h]
+    int v63; // [rsp+50h] [rbp-B0h]
+    _BYTE *v64; // [rsp+58h] [rbp-A8h] BYREF
+    int v65; // [rsp+60h] [rbp-A0h]
+    unsigned int v66; // [rsp+64h] [rbp-9Ch]
+    _BYTE v67[264]; // [rsp+68h] [rbp-98h] BYREF
+    int v68; // [rsp+170h] [rbp+70h] BYREF
+    int v69; // [rsp+174h] [rbp+74h]
+    char *v70; // [rsp+178h] [rbp+78h] BYREF
+    char v71; // [rsp+280h] [rbp+180h] BYREF
+    char v72; // [rsp+288h] [rbp+188h]
+    __int64 v73; // [rsp+290h] [rbp+190h]
+
+    v73 = a3;
+    v3 = *(_BYTE *)(a1 + 480);
+    v72 = v3;
+    v4 = a2;
+    v6 = 0;
+    v7 = a2 & 1;
+    if ( (a2 & 1) != 0 )
+    {
+      sub_180C0A780(a1, *(_QWORD *)(a1 + 464));
+      v8 = *(__int64 **)(a1 + 464);
+      if ( v8 )
+      {
+        v9 = *v8;
+        *(_QWORD *)(a1 + 496) = v8;
+        if ( v9 )
+        {
+          *(_WORD *)(a1 + 880) = sub_181305AF0(v9 + 304);
+          v10 = (int)sub_181303540(v9) > 0;
+  LABEL_7:
+          *(_BYTE *)(a1 + 887) = v10;
+          v11 = v10 && (int)sub_181305B00(v9) > 0;
+          *(_BYTE *)(a1 + 888) = v11;
+          sub_180C0ADD0(a1 + 304);
+          goto LABEL_46;
+        }
+      }
+      else
+      {
+        *(_QWORD *)(a1 + 496) = 0;
+        v9 = 0;
+      }
+      *(_WORD *)(a1 + 880) = 0;
+      v10 = 0;
+      goto LABEL_7;
+    }
+    if ( v3 )
+    {
+      for ( i = *(_QWORD *)(a1 + 64); i; i = *(_QWORD *)(i + 72) )
+      {
+        v13 = *(_QWORD *)(*(_QWORD *)(i + 48) + 16LL);
+        if ( (*(_DWORD *)(v13 + 48) & 0x800) != 0 )
+        {
+          v14 = (*(_DWORD *)(v13 + 48) & 0x40) != 0;
+        }
+        else
+        {
+          if ( v13 )
+          {
+            LOWORD(v15) = 0x7FFF;
+            if ( *(_DWORD *)(v13 + 16) != -1 )
+              v15 = *(_DWORD *)(v13 + 16);
+          }
+          else
+          {
+            LOWORD(v15) = -1;
+          }
+          v14 = (v15 & 0x7FFFu) < 0x4000;
+        }
+        if ( !v14 && *(_BYTE *)(i + 236) != 3 && (*(_BYTE *)(i + 244) || (unsigned __int8)sub_1801BD270(i)) )
+          sub_180B42250(i);
+      }
+      if ( *(_BYTE *)(a1 + 236) == 1 )
+      {
+        LOBYTE(a2) = 1;
+        sub_180B4AD90(a1, a2);
+      }
+      v16 = operator_new(592);
+      if ( v16 )
+        v6 = sub_180BF2A20(v16);
+      else
+        v6 = 0;
+      sub_180BF8F80(a1 + 304, a1, v6);
+      sub_180C09C30(a1 + 304, *(_QWORD *)(a1 + 488));
+      v17 = *(_QWORD *)(a1 + 464);
+      if ( v17 )
+      {
+        v18 = *(const char ***)(v17 + 8);
+        v19 = byte_18159A988;
+        v20 = -1073741624;
+        v69 = -1073741624;
+        v21 = nullptr;
+        v70 = nullptr;
+        v68 = 0;
+        if ( v18 )
+        {
+          v22 = *v18;
+          v23 = *v18 == nullptr;
+          v24 = byte_18159A988;
+          if ( !v23 )
+            v24 = v22;
+          CBufferString::Insert((CBufferString *)&v68, 0, v24, -1, 0);
+          v21 = v70;
+          v20 = v69;
+        }
+        if ( (v20 & 0x40000000) != 0 )
+        {
+          v19 = (char *)&v70;
+        }
+        else if ( (v20 & 0x3FFFFFFF) != 0 )
+        {
+          v19 = v21;
+        }
+        *(_QWORD *)(a1 + 472) = *(_QWORD *)sub_1811E5EF0(g_pEntitySystem, &v71, v19);
+        CBufferString::Purge((CBufferString *)&v68, 0);
+      }
+      else
+      {
+        *(_QWORD *)(a1 + 472) = 0;
+      }
+      *(_QWORD *)(a1 + 488) = 0;
+      *(_BYTE *)(a1 + 480) = 0;
+      sub_180C0ADD0(a1 + 304);
+      if ( *(_DWORD *)(a1 + 120) != -1 || *(_DWORD *)(a1 + 124) )
+        *(_BYTE *)(a1 + 233) |= 1u;
+    }
+  LABEL_46:
+    v25 = v73;
+    CGameSceneNode_PostDataUpdate(a1, v4);
+    if ( v3 )
+    {
+      if ( v7 )
+      {
+        v61 = 1872;
+        v60[0] = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\shared\\skeletoninstance.cpp";
+        v62 = 20;
+        v60[1] = "CSkeletonInstance::PostDataUpdate";
+        v60[2] = "!IsFlagSet( type, DATA_UPDATE_TYPE_CREATED )";
+        if ( Assert_ConditionFailed((const struct _AssertCompileTimeConstantStruct_t *)v60) )
+          __debugbreak();
+      }
+      if ( *(_BYTE *)(a1 + 244) || (unsigned __int8)sub_1801BD270(a1) )
+        sub_180B42250(a1);
+      sub_180C0B160(a1 + 304, v6, a1, a1 + 16);
+      v27 = *(_QWORD *)(a1 + 960);
+      if ( v27 )
+        *(_QWORD *)(v27 + 4288) = 0;
+      v28 = *(_QWORD *)(a1 + 912);
+      if ( v28 )
+      {
+        LOBYTE(v26) = -1;
+        (*(void (__fastcall **)(__int64, _QWORD, _QWORD, __int64))(*(_QWORD *)v28 + 88LL))(
+          v28,
+          *(_QWORD *)(v6 + 160),
+          *(_QWORD *)(a1 + 464),
+          v26);
+      }
+      if ( *(_QWORD *)(sub_180B58100(a1) + 984) )
+      {
+        v29 = sub_180B58100(a1);
+        (*(void (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)v29 + 416LL))(
+          v29,
+          *(_QWORD *)(v6 + 160),
+          *(_QWORD *)(a1 + 464));
+      }
+      sub_180BF7B10(v6, a1);
+      v30 = *(_QWORD *)(v6 + 128);
+      if ( v30 )
+      {
+        sub_180E75C10(v30);
+        *(_QWORD *)(v6 + 128) = 0;
+      }
+      v31 = *(_QWORD *)(v6 + 136);
+      if ( v31 )
+      {
+        sub_180E75C10(v31);
+        *(_QWORD *)(v6 + 136) = 0;
+      }
+      *(_QWORD *)(v6 + 148) = 0;
+      *(_DWORD *)(v6 + 144) = 0;
+      sub_181307C00(v6 + 64);
+      sub_181307C00(v6 + 16);
+      v32 = *(_QWORD *)(v6 + 200);
+      if ( v32 )
+      {
+        sub_180E75C10(v32);
+        *(_QWORD *)(v6 + 200) = 0;
+      }
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 88LL))(a1, 112);
+      v64 = nullptr;
+      v66 = 0x80000000;
+      v33 = 32;
+      v65 = 32;
+      if ( ((unsigned __int8)&v64 & 7) != 0 )
+      {
+        sub_1814DD520();
+        v33 = v65;
+      }
+      v34 = *(_QWORD *)(a1 + 64);
+      v35 = v67;
+      v64 = v67;
+      v63 = 0;
+      if ( v34 )
+      {
+        do
+        {
+          if ( *(_BYTE *)(v34 + 236) != 3 )
+          {
+            v36 = *(_QWORD *)(*(_QWORD *)(v34 + 48) + 16LL);
+            if ( (*(_DWORD *)(v36 + 48) & 0x800) != 0 )
+            {
+              v37 = (*(_DWORD *)(v36 + 48) & 0x40) != 0;
+            }
+            else
+            {
+              if ( v36 )
+              {
+                LOWORD(v38) = 0x7FFF;
+                if ( *(_DWORD *)(v36 + 16) != -1 )
+                  v38 = *(_DWORD *)(v36 + 16);
+              }
+              else
+              {
+                LOWORD(v38) = -1;
+              }
+              v37 = (v38 & 0x7FFFu) < 0x4000;
+            }
+            if ( v37 )
+            {
+              *(_BYTE *)(v34 + 233) |= 1u;
+              sub_18052DD40(g_pBodyGameSystem, v34);
+            }
+            else
+            {
+              v39 = v63;
+              if ( v63 == v33 && (v66 & 0x40000000) == 0 )
+              {
+                if ( v33 == 0x7FFFFFFF )
+                {
+                  UtlVectorMemory_FailedAllocation(0x7FFFFFFF, 1);
+                  v33 = v65;
+                }
+                v40 = v33 + 1;
+                v41 = UtlVectorMemory_CalcNewAllocationCount(
+                        (unsigned int)v33,
+                        v66 & 0x3FFFFFFF,
+                        (unsigned int)(v33 + 1),
+                        8);
+                v43 = v41;
+                if ( v41 < v40 )
+                {
+                  if ( v41 || v40 > -1 )
+                  {
+                    do
+                    {
+                      v42 = (unsigned int)((v43 + v40) >> 31);
+                      v43 = (v43 + v40) / 2;
+                    }
+                    while ( v43 < v40 );
+                  }
+                  else
+                  {
+                    v43 = -1;
+                  }
+                }
+                LOBYTE(v42) = (v66 & 0xC0000000) == 0;
+                v35 = (_BYTE *)UtlVectorMemory_Alloc(v64, v42, 8LL * v43, 8LL * v65);
+                v64 = v35;
+                if ( (v66 & 0xC0000000) != 0 )
+                  v66 &= 0x3FFFFFFFu;
+                v65 = v43;
+              }
+              ++v63;
+              *(_QWORD *)&v35[8 * v39] = v34;
+              *(_BYTE *)(v34 + 233) |= 1u;
+            }
+            v35 = v64;
+            v33 = v65;
+          }
+          v34 = *(_QWORD *)(v34 + 72);
+        }
+        while ( v34 );
+        v3 = v72;
+      }
+      v44 = v63;
+      if ( v63 > 0 )
+      {
+        v45 = 0;
+        do
+        {
+          *(_BYTE *)(*(_QWORD *)&v35[8 * v45] + 244LL) = 0;
+          v46 = *(_QWORD *)&v64[8 * v45];
+          *(_BYTE *)(v46 + 233) &= ~1u;
+          LOBYTE(v46) = 1;
+          sub_180B689C0(*(_QWORD *)&v64[8 * v45], v46);
+          v35 = v64;
+          ++v45;
+        }
+        while ( v45 < v44 );
+        v33 = v65;
+      }
+      v63 = 0;
+      if ( v33 >= 0 && v35 != v67 )
+      {
+        if ( v35 && (v66 & 0xC0000000) == 0 )
+          (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+        v35 = v67;
+        v64 = v67;
+        v65 = 32;
+        v66 = v66 & 0x3FFFFFFF | 0x80000000;
+      }
+      if ( (v66 & 0xC0000000) == 0 && v35 )
+        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+      v25 = v73;
+    }
+    if ( v7 )
+    {
+      if ( !v3 )
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 88LL))(a1, 112);
+      if ( *(_QWORD *)(a1 + 912) )
+        sub_180BF4880(v25);
+    }
+    LOBYTE(v47) = *(_BYTE *)(a1 + 898);
+    if ( (v47 & 1) != 0 )
+    {
+      LOBYTE(v47) = v47 & 0xFE;
+      *(_BYTE *)(a1 + 898) = v47;
+      v48 = *(_QWORD *)(a1 + 528);
+      if ( !v48 )
+        goto LABEL_130;
+      v49 = *(_QWORD *)(a1 + 56);
+      if ( v49 && (v50 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v49 + 80LL))(v49)) != 0 )
+      {
+        if ( *(_QWORD *)(v50 + 528) && (unsigned int)sub_180BF82B0(v50 + 304) == 1 && *(_BYTE *)(a1 + 236) == 3 )
+        {
+  LABEL_121:
+          if ( ((*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v48 + 48LL))(v48, 1) & 0xFFFFFFFB) == 0
+            || (v51 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)v48 + 192LL))(v48, 0),
+                (*(unsigned int (__fastcall **)(__int64))(*(_QWORD *)v51 + 32LL))(v51) == 2) )
+          {
+            sub_18050FD90(qword_181E13168, a1);
+          }
+          else
+          {
+            sub_1805114D0(qword_181E13168, a1);
+          }
+          goto LABEL_129;
+        }
+      }
+      else
+      {
+        v52 = *(char *)(a1 + 882);
+        if ( v52 != 3 )
+        {
+          if ( v52 != 2 )
+            goto LABEL_121;
+          sub_1805114D0(qword_181E13168, a1);
+          (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v48 + 48LL))(v48, 2);
+  LABEL_129:
+          LOBYTE(v47) = sub_180525000(qword_181E13168, a1);
+  LABEL_130:
+          for ( j = *(_QWORD **)(a1 + 64); j; j = (_QWORD *)j[9] )
+          {
+            v47 = (*(__int64 (__fastcall **)(_QWORD *))(*j + 80LL))(j);
+            v54 = v47;
+            if ( v47 )
+            {
+              v55 = *(_QWORD *)(*(_QWORD *)(v47 + 48) + 16LL);
+              if ( (*(_DWORD *)(v55 + 48) & 0x800) != 0 )
+              {
+                v56 = (*(_DWORD *)(v55 + 48) & 0x40) != 0;
+              }
+              else
+              {
+                if ( v55 )
+                {
+                  LOWORD(v57) = 0x7FFF;
+                  if ( *(_DWORD *)(v55 + 16) != -1 )
+                    v57 = *(_DWORD *)(v55 + 16);
+                }
+                else
+                {
+                  LOWORD(v57) = -1;
+                }
+                v56 = (v57 & 0x7FFFu) < 0x4000;
+              }
+              if ( v56 )
+              {
+                *(_BYTE *)(v54 + 898) |= 1u;
+                LOBYTE(v47) = sub_18052DD40(g_pBodyGameSystem, j);
+              }
+              else
+              {
+                v58 = v54 + 304;
+                LOBYTE(v54) = 1;
+                LOBYTE(v47) = sub_180C0E790(v58, v54);
+              }
+            }
+          }
+          goto LABEL_144;
+        }
+      }
+      sub_1805114D0(qword_181E13168, a1);
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v48 + 48LL))(v48, 3);
+      goto LABEL_129;
+    }
+  LABEL_144:
+    if ( v6 )
+    {
+      sub_180BF3610(v6);
+      LOBYTE(v47) = sub_180E75BB0(v6);
+    }
+    return v47;
+  }

--- a/ida_preprocessor_scripts/references/server/EntInfo_CommandHandler.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/EntInfo_CommandHandler.linux.yaml
@@ -1,0 +1,349 @@
+func_name: EntInfo_CommandHandler
+func_va: '0x169dc10'
+disasm_code: |-
+  .text:000000000169DC10                 push    rbp
+  .text:000000000169DC11                 mov     rbp, rsp
+  .text:000000000169DC14                 push    r15
+  .text:000000000169DC16                 push    r14
+  .text:000000000169DC18                 push    r13
+  .text:000000000169DC1A                 push    r12
+  .text:000000000169DC1C                 push    rbx
+  .text:000000000169DC1D                 mov     rbx, rsi
+  .text:000000000169DC20                 sub     rsp, 88h
+  .text:000000000169DC27                 call    sub_163B6B0
+  .text:000000000169DC2C                 test    rax, rax
+  .text:000000000169DC2F                 jz      loc_169DE66
+  .text:000000000169DC35                 cmp     dword ptr [rbx+438h], 1
+  .text:000000000169DC3C                 mov     r13, rax
+  .text:000000000169DC3F                 jle     loc_169DE78
+  .text:000000000169DC45                 lea     rax, g_pEntitySystem
+  .text:000000000169DC4C                 sub     rsp, 8
+  .text:000000000169DC50                 xor     ecx, ecx
+  .text:000000000169DC52                 xor     esi, esi
+  .text:000000000169DC54                 mov     r9d, 0FFFFFFFFh
+  .text:000000000169DC5A                 mov     r8d, 0FFFFFFFFh
+  .text:000000000169DC60                 mov     rdi, [rax]
+  .text:000000000169DC63                 mov     rax, [rbx+440h]
+  .text:000000000169DC6A                 mov     rdx, [rax+8]
+  .text:000000000169DC6E                 push    0
+  .text:000000000169DC70                 call    CEntitySystem_CreateEntityByName
+  .text:000000000169DC75                 pop     r9
+  .text:000000000169DC77                 mov     r15, rax
+  .text:000000000169DC7A                 pop     r10
+  .text:000000000169DC7C                 test    rax, rax
+  .text:000000000169DC7F                 jz      loc_169DEB0
+  .text:000000000169DC85                 mov     [rbp+var_A0], 0
+  .text:000000000169DC90                 mov     rdi, [rax+10h]
+  .text:000000000169DC94                 lea     rsi, [rbp+var_B0]
+  .text:000000000169DC9B                 mov     [rbp+var_B0], 0
+  .text:000000000169DCA6                 mov     [rbp+var_A8], 0
+  .text:000000000169DCB1                 call    sub_1E441C0
+  .text:000000000169DCB6                 movsxd  r14, dword ptr [rbp+var_B0]
+  .text:000000000169DCBD                 test    r14d, r14d
+  .text:000000000169DCC0                 jle     short loc_169DD3D
+  .text:000000000169DCC2                 lea     rbx, [rbp+var_70]
+  .text:000000000169DCC6                 shl     r14, 3
+  .text:000000000169DCCA                 xor     r12d, r12d
+  .text:000000000169DCCD                 nop     dword ptr [rax]
+  .text:000000000169DCD0                 mov     rax, [rbp+var_A8]
+  .text:000000000169DCD7                 lea     rsi, aOutputS; "  output: %s\n"
+  .text:000000000169DCDE                 ; void *
+  .text:000000000169DCDE                 mov     rdi, rbx; void *
+  .text:000000000169DCE1                 mov     rax, [rax+r12]
+  .text:000000000169DCE5                 mov     rdx, [rax]
+  .text:000000000169DCE8                 xor     eax, eax
+  .text:000000000169DCEA                 call    CBufferString__AppendFormat
+  .text:000000000169DCEF                 lea     rdx, [rbp+var_68]
+  .text:000000000169DCF3                 test    [rbp+var_69], 40h
+  .text:000000000169DCF7                 jnz     short loc_169DD0D
+  .text:000000000169DCF9                 lea     rdx, haystack
+  .text:000000000169DD00                 test    dword ptr [rbp-6Ch], 3FFFFFFFh
+  .text:000000000169DD07                 jz      short loc_169DD0D
+  .text:000000000169DD09                 mov     rdx, qword ptr [rbp+var_68]
+  .text:000000000169DD0D                 sub     rsp, 8
+  .text:000000000169DD11                 xor     ecx, ecx
+  .text:000000000169DD13                 xor     r9d, r9d
+  .text:000000000169DD16                 push    0
+  .text:000000000169DD18                 xor     r8d, r8d
+  .text:000000000169DD1B                 mov     esi, 2
+  .text:000000000169DD20                 mov     rdi, r13
+  .text:000000000169DD23                 call    ClientPrintToController
+  .text:000000000169DD28                 add     r12, 8
+  .text:000000000169DD2C                 ; int
+  .text:000000000169DD2C                 xor     esi, esi; int
+  .text:000000000169DD2E                 ; this
+  .text:000000000169DD2E                 mov     rdi, rbx; this
+  .text:000000000169DD31                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:000000000169DD36                 pop     rcx
+  .text:000000000169DD37                 pop     rsi
+  .text:000000000169DD38                 cmp     r14, r12
+  .text:000000000169DD3B                 jnz     short loc_169DCD0
+  .text:000000000169DD3D                 mov     [rbp+var_80], 0
+  .text:000000000169DD45                 mov     rdi, [r15+10h]
+  .text:000000000169DD49                 lea     rsi, [rbp+var_90]
+  .text:000000000169DD50                 mov     [rbp+var_90], 0
+  .text:000000000169DD5B                 mov     [rbp+var_88], 0
+  .text:000000000169DD66                 call    sub_1E44070
+  .text:000000000169DD6B                 movsxd  r14, dword ptr [rbp+var_90]
+  .text:000000000169DD72                 test    r14d, r14d
+  .text:000000000169DD75                 jle     short loc_169DDF2
+  .text:000000000169DD77                 lea     rbx, [rbp+var_70]
+  .text:000000000169DD7B                 shl     r14, 3
+  .text:000000000169DD7F                 xor     r12d, r12d
+  .text:000000000169DD82                 nop     word ptr [rax+rax+00h]
+  .text:000000000169DD88                 mov     rax, [rbp+var_88]
+  .text:000000000169DD8F                 lea     rsi, aInputS; "  input: %s\n"
+  .text:000000000169DD96                 ; void *
+  .text:000000000169DD96                 mov     rdi, rbx; void *
+  .text:000000000169DD99                 mov     rdx, [rax+r12]
+  .text:000000000169DD9D                 xor     eax, eax
+  .text:000000000169DD9F                 call    CBufferString__AppendFormat
+  .text:000000000169DDA4                 lea     rdx, [rbp+var_68]
+  .text:000000000169DDA8                 test    [rbp+var_69], 40h
+  .text:000000000169DDAC                 jnz     short loc_169DDC2
+  .text:000000000169DDAE                 lea     rdx, haystack
+  .text:000000000169DDB5                 test    dword ptr [rbp-6Ch], 3FFFFFFFh
+  .text:000000000169DDBC                 jz      short loc_169DDC2
+  .text:000000000169DDBE                 mov     rdx, qword ptr [rbp+var_68]
+  .text:000000000169DDC2                 sub     rsp, 8
+  .text:000000000169DDC6                 xor     r9d, r9d
+  .text:000000000169DDC9                 xor     r8d, r8d
+  .text:000000000169DDCC                 push    0
+  .text:000000000169DDCE                 xor     ecx, ecx
+  .text:000000000169DDD0                 mov     esi, 2
+  .text:000000000169DDD5                 mov     rdi, r13
+  .text:000000000169DDD8                 call    ClientPrintToController
+  .text:000000000169DDDD                 add     r12, 8
+  .text:000000000169DDE1                 ; int
+  .text:000000000169DDE1                 xor     esi, esi; int
+  .text:000000000169DDE3                 ; this
+  .text:000000000169DDE3                 mov     rdi, rbx; this
+  .text:000000000169DDE6                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:000000000169DDEB                 pop     rax
+  .text:000000000169DDEC                 pop     rdx
+  .text:000000000169DDED                 cmp     r12, r14
+  .text:000000000169DDF0                 jnz     short loc_169DD88
+  .text:000000000169DDF2                 lea     rax, g_pEntitySystem
+  .text:000000000169DDF9                 mov     rsi, [r15+10h]
+  .text:000000000169DDFD                 mov     rdi, [rax]
+  .text:000000000169DE00                 call    CEntitySystem_RemoveEntityImmediate
+  .text:000000000169DE05                 cmp     dword ptr [rbp+var_80+4], 3FFFFFFFh
+  .text:000000000169DE0C                 mov     dword ptr [rbp+var_90], 0
+  .text:000000000169DE16                 ja      short loc_169DE34
+  .text:000000000169DE18                 mov     rsi, [rbp+var_88]
+  .text:000000000169DE1F                 test    rsi, rsi
+  .text:000000000169DE22                 jz      short loc_169DE34
+  .text:000000000169DE24                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:000000000169DE2B                 mov     rdi, [rax]
+  .text:000000000169DE2E                 mov     rax, [rdi]
+  .text:000000000169DE31                 call    qword ptr [rax+20h]
+  .text:000000000169DE34                 cmp     dword ptr [rbp+var_A0+4], 3FFFFFFFh
+  .text:000000000169DE3E                 mov     dword ptr [rbp+var_B0], 0
+  .text:000000000169DE48                 ja      short loc_169DE66
+  .text:000000000169DE4A                 mov     rsi, [rbp+var_A8]
+  .text:000000000169DE51                 test    rsi, rsi
+  .text:000000000169DE54                 jz      short loc_169DE66
+  .text:000000000169DE56                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:000000000169DE5D                 mov     rdi, [rax]
+  .text:000000000169DE60                 mov     rax, [rdi]
+  .text:000000000169DE63                 call    qword ptr [rax+20h]
+  .text:000000000169DE66                 lea     rsp, [rbp-28h]
+  .text:000000000169DE6A                 pop     rbx
+  .text:000000000169DE6B                 pop     r12
+  .text:000000000169DE6D                 pop     r13
+  .text:000000000169DE6F                 pop     r14
+  .text:000000000169DE71                 pop     r15
+  .text:000000000169DE73                 pop     rbp
+  .text:000000000169DE74                 retn
+  .text:000000000169DE78                 sub     rsp, 8
+  .text:000000000169DE7C                 xor     r9d, r9d
+  .text:000000000169DE7F                 xor     r8d, r8d
+  .text:000000000169DE82                 push    0
+  .text:000000000169DE84                 xor     ecx, ecx
+  .text:000000000169DE86                 mov     esi, 2
+  .text:000000000169DE8B                 mov     rdi, rax
+  .text:000000000169DE8E                 lea     rdx, aUsageEntInfoCl; "Usage:\n   ent_info <class name>\n"
+  .text:000000000169DE95                 call    ClientPrintToController
+  .text:000000000169DE9A                 pop     r11
+  .text:000000000169DE9C                 pop     rbx
+  .text:000000000169DE9D                 lea     rsp, [rbp-28h]
+  .text:000000000169DEA1                 pop     rbx
+  .text:000000000169DEA2                 pop     r12
+  .text:000000000169DEA4                 pop     r13
+  .text:000000000169DEA6                 pop     r14
+  .text:000000000169DEA8                 pop     r15
+  .text:000000000169DEAA                 pop     rbp
+  .text:000000000169DEAB                 retn
+  .text:000000000169DEB0                 cmp     dword ptr [rbx+438h], 1
+  .text:000000000169DEB7                 lea     rdx, haystack
+  .text:000000000169DEBE                 jle     short loc_169DECB
+  .text:000000000169DEC0                 mov     rax, [rbx+440h]
+  .text:000000000169DEC7                 mov     rdx, [rax+8]
+  .text:000000000169DECB                 lea     rbx, [rbp+var_70]
+  .text:000000000169DECF                 xor     eax, eax
+  .text:000000000169DED1                 lea     rsi, aNoSuchEntityS; "no such entity %s\n"
+  .text:000000000169DED8                 ; void *
+  .text:000000000169DED8                 mov     rdi, rbx; void *
+  .text:000000000169DEDB                 call    CBufferString__AppendFormat
+  .text:000000000169DEE0                 lea     rdx, [rbp+var_68]
+  .text:000000000169DEE4                 test    [rbp+var_69], 40h
+  .text:000000000169DEE8                 jnz     short loc_169DEFE
+  .text:000000000169DEEA                 lea     rdx, haystack
+  .text:000000000169DEF1                 test    dword ptr [rbp-6Ch], 3FFFFFFFh
+  .text:000000000169DEF8                 jz      short loc_169DEFE
+  .text:000000000169DEFA                 mov     rdx, qword ptr [rbp+var_68]
+  .text:000000000169DEFE                 sub     rsp, 8
+  .text:000000000169DF02                 xor     r8d, r8d
+  .text:000000000169DF05                 mov     rdi, r13
+  .text:000000000169DF08                 push    0
+  .text:000000000169DF0A                 xor     r9d, r9d
+  .text:000000000169DF0D                 xor     ecx, ecx
+  .text:000000000169DF0F                 mov     esi, 2
+  .text:000000000169DF14                 call    ClientPrintToController
+  .text:000000000169DF19                 ; this
+  .text:000000000169DF19                 mov     rdi, rbx; this
+  .text:000000000169DF1C                 ; int
+  .text:000000000169DF1C                 xor     esi, esi; int
+  .text:000000000169DF1E                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:000000000169DF23                 pop     rdi
+  .text:000000000169DF24                 pop     r8
+  .text:000000000169DF26                 lea     rsp, [rbp-28h]
+  .text:000000000169DF2A                 pop     rbx
+  .text:000000000169DF2B                 pop     r12
+  .text:000000000169DF2D                 pop     r13
+  .text:000000000169DF2F                 pop     r14
+  .text:000000000169DF31                 pop     r15
+  .text:000000000169DF33                 pop     rbp
+  .text:000000000169DF34                 retn
+procedure: |-
+  void __fastcall EntInfo_CommandHandler(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // rax
+    int v3; // r13d
+    __int64 EntityByName; // rax
+    __int64 v5; // rdx
+    __int64 v6; // rcx
+    __int64 v7; // r8
+    __int64 v8; // r15
+    __int64 v9; // rdi
+    __int64 v10; // r14
+    __int64 v11; // r12
+    char *v12; // rdx
+    __int64 v13; // rdi
+    __int64 v14; // r14
+    __int64 v15; // r12
+    char *v16; // rdx
+    const char *v17; // rdx
+    char *v18; // rdx
+    __int64 v19; // [rsp-10h] [rbp-C0h]
+    __int64 v20; // [rsp+0h] [rbp-B0h] BYREF
+    __int64 v21; // [rsp+8h] [rbp-A8h]
+    __int64 v22; // [rsp+10h] [rbp-A0h]
+    __int64 v23; // [rsp+20h] [rbp-90h] BYREF
+    __int64 v24; // [rsp+28h] [rbp-88h]
+    __int64 v25; // [rsp+30h] [rbp-80h]
+    _BYTE v26[4]; // [rsp+40h] [rbp-70h] BYREF
+    int v27; // [rsp+44h] [rbp-6Ch]
+    _DWORD v28[26]; // [rsp+48h] [rbp-68h] BYREF
+
+    v2 = sub_163B6B0(a1);
+    if ( v2 )
+    {
+      v3 = v2;
+      if ( *(int *)(a2 + 1080) <= 1 )
+      {
+        ClientPrintToController(v2, 2, (int)"Usage:\n   ent_info <class name>\n", 0, 0, 0, 0);
+      }
+      else
+      {
+        EntityByName = CEntitySystem_CreateEntityByName(
+                         (_DWORD *)g_pEntitySystem,
+                         0,
+                         *(_BYTE **)(*(_QWORD *)(a2 + 1088) + 8LL),
+                         0,
+                         0xFFFFFFFF,
+                         0xFFFFFFFF,
+                         0);
+        v8 = EntityByName;
+        if ( EntityByName )
+        {
+          v22 = 0;
+          v9 = *(_QWORD *)(EntityByName + 16);
+          v20 = 0;
+          v21 = 0;
+          sub_1E441C0(v9, &v20, v5, v6, v7, v19);
+          if ( (int)v20 > 0 )
+          {
+            v10 = 8LL * (int)v20;
+            v11 = 0;
+            do
+            {
+              CBufferString::AppendFormat(v26, "  output: %s\n", **(const char ***)(v21 + v11));
+              v12 = (char *)v28;
+              if ( (v27 & 0x40000000) == 0 )
+              {
+                v12 = &haystack;
+                if ( (v27 & 0x3FFFFFFF) != 0 )
+                  LODWORD(v12) = v28[0];
+              }
+              ClientPrintToController(v3, 2, (int)v12, 0, 0, 0, 0);
+              v11 += 8;
+              CBufferString::Purge((CBufferString *)v26, 0);
+            }
+            while ( v10 != v11 );
+          }
+          v25 = 0;
+          v13 = *(_QWORD *)(v8 + 16);
+          v23 = 0;
+          v24 = 0;
+          sub_1E44070(v13, &v23);
+          if ( (int)v23 > 0 )
+          {
+            v14 = 8LL * (int)v23;
+            v15 = 0;
+            do
+            {
+              CBufferString::AppendFormat(v26, "  input: %s\n", *(const char **)(v24 + v15));
+              v16 = (char *)v28;
+              if ( (v27 & 0x40000000) == 0 )
+              {
+                v16 = &haystack;
+                if ( (v27 & 0x3FFFFFFF) != 0 )
+                  LODWORD(v16) = v28[0];
+              }
+              ClientPrintToController(v3, 2, (int)v16, 0, 0, 0, 0);
+              v15 += 8;
+              CBufferString::Purge((CBufferString *)v26, 0);
+            }
+            while ( v15 != v14 );
+          }
+          CEntitySystem_RemoveEntityImmediate((__int64 *)g_pEntitySystem, *(_QWORD *)(v8 + 16));
+          LODWORD(v23) = 0;
+          if ( HIDWORD(v25) <= 0x3FFFFFFF && v24 )
+            (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+          LODWORD(v20) = 0;
+          if ( HIDWORD(v22) <= 0x3FFFFFFF )
+          {
+            if ( v21 )
+              (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+          }
+        }
+        else
+        {
+          v17 = &haystack;
+          if ( *(int *)(a2 + 1080) > 1 )
+            v17 = *(const char **)(*(_QWORD *)(a2 + 1088) + 8LL);
+          CBufferString::AppendFormat(v26, "no such entity %s\n", v17);
+          v18 = (char *)v28;
+          if ( (v27 & 0x40000000) == 0 )
+          {
+            v18 = &haystack;
+            if ( (v27 & 0x3FFFFFFF) != 0 )
+              LODWORD(v18) = v28[0];
+          }
+          ClientPrintToController(v3, 2, (int)v18, 0, 0, 0, 0);
+          CBufferString::Purge((CBufferString *)v26, 0);
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/EntInfo_CommandHandler.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/EntInfo_CommandHandler.windows.yaml
@@ -1,0 +1,396 @@
+func_name: EntInfo_CommandHandler
+func_va: '0x180c25ca0'
+disasm_code: |-
+  .text:0000000180C25CA0                 push    rbp
+  .text:0000000180C25CA2                 push    rbx
+  .text:0000000180C25CA3                 push    r14
+  .text:0000000180C25CA5                 lea     rbp, [rsp-47h]
+  .text:0000000180C25CAA                 sub     rsp, 0B0h
+  .text:0000000180C25CB1                 mov     rbx, rdx
+  .text:0000000180C25CB4                 call    sub_180C0D740
+  .text:0000000180C25CB9                 mov     r14, rax
+  .text:0000000180C25CBC                 test    rax, rax
+  .text:0000000180C25CBF                 jz      loc_180C25FF0
+  .text:0000000180C25CC5                 cmp     dword ptr [rbx+438h], 2
+  .text:0000000180C25CCC                 jge     short loc_180C25D02
+  .text:0000000180C25CCE                 xor     ebx, ebx
+  .text:0000000180C25CD0                 lea     r8, aUsageEntInfoCl; "Usage:\n   ent_info <class name>\n"
+  .text:0000000180C25CD7                 mov     [rsp+0C0h+var_90], rbx
+  .text:0000000180C25CDC                 xor     r9d, r9d
+  .text:0000000180C25CDF                 mov     [rsp+0C0h+var_98], rbx
+  .text:0000000180C25CE4                 mov     edx, 2
+  .text:0000000180C25CE9                 mov     rcx, rax
+  .text:0000000180C25CEC                 mov     [rsp+0C0h+var_A0], rbx
+  .text:0000000180C25CF1                 call    ClientPrintToController
+  .text:0000000180C25CF6                 add     rsp, 0B0h
+  .text:0000000180C25CFD                 pop     r14
+  .text:0000000180C25CFF                 pop     rbx
+  .text:0000000180C25D00                 pop     rbp
+  .text:0000000180C25D01                 retn
+  .text:0000000180C25D02                 mov     rax, [rbx+440h]
+  .text:0000000180C25D09                 xor     r9d, r9d
+  .text:0000000180C25D0C                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180C25D13                 xor     edx, edx
+  .text:0000000180C25D15                 mov     byte ptr [rsp+0C0h+var_90], 0
+  .text:0000000180C25D1A                 mov     [rsp+0C0h+arg_8], rdi
+  .text:0000000180C25D22                 mov     r8, [rax+8]
+  .text:0000000180C25D26                 mov     dword ptr [rsp+0C0h+var_98], 0FFFFFFFFh
+  .text:0000000180C25D2E                 mov     [rsp+0C0h+arg_10], r13
+  .text:0000000180C25D36                 mov     dword ptr [rsp+0C0h+var_A0], 0FFFFFFFFh
+  .text:0000000180C25D3E                 call    CEntitySystem_CreateEntityByName
+  .text:0000000180C25D43                 mov     r13, rax
+  .text:0000000180C25D46                 test    rax, rax
+  .text:0000000180C25D49                 jnz     loc_180C25DCF
+  .text:0000000180C25D4F                 cmp     dword ptr [rbx+438h], 1
+  .text:0000000180C25D56                 lea     rdi, unk_18159A988
+  .text:0000000180C25D5D                 jle     short loc_180C25D6C
+  .text:0000000180C25D5F                 mov     rax, [rbx+440h]
+  .text:0000000180C25D66                 mov     r8, [rax+8]
+  .text:0000000180C25D6A                 jmp     short loc_180C25D6F
+  .text:0000000180C25D6C                 mov     r8, rdi
+  .text:0000000180C25D6F                 lea     rdx, aNoSuchEntityS; "no such entity %s\n"
+  .text:0000000180C25D76                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25D7A                 call    CBufferString__AppendFormat
+  .text:0000000180C25D7F                 mov     ecx, [rax+4]
+  .text:0000000180C25D82                 bt      ecx, 1Eh
+  .text:0000000180C25D86                 jnb     short loc_180C25D8E
+  .text:0000000180C25D88                 lea     rdi, [rax+8]
+  .text:0000000180C25D8C                 jmp     short loc_180C25D9A
+  .text:0000000180C25D8E                 test    ecx, 3FFFFFFFh
+  .text:0000000180C25D94                 jbe     short loc_180C25D9A
+  .text:0000000180C25D96                 mov     rdi, [rax+8]
+  .text:0000000180C25D9A                 xor     ebx, ebx
+  .text:0000000180C25D9C                 xor     r9d, r9d
+  .text:0000000180C25D9F                 mov     [rsp+0C0h+var_90], rbx
+  .text:0000000180C25DA4                 mov     r8, rdi
+  .text:0000000180C25DA7                 mov     [rsp+0C0h+var_98], rbx
+  .text:0000000180C25DAC                 mov     edx, 2
+  .text:0000000180C25DB1                 mov     rcx, r14
+  .text:0000000180C25DB4                 mov     [rsp+0C0h+var_A0], rbx
+  .text:0000000180C25DB9                 call    ClientPrintToController
+  .text:0000000180C25DBE                 xor     edx, edx
+  .text:0000000180C25DC0                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25DC4                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180C25DCA                 jmp     loc_180C25FE0
+  .text:0000000180C25DCF                 xor     ebx, ebx
+  .text:0000000180C25DD1                 mov     [rsp+0C0h+arg_0], rsi
+  .text:0000000180C25DD9                 mov     [rbp+57h+var_60], rbx
+  .text:0000000180C25DDD                 lea     rdx, [rbp+57h+var_68]
+  .text:0000000180C25DE1                 mov     [rbp+57h+var_58], rbx
+  .text:0000000180C25DE5                 mov     [rbp+57h+var_68], ebx
+  .text:0000000180C25DE8                 mov     rcx, [rax+10h]
+  .text:0000000180C25DEC                 mov     [rsp+0C0h+arg_18], r15
+  .text:0000000180C25DF4                 call    sub_18120E8B0
+  .text:0000000180C25DF9                 movsxd  r15, [rbp+57h+var_68]
+  .text:0000000180C25DFD                 lea     rdi, unk_18159A988
+  .text:0000000180C25E04                 test    r15, r15
+  .text:0000000180C25E07                 jle     short loc_180C25E7E
+  .text:0000000180C25E09                 mov     esi, ebx
+  .text:0000000180C25E0B                 nop     dword ptr [rax+rax+00h]
+  .text:0000000180C25E10                 mov     rax, [rbp+57h+var_60]
+  .text:0000000180C25E14                 lea     rdx, aOutputS; "  output: %s\n"
+  .text:0000000180C25E1B                 mov     rcx, [rax+rsi*8]
+  .text:0000000180C25E1F                 mov     r8, [rcx]
+  .text:0000000180C25E22                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25E26                 call    CBufferString__AppendFormat
+  .text:0000000180C25E2B                 mov     ecx, [rax+4]
+  .text:0000000180C25E2E                 bt      ecx, 1Eh
+  .text:0000000180C25E32                 jnb     short loc_180C25E3A
+  .text:0000000180C25E34                 lea     r8, [rax+8]
+  .text:0000000180C25E38                 jmp     short loc_180C25E4B
+  .text:0000000180C25E3A                 test    ecx, 3FFFFFFFh
+  .text:0000000180C25E40                 jbe     short loc_180C25E48
+  .text:0000000180C25E42                 mov     r8, [rax+8]
+  .text:0000000180C25E46                 jmp     short loc_180C25E4B
+  .text:0000000180C25E48                 mov     r8, rdi
+  .text:0000000180C25E4B                 mov     [rsp+0C0h+var_90], rbx
+  .text:0000000180C25E50                 xor     r9d, r9d
+  .text:0000000180C25E53                 mov     [rsp+0C0h+var_98], rbx
+  .text:0000000180C25E58                 mov     edx, 2
+  .text:0000000180C25E5D                 mov     rcx, r14
+  .text:0000000180C25E60                 mov     [rsp+0C0h+var_A0], rbx
+  .text:0000000180C25E65                 call    ClientPrintToController
+  .text:0000000180C25E6A                 xor     edx, edx
+  .text:0000000180C25E6C                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25E70                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180C25E76                 inc     rsi
+  .text:0000000180C25E79                 cmp     rsi, r15
+  .text:0000000180C25E7C                 jl      short loc_180C25E10
+  .text:0000000180C25E7E                 mov     [rbp+57h+var_78], rbx
+  .text:0000000180C25E82                 lea     rdx, [rbp+57h+var_80]
+  .text:0000000180C25E86                 mov     [rbp+57h+var_70], rbx
+  .text:0000000180C25E8A                 mov     [rbp+57h+var_80], ebx
+  .text:0000000180C25E8D                 mov     rcx, [r13+10h]
+  .text:0000000180C25E91                 call    sub_18120E780
+  .text:0000000180C25E96                 movsxd  r15, [rbp+57h+var_80]
+  .text:0000000180C25E9A                 test    r15, r15
+  .text:0000000180C25E9D                 jle     short loc_180C25F1B
+  .text:0000000180C25E9F                 mov     rsi, rbx
+  .text:0000000180C25EA2                 nop     dword ptr [rax+00h]
+  .text:0000000180C25EA6                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180C25EB0                 mov     rax, [rbp+57h+var_78]
+  .text:0000000180C25EB4                 lea     rdx, aInputS; "  input: %s\n"
+  .text:0000000180C25EBB                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25EBF                 mov     r8, [rax+rsi*8]
+  .text:0000000180C25EC3                 call    CBufferString__AppendFormat
+  .text:0000000180C25EC8                 mov     ecx, [rax+4]
+  .text:0000000180C25ECB                 bt      ecx, 1Eh
+  .text:0000000180C25ECF                 jnb     short loc_180C25ED7
+  .text:0000000180C25ED1                 lea     r8, [rax+8]
+  .text:0000000180C25ED5                 jmp     short loc_180C25EE8
+  .text:0000000180C25ED7                 test    ecx, 3FFFFFFFh
+  .text:0000000180C25EDD                 jbe     short loc_180C25EE5
+  .text:0000000180C25EDF                 mov     r8, [rax+8]
+  .text:0000000180C25EE3                 jmp     short loc_180C25EE8
+  .text:0000000180C25EE5                 mov     r8, rdi
+  .text:0000000180C25EE8                 mov     [rsp+0C0h+var_90], rbx
+  .text:0000000180C25EED                 xor     r9d, r9d
+  .text:0000000180C25EF0                 mov     [rsp+0C0h+var_98], rbx
+  .text:0000000180C25EF5                 mov     edx, 2
+  .text:0000000180C25EFA                 mov     rcx, r14
+  .text:0000000180C25EFD                 mov     [rsp+0C0h+var_A0], rbx
+  .text:0000000180C25F02                 call    ClientPrintToController
+  .text:0000000180C25F07                 xor     edx, edx
+  .text:0000000180C25F09                 lea     rcx, [rbp+57h+var_50]
+  .text:0000000180C25F0D                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180C25F13                 inc     rsi
+  .text:0000000180C25F16                 cmp     rsi, r15
+  .text:0000000180C25F19                 jl      short loc_180C25EB0
+  .text:0000000180C25F1B                 mov     rdx, [r13+10h]
+  .text:0000000180C25F1F                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180C25F26                 call    CEntitySystem_RemoveEntityImmediate
+  .text:0000000180C25F2B                 mov     eax, dword ptr [rbp+57h+var_70+4]
+  .text:0000000180C25F2E                 mov     r15, [rsp+0C0h+arg_18]
+  .text:0000000180C25F36                 mov     rsi, [rsp+0C0h+arg_0]
+  .text:0000000180C25F3E                 mov     rdx, [rbp+57h+var_78]
+  .text:0000000180C25F42                 mov     [rbp+57h+var_80], ebx
+  .text:0000000180C25F45                 test    eax, 0C0000000h
+  .text:0000000180C25F4A                 jnz     short loc_180C25F91
+  .text:0000000180C25F4C                 test    rdx, rdx
+  .text:0000000180C25F4F                 jz      short loc_180C25F6B
+  .text:0000000180C25F51                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C25F58                 mov     rcx, [rax]
+  .text:0000000180C25F5B                 mov     rax, [rcx]
+  .text:0000000180C25F5E                 call    qword ptr [rax+18h]
+  .text:0000000180C25F61                 mov     eax, dword ptr [rbp+57h+var_70+4]
+  .text:0000000180C25F64                 mov     rdx, rbx
+  .text:0000000180C25F67                 mov     [rbp+57h+var_78], rbx
+  .text:0000000180C25F6B                 mov     dword ptr [rbp+57h+var_70], ebx
+  .text:0000000180C25F6E                 test    eax, 0C0000000h
+  .text:0000000180C25F73                 jnz     short loc_180C25F91
+  .text:0000000180C25F75                 test    rdx, rdx
+  .text:0000000180C25F78                 jz      short loc_180C25F8E
+  .text:0000000180C25F7A                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C25F81                 mov     rcx, [rax]
+  .text:0000000180C25F84                 mov     rax, [rcx]
+  .text:0000000180C25F87                 call    qword ptr [rax+18h]
+  .text:0000000180C25F8A                 mov     [rbp+57h+var_78], rbx
+  .text:0000000180C25F8E                 mov     dword ptr [rbp+57h+var_70], ebx
+  .text:0000000180C25F91                 mov     eax, dword ptr [rbp+57h+var_58+4]
+  .text:0000000180C25F94                 mov     rdx, [rbp+57h+var_60]
+  .text:0000000180C25F98                 mov     [rbp+57h+var_68], ebx
+  .text:0000000180C25F9B                 test    eax, 0C0000000h
+  .text:0000000180C25FA0                 jnz     short loc_180C25FE0
+  .text:0000000180C25FA2                 test    rdx, rdx
+  .text:0000000180C25FA5                 jz      short loc_180C25FC1
+  .text:0000000180C25FA7                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C25FAE                 mov     rcx, [rax]
+  .text:0000000180C25FB1                 mov     rax, [rcx]
+  .text:0000000180C25FB4                 call    qword ptr [rax+18h]
+  .text:0000000180C25FB7                 mov     eax, dword ptr [rbp+57h+var_58+4]
+  .text:0000000180C25FBA                 mov     rdx, rbx
+  .text:0000000180C25FBD                 mov     [rbp+57h+var_60], rbx
+  .text:0000000180C25FC1                 mov     dword ptr [rbp+57h+var_58], ebx
+  .text:0000000180C25FC4                 test    eax, 0C0000000h
+  .text:0000000180C25FC9                 jnz     short loc_180C25FE0
+  .text:0000000180C25FCB                 test    rdx, rdx
+  .text:0000000180C25FCE                 jz      short loc_180C25FE0
+  .text:0000000180C25FD0                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180C25FD7                 mov     rcx, [rax]
+  .text:0000000180C25FDA                 mov     rax, [rcx]
+  .text:0000000180C25FDD                 call    qword ptr [rax+18h]
+  .text:0000000180C25FE0                 mov     rdi, [rsp+0C0h+arg_8]
+  .text:0000000180C25FE8                 mov     r13, [rsp+0C0h+arg_10]
+  .text:0000000180C25FF0                 add     rsp, 0B0h
+  .text:0000000180C25FF7                 pop     r14
+  .text:0000000180C25FF9                 pop     rbx
+  .text:0000000180C25FFA                 pop     rbp
+  .text:0000000180C25FFB                 retn
+procedure: |-
+  void __fastcall EntInfo_CommandHandler(__int64 a1, __int64 a2)
+  {
+    __int64 v3; // rax
+    int v4; // r14d
+    __int64 EntityByName; // rax
+    __int64 v6; // r13
+    void *v7; // rdi
+    const char *v8; // r8
+    __int64 v9; // rax
+    int v10; // ecx
+    __int64 v11; // r15
+    __int64 v12; // rsi
+    __int64 v13; // rax
+    int v14; // ecx
+    void *v15; // r8
+    __int64 v16; // r15
+    __int64 v17; // rsi
+    __int64 v18; // rax
+    int v19; // ecx
+    void *v20; // r8
+    int v21; // eax
+    __int64 v22; // rdx
+    int v23; // eax
+    __int64 v24; // rdx
+    int v25; // [rsp+40h] [rbp-29h] BYREF
+    __int64 v26; // [rsp+48h] [rbp-21h]
+    __int64 v27; // [rsp+50h] [rbp-19h]
+    int v28; // [rsp+58h] [rbp-11h] BYREF
+    __int64 v29; // [rsp+60h] [rbp-9h]
+    __int64 v30; // [rsp+68h] [rbp-1h]
+    _BYTE v31[80]; // [rsp+70h] [rbp+7h] BYREF
+
+    v3 = sub_180C0D740(a1);
+    v4 = v3;
+    if ( v3 )
+    {
+      if ( *(int *)(a2 + 1080) >= 2 )
+      {
+        EntityByName = CEntitySystem_CreateEntityByName(
+                         g_pEntitySystem,
+                         0,
+                         *(const char **)(*(_QWORD *)(a2 + 1088) + 8LL),
+                         0,
+                         -1,
+                         -1,
+                         0);
+        v6 = EntityByName;
+        if ( EntityByName )
+        {
+          v29 = 0;
+          v30 = 0;
+          v28 = 0;
+          sub_18120E8B0(*(_QWORD *)(EntityByName + 16), &v28);
+          v11 = v28;
+          if ( v28 > 0 )
+          {
+            v12 = 0;
+            do
+            {
+              v13 = CBufferString::AppendFormat(v31, "  output: %s\n", **(const char ***)(v29 + 8 * v12));
+              v14 = *(_DWORD *)(v13 + 4);
+              if ( (v14 & 0x40000000) != 0 )
+              {
+                LODWORD(v15) = v13 + 8;
+              }
+              else if ( (v14 & 0x3FFFFFFF) != 0 )
+              {
+                v15 = *(void **)(v13 + 8);
+              }
+              else
+              {
+                v15 = &unk_18159A988;
+              }
+              ClientPrintToController(v4, 2, (_DWORD)v15, 0, 0, 0, 0);
+              CBufferString::Purge((CBufferString *)v31, 0);
+              ++v12;
+            }
+            while ( v12 < v11 );
+          }
+          v26 = 0;
+          v27 = 0;
+          v25 = 0;
+          sub_18120E780(*(_QWORD *)(v6 + 16), &v25);
+          v16 = v25;
+          if ( v25 > 0 )
+          {
+            v17 = 0;
+            do
+            {
+              v18 = CBufferString::AppendFormat(v31, "  input: %s\n", *(const char **)(v26 + 8 * v17));
+              v19 = *(_DWORD *)(v18 + 4);
+              if ( (v19 & 0x40000000) != 0 )
+              {
+                LODWORD(v20) = v18 + 8;
+              }
+              else if ( (v19 & 0x3FFFFFFF) != 0 )
+              {
+                v20 = *(void **)(v18 + 8);
+              }
+              else
+              {
+                v20 = &unk_18159A988;
+              }
+              ClientPrintToController(v4, 2, (_DWORD)v20, 0, 0, 0, 0);
+              CBufferString::Purge((CBufferString *)v31, 0);
+              ++v17;
+            }
+            while ( v17 < v16 );
+          }
+          CEntitySystem_RemoveEntityImmediate(g_pEntitySystem, *(_DWORD **)(v6 + 16));
+          v21 = HIDWORD(v27);
+          v22 = v26;
+          v25 = 0;
+          if ( (v27 & 0xC000000000000000uLL) == 0 )
+          {
+            if ( v26 )
+            {
+              (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v26);
+              v21 = HIDWORD(v27);
+              v22 = 0;
+              v26 = 0;
+            }
+            LODWORD(v27) = 0;
+            if ( (v21 & 0xC0000000) == 0 )
+            {
+              if ( v22 )
+              {
+                (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+                v26 = 0;
+              }
+              LODWORD(v27) = 0;
+            }
+          }
+          v23 = HIDWORD(v30);
+          v24 = v29;
+          v28 = 0;
+          if ( (v30 & 0xC000000000000000uLL) == 0 )
+          {
+            if ( v29 )
+            {
+              (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v29);
+              v23 = HIDWORD(v30);
+              v24 = 0;
+              v29 = 0;
+            }
+            LODWORD(v30) = 0;
+            if ( (v23 & 0xC0000000) == 0 && v24 )
+              (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+          }
+        }
+        else
+        {
+          v7 = &unk_18159A988;
+          if ( *(int *)(a2 + 1080) <= 1 )
+            v8 = (const char *)&unk_18159A988;
+          else
+            v8 = *(const char **)(*(_QWORD *)(a2 + 1088) + 8LL);
+          v9 = CBufferString::AppendFormat(v31, "no such entity %s\n", v8);
+          v10 = *(_DWORD *)(v9 + 4);
+          if ( (v10 & 0x40000000) != 0 )
+          {
+            LODWORD(v7) = v9 + 8;
+          }
+          else if ( (v10 & 0x3FFFFFFF) != 0 )
+          {
+            v7 = *(void **)(v9 + 8);
+          }
+          ClientPrintToController(v4, 2, (_DWORD)v7, 0, 0, 0, 0);
+          CBufferString::Purge((CBufferString *)v31, 0);
+        }
+      }
+      else
+      {
+        ClientPrintToController(v3, 2, (unsigned int)"Usage:\n   ent_info <class name>\n", 0, 0, 0, 0);
+      }
+    }
+  }


### PR DESCRIPTION
## Summary

- Add preprocessor scripts for entity removal/lifecycle vfuncs: `CEntitySystem_RemoveEntity`, `CEntitySystem_RemoveEntityImmediate`, `CEntitySystem_NotifyRemoveEntity`, `CEntitySystem_DestroyEntityInternal`, `CEntitySystem_OnEntityParentChanged`, `CEntityInstance_UpdateOnRemove`, `CEntityInstance_OnRemoveEntity` (renamed to `CEntitySystem_OnRemoveEntity`)
- Add preprocessor scripts for scene node/skeleton vfuncs: `CGameSceneNode_PostDataUpdate`, `CSkeletonInstance_PostDataUpdate`, `CGameSceneNode_AcquireParent`, `CGameSceneNode_OnParentChanged`, `CCSPlayerPawnBase_OnSetDormant`
- Add preprocessor scripts for entity I/O: `CEntityInstance_FindOutputsByName`, `CEntityInstance_ScriptEntityIO` (slot-only vfunc)
- Add command handler scripts: `EntInfo_CommandHandler`, `SV_Kill_SmokeGrenade_CommandHandler`
- Add `_direct_branch_target_common.py` shared helper for branch-target-based function discovery
- Update `find-CGameSceneNode_PostDataUpdate` to use `INHERIT_VFUNCS` from `CSkeletonInstance_PostDataUpdate`

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures on all new scripts
- [ ] Output YAMLs verified for both Windows and Linux platforms (game version 14155)

🤖 Generated with [Claude Code](https://claude.com/claude-code)