### PR TITLE
rename IGameSystem vfunc symbols to consistent naming convention

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1428,10 +1428,10 @@ modules:
           - CLoopModeGame_OnClientPauseSimulate.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
 
-      - name: find-IGameSystem_OnPreClientUpdate-AND-IGameSystem_OnClientUpdate
+      - name: find-IGameSystem_OnClientPreUpdate-AND-IGameSystem_OnClientPostUpdate
         expected_output:
-          - IGameSystem_OnPreClientUpdate.{platform}.yaml
-          - IGameSystem_OnClientUpdate.{platform}.yaml
+          - IGameSystem_OnClientPreUpdate.{platform}.yaml
+          - IGameSystem_OnClientPostUpdate.{platform}.yaml
         expected_input:
           - CLoopModeGame_OnClientSimulate.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
@@ -1485,10 +1485,10 @@ modules:
           - CLoopModeGame_OnClientPostOutput.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
 
-      - name: find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderEx
+      - name: find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderAlt
         expected_output:
           - IGameSystem_OnClientPreRender.{platform}.yaml
-          - IGameSystem_OnClientPreRenderEx.{platform}.yaml
+          - IGameSystem_OnClientPreRenderAlt.{platform}.yaml
         expected_input:
           - CLoopModeGame_OnClientPreOutput.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
@@ -1805,15 +1805,15 @@ modules:
         alias:
           - IGameSystem::OnClientPauseSimulate
 
-      - name: IGameSystem_OnPreClientUpdate
+      - name: IGameSystem_OnClientPreUpdate
         category: vfunc
         alias:
-          - IGameSystem::OnPreClientUpdate
+          - IGameSystem::OnClientPreUpdate
 
-      - name: IGameSystem_OnClientUpdate
+      - name: IGameSystem_OnClientPostUpdate
         category: vfunc
         alias:
-          - IGameSystem::OnClientUpdate
+          - IGameSystem::OnClientPostUpdate
 
       - name: IGameSystem_OnClientPostDataUpdate
         category: vfunc
@@ -1855,10 +1855,10 @@ modules:
         alias:
           - IGameSystem::OnClientPreRender
 
-      - name: IGameSystem_OnClientPreRenderEx
+      - name: IGameSystem_OnClientPreRenderAlt
         category: vfunc
         alias:
-          - IGameSystem::OnClientPreRenderEx
+          - IGameSystem::OnClientPreRenderAlt
 
       - name: CSource2Client_vtable
         category: vtable
@@ -3679,10 +3679,10 @@ modules:
           - CLoopModeGame_OnServerBeginAsyncPostTickWork.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
 
-      - name: find-IGameSystem_OnBeforeServerEndAsyncPostTickWork-AND-IGameSystem_OnServerEndAsyncPostTickWork
+      - name: find-IGameSystem_OnServerPreEndAsyncPostTickWork-AND-IGameSystem_OnServerPostEndAsyncPostTickWork
         expected_output:
-          - IGameSystem_OnBeforeServerEndAsyncPostTickWork.{platform}.yaml
-          - IGameSystem_OnServerEndAsyncPostTickWork.{platform}.yaml
+          - IGameSystem_OnServerPreEndAsyncPostTickWork.{platform}.yaml
+          - IGameSystem_OnServerPostEndAsyncPostTickWork.{platform}.yaml
         expected_input:
           - CLoopModeGame_OnServerEndAsyncPostTickWork.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
@@ -4907,15 +4907,15 @@ modules:
         alias:
           - IGameSystem::OnServerBeginAsyncPostTickWork
 
-      - name: IGameSystem_OnBeforeServerEndAsyncPostTickWork
+      - name: IGameSystem_OnServerPreEndAsyncPostTickWork
         category: vfunc
         alias:
-          - IGameSystem::OnBeforeServerEndAsyncPostTickWork
+          - IGameSystem::OnServerPreEndAsyncPostTickWork
 
-      - name: IGameSystem_OnServerEndAsyncPostTickWork
+      - name: IGameSystem_OnServerPostEndAsyncPostTickWork
         category: vfunc
         alias:
-          - IGameSystem::OnServerEndAsyncPostTickWork
+          - IGameSystem::OnServerPostEndAsyncPostTickWork
 
       - name: IGameSystem_OnOutOfGameFrameBoundary
         category: vfunc

--- a/ida_preprocessor_scripts/find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderAlt.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderAlt.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystem_OnPreClientUpdate-AND-IGameSystem_OnClientUpdate skill."""
+"""Preprocess script for find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderAlt skill."""
 
 from ida_preprocessor_scripts._igamesystem_dispatch_common import (
     preprocess_igamesystem_dispatch_skill,
 )
 
-SOURCE_YAML_STEM = "CLoopModeGame_OnClientSimulate"
+SOURCE_YAML_STEM = "CLoopModeGame_OnClientPreOutput"
 TARGET_SPECS = [
-    {"target_name": "IGameSystem_OnPreClientUpdate", "rename_to": "GameSystem_OnPreClientUpdate"},
-    {"target_name": "IGameSystem_OnClientUpdate", "rename_to": "GameSystem_OnClientUpdate"},
+    {"target_name": "IGameSystem_OnClientPreRender", "rename_to": "GameSystem_OnClientPreRender"},
+    {"target_name": "IGameSystem_OnClientPreRenderAlt", "rename_to": "GameSystem_OnClientPreRenderAlt"},
 ]
-VIA_INTERNAL_WRAPPER = False
-INTERNAL_RENAME_TO = None
-MULTI_ORDER = "scan"
+VIA_INTERNAL_WRAPPER = True
+INTERNAL_RENAME_TO = "CLoopModeGame_OnClientPreOutputInternal"
+MULTI_ORDER = "index"
 
 
 async def preprocess_skill(

--- a/ida_preprocessor_scripts/find-IGameSystem_OnClientPreUpdate-AND-IGameSystem_OnClientPostUpdate.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_OnClientPreUpdate-AND-IGameSystem_OnClientPostUpdate.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystem_OnBeforeServerEndAsyncPostTickWork-AND-IGameSystem_OnServerEndAsyncPostTickWork skill."""
+"""Preprocess script for find-IGameSystem_OnClientPreUpdate-AND-IGameSystem_OnClientPostUpdate skill."""
 
 from ida_preprocessor_scripts._igamesystem_dispatch_common import (
     preprocess_igamesystem_dispatch_skill,
 )
 
-SOURCE_YAML_STEM = "CLoopModeGame_OnServerEndAsyncPostTickWork"
+SOURCE_YAML_STEM = "CLoopModeGame_OnClientSimulate"
 TARGET_SPECS = [
-    {"target_name": "IGameSystem_OnBeforeServerEndAsyncPostTickWork", "rename_to": "GameSystem_OnBeforeServerEndAsyncPostTickWork"},
-    {"target_name": "IGameSystem_OnServerEndAsyncPostTickWork", "rename_to": "GameSystem_OnServerEndAsyncPostTickWork"},
+    {"target_name": "IGameSystem_OnClientPreUpdate", "rename_to": "GameSystem_OnClientPreUpdate"},
+    {"target_name": "IGameSystem_OnClientPostUpdate", "rename_to": "GameSystem_OnClientPostUpdate"},
 ]
 VIA_INTERNAL_WRAPPER = False
 INTERNAL_RENAME_TO = None
-MULTI_ORDER = "index"
+MULTI_ORDER = "scan"
 
 
 async def preprocess_skill(

--- a/ida_preprocessor_scripts/find-IGameSystem_OnServerPreEndAsyncPostTickWork-AND-IGameSystem_OnServerPostEndAsyncPostTickWork.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_OnServerPreEndAsyncPostTickWork-AND-IGameSystem_OnServerPostEndAsyncPostTickWork.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystem_OnClientPreRender-AND-IGameSystem_OnClientPreRenderEx skill."""
+"""Preprocess script for find-IGameSystem_OnServerPreEndAsyncPostTickWork-AND-IGameSystem_OnServerPostEndAsyncPostTickWork skill."""
 
 from ida_preprocessor_scripts._igamesystem_dispatch_common import (
     preprocess_igamesystem_dispatch_skill,
 )
 
-SOURCE_YAML_STEM = "CLoopModeGame_OnClientPreOutput"
+SOURCE_YAML_STEM = "CLoopModeGame_OnServerEndAsyncPostTickWork"
 TARGET_SPECS = [
-    {"target_name": "IGameSystem_OnClientPreRender", "rename_to": "GameSystem_OnClientPreRender"},
-    {"target_name": "IGameSystem_OnClientPreRenderEx", "rename_to": "GameSystem_OnClientPreRenderEx"},
+    {"target_name": "IGameSystem_OnServerPreEndAsyncPostTickWork", "rename_to": "GameSystem_OnServerPreEndAsyncPostTickWork"},
+    {"target_name": "IGameSystem_OnServerPostEndAsyncPostTickWork", "rename_to": "GameSystem_OnServerPostEndAsyncPostTickWork"},
 ]
-VIA_INTERNAL_WRAPPER = True
-INTERNAL_RENAME_TO = "CLoopModeGame_OnClientPreOutputInternal"
+VIA_INTERNAL_WRAPPER = False
+INTERNAL_RENAME_TO = None
 MULTI_ORDER = "index"
 
 


### PR DESCRIPTION
## Summary

- `IGameSystem_OnClientPreRenderEx` → `IGameSystem_OnClientPreRenderAlt`
- `IGameSystem_OnPreClientUpdate` → `IGameSystem_OnClientPreUpdate`
- `IGameSystem_OnClientUpdate` → `IGameSystem_OnClientPostUpdate`
- `IGameSystem_OnBeforeServerEndAsyncPostTickWork` → `IGameSystem_OnServerPreEndAsyncPostTickWork`
- `IGameSystem_OnServerEndAsyncPostTickWork` → `IGameSystem_OnServerPostEndAsyncPostTickWork`

Applies consistent `Pre`/`Post` positional naming to all affected IGameSystem vfunc symbols, preprocessor scripts, config.yaml entries, and per-gamever output YAMLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)