### PR TITLE
下沉 OpenAI client 创建到 call_llm_text

### DIFF
--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -18,13 +18,11 @@ except ImportError:
 try:
     from ida_llm_utils import (
         call_llm_text,
-        create_openai_client,
         normalize_optional_effort,
         normalize_optional_temperature,
     )
 except Exception:
     call_llm_text = None
-    create_openai_client = None
     normalize_optional_effort = None
     normalize_optional_temperature = None
 
@@ -2469,11 +2467,6 @@ def _prepare_llm_decompile_request(
         default=8.0,
     )
 
-    if fake_as != "codex" and not callable(create_openai_client):
-        if debug:
-            print(f"    Preprocess: create_openai_client unavailable for {func_name}")
-        return None
-
     if isinstance(llm_spec, dict):
         llm_specs = [llm_spec]
     elif isinstance(llm_spec, (tuple, list)) and llm_spec:
@@ -2602,25 +2595,6 @@ def _prepare_llm_decompile_request(
     reference_yaml_path = reference_yaml_paths[0]
     target_func_name = target_func_names[0]
 
-    if fake_as == "codex":
-        client = None
-    else:
-        try:
-            client = create_openai_client(
-                api_key,
-                base_url,
-                api_key_required_message=(
-                    "llm_config.api_key is required for llm_decompile fallback"
-                ),
-            )
-        except Exception as exc:
-            if debug:
-                print(
-                    f"    Preprocess: llm_decompile client unavailable for "
-                    f"{func_name}: {exc}"
-                )
-            return None
-
     if debug:
         print(
             f"    Preprocess: llm_decompile request ready for {func_name}: "
@@ -2635,7 +2609,6 @@ def _prepare_llm_decompile_request(
         )
 
     return {
-        "client": client,
         "model": model,
         "prompt_path": os.fspath(prompt_path),
         "reference_items": reference_items,
@@ -2683,9 +2656,9 @@ def _build_llm_decompile_request_cache_key(llm_request):
 
 
 async def call_llm_decompile(
-    client,
-    model,
-    symbol_name_list,
+    client=None,
+    model=None,
+    symbol_name_list=None,
     disasm_code="",
     procedure="",
     disasm_for_reference="",
@@ -2785,7 +2758,6 @@ async def call_llm_decompile(
             debug=True,
         )
     request_kwargs = {
-        "client": client,
         "model": str(model).strip(),
         "messages": [
             {"role": "system", "content": system_prompt},
@@ -2793,6 +2765,8 @@ async def call_llm_decompile(
         ],
         "debug": debug,
     }
+    if client is not None:
+        request_kwargs["client"] = client
     try:
         normalized_temperature = temperature
         if normalized_temperature is not None and callable(normalize_optional_temperature):
@@ -8435,7 +8409,6 @@ async def preprocess_common_skill(
             )
             primary_target_detail = llm_target_details[0]
             return await call_llm_decompile(
-                client=llm_request["client"],
                 model=llm_request["model"],
                 symbol_name_list=llm_symbol_name_list,
                 disasm_code=primary_target_detail.get("disasm_code", ""),

--- a/ida_llm_utils.py
+++ b/ida_llm_utils.py
@@ -294,6 +294,15 @@ def call_llm_text(
             temperature=temperature,
         )
 
+    if client is None:
+        client = create_openai_client(
+            api_key,
+            base_url,
+            api_key_required_message=(
+                "api_key is required for OpenAI-compatible LLM requests"
+            ),
+        )
+
     request_kwargs = {
         "model": require_nonempty_text(model, "model"),
         "messages": messages,

--- a/ida_vcall_finder.py
+++ b/ida_vcall_finder.py
@@ -13,7 +13,6 @@ import yaml
 from ida_analyze_util import build_remote_text_export_py_eval, parse_mcp_result
 from ida_llm_utils import (
     call_llm_text,
-    create_openai_client,
     normalize_optional_temperature,
     require_nonempty_text,
 )
@@ -270,13 +269,14 @@ def call_openai_for_vcalls(
     started_at = time.monotonic()
     request_kwargs = {
         "model": model,
-        "client": client,
         "messages": [
             {"role": "system", "content": "You are a reverse engineering expert."},
             {"role": "user", "content": render_vcall_prompt(detail)},
         ],
         "debug": debug,
     }
+    if client is not None:
+        request_kwargs["client"] = client
     normalized_temperature = normalize_optional_temperature(temperature)
     if normalized_temperature is not None:
         request_kwargs["temperature"] = normalized_temperature
@@ -305,7 +305,6 @@ def call_openai_for_vcalls(
 
 def _aggregate_vcall_detail_file(
     *,
-    client_ref,
     api_key,
     base_url,
     temperature,
@@ -340,14 +339,8 @@ def _aggregate_vcall_detail_file(
                 debug,
             )
         else:
-            llm_client = _get_or_create_llm_client(
-                client_ref,
-                api_key=api_key,
-                base_url=base_url,
-                fake_as=fake_as,
-            )
             found_vcall = call_openai_for_vcalls(
-                llm_client,
+                None,
                 detail,
                 model,
                 temperature=temperature,
@@ -394,7 +387,6 @@ def _aggregate_vcall_detail_file(
 
 def _aggregate_vcall_detail_paths(
     *,
-    client_ref,
     api_key,
     base_url,
     temperature,
@@ -412,7 +404,6 @@ def _aggregate_vcall_detail_paths(
     for detail_index, detail_path in enumerate(detail_paths, start=1):
         request_label = f"[{detail_index}/{total_paths}] '{detail_path}'"
         success = _aggregate_vcall_detail_file(
-            client_ref=client_ref,
             api_key=api_key,
             base_url=base_url,
             temperature=temperature,
@@ -453,7 +444,6 @@ def aggregate_vcall_results_for_object(
         return {"status": "skipped", "processed": 0, "failed": 0}
 
     initialize_vcall_summary_stream(summary_path)
-    client_ref = {"client": client}
     _print_vcall_debug(f"summary stream reset '{summary_path}'", debug)
     _print_vcall_debug(
         "OpenAI aggregation "
@@ -463,7 +453,6 @@ def aggregate_vcall_results_for_object(
     )
 
     processed, failed = _aggregate_vcall_detail_paths(
-        client_ref=client_ref,
         api_key=api_key,
         base_url=base_url,
         temperature=temperature,
@@ -565,27 +554,6 @@ def _read_cached_found_vcalls(detail: Mapping[str, Any]) -> tuple[bool, list[dic
     if "found_vcall" not in detail_data:
         return False, []
     return True, normalize_found_vcalls(detail_data.get("found_vcall"))
-
-
-def _get_or_create_llm_client(
-    client_ref: dict[str, Any],
-    *,
-    api_key: str | None,
-    base_url: str | None,
-    fake_as: str | None,
-):
-    if str(fake_as or "").strip().lower() == "codex":
-        return None
-
-    llm_client = client_ref.get("client")
-    if llm_client is None:
-        llm_client = create_openai_client(
-            api_key=api_key,
-            base_url=base_url,
-            api_key_required_message="-llm_apikey is required when -vcall_finder is enabled",
-        )
-        client_ref["client"] = llm_client
-    return llm_client
 
 
 def _resolve_vcall_aggregation_status(processed: int, failed: int) -> str:

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -5073,7 +5073,7 @@ found_struct_offset: []
                 )
 
         self.assertIsNotNone(request)
-        self.assertIsNone(request["client"])
+        self.assertNotIn("client", request)
         self.assertEqual("codex", request["fake_as"])
         self.assertEqual("high", request["effort"])
         self.assertEqual("test-api-key", request["api_key"])
@@ -6880,7 +6880,6 @@ found_struct_offset: []
                     "procedure": "return this->vfptr[13](this);",
                 },
             )
-            fake_client = object()
             expected_detail_export_code = _function_detail_export_py_eval(
                 target_detail_payload["func_va"]
             )
@@ -6907,11 +6906,6 @@ found_struct_offset: []
                 ida_analyze_util,
                 "_get_preprocessor_scripts_dir",
                 return_value=preprocessor_dir,
-            ), patch.object(
-                ida_analyze_util,
-                "create_openai_client",
-                return_value=fake_client,
-                create=True,
             ), patch.object(
                 ida_analyze_util,
                 "preprocess_func_sig_via_mcp",
@@ -6997,7 +6991,7 @@ found_struct_offset: []
 
         self.assertTrue(result)
         mock_call_llm_decompile.assert_awaited_once()
-        self.assertIs(fake_client, mock_call_llm_decompile.call_args.kwargs["client"])
+        self.assertNotIn("client", mock_call_llm_decompile.call_args.kwargs)
         self.assertEqual(
             "gpt-4.1-mini",
             mock_call_llm_decompile.call_args.kwargs["model"],

--- a/tests/test_ida_llm_utils.py
+++ b/tests/test_ida_llm_utils.py
@@ -175,6 +175,44 @@ class TestCallLlmText(unittest.TestCase):
             reasoning_effort="medium",
         )
 
+    @patch("ida_llm_utils.create_openai_client")
+    def test_call_llm_text_creates_request_client_when_missing(
+        self,
+        mock_create_openai_client,
+    ) -> None:
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="done"))]
+        )
+        create = MagicMock(return_value=response)
+        client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=create),
+            )
+        )
+        mock_create_openai_client.return_value = client
+        messages = [{"role": "user", "content": "hello"}]
+
+        text = ida_llm_utils.call_llm_text(
+            model="gpt-5.4",
+            messages=messages,
+            api_key="test-api-key",
+            base_url="https://example.invalid/v1",
+        )
+
+        self.assertEqual("done", text)
+        mock_create_openai_client.assert_called_once_with(
+            "test-api-key",
+            "https://example.invalid/v1",
+            api_key_required_message=(
+                "api_key is required for OpenAI-compatible LLM requests"
+            ),
+        )
+        create.assert_called_once_with(
+            model="gpt-5.4",
+            messages=messages,
+            reasoning_effort="medium",
+        )
+
 
 class _CodexHandler(BaseHTTPRequestHandler):
     content_type = "text/event-stream"

--- a/tests/test_ida_vcall_finder.py
+++ b/tests/test_ida_vcall_finder.py
@@ -221,13 +221,10 @@ found_vcall:
 
 class TestAggregateVcallResultsForObject(unittest.TestCase):
     @patch("ida_vcall_finder.call_llm_text")
-    @patch("ida_vcall_finder.create_openai_client")
-    def test_aggregate_vcall_results_for_object_uses_shared_client_factory(
+    def test_aggregate_vcall_results_for_object_passes_request_credentials(
         self,
-        mock_create_openai_client,
         mock_call_llm_text,
     ) -> None:
-        mock_create_openai_client.return_value = object()
         mock_call_llm_text.return_value = """
 found_vcall:
   - insn_va: 0x12345678
@@ -269,11 +266,6 @@ found_vcall:
             )
 
             self.assertEqual({"status": "success", "processed": 1, "failed": 0}, stats)
-            mock_create_openai_client.assert_called_once_with(
-                api_key="test-api-key",
-                base_url="https://example.invalid/v1",
-                api_key_required_message="-llm_apikey is required when -vcall_finder is enabled",
-            )
             saved_detail = ida_vcall_finder.load_yaml_file(detail_path)
             self.assertEqual(
                 [
@@ -293,15 +285,21 @@ found_vcall:
             self.assertIn("insn_va: '0x12345678'", summary_text)
             self.assertIn("func_name: sub_2000", summary_text)
             self.assertEqual(0.45, mock_call_llm_text.call_args.kwargs["temperature"])
+            self.assertEqual(
+                "test-api-key",
+                mock_call_llm_text.call_args.kwargs["api_key"],
+            )
+            self.assertEqual(
+                "https://example.invalid/v1",
+                mock_call_llm_text.call_args.kwargs["base_url"],
+            )
+            self.assertNotIn("client", mock_call_llm_text.call_args.kwargs)
 
     @patch("ida_vcall_finder.call_openai_for_vcalls")
-    @patch("ida_vcall_finder._get_or_create_llm_client")
     def test_aggregate_vcall_results_for_object_forwards_effort_and_codex(
         self,
-        mock_get_or_create_llm_client,
         mock_call_openai_for_vcalls,
     ) -> None:
-        mock_get_or_create_llm_client.return_value = None
         mock_call_openai_for_vcalls.return_value = [
             {
                 "insn_va": "0x12345678",
@@ -346,17 +344,8 @@ found_vcall:
             )
 
         self.assertEqual({"status": "success", "processed": 1, "failed": 0}, stats)
-        mock_get_or_create_llm_client.assert_called_once()
-        self.assertEqual("codex", mock_get_or_create_llm_client.call_args.kwargs["fake_as"])
-        self.assertEqual(
-            "test-api-key",
-            mock_get_or_create_llm_client.call_args.kwargs["api_key"],
-        )
-        self.assertEqual(
-            "https://example.invalid/v1",
-            mock_get_or_create_llm_client.call_args.kwargs["base_url"],
-        )
         mock_call_openai_for_vcalls.assert_called_once()
+        self.assertIsNone(mock_call_openai_for_vcalls.call_args.args[0])
         self.assertEqual("high", mock_call_openai_for_vcalls.call_args.kwargs["effort"])
         self.assertEqual("codex", mock_call_openai_for_vcalls.call_args.kwargs["fake_as"])
         self.assertEqual(
@@ -368,27 +357,6 @@ found_vcall:
             mock_call_openai_for_vcalls.call_args.kwargs["base_url"],
         )
         self.assertEqual(0.45, mock_call_openai_for_vcalls.call_args.kwargs["temperature"])
-
-    @patch("ida_vcall_finder.create_openai_client")
-    def test_get_or_create_llm_client_skips_client_factory_for_codex(
-        self,
-        mock_create_openai_client,
-    ) -> None:
-        mock_create_openai_client.side_effect = AssertionError(
-            "should not be called in codex mode"
-        )
-
-        client_ref = {"client": None}
-        llm_client = ida_vcall_finder._get_or_create_llm_client(
-            client_ref,
-            api_key="test-api-key",
-            base_url="https://example.invalid/v1",
-            fake_as="codex",
-        )
-
-        self.assertIsNone(llm_client)
-        self.assertIsNone(client_ref["client"])
-        mock_create_openai_client.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Move OpenAI-compatible client creation into `call_llm_text` when no explicit client is provided.
- Stop pre-creating or sharing LLM clients in `llm_decompile` and `ida_vcall_finder` flows.
- Update tests to assert request-level credential forwarding and client creation semantics.

## Verification
- `git diff --check -- ida_llm_utils.py ida_analyze_util.py ida_vcall_finder.py tests\test_ida_llm_utils.py tests\test_ida_analyze_util.py tests\test_ida_vcall_finder.py`
- `python -m py_compile ida_llm_utils.py ida_analyze_util.py ida_vcall_finder.py tests\test_ida_llm_utils.py tests\test_ida_analyze_util.py tests\test_ida_vcall_finder.py`

## Notes
- Full test/build commands were not run because the repository instructions say not to run them unless explicitly requested.