### PR TITLE
Add SDL3 mouse preprocessor scripts (windows)

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -125,3 +125,14 @@ ls_specific_settings: {}
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,7 @@ modules:
           - SDL_mouse_initialized.{platform}.yaml            # gv
           - SDL_Mouse_was_touch_mouse_events.{platform}.yaml # F0h     bool was_touch_mouse_events;
           - SDL_Mouse_cursor_visible.{platform}.yaml         # 128h bool cursor_visible;
+          - SDL_MouseWarpEmulationChanged.{platform}.yaml    # func
         platform: windows
 
     symbols:
@@ -49,6 +50,9 @@ modules:
         category: structmember
         struct: SDL_Mouse
         member: cursor_visible
+
+      - name: SDL_MouseWarpEmulationChanged
+        category: func
         
   - name: vphysics2
     path_windows: game/bin/win64/vphysics2.dll

--- a/config.yaml
+++ b/config.yaml
@@ -14,7 +14,7 @@ modules:
           - SDL_QuitMouse.{platform}.yaml
         platform: windows
 
-      - name: find-SDL_GetMouse-AND-SDL_mouse_initialized-windows # by LLM_DECOMPILE SDL_PreInitMouse, 
+      - name: find-SDL_GetMouse-AND-SDL_mouse_initialized-windows # by LLM_DECOMPILE SDL_PreInitMouse
         expected_input:
           - SDL_PreInitMouse.{platform}.yaml
         expected_output:
@@ -23,6 +23,21 @@ modules:
           - SDL_Mouse_was_touch_mouse_events.{platform}.yaml # F0h     bool was_touch_mouse_events;
           - SDL_Mouse_cursor_visible.{platform}.yaml         # 128h bool cursor_visible;
           - SDL_MouseWarpEmulationChanged.{platform}.yaml    # func
+        platform: windows
+
+      - name: find-SDL_SetRelativeMouseMode-AND-SDL_Mouse_warp_emulation_active-windows # by LLM_DECOMPILE SDL_MouseWarpEmulationChanged
+        expected_input:
+          - SDL_MouseWarpEmulationChanged.{platform}.yaml
+        expected_output:
+          - SDL_SetRelativeMouseMode.{platform}.yaml         # func
+          - SDL_Mouse_warp_emulation_active.{platform}.yaml  # C6h     bool warp_emulation_active;
+        platform: windows
+
+      - name: find-SDL_Mouse_relative_mode-windows # by LLM_DECOMPILE SDL_SetRelativeMouseMode
+        expected_input:
+          - SDL_SetRelativeMouseMode.{platform}.yaml
+        expected_output:
+          - SDL_Mouse_relative_mode.{platform}.yaml          # C1h     bool relative_mode;
         platform: windows
 
     symbols:
@@ -53,7 +68,20 @@ modules:
 
       - name: SDL_MouseWarpEmulationChanged
         category: func
-        
+
+      - name: SDL_SetRelativeMouseMode
+        category: func
+
+      - name: SDL_Mouse_warp_emulation_active
+        category: structmember
+        struct: SDL_Mouse
+        member: warp_emulation_active
+
+      - name: SDL_Mouse_relative_mode
+        category: structmember
+        struct: SDL_Mouse
+        member: relative_mode
+
   - name: vphysics2
     path_windows: game/bin/win64/vphysics2.dll
     path_linux: game/bin/linuxsteamrt64/libvphysics2.so

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,55 @@
 modules:
+  - name: SDL3
+    path_windows: game/bin/win64/SDL3.dll
+    path_linux: game/bin/linuxsteamrt64/libSDL3.so.0
+
+    skills:
+      - name: find-SDL_PreInitMouse-windows # xref_signatures "B0 01 48 83 C4 ??" + xref_strings "FULLMATCH:SDL_MOUSE_DOUBLE_CLICK_TIME"
+        expected_output:
+          - SDL_PreInitMouse.{platform}.yaml
+        platform: windows
+
+      - name: find-SDL_QuitMouse-windows # exclude_signatures "B0 01 48 83 C4 ??" + xref_strings "FULLMATCH:SDL_MOUSE_DOUBLE_CLICK_TIME"
+        expected_output:
+          - SDL_QuitMouse.{platform}.yaml
+        platform: windows
+
+      - name: find-SDL_GetMouse-AND-SDL_mouse_initialized-windows # by LLM_DECOMPILE SDL_PreInitMouse, 
+        expected_input:
+          - SDL_PreInitMouse.{platform}.yaml
+        expected_output:
+          - SDL_GetMouse.{platform}.yaml                     # func, func_sig_allow_across_function_boundary: true
+          - SDL_mouse_initialized.{platform}.yaml            # gv
+          - SDL_Mouse_was_touch_mouse_events.{platform}.yaml # F0h     bool was_touch_mouse_events;
+          - SDL_Mouse_cursor_visible.{platform}.yaml         # 128h bool cursor_visible;
+        platform: windows
+
+    symbols:
+      - name: SDL_PreInitMouse
+        category: func
+
+      - name: SDL_QuitMouse
+        category: func
+
+      - name: SDL_GetMouse
+        category: func
+
+      - name: SDL_mouse_initialized
+        category: gv
+
+      - name: SDL_Mouse
+        category: struct
+
+      - name: SDL_Mouse_was_touch_mouse_events
+        category: structmember
+        struct: SDL_Mouse
+        member: was_touch_mouse_events
+        
+      - name: SDL_Mouse_cursor_visible
+        category: structmember
+        struct: SDL_Mouse
+        member: cursor_visible
+        
   - name: vphysics2
     path_windows: game/bin/win64/vphysics2.dll
     path_linux: game/bin/linuxsteamrt64/libvphysics2.so

--- a/config.yaml
+++ b/config.yaml
@@ -33,11 +33,13 @@ modules:
           - SDL_Mouse_warp_emulation_active.{platform}.yaml  # C6h     bool warp_emulation_active;
         platform: windows
 
-      - name: find-SDL_Mouse_relative_mode-windows # by LLM_DECOMPILE SDL_SetRelativeMouseMode
+      - name: find-SDL_Mouse_relative_mode-AND-SDL_Mouse_SetRelativeMouseMode-AND-SDL_PerformWarpMouseInWindow-windows # by LLM_DECOMPILE SDL_SetRelativeMouseMode
         expected_input:
           - SDL_SetRelativeMouseMode.{platform}.yaml
         expected_output:
           - SDL_Mouse_relative_mode.{platform}.yaml          # C1h     bool relative_mode;
+          - SDL_Mouse_SetRelativeMouseMode.{platform}.yaml   # 40h     bool (*SetRelativeMouseMode)(bool enabled);
+          - SDL_PerformWarpMouseInWindow.{platform}.yaml     # func
         platform: windows
 
     symbols:
@@ -81,6 +83,14 @@ modules:
         category: structmember
         struct: SDL_Mouse
         member: relative_mode
+
+      - name: SDL_Mouse_SetRelativeMouseMode
+        category: structmember
+        struct: SDL_Mouse
+        member: SetRelativeMouseMode
+
+      - name: SDL_PerformWarpMouseInWindow
+        category: func
 
   - name: vphysics2
     path_windows: game/bin/win64/vphysics2.dll

--- a/ida_preprocessor_scripts/find-SDL_GetMouse-AND-SDL_mouse_initialized-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_GetMouse-AND-SDL_mouse_initialized-windows.py
@@ -5,6 +5,7 @@ from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "SDL_GetMouse",
+    "SDL_MouseWarpEmulationChanged",
 ]
 
 TARGET_GLOBALVAR_NAMES = [
@@ -35,6 +36,11 @@ LLM_DECOMPILE = [
     ),
     (
         "SDL_Mouse_cursor_visible",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
+    ),
+    (
+        "SDL_MouseWarpEmulationChanged",
         "prompt/call_llm_decompile.md",
         "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
     ),
@@ -86,6 +92,16 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "size",
             "offset_sig",
             "offset_sig_disp",
+        ],
+    ),
+    (
+        "SDL_MouseWarpEmulationChanged",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-SDL_GetMouse-AND-SDL_mouse_initialized-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_GetMouse-AND-SDL_mouse_initialized-windows.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SDL_GetMouse-AND-SDL_mouse_initialized-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "SDL_GetMouse",
+]
+
+TARGET_GLOBALVAR_NAMES = [
+    "SDL_mouse_initialized",
+]
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "SDL_Mouse_was_touch_mouse_events",
+    "SDL_Mouse_cursor_visible",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "SDL_GetMouse",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
+    ),
+    (
+        "SDL_mouse_initialized",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
+    ),
+    (
+        "SDL_Mouse_was_touch_mouse_events",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
+    ),
+    (
+        "SDL_Mouse_cursor_visible",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_PreInitMouse.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SDL_GetMouse",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "SDL_mouse_initialized",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+    (
+        "SDL_Mouse_was_touch_mouse_events",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "SDL_Mouse_cursor_visible",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig/gv_sig/offset_sig to locate targets and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SDL_Mouse_relative_mode-AND-SDL_Mouse_SetRelativeMouseMode-AND-SDL_PerformWarpMouseInWindow-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_Mouse_relative_mode-AND-SDL_Mouse_SetRelativeMouseMode-AND-SDL_PerformWarpMouseInWindow-windows.py
@@ -1,16 +1,31 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-SDL_Mouse_relative_mode-windows skill."""
+"""Preprocess script for find-SDL_Mouse_relative_mode-AND-SDL_Mouse_SetRelativeMouseMode-AND-SDL_PerformWarpMouseInWindow-windows skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
+TARGET_FUNCTION_NAMES = [
+    "SDL_PerformWarpMouseInWindow",
+]
+
 TARGET_STRUCT_MEMBER_NAMES = [
     "SDL_Mouse_relative_mode",
+    "SDL_Mouse_SetRelativeMouseMode",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
         "SDL_Mouse_relative_mode",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_SetRelativeMouseMode.{platform}.yaml",
+    ),
+    (
+        "SDL_Mouse_SetRelativeMouseMode",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_SetRelativeMouseMode.{platform}.yaml",
+    ),
+    (
+        "SDL_PerformWarpMouseInWindow",
         "prompt/call_llm_decompile.md",
         "references/SDL3/SDL_SetRelativeMouseMode.{platform}.yaml",
     ),
@@ -29,13 +44,34 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "offset_sig_disp",
         ],
     ),
+    (
+        "SDL_Mouse_SetRelativeMouseMode",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "SDL_PerformWarpMouseInWindow",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever offset_sig to locate target struct member and write YAML."""
+    """Reuse previous gamever func_sig/offset_sig to locate targets and write YAML."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -43,6 +79,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
         struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
         llm_decompile_specs=LLM_DECOMPILE,
         llm_config=llm_config,

--- a/ida_preprocessor_scripts/find-SDL_Mouse_relative_mode-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_Mouse_relative_mode-windows.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SDL_Mouse_relative_mode-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "SDL_Mouse_relative_mode",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "SDL_Mouse_relative_mode",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_SetRelativeMouseMode.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SDL_Mouse_relative_mode",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct member and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SDL_PreInitMouse-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_PreInitMouse-windows.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SDL_PreInitMouse-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "SDL_PreInitMouse",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "SDL_PreInitMouse",
+        "xref_strings": [
+            "FULLMATCH:SDL_MOUSE_DOUBLE_CLICK_TIME",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": ["B0 01 48 83 C4 ??"],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SDL_PreInitMouse",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SDL_QuitMouse-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_QuitMouse-windows.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SDL_QuitMouse-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "SDL_QuitMouse",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "SDL_QuitMouse",
+        "xref_strings": [
+            "FULLMATCH:SDL_MOUSE_DOUBLE_CLICK_TIME",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": ["B0 01 48 83 C4 ??"],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SDL_QuitMouse",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SDL_SetRelativeMouseMode-AND-SDL_Mouse_warp_emulation_active-windows.py
+++ b/ida_preprocessor_scripts/find-SDL_SetRelativeMouseMode-AND-SDL_Mouse_warp_emulation_active-windows.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SDL_SetRelativeMouseMode-AND-SDL_Mouse_warp_emulation_active-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "SDL_SetRelativeMouseMode",
+]
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "SDL_Mouse_warp_emulation_active",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "SDL_SetRelativeMouseMode",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_MouseWarpEmulationChanged.{platform}.yaml",
+    ),
+    (
+        "SDL_Mouse_warp_emulation_active",
+        "prompt/call_llm_decompile.md",
+        "references/SDL3/SDL_MouseWarpEmulationChanged.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SDL_SetRelativeMouseMode",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "SDL_Mouse_warp_emulation_active",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig/offset_sig to locate targets and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/prompt/call_llm_decompile.md
+++ b/ida_preprocessor_scripts/prompt/call_llm_decompile.md
@@ -14,39 +14,58 @@ Example:
 
 ```yaml
 found_vcall: # This is for indirect call to virtual function or virtual function pointer fetching.
+
   - insn_va: '0x180777700'               # Always be the instruction with displacement offset
     insn_disasm: call    [rax+68h]       # Always be the instruction with displacement offset
     vfunc_offset: '0x68'
     func_name: ILoopMode_OnLoopActivate
+
   - insn_va: '0x180777778'               # Always be the instruction with displacement offset
     insn_disasm: mov     rax, [rax+80h]  # Always be the instruction with displacement offset
     vfunc_offset: '0x80'
     func_name: INetworkMessages_GetNetworkGroupCount # This must be the true function name we asked to collect, not the sub_XXXXXXXX
+
 found_call: # This is for direct call to non-virtual regular function.
+
   - insn_va: '0x180888800'
     insn_disasm: call    sub_180999900
     func_name: CLoopModeGame_RegisterEventMapInternal
+
   - insn_va: '0x180888880'
     insn_disasm: call    sub_180555500
     func_name: CLoopModeGame_SetGameSystemState   # This must be the true function name we asked to collect, not the sub_XXXXXXXX
+
 found_funcptr: # This is for non-virtual regular function pointer.
+
   - insn_va: '0x180666600'                # Must load/reference the function pointer target address
     insn_disasm: lea     rdx, sub_15BC910 # Must load/reference the function pointer target address
     funcptr_name: CLoopModeGame_OnClientPollNetworking   # This must be the true function name we asked to collect, not the sub_XXXXXXXX
+
 found_gv: # This is for reference to global variable.
+
   - insn_va: '0x180444400'
     insn_disasm: mov     rcx, cs:qword_180666600 # Must load/reference the global variable
     gv_name: g_pNetworkMessages  # This must be the true globalvar name we asked to collect, not the qword_XXXXXXXX or unk_XXXXXXXX
+
   - insn_va: '0x180333300'
     insn_disasm: lea     rax, unk_180222200      # Must load/reference the global variable
     gv_name: s_GameEventManager  # This must be the true globalvar name we asked to collect, not the qword_XXXXXXXX or unk_XXXXXXXX
-found_struct_offset: # This is for reference to struct offset. NOTE THAT virtual function pointer should not be here! virtual function pointer should ALWAYS be in found_vcall !
-  - insn_va: '0x1801BA12A'                # Always be the instruction with displacement offset
+
+found_struct_offset: # This is for reference to struct member offset.
+
+  - insn_va: '0x1801BA12A'                # Always be the instruction with displacement offset, when instruction access CGameResourceService::m_pEntitySystem
     insn_disasm: mov     rcx, [r14+58h]   # Always be the instruction with displacement offset
     offset: '0x58'
     size: 8
     struct_name: CGameResourceService
     member_name: m_pEntitySystem
+
+  - insn_va: '0x180075B6B'                # Always be the instruction with displacement offset, when instruction access SDL_Mouse::SetRelativeMouseMode
+    insn_disasm: mov     rax, [rsi+40h]   # Always be the instruction with displacement offset
+    offset: '0x40'
+    size: 8
+    struct_name: SDL_Mouse
+    member_name: SetRelativeMouseMode
 ```
 
 If nothing found, output an empty YAML. DO NOT output anything other than the desired YAML. DO NOT collect unrelated symbols.

--- a/ida_preprocessor_scripts/references/SDL3/SDL_MouseWarpEmulationChanged.windows.yaml
+++ b/ida_preprocessor_scripts/references/SDL3/SDL_MouseWarpEmulationChanged.windows.yaml
@@ -1,0 +1,36 @@
+func_name: SDL_MouseWarpEmulationChanged
+func_va: '0x180074620'
+disasm_code: |-
+  .text:0000000180074620                 push    rbx
+  .text:0000000180074622                 sub     rsp, 20h
+  .text:0000000180074626                 mov     rbx, rcx
+  .text:0000000180074629                 mov     dl, 1
+  .text:000000018007462B                 mov     rcx, r9
+  .text:000000018007462E                 call    SDL_GetStringBoolean
+  .text:0000000180074633                 mov     [rbx+0C5h], al
+  .text:0000000180074639                 test    al, al
+  .text:000000018007463B                 jnz     short loc_180074653
+  .text:000000018007463D                 cmp     [rbx+0C6h], al              ; 0C6h = SDL_Mouse_warp_emulation_active (structmember)
+  .text:0000000180074643                 jz      short loc_180074653
+  .text:0000000180074645                 ; bool
+  .text:0000000180074645                 xor     ecx, ecx; bool
+  .text:0000000180074647                 call    SDL_SetRelativeMouseMode    ; SDL_SetRelativeMouseMode (func)
+  .text:000000018007464C                 mov     byte ptr [rbx+0C6h], 0     ; 0C6h = SDL_Mouse_warp_emulation_active (structmember)
+  .text:0000000180074653                 add     rsp, 20h
+  .text:0000000180074657                 pop     rbx
+  .text:0000000180074658                 retn
+procedure: |-
+  char __fastcall SDL_MouseWarpEmulationChanged(SDL_Mouse *a1, __int64 a2, __int64 a3, __int64 a4)
+  {
+    char result; // al
+
+    LOBYTE(a2) = 1;
+    result = SDL_GetStringBoolean(a4, a2);
+    a1->warp_emulation_hint = result;
+    if ( !result && a1->warp_emulation_active ) // 0xC6 = SDL_Mouse_warp_emulation_active (structmember)
+    {
+      result = SDL_SetRelativeMouseMode(0); // SDL_SetRelativeMouseMode (func)
+      a1->warp_emulation_active = 0; // 0xC6 = SDL_Mouse_warp_emulation_active (structmember)
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/SDL3/SDL_PreInitMouse.windows.yaml
+++ b/ida_preprocessor_scripts/references/SDL3/SDL_PreInitMouse.windows.yaml
@@ -1,0 +1,123 @@
+func_name: SDL_PreInitMouse
+func_va: '0x180074850'
+disasm_code: |-
+  .text:0000000180074850                 push    rbx
+  .text:0000000180074852                 sub     rsp, 30h
+  .text:0000000180074856                 call    SDL_GetMouse
+  .text:000000018007485B                 xor     edx, edx
+  .text:000000018007485D                 mov     cs:SDL_mouse_initialized, 1
+  .text:0000000180074864                 mov     r8d, 138h
+  .text:000000018007486A                 mov     rcx, rax
+  .text:000000018007486D                 mov     rbx, rax
+  .text:0000000180074870                 call    SDL_memset_0
+  .text:0000000180074875                 mov     r8, rbx
+  .text:0000000180074878                 lea     rdx, SDL_MouseDoubleClickTimeChanged
+  .text:000000018007487F                 lea     rcx, aSdlMouseDouble; "SDL_MOUSE_DOUBLE_CLICK_TIME"
+  .text:0000000180074886                 call    SDL_AddHintCallback_0
+  .text:000000018007488B                 mov     r8, rbx
+  .text:000000018007488E                 lea     rdx, SDL_MouseDoubleClickRadiusChanged
+  .text:0000000180074895                 lea     rcx, aSdlMouseDouble_0; "SDL_MOUSE_DOUBLE_CLICK_RADIUS"
+  .text:000000018007489C                 call    SDL_AddHintCallback_0
+  .text:00000001800748A1                 mov     r8, rbx
+  .text:00000001800748A4                 lea     rdx, SDL_MouseNormalSpeedScaleChanged
+  .text:00000001800748AB                 lea     rcx, aSdlMouseNormal; "SDL_MOUSE_NORMAL_SPEED_SCALE"
+  .text:00000001800748B2                 call    SDL_AddHintCallback_0
+  .text:00000001800748B7                 mov     r8, rbx
+  .text:00000001800748BA                 lea     rdx, SDL_MouseRelativeSpeedScaleChanged
+  .text:00000001800748C1                 lea     rcx, aSdlMouseRelati; "SDL_MOUSE_RELATIVE_SPEED_SCALE"
+  .text:00000001800748C8                 call    SDL_AddHintCallback_0
+  .text:00000001800748CD                 mov     r8, rbx
+  .text:00000001800748D0                 lea     rdx, SDL_MouseRelativeSystemScaleChanged
+  .text:00000001800748D7                 lea     rcx, aSdlMouseRelati_0; "SDL_MOUSE_RELATIVE_SYSTEM_SCALE"
+  .text:00000001800748DE                 call    SDL_AddHintCallback_0
+  .text:00000001800748E3                 mov     r8, rbx
+  .text:00000001800748E6                 lea     rdx, SDL_MouseRelativeModeCenterChanged
+  .text:00000001800748ED                 lea     rcx, aSdlMouseRelati_1; "SDL_MOUSE_RELATIVE_MODE_CENTER"
+  .text:00000001800748F4                 call    SDL_AddHintCallback_0
+  .text:00000001800748F9                 mov     r8, rbx
+  .text:00000001800748FC                 lea     rdx, SDL_MouseWarpEmulationChanged
+  .text:0000000180074903                 lea     rcx, aSdlMouseEmulat; "SDL_MOUSE_EMULATE_WARP_WITH_RELATIVE"
+  .text:000000018007490A                 call    SDL_AddHintCallback_0
+  .text:000000018007490F                 mov     r8, rbx
+  .text:0000000180074912                 lea     rdx, SDL_TouchMouseEventsChanged
+  .text:0000000180074919                 lea     rcx, aSdlTouchMouseE; "SDL_TOUCH_MOUSE_EVENTS"
+  .text:0000000180074920                 call    SDL_AddHintCallback_0
+  .text:0000000180074925                 mov     r8, rbx
+  .text:0000000180074928                 lea     rdx, SDL_MouseTouchEventsChanged
+  .text:000000018007492F                 lea     rcx, aSdlMouseTouchE; "SDL_MOUSE_TOUCH_EVENTS"
+  .text:0000000180074936                 call    SDL_AddHintCallback_0
+  .text:000000018007493B                 mov     r8, rbx
+  .text:000000018007493E                 lea     rdx, SDL_PenMouseEventsChanged
+  .text:0000000180074945                 lea     rcx, aSdlPenMouseEve; "SDL_PEN_MOUSE_EVENTS"
+  .text:000000018007494C                 call    SDL_AddHintCallback_0
+  .text:0000000180074951                 mov     r8, rbx
+  .text:0000000180074954                 lea     rdx, SDL_PenTouchEventsChanged
+  .text:000000018007495B                 lea     rcx, aSdlPenTouchEve; "SDL_PEN_TOUCH_EVENTS"
+  .text:0000000180074962                 call    SDL_AddHintCallback_0
+  .text:0000000180074967                 mov     r8, rbx
+  .text:000000018007496A                 lea     rdx, SDL_MouseAutoCaptureChanged
+  .text:0000000180074971                 lea     rcx, aSdlMouseAutoCa; "SDL_MOUSE_AUTO_CAPTURE"
+  .text:0000000180074978                 call    SDL_AddHintCallback_0
+  .text:000000018007497D                 mov     r8, rbx
+  .text:0000000180074980                 lea     rdx, SDL_MouseRelativeWarpMotionChanged
+  .text:0000000180074987                 lea     rcx, aSdlMouseRelati_2; "SDL_MOUSE_RELATIVE_WARP_MOTION"
+  .text:000000018007498E                 call    SDL_AddHintCallback_0
+  .text:0000000180074993                 mov     r8, rbx
+  .text:0000000180074996                 lea     rdx, SDL_MouseRelativeCursorVisibleChanged
+  .text:000000018007499D                 lea     rcx, aSdlMouseRelati_3; "SDL_MOUSE_RELATIVE_CURSOR_VISIBLE"
+  .text:00000001800749A4                 call    SDL_AddHintCallback_0
+  .text:00000001800749A9                 mov     r8, rbx
+  .text:00000001800749AC                 lea     rdx, SDL_MouseIntegerModeChanged
+  .text:00000001800749B3                 lea     rcx, aSdlMouseIntege; "SDL_MOUSE_INTEGER_MODE"
+  .text:00000001800749BA                 call    SDL_AddHintCallback_0
+  .text:00000001800749BF                 lea     rax, SDL_DestroyHashValue
+  .text:00000001800749C6                 ; _QWORD
+  .text:00000001800749C6                 mov     [rsp+38h+var_10], 0; _QWORD
+  .text:00000001800749CF                 ; _QWORD
+  .text:00000001800749CF                 lea     r9, SDL_KeyMatchID; _QWORD
+  .text:00000001800749D6                 ; _QWORD
+  .text:00000001800749D6                 mov     [rsp+38h+var_18], rax; _QWORD
+  .text:00000001800749DB                 ; _QWORD
+  .text:00000001800749DB                 lea     r8, SDL_HashID; _QWORD
+  .text:00000001800749E2                 mov     byte ptr [rbx+0F0h], 0; 0F0h = SDL_Mouse::was_touch_mouse_events
+  .text:00000001800749E9                 ; bool
+  .text:00000001800749E9                 mov     dl, 1; bool
+  .text:00000001800749EB                 mov     byte ptr [rbx+128h], 1; 128h = SDL_Mouse::cursor_visible
+  .text:00000001800749F2                 ; _QWORD
+  .text:00000001800749F2                 xor     ecx, ecx; _QWORD
+  .text:00000001800749F4                 call    SDL_CreateHashTable
+  .text:00000001800749F9                 mov     cs:SDL_mouse_names, rax
+  .text:0000000180074A00                 mov     al, 1
+  .text:0000000180074A02                 add     rsp, 30h
+  .text:0000000180074A06                 pop     rbx
+  .text:0000000180074A07                 retn
+procedure: |-
+  char SDL_PreInitMouse()
+  {
+    SDL_Mouse *Mouse; // rax
+    SDL_Mouse *v1; // rbx
+
+    Mouse = (SDL_Mouse *)SDL_GetMouse();
+    SDL_mouse_initialized = 1;
+    v1 = Mouse;
+    SDL_memset_0(Mouse, 0, 312);
+    SDL_AddHintCallback_0("SDL_MOUSE_DOUBLE_CLICK_TIME", SDL_MouseDoubleClickTimeChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_DOUBLE_CLICK_RADIUS", SDL_MouseDoubleClickRadiusChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_NORMAL_SPEED_SCALE", SDL_MouseNormalSpeedScaleChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_RELATIVE_SPEED_SCALE", SDL_MouseRelativeSpeedScaleChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_RELATIVE_SYSTEM_SCALE", SDL_MouseRelativeSystemScaleChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_RELATIVE_MODE_CENTER", SDL_MouseRelativeModeCenterChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_EMULATE_WARP_WITH_RELATIVE", SDL_MouseWarpEmulationChanged, v1);
+    SDL_AddHintCallback_0("SDL_TOUCH_MOUSE_EVENTS", SDL_TouchMouseEventsChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_TOUCH_EVENTS", SDL_MouseTouchEventsChanged, v1);
+    SDL_AddHintCallback_0("SDL_PEN_MOUSE_EVENTS", SDL_PenMouseEventsChanged, v1);
+    SDL_AddHintCallback_0("SDL_PEN_TOUCH_EVENTS", SDL_PenTouchEventsChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_AUTO_CAPTURE", SDL_MouseAutoCaptureChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_RELATIVE_WARP_MOTION", SDL_MouseRelativeWarpMotionChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_RELATIVE_CURSOR_VISIBLE", SDL_MouseRelativeCursorVisibleChanged, v1);
+    SDL_AddHintCallback_0("SDL_MOUSE_INTEGER_MODE", SDL_MouseIntegerModeChanged, v1);
+    v1->was_touch_mouse_events = 0;
+    v1->cursor_visible = 1;
+    SDL_mouse_names = SDL_CreateHashTable(0, 1, SDL_HashID, SDL_KeyMatchID, SDL_DestroyHashValue, 0);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/SDL3/SDL_SetRelativeMouseMode.windows.yaml
+++ b/ida_preprocessor_scripts/references/SDL3/SDL_SetRelativeMouseMode.windows.yaml
@@ -1,0 +1,122 @@
+func_name: SDL_SetRelativeMouseMode
+func_va: '0x180075b30'
+disasm_code: |-
+  .text:0000000180075B30                 mov     [rsp+arg_0], rbx
+  .text:0000000180075B35                 mov     [rsp+arg_8], rsi
+  .text:0000000180075B3A                 push    rdi
+  .text:0000000180075B3B                 sub     rsp, 20h
+  .text:0000000180075B3F                 movzx   edi, cl
+  .text:0000000180075B42                 call    SDL_GetMouse
+  .text:0000000180075B47                 mov     rsi, rax
+  .text:0000000180075B4A                 call    SDL_GetKeyboardFocus_0
+  .text:0000000180075B4F                 mov     rbx, rax
+  .text:0000000180075B52                 test    dil, dil
+  .text:0000000180075B55                 jnz     short loc_180075B5E
+  .text:0000000180075B57                 mov     [rsi+0C6h], dil
+  .text:0000000180075B5E                 cmp     dil, [rsi+0C1h]             ; 0C1h = SDL_Mouse_relative_mode (structmember)
+  .text:0000000180075B65                 jz      loc_180075C14
+  .text:0000000180075B6B                 mov     rax, [rsi+40h]
+  .text:0000000180075B6F                 test    rax, rax
+  .text:0000000180075B72                 jnz     short loc_180075B8F
+  .text:0000000180075B74                 lea     rcx, aThatOperationI; "That operation is not supported"
+  .text:0000000180075B7B                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180075B80                 mov     rsi, [rsp+28h+arg_8]
+  .text:0000000180075B85                 add     rsp, 20h
+  .text:0000000180075B89                 pop     rdi
+  .text:0000000180075B8A                 jmp     SDL_SetError_0
+  .text:0000000180075B8F                 movzx   ecx, dil
+  .text:0000000180075B93                 call    rax
+  .text:0000000180075B95                 test    al, al
+  .text:0000000180075B97                 jnz     short loc_180075BA9
+  .text:0000000180075B99                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180075B9E                 mov     rsi, [rsp+28h+arg_8]
+  .text:0000000180075BA3                 add     rsp, 20h
+  .text:0000000180075BA7                 pop     rdi
+  .text:0000000180075BA8                 retn
+  .text:0000000180075BA9                 mov     [rsi+0C1h], dil             ; 0C1h = SDL_Mouse_relative_mode (structmember)
+  .text:0000000180075BB0                 test    dil, dil
+  .text:0000000180075BB3                 jz      short loc_180075BD1
+  .text:0000000180075BB5                 call    SDL_RedrawCursor
+  .text:0000000180075BBA                 test    rbx, rbx
+  .text:0000000180075BBD                 jz      short loc_180075C0A
+  .text:0000000180075BBF                 mov     rcx, rbx
+  .text:0000000180075BC2                 call    SDL_SetMouseFocus
+  .text:0000000180075BC7                 mov     rcx, rbx
+  .text:0000000180075BCA                 call    SDL_UpdateWindowGrab
+  .text:0000000180075BCF                 jmp     short loc_180075BF9
+  .text:0000000180075BD1                 test    rbx, rbx
+  .text:0000000180075BD4                 jz      short loc_180075C05
+  .text:0000000180075BD6                 mov     rcx, rbx
+  .text:0000000180075BD9                 call    SDL_UpdateWindowGrab
+  .text:0000000180075BDE                 ; a3
+  .text:0000000180075BDE                 movss   xmm2, dword ptr [rsi+94h]; a3
+  .text:0000000180075BE6                 ; a4
+  .text:0000000180075BE6                 mov     r9b, 1; a4
+  .text:0000000180075BE9                 ; X
+  .text:0000000180075BE9                 movss   xmm1, dword ptr [rsi+90h]; X
+  .text:0000000180075BF1                 ; a1
+  .text:0000000180075BF1                 mov     rcx, rbx; a1
+  .text:0000000180075BF4                 call    SDL_PerformWarpMouseInWindow
+  .text:0000000180075BF9                 ; bool
+  .text:0000000180075BF9                 xor     ecx, ecx; bool
+  .text:0000000180075BFB                 call    SDL_UpdateMouseCapture
+  .text:0000000180075C00                 test    dil, dil
+  .text:0000000180075C03                 jnz     short loc_180075C0A
+  .text:0000000180075C05                 call    SDL_RedrawCursor
+  .text:0000000180075C0A                 mov     ecx, 400h
+  .text:0000000180075C0F                 call    SDL_FlushEvent_0
+  .text:0000000180075C14                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180075C19                 mov     al, 1
+  .text:0000000180075C1B                 mov     rsi, [rsp+28h+arg_8]
+  .text:0000000180075C20                 add     rsp, 20h
+  .text:0000000180075C24                 pop     rdi
+  .text:0000000180075C25                 retn
+procedure: |-
+  void __fastcall SDL_SetRelativeMouseMode(bool a1)
+  {
+    SDL_Mouse *Mouse; // rsi
+    _BYTE *KeyboardFocus_0; // rbx
+    bool (*SetRelativeMouseMode)(bool); // rax
+
+    Mouse = (SDL_Mouse *)SDL_GetMouse();
+    KeyboardFocus_0 = (_BYTE *)SDL_GetKeyboardFocus_0();
+    if ( !a1 )
+      Mouse->warp_emulation_active = 0;
+    if ( a1 != Mouse->relative_mode ) // 0xC1 = SDL_Mouse_relative_mode (structmember)
+    {
+      SetRelativeMouseMode = Mouse->SetRelativeMouseMode;
+      if ( !SetRelativeMouseMode )
+      {
+        SDL_SetError_0("That operation is not supported");
+        return;
+      }
+      if ( ((unsigned __int8 (__fastcall *)(bool))SetRelativeMouseMode)(a1) )
+      {
+        Mouse->relative_mode = a1; // 0xC1 = SDL_Mouse_relative_mode (structmember)
+        if ( a1 )
+        {
+          SDL_RedrawCursor();
+          if ( !KeyboardFocus_0 )
+            goto LABEL_14;
+          SDL_SetMouseFocus((__int64)KeyboardFocus_0);
+          SDL_UpdateWindowGrab((__int64)KeyboardFocus_0);
+        }
+        else
+        {
+          if ( !KeyboardFocus_0 )
+          {
+  LABEL_13:
+            SDL_RedrawCursor();
+            goto LABEL_14;
+          }
+          SDL_UpdateWindowGrab((__int64)KeyboardFocus_0);
+          SDL_PerformWarpMouseInWindow(KeyboardFocus_0, Mouse->x, Mouse->y, 1);
+        }
+        SDL_UpdateMouseCapture(0);
+        if ( !a1 )
+          goto LABEL_13;
+  LABEL_14:
+        SDL_FlushEvent_0(1024);
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/SDL3/SDL_SetRelativeMouseMode.windows.yaml
+++ b/ida_preprocessor_scripts/references/SDL3/SDL_SetRelativeMouseMode.windows.yaml
@@ -13,9 +13,9 @@ disasm_code: |-
   .text:0000000180075B52                 test    dil, dil
   .text:0000000180075B55                 jnz     short loc_180075B5E
   .text:0000000180075B57                 mov     [rsi+0C6h], dil
-  .text:0000000180075B5E                 cmp     dil, [rsi+0C1h]             ; 0C1h = SDL_Mouse_relative_mode (structmember)
+  .text:0000000180075B5E                 cmp     dil, [rsi+0C1h]             ; 0C1h = SDL_Mouse::relative_mode (structmember, struct=SDL_Mouse, member=relative_mode)
   .text:0000000180075B65                 jz      loc_180075C14
-  .text:0000000180075B6B                 mov     rax, [rsi+40h]
+  .text:0000000180075B6B                 mov     rax, [rsi+40h]              ; 40h = SDL_Mouse::SetRelativeMouseMode (structmember, struct=SDL_Mouse, member=SetRelativeMouseMode)
   .text:0000000180075B6F                 test    rax, rax
   .text:0000000180075B72                 jnz     short loc_180075B8F
   .text:0000000180075B74                 lea     rcx, aThatOperationI; "That operation is not supported"
@@ -33,7 +33,7 @@ disasm_code: |-
   .text:0000000180075BA3                 add     rsp, 20h
   .text:0000000180075BA7                 pop     rdi
   .text:0000000180075BA8                 retn
-  .text:0000000180075BA9                 mov     [rsi+0C1h], dil             ; 0C1h = SDL_Mouse_relative_mode (structmember)
+  .text:0000000180075BA9                 mov     [rsi+0C1h], dil             ; 0C1h = SDL_Mouse::relative_mode (structmember, struct=SDL_Mouse, member=relative_mode)
   .text:0000000180075BB0                 test    dil, dil
   .text:0000000180075BB3                 jz      short loc_180075BD1
   .text:0000000180075BB5                 call    SDL_RedrawCursor
@@ -56,7 +56,7 @@ disasm_code: |-
   .text:0000000180075BE9                 movss   xmm1, dword ptr [rsi+90h]; X
   .text:0000000180075BF1                 ; a1
   .text:0000000180075BF1                 mov     rcx, rbx; a1
-  .text:0000000180075BF4                 call    SDL_PerformWarpMouseInWindow
+  .text:0000000180075BF4                 call    SDL_PerformWarpMouseInWindow ; SDL_PerformWarpMouseInWindow (func)
   .text:0000000180075BF9                 ; bool
   .text:0000000180075BF9                 xor     ecx, ecx; bool
   .text:0000000180075BFB                 call    SDL_UpdateMouseCapture
@@ -82,9 +82,9 @@ procedure: |-
     KeyboardFocus_0 = (_BYTE *)SDL_GetKeyboardFocus_0();
     if ( !a1 )
       Mouse->warp_emulation_active = 0;
-    if ( a1 != Mouse->relative_mode ) // 0xC1 = SDL_Mouse_relative_mode (structmember)
+    if ( a1 != Mouse->relative_mode ) // 0xC1 = SDL_Mouse::relative_mode (structmember, struct=SDL_Mouse, member=relative_mode)
     {
-      SetRelativeMouseMode = Mouse->SetRelativeMouseMode;
+      SetRelativeMouseMode = Mouse->SetRelativeMouseMode; // 0x40 = SDL_Mouse::SetRelativeMouseMode (structmember, struct=SDL_Mouse, member=SetRelativeMouseMode)
       if ( !SetRelativeMouseMode )
       {
         SDL_SetError_0("That operation is not supported");
@@ -92,7 +92,7 @@ procedure: |-
       }
       if ( ((unsigned __int8 (__fastcall *)(bool))SetRelativeMouseMode)(a1) )
       {
-        Mouse->relative_mode = a1; // 0xC1 = SDL_Mouse_relative_mode (structmember)
+        Mouse->relative_mode = a1; // 0xC1 = SDL_Mouse::relative_mode (structmember, struct=SDL_Mouse, member=relative_mode)
         if ( a1 )
         {
           SDL_RedrawCursor();
@@ -110,7 +110,7 @@ procedure: |-
             goto LABEL_14;
           }
           SDL_UpdateWindowGrab((__int64)KeyboardFocus_0);
-          SDL_PerformWarpMouseInWindow(KeyboardFocus_0, Mouse->x, Mouse->y, 1);
+          SDL_PerformWarpMouseInWindow(KeyboardFocus_0, Mouse->x, Mouse->y, 1); // SDL_PerformWarpMouseInWindow (func)
         }
         SDL_UpdateMouseCapture(0);
         if ( !a1 )


### PR DESCRIPTION
## Summary

- Add `find-SDL_PreInitMouse-windows`, `find-SDL_QuitMouse-windows`, `find-SDL_GetMouse-AND-SDL_mouse_initialized-windows` (xref-string / LLM_DECOMPILE patterns)
- Add `find-SDL_SetRelativeMouseMode-AND-SDL_Mouse_warp_emulation_active-windows` (LLM_DECOMPILE from `SDL_MouseWarpEmulationChanged`)
- Add `find-SDL_Mouse_relative_mode-AND-SDL_Mouse_SetRelativeMouseMode-AND-SDL_PerformWarpMouseInWindow-windows` (LLM_DECOMPILE from `SDL_SetRelativeMouseMode`)
- All scripts are windows-only; validated with `uv run ida_analyze_bin.py -debug` (Failed: 0)

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with Failed: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)