### PR TITLE
Add CSource2GameClients vfunc and related preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2253,6 +2253,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_SendHLTVStatusMessage
+        expected_output:
+          - CSource2GameClients_SendHLTVStatusMessage.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4223,6 +4229,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientDiagnostic
+
+      - name: CSource2GameClients_SendHLTVStatusMessage
+        category: vfunc
+        alias:
+          - CSource2GameClients::SendHLTVStatusMessage
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2259,6 +2259,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_OnClientConnected
+        expected_output:
+          - CSource2GameClients_OnClientConnected.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4234,6 +4240,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::SendHLTVStatusMessage
+
+      - name: CSource2GameClients_OnClientConnected
+        category: vfunc
+        alias:
+          - CSource2GameClients::OnClientConnected
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2217,6 +2217,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_ClientActive
+        expected_output:
+          - CSource2GameClients_ClientActive.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4157,6 +4163,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientPutInServer
+
+      - name: CSource2GameClients_ClientActive
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientActive
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2229,6 +2229,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_ClientCommand
+        expected_output:
+          - CSource2GameClients_ClientCommand.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4179,6 +4185,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientFullyConnect
+
+      - name: CSource2GameClients_ClientCommand
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientCommand
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2223,6 +2223,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_ClientFullyConnect
+        expected_output:
+          - CSource2GameClients_ClientFullyConnect.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4168,6 +4174,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientActive
+
+      - name: CSource2GameClients_ClientFullyConnect
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientFullyConnect
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2247,6 +2247,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_ClientDiagnostic
+        expected_output:
+          - CSource2GameClients_ClientDiagnostic.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4212,6 +4218,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::GetBugReportInfo
+
+      - name: CSource2GameClients_ClientDiagnostic
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientDiagnostic
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2235,6 +2235,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_ProcessUsercmds
+        expected_output:
+          - CSource2GameClients_ProcessUsercmds.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4190,6 +4196,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientCommand
+
+      - name: CSource2GameClients_ProcessUsercmds
+        category: vfunc
+        alias:
+          - CSource2GameClients::ProcessUsercmds
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2217,6 +2217,10 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-ClientPutInServer
+        expected_output:
+          - ClientPutInServer.{platform}.yaml
+
       - name: find-CSource2GameClients_ClientActive
         expected_output:
           - CSource2GameClients_ClientActive.{platform}.yaml
@@ -4205,6 +4209,9 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ClientPutInServer
+
+      - name: ClientPutInServer
+        category: func
 
       - name: CSource2GameClients_ClientActive
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2241,6 +2241,12 @@ modules:
         expected_input:
           - CSource2GameClients_vtable.{platform}.yaml
 
+      - name: find-CSource2GameClients_GetBugReportInfo
+        expected_output:
+          - CSource2GameClients_GetBugReportInfo.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CBasePlayerController_SetPawn-AND-CBasePlayerController_GetPawn
         expected_output:
           - CBasePlayerController_SetPawn.{platform}.yaml
@@ -4201,6 +4207,11 @@ modules:
         category: vfunc
         alias:
           - CSource2GameClients::ProcessUsercmds
+
+      - name: CSource2GameClients_GetBugReportInfo
+        category: vfunc
+        alias:
+          - CSource2GameClients::GetBugReportInfo
 
       - name: FireTarget_CommandHandler
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2221,6 +2221,14 @@ modules:
         expected_output:
           - ClientPutInServer.{platform}.yaml
 
+      - name: find-CSource2GameClients_ClientConnect
+        expected_output:
+          - CSource2GameClients_ClientConnect.{platform}.yaml
+        expected_input:
+          - ClientPutInServer.{platform}.yaml
+          - CSource2GameClients_ClientPutInServer.{platform}.yaml
+          - CSource2GameClients_vtable.{platform}.yaml
+
       - name: find-CSource2GameClients_ClientActive
         expected_output:
           - CSource2GameClients_ClientActive.{platform}.yaml
@@ -4212,6 +4220,11 @@ modules:
 
       - name: ClientPutInServer
         category: func
+
+      - name: CSource2GameClients_ClientConnect
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientConnect
 
       - name: CSource2GameClients_ClientActive
         category: vfunc

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientActive.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientActive.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientActive skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientActive",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ClientActive",
+        "xref_strings": [
+            "FULLMATCH:player_activate",
+            "FULLMATCH:userid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientActive", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ClientActive",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientCommand.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientCommand.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientCommand skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientCommand",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ClientCommand",
+        "xref_strings": [
+            "Console command too long.",
+            "Unknown command: %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientCommand", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ClientCommand",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientConnect.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientConnect.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientConnect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientConnect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ClientConnect",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["ClientPutInServer"],
+        "exclude_funcs": ["CSource2GameClients_ClientPutInServer"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientConnect", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ClientConnect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientDiagnostic.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientDiagnostic.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientDiagnostic skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientDiagnostic",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ClientDiagnostic",
+        "xref_strings": [
+            "Received system specs from player %d '%s'",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientDiagnostic", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ClientDiagnostic",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientFullyConnect.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientFullyConnect.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientFullyConnect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientFullyConnect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ClientFullyConnect",
+        "xref_strings": [
+            "FULLMATCH:player_connect_full",
+            "FULLMATCH:userid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientFullyConnect", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ClientFullyConnect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_GetBugReportInfo.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_GetBugReportInfo.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_GetBugReportInfo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_GetBugReportInfo",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_GetBugReportInfo",
+        "xref_strings": [
+            "Picker %i/%s - ent %s model %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_GetBugReportInfo", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_GetBugReportInfo",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_OnClientConnected.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_OnClientConnected.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_OnClientConnected skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_OnClientConnected",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_OnClientConnected",
+        "xref_strings": [
+            "FULLMATCH:player_connect",
+            "FULLMATCH:networkid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_OnClientConnected", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_OnClientConnected",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ProcessUsercmds.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ProcessUsercmds.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ProcessUsercmds skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ProcessUsercmds",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_ProcessUsercmds",
+        "xref_strings": [
+            "[%s] sent command that failed delta decode, discarding move msg",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ProcessUsercmds", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_ProcessUsercmds",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_SendHLTVStatusMessage.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_SendHLTVStatusMessage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_SendHLTVStatusMessage skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_SendHLTVStatusMessage",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameClients_SendHLTVStatusMessage",
+        "xref_strings": [
+            "FULLMATCH:hltv_message",
+            "SourceTV reconnecting ...",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_SendHLTVStatusMessage", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameClients_SendHLTVStatusMessage",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-ClientPutInServer.py
+++ b/ida_preprocessor_scripts/find-ClientPutInServer.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-ClientPutInServer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ClientPutInServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "ClientPutInServer",
+        "xref_strings": [
+            "ClientPutInServer reconnecting player controller [%s]",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": ["83 ?? 02 74 ??"],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "ClientPutInServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CSource2GameClients_ClientActive` (Pattern B, xref: `player_activate`, `userid`)
- Add `find-CSource2GameClients_ClientFullyConnect` (Pattern B, xref: `player_connect_full`, `userid`)
- Add `find-CSource2GameClients_ClientCommand` (Pattern B, xref: `Console command too long.`, `Unknown command: %s`)
- Add `find-CSource2GameClients_ProcessUsercmds` (Pattern B, xref: delta decode discard msg)
- Add `find-CSource2GameClients_GetBugReportInfo` (Pattern B, xref: `Picker %i/%s - ent %s model %s`)
- Add `find-CSource2GameClients_ClientDiagnostic` (Pattern B, xref: system specs msg)
- Add `find-CSource2GameClients_SendHLTVStatusMessage` (Pattern B, xref: `hltv_message`, `SourceTV reconnecting ...`)
- Add `find-CSource2GameClients_OnClientConnected` (Pattern B, xref: `player_connect`, `networkid`)
- Add `find-ClientPutInServer` (Pattern A, regular func, xref string + exclude_signatures)
- Add `find-CSource2GameClients_ClientConnect` (Pattern B, xref_funcs: `ClientPutInServer`, exclude_funcs: `CSource2GameClients_ClientPutInServer`)

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures for all new scripts (both platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)