### PR TITLE
Add CSource2Server vfunc preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2413,6 +2413,12 @@ modules:
         expected_input:
           - CCSPlayerPawn_ProcessSuicideAsKillReward.{platform}.yaml
 
+      - name: find-CSource2Server_ApplyGameSettings
+        expected_output:
+          - CSource2Server_ApplyGameSettings.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4321,6 +4327,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::Init
+
+      - name: CSource2Server_ApplyGameSettings
+        category: vfunc
+        alias:
+          - CSource2Server::ApplyGameSettings
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2437,6 +2437,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_GameServerSteamAPIActivated
+        expected_output:
+          - CSource2Server_GameServerSteamAPIActivated.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4365,6 +4371,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GetMatchmakingGameData
+
+      - name: CSource2Server_GameServerSteamAPIActivated
+        category: vfunc
+        alias:
+          - CSource2Server::GameServerSteamAPIActivated
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2461,6 +2461,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_ServerConVarChanged
+        expected_output:
+          - CSource2Server_ServerConVarChanged.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4409,6 +4415,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GetLevelsFromSaveFile
+
+      - name: CSource2Server_ServerConVarChanged
+        category: vfunc
+        alias:
+          - CSource2Server::ServerConVarChanged
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2431,6 +2431,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_GetMatchmakingGameData
+        expected_output:
+          - CSource2Server_GetMatchmakingGameData.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4354,6 +4360,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GameCreateNetworkStringTables
+
+      - name: CSource2Server_GetMatchmakingGameData
+        category: vfunc
+        alias:
+          - CSource2Server::GetMatchmakingGameData
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -584,9 +584,9 @@ modules:
           - CNetworkGameServer_vtable.{platform}.yaml
           - INetworkGameServer_ClientUpdate.{platform}.yaml
 
-      - name: find-ISource2Server_ClientUpdate
+      - name: find-ISource2Server_PreWorldUpdate
         expected_output:
-          - ISource2Server_ClientUpdate.{platform}.yaml
+          - ISource2Server_PreWorldUpdate.{platform}.yaml
         expected_input:
           - CNetworkGameServer_ClientUpdate.{platform}.yaml
 
@@ -1049,10 +1049,10 @@ modules:
         alias:
           - CNetworkGameServer::ClientUpdate
 
-      - name: ISource2Server_ClientUpdate
+      - name: ISource2Server_PreWorldUpdate
         category: vfunc
         alias:
-          - ISource2Server::ClientUpdate
+          - ISource2Server::PreWorldUpdate
         shared: true
 
       - name: ISource2Server_OutOfGameFrameBoundary
@@ -2479,18 +2479,18 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
-      - name: find-CSource2Server_ClientUpdate
+      - name: find-CSource2Server_PreWorldUpdate
         expected_output:
-          - CSource2Server_ClientUpdate.{platform}.yaml
+          - CSource2Server_PreWorldUpdate.{platform}.yaml
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
-          - ../engine/ISource2Server_ClientUpdate.{platform}.yaml
+          - ../engine/ISource2Server_PreWorldUpdate.{platform}.yaml
 
       - name: find-IGameSystem_OnServerPreClientUpdate
         expected_output:
           - IGameSystem_OnServerPreClientUpdate.{platform}.yaml
         expected_input:
-          - CSource2Server_ClientUpdate.{platform}.yaml
+          - CSource2Server_PreWorldUpdate.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
 
       - name: find-IGameSystem_OnServerPreEntityThink-AND-IGameSystem_OnServerPostEntityThink
@@ -3784,10 +3784,10 @@ modules:
       - name: CSource2Server_vtable
         category: vtable
 
-      - name: CSource2Server_ClientUpdate
+      - name: CSource2Server_PreWorldUpdate
         category: vfunc
         alias:
-          - CSource2Server::ClientUpdate
+          - CSource2Server::PreWorldUpdate
 
       - name: CSource2Server_OutOfGameFrameBoundary
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2449,6 +2449,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_OnHostNameChanged
+        expected_output:
+          - CSource2Server_OnHostNameChanged.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4387,6 +4393,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GameServerSteamAPIDeactivated
+
+      - name: CSource2Server_OnHostNameChanged
+        category: vfunc
+        alias:
+          - CSource2Server::OnHostNameChanged
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2467,6 +2467,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_Save
+        expected_output:
+          - CSource2Server_Save.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4420,6 +4426,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::ServerConVarChanged
+
+      - name: CSource2Server_Save
+        category: vfunc
+        alias:
+          - CSource2Server::Save
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2455,6 +2455,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_GetLevelsFromSaveFile
+        expected_output:
+          - CSource2Server_GetLevelsFromSaveFile.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4398,6 +4404,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::OnHostNameChanged
+
+      - name: CSource2Server_GetLevelsFromSaveFile
+        category: vfunc
+        alias:
+          - CSource2Server::GetLevelsFromSaveFile
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2473,6 +2473,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_Connect
+        expected_output:
+          - CSource2Server_Connect.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4431,6 +4437,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::Save
+
+      - name: CSource2Server_Connect
+        category: vfunc
+        alias:
+          - CSource2Server::Connect
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2443,6 +2443,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_GameServerSteamAPIDeactivated
+        expected_output:
+          - CSource2Server_GameServerSteamAPIDeactivated.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4376,6 +4382,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GameServerSteamAPIActivated
+
+      - name: CSource2Server_GameServerSteamAPIDeactivated
+        category: vfunc
+        alias:
+          - CSource2Server::GameServerSteamAPIDeactivated
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2425,6 +2425,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_GameCreateNetworkStringTables
+        expected_output:
+          - CSource2Server_GameCreateNetworkStringTables.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4343,6 +4349,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::WriteSignonMessages
+
+      - name: CSource2Server_GameCreateNetworkStringTables
+        category: vfunc
+        alias:
+          - CSource2Server::GameCreateNetworkStringTables
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2419,6 +2419,12 @@ modules:
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
 
+      - name: find-CSource2Server_WriteSignonMessages
+        expected_output:
+          - CSource2Server_WriteSignonMessages.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -4332,6 +4338,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::ApplyGameSettings
+
+      - name: CSource2Server_WriteSignonMessages
+        category: vfunc
+        alias:
+          - CSource2Server::WriteSignonMessages
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/ida_preprocessor_scripts/find-CSource2Server_ApplyGameSettings.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_ApplyGameSettings.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_ApplyGameSettings skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_ApplyGameSettings",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_ApplyGameSettings",
+        "xref_strings": [
+            "CSource2Server::ApplyGameSettings game settings payload received:",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_ApplyGameSettings", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_ApplyGameSettings",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_Connect.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_Connect.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_Connect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_Connect",
+        "xref_strings": [
+            "ERROR: CSource2Server::Connect - 'g_pCVar' is nullptr",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_Connect", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_Connect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GameCreateNetworkStringTables.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GameCreateNetworkStringTables.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GameCreateNetworkStringTables skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GameCreateNetworkStringTables",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GameCreateNetworkStringTables",
+        "xref_strings": [
+            "Forcing S1 g_pNetworkStringTable to use version from engine.dll",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_GameCreateNetworkStringTables", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_GameCreateNetworkStringTables",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GameServerSteamAPIActivated.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GameServerSteamAPIActivated.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GameServerSteamAPIActivated skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GameServerSteamAPIActivated",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GameServerSteamAPIActivated",
+        "xref_strings": [
+            "CSource2Server::GameServerSteamAPIActivated()",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_GameServerSteamAPIActivated", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_GameServerSteamAPIActivated",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GameServerSteamAPIDeactivated.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GameServerSteamAPIDeactivated.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GameServerSteamAPIDeactivated skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GameServerSteamAPIDeactivated",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GameServerSteamAPIDeactivated",
+        "xref_strings": [
+            "CSource2Server::GameServerSteamAPIDeactivated()",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_GameServerSteamAPIDeactivated", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_GameServerSteamAPIDeactivated",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GetLevelsFromSaveFile.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetLevelsFromSaveFile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GetLevelsFromSaveFile skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GetLevelsFromSaveFile",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GetLevelsFromSaveFile",
+        "xref_strings": [
+            "OpenSaveFileAndExtractLevels() failed for save file: %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_GetLevelsFromSaveFile", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_GetLevelsFromSaveFile",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GetMatchmakingGameData.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetMatchmakingGameData.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GetMatchmakingGameData skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GetMatchmakingGameData",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GetMatchmakingGameData",
+        "xref_strings": [
+            "g:cs2,gt:%u,gm:%u,sk:%u,%s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_GetMatchmakingGameData", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_GetMatchmakingGameData",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_OnHostNameChanged.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_OnHostNameChanged.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_OnHostNameChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_OnHostNameChanged",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_OnHostNameChanged",
+        "xref_strings": [
+            "FULLMATCH:hostname_changed",
+            "FULLMATCH:hostname",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_OnHostNameChanged", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_OnHostNameChanged",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_PreWorldUpdate.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_PreWorldUpdate.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CSource2Server_ClientUpdate skill."""
+"""Preprocess script for find-CSource2Server_PreWorldUpdate skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
-    ("CSource2Server_ClientUpdate", "CSource2Server", "../engine/ISource2Server_ClientUpdate", False),
+    ("CSource2Server_PreWorldUpdate", "CSource2Server", "../engine/ISource2Server_PreWorldUpdate", False),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CSource2Server_ClientUpdate",
+        "CSource2Server_PreWorldUpdate",
         [
             "func_name",
             "func_va",
@@ -34,7 +34,7 @@ async def preprocess_skill(
     image_base,
     debug=False,
 ):
-    """Reuse old vfunc slot; fallback to inheriting slot index from ISource2Server_ClientUpdate."""
+    """Reuse old vfunc slot; fallback to inheriting slot index from ISource2Server_PreWorldUpdate."""
     _ = skill_name
 
     return await preprocess_common_skill(

--- a/ida_preprocessor_scripts/find-CSource2Server_Save.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_Save.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_Save skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_Save",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_Save",
+        "xref_strings": [
+            "SV:  can't save, no IEntity2SaveRestore",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_Save", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_Save",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_ServerConVarChanged.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_ServerConVarChanged.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_ServerConVarChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_ServerConVarChanged",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_ServerConVarChanged",
+        "xref_strings": [
+            "FULLMATCH:server_cvar",
+            "FULLMATCH:cvarname",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_ServerConVarChanged", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_ServerConVarChanged",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_WriteSignonMessages.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_WriteSignonMessages.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_WriteSignonMessages skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_WriteSignonMessages",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_WriteSignonMessages",
+        "xref_strings": [
+            "CSource2Server::WriteSignonMessages: Failed to serialize Source1LegacyGameEventList_t",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_WriteSignonMessages", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_WriteSignonMessages",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystem_OnServerPreClientUpdate.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_OnServerPreClientUpdate.py
@@ -5,7 +5,7 @@ from ida_preprocessor_scripts._igamesystem_dispatch_common import (
     preprocess_igamesystem_dispatch_skill,
 )
 
-SOURCE_YAML_STEM = "CSource2Server_ClientUpdate"
+SOURCE_YAML_STEM = "CSource2Server_PreWorldUpdate"
 TARGET_SPECS = [
     {"target_name": "IGameSystem_OnServerPreClientUpdate", "rename_to": "GameSystem_OnServerPreClientUpdate"},
 ]

--- a/ida_preprocessor_scripts/find-ISource2Server_PreWorldUpdate.py
+++ b/ida_preprocessor_scripts/find-ISource2Server_PreWorldUpdate.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-ISource2Server_ClientUpdate skill."""
+"""Preprocess script for find-ISource2Server_PreWorldUpdate skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "ISource2Server_ClientUpdate",
+    "ISource2Server_PreWorldUpdate",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
-        "ISource2Server_ClientUpdate",
+        "ISource2Server_PreWorldUpdate",
         "prompt/call_llm_decompile.md",
         "references/engine/CNetworkGameServer_ClientUpdate.{platform}.yaml",
     ),
@@ -19,13 +19,13 @@ LLM_DECOMPILE = [
 # ISource2Server is an abstract interface -- no vtable YAML needed; vtable_name is metadata only
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("ISource2Server_ClientUpdate", "ISource2Server"),
+    ("ISource2Server_PreWorldUpdate", "ISource2Server"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "ISource2Server_ClientUpdate",
+        "ISource2Server_PreWorldUpdate",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ClientUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ClientUpdate.linux.yaml
@@ -9,7 +9,7 @@ disasm_code: |-
   .text:00000000006AEBAA                 jz      short locret_6AEB96
   .text:00000000006AEBAC                 mov     rax, [rdi]
   .text:00000000006AEBAF                 mov     esi, 1
-  .text:00000000006AEBB4                 mov     rax, [rax+78h]; 0x78 = 120 = ISource2Server_ClientUpdate
+  .text:00000000006AEBB4                 mov     rax, [rax+78h]; 0x78 = 120 = ISource2Server_PreWorldUpdate
   .text:00000000006AEBB8                 jmp     rax
 procedure: |-
   __int64 __fastcall CNetworkGameServer_ClientUpdate(__int64 a1)
@@ -19,7 +19,7 @@ procedure: |-
     if ( *(_DWORD *)(a1 + 56) == 3 )
     {
       if ( g_pSource2Server )
-        return (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pSource2Server + 120LL))(g_pSource2Server, 1);// 0x78 = 120 = ISource2Server_ClientUpdate
+        return (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pSource2Server + 120LL))(g_pSource2Server, 1);// 0x78 = 120 = ISource2Server_PreWorldUpdate
     }
     return result;
   }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ClientUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ClientUpdate.windows.yaml
@@ -8,8 +8,8 @@ disasm_code: |-
   .text:00000001800ABA50                 jz      short locret_1800ABA5B
   .text:00000001800ABA52                 mov     rax, [rcx]
   .text:00000001800ABA55                 mov     dl, 1
-  .text:00000001800ABA57                 ; 0x78 = 120LL = ISource2Server_ClientUpdate
-  .text:00000001800ABA57                 jmp     qword ptr [rax+78h]; 0x78 = 120LL = ISource2Server_ClientUpdate
+  .text:00000001800ABA57                 ; 0x78 = 120LL = ISource2Server_PreWorldUpdate
+  .text:00000001800ABA57                 jmp     qword ptr [rax+78h]; 0x78 = 120LL = ISource2Server_PreWorldUpdate
   .text:00000001800ABA5B                 retn
 procedure: |-
   __int64 __fastcall CNetworkGameServer_ClientUpdate(__int64 a1, __int64 a2)
@@ -21,7 +21,7 @@ procedure: |-
       if ( g_pSource2Server )
       {
         LOBYTE(a2) = 1;
-        return (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pSource2Server + 120LL))(g_pSource2Server, a2);// 0x78 = 120LL = ISource2Server_ClientUpdate
+        return (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pSource2Server + 120LL))(g_pSource2Server, a2);// 0x78 = 120LL = ISource2Server_PreWorldUpdate
       }
     }
     return result;


### PR DESCRIPTION
## Summary

- Add preprocessor scripts to find `CSource2Server` virtual functions via xref strings and vtable relations
- Covers 10 new vfuncs plus a rename of `ClientUpdate` → `PreWorldUpdate` for `ISource2Server`/`CSource2Server`

## Scripts added

| Script | Discovery | Vtable index |
|--------|-----------|-------------|
| `find-CSource2Server_ApplyGameSettings` | xref string | — |
| `find-CSource2Server_WriteSignonMessages` | xref string | — |
| `find-CSource2Server_GameCreateNetworkStringTables` | xref string | — |
| `find-CSource2Server_GetMatchmakingGameData` | xref string | — |
| `find-CSource2Server_GameServerSteamAPIActivated` | xref string | — |
| `find-CSource2Server_GameServerSteamAPIDeactivated` | xref string | — |
| `find-CSource2Server_OnHostNameChanged` | xref string | — |
| `find-CSource2Server_GetLevelsFromSaveFile` | xref string | — |
| `find-CSource2Server_ServerConVarChanged` | xref string | — |
| `find-CSource2Server_Save` | xref string | 57 (0x1c8) |
| `find-CSource2Server_Connect` | xref string | 0 (0x0) |

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures on both Windows and Linux platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)