### PR TITLE
Add CEntityInstance/CEntitySystem/CBaseModelEntity preprocessor scripts

### DIFF
--- a/.claude/skills/create-preprocessor-scripts/SKILL.md
+++ b/.claude/skills/create-preprocessor-scripts/SKILL.md
@@ -68,7 +68,7 @@ From the user's input, determine:
    - Has `xref_gvs` (vtable VA from a vtable YAML) + category `vfunc` -> **Pattern B** with dynamic FUNC_XREFS
    - Has `xref_funcs` (known callee function name) + category `func` -> **Pattern A** (static FUNC_XREFS; see "xref_funcs: finding callers of a known function" note)
    - Has `xref_funcs` (known callee function name) + category `vfunc` -> **Pattern B** (static FUNC_XREFS)
-   - Has predecessor function + category `vfunc` -> **Pattern C**
+   - Has predecessor function + category `vfunc` -> **Pattern C** (`vfunc_sig` is ALWAYS required in `GENERATE_YAML_DESIRED_FIELDS` -- see "vfunc_sig is MANDATORY for Pattern C" note below)
    - Has predecessor function + category `func` -> **Pattern D**
    - Has predecessor function + category `structmember` -> **Pattern E**
    - Has base vfunc name + category `vfunc` (derived-class override of known base vfunc) -> **Pattern F**
@@ -269,6 +269,16 @@ The `vtable_name` from `FUNC_VTABLE_RELATIONS` is used as **metadata** written t
 
 **Rule of thumb:** If any field in `GENERATE_YAML_DESIRED_FIELDS` starts with `vfunc_` or equals `vtable_name`, the target MUST have an entry in `FUNC_VTABLE_RELATIONS`.
 
+#### CRITICAL -- `vfunc_sig` is MANDATORY for Pattern C (vfunc via LLM_DECOMPILE)
+
+For ANY vfunc discovered via LLM_DECOMPILE (Pattern C), `GENERATE_YAML_DESIRED_FIELDS` **MUST** include `vfunc_sig`. This is non-negotiable -- the slot index alone is not stable across binary updates without a signature anchor on the actual vfunc body.
+
+This rule applies to BOTH variants:
+- **Standard Pattern C** (also a downstream predecessor): `func_name, func_va, func_rva, func_size, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`
+- **Slim Pattern C** (not a downstream predecessor): `func_name, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`
+
+Pure slot-only output (`func_name, vtable_name, vfunc_offset, vfunc_index` with NO `vfunc_sig`) is reserved for Pattern F slot-only / Pattern I / Pattern K -- it is NOT a valid output shape for Pattern C. Examples that follow this rule: `find-CEntityInstance_ScriptEntityIO.py`, `find-CEntityInstance_Restore.py`, `find-CEntityInstance_RequiredEdictIndex.py`, `find-CEntityInstance_PreDataUpdate.py`, `find-CEntityInstance_PostDataUpdate.py`, `find-CEntityInstance_NetworkUpdateState.py`.
+
 ### Key Differences Between Patterns
 
 | Aspect | Pattern A (func + xref) | Pattern B (vfunc + xref) | Pattern C (vfunc + LLM) | Pattern D (func + LLM) | Pattern E (structmember + LLM) | Pattern F (vfunc + inherit) | Pattern G (ConCommand handler) | Pattern H (ordinal vtable) | Pattern I (iface vfunc thunk walk) | Pattern J (IGameSystem dispatch) | Pattern K (IGameSystem slot dispatch) |
@@ -281,7 +291,7 @@ The `vtable_name` from `FUNC_VTABLE_RELATIONS` is used as **metadata** written t
 | Helper module | `preprocess_common_skill` | `preprocess_common_skill` | `preprocess_common_skill` | `preprocess_common_skill` | `preprocess_common_skill` | `preprocess_common_skill` | `preprocess_registerconcommand_skill` | `preprocess_ordinal_vtable_via_mcp` | `py_eval` + `write_func_yaml` (custom) | `preprocess_igamesystem_dispatch_skill` | `preprocess_igamesystem_slot_dispatch_skill` (from `_igamesystem_slot_dispatch_common`) |
 | Target list | `TARGET_FUNCTION_NAMES` | `TARGET_FUNCTION_NAMES` | `TARGET_FUNCTION_NAMES` | `TARGET_FUNCTION_NAMES` | `TARGET_STRUCT_MEMBER_NAMES` | (none -- defined in INHERIT_VFUNCS) | `TARGET_FUNCTION_NAMES` | `TARGET_CLASS_NAME` (single string) | `TARGET_FUNC_NAME` + `PREDECESSOR_STEM` (module-level constants) | `TARGET_SPECS` (list of dicts with `target_name`, `rename_to`, optional `dispatch_rank`) | `TARGET_SPECS` (list of dicts with `target_name`, `vtable_name`, optional `dispatch_rank`) |
 | preprocess param | `func_names=` | `func_names=` | `func_names=` | `func_names=` | `struct_member_names=` | `inherit_vfuncs=` | `command_name=`, `help_string=` | `class_name=`, `ordinal=` | (custom: reads YAML, calls `py_eval`) | `source_yaml_stem=`, `target_specs=`, `via_internal_wrapper=`, `multi_order=` | `dispatcher_yaml_stem=`, `target_specs=`, `multi_order=`, `expected_dispatch_count=` |
-| YAML fields | func_name, func_sig, func_va, func_rva, func_size | Same + vtable_name, vfunc_offset, vfunc_index | func_name, func_va, func_rva, func_size, vfunc_sig, vfunc_offset, vfunc_index, vtable_name | func_name, func_sig, func_va, func_rva, func_size | struct_name, member_name, offset, size, offset_sig, offset_sig_disp | Standard: func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index; Slot-only: func_name, vtable_name, vfunc_offset, vfunc_index | func_name, func_sig, func_va, func_rva, func_size | (vtable YAML via write_vtable_yaml) | func_name, vtable_name, vfunc_offset, vfunc_index | func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index | func_name, vtable_name, vfunc_offset, vfunc_index |
+| YAML fields | func_name, func_sig, func_va, func_rva, func_size | Same + vtable_name, vfunc_offset, vfunc_index | **vfunc_sig ALWAYS required**. Standard: func_name, func_va, func_rva, func_size, vfunc_sig, vfunc_offset, vfunc_index, vtable_name. Slim (not a downstream predecessor): func_name, vfunc_sig, vfunc_offset, vfunc_index, vtable_name | func_name, func_sig, func_va, func_rva, func_size | struct_name, member_name, offset, size, offset_sig, offset_sig_disp | Standard: func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index; Slot-only: func_name, vtable_name, vfunc_offset, vfunc_index | func_name, func_sig, func_va, func_rva, func_size | (vtable YAML via write_vtable_yaml) | func_name, vtable_name, vfunc_offset, vfunc_index | func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index | func_name, vtable_name, vfunc_offset, vfunc_index |
 | config category | `func` | `vfunc` | `vfunc` | `func` | `structmember` | `vfunc` | `func` | `vtable` | `vfunc` | `vfunc` | `vfunc` |
 
 ---

--- a/.claude/skills/create-preprocessor-scripts/references/pattern-C.md
+++ b/.claude/skills/create-preprocessor-scripts/references/pattern-C.md
@@ -2,9 +2,20 @@
 
 **Use when:** function IS virtual (has vtable slot), discovered by decompiling a known predecessor function.
 
+## CRITICAL -- `vfunc_sig` is ALWAYS required for Pattern C
+
+For ANY vfunc discovered via LLM_DECOMPILE, `GENERATE_YAML_DESIRED_FIELDS` **MUST** include `vfunc_sig`. This rule applies regardless of whether the script also emits `func_va`/`func_rva`/`func_size`. Pure slot-only (`func_name, vtable_name, vfunc_offset, vfunc_index` only, no `vfunc_sig`) is reserved for Pattern F slot-only / Pattern I / Pattern K -- it is NOT a valid output shape for Pattern C.
+
+Why: LLM_DECOMPILE picks the slot from a decompile of the predecessor; without a `vfunc_sig` the discovered slot has no signature anchor for cross-binary stability. `vfunc_sig` provides the signature byte pattern of the actual vfunc body so it can be re-located across binary updates even if the vtable layout shifts.
+
+The two valid Pattern C field sets are:
+
+- **Standard Pattern C** (also a downstream predecessor): `func_name, func_va, func_rva, func_size, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`
+- **Slim Pattern C** (not a predecessor): `func_name, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`
+
 ## Important -- `func_va` in output YAMLs
 
-If this function will be used as a **predecessor** by a downstream LLM_DECOMPILE script (i.e., another script decompiles this function to find further targets), you **MUST** include `func_va`, `func_rva`, and `func_size` in `GENERATE_YAML_DESIRED_FIELDS`. The downstream script resolves the predecessor's address by reading `func_va` from the output YAML. Without it, the LLM_DECOMPILE fallback fails with "failed to resolve llm_decompile target function address". When in doubt, always include `func_va` -- it never hurts.
+If this function will be used as a **predecessor** by a downstream LLM_DECOMPILE script (i.e., another script decompiles this function to find further targets), you **MUST** also include `func_va`, `func_rva`, and `func_size` in `GENERATE_YAML_DESIRED_FIELDS` (Standard Pattern C). The downstream script resolves the predecessor's address by reading `func_va` from the output YAML. Without it, the LLM_DECOMPILE fallback fails with "failed to resolve llm_decompile target function address". When in doubt, always include `func_va` -- it never hurts.
 
 ## Template
 
@@ -34,15 +45,16 @@ FUNC_VTABLE_RELATIONS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # Include func_va/func_rva/func_size if this function is a predecessor for downstream LLM_DECOMPILE
+    # ALWAYS include "vfunc_sig" for Pattern C.
+    # Include func_va/func_rva/func_size only if this function is a predecessor for downstream LLM_DECOMPILE.
     (
         "{FUNC_NAME_1}",
         [
             "func_name",
-            "func_va",
-            "func_rva",
-            "func_size",
-            "vfunc_sig",
+            "func_va",      # omit if not a downstream predecessor
+            "func_rva",     # omit if not a downstream predecessor
+            "func_size",    # omit if not a downstream predecessor
+            "vfunc_sig",    # REQUIRED -- never omit for Pattern C
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",
@@ -76,6 +88,7 @@ async def preprocess_skill(
 
 - [ ] `TARGET_FUNCTION_NAMES` lists all functions the script should find
 - [ ] `LLM_DECOMPILE` reference path points to the correct predecessor function YAML
+- [ ] `GENERATE_YAML_DESIRED_FIELDS` includes `vfunc_sig` for EVERY target (mandatory for Pattern C)
 - [ ] `FUNC_VTABLE_RELATIONS` lists correct vtable class for each target that has `vtable_name` or `vfunc_*` in its `GENERATE_YAML_DESIRED_FIELDS`
 - [ ] `preprocess_skill` signature includes `llm_config=None`
 - [ ] `preprocess_common_skill` call passes `func_names=`, `func_vtable_relations=`, `llm_decompile_specs=`, and `llm_config=`

--- a/config.yaml
+++ b/config.yaml
@@ -3513,12 +3513,13 @@ modules:
         expected_input:
           - CBaseEntity_vtable.{platform}.yaml
 
-      - name: find-CBaseEntity_PostDataUpdate
+      - name: find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta
         expected_output:
-          - CBaseEntity_PostDataUpdate.{platform}.yaml
+          - CEntityInstance_PostDataUpdatePreserve.{platform}.yaml
+          - CEntityInstance_PostDataUpdateDelta.{platform}.yaml
         expected_input:
           - CEntitySystem_PostDataUpdate.{platform}.yaml
-          - CBaseEntity_vtable.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
 
       - name: find-CBaseEntity_Spawn
         expected_output:
@@ -3840,7 +3841,8 @@ modules:
         expected_output:
           - CEntityInstance_PostDataUpdate.{platform}.yaml
         expected_input:
-          - CBaseEntity_PostDataUpdate.{platform}.yaml
+          - CEntityInstance_PostDataUpdateDelta.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
 
       - name: find-CEntityInstance_Connect
         expected_output:
@@ -5643,11 +5645,6 @@ modules:
         alias:
           - CBaseEntity::ReloadPrivateScripts
 
-      - name: CBaseEntity_PostDataUpdate
-        category: vfunc
-        alias:
-          - CBaseEntity::PostDataUpdate
-
       - name: CCheckTransmitInfo
         category: struct
 
@@ -5968,10 +5965,20 @@ modules:
         alias:
           - CEntityInstance::DrawDebugTextOverlays
 
+      - name: CEntityInstance_PostDataUpdateDelta
+        category: vfunc
+        alias:
+          - CEntityInstance::PostDataUpdateDelta
+
       - name: CEntityInstance_PostDataUpdate
         category: vfunc
         alias:
           - CEntityInstance::PostDataUpdate
+
+      - name: CEntityInstance_PostDataUpdatePreserve
+        category: vfunc
+        alias:
+          - CEntityInstance::PostDataUpdatePreserve
 
       - name: CEntityInstance_Connect
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -6277,6 +6277,33 @@ modules:
         shared: true
 
 cpp_tests:
+  - name: CEntityInstance_MSVC
+    symbol: CEntityInstance
+    cpp: cpp_tests/centityinstance.cpp
+    headers:
+    - hl2sdk_cs2/public/entity2/entityinstance.h # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/mathlib
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - server # bin/{gamever}/server/CEntityInstance_*.{platform}.yaml
+
   - name: IGameSystem_MSVC
     symbol: IGameSystem
     cpp: cpp_tests/igamesystem.cpp

--- a/config.yaml
+++ b/config.yaml
@@ -3837,6 +3837,22 @@ modules:
         expected_input:
           - CBaseEntity_DrawDebugTextOverlays.{platform}.yaml
 
+      - name: find-CRagdollProp_vtable
+        expected_output:
+          - CRagdollProp_vtable.{platform}.yaml
+
+      - name: find-CRagdollProp_DrawEntityDebugOverlays
+        expected_output:
+          - CRagdollProp_DrawEntityDebugOverlays.{platform}.yaml
+        expected_input:
+          - CRagdollProp_vtable.{platform}.yaml
+
+      - name: find-CEntityInstance_DrawEntityDebugOverlays
+        expected_output:
+          - CEntityInstance_DrawEntityDebugOverlays.{platform}.yaml
+        expected_input:
+          - CRagdollProp_DrawEntityDebugOverlays.{platform}.yaml
+
       - name: find-CEntityInstance_PostDataUpdate
         expected_output:
           - CEntityInstance_PostDataUpdate.{platform}.yaml
@@ -5680,6 +5696,11 @@ modules:
         alias:
           - CBaseEntity::DrawDebugTextOverlays
 
+      - name: CRagdollProp_DrawEntityDebugOverlays
+        category: vfunc
+        alias:
+          - CRagdollProp::DrawEntityDebugOverlays
+
       - name: CBaseEntity_ReloadPrivateScripts
         category: vfunc
         alias:
@@ -6005,6 +6026,11 @@ modules:
         alias:
           - CEntityInstance::DrawDebugTextOverlays
 
+      - name: CEntityInstance_DrawEntityDebugOverlays
+        category: vfunc
+        alias:
+          - CEntityInstance::DrawEntityDebugOverlays
+
       - name: CEntityInstance_PostDataUpdateDelta
         category: vfunc
         alias:
@@ -6075,6 +6101,9 @@ modules:
         alias:
           - INetworkMessages::GetLoggingChannel
         shared: true
+
+      - name: CRagdollProp_vtable
+        category: vtable
 
       - name: CPhysicsEntitySolver_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -4122,6 +4122,19 @@ modules:
           - CEntitySaveRestoreBlockHandler_DoRestoreEntity.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CEntitySaveRestoreBlockHandler_SaveInitEntities
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_SaveInitEntities.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_PreSave.{platform}.yaml
+
+      - name: find-CEntityInstance_RequiredEdictIndex
+        expected_output:
+          - CEntityInstance_RequiredEdictIndex.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_SaveInitEntities.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CEntityInstance_ObjectCaps-AND-CEntityInstance_Save
         expected_output:
           - CEntityInstance_ObjectCaps.{platform}.yaml
@@ -4336,6 +4349,16 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::Restore
+
+      - name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+        category: func
+        alias:
+          - CEntitySaveRestoreBlockHandler::SaveInitEntities
+
+      - name: CEntityInstance_RequiredEdictIndex
+        category: vfunc
+        alias:
+          - CEntityInstance::RequiredEdictIndex
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -4145,6 +4145,13 @@ modules:
         expected_input:
           - CEntitySaveRestoreBlockHandler_RestoreEntity.{platform}.yaml
 
+      - name: find-CEntitySystem_OnSetDormant
+        expected_output:
+          - CEntitySystem_OnSetDormant.{platform}.yaml
+        expected_input:
+          - CEntitySystem_SetInPVS.{platform}.yaml
+          - CEntitySystem_vtable.{platform}.yaml
+
       - name: find-CEntityInstance_Restore
         expected_output:
           - CEntityInstance_Restore.{platform}.yaml
@@ -4374,6 +4381,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::SetInPVS
+
+      - name: CEntitySystem_OnSetDormant
+        category: vfunc
+        alias:
+          - CEntitySystem::OnSetDormant
 
       - name: CEntityInstance_ObjectCaps
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2330,6 +2330,18 @@ modules:
         expected_output:
           - CBaseModelEntity_SetRenderAttribute.{platform}.yaml
 
+      - name: find-CEntityInstance_NetworkUpdateState_thunk
+        expected_output:
+          - CEntityInstance_NetworkUpdateState_thunk.{platform}.yaml
+        expected_input:
+          - CBaseModelEntity_SetRenderAttribute.{platform}.yaml
+
+      - name: find-CEntityInstance_NetworkUpdateState
+        expected_output:
+          - CEntityInstance_NetworkUpdateState.{platform}.yaml
+        expected_input:
+          - CEntityInstance_NetworkUpdateState_thunk.{platform}.yaml
+
       - name: find-CTriggerGravity_GetTouchFunction
         expected_output:
           - CTriggerGravity_GetTouchFunction.{platform}.yaml
@@ -4488,6 +4500,11 @@ modules:
         alias:
           - CBaseModelEntity::SetRenderAttribute
 
+      - name: CEntityInstance_NetworkUpdateState_thunk
+        category: func
+        alias:
+          - CEntityInstance::NetworkUpdateState_thunk
+
       - name: CBaseEntity_SetGravityScale
         category: func
         alias:
@@ -5935,6 +5952,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::NetworkStateChanged
+
+      - name: CEntityInstance_NetworkUpdateState
+        category: vfunc
+        alias:
+          - CEntityInstance::NetworkUpdateState
 
       - name: CEntityInstance_NetworkStateChangedLog
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2326,6 +2326,10 @@ modules:
         expected_input:
           - CFlashbangProjectile_Spawn.{platform}.yaml
 
+      - name: find-CBaseModelEntity_SetRenderAttribute
+        expected_output:
+          - CBaseModelEntity_SetRenderAttribute.{platform}.yaml
+
       - name: find-CTriggerGravity_GetTouchFunction
         expected_output:
           - CTriggerGravity_GetTouchFunction.{platform}.yaml
@@ -4478,6 +4482,11 @@ modules:
         category: func
         alias:
           - CBaseModelEntity::SetModel
+
+      - name: CBaseModelEntity_SetRenderAttribute
+        category: func
+        alias:
+          - CBaseModelEntity::SetRenderAttribute
 
       - name: CBaseEntity_SetGravityScale
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -4139,6 +4139,12 @@ modules:
         expected_input:
           - CEntitySaveRestoreBlockHandler_DoRestoreEntity.{platform}.yaml
 
+      - name: find-CEntitySystem_SetInPVS
+        expected_output:
+          - CEntitySystem_SetInPVS.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_RestoreEntity.{platform}.yaml
+
       - name: find-CEntityInstance_Restore
         expected_output:
           - CEntityInstance_Restore.{platform}.yaml
@@ -4363,6 +4369,11 @@ modules:
         category: func
         alias:
           - CEntitySaveRestoreBlockHandler::RestoreEntity
+
+      - name: CEntitySystem_SetInPVS
+        category: func
+        alias:
+          - CEntitySystem::SetInPVS
 
       - name: CEntityInstance_ObjectCaps
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -1393,6 +1393,10 @@ modules:
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_vtable
+        expected_output:
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
           - CLoopModeGame_OnLoopActivate.{platform}.yaml
@@ -1577,6 +1581,13 @@ modules:
         expected_input:
           - CLoopModeGame_OnPostDataUpdate.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
+
+      - name: find-CEntityInstance_PreDataUpdate
+        expected_output:
+          - CEntityInstance_PreDataUpdate.{platform}.yaml
+        expected_input:
+          - CLoopModeGame_OnPreDataUpdate.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
 
       - name: find-IGameSystem_OnGameFrameBoundary
         expected_output:
@@ -6035,6 +6046,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::PostDataUpdateDelta
+
+      - name: CEntityInstance_PreDataUpdate
+        category: vfunc
+        alias:
+          - CEntityInstance::PreDataUpdate
 
       - name: CEntityInstance_PostDataUpdate
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -3857,6 +3857,12 @@ modules:
         expected_input:
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_OnSetDormant
+        expected_output:
+          - CEntityInstance_OnSetDormant.{platform}.yaml
+        expected_input:
+          - CCSPlayerPawnBase_OnSetDormant.{platform}.yaml
+
       - name: find-CScriptedSequence_SynchronizeSequence
         expected_output:
           - CScriptedSequence_SynchronizeSequence.{platform}.yaml
@@ -6033,6 +6039,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::AddedToEntityDatabase
+
+      - name: CEntityInstance_OnSetDormant
+        category: vfunc
+        alias:
+          - CEntityInstance::OnSetDormant
 
       - name: CEntitySystem_OnRemoveEntity
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4133,6 +4133,12 @@ modules:
         expected_output:
           - CEntitySaveRestoreBlockHandler_DoRestoreEntity.{platform}.yaml
 
+      - name: find-CEntitySaveRestoreBlockHandler_RestoreEntity
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_RestoreEntity.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_DoRestoreEntity.{platform}.yaml
+
       - name: find-CEntityInstance_Restore
         expected_output:
           - CEntityInstance_Restore.{platform}.yaml
@@ -4352,6 +4358,11 @@ modules:
         category: func
         alias:
           - CEntitySaveRestoreBlockHandler::DoRestoreEntity
+
+      - name: CEntitySaveRestoreBlockHandler_RestoreEntity
+        category: func
+        alias:
+          - CEntitySaveRestoreBlockHandler::RestoreEntity
 
       - name: CEntityInstance_ObjectCaps
         category: vfunc

--- a/cpp_tests/centityinstance.cpp
+++ b/cpp_tests/centityinstance.cpp
@@ -1,0 +1,14 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+#include <entity2/entityinstance.h>
+
+CEntityInstance * entityinstance();
+
+int main() {
+
+    entityinstance()->Connect();
+
+    return 0;
+}

--- a/ida_preprocessor_scripts/find-CBaseModelEntity_SetRenderAttribute.py
+++ b/ida_preprocessor_scripts/find-CBaseModelEntity_SetRenderAttribute.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseModelEntity_SetRenderAttribute skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseModelEntity_SetRenderAttribute",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBaseModelEntity_SetRenderAttribute",
+        "xref_strings": [
+            "SetRenderAttribute on %s: FAILED to set %s, no more slots available (maximum %d)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CBaseModelEntity_SetRenderAttribute",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_DrawEntityDebugOverlays.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_DrawEntityDebugOverlays.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_DrawEntityDebugOverlays skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_DrawEntityDebugOverlays", "CEntityInstance", "CRagdollProp_DrawEntityDebugOverlays", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only mode: empty vfunc, only vtable slot position is needed.
+    (
+        "CEntityInstance_DrawEntityDebugOverlays",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CRagdollProp_DrawEntityDebugOverlays."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_NetworkUpdateState skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_NetworkUpdateState",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_NetworkUpdateState",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityInstance_NetworkUpdateState_thunk.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_NetworkUpdateState", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
+    (
+        "CEntityInstance_NetworkUpdateState",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc slot; fallback to LLM_DECOMPILE on CEntityInstance_NetworkUpdateState_thunk."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
@@ -28,9 +28,10 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_NetworkUpdateState",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState_thunk.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState_thunk.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_NetworkUpdateState_thunk skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_NetworkUpdateState_thunk",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_NetworkUpdateState_thunk",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBaseModelEntity_SetRenderAttribute.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_NetworkUpdateState_thunk",
+        [
+            "func_name",
+            "func_sig",
+            "func_sig_allow_across_function_boundary:true",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_OnSetDormant.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_OnSetDormant.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_OnSetDormant skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_OnSetDormant", "CEntityInstance", "CCSPlayerPawnBase_OnSetDormant", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Exactly these four fields to trigger slot-only mode (no vtable lookup needed)
+    (
+        "CEntityInstance_OnSetDormant",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CCSPlayerPawnBase_OnSetDormant."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdate.py
@@ -3,14 +3,27 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-INHERIT_VFUNCS = [
-    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
-    ("CEntityInstance_PostDataUpdate", "CEntityInstance", "CBaseEntity_PostDataUpdate", False),
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_PostDataUpdate",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_PostDataUpdate",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityInstance_PostDataUpdateDelta.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_PostDataUpdate", "CEntityInstance"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # Slot-only mode: empty vfunc, only vtable slot position is needed.
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
     (
         "CEntityInstance_PostDataUpdate",
         [
@@ -23,18 +36,10 @@ GENERATE_YAML_DESIRED_FIELDS = [
 ]
 
 async def preprocess_skill(
-    session,
-    skill_name,
-    expected_outputs,
-    old_yaml_map,
-    new_binary_dir,
-    platform,
-    image_base,
-    debug=False,
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
-    _ = skill_name
-
+    """Reuse previous gamever vfunc slot; fallback to LLM_DECOMPILE on CEntityInstance_PostDataUpdateDelta wrapper."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -42,7 +47,10 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        inherit_vfuncs=INHERIT_VFUNCS,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdate.py
@@ -28,9 +28,10 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_PostDataUpdate",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CBaseEntity_PostDataUpdate skill."""
+"""Preprocess script for find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CBaseEntity_PostDataUpdate",
+    "CEntityInstance_PostDataUpdatePreserve",
+    "CEntityInstance_PostDataUpdateDelta",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
-        "CBaseEntity_PostDataUpdate",
+        "CEntityInstance_PostDataUpdatePreserve",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
+    ),
+    (
+        "CEntityInstance_PostDataUpdateDelta",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
     ),
@@ -18,22 +24,29 @@ LLM_DECOMPILE = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CBaseEntity_PostDataUpdate", "CBaseEntity"),
+    ("CEntityInstance_PostDataUpdatePreserve", "CEntityInstance"),
+    ("CEntityInstance_PostDataUpdateDelta", "CEntityInstance"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
     (
-        "CBaseEntity_PostDataUpdate",
+        "CEntityInstance_PostDataUpdatePreserve",
         [
             "func_name",
-            "func_va",
-            "func_rva",
-            "func_size",
-            "vfunc_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
+        ],
+    ),
+    (
+        "CEntityInstance_PostDataUpdateDelta",
+        [
+            "func_name",
             "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
         ],
     ),
 ]
@@ -42,7 +55,7 @@ async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Reuse previous gamever vfunc slots; fallback to LLM_DECOMPILE on CEntitySystem_PostDataUpdate."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,

--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
@@ -35,18 +35,20 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_PostDataUpdatePreserve",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
     (
         "CEntityInstance_PostDataUpdateDelta",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CEntityInstance_PreDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PreDataUpdate.py
@@ -23,14 +23,14 @@ FUNC_VTABLE_RELATIONS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
     (
         "CEntityInstance_PreDataUpdate",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CEntityInstance_PreDataUpdate.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PreDataUpdate.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_PreDataUpdate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_PreDataUpdate",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_PreDataUpdate",
+        "prompt/call_llm_decompile.md",
+        "references/client/CLoopModeGame_OnPreDataUpdate.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_PreDataUpdate", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
+    (
+        "CEntityInstance_PreDataUpdate",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc slot; fallback to LLM_DECOMPILE on CLoopModeGame_OnPreDataUpdate."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_RequiredEdictIndex.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_RequiredEdictIndex.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_RequiredEdictIndex skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_RequiredEdictIndex",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_RequiredEdictIndex",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySaveRestoreBlockHandler_SaveInitEntities.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_RequiredEdictIndex", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # slot-only: CEntityInstance_RequiredEdictIndex is an abstract/interface vfunc -- no func_sig needed
+    (
+        "CEntityInstance_RequiredEdictIndex",
+        [
+            "func_name",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_RequiredEdictIndex.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_RequiredEdictIndex.py
@@ -28,6 +28,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_RequiredEdictIndex",
         [
             "func_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/ida_preprocessor_scripts/find-CEntityInstance_Restore.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_Restore.py
@@ -28,6 +28,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_Restore",
         [
             "func_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/ida_preprocessor_scripts/find-CEntityInstance_ScriptEntityIO.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_ScriptEntityIO.py
@@ -24,9 +24,10 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CEntityInstance_ScriptEntityIO",
         [
             "func_name",
-            "vtable_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
+            "vtable_name",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_RestoreEntity.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_RestoreEntity.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_RestoreEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySaveRestoreBlockHandler_RestoreEntity",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySaveRestoreBlockHandler_RestoreEntity",
+        "xref_strings": [
+            "%s:  added global entity %d %s (%s)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEntitySaveRestoreBlockHandler_DoRestoreEntity"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySaveRestoreBlockHandler_RestoreEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_SaveInitEntities.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_SaveInitEntities.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_SaveInitEntities skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySaveRestoreBlockHandler_SaveInitEntities",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySaveRestoreBlockHandler_SaveInitEntities",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySaveRestoreBlockHandler_PreSave.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Include func_va/func_rva/func_size because this function is a predecessor for downstream LLM_DECOMPILE
+    (
+        "CEntitySaveRestoreBlockHandler_SaveInitEntities",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_OnSetDormant.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_OnSetDormant.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_OnSetDormant skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_OnSetDormant",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_OnSetDormant",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_SetInPVS.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySystem_OnSetDormant", "CEntitySystem"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_OnSetDormant",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_SetInPVS.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_SetInPVS.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_SetInPVS skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_SetInPVS",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_SetInPVS",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySaveRestoreBlockHandler_RestoreEntity.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_SetInPVS",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CRagdollProp_DrawEntityDebugOverlays.py
+++ b/ida_preprocessor_scripts/find-CRagdollProp_DrawEntityDebugOverlays.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CRagdollProp_DrawEntityDebugOverlays skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CRagdollProp_DrawEntityDebugOverlays",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CRagdollProp_DrawEntityDebugOverlays",
+        "xref_strings": [
+            "mass %.1f",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CRagdollProp_DrawEntityDebugOverlays", "CRagdollProp"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CRagdollProp_DrawEntityDebugOverlays",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CRagdollProp_vtable.py
+++ b/ida_preprocessor_scripts/find-CRagdollProp_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CRagdollProp_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CRagdollProp"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CRagdollProp",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CRagdollProp vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CLoopModeGame_OnPreDataUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CLoopModeGame_OnPreDataUpdate.linux.yaml
@@ -1,0 +1,97 @@
+func_name: CLoopModeGame_OnPreDataUpdate
+func_va: '0x15cb960'
+disasm_code: |-
+  .text:00000000015CB960                 mov     edi, [rsi]
+  .text:00000000015CB962                 test    edi, edi
+  .text:00000000015CB964                 jle     locret_15CBA07
+  .text:00000000015CB96A                 push    rbp
+  .text:00000000015CB96B                 mov     rbp, rsp
+  .text:00000000015CB96E                 push    r12
+  .text:00000000015CB970                 xor     r12d, r12d
+  .text:00000000015CB973                 push    rbx
+  .text:00000000015CB974                 mov     rbx, rsi
+  .text:00000000015CB977                 mov     r8, [rbx+8]
+  .text:00000000015CB97B                 lea     rcx, [r8+r12*8]
+  .text:00000000015CB97F                 mov     esi, [rcx]
+  .text:00000000015CB981                 cmp     esi, 7FFEh
+  .text:00000000015CB987                 ja      short loc_15CB9C1
+  .text:00000000015CB989                 lea     rax, qword_47FAC88
+  .text:00000000015CB990                 mov     rdx, [rax]
+  .text:00000000015CB993                 mov     eax, esi
+  .text:00000000015CB995                 sar     eax, 9
+  .text:00000000015CB998                 cdqe
+  .text:00000000015CB99A                 mov     rax, [rdx+rax*8+10h]
+  .text:00000000015CB99F                 test    rax, rax
+  .text:00000000015CB9A2                 jz      short loc_15CB9C1
+  .text:00000000015CB9A4                 mov     edx, esi
+  .text:00000000015CB9A6                 and     edx, 1FFh
+  .text:00000000015CB9AC                 imul    rdx, 70h ; 'p'
+  .text:00000000015CB9B0                 add     rax, rdx
+  .text:00000000015CB9B3                 movzx   edx, word ptr [rax+10h]
+  .text:00000000015CB9B7                 and     edx, 7FFFh
+  .text:00000000015CB9BD                 cmp     edx, esi
+  .text:00000000015CB9BF                 jz      short loc_15CB9D0
+  .text:00000000015CB9C1                 lea     rdi, aOnpredataupdat; "OnPreDataUpdate: missing ent %d"
+  .text:00000000015CB9C8                 xor     eax, eax
+  .text:00000000015CB9CA                 call    _Plat_FatalError
+  .text:00000000015CB9CF                 nop
+  .text:00000000015CB9D0                 mov     esi, [rcx+4]
+  .text:00000000015CB9D3                 test    sil, 4
+  .text:00000000015CB9D7                 jnz     short loc_15CB9F8
+  .text:00000000015CB9D9                 mov     rdi, [rax]
+  .text:00000000015CB9DC                 add     r12, 1
+  .text:00000000015CB9E0                 mov     rax, [rdi]
+  .text:00000000015CB9E3                 call    qword ptr [rax+98h]  ; 98h = CEntityInstance_PreDataUpdate
+  .text:00000000015CB9E9                 mov     edi, [rbx]
+  .text:00000000015CB9EB                 cmp     edi, r12d
+  .text:00000000015CB9EE                 jg      short loc_15CB977
+  .text:00000000015CB9F0                 pop     rbx
+  .text:00000000015CB9F1                 pop     r12
+  .text:00000000015CB9F3                 pop     rbp
+  .text:00000000015CB9F4                 retn
+  .text:00000000015CB9F8                 add     r12, 1
+  .text:00000000015CB9FC                 cmp     edi, r12d
+  .text:00000000015CB9FF                 jg      loc_15CB97B
+  .text:00000000015CBA05                 jmp     short loc_15CB9F0
+  .text:00000000015CBA07                 retn
+procedure: |-
+  void __fastcall CLoopModeGame_OnPreDataUpdate(__int64 a1, __int64 a2)
+  {
+    const char *v2; // rdi
+    __int64 v3; // r12
+    __int64 v5; // r8
+    int *v6; // rcx
+    int v7; // esi
+    __int64 v8; // rax
+    _WORD *v9; // rax
+
+    LODWORD(v2) = *(_DWORD *)a2;
+    if ( *(int *)a2 > 0 )
+    {
+      v3 = 0;
+      do
+      {
+        v5 = *(_QWORD *)(a2 + 8);
+        while ( 1 )
+        {
+          v6 = (int *)(v5 + 8 * v3);
+          v7 = *v6;
+          if ( (unsigned int)*v6 > 0x7FFE
+            || (v8 = *(_QWORD *)(qword_47FAC88 + 8LL * (v7 >> 9) + 16)) == 0
+            || (v9 = (_WORD *)(112LL * (v7 & 0x1FF) + v8), (v9[8] & 0x7FFF) != v7) )
+          {
+            v2 = "OnPreDataUpdate: missing ent %d";
+            v9 = (_WORD *)Plat_FatalError("OnPreDataUpdate: missing ent %d", v7);
+          }
+          if ( (v6[1] & 4) == 0 )
+            break;
+          if ( (int)v2 <= (int)++v3 )
+            return;
+        }
+        ++v3;
+        (*(void (__fastcall **)(_QWORD))(**(_QWORD **)v9 + 152LL))(*(_QWORD *)v9);  // 152LL = 0x98 = CEntityInstance_PreDataUpdate
+        LODWORD(v2) = *(_DWORD *)a2;
+      }
+      while ( *(_DWORD *)a2 > (int)v3 );
+    }
+  }

--- a/ida_preprocessor_scripts/references/client/CLoopModeGame_OnPreDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CLoopModeGame_OnPreDataUpdate.windows.yaml
@@ -1,0 +1,113 @@
+func_name: CLoopModeGame_OnPreDataUpdate
+func_va: '0x1809b7850'
+disasm_code: |-
+  .text:00000001809B7850                 mov     [rsp+arg_10], rbx
+  .text:00000001809B7855                 push    rsi
+  .text:00000001809B7856                 sub     rsp, 20h
+  .text:00000001809B785A                 xor     ebx, ebx
+  .text:00000001809B785C                 mov     rsi, rdx
+  .text:00000001809B785F                 cmp     [rdx], ebx
+  .text:00000001809B7861                 jle     loc_1809B790D
+  .text:00000001809B7867                 mov     [rsp+28h+arg_0], rdi
+  .text:00000001809B786C                 mov     edi, ebx
+  .text:00000001809B786E                 xchg    ax, ax
+  .text:00000001809B7870                 mov     rcx, [rsi+8]
+  .text:00000001809B7874                 mov     r11, cs:qword_1824D0DC0
+  .text:00000001809B787B                 mov     eax, [rcx+rdi]
+  .text:00000001809B787E                 mov     r8d, eax
+  .text:00000001809B7881                 mov     r10d, [rcx+rdi+4]
+  .text:00000001809B7886                 mov     [rsp+28h+arg_8], eax
+  .text:00000001809B788A                 cmp     eax, 7FFEh
+  .text:00000001809B788F                 ja      loc_1809B7918
+  .text:00000001809B7895                 mov     edx, eax
+  .text:00000001809B7897                 sar     edx, 9
+  .text:00000001809B789A                 cmp     edx, 3Fh ; '?'
+  .text:00000001809B789D                 ja      short loc_1809B7918
+  .text:00000001809B789F                 movsxd  rcx, edx
+  .text:00000001809B78A2                 mov     r9, [r11+rcx*8+10h]
+  .text:00000001809B78A7                 test    r9, r9
+  .text:00000001809B78AA                 jz      short loc_1809B7918
+  .text:00000001809B78AC                 and     r8d, 1FFh
+  .text:00000001809B78B3                 imul    rcx, r8, 70h ; 'p'
+  .text:00000001809B78B7                 add     rcx, r9
+  .text:00000001809B78BA                 jz      short loc_1809B7918
+  .text:00000001809B78BC                 mov     ecx, [rcx+10h]
+  .text:00000001809B78BF                 and     ecx, 7FFFh
+  .text:00000001809B78C5                 cmp     ecx, eax
+  .text:00000001809B78C7                 setz    cl
+  .text:00000001809B78CA                 test    cl, cl
+  .text:00000001809B78CC                 jz      short loc_1809B7918
+  .text:00000001809B78CE                 and     eax, 1FFh
+  .text:00000001809B78D3                 movsxd  rcx, edx
+  .text:00000001809B78D6                 imul    r8, rax, 70h ; 'p'
+  .text:00000001809B78DA                 add     r8, [r11+rcx*8+10h]
+  .text:00000001809B78DF                 jz      short loc_1809B7918
+  .text:00000001809B78E1                 mov     eax, r10d
+  .text:00000001809B78E4                 shr     eax, 2
+  .text:00000001809B78E7                 test    al, 1
+  .text:00000001809B78E9                 jnz     short loc_1809B78FA
+  .text:00000001809B78EB                 mov     rcx, [r8]
+  .text:00000001809B78EE                 mov     edx, r10d
+  .text:00000001809B78F1                 mov     rax, [rcx]
+  .text:00000001809B78F4                 ; 0x90 = 144LL = CEntityInstance_PreDataUpdate
+  .text:00000001809B78F4                 call    qword ptr [rax+90h]; 0x90 = 144LL = CEntityInstance_PreDataUpdate
+  .text:00000001809B78FA                 inc     ebx
+  .text:00000001809B78FC                 add     rdi, 8
+  .text:00000001809B7900                 cmp     ebx, [rsi]
+  .text:00000001809B7902                 jl      loc_1809B7870
+  .text:00000001809B7908                 mov     rdi, [rsp+28h+arg_0]
+  .text:00000001809B790D                 mov     rbx, [rsp+28h+arg_10]
+  .text:00000001809B7912                 add     rsp, 20h
+  .text:00000001809B7916                 pop     rsi
+  .text:00000001809B7917                 retn
+  .text:00000001809B7918                 lea     rcx, [rsp+28h+arg_8]
+  .text:00000001809B791D                 call    sub_180958D30
+  .text:00000001809B7922                 mov     edx, eax
+  .text:00000001809B7924                 lea     rcx, aOnpredataupdat; "OnPreDataUpdate: missing ent %d"
+  .text:00000001809B792B                 call    cs:Plat_FatalError
+procedure: |-
+  void __fastcall CLoopModeGame_OnPreDataUpdate(__int64 a1, unsigned __int64 a2)
+  {
+    int v2; // ebx
+    unsigned __int64 v3; // rsi
+    __int64 v4; // rdi
+    __int64 v5; // rcx
+    int v6; // eax
+    __int64 pEntity; // r8
+    unsigned int v8; // r10d
+    __int64 v9; // r9
+    __int64 v10; // rcx
+    int v11; // eax
+    int v12; // [rsp+38h] [rbp+10h] BYREF
+
+    v2 = 0;
+    v3 = a2;
+    if ( *(int *)a2 > 0 )
+    {
+      v4 = 0;
+      do
+      {
+        v5 = *(_QWORD *)(v3 + 8);
+        v6 = *(_DWORD *)(v5 + v4);
+        pEntity = (unsigned int)v6;
+        v8 = *(_DWORD *)(v5 + v4 + 4);
+        v12 = v6;
+        if ( (unsigned int)v6 > 0x7FFE
+          || (a2 = (unsigned int)(v6 >> 9), (unsigned int)a2 > 0x3F)
+          || (v9 = *(_QWORD *)(qword_1824D0DC0 + 8LL * (int)a2 + 16)) == 0
+          || (pEntity = v6 & 0x1FF, (v10 = v9 + 112 * pEntity) == 0)
+          || (*(_DWORD *)(v10 + 16) & 0x7FFF) != v6
+          || (pEntity = *(_QWORD *)(qword_1824D0DC0 + 8LL * (int)a2 + 16) + 112LL * (v6 & 0x1FF)) == 0 )
+        {
+          v11 = sub_180958D30(&v12, a2, pEntity);
+          Plat_FatalError("OnPreDataUpdate: missing ent %d", v11);
+          JUMPOUT(0x1809B7931LL);
+        }
+        if ( (v8 & 4) == 0 )
+          (*(void (__fastcall **)(_QWORD, _QWORD))(**(_QWORD **)pEntity + 144LL))(*(_QWORD *)pEntity, v8);// 0x90 = 144LL = CEntityInstance_PreDataUpdate
+        ++v2;
+        v4 += 8;
+      }
+      while ( v2 < *(_DWORD *)v3 );
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CBaseModelEntity_SetRenderAttribute.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseModelEntity_SetRenderAttribute.linux.yaml
@@ -1,0 +1,818 @@
+func_name: CBaseModelEntity_SetRenderAttribute
+func_va: '0x14b3de0'
+disasm_code: |-
+  .text:00000000014B3DE0                 test    rsi, rsi
+  .text:00000000014B3DE3                 jz      locret_14B4130
+  .text:00000000014B3DE9                 push    rbp
+  .text:00000000014B3DEA                 mov     rbp, rsp
+  .text:00000000014B3DED                 push    r15
+  .text:00000000014B3DEF                 push    r14
+  .text:00000000014B3DF1                 push    r13
+  .text:00000000014B3DF3                 push    r12
+  .text:00000000014B3DF5                 mov     r12, rsi
+  .text:00000000014B3DF8                 push    rbx
+  .text:00000000014B3DF9                 sub     rsp, 88h
+  .text:00000000014B3E00                 cmp     byte ptr [rsi], 0
+  .text:00000000014B3E03                 jnz     short loc_14B3E20
+  .text:00000000014B3E05                 add     rsp, 88h
+  .text:00000000014B3E0C                 pop     rbx
+  .text:00000000014B3E0D                 pop     r12
+  .text:00000000014B3E0F                 pop     r13
+  .text:00000000014B3E11                 pop     r14
+  .text:00000000014B3E13                 pop     r15
+  .text:00000000014B3E15                 pop     rbp
+  .text:00000000014B3E16                 retn
+  .text:00000000014B3E20                 mov     rbx, rdi
+  .text:00000000014B3E23                 movq    rax, xmm1
+  .text:00000000014B3E28                 movdqa  xmm2, xmm0
+  .text:00000000014B3E2C                 mov     rdi, r12
+  .text:00000000014B3E2F                 mov     esi, 31415926h
+  .text:00000000014B3E34                 pinsrq  xmm2, rax, 1
+  .text:00000000014B3E3B                 movaps  xmmword ptr [rbp-90h], xmm2
+  .text:00000000014B3E42                 movss   dword ptr [rbp-74h], xmm2
+  .text:00000000014B3E47                 extractps dword ptr [rbp-80h], xmm2, 3
+  .text:00000000014B3E4E                 extractps dword ptr [rbp-7Ch], xmm2, 2
+  .text:00000000014B3E55                 extractps dword ptr [rbp-78h], xmm2, 1
+  .text:00000000014B3E5C                 call    sub_A30640
+  .text:00000000014B3E61                 mov     edi, [rbx+858h]
+  .text:00000000014B3E67                 mov     r14d, eax
+  .text:00000000014B3E6A                 test    edi, edi
+  .text:00000000014B3E6C                 jle     loc_14B4141
+  .text:00000000014B3E72                 movsxd  rax, edi
+  .text:00000000014B3E75                 mov     rsi, [rbx+860h]
+  .text:00000000014B3E7C                 xor     r15d, r15d
+  .text:00000000014B3E7F                 lea     rdx, [rax+rax*8]
+  .text:00000000014B3E83                 shl     rdx, 3
+  .text:00000000014B3E87                 jmp     short loc_14B3E9D
+  .text:00000000014B3E90                 add     r15, 48h ; 'H'
+  .text:00000000014B3E94                 cmp     rdx, r15
+  .text:00000000014B3E97                 jz      loc_14B3FA8
+  .text:00000000014B3E9D                 cmp     [rsi+r15+30h], r14d
+  .text:00000000014B3EA2                 jnz     short loc_14B3E90
+  .text:00000000014B3EA4                 mov     r12, qword ptr cs:xmmword_86BBF0
+  .text:00000000014B3EAB                 lea     r13, [rbp-70h]
+  .text:00000000014B3EAF                 mov     esi, 1
+  .text:00000000014B3EB4                 lea     rdi, [rbx+858h]
+  .text:00000000014B3EBB                 mov     rdx, r13
+  .text:00000000014B3EBE                 mov     [rbp-70h], r12
+  .text:00000000014B3EC2                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B3EC7                 add     r15, [rbx+860h]
+  .text:00000000014B3ECE                 movss   xmm7, dword ptr [rbp-74h]
+  .text:00000000014B3ED3                 ucomiss xmm7, dword ptr [r15+34h]
+  .text:00000000014B3ED8                 jp      short loc_14B3F10
+  .text:00000000014B3EDA                 jnz     short loc_14B3F10
+  .text:00000000014B3EDC                 movss   xmm7, dword ptr [rbp-78h]
+  .text:00000000014B3EE1                 ucomiss xmm7, dword ptr [r15+38h]
+  .text:00000000014B3EE6                 jp      short loc_14B3F10
+  .text:00000000014B3EE8                 jnz     short loc_14B3F10
+  .text:00000000014B3EEA                 movss   xmm6, dword ptr [rbp-7Ch]
+  .text:00000000014B3EEF                 ucomiss xmm6, dword ptr [r15+3Ch]
+  .text:00000000014B3EF4                 jp      short loc_14B3F10
+  .text:00000000014B3EF6                 jnz     short loc_14B3F10
+  .text:00000000014B3EF8                 movss   xmm4, dword ptr [rbp-80h]
+  .text:00000000014B3EFD                 ucomiss xmm4, dword ptr [r15+40h]
+  .text:00000000014B3F02                 jp      short loc_14B3F10
+  .text:00000000014B3F04                 jz      loc_14B3E05
+  .text:00000000014B3F0A                 nop     word ptr [rax+rax+00h]
+  .text:00000000014B3F10                 xor     r9d, r9d
+  .text:00000000014B3F13                 mov     esi, 1
+  .text:00000000014B3F18                 pxor    xmm0, xmm0
+  .text:00000000014B3F1C                 mov     qword ptr [rbp-70h], 1
+  .text:00000000014B3F24                 lea     rdi, [rbp-60h]
+  .text:00000000014B3F28                 mov     qword ptr [rbp-68h], 0
+  .text:00000000014B3F30                 mov     qword ptr [rbp-60h], 0
+  .text:00000000014B3F38                 mov     qword ptr [rbp-58h], 0
+  .text:00000000014B3F40                 movaps  xmmword ptr [rbp-50h], xmm0
+  .text:00000000014B3F44                 mov     [rbp-40h], r12
+  .text:00000000014B3F48                 mov     dword ptr [rbp-38h], 0FFFFFFFFh
+  .text:00000000014B3F4F                 mov     [rbp-34h], r9w
+  .text:00000000014B3F54                 call    sub_9B9640
+  .text:00000000014B3F59                 mov     rax, [rbp-60h]
+  .text:00000000014B3F5D                 lea     rdx, sub_E9D6F0
+  .text:00000000014B3F64                 add     dword ptr [rbp-68h], 1
+  .text:00000000014B3F68                 mov     dword ptr [rax], 34h ; '4'
+  .text:00000000014B3F6E                 mov     rax, [r15]
+  .text:00000000014B3F71                 mov     rax, [rax+8]
+  .text:00000000014B3F75                 cmp     rax, rdx
+  .text:00000000014B3F78                 jnz     loc_14B45C1
+  .text:00000000014B3F7E                 cmp     byte ptr [r15+2Ch], 0
+  .text:00000000014B3F83                 jnz     loc_14B45B0
+  .text:00000000014B3F89                 lea     rdi, [rbp-68h]
+  .text:00000000014B3F8D                 call    sub_9B9010
+  .text:00000000014B3F92                 movaps  xmm7, xmmword ptr [rbp-90h]
+  .text:00000000014B3F99                 movups  xmmword ptr [r15+34h], xmm7
+  .text:00000000014B3F9E                 jmp     loc_14B3E05
+  .text:00000000014B3FA8                 xor     r15d, r15d
+  .text:00000000014B3FAB                 jmp     short loc_14B3FCD
+  .text:00000000014B3FC0                 add     r15, 48h ; 'H'
+  .text:00000000014B3FC4                 cmp     rdx, r15
+  .text:00000000014B3FC7                 jz      loc_14B4138
+  .text:00000000014B3FCD                 mov     r8d, [rsi+r15+30h]
+  .text:00000000014B3FD2                 test    r8d, r8d
+  .text:00000000014B3FD5                 jnz     short loc_14B3FC0
+  .text:00000000014B3FD7                 mov     r12, qword ptr cs:xmmword_86BBF0
+  .text:00000000014B3FDE                 lea     r13, [rbp-70h]
+  .text:00000000014B3FE2                 mov     esi, 1
+  .text:00000000014B3FE7                 lea     rax, [rbx+858h]
+  .text:00000000014B3FEE                 mov     rdx, r13
+  .text:00000000014B3FF1                 mov     rdi, rax
+  .text:00000000014B3FF4                 mov     [rbp-98h], rax
+  .text:00000000014B3FFB                 mov     [rbp-70h], r12
+  .text:00000000014B3FFF                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B4004                 mov     rdx, [rbx+860h]
+  .text:00000000014B400B                 add     rdx, r15
+  .text:00000000014B400E                 cmp     [rdx+30h], r14d
+  .text:00000000014B4012                 mov     [rbp-0A0h], rdx
+  .text:00000000014B4019                 jnz     loc_14B44E8
+  .text:00000000014B401F                 mov     rdi, [rbp-98h]
+  .text:00000000014B4026                 mov     rdx, r13
+  .text:00000000014B4029                 mov     esi, 1
+  .text:00000000014B402E                 mov     [rbp-70h], r12
+  .text:00000000014B4032                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B4037                 add     r15, [rbx+860h]
+  .text:00000000014B403E                 movss   xmm3, dword ptr [rbp-74h]
+  .text:00000000014B4043                 ucomiss xmm3, dword ptr [r15+34h]
+  .text:00000000014B4048                 mov     rbx, r15
+  .text:00000000014B404B                 jp      short loc_14B4080
+  .text:00000000014B404D                 jnz     short loc_14B4080
+  .text:00000000014B404F                 movss   xmm5, dword ptr [rbp-78h]
+  .text:00000000014B4054                 ucomiss xmm5, dword ptr [r15+38h]
+  .text:00000000014B4059                 jp      short loc_14B4080
+  .text:00000000014B405B                 jnz     short loc_14B4080
+  .text:00000000014B405D                 movss   xmm3, dword ptr [rbp-7Ch]
+  .text:00000000014B4062                 ucomiss xmm3, dword ptr [r15+3Ch]
+  .text:00000000014B4067                 jp      short loc_14B4080
+  .text:00000000014B4069                 jnz     short loc_14B4080
+  .text:00000000014B406B                 movss   xmm6, dword ptr [rbp-80h]
+  .text:00000000014B4070                 ucomiss xmm6, dword ptr [r15+40h]
+  .text:00000000014B4075                 jp      short loc_14B4080
+  .text:00000000014B4077                 jz      loc_14B3E05
+  .text:00000000014B407D                 nop     dword ptr [rax]
+  .text:00000000014B4080                 xor     edx, edx
+  .text:00000000014B4082                 mov     esi, 1
+  .text:00000000014B4087                 pxor    xmm0, xmm0
+  .text:00000000014B408B                 mov     qword ptr [rbp-70h], 1
+  .text:00000000014B4093                 lea     rdi, [rbp-60h]
+  .text:00000000014B4097                 mov     [rbp-34h], dx
+  .text:00000000014B409B                 mov     qword ptr [rbp-68h], 0
+  .text:00000000014B40A3                 mov     qword ptr [rbp-60h], 0
+  .text:00000000014B40AB                 mov     qword ptr [rbp-58h], 0
+  .text:00000000014B40B3                 movaps  xmmword ptr [rbp-50h], xmm0
+  .text:00000000014B40B7                 mov     [rbp-40h], r12
+  .text:00000000014B40BB                 mov     dword ptr [rbp-38h], 0FFFFFFFFh
+  .text:00000000014B40C2                 call    sub_9B9640
+  .text:00000000014B40C7                 mov     rax, [rbp-60h]
+  .text:00000000014B40CB                 lea     rdx, sub_E9D6F0
+  .text:00000000014B40D2                 add     dword ptr [rbp-68h], 1
+  .text:00000000014B40D6                 mov     dword ptr [rax], 34h ; '4'
+  .text:00000000014B40DC                 mov     rax, [rbx]
+  .text:00000000014B40DF                 mov     rax, [rax+8]
+  .text:00000000014B40E3                 cmp     rax, rdx
+  .text:00000000014B40E6                 jnz     loc_14B45DF
+  .text:00000000014B40EC                 cmp     byte ptr [rbx+2Ch], 0
+  .text:00000000014B40F0                 jnz     loc_14B45CE
+  .text:00000000014B40F6                 cmp     dword ptr [rbp-54h], 3FFFFFFFh
+  .text:00000000014B40FD                 mov     dword ptr [rbp-68h], 0
+  .text:00000000014B4104                 ja      short loc_14B411F
+  .text:00000000014B4106                 mov     rsi, [rbp-60h]
+  .text:00000000014B410A                 test    rsi, rsi
+  .text:00000000014B410D                 jz      short loc_14B411F
+  .text:00000000014B410F                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000014B4116                 mov     rdi, [rax]
+  .text:00000000014B4119                 mov     rax, [rdi]
+  .text:00000000014B411C                 call    qword ptr [rax+20h]
+  .text:00000000014B411F                 movaps  xmm4, xmmword ptr [rbp-90h]
+  .text:00000000014B4126                 movups  xmmword ptr [rbx+34h], xmm4
+  .text:00000000014B412A                 jmp     loc_14B3E05
+  .text:00000000014B4130                 retn
+  .text:00000000014B4138                 cmp     edi, 3
+  .text:00000000014B413B                 jg      loc_14B43C0
+  .text:00000000014B4141                 mov     rax, qword ptr cs:xmmword_86C2F0+8
+  .text:00000000014B4148                 lea     r13, [rbp-70h]
+  .text:00000000014B414C                 mov     esi, 1
+  .text:00000000014B4151                 lea     rdi, [rbx+858h]
+  .text:00000000014B4158                 mov     rdx, r13
+  .text:00000000014B415B                 mov     [rbp-98h], rdi
+  .text:00000000014B4162                 mov     [rbp-70h], rax
+  .text:00000000014B4166                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B416B                 cmp     cs:_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE_ptr, 0
+  .text:00000000014B4173                 mov     r12, [rbx+870h]
+  .text:00000000014B417A                 jz      short loc_14B4181
+  .text:00000000014B417C                 call    _ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE
+  .text:00000000014B4181                 ; _QWORD
+  .text:00000000014B4181                 lea     rdi, qword_24356D8; _QWORD
+  .text:00000000014B4189                 call    ___tls_get_addr
+  .text:00000000014B4191                 cmp     cs:_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE_ptr, 0
+  .text:00000000014B4199                 mov     rax, [rax]
+  .text:00000000014B419C                 mov     [rbp-0A0h], rax
+  .text:00000000014B41A3                 jz      short loc_14B41AA
+  .text:00000000014B41A5                 call    _ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE
+  .text:00000000014B41AA                 ; _QWORD
+  .text:00000000014B41AA                 lea     rdi, qword_24356D8; _QWORD
+  .text:00000000014B41B2                 call    ___tls_get_addr
+  .text:00000000014B41BA                 mov     [rax], r12
+  .text:00000000014B41BD                 mov     rax, [rbx+870h]
+  .text:00000000014B41C4                 mov     [rbp-0A8h], rax
+  .text:00000000014B41CB                 test    rax, rax
+  .text:00000000014B41CE                 jz      short loc_14B41DD
+  .text:00000000014B41D0                 mov     esi, 1
+  .text:00000000014B41D5                 mov     rdi, rax
+  .text:00000000014B41D8                 call    CEntityInstance_NetworkUpdateState_thunk
+  .text:00000000014B41DD                 mov     r12d, [rbx+858h]
+  .text:00000000014B41E4                 mov     eax, r12d
+  .text:00000000014B41E7                 cmp     r12d, [rbx+868h]
+  .text:00000000014B41EE                 jz      loc_14B45EC
+  .text:00000000014B41F4                 mov     rdx, [rbx+860h]
+  .text:00000000014B41FB                 add     eax, 1
+  .text:00000000014B41FE                 mov     [rbx+858h], eax
+  .text:00000000014B4204                 movsxd  rax, r12d
+  .text:00000000014B4207                 lea     rax, [rax+rax*8]
+  .text:00000000014B420B                 lea     r15, ds:0[rax*8]
+  .text:00000000014B4213                 lea     rax, off_22915B0
+  .text:00000000014B421A                 add     rdx, r15
+  .text:00000000014B421D                 cmp     cs:_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE_ptr, 0
+  .text:00000000014B4225                 mov     [rdx], rax
+  .text:00000000014B4228                 mov     qword ptr [rdx+8], 0
+  .text:00000000014B4230                 jz      short loc_14B4245
+  .text:00000000014B4232                 mov     [rbp-0B0h], rdx
+  .text:00000000014B4239                 call    _ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE
+  .text:00000000014B423E                 mov     rdx, [rbp-0B0h]
+  .text:00000000014B4245                 mov     [rbp-0B0h], rdx
+  .text:00000000014B424C                 ; _QWORD
+  .text:00000000014B424C                 lea     rdi, qword_24356D8; _QWORD
+  .text:00000000014B4254                 call    ___tls_get_addr
+  .text:00000000014B425C                 mov     rdx, [rbp-0B0h]
+  .text:00000000014B4263                 pxor    xmm0, xmm0
+  .text:00000000014B4267                 mov     qword ptr [rdx+10h], 0
+  .text:00000000014B426F                 mov     qword ptr [rdx+18h], 0
+  .text:00000000014B4277                 mov     rax, [rax]
+  .text:00000000014B427A                 mov     qword ptr [rdx+20h], 0
+  .text:00000000014B4282                 mov     dword ptr [rdx+28h], 0FFFFFFFFh
+  .text:00000000014B4289                 mov     byte ptr [rdx+2Ch], 0
+  .text:00000000014B428D                 mov     dword ptr [rdx+30h], 0
+  .text:00000000014B4294                 mov     [rdx+8], rax
+  .text:00000000014B4298                 mov     rax, [rbp-0A8h]
+  .text:00000000014B429F                 movups  xmmword ptr [rdx+34h], xmm0
+  .text:00000000014B42A3                 test    rax, rax
+  .text:00000000014B42A6                 jz      short loc_14B42B2
+  .text:00000000014B42A8                 xor     esi, esi
+  .text:00000000014B42AA                 mov     rdi, rax
+  .text:00000000014B42AD                 call    CEntityInstance_NetworkUpdateState_thunk
+  .text:00000000014B42B2                 cmp     cs:_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE_ptr, 0
+  .text:00000000014B42BA                 jz      short loc_14B42C1
+  .text:00000000014B42BC                 call    _ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE
+  .text:00000000014B42C1                 ; _QWORD
+  .text:00000000014B42C1                 lea     rdi, qword_24356D8; _QWORD
+  .text:00000000014B42C9                 call    ___tls_get_addr
+  .text:00000000014B42D1                 mov     rcx, [rbp-0A0h]
+  .text:00000000014B42D8                 movd    xmm0, r12d
+  .text:00000000014B42DD                 mov     rdx, r13
+  .text:00000000014B42E0                 mov     rdi, [rbp-98h]
+  .text:00000000014B42E7                 mov     esi, 0Fh
+  .text:00000000014B42EC                 mov     [rax], rcx
+  .text:00000000014B42EF                 lea     eax, [r12+1]
+  .text:00000000014B42F4                 pinsrd  xmm0, eax, 1
+  .text:00000000014B42FA                 movq    qword ptr [rbp-70h], xmm0
+  .text:00000000014B42FF                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B4304                 mov     r12, qword ptr cs:xmmword_86BBF0
+  .text:00000000014B430B                 mov     rdx, r13
+  .text:00000000014B430E                 mov     esi, 1
+  .text:00000000014B4313                 mov     rdi, [rbp-98h]
+  .text:00000000014B431A                 mov     [rbp-70h], r12
+  .text:00000000014B431E                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B4323                 mov     rax, [rbx+860h]
+  .text:00000000014B432A                 add     rax, r15
+  .text:00000000014B432D                 cmp     [rax+30h], r14d
+  .text:00000000014B4331                 mov     [rbp-0A0h], rax
+  .text:00000000014B4338                 jnz     loc_14B4427
+  .text:00000000014B433E                 mov     rdi, [rbp-98h]
+  .text:00000000014B4345                 mov     rdx, r13
+  .text:00000000014B4348                 mov     esi, 1
+  .text:00000000014B434D                 mov     [rbp-70h], r12
+  .text:00000000014B4351                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:00000000014B4356                 add     r15, [rbx+860h]
+  .text:00000000014B435D                 movss   xmm5, dword ptr [rbp-74h]
+  .text:00000000014B4362                 ucomiss xmm5, dword ptr [r15+34h]
+  .text:00000000014B4367                 lea     rdi, [r15+34h]
+  .text:00000000014B436B                 jp      short loc_14B43A0
+  .text:00000000014B436D                 jnz     short loc_14B43A0
+  .text:00000000014B436F                 movss   xmm7, dword ptr [rbp-78h]
+  .text:00000000014B4374                 ucomiss xmm7, dword ptr [r15+38h]
+  .text:00000000014B4379                 jp      short loc_14B43A0
+  .text:00000000014B437B                 jnz     short loc_14B43A0
+  .text:00000000014B437D                 movss   xmm7, dword ptr [rbp-7Ch]
+  .text:00000000014B4382                 ucomiss xmm7, dword ptr [r15+3Ch]
+  .text:00000000014B4387                 jp      short loc_14B43A0
+  .text:00000000014B4389                 jnz     short loc_14B43A0
+  .text:00000000014B438B                 movss   xmm4, dword ptr [rbp-80h]
+  .text:00000000014B4390                 ucomiss xmm4, dword ptr [r15+40h]
+  .text:00000000014B4395                 jp      short loc_14B43A0
+  .text:00000000014B4397                 jz      loc_14B3E05
+  .text:00000000014B439D                 nop     dword ptr [rax]
+  .text:00000000014B43A0                 mov     edx, 0FFFFFFFFh
+  .text:00000000014B43A5                 mov     esi, 0FFFFFFFFh
+  .text:00000000014B43AA                 call    sub_1498EB0
+  .text:00000000014B43AF                 movaps  xmm6, xmmword ptr [rbp-90h]
+  .text:00000000014B43B6                 movups  xmmword ptr [r15+34h], xmm6
+  .text:00000000014B43BB                 jmp     loc_14B3E05
+  .text:00000000014B43C0                 lea     r13, dword_27BB45C
+  .text:00000000014B43C7                 ; _QWORD
+  .text:00000000014B43C7                 mov     esi, 3; _QWORD
+  .text:00000000014B43CC                 ; _QWORD
+  .text:00000000014B43CC                 mov     edi, [r13+0]; _QWORD
+  .text:00000000014B43D0                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000014B43D5                 test    al, al
+  .text:00000000014B43D7                 jz      loc_14B3E05
+  .text:00000000014B43DD                 mov     rax, [rbx+10h]
+  .text:00000000014B43E1                 lea     rdx, haystack
+  .text:00000000014B43E8                 mov     r8, r12
+  .text:00000000014B43EB                 ; _QWORD
+  .text:00000000014B43EB                 mov     esi, 3; _QWORD
+  .text:00000000014B43F0                 mov     rcx, rdx
+  .text:00000000014B43F3                 ; _QWORD
+  .text:00000000014B43F3                 mov     edi, [r13+0]; _QWORD
+  .text:00000000014B43F7                 mov     r9d, 4
+  .text:00000000014B43FD                 lea     rdx, aSetrenderattri_0; "SetRenderAttribute on %s: FAILED to set"...
+  .text:00000000014B4404                 mov     rax, [rax+18h]
+  .text:00000000014B4408                 test    rax, rax
+  .text:00000000014B440B                 cmovnz  rcx, rax
+  .text:00000000014B440F                 add     rsp, 88h
+  .text:00000000014B4416                 xor     eax, eax
+  .text:00000000014B4418                 pop     rbx
+  .text:00000000014B4419                 pop     r12
+  .text:00000000014B441B                 pop     r13
+  .text:00000000014B441D                 pop     r14
+  .text:00000000014B441F                 pop     r15
+  .text:00000000014B4421                 pop     rbp
+  .text:00000000014B4422                 jmp     _LoggingSystem_Log
+  .text:00000000014B4427                 xor     eax, eax
+  .text:00000000014B4429                 mov     esi, 1
+  .text:00000000014B442E                 pxor    xmm0, xmm0
+  .text:00000000014B4432                 mov     qword ptr [rbp-70h], 1
+  .text:00000000014B443A                 lea     rdi, [rbp-60h]
+  .text:00000000014B443E                 mov     [rbp-34h], ax
+  .text:00000000014B4442                 mov     qword ptr [rbp-68h], 0
+  .text:00000000014B444A                 mov     qword ptr [rbp-60h], 0
+  .text:00000000014B4452                 mov     qword ptr [rbp-58h], 0
+  .text:00000000014B445A                 movaps  xmmword ptr [rbp-50h], xmm0
+  .text:00000000014B445E                 mov     [rbp-40h], r12
+  .text:00000000014B4462                 mov     dword ptr [rbp-38h], 0FFFFFFFFh
+  .text:00000000014B4469                 call    sub_9B9640
+  .text:00000000014B446E                 mov     rdx, [rbp-60h]
+  .text:00000000014B4472                 lea     rsi, sub_E9D6F0
+  .text:00000000014B4479                 mov     rax, [rbp-0A0h]
+  .text:00000000014B4480                 add     dword ptr [rbp-68h], 1
+  .text:00000000014B4484                 mov     dword ptr [rdx], 30h ; '0'
+  .text:00000000014B448A                 mov     rdx, [rax]
+  .text:00000000014B448D                 mov     rdx, [rdx+8]
+  .text:00000000014B4491                 cmp     rdx, rsi
+  .text:00000000014B4494                 jnz     loc_14B4654
+  .text:00000000014B449A                 cmp     byte ptr [rax+2Ch], 0
+  .text:00000000014B449E                 jnz     loc_14B463C
+  .text:00000000014B44A4                 cmp     dword ptr [rbp-54h], 3FFFFFFFh
+  .text:00000000014B44AB                 mov     dword ptr [rbp-68h], 0
+  .text:00000000014B44B2                 ja      short loc_14B44DB
+  .text:00000000014B44B4                 mov     rsi, [rbp-60h]
+  .text:00000000014B44B8                 test    rsi, rsi
+  .text:00000000014B44BB                 jz      short loc_14B44DB
+  .text:00000000014B44BD                 mov     rdx, cs:g_pMemAlloc_ptr
+  .text:00000000014B44C4                 mov     [rbp-0A0h], rax
+  .text:00000000014B44CB                 mov     rdi, [rdx]
+  .text:00000000014B44CE                 mov     rdx, [rdi]
+  .text:00000000014B44D1                 call    qword ptr [rdx+20h]
+  .text:00000000014B44D4                 mov     rax, [rbp-0A0h]
+  .text:00000000014B44DB                 mov     [rax+30h], r14d
+  .text:00000000014B44DF                 jmp     loc_14B433E
+  .text:00000000014B44E8                 xor     ecx, ecx
+  .text:00000000014B44EA                 mov     esi, 1
+  .text:00000000014B44EF                 pxor    xmm0, xmm0
+  .text:00000000014B44F3                 mov     qword ptr [rbp-70h], 1
+  .text:00000000014B44FB                 lea     rdi, [rbp-60h]
+  .text:00000000014B44FF                 mov     qword ptr [rbp-68h], 0
+  .text:00000000014B4507                 mov     qword ptr [rbp-60h], 0
+  .text:00000000014B450F                 mov     qword ptr [rbp-58h], 0
+  .text:00000000014B4517                 movaps  xmmword ptr [rbp-50h], xmm0
+  .text:00000000014B451B                 mov     [rbp-40h], r12
+  .text:00000000014B451F                 mov     dword ptr [rbp-38h], 0FFFFFFFFh
+  .text:00000000014B4526                 mov     [rbp-34h], cx
+  .text:00000000014B452A                 call    sub_9B9640
+  .text:00000000014B452F                 mov     rsi, [rbp-60h]
+  .text:00000000014B4533                 mov     rdx, [rbp-0A0h]
+  .text:00000000014B453A                 add     dword ptr [rbp-68h], 1
+  .text:00000000014B453E                 mov     dword ptr [rsi], 30h ; '0'
+  .text:00000000014B4544                 mov     rsi, [rdx]
+  .text:00000000014B4547                 mov     r8, [rsi+8]
+  .text:00000000014B454B                 lea     rsi, sub_E9D6F0
+  .text:00000000014B4552                 cmp     r8, rsi
+  .text:00000000014B4555                 jnz     loc_14B4620
+  .text:00000000014B455B                 cmp     byte ptr [rdx+2Ch], 0
+  .text:00000000014B455F                 jnz     loc_14B4608
+  .text:00000000014B4565                 cmp     dword ptr [rbp-54h], 3FFFFFFFh
+  .text:00000000014B456C                 mov     dword ptr [rbp-68h], 0
+  .text:00000000014B4573                 ja      short loc_14B459D
+  .text:00000000014B4575                 mov     rsi, [rbp-60h]
+  .text:00000000014B4579                 test    rsi, rsi
+  .text:00000000014B457C                 jz      short loc_14B459D
+  .text:00000000014B457E                 mov     rdi, cs:g_pMemAlloc_ptr
+  .text:00000000014B4585                 mov     [rbp-0A0h], rdx
+  .text:00000000014B458C                 mov     rdi, [rdi]
+  .text:00000000014B458F                 mov     r8, [rdi]
+  .text:00000000014B4592                 call    qword ptr [r8+20h]
+  .text:00000000014B4596                 mov     rdx, [rbp-0A0h]
+  .text:00000000014B459D                 mov     [rdx+30h], r14d
+  .text:00000000014B45A1                 jmp     loc_14B401F
+  .text:00000000014B45B0                 lea     rdi, [r15+8]
+  .text:00000000014B45B4                 mov     rsi, r13
+  .text:00000000014B45B7                 call    sub_1E75750
+  .text:00000000014B45BC                 jmp     loc_14B3F89
+  .text:00000000014B45C1                 mov     rsi, r13
+  .text:00000000014B45C4                 mov     rdi, r15
+  .text:00000000014B45C7                 call    rax
+  .text:00000000014B45C9                 jmp     loc_14B3F89
+  .text:00000000014B45CE                 lea     rdi, [rbx+8]
+  .text:00000000014B45D2                 mov     rsi, r13
+  .text:00000000014B45D5                 call    sub_1E75750
+  .text:00000000014B45DA                 jmp     loc_14B40F6
+  .text:00000000014B45DF                 mov     rsi, r13
+  .text:00000000014B45E2                 mov     rdi, rbx
+  .text:00000000014B45E5                 call    rax
+  .text:00000000014B45E7                 jmp     loc_14B40F6
+  .text:00000000014B45EC                 lea     rdi, [rbx+860h]
+  .text:00000000014B45F3                 mov     esi, 1
+  .text:00000000014B45F8                 call    sub_EEE160
+  .text:00000000014B45FD                 mov     eax, [rbx+858h]
+  .text:00000000014B4603                 jmp     loc_14B41F4
+  .text:00000000014B4608                 lea     rdi, [rdx+8]
+  .text:00000000014B460C                 mov     rsi, r13
+  .text:00000000014B460F                 call    sub_1E75750
+  .text:00000000014B4614                 mov     rdx, [rbp-0A0h]
+  .text:00000000014B461B                 jmp     loc_14B4565
+  .text:00000000014B4620                 mov     rdi, rdx
+  .text:00000000014B4623                 mov     [rbp-0A0h], rdx
+  .text:00000000014B462A                 mov     rsi, r13
+  .text:00000000014B462D                 call    r8
+  .text:00000000014B4630                 mov     rdx, [rbp-0A0h]
+  .text:00000000014B4637                 jmp     loc_14B4565
+  .text:00000000014B463C                 lea     rdi, [rax+8]
+  .text:00000000014B4640                 mov     rsi, r13
+  .text:00000000014B4643                 call    sub_1E75750
+  .text:00000000014B4648                 mov     rax, [rbp-0A0h]
+  .text:00000000014B464F                 jmp     loc_14B44A4
+  .text:00000000014B4654                 mov     rdi, rax
+  .text:00000000014B4657                 mov     [rbp-0A0h], rax
+  .text:00000000014B465E                 mov     rsi, r13
+  .text:00000000014B4661                 call    rdx
+  .text:00000000014B4663                 mov     rax, [rbp-0A0h]
+  .text:00000000014B466A                 jmp     loc_14B44A4
+procedure: |-
+  void __fastcall CBaseModelEntity_SetRenderAttribute(__int64 a1, _BYTE *a2, __m128i a3, double a4)
+  {
+    int v6; // eax
+    void *(__fastcall *v7)(__int64, _DWORD *, __int64, __int64, int, int); // rcx
+    __int64 v8; // r8
+    unsigned int *v9; // r9
+    int v10; // edi
+    int v11; // r14d
+    __int64 v12; // rsi
+    __int64 v13; // r15
+    __int64 v14; // rdx
+    __int64 v15; // r15
+    __int64 (__fastcall *v16)(__int64, __int64); // rax
+    __int64 v17; // r15
+    void *(__fastcall *v18)(__int64, _DWORD *, __int64, __int64, int, int); // rcx
+    __int64 (__fastcall *v19)(__int64, __int64); // r8
+    unsigned int *v20; // r9
+    __int64 v21; // r15
+    __int64 (__fastcall *v22)(__int64, __int64); // rax
+    __int64 v23; // r12
+    __int64 v24; // rax
+    signed int v25; // r12d
+    signed int v26; // eax
+    __int64 v27; // rdx
+    __int64 v28; // r15
+    _QWORD *v29; // rdx
+    __int64 *addr; // rax
+    __int64 v31; // rax
+    __int64 v32; // r8
+    unsigned int *v33; // r9
+    void *(__fastcall *v34)(__int64, _DWORD *, __int64, __int64, int, int); // rcx
+    __int64 v35; // r8
+    unsigned int *v36; // r9
+    void *(__fastcall *v37)(__int64, _DWORD *, __int64, __int64, int, int); // rcx
+    __int64 v38; // r8
+    unsigned int *v39; // r9
+    __int64 v40; // r15
+    const bool *v41; // rcx
+    __int64 v42; // rax
+    __int64 (__fastcall *v43)(__int64, __int64); // rdx
+    __int64 v44; // rdx
+    _QWORD *v45; // [rsp-B8h] [rbp-B8h]
+    _QWORD *v46; // [rsp-B8h] [rbp-B8h]
+    __int64 v47; // [rsp-B0h] [rbp-B0h]
+    __int64 v48; // [rsp-A8h] [rbp-A8h]
+    void *(__fastcall *v49)(__int64, _DWORD *, __int64, __int64, int, int); // [rsp-A8h] [rbp-A8h]
+    __int64 v50; // [rsp-A8h] [rbp-A8h]
+    __int64 v51; // [rsp-A8h] [rbp-A8h]
+    __int64 v52; // [rsp-A8h] [rbp-A8h]
+    unsigned int *v53; // [rsp-A0h] [rbp-A0h]
+    __m128 inserted; // [rsp-98h] [rbp-98h]
+    float v55; // [rsp-88h] [rbp-88h]
+    float v56; // [rsp-84h] [rbp-84h]
+    float v57; // [rsp-80h] [rbp-80h]
+    unsigned __int64 v58; // [rsp-78h] [rbp-78h] BYREF
+    __int64 v59; // [rsp-70h] [rbp-70h] BYREF
+    _DWORD *v60; // [rsp-68h] [rbp-68h] BYREF
+    __int64 v61; // [rsp-60h] [rbp-60h]
+    __int128 v62; // [rsp-58h] [rbp-58h]
+    __int64 v63; // [rsp-48h] [rbp-48h]
+    int v64; // [rsp-40h] [rbp-40h]
+    __int16 v65; // [rsp-3Ch] [rbp-3Ch]
+
+    if ( a2 && *a2 )
+    {
+      inserted = (__m128)_mm_insert_epi64(a3, *(signed __int64 *)&a4, 1);
+      v55 = COERCE_FLOAT(_mm_extract_ps(inserted, 3));
+      v56 = COERCE_FLOAT(_mm_extract_ps(inserted, 2));
+      v57 = COERCE_FLOAT(_mm_extract_ps(inserted, 1));
+      v6 = sub_A30640(a2, 826366246);
+      v10 = *(_DWORD *)(a1 + 2136);
+      v11 = v6;
+      if ( v10 <= 0 )
+      {
+  LABEL_33:
+        v53 = (unsigned int *)(a1 + 2136);
+        v58 = 0xFFFFFFFFLL;
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(
+          (unsigned int *)(a1 + 2136),
+          1,
+          (unsigned int *)&v58,
+          v7,
+          v8,
+          v9);
+        v23 = *(_QWORD *)(a1 + 2160);
+        if ( &_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE )
+          ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE();
+        v49 = *(void *(__fastcall **)(__int64, _DWORD *, __int64, __int64, int, int))__tls_get_addr(&qword_24356D8);
+        if ( &_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE )
+          ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE();
+        *(_QWORD *)__tls_get_addr(&qword_24356D8) = v23;
+        v24 = *(_QWORD *)(a1 + 2160);
+        v47 = v24;
+        if ( v24 )
+          CEntityInstance_NetworkUpdateState_thunk(v24, 1u);
+        v25 = *(_DWORD *)(a1 + 2136);
+        v26 = v25;
+        if ( v25 == *(_DWORD *)(a1 + 2152) )
+        {
+          sub_EEE160(a1 + 2144, 1);
+          v26 = *(_DWORD *)(a1 + 2136);
+        }
+        v27 = *(_QWORD *)(a1 + 2144);
+        *(_DWORD *)(a1 + 2136) = v26 + 1;
+        v28 = 72LL * v25;
+        v29 = (_QWORD *)(v28 + v27);
+        *v29 = off_22915B0;
+        v29[1] = 0;
+        if ( &_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE )
+        {
+          v45 = v29;
+          ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE();
+          v29 = v45;
+        }
+        v46 = v29;
+        addr = (__int64 *)__tls_get_addr(&qword_24356D8);
+        v46[2] = 0;
+        v46[3] = 0;
+        v31 = *addr;
+        v46[4] = 0;
+        *((_DWORD *)v46 + 10) = -1;
+        *((_BYTE *)v46 + 44) = 0;
+        *((_DWORD *)v46 + 12) = 0;
+        v46[1] = v31;
+        *(_OWORD *)((char *)v46 + 52) = 0;
+        if ( v47 )
+          CEntityInstance_NetworkUpdateState_thunk(v47, 0);
+        if ( &_ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE )
+          ZTHN18CEntitySpawnHelper16tm_pCurEntityPtrE();
+        *(_QWORD *)__tls_get_addr(&qword_24356D8) = v49;
+        v58 = _mm_insert_epi32(_mm_cvtsi32_si128(v25), v25 + 1, 1).m128i_u64[0];
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v53, 15, (unsigned int *)&v58, v49, v32, v33);
+        v58 = -1;
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v53, 1, (unsigned int *)&v58, v34, v35, v36);
+        v50 = v28 + *(_QWORD *)(a1 + 2144);
+        if ( *(_DWORD *)(v50 + 48) != v11 )
+        {
+          v58 = 1;
+          v65 = 0;
+          v59 = 0;
+          v60 = nullptr;
+          v61 = 0;
+          v62 = 0;
+          v63 = -1;
+          v64 = -1;
+          sub_9B9640((__int64)&v60, 1);
+          v42 = v50;
+          LODWORD(v59) = v59 + 1;
+          *v60 = 48;
+          v43 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v50 + 8LL);
+          if ( v43 == sub_E9D6F0 )
+          {
+            if ( *(_BYTE *)(v50 + 44) )
+            {
+              sub_1E75750(v50 + 8, (__int64)&v58);
+              v42 = v50;
+            }
+          }
+          else
+          {
+            v43(v50, (__int64)&v58);
+            v42 = v50;
+          }
+          LODWORD(v59) = 0;
+          if ( HIDWORD(v61) <= 0x3FFFFFFF && v60 )
+          {
+            v51 = v42;
+            (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+            v42 = v51;
+          }
+          *(_DWORD *)(v42 + 48) = v11;
+        }
+        v58 = -1;
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v53, 1, (unsigned int *)&v58, v37, v38, v39);
+        v40 = *(_QWORD *)(a1 + 2144) + v28;
+        if ( inserted.m128_f32[0] != *(float *)(v40 + 52)
+          || v57 != *(float *)(v40 + 56)
+          || v56 != *(float *)(v40 + 60)
+          || v55 != *(float *)(v40 + 64) )
+        {
+          sub_1498EB0(v40 + 52, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+          *(__m128 *)(v40 + 52) = inserted;
+        }
+      }
+      else
+      {
+        v12 = *(_QWORD *)(a1 + 2144);
+        v13 = 0;
+        v14 = 72LL * v10;
+        do
+        {
+          if ( *(_DWORD *)(v12 + v13 + 48) == v6 )
+          {
+            v58 = -1;
+            CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(
+              (unsigned int *)(a1 + 2136),
+              1,
+              (unsigned int *)&v58,
+              v7,
+              v8,
+              v9);
+            v15 = *(_QWORD *)(a1 + 2144) + v13;
+            if ( inserted.m128_f32[0] != *(float *)(v15 + 52)
+              || v57 != *(float *)(v15 + 56)
+              || v56 != *(float *)(v15 + 60)
+              || v55 != *(float *)(v15 + 64) )
+            {
+              v58 = 1;
+              v59 = 0;
+              v60 = nullptr;
+              v61 = 0;
+              v62 = 0;
+              v63 = -1;
+              v64 = -1;
+              v65 = 0;
+              sub_9B9640((__int64)&v60, 1);
+              LODWORD(v59) = v59 + 1;
+              *v60 = 52;
+              v16 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v15 + 8LL);
+              if ( v16 == sub_E9D6F0 )
+              {
+                if ( *(_BYTE *)(v15 + 44) )
+                  sub_1E75750(v15 + 8, (__int64)&v58);
+              }
+              else
+              {
+                v16(v15, (__int64)&v58);
+              }
+              sub_9B9010(&v59);
+              *(__m128 *)(v15 + 52) = inserted;
+            }
+            return;
+          }
+          v13 += 72;
+        }
+        while ( v14 != v13 );
+        v17 = 0;
+        do
+        {
+          v8 = *(unsigned int *)(v12 + v17 + 48);
+          if ( !(_DWORD)v8 )
+          {
+            v58 = -1;
+            CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(
+              (unsigned int *)(a1 + 2136),
+              1,
+              (unsigned int *)&v58,
+              v7,
+              v8,
+              v9);
+            v48 = v17 + *(_QWORD *)(a1 + 2144);
+            if ( *(_DWORD *)(v48 + 48) != v11 )
+            {
+              v58 = 1;
+              v59 = 0;
+              v60 = nullptr;
+              v61 = 0;
+              v62 = 0;
+              v63 = -1;
+              v64 = -1;
+              v65 = 0;
+              sub_9B9640((__int64)&v60, 1);
+              v44 = v48;
+              LODWORD(v59) = v59 + 1;
+              *v60 = 48;
+              v19 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v48 + 8LL);
+              if ( v19 == sub_E9D6F0 )
+              {
+                if ( *(_BYTE *)(v48 + 44) )
+                {
+                  sub_1E75750(v48 + 8, (__int64)&v58);
+                  v44 = v48;
+                }
+              }
+              else
+              {
+                v19(v48, (__int64)&v58);
+                v44 = v48;
+              }
+              LODWORD(v59) = 0;
+              if ( HIDWORD(v61) <= 0x3FFFFFFF && v60 )
+              {
+                v52 = v44;
+                (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+                v44 = v52;
+              }
+              *(_DWORD *)(v44 + 48) = v11;
+            }
+            v58 = -1;
+            CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(
+              (unsigned int *)(a1 + 2136),
+              1,
+              (unsigned int *)&v58,
+              v18,
+              (__int64)v19,
+              v20);
+            v21 = *(_QWORD *)(a1 + 2144) + v17;
+            if ( inserted.m128_f32[0] != *(float *)(v21 + 52)
+              || v57 != *(float *)(v21 + 56)
+              || v56 != *(float *)(v21 + 60)
+              || v55 != *(float *)(v21 + 64) )
+            {
+              v58 = 1;
+              v65 = 0;
+              v59 = 0;
+              v60 = nullptr;
+              v61 = 0;
+              v62 = 0;
+              v63 = -1;
+              v64 = -1;
+              sub_9B9640((__int64)&v60, 1);
+              LODWORD(v59) = v59 + 1;
+              *v60 = 52;
+              v22 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v21 + 8LL);
+              if ( v22 == sub_E9D6F0 )
+              {
+                if ( *(_BYTE *)(v21 + 44) )
+                  sub_1E75750(v21 + 8, (__int64)&v58);
+              }
+              else
+              {
+                v22(v21, (__int64)&v58);
+              }
+              LODWORD(v59) = 0;
+              if ( HIDWORD(v61) <= 0x3FFFFFFF && v60 )
+                (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+              *(__m128 *)(v21 + 52) = inserted;
+            }
+            return;
+          }
+          v17 += 72;
+        }
+        while ( v14 != v17 );
+        if ( v10 <= 3 )
+          goto LABEL_33;
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27BB45C, 3) )
+        {
+          v41 = &haystack;
+          if ( *(_QWORD *)(*(_QWORD *)(a1 + 16) + 24LL) )
+            v41 = *(const bool **)(*(_QWORD *)(a1 + 16) + 24LL);
+          LoggingSystem_Log(
+            (unsigned int)dword_27BB45C,
+            3,
+            "SetRenderAttribute on %s: FAILED to set %s, no more slots available (maximum %d)\n",
+            v41,
+            a2,
+            4);
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CBaseModelEntity_SetRenderAttribute.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseModelEntity_SetRenderAttribute.windows.yaml
@@ -1,0 +1,433 @@
+func_name: CBaseModelEntity_SetRenderAttribute
+func_va: '0x180ad7d60'
+disasm_code: |-
+  .text:0000000180AD7D60                 test    rdx, rdx
+  .text:0000000180AD7D63                 jz      locret_180AD814F
+  .text:0000000180AD7D69                 push    rbp
+  .text:0000000180AD7D6A                 push    rsi
+  .text:0000000180AD7D6B                 push    r13
+  .text:0000000180AD7D6D                 push    r15
+  .text:0000000180AD7D6F                 mov     rbp, rsp
+  .text:0000000180AD7D72                 sub     rsp, 68h
+  .text:0000000180AD7D76                 cmp     byte ptr [rdx], 0
+  .text:0000000180AD7D79                 mov     r13, r8
+  .text:0000000180AD7D7C                 mov     rsi, rdx
+  .text:0000000180AD7D7F                 mov     r15, rcx
+  .text:0000000180AD7D82                 jz      loc_180AD8145
+  .text:0000000180AD7D88                 mov     [rsp+68h+arg_0], rbx
+  .text:0000000180AD7D90                 mov     edx, 31415926h
+  .text:0000000180AD7D95                 mov     [rsp+68h+var_8], rdi
+  .text:0000000180AD7D9A                 mov     rcx, rsi
+  .text:0000000180AD7D9D                 mov     [rsp+68h+var_18], r14
+  .text:0000000180AD7DA2                 call    sub_180189650
+  .text:0000000180AD7DA7                 lea     r14, [r15+578h]
+  .text:0000000180AD7DAE                 xor     edi, edi
+  .text:0000000180AD7DB0                 mov     r8d, [r14]
+  .text:0000000180AD7DB3                 mov     ebx, eax
+  .text:0000000180AD7DB5                 test    r8d, r8d
+  .text:0000000180AD7DB8                 jle     short loc_180AD7E0F
+  .text:0000000180AD7DBA                 mov     rax, [r15+580h]
+  .text:0000000180AD7DC1                 xor     ecx, ecx
+  .text:0000000180AD7DC3                 add     rax, 30h ; '0'
+  .text:0000000180AD7DC7                 movsxd  rdx, r8d
+  .text:0000000180AD7DCA                 nop     word ptr [rax+rax+00h]
+  .text:0000000180AD7DD0                 cmp     ebx, [rax]
+  .text:0000000180AD7DD2                 jz      loc_180AD7F2D
+  .text:0000000180AD7DD8                 inc     edi
+  .text:0000000180AD7DDA                 inc     rcx
+  .text:0000000180AD7DDD                 add     rax, 48h ; 'H'
+  .text:0000000180AD7DE1                 cmp     rcx, rdx
+  .text:0000000180AD7DE4                 jl      short loc_180AD7DD0
+  .text:0000000180AD7DE6                 mov     rax, [r15+580h]
+  .text:0000000180AD7DED                 xor     edi, edi
+  .text:0000000180AD7DEF                 xor     ecx, ecx
+  .text:0000000180AD7DF1                 add     rax, 30h ; '0'
+  .text:0000000180AD7DF5                 cmp     dword ptr [rax], 0
+  .text:0000000180AD7DF8                 jz      short loc_180AD7E72
+  .text:0000000180AD7DFA                 inc     edi
+  .text:0000000180AD7DFC                 inc     rcx
+  .text:0000000180AD7DFF                 add     rax, 48h ; 'H'
+  .text:0000000180AD7E03                 cmp     rcx, r8
+  .text:0000000180AD7E06                 jl      short loc_180AD7DF5
+  .text:0000000180AD7E08                 lea     r14, [r15+578h]
+  .text:0000000180AD7E0F                 cmp     dword ptr [r14], 4
+  .text:0000000180AD7E13                 jl      loc_180AD7F92
+  .text:0000000180AD7E19                 mov     ecx, cs:dword_1820B1788
+  .text:0000000180AD7E1F                 mov     edx, 3
+  .text:0000000180AD7E24                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180AD7E2A                 test    al, al
+  .text:0000000180AD7E2C                 jz      loc_180AD8133
+  .text:0000000180AD7E32                 mov     rax, [r15+10h]
+  .text:0000000180AD7E36                 lea     r9, byte_18159B990
+  .text:0000000180AD7E3D                 mov     [rsp+68h+var_40], 4
+  .text:0000000180AD7E45                 lea     r8, aSetrenderattri; "SetRenderAttribute on %s: FAILED to set"...
+  .text:0000000180AD7E4C                 mov     edx, 3
+  .text:0000000180AD7E51                 mov     [rsp+68h+var_48], rsi
+  .text:0000000180AD7E56                 mov     rcx, [rax+18h]
+  .text:0000000180AD7E5A                 test    rcx, rcx
+  .text:0000000180AD7E5D                 cmovnz  r9, rcx
+  .text:0000000180AD7E61                 mov     ecx, cs:dword_1820B1788
+  .text:0000000180AD7E67                 call    cs:LoggingSystem_Log
+  .text:0000000180AD7E6D                 jmp     loc_180AD8133
+  .text:0000000180AD7E72                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD7E76                 mov     [rbp+arg_8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180AD7E7E                 mov     dl, 1
+  .text:0000000180AD7E80                 lea     rcx, [r15+578h]
+  .text:0000000180AD7E87                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD7E8C                 movsxd  rax, edi
+  .text:0000000180AD7E8F                 mov     rdi, [r15+580h]
+  .text:0000000180AD7E96                 lea     rcx, [rax+rax*8]
+  .text:0000000180AD7E9A                 cmp     ebx, [rdi+rcx*8+30h]
+  .text:0000000180AD7E9E                 lea     r14, ds:0[rcx*8]
+  .text:0000000180AD7EA6                 jz      short loc_180AD7EC4
+  .text:0000000180AD7EA8                 lea     rcx, [rdi+30h]
+  .text:0000000180AD7EAC                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AD7EB1                 add     rcx, r14
+  .text:0000000180AD7EB4                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180AD7EBA                 call    sub_1805FF7D0
+  .text:0000000180AD7EBF                 mov     [rdi+r14+30h], ebx
+  .text:0000000180AD7EC4                 lea     rcx, [r15+578h]
+  .text:0000000180AD7ECB                 mov     [rbp+arg_8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180AD7ED3                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD7ED7                 mov     dl, 1
+  .text:0000000180AD7ED9                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD7EDE                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD7EE3                 mov     rbx, [r15+580h]
+  .text:0000000180AD7EEA                 lea     rdx, [rbp+var_30]
+  .text:0000000180AD7EEE                 movups  [rbp+var_30], xmm0
+  .text:0000000180AD7EF2                 lea     rcx, [rbx+34h]
+  .text:0000000180AD7EF6                 add     rcx, r14
+  .text:0000000180AD7EF9                 call    sub_180551520
+  .text:0000000180AD7EFE                 test    al, al
+  .text:0000000180AD7F00                 jz      loc_180AD8133
+  .text:0000000180AD7F06                 lea     rcx, [rbx+34h]
+  .text:0000000180AD7F0A                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AD7F0F                 add     rcx, r14
+  .text:0000000180AD7F12                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180AD7F18                 call    sub_1805FFA50
+  .text:0000000180AD7F1D                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD7F22                 movups  xmmword ptr [rbx+r14+34h], xmm0
+  .text:0000000180AD7F28                 jmp     loc_180AD8133
+  .text:0000000180AD7F2D                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD7F31                 mov     [rbp+arg_8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180AD7F39                 mov     dl, 1
+  .text:0000000180AD7F3B                 mov     rcx, r14
+  .text:0000000180AD7F3E                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD7F43                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD7F48                 movsxd  rax, edi
+  .text:0000000180AD7F4B                 lea     rdx, [rbp+var_30]
+  .text:0000000180AD7F4F                 movups  [rbp+var_30], xmm0
+  .text:0000000180AD7F53                 lea     rcx, [rax+rax*8]
+  .text:0000000180AD7F57                 mov     rax, [r14+8]
+  .text:0000000180AD7F5B                 lea     rbx, [rax+rcx*8]
+  .text:0000000180AD7F5F                 lea     rcx, [rbx+34h]
+  .text:0000000180AD7F63                 call    sub_180551520
+  .text:0000000180AD7F68                 test    al, al
+  .text:0000000180AD7F6A                 jz      loc_180AD8133
+  .text:0000000180AD7F70                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AD7F75                 lea     rcx, [rbx+34h]
+  .text:0000000180AD7F79                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180AD7F7F                 call    sub_1805FFA50
+  .text:0000000180AD7F84                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD7F89                 movups  xmmword ptr [rbx+34h], xmm0
+  .text:0000000180AD7F8D                 jmp     loc_180AD8133
+  .text:0000000180AD7F92                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD7F96                 mov     [rsp+68h+var_10], r12
+  .text:0000000180AD7F9B                 mov     dl, 1
+  .text:0000000180AD7F9D                 mov     dword ptr [rbp+arg_8], 0FFFFFFFFh
+  .text:0000000180AD7FA4                 mov     rcx, r14
+  .text:0000000180AD7FA7                 mov     dword ptr [rbp+arg_8+4], 0
+  .text:0000000180AD7FAE                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD7FB3                 mov     rax, [r14+18h]
+  .text:0000000180AD7FB7                 mov     ecx, cs:TlsIndex
+  .text:0000000180AD7FBD                 mov     [rbp+arg_8], rax
+  .text:0000000180AD7FC1                 mov     rax, gs:58h
+  .text:0000000180AD7FCA                 mov     r12d, 21Ch
+  .text:0000000180AD7FD0                 mov     [rbp+arg_18], r14
+  .text:0000000180AD7FD4                 mov     rdi, [rax+rcx*8]
+  .text:0000000180AD7FD8                 cmp     byte ptr [rdi+r12], 0
+  .text:0000000180AD7FDD                 lea     rcx, [rdi+r12]
+  .text:0000000180AD7FE1                 mov     [rbp+var_38], rdi
+  .text:0000000180AD7FE5                 jnz     short loc_180AD7FFB
+  .text:0000000180AD7FE7                 call    sub_1814F7250
+  .text:0000000180AD7FEC                 lea     rax, [r15+578h]
+  .text:0000000180AD7FF3                 mov     [rbp+arg_18], rax
+  .text:0000000180AD7FF7                 lea     rcx, [rdi+r12]
+  .text:0000000180AD7FFB                 mov     eax, 40h ; '@'
+  .text:0000000180AD8000                 add     rdi, rax
+  .text:0000000180AD8003                 cmp     byte ptr [rcx], 0
+  .text:0000000180AD8006                 mov     rsi, [rdi]
+  .text:0000000180AD8009                 jnz     short loc_180AD8010
+  .text:0000000180AD800B                 call    sub_1814F7250
+  .text:0000000180AD8010                 mov     rax, [rbp+arg_8]
+  .text:0000000180AD8014                 mov     [rdi], rax
+  .text:0000000180AD8017                 mov     rdi, [r14+18h]
+  .text:0000000180AD801B                 test    rdi, rdi
+  .text:0000000180AD801E                 jz      short loc_180AD8048
+  .text:0000000180AD8020                 mov     dl, 1
+  .text:0000000180AD8022                 mov     rcx, rdi
+  .text:0000000180AD8025                 call    CEntityInstance_NetworkUpdateState_thunk
+  .text:0000000180AD802A                 mov     rcx, r14
+  .text:0000000180AD802D                 add     r15, 578h
+  .text:0000000180AD8034                 call    sub_180AAAAD0
+  .text:0000000180AD8039                 xor     edx, edx
+  .text:0000000180AD803B                 mov     dword ptr [rbp+arg_8], eax
+  .text:0000000180AD803E                 mov     rcx, rdi
+  .text:0000000180AD8041                 call    CEntityInstance_NetworkUpdateState_thunk
+  .text:0000000180AD8046                 jmp     short loc_180AD8057
+  .text:0000000180AD8048                 mov     rcx, r14
+  .text:0000000180AD804B                 call    sub_180AAAAD0
+  .text:0000000180AD8050                 mov     r15, [rbp+arg_18]
+  .text:0000000180AD8054                 mov     dword ptr [rbp+arg_8], eax
+  .text:0000000180AD8057                 mov     rax, [rbp+var_38]
+  .text:0000000180AD805B                 mov     edi, 40h ; '@'
+  .text:0000000180AD8060                 cmp     byte ptr [rax+r12], 0
+  .text:0000000180AD8065                 mov     r12, [rsp+68h+var_10]
+  .text:0000000180AD806A                 jnz     short loc_180AD8075
+  .text:0000000180AD806C                 call    sub_1814F7250
+  .text:0000000180AD8071                 mov     rax, [rbp+var_38]
+  .text:0000000180AD8075                 mov     [rax+rdi], rsi
+  .text:0000000180AD8079                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD807D                 movsxd  rdi, dword ptr [rbp+arg_8]
+  .text:0000000180AD8081                 mov     dl, 0Fh
+  .text:0000000180AD8083                 mov     rcx, r14
+  .text:0000000180AD8086                 mov     dword ptr [rbp+arg_8], edi
+  .text:0000000180AD8089                 lea     eax, [rdi+1]
+  .text:0000000180AD808C                 mov     dword ptr [rbp+arg_8+4], eax
+  .text:0000000180AD808F                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD8094                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD8098                 mov     [rbp+arg_8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180AD80A0                 mov     dl, 1
+  .text:0000000180AD80A2                 mov     rcx, r15
+  .text:0000000180AD80A5                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD80AA                 lea     rcx, [rdi+rdi*8]
+  .text:0000000180AD80AE                 mov     rdi, [r15+8]
+  .text:0000000180AD80B2                 lea     rsi, ds:0[rcx*8]
+  .text:0000000180AD80BA                 cmp     ebx, [rdi+rsi+30h]
+  .text:0000000180AD80BE                 jz      short loc_180AD80DB
+  .text:0000000180AD80C0                 lea     rcx, [rsi+30h]
+  .text:0000000180AD80C4                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AD80C9                 add     rcx, rdi
+  .text:0000000180AD80CC                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180AD80D2                 call    sub_1805FF7D0
+  .text:0000000180AD80D7                 mov     [rdi+rsi+30h], ebx
+  .text:0000000180AD80DB                 lea     r8, [rbp+arg_8]
+  .text:0000000180AD80DF                 mov     [rbp+arg_8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180AD80E7                 mov     dl, 1
+  .text:0000000180AD80E9                 mov     rcx, r15
+  .text:0000000180AD80EC                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:0000000180AD80F1                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD80F6                 mov     rbx, [r15+8]
+  .text:0000000180AD80FA                 lea     rcx, [rsi+34h]
+  .text:0000000180AD80FE                 lea     rdx, [rbp+var_30]
+  .text:0000000180AD8102                 add     rcx, rbx
+  .text:0000000180AD8105                 movups  [rbp+var_30], xmm0
+  .text:0000000180AD8109                 call    sub_180551520
+  .text:0000000180AD810E                 test    al, al
+  .text:0000000180AD8110                 jz      short loc_180AD8133
+  .text:0000000180AD8112                 lea     rcx, [rsi+34h]
+  .text:0000000180AD8116                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AD811B                 add     rcx, rbx
+  .text:0000000180AD811E                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180AD8124                 call    sub_1805FFA50
+  .text:0000000180AD8129                 movups  xmm0, xmmword ptr [r13+0]
+  .text:0000000180AD812E                 movups  xmmword ptr [rbx+rsi+34h], xmm0
+  .text:0000000180AD8133                 mov     rdi, [rsp+68h+var_8]
+  .text:0000000180AD8138                 mov     rbx, [rsp+68h+arg_0]
+  .text:0000000180AD8140                 mov     r14, [rsp+68h+var_18]
+  .text:0000000180AD8145                 add     rsp, 68h
+  .text:0000000180AD8149                 pop     r15
+  .text:0000000180AD814B                 pop     r13
+  .text:0000000180AD814D                 pop     rsi
+  .text:0000000180AD814E                 pop     rbp
+  .text:0000000180AD814F                 retn
+procedure: |-
+  void __fastcall CBaseModelEntity_SetRenderAttribute(__int64 a1, const char *a2, __int128 *a3)
+  {
+    int v6; // eax
+    __int64 v7; // r14
+    int v8; // edi
+    __int64 v9; // r8
+    int v10; // ebx
+    __int64 v11; // rcx
+    _DWORD *v12; // rax
+    int v13; // edi
+    __int64 v14; // rcx
+    _DWORD *v15; // rax
+    __int64 v16; // rax
+    char *v17; // r9
+    __int64 v18; // rax
+    __int64 v19; // rdi
+    __int64 v20; // r14
+    __int64 v21; // rbx
+    __int64 v22; // rbx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v24; // rdi
+    _BYTE *v25; // rcx
+    __int64 *v26; // rdi
+    __int64 v27; // rsi
+    __int64 v28; // rdi
+    __int64 v29; // r15
+    int v30; // eax
+    __int64 v31; // rax
+    __int64 v32; // rdi
+    __int64 v33; // rcx
+    __int64 v34; // rdi
+    __int64 v35; // rsi
+    __int64 v36; // rbx
+    __int64 v37; // [rsp+30h] [rbp-38h]
+    __int128 v38; // [rsp+38h] [rbp-30h] BYREF
+    __int64 v39; // [rsp+98h] [rbp+30h] BYREF
+    __int64 v40; // [rsp+A8h] [rbp+40h]
+
+    if ( a2 && *a2 )
+    {
+      v6 = sub_180189650(a2, 0x31415926);
+      v7 = a1 + 1400;
+      v8 = 0;
+      v9 = *(unsigned int *)(a1 + 1400);
+      v10 = v6;
+      if ( (int)v9 <= 0 )
+      {
+  LABEL_11:
+        if ( *(int *)v7 < 4 )
+        {
+          v39 = 0xFFFFFFFFLL;
+          CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v7, 1, (unsigned int *)&v39);
+          v39 = *(_QWORD *)(v7 + 24);
+          ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+          v40 = v7;
+          v24 = ThreadLocalStoragePointer[TlsIndex];
+          v25 = (_BYTE *)(v24 + 540);
+          v37 = v24;
+          if ( !*(_BYTE *)(v24 + 540) )
+          {
+            sub_1814F7250();
+            v40 = a1 + 1400;
+            v25 = (_BYTE *)(v24 + 540);
+          }
+          v26 = (__int64 *)(v24 + 64);
+          v27 = *v26;
+          if ( !*v25 )
+            sub_1814F7250();
+          *v26 = v39;
+          v28 = *(_QWORD *)(v7 + 24);
+          if ( v28 )
+          {
+            CEntityInstance_NetworkUpdateState_thunk(*(_QWORD *)(v7 + 24), 1);
+            v29 = a1 + 1400;
+            LODWORD(v39) = sub_180AAAAD0((int *)v7);
+            CEntityInstance_NetworkUpdateState_thunk(v28, 0);
+          }
+          else
+          {
+            v30 = sub_180AAAAD0((int *)v7);
+            v29 = v40;
+            LODWORD(v39) = v30;
+          }
+          v31 = v37;
+          if ( !*(_BYTE *)(v37 + 540) )
+          {
+            sub_1814F7250();
+            v31 = v37;
+          }
+          *(_QWORD *)(v31 + 64) = v27;
+          v32 = (int)v39;
+          LODWORD(v39) = v32;
+          HIDWORD(v39) = v32 + 1;
+          CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v7, 15, (unsigned int *)&v39);
+          v39 = -1;
+          CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v29, 1, (unsigned int *)&v39);
+          v33 = 9 * v32;
+          v34 = *(_QWORD *)(v29 + 8);
+          v35 = 8 * v33;
+          if ( v10 != *(_DWORD *)(v34 + 8 * v33 + 48) )
+          {
+            sub_1805FF7D0(v34 + v35 + 48, -1, -1);
+            *(_DWORD *)(v34 + v35 + 48) = v10;
+          }
+          v39 = -1;
+          CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(v29, 1, (unsigned int *)&v39);
+          v36 = *(_QWORD *)(v29 + 8);
+          v38 = *a3;
+          if ( (unsigned __int8)sub_180551520(v36 + v35 + 52, &v38) )
+          {
+            sub_1805FFA50(v36 + v35 + 52, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+            *(_OWORD *)(v36 + v35 + 52) = *a3;
+          }
+        }
+        else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1788, 3) )
+        {
+          v16 = *(_QWORD *)(a1 + 16);
+          v17 = byte_18159B990;
+          if ( *(_QWORD *)(v16 + 24) )
+            v17 = *(char **)(v16 + 24);
+          LoggingSystem_Log(
+            (unsigned int)dword_1820B1788,
+            3,
+            "SetRenderAttribute on %s: FAILED to set %s, no more slots available (maximum %d)\n",
+            v17,
+            a2,
+            4);
+        }
+      }
+      else
+      {
+        v11 = 0;
+        v12 = (_DWORD *)(*(_QWORD *)(a1 + 1408) + 48LL);
+        do
+        {
+          if ( v10 == *v12 )
+          {
+            v39 = -1;
+            CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(a1 + 1400, 1, (unsigned int *)&v39);
+            v38 = *a3;
+            v22 = *(_QWORD *)(a1 + 1408) + 72LL * v8;
+            if ( (unsigned __int8)sub_180551520(v22 + 52, &v38) )
+            {
+              sub_1805FFA50(v22 + 52, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+              *(_OWORD *)(v22 + 52) = *a3;
+            }
+            return;
+          }
+          ++v8;
+          ++v11;
+          v12 += 18;
+        }
+        while ( v11 < (int)v9 );
+        v13 = 0;
+        v14 = 0;
+        v15 = (_DWORD *)(*(_QWORD *)(a1 + 1408) + 48LL);
+        while ( *v15 )
+        {
+          ++v13;
+          ++v14;
+          v15 += 18;
+          if ( v14 >= v9 )
+          {
+            v7 = a1 + 1400;
+            goto LABEL_11;
+          }
+        }
+        v39 = -1;
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(a1 + 1400, 1, (unsigned int *)&v39);
+        v18 = v13;
+        v19 = *(_QWORD *)(a1 + 1408);
+        v20 = 72 * v18;
+        if ( v10 != *(_DWORD *)(v19 + 72 * v18 + 48) )
+        {
+          sub_1805FF7D0(v20 + v19 + 48, -1, -1);
+          *(_DWORD *)(v19 + v20 + 48) = v10;
+        }
+        v39 = -1;
+        CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(a1 + 1400, 1, (unsigned int *)&v39);
+        v21 = *(_QWORD *)(a1 + 1408);
+        v38 = *a3;
+        if ( (unsigned __int8)sub_180551520(v20 + v21 + 52, &v38) )
+        {
+          sub_1805FFA50(v20 + v21 + 52, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+          *(_OWORD *)(v21 + v20 + 52) = *a3;
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_NetworkUpdateState_thunk.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_NetworkUpdateState_thunk.linux.yaml
@@ -1,0 +1,22 @@
+func_name: CEntityInstance_NetworkUpdateState_thunk
+func_va: '0x1e757f0'
+disasm_code: |-
+  .text:0000000001E757F0                 mov     rax, [rdi]
+  .text:0000000001E757F3                 lea     rdx, nullsub_1663
+  .text:0000000001E757FA                 ; 0x100 = 256LL = CEntityInstance_NetworkUpdateState
+  .text:0000000001E757FA                 mov     rax, [rax+100h]; 0x100 = 256LL = CEntityInstance_NetworkUpdateState
+  .text:0000000001E75801                 cmp     rax, rdx
+  .text:0000000001E75804                 jnz     short loc_1E75810
+  .text:0000000001E75806                 retn
+  .text:0000000001E75810                 movzx   esi, sil
+  .text:0000000001E75814                 jmp     rax
+procedure: |-
+  __int64 (__fastcall *__fastcall CEntityInstance_NetworkUpdateState_thunk(__int64 a1, unsigned __int8 a2))()
+  {
+    __int64 (__fastcall *result)(); // rax
+
+    result = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 256LL);// 0x100 = 256LL = CEntityInstance_NetworkUpdateState
+    if ( result != nullsub_1663 )
+      return (__int64 (__fastcall *)())((__int64 (__fastcall *)(__int64, _QWORD))result)(a1, a2);
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_NetworkUpdateState_thunk.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_NetworkUpdateState_thunk.windows.yaml
@@ -1,0 +1,11 @@
+func_name: CEntityInstance_NetworkUpdateState_thunk
+func_va: '0x18120f480'
+disasm_code: |-
+  .text:000000018120F480                 mov     rax, [rcx]
+  .text:000000018120F483                 ; 0xF8 = 248LL = CEntityInstance_NetworkUpdateState
+  .text:000000018120F483                 jmp     qword ptr [rax+0F8h]; 0xF8 = 248LL = CEntityInstance_NetworkUpdateState
+procedure: |-
+  __int64 __fastcall sub_18120F480(__int64 a1, bool a2)
+  {
+    return (*(__int64 (__fastcall **)(__int64, bool))(*(_QWORD *)a1 + 248LL))(a1, a2);// 0xF8 = 248LL = CEntityInstance_NetworkUpdateState
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_PostDataUpdateDelta.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_PostDataUpdateDelta.linux.yaml
@@ -1,0 +1,23 @@
+func_name: CEntityInstance_PostDataUpdateDelta
+func_va: '0x1e461e0'
+disasm_code: |-
+  .text:0000000001E461E0                 mov     rax, [rdi]
+  .text:0000000001E461E3                 lea     rdx, CEntityInstance_PostDataUpdatePreserve
+  .text:0000000001E461EA                 ; 60h = CEntityInstance_PostDataUpdate
+  .text:0000000001E461EA                 mov     rax, [rax+60h]   ; 60h = CEntityInstance_PostDataUpdate
+  .text:0000000001E461EE                 cmp     rax, rdx
+  .text:0000000001E461F1                 jnz     short loc_1E46200
+  .text:0000000001E461F3                 mov     cs:byte_27BB16B, 1
+  .text:0000000001E461FA                 retn
+  .text:0000000001E46200                 jmp     rax              ; tail-call CEntityInstance_PostDataUpdate (loaded above from [vtable+60h])
+procedure: |-
+  __int64 (*__fastcall CEntityInstance_PostDataUpdateDelta(__int64 a1))(void)
+  {
+    __int64 (*result)(void); // rax
+
+    result = *(__int64 (**)(void))(*(_QWORD *)a1 + 96LL);   // 96LL = 0x60 = CEntityInstance_PostDataUpdate
+    if ( result != CEntityInstance_PostDataUpdatePreserve )
+      return (__int64 (*)(void))result();
+    byte_27BB16B = 1;
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_PostDataUpdateDelta.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_PostDataUpdateDelta.windows.yaml
@@ -1,0 +1,11 @@
+func_name: CEntityInstance_PostDataUpdateDelta
+func_va: '0x18120baf0'
+disasm_code: |-
+  .text:000000018120BAF0                 mov     rax, [rcx]
+  .text:000000018120BAF3                 ; 58h = CEntityInstance_PostDataUpdate
+  .text:000000018120BAF3                 jmp     qword ptr [rax+58h]; 58h = CEntityInstance_PostDataUpdate
+procedure: |-
+  __int64 __fastcall CEntityInstance_PostDataUpdateDelta(__int64 a1)
+  {
+    return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 88LL))(a1);   // 88LL = 0x58 = CEntityInstance_PostDataUpdate
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_PreSave.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_PreSave.linux.yaml
@@ -1,0 +1,242 @@
+func_name: CEntitySaveRestoreBlockHandler_PreSave
+func_va: '0x1551300'
+disasm_code: |-
+  .text:0000000001551300                 push    rbp
+  .text:0000000001551301                 mov     rbp, rsp
+  .text:0000000001551304                 push    r15
+  .text:0000000001551306                 mov     r15, rsi
+  .text:0000000001551309                 push    r14
+  .text:000000000155130B                 push    r13
+  .text:000000000155130D                 push    r12
+  .text:000000000155130F                 push    rbx
+  .text:0000000001551310                 mov     rbx, rdx
+  .text:0000000001551313                 sub     rsp, 38h
+  .text:0000000001551317                 mov     [rbp+var_58], rdi
+  .text:000000000155131B                 mov     edi, cs:dword_246E410
+  .text:0000000001551321                 mov     [rbp+var_48], rdx
+  .text:0000000001551325                 test    edi, edi
+  .text:0000000001551327                 js      loc_1551480
+  .text:000000000155132D                 lea     rcx, [rbp+var_48]
+  .text:0000000001551331                 mov     esi, 189h
+  .text:0000000001551336                 xor     edx, edx
+  .text:0000000001551338                 call    sub_DEF450
+  .text:000000000155133D                 mov     eax, [rbx]
+  .text:000000000155133F                 xor     r14d, r14d
+  .text:0000000001551342                 test    eax, eax
+  .text:0000000001551344                 jg      short loc_1551373
+  .text:0000000001551346                 jmp     loc_15513FF
+  .text:0000000001551350                 mov     rdi, [r13+0]
+  .text:0000000001551354                 test    rdi, rdi
+  .text:0000000001551357                 jz      loc_1551420
+  .text:000000000155135D                 mov     rax, [rdi]
+  .text:0000000001551360                 call    qword ptr [rax+0C0h]
+  .text:0000000001551366                 add     r14, 1
+  .text:000000000155136A                 cmp     [rbx], r14d
+  .text:000000000155136D                 jle     loc_15513FF
+  .text:0000000001551373                 mov     rax, [rbx+8]
+  .text:0000000001551377                 mov     r12d, r14d
+  .text:000000000155137A                 lea     rax, [rax+r14*4]
+  .text:000000000155137E                 mov     ecx, [rax]
+  .text:0000000001551380                 cmp     ecx, 0FFFFFFFFh
+  .text:0000000001551383                 jz      short loc_15513BF
+  .text:0000000001551385                 mov     rsi, cs:qword_2566120
+  .text:000000000155138C                 cmp     ecx, 0FFFFFFFEh
+  .text:000000000155138F                 jz      short loc_15513BF
+  .text:0000000001551391                 test    rsi, rsi
+  .text:0000000001551394                 jz      short loc_15513BF
+  .text:0000000001551396                 movzx   eax, word ptr [rax]
+  .text:0000000001551399                 mov     rdx, rax
+  .text:000000000155139C                 shr     rdx, 9
+  .text:00000000015513A0                 and     edx, 3Fh
+  .text:00000000015513A3                 mov     rdx, [rsi+rdx*8]
+  .text:00000000015513A7                 test    rdx, rdx
+  .text:00000000015513AA                 jz      short loc_15513BF
+  .text:00000000015513AC                 and     eax, 1FFh
+  .text:00000000015513B1                 imul    rax, 70h ; 'p'
+  .text:00000000015513B5                 lea     r13, [rdx+rax]
+  .text:00000000015513B9                 cmp     ecx, [r13+10h]
+  .text:00000000015513BD                 jz      short loc_1551350
+  .text:00000000015513BF                 lea     r13, dword_265D880
+  .text:00000000015513C6                 ; _QWORD
+  .text:00000000015513C6                 mov     esi, 3; _QWORD
+  .text:00000000015513CB                 ; _QWORD
+  .text:00000000015513CB                 mov     edi, [r13+0]; _QWORD
+  .text:00000000015513CF                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000015513D4                 test    al, al
+  .text:00000000015513D6                 jz      short loc_1551366
+  .text:00000000015513D8                 ; _QWORD
+  .text:00000000015513D8                 mov     edi, [r13+0]; _QWORD
+  .text:00000000015513DC                 mov     ecx, r12d
+  .text:00000000015513DF                 ; _QWORD
+  .text:00000000015513DF                 mov     esi, 3; _QWORD
+  .text:00000000015513E4                 xor     eax, eax
+  .text:00000000015513E6                 lea     rdx, aPresaveDEntity; "PreSave(%d):  entity identity is missin"...
+  .text:00000000015513ED                 add     r14, 1
+  .text:00000000015513F1                 call    _LoggingSystem_Log
+  .text:00000000015513F6                 cmp     [rbx], r14d
+  .text:00000000015513F9                 jg      loc_1551373
+  .text:00000000015513FF                 mov     rdi, [rbp+var_58]
+  .text:0000000001551403                 mov     rdx, rbx
+  .text:0000000001551406                 mov     rsi, r15
+  .text:0000000001551409                 call    CEntitySaveRestoreBlockHandler_SaveInitEntities
+  .text:000000000155140E                 add     rsp, 38h
+  .text:0000000001551412                 pop     rbx
+  .text:0000000001551413                 pop     r12
+  .text:0000000001551415                 pop     r13
+  .text:0000000001551417                 pop     r14
+  .text:0000000001551419                 pop     r15
+  .text:000000000155141B                 pop     rbp
+  .text:000000000155141C                 retn
+  .text:0000000001551420                 lea     rax, dword_265D880
+  .text:0000000001551427                 ; _QWORD
+  .text:0000000001551427                 mov     esi, 3; _QWORD
+  .text:000000000155142C                 ; _QWORD
+  .text:000000000155142C                 mov     edi, [rax]; _QWORD
+  .text:000000000155142E                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001551433                 test    al, al
+  .text:0000000001551435                 jz      loc_1551366
+  .text:000000000155143B                 mov     r9, [r13+20h]
+  .text:000000000155143F                 lea     rax, haystack
+  .text:0000000001551446                 mov     ecx, r14d
+  .text:0000000001551449                 lea     rsi, dword_265D880
+  .text:0000000001551450                 lea     rdx, aPresaveDEntity_0; "PreSave(%d):  entity instance is missin"...
+  .text:0000000001551457                 mov     r8, [r13+18h]
+  .text:000000000155145B                 test    r9, r9
+  .text:000000000155145E                 cmovz   r9, rax
+  .text:0000000001551462                 ; _QWORD
+  .text:0000000001551462                 mov     edi, [rsi]; _QWORD
+  .text:0000000001551464                 ; _QWORD
+  .text:0000000001551464                 mov     esi, 3; _QWORD
+  .text:0000000001551469                 test    r8, r8
+  .text:000000000155146C                 cmovz   r8, rax
+  .text:0000000001551470                 xor     eax, eax
+  .text:0000000001551472                 call    _LoggingSystem_Log
+  .text:0000000001551477                 jmp     loc_1551366
+  .text:0000000001551480                 lea     r13, off_2288498
+  .text:0000000001551487                 mov     [rbp+var_38], 0
+  .text:000000000155148F                 mov     [rbp+var_40], r13
+  .text:0000000001551493                 movzx   eax, cs:byte_25EF240
+  .text:000000000155149A                 test    al, al
+  .text:000000000155149C                 jz      short loc_15514D3
+  .text:000000000155149E                 mov     rax, cs:qword_25EF248
+  .text:00000000015514A5                 lea     r12, [rbp+var_40]
+  .text:00000000015514A9                 mov     rdi, r12
+  .text:00000000015514AC                 mov     [rbp+var_40], rax
+  .text:00000000015514B0                 call    qword ptr [rax+188h]
+  .text:00000000015514B6                 mov     rdi, r12
+  .text:00000000015514B9                 mov     [rbp+var_40], r13
+  .text:00000000015514BD                 mov     cs:dword_246E410, eax
+  .text:00000000015514C3                 call    nullsub_503
+  .text:00000000015514C8                 mov     edi, cs:dword_246E410
+  .text:00000000015514CE                 jmp     loc_155132D
+  .text:00000000015514D3                 lea     r12, byte_25EF240
+  .text:00000000015514DA                 ; _QWORD
+  .text:00000000015514DA                 mov     rdi, r12; _QWORD
+  .text:00000000015514DD                 call    ___cxa_guard_acquire
+  .text:00000000015514E2                 test    eax, eax
+  .text:00000000015514E4                 jz      short loc_155149E
+  .text:00000000015514E6                 mov     rax, cs:off_246DDC0
+  .text:00000000015514ED                 ; _QWORD
+  .text:00000000015514ED                 mov     rdi, r12; _QWORD
+  .text:00000000015514F0                 mov     cs:qword_25EF248, rax
+  .text:00000000015514F7                 call    ___cxa_guard_release
+  .text:00000000015514FC                 jmp     short loc_155149E
+procedure: |-
+  __int64 __fastcall CEntitySaveRestoreBlockHandler_PreSave(__int64 a1, __int64 a2, __int64 a3)
+  {
+    __int64 v4; // rdi
+    __int64 v5; // r14
+    unsigned __int16 *v6; // rax
+    int v7; // ecx
+    unsigned __int64 v8; // rax
+    __int64 v9; // rdx
+    _QWORD *v10; // r13
+    int v11; // ecx
+    const bool *v13; // r9
+    const bool *v14; // r8
+    int v15; // eax
+    __int64 v17; // [rsp+18h] [rbp-48h] BYREF
+    _QWORD v18[8]; // [rsp+20h] [rbp-40h] BYREF
+
+    v4 = (unsigned int)dword_246E410;
+    v17 = a3;
+    if ( dword_246E410 < 0 )
+    {
+      v18[1] = 0;
+      v18[0] = off_2288498;
+      if ( !(_BYTE)byte_25EF240 && (unsigned int)__cxa_guard_acquire(&byte_25EF240) )
+      {
+        qword_25EF248 = (__int64)off_246DDC0[0];
+        __cxa_guard_release(&byte_25EF240);
+      }
+      v18[0] = qword_25EF248;
+      v15 = (*(__int64 (__fastcall **)(_QWORD *))(qword_25EF248 + 392))(v18);
+      v18[0] = off_2288498;
+      dword_246E410 = v15;
+      nullsub_503(v18);
+      v4 = (unsigned int)dword_246E410;
+    }
+    sub_DEF450(v4, 393, 0, &v17);
+    v5 = 0;
+    if ( *(int *)a3 > 0 )
+    {
+      while ( 1 )
+      {
+        v6 = (unsigned __int16 *)(*(_QWORD *)(a3 + 8) + 4 * v5);
+        v7 = *(_DWORD *)v6;
+        if ( *(_DWORD *)v6 != -1 && v7 != -2 )
+        {
+          if ( qword_2566120 )
+          {
+            v8 = *v6;
+            v9 = *(_QWORD *)(qword_2566120 + 8 * ((v8 >> 9) & 0x3F));
+            if ( v9 )
+            {
+              v10 = (_QWORD *)(v9 + 112 * (v8 & 0x1FF));
+              if ( v7 == *((_DWORD *)v10 + 4) )
+                break;
+            }
+          }
+        }
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_265D880, 3) )
+        {
+          v11 = v5++;
+          LoggingSystem_Log(
+            (unsigned int)dword_265D880,
+            3,
+            "PreSave(%d):  entity identity is missing, may cause a crash\n",
+            v11);
+          if ( *(_DWORD *)a3 <= (int)v5 )
+            return CEntitySaveRestoreBlockHandler_SaveInitEntities(a1, a2, a3);
+        }
+        else
+        {
+  LABEL_6:
+          if ( *(_DWORD *)a3 <= (int)++v5 )
+            return CEntitySaveRestoreBlockHandler_SaveInitEntities(a1, a2, a3);
+        }
+      }
+      if ( *v10 )
+      {
+        (*(void (__fastcall **)(_QWORD))(*(_QWORD *)*v10 + 192LL))(*v10);
+      }
+      else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_265D880, 3) )
+      {
+        v13 = (const bool *)v10[4];
+        v14 = (const bool *)v10[3];
+        if ( !v13 )
+          v13 = &haystack;
+        if ( !v14 )
+          v14 = &haystack;
+        LoggingSystem_Log(
+          (unsigned int)dword_265D880,
+          3,
+          "PreSave(%d):  entity instance is missing for (%s, %s), may cause a crash\n",
+          (unsigned int)v5,
+          v14,
+          v13);
+      }
+      goto LABEL_6;
+    }
+    return CEntitySaveRestoreBlockHandler_SaveInitEntities(a1, a2, a3);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_PreSave.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_PreSave.windows.yaml
@@ -1,0 +1,238 @@
+func_name: CEntitySaveRestoreBlockHandler_PreSave
+func_va: '0x180b21050'
+disasm_code: |-
+  .text:0000000180B21050                 mov     r11, rsp
+  .text:0000000180B21053                 mov     [r11+10h], rbx
+  .text:0000000180B21057                 push    rbp
+  .text:0000000180B21058                 push    rsi
+  .text:0000000180B21059                 push    rdi
+  .text:0000000180B2105A                 push    r12
+  .text:0000000180B2105C                 push    r15
+  .text:0000000180B2105E                 sub     rsp, 40h
+  .text:0000000180B21062                 mov     r15, rcx
+  .text:0000000180B21065                 mov     [r11+18h], r8
+  .text:0000000180B21069                 mov     ecx, cs:dword_181B9ADE0
+  .text:0000000180B2106F                 xor     r12d, r12d
+  .text:0000000180B21072                 mov     rsi, r8
+  .text:0000000180B21075                 mov     rbp, rdx
+  .text:0000000180B21078                 test    ecx, ecx
+  .text:0000000180B2107A                 jns     short loc_180B210E9
+  .text:0000000180B2107C                 mov     r9d, cs:TlsIndex
+  .text:0000000180B21083                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180B2108A                 mov     [r11-38h], rax
+  .text:0000000180B2108E                 mov     rax, gs:58h
+  .text:0000000180B21097                 mov     ecx, 218h
+  .text:0000000180B2109C                 mov     [r11-30h], r12
+  .text:0000000180B210A0                 mov     rax, [rax+r9*8]
+  .text:0000000180B210A4                 mov     eax, [rcx+rax]
+  .text:0000000180B210A7                 cmp     cs:dword_181E148B8, eax
+  .text:0000000180B210AD                 jg      loc_180B21246
+  .text:0000000180B210B3                 mov     rax, cs:qword_181E148B0
+  .text:0000000180B210BA                 lea     rcx, [rsp+68h+var_38]
+  .text:0000000180B210BF                 mov     rbx, [rsp+68h+var_38]
+  .text:0000000180B210C4                 mov     [rsp+68h+var_38], rax
+  .text:0000000180B210C9                 call    GameSystem_OnSaveGame
+  .text:0000000180B210CE                 lea     rcx, [rsp+68h+var_38]
+  .text:0000000180B210D3                 mov     [rsp+68h+var_38], rbx
+  .text:0000000180B210D8                 mov     cs:dword_181B9ADE0, eax
+  .text:0000000180B210DE                 call    sub_180507F70
+  .text:0000000180B210E3                 mov     ecx, cs:dword_181B9ADE0
+  .text:0000000180B210E9                 lea     r8, [rsp+68h+arg_10]
+  .text:0000000180B210F1                 lea     rdx, GameSystem_OnSaveGame
+  .text:0000000180B210F8                 call    IGameSystem__DispatchEventInternal
+  .text:0000000180B210FD                 mov     edi, r12d
+  .text:0000000180B21100                 cmp     [rsi], r12d
+  .text:0000000180B21103                 jle     loc_180B21227
+  .text:0000000180B21109                 mov     [rsp+68h+arg_0], r14
+  .text:0000000180B2110E                 mov     r14, r12
+  .text:0000000180B21111                 mov     rax, [rsi+8]
+  .text:0000000180B21115                 mov     ecx, [r14+rax]
+  .text:0000000180B21119                 cmp     ecx, 0FFFFFFFFh
+  .text:0000000180B2111C                 jz      loc_180B211E4
+  .text:0000000180B21122                 mov     r8, cs:qword_181D958F8
+  .text:0000000180B21129                 test    r8, r8
+  .text:0000000180B2112C                 jz      loc_180B211E4
+  .text:0000000180B21132                 cmp     ecx, 0FFFFFFFEh
+  .text:0000000180B21135                 jz      short loc_180B21165
+  .text:0000000180B21137                 mov     eax, ecx
+  .text:0000000180B21139                 and     eax, 7FFFh
+  .text:0000000180B2113E                 mov     edx, eax
+  .text:0000000180B21140                 shr     rax, 9
+  .text:0000000180B21144                 mov     r9, [r8+rax*8]
+  .text:0000000180B21148                 test    r9, r9
+  .text:0000000180B2114B                 jz      short loc_180B21165
+  .text:0000000180B2114D                 and     edx, 1FFh
+  .text:0000000180B21153                 imul    rbx, rdx, 70h ; 'p'
+  .text:0000000180B21157                 add     rbx, r9
+  .text:0000000180B2115A                 jz      short loc_180B21165
+  .text:0000000180B2115C                 cmp     [rbx+10h], ecx
+  .text:0000000180B2115F                 cmovnz  rbx, r12
+  .text:0000000180B21163                 jmp     short loc_180B21168
+  .text:0000000180B21165                 mov     rbx, r12
+  .text:0000000180B21168                 test    rbx, rbx
+  .text:0000000180B2116B                 jz      short loc_180B211E4
+  .text:0000000180B2116D                 mov     rcx, [rbx]
+  .text:0000000180B21170                 test    rcx, rcx
+  .text:0000000180B21173                 jnz     short loc_180B211D9
+  .text:0000000180B21175                 mov     ecx, cs:dword_181EE6690
+  .text:0000000180B2117B                 mov     edx, 3
+  .text:0000000180B21180                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B21186                 test    al, al
+  .text:0000000180B21188                 jz      loc_180B21214
+  .text:0000000180B2118E                 mov     rax, [rbx+20h]
+  .text:0000000180B21192                 lea     rdx, byte_18159B990
+  .text:0000000180B21199                 test    rax, rax
+  .text:0000000180B2119C                 lea     rcx, byte_18159B990
+  .text:0000000180B211A3                 mov     r9d, edi
+  .text:0000000180B211A6                 lea     r8, aPresaveDEntity; "PreSave(%d):  entity instance is missin"...
+  .text:0000000180B211AD                 cmovnz  rdx, rax
+  .text:0000000180B211B1                 mov     rax, [rbx+18h]
+  .text:0000000180B211B5                 mov     [rsp+68h+var_40], rdx
+  .text:0000000180B211BA                 test    rax, rax
+  .text:0000000180B211BD                 mov     edx, 3
+  .text:0000000180B211C2                 cmovnz  rcx, rax
+  .text:0000000180B211C6                 mov     [rsp+68h+var_48], rcx
+  .text:0000000180B211CB                 mov     ecx, cs:dword_181EE6690
+  .text:0000000180B211D1                 call    cs:LoggingSystem_Log
+  .text:0000000180B211D7                 jmp     short loc_180B21214
+  .text:0000000180B211D9                 mov     rax, [rcx]
+  .text:0000000180B211DC                 call    qword ptr [rax+0B8h]
+  .text:0000000180B211E2                 jmp     short loc_180B21214
+  .text:0000000180B211E4                 mov     ecx, cs:dword_181EE6690
+  .text:0000000180B211EA                 mov     edx, 3
+  .text:0000000180B211EF                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B211F5                 test    al, al
+  .text:0000000180B211F7                 jz      short loc_180B21214
+  .text:0000000180B211F9                 mov     ecx, cs:dword_181EE6690
+  .text:0000000180B211FF                 lea     r8, aPresaveDEntity_0; "PreSave(%d):  entity identity is missin"...
+  .text:0000000180B21206                 mov     r9d, edi
+  .text:0000000180B21209                 mov     edx, 3
+  .text:0000000180B2120E                 call    cs:LoggingSystem_Log
+  .text:0000000180B21214                 inc     edi
+  .text:0000000180B21216                 add     r14, 4
+  .text:0000000180B2121A                 cmp     edi, [rsi]
+  .text:0000000180B2121C                 jl      loc_180B21111
+  .text:0000000180B21222                 mov     r14, [rsp+68h+arg_0]
+  .text:0000000180B21227                 mov     r8, rsi
+  .text:0000000180B2122A                 mov     rdx, rbp
+  .text:0000000180B2122D                 mov     rcx, r15
+  .text:0000000180B21230                 call    CEntitySaveRestoreBlockHandler_SaveInitEntities
+  .text:0000000180B21235                 mov     rbx, [rsp+68h+arg_8]
+  .text:0000000180B2123A                 add     rsp, 40h
+  .text:0000000180B2123E                 pop     r15
+  .text:0000000180B21240                 pop     r12
+  .text:0000000180B21242                 pop     rdi
+  .text:0000000180B21243                 pop     rsi
+  .text:0000000180B21244                 pop     rbp
+  .text:0000000180B21245                 retn
+  .text:0000000180B21246                 lea     rcx, dword_181E148B8
+  .text:0000000180B2124D                 call    sub_1814F7154
+  .text:0000000180B21252                 cmp     cs:dword_181E148B8, 0FFFFFFFFh
+  .text:0000000180B21259                 jnz     loc_180B210B3
+  .text:0000000180B2125F                 mov     rax, cs:off_181B9AF10
+  .text:0000000180B21266                 lea     rcx, dword_181E148B8
+  .text:0000000180B2126D                 mov     cs:qword_181E148B0, rax
+  .text:0000000180B21274                 call    sub_1814F70E8
+  .text:0000000180B21279                 jmp     loc_180B210B3
+procedure: |-
+  __int64 __fastcall CEntitySaveRestoreBlockHandler_PreSave(__int64 a1, __int64 a2, __int64 a3)
+  {
+    __int64 v4; // rcx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v8; // rbx
+    int v9; // eax
+    unsigned int v10; // edi
+    __int64 v11; // r14
+    int v12; // ecx
+    __int64 v13; // r9
+    _QWORD *v14; // rbx
+    char *v15; // rdx
+    char *v16; // rcx
+    _QWORD v18[7]; // [rsp+30h] [rbp-38h] BYREF
+    __int64 v19; // [rsp+80h] [rbp+18h] BYREF
+
+    v19 = a3;
+    v4 = (unsigned int)dword_181B9ADE0;
+    if ( dword_181B9ADE0 < 0 )
+    {
+      v18[0] = &CDontUseThisGameSystem::`vftable';
+      ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+      v18[1] = 0;
+      if ( dword_181E148B8 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 536LL) )
+      {
+        sub_1814F7154(&dword_181E148B8);
+        if ( dword_181E148B8 == -1 )
+        {
+          qword_181E148B0 = (__int64)off_181B9AF10[0];
+          sub_1814F70E8(&dword_181E148B8);
+        }
+      }
+      v8 = v18[0];
+      v18[0] = qword_181E148B0;
+      v9 = GameSystem_OnSaveGame(v18);
+      v18[0] = v8;
+      dword_181B9ADE0 = v9;
+      sub_180507F70(v18);
+      v4 = (unsigned int)dword_181B9ADE0;
+    }
+    IGameSystem::DispatchEventInternal(v4, GameSystem_OnSaveGame, &v19);
+    v10 = 0;
+    if ( *(int *)a3 > 0 )
+    {
+      v11 = 0;
+      do
+      {
+        v12 = *(_DWORD *)(v11 + *(_QWORD *)(a3 + 8));
+        if ( v12 == -1 || !qword_181D958F8 )
+          goto LABEL_32;
+        if ( v12 != -2
+          && (v13 = *(_QWORD *)(qword_181D958F8 + 8 * ((unsigned __int64)(v12 & 0x7FFF) >> 9))) != 0
+          && (v14 = (_QWORD *)(v13 + 112LL * (v12 & 0x1FF))) != nullptr )
+        {
+          if ( *((_DWORD *)v14 + 4) != v12 )
+            v14 = nullptr;
+        }
+        else
+        {
+          v14 = nullptr;
+        }
+        if ( v14 )
+        {
+          if ( *v14 )
+          {
+            (*(void (__fastcall **)(_QWORD))(*(_QWORD *)*v14 + 184LL))(*v14);
+          }
+          else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181EE6690, 3) )
+          {
+            v15 = byte_18159B990;
+            v16 = byte_18159B990;
+            if ( v14[4] )
+              v15 = (char *)v14[4];
+            if ( v14[3] )
+              v16 = (char *)v14[3];
+            LoggingSystem_Log(
+              (unsigned int)dword_181EE6690,
+              3,
+              "PreSave(%d):  entity instance is missing for (%s, %s), may cause a crash\n",
+              v10,
+              v16,
+              v15);
+          }
+        }
+        else
+        {
+  LABEL_32:
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181EE6690, 3) )
+            LoggingSystem_Log(
+              (unsigned int)dword_181EE6690,
+              3,
+              "PreSave(%d):  entity identity is missing, may cause a crash\n",
+              v10);
+        }
+        ++v10;
+        v11 += 4;
+      }
+      while ( (signed int)v10 < *(_DWORD *)a3 );
+    }
+    return CEntitySaveRestoreBlockHandler_SaveInitEntities(a1, a2, a3);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_RestoreEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_RestoreEntity.linux.yaml
@@ -1,0 +1,339 @@
+func_name: CEntitySaveRestoreBlockHandler_RestoreEntity
+func_va: '0x1566af0'
+disasm_code: |-
+  .text:0000000001566AF0                 push    rbp
+  .text:0000000001566AF1                 mov     ecx, r8d
+  .text:0000000001566AF4                 mov     rbp, rsp
+  .text:0000000001566AF7                 push    r15
+  .text:0000000001566AF9                 push    r14
+  .text:0000000001566AFB                 push    r13
+  .text:0000000001566AFD                 push    r12
+  .text:0000000001566AFF                 push    rbx
+  .text:0000000001566B00                 mov     rbx, rsi
+  .text:0000000001566B03                 sub     rsp, 38h
+  .text:0000000001566B07                 call    CEntitySaveRestoreBlockHandler_DoRestoreEntity
+  .text:0000000001566B0C                 test    rbx, rbx
+  .text:0000000001566B0F                 jz      loc_1566B98
+  .text:0000000001566B15                 test    al, al
+  .text:0000000001566B17                 jz      short loc_1566B98
+  .text:0000000001566B19                 mov     rsi, [rbx+628h]
+  .text:0000000001566B20                 test    rsi, rsi
+  .text:0000000001566B23                 jz      short loc_1566B98
+  .text:0000000001566B25                 lea     r13, off_24FA7F8
+  .text:0000000001566B2C                 mov     rdi, [r13+0]
+  .text:0000000001566B30                 mov     rax, [rdi]
+  .text:0000000001566B33                 call    qword ptr [rax+20h]
+  .text:0000000001566B36                 mov     rdi, [r13+0]
+  .text:0000000001566B3A                 mov     r12d, eax
+  .text:0000000001566B3D                 mov     rax, [rdi]
+  .text:0000000001566B40                 test    r12d, r12d
+  .text:0000000001566B43                 js      short loc_1566BB0
+  .text:0000000001566B45                 mov     esi, r12d
+  .text:0000000001566B48                 call    qword ptr [rax+28h]
+  .text:0000000001566B4B                 cmp     al, 2
+  .text:0000000001566B4D                 jz      loc_1566D43
+  .text:0000000001566B53                 mov     rdi, [r13+0]
+  .text:0000000001566B57                 mov     esi, r12d
+  .text:0000000001566B5A                 mov     rax, [rdi]
+  .text:0000000001566B5D                 call    qword ptr [rax+30h]
+  .text:0000000001566B60                 lea     r14, off_24FA868
+  .text:0000000001566B67                 mov     rdx, [r14]
+  .text:0000000001566B6A                 ; s1
+  .text:0000000001566B6A                 mov     rdi, [rdx+60h]; s1
+  .text:0000000001566B6E                 cmp     rax, rdi
+  .text:0000000001566B71                 jz      short loc_1566B98
+  .text:0000000001566B73                 test    rdi, rdi
+  .text:0000000001566B76                 jz      loc_1566C60
+  .text:0000000001566B7C                 test    rax, rax
+  .text:0000000001566B7F                 jz      loc_1566C60
+  .text:0000000001566B85                 ; s2
+  .text:0000000001566B85                 mov     rsi, rax; s2
+  .text:0000000001566B88                 call    strcmp
+  .text:0000000001566B8D                 test    eax, eax
+  .text:0000000001566B8F                 jnz     loc_1566C60
+  .text:0000000001566B95                 nop     dword ptr [rax]
+  .text:0000000001566B98                 xor     eax, eax
+  .text:0000000001566B9A                 lea     rsp, [rbp-28h]
+  .text:0000000001566B9E                 pop     rbx
+  .text:0000000001566B9F                 pop     r12
+  .text:0000000001566BA1                 pop     r13
+  .text:0000000001566BA3                 pop     r14
+  .text:0000000001566BA5                 pop     r15
+  .text:0000000001566BA7                 pop     rbp
+  .text:0000000001566BA8                 retn
+  .text:0000000001566BB0                 lea     rdx, off_24FA868
+  .text:0000000001566BB7                 lea     r12, haystack
+  .text:0000000001566BBE                 mov     ecx, 1
+  .text:0000000001566BC3                 mov     rsi, [rbx+628h]
+  .text:0000000001566BCA                 mov     rdx, [rdx]
+  .text:0000000001566BCD                 test    rsi, rsi
+  .text:0000000001566BD0                 cmovz   rsi, r12
+  .text:0000000001566BD4                 mov     rdx, [rdx+60h]
+  .text:0000000001566BD8                 call    qword ptr [rax+10h]
+  .text:0000000001566BDB                 lea     r15, dword_26DB0B0
+  .text:0000000001566BE2                 ; _QWORD
+  .text:0000000001566BE2                 mov     esi, 1; _QWORD
+  .text:0000000001566BE7                 ; _QWORD
+  .text:0000000001566BE7                 mov     edi, [r15]; _QWORD
+  .text:0000000001566BEA                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001566BEF                 test    al, al
+  .text:0000000001566BF1                 jz      short loc_1566B98
+  .text:0000000001566BF3                 mov     rdi, [rbx+10h]
+  .text:0000000001566BF7                 ; _QWORD
+  .text:0000000001566BF7                 mov     esi, 1; _QWORD
+  .text:0000000001566BFC                 mov     rax, [rbx+628h]
+  .text:0000000001566C03                 mov     r9, [rdi+20h]
+  .text:0000000001566C07                 test    rax, rax
+  .text:0000000001566C0A                 cmovz   rax, r12
+  .text:0000000001566C0E                 test    r9, r9
+  .text:0000000001566C11                 mov     rcx, rax
+  .text:0000000001566C14                 cmovz   r9, r12
+  .text:0000000001566C18                 call    sub_152CA40
+  .text:0000000001566C1D                 ; _QWORD
+  .text:0000000001566C1D                 mov     edi, [r15]; _QWORD
+  .text:0000000001566C20                 lea     rdx, aSAddedGlobalEn; "%s:  added global entity %d %s (%s)\n"
+  .text:0000000001566C27                 mov     r8d, eax
+  .text:0000000001566C2A                 and     r8d, 7FFFh
+  .text:0000000001566C31                 cmp     eax, 0FFFFFFFFh
+  .text:0000000001566C34                 mov     eax, 7FFFh
+  .text:0000000001566C39                 cmovz   r8d, eax
+  .text:0000000001566C3D                 sub     rsp, 8
+  .text:0000000001566C41                 xor     eax, eax
+  .text:0000000001566C43                 push    rcx
+  .text:0000000001566C44                 lea     rcx, aSv_0; "SV"
+  .text:0000000001566C4B                 call    _LoggingSystem_Log
+  .text:0000000001566C50                 pop     rax
+  .text:0000000001566C51                 pop     rdx
+  .text:0000000001566C52                 jmp     loc_1566B98
+  .text:0000000001566C60                 mov     rax, [rbx+10h]
+  .text:0000000001566C64                 test    byte ptr [rax+30h], 80h
+  .text:0000000001566C68                 jnz     loc_1566B98
+  .text:0000000001566C6E                 lea     r15, dword_26DB0B0
+  .text:0000000001566C75                 ; _QWORD
+  .text:0000000001566C75                 mov     esi, 1; _QWORD
+  .text:0000000001566C7A                 ; _QWORD
+  .text:0000000001566C7A                 mov     edi, [r15]; _QWORD
+  .text:0000000001566C7D                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001566C82                 test    al, al
+  .text:0000000001566C84                 jz      loc_1566D21
+  .text:0000000001566C8A                 mov     rdi, [rbx+10h]
+  .text:0000000001566C8E                 lea     rax, haystack
+  .text:0000000001566C95                 mov     esi, r12d
+  .text:0000000001566C98                 mov     rcx, [rbx+628h]
+  .text:0000000001566C9F                 mov     rdx, [rdi+20h]
+  .text:0000000001566CA3                 test    rcx, rcx
+  .text:0000000001566CA6                 cmovz   rcx, rax
+  .text:0000000001566CAA                 test    rdx, rdx
+  .text:0000000001566CAD                 mov     [rbp+var_58], rcx
+  .text:0000000001566CB1                 cmovz   rdx, rax
+  .text:0000000001566CB5                 mov     [rbp+var_50], rdx
+  .text:0000000001566CB9                 call    sub_152CA40
+  .text:0000000001566CBE                 mov     rdi, [r13+0]
+  .text:0000000001566CC2                 mov     r10d, eax
+  .text:0000000001566CC5                 and     r10d, 7FFFh
+  .text:0000000001566CCC                 cmp     eax, 0FFFFFFFFh
+  .text:0000000001566CCF                 mov     eax, 7FFFh
+  .text:0000000001566CD4                 cmovz   r10d, eax
+  .text:0000000001566CD8                 mov     rax, [rdi]
+  .text:0000000001566CDB                 mov     [rbp+var_44], r10d
+  .text:0000000001566CDF                 call    qword ptr [rax+30h]
+  .text:0000000001566CE2                 mov     rcx, [rbp+var_58]
+  .text:0000000001566CE6                 sub     rsp, 8
+  .text:0000000001566CEA                 ; _QWORD
+  .text:0000000001566CEA                 mov     esi, 1; _QWORD
+  .text:0000000001566CEF                 mov     r9, rax
+  .text:0000000001566CF2                 mov     rax, [r14]
+  .text:0000000001566CF5                 ; _QWORD
+  .text:0000000001566CF5                 mov     edi, [r15]; _QWORD
+  .text:0000000001566CF8                 mov     r8, [rax+60h]
+  .text:0000000001566CFC                 push    rcx
+  .text:0000000001566CFD                 lea     rcx, aSv_0; "SV"
+  .text:0000000001566D04                 xor     eax, eax
+  .text:0000000001566D06                 mov     rdx, [rbp+var_50]
+  .text:0000000001566D0A                 push    rdx
+  .text:0000000001566D0B                 mov     r10d, [rbp+var_44]
+  .text:0000000001566D0F                 lea     rdx, aSMarkingGlobal; "%s:  marking global entity dormant (cur"...
+  .text:0000000001566D16                 push    r10
+  .text:0000000001566D18                 call    _LoggingSystem_Log
+  .text:0000000001566D1D                 add     rsp, 20h
+  .text:0000000001566D21                 mov     rdi, cs:g_pGameEntitySystem
+  .text:0000000001566D28                 lea     rdx, [rbp+var_40]
+  .text:0000000001566D2C                 mov     esi, 1
+  .text:0000000001566D31                 mov     [rbp+var_40], rbx
+  .text:0000000001566D35                 mov     [rbp+var_38], 0
+  .text:0000000001566D39                 call    CEntitySystem_SetInPVS
+  .text:0000000001566D3E                 jmp     loc_1566B98
+  .text:0000000001566D43                 lea     r15, dword_26DB0B0
+  .text:0000000001566D4A                 ; _QWORD
+  .text:0000000001566D4A                 mov     esi, 1; _QWORD
+  .text:0000000001566D4F                 ; _QWORD
+  .text:0000000001566D4F                 mov     edi, [r15]; _QWORD
+  .text:0000000001566D52                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001566D57                 test    al, al
+  .text:0000000001566D59                 jz      short loc_1566DBC
+  .text:0000000001566D5B                 mov     rax, [rbx+628h]
+  .text:0000000001566D62                 lea     rcx, haystack
+  .text:0000000001566D69                 mov     rdi, [rbx+10h]
+  .text:0000000001566D6D                 lea     r9, haystack
+  .text:0000000001566D74                 test    rax, rax
+  .text:0000000001566D77                 cmovnz  rcx, rax
+  .text:0000000001566D7B                 mov     rax, [rdi+20h]
+  .text:0000000001566D7F                 test    rax, rax
+  .text:0000000001566D82                 cmovnz  r9, rax
+  .text:0000000001566D86                 call    sub_152CA40
+  .text:0000000001566D8B                 mov     r8d, eax
+  .text:0000000001566D8E                 cmp     eax, 0FFFFFFFFh
+  .text:0000000001566D91                 jz      short loc_1566DC4
+  .text:0000000001566D93                 and     r8d, 7FFFh
+  .text:0000000001566D9A                 push    rsi
+  .text:0000000001566D9B                 lea     rdx, aSRemovingGloba; "%s:  removing GLOBAL_DEAD global entity"...
+  .text:0000000001566DA2                 ; _QWORD
+  .text:0000000001566DA2                 mov     esi, 1; _QWORD
+  .text:0000000001566DA7                 xor     eax, eax
+  .text:0000000001566DA9                 push    rcx
+  .text:0000000001566DAA                 ; _QWORD
+  .text:0000000001566DAA                 mov     edi, [r15]; _QWORD
+  .text:0000000001566DAD                 lea     rcx, aSv_0; "SV"
+  .text:0000000001566DB4                 call    _LoggingSystem_Log
+  .text:0000000001566DB9                 pop     rdi
+  .text:0000000001566DBA                 pop     r8
+  .text:0000000001566DBC                 or      eax, 0FFFFFFFFh
+  .text:0000000001566DBF                 jmp     loc_1566B9A
+  .text:0000000001566DC4                 mov     r8d, 7FFFh
+  .text:0000000001566DCA                 jmp     short loc_1566D9A
+procedure: |-
+  __int64 __fastcall CEntitySaveRestoreBlockHandler_RestoreEntity(__int64 a1, _QWORD *a2, _QWORD *a3)
+  {
+    char v4; // al
+    unsigned int v5; // r12d
+    __int64 v6; // rax
+    const char *v7; // rax
+    const char *v8; // rdi
+    const bool *v10; // rsi
+    __int64 v11; // rdx
+    __int64 v12; // r8
+    __int64 v13; // rdi
+    const bool *v14; // rax
+    const bool *v15; // r9
+    int v16; // eax
+    __int64 v17; // r8
+    __int64 v18; // r8
+    __int64 v19; // r9
+    __int64 v20; // rdi
+    const bool *v21; // rcx
+    const bool *v22; // rdx
+    int v23; // eax
+    int v24; // r10d
+    const char *v25; // rax
+    __int64 v26; // rdx
+    __int64 v27; // r8
+    const bool *v28; // rcx
+    __int64 v29; // rdi
+    const bool *v30; // r9
+    int v31; // eax
+    const char *v32; // rcx
+    const char *v33; // r9
+    int v34; // r8d
+    const char *v35; // [rsp+8h] [rbp-58h]
+    const char *v36; // [rsp+10h] [rbp-50h]
+    int v37; // [rsp+1Ch] [rbp-44h]
+    _QWORD *v38; // [rsp+20h] [rbp-40h] BYREF
+    char v39; // [rsp+28h] [rbp-38h]
+
+    v4 = CEntitySaveRestoreBlockHandler_DoRestoreEntity(a1, a2, a3);
+    if ( !a2 || !v4 || !a2[197] )
+      return 0;
+    v5 = (*(__int64 (__fastcall **)(__int64 *))(*off_24FA7F8[0] + 32))(off_24FA7F8[0]);
+    v6 = *off_24FA7F8[0];
+    if ( (v5 & 0x80000000) != 0 )
+    {
+      v10 = (const bool *)a2[197];
+      if ( !v10 )
+        v10 = &haystack;
+      (*(void (__fastcall **)(__int64 *, const bool *, _QWORD, __int64))(v6 + 16))(
+        off_24FA7F8[0],
+        v10,
+        *((_QWORD *)off_24FA868 + 12),
+        1);
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_26DB0B0, 1) )
+      {
+        v13 = a2[2];
+        v14 = (const bool *)a2[197];
+        v15 = *(const bool **)(v13 + 32);
+        if ( !v14 )
+          v14 = &haystack;
+        if ( !v15 )
+          v15 = &haystack;
+        v16 = sub_152CA40(v13, 1, v11, v14, v12, v15);
+        v17 = v16 & 0x7FFF;
+        if ( v16 == -1 )
+          v17 = 0x7FFF;
+        LoggingSystem_Log((unsigned int)dword_26DB0B0, 1, "%s:  added global entity %d %s (%s)\n", "SV", v17);
+      }
+      return 0;
+    }
+    if ( (*(unsigned __int8 (__fastcall **)(__int64 *, _QWORD))(v6 + 40))(off_24FA7F8[0], v5) != 2 )
+    {
+      v7 = (const char *)(*(__int64 (__fastcall **)(__int64 *, _QWORD))(*off_24FA7F8[0] + 48))(off_24FA7F8[0], v5);
+      v8 = *((const char **)off_24FA868 + 12);
+      if ( v7 != v8 && (!v8 || !v7 || strcmp(v8, v7)) && *(char *)(a2[2] + 48LL) >= 0 )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_26DB0B0, 1) )
+        {
+          v20 = a2[2];
+          v21 = (const bool *)a2[197];
+          v22 = *(const bool **)(v20 + 32);
+          if ( !v21 )
+            v21 = &haystack;
+          v35 = (const char *)v21;
+          if ( !v22 )
+            v22 = &haystack;
+          v36 = (const char *)v22;
+          v23 = sub_152CA40(v20, v5, v22, v21, v18, v19);
+          v24 = v23 & 0x7FFF;
+          if ( v23 == -1 )
+            v24 = 0x7FFF;
+          v37 = v24;
+          v25 = (const char *)(*(__int64 (__fastcall **)(__int64 *))(*off_24FA7F8[0] + 48))(off_24FA7F8[0]);
+          LoggingSystem_Log(
+            (unsigned int)dword_26DB0B0,
+            1,
+            "%s:  marking global entity dormant (current:'%s' vs last active in:'%s') %d %s (%s)\n",
+            "SV",
+            *((const char **)off_24FA868 + 12),
+            v25,
+            v37,
+            v36,
+            v35);
+        }
+        v38 = a2;
+        v39 = 0;
+        CEntitySystem_SetInPVS(g_pGameEntitySystem, 1, &v38);
+      }
+      return 0;
+    }
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_26DB0B0, 1) )
+    {
+      v28 = &haystack;
+      v29 = a2[2];
+      v30 = &haystack;
+      if ( a2[197] )
+        v28 = (const bool *)a2[197];
+      if ( *(_QWORD *)(v29 + 32) )
+        v30 = *(const bool **)(v29 + 32);
+      v31 = sub_152CA40(v29, 1, v26, v28, v27, v30);
+      if ( v31 == -1 )
+        v34 = 0x7FFF;
+      else
+        v34 = v31 & 0x7FFF;
+      LoggingSystem_Log(
+        (unsigned int)dword_26DB0B0,
+        1,
+        "%s:  removing GLOBAL_DEAD global entity %d %s (%s)\n",
+        "SV",
+        v34,
+        v33,
+        v32);
+    }
+    return 0xFFFFFFFFLL;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_RestoreEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_RestoreEntity.windows.yaml
@@ -1,0 +1,399 @@
+func_name: CEntitySaveRestoreBlockHandler_RestoreEntity
+func_va: '0x180b792b0'
+disasm_code: |-
+  .text:0000000180B792B0                 mov     [rsp+arg_10], rbx
+  .text:0000000180B792B5                 mov     [rsp+arg_18], rbp
+  .text:0000000180B792BA                 push    rdi
+  .text:0000000180B792BB                 sub     rsp, 60h
+  .text:0000000180B792BF                 mov     r9d, [rsp+68h+arg_20]
+  .text:0000000180B792C7                 mov     rbx, rdx
+  .text:0000000180B792CA                 call    CEntitySaveRestoreBlockHandler_DoRestoreEntity
+  .text:0000000180B792CF                 test    al, al
+  .text:0000000180B792D1                 jz      loc_180B79630
+  .text:0000000180B792D7                 test    rbx, rbx
+  .text:0000000180B792DA                 jz      loc_180B79630
+  .text:0000000180B792E0                 mov     rdx, [rbx+348h]
+  .text:0000000180B792E7                 test    rdx, rdx
+  .text:0000000180B792EA                 jz      loc_180B79630
+  .text:0000000180B792F0                 mov     rcx, cs:off_181C46F88
+  .text:0000000180B792F7                 mov     rax, [rcx]
+  .text:0000000180B792FA                 call    qword ptr [rax+20h]
+  .text:0000000180B792FD                 mov     rcx, cs:off_181C46F88
+  .text:0000000180B79304                 mov     ebp, eax
+  .text:0000000180B79306                 mov     rdx, [rcx]
+  .text:0000000180B79309                 test    eax, eax
+  .text:0000000180B7930B                 js      loc_180B79556
+  .text:0000000180B79311                 mov     r8, [rdx+28h]
+  .text:0000000180B79315                 mov     edx, eax
+  .text:0000000180B79317                 call    r8
+  .text:0000000180B7931A                 cmp     al, 2
+  .text:0000000180B7931C                 jnz     loc_180B793ED
+  .text:0000000180B79322                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B79328                 mov     edx, 1
+  .text:0000000180B7932D                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B79333                 test    al, al
+  .text:0000000180B79335                 jz      loc_180B793D6
+  .text:0000000180B7933B                 mov     rax, [rbx+348h]
+  .text:0000000180B79342                 lea     rdi, byte_18159B990
+  .text:0000000180B79349                 mov     rcx, [rbx+10h]
+  .text:0000000180B7934D                 test    rax, rax
+  .text:0000000180B79350                 mov     r9, rdi
+  .text:0000000180B79353                 cmovnz  r9, rax
+  .text:0000000180B79357                 mov     rax, [rcx+20h]
+  .text:0000000180B7935B                 test    rax, rax
+  .text:0000000180B7935E                 cmovnz  rdi, rax
+  .text:0000000180B79362                 test    rcx, rcx
+  .text:0000000180B79365                 jz      short loc_180B793A2
+  .text:0000000180B79367                 mov     edx, [rcx+10h]
+  .text:0000000180B7936A                 mov     r8d, edx
+  .text:0000000180B7936D                 mov     eax, [rcx+30h]
+  .text:0000000180B79370                 mov     ecx, 7FFFh
+  .text:0000000180B79375                 shr     r8d, 0Fh
+  .text:0000000180B79379                 and     eax, 1
+  .text:0000000180B7937C                 sub     r8d, eax
+  .text:0000000180B7937F                 mov     eax, edx
+  .text:0000000180B79381                 and     eax, 7FFFh
+  .text:0000000180B79386                 shl     r8d, 0Fh
+  .text:0000000180B7938A                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180B7938D                 cmovnz  ecx, eax
+  .text:0000000180B79390                 or      r8d, ecx
+  .text:0000000180B79393                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180B79397                 jz      short loc_180B793A2
+  .text:0000000180B79399                 and     r8d, 7FFFh
+  .text:0000000180B793A0                 jmp     short loc_180B793A8
+  .text:0000000180B793A2                 mov     r8d, 7FFFh
+  .text:0000000180B793A8                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B793AE                 mov     edx, 1
+  .text:0000000180B793B3                 mov     [rsp+68h+var_38], r9
+  .text:0000000180B793B8                 lea     r9, aSv; "SV"
+  .text:0000000180B793BF                 mov     [rsp+68h+var_40], rdi
+  .text:0000000180B793C4                 mov     dword ptr [rsp+68h+var_48], r8d
+  .text:0000000180B793C9                 lea     r8, aSRemovingGloba; "%s:  removing GLOBAL_DEAD global entity"...
+  .text:0000000180B793D0                 call    cs:LoggingSystem_Log
+  .text:0000000180B793D6                 mov     eax, 0FFFFFFFFh
+  .text:0000000180B793DB                 lea     r11, [rsp+68h+var_8]
+  .text:0000000180B793E0                 mov     rbx, [r11+20h]
+  .text:0000000180B793E4                 mov     rbp, [r11+28h]
+  .text:0000000180B793E8                 mov     rsp, r11
+  .text:0000000180B793EB                 pop     rdi
+  .text:0000000180B793EC                 retn
+  .text:0000000180B793ED                 mov     rcx, cs:off_181C46F88
+  .text:0000000180B793F4                 mov     edx, ebp
+  .text:0000000180B793F6                 mov     rax, [rcx]
+  .text:0000000180B793F9                 call    qword ptr [rax+30h]
+  .text:0000000180B793FC                 mov     rcx, cs:off_181C47C28
+  .text:0000000180B79403                 mov     r8, rax
+  .text:0000000180B79406                 mov     rdx, [rcx+60h]
+  .text:0000000180B7940A                 cmp     rdx, rax
+  .text:0000000180B7940D                 jz      loc_180B79630
+  .text:0000000180B79413                 test    rdx, rdx
+  .text:0000000180B79416                 jz      short loc_180B7943B
+  .text:0000000180B79418                 test    rax, rax
+  .text:0000000180B7941B                 jz      short loc_180B7943B
+  .text:0000000180B7941D                 sub     r8, rdx
+  .text:0000000180B79420                 movzx   ecx, byte ptr [rdx]
+  .text:0000000180B79423                 movzx   eax, byte ptr [rdx+r8]
+  .text:0000000180B79428                 sub     ecx, eax
+  .text:0000000180B7942A                 jnz     short loc_180B79433
+  .text:0000000180B7942C                 inc     rdx
+  .text:0000000180B7942F                 test    eax, eax
+  .text:0000000180B79431                 jnz     short loc_180B79420
+  .text:0000000180B79433                 test    ecx, ecx
+  .text:0000000180B79435                 jz      loc_180B79630
+  .text:0000000180B7943B                 mov     rax, [rbx+10h]
+  .text:0000000180B7943F                 mov     ecx, [rax+30h]
+  .text:0000000180B79442                 shr     ecx, 7
+  .text:0000000180B79445                 test    cl, 1
+  .text:0000000180B79448                 jnz     loc_180B79630
+  .text:0000000180B7944E                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B79454                 mov     edx, 1
+  .text:0000000180B79459                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B7945F                 test    al, al
+  .text:0000000180B79461                 jz      loc_180B79531
+  .text:0000000180B79467                 mov     rax, [rbx+348h]
+  .text:0000000180B7946E                 lea     rdi, byte_18159B990
+  .text:0000000180B79475                 mov     rcx, [rbx+10h]
+  .text:0000000180B79479                 test    rax, rax
+  .text:0000000180B7947C                 mov     [rsp+68h+arg_0], rsi
+  .text:0000000180B79481                 mov     [rsp+68h+arg_8], r14
+  .text:0000000180B79486                 mov     r14, rdi
+  .text:0000000180B79489                 cmovnz  r14, rax
+  .text:0000000180B7948D                 mov     rax, [rcx+20h]
+  .text:0000000180B79491                 test    rax, rax
+  .text:0000000180B79494                 cmovnz  rdi, rax
+  .text:0000000180B79498                 test    rcx, rcx
+  .text:0000000180B7949B                 jz      short loc_180B794D1
+  .text:0000000180B7949D                 mov     edx, [rcx+10h]
+  .text:0000000180B794A0                 mov     esi, edx
+  .text:0000000180B794A2                 mov     eax, [rcx+30h]
+  .text:0000000180B794A5                 mov     ecx, 7FFFh
+  .text:0000000180B794AA                 shr     esi, 0Fh
+  .text:0000000180B794AD                 and     eax, 1
+  .text:0000000180B794B0                 sub     esi, eax
+  .text:0000000180B794B2                 mov     eax, edx
+  .text:0000000180B794B4                 and     eax, 7FFFh
+  .text:0000000180B794B9                 shl     esi, 0Fh
+  .text:0000000180B794BC                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180B794BF                 cmovnz  ecx, eax
+  .text:0000000180B794C2                 or      esi, ecx
+  .text:0000000180B794C4                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180B794C7                 jz      short loc_180B794D1
+  .text:0000000180B794C9                 and     esi, 7FFFh
+  .text:0000000180B794CF                 jmp     short loc_180B794D6
+  .text:0000000180B794D1                 mov     esi, 7FFFh
+  .text:0000000180B794D6                 mov     rcx, cs:off_181C46F88
+  .text:0000000180B794DD                 mov     edx, ebp
+  .text:0000000180B794DF                 mov     rax, [rcx]
+  .text:0000000180B794E2                 call    qword ptr [rax+30h]
+  .text:0000000180B794E5                 mov     [rsp+68h+var_28], r14
+  .text:0000000180B794EA                 lea     r9, aSv; "SV"
+  .text:0000000180B794F1                 mov     [rsp+68h+var_30], rdi
+  .text:0000000180B794F6                 lea     r8, aSMarkingGlobal; "%s:  marking global entity dormant (cur"...
+  .text:0000000180B794FD                 mov     dword ptr [rsp+68h+var_38], esi
+  .text:0000000180B79501                 mov     edx, 1
+  .text:0000000180B79506                 mov     [rsp+68h+var_40], rax
+  .text:0000000180B7950B                 mov     rax, cs:off_181C47C28
+  .text:0000000180B79512                 mov     rcx, [rax+60h]
+  .text:0000000180B79516                 mov     [rsp+68h+var_48], rcx
+  .text:0000000180B7951B                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B79521                 call    cs:LoggingSystem_Log
+  .text:0000000180B79527                 mov     r14, [rsp+68h+arg_8]
+  .text:0000000180B7952C                 mov     rsi, [rsp+68h+arg_0]
+  .text:0000000180B79531                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180B79538                 lea     r8, [rsp+68h+var_18]
+  .text:0000000180B7953D                 mov     edx, 1
+  .text:0000000180B79542                 mov     [rsp+68h+var_18], rbx
+  .text:0000000180B79547                 mov     [rsp+68h+var_10], 0
+  .text:0000000180B7954C                 call    CEntitySystem_SetInPVS
+  .text:0000000180B79551                 jmp     loc_180B79630
+  .text:0000000180B79556                 mov     rax, cs:off_181C47C28
+  .text:0000000180B7955D                 lea     rdi, byte_18159B990
+  .text:0000000180B79564                 mov     r10, [rdx+10h]
+  .text:0000000180B79568                 mov     r9b, 1
+  .text:0000000180B7956B                 mov     rdx, rdi
+  .text:0000000180B7956E                 mov     r8, [rax+60h]
+  .text:0000000180B79572                 mov     rax, [rbx+348h]
+  .text:0000000180B79579                 test    rax, rax
+  .text:0000000180B7957C                 cmovnz  rdx, rax
+  .text:0000000180B79580                 call    r10
+  .text:0000000180B79583                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B79589                 mov     edx, 1
+  .text:0000000180B7958E                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B79594                 test    al, al
+  .text:0000000180B79596                 jz      loc_180B79630
+  .text:0000000180B7959C                 mov     rax, [rbx+348h]
+  .text:0000000180B795A3                 mov     r9, rdi
+  .text:0000000180B795A6                 mov     rcx, [rbx+10h]
+  .text:0000000180B795AA                 test    rax, rax
+  .text:0000000180B795AD                 cmovnz  r9, rax
+  .text:0000000180B795B1                 mov     rax, [rcx+20h]
+  .text:0000000180B795B5                 test    rax, rax
+  .text:0000000180B795B8                 cmovnz  rdi, rax
+  .text:0000000180B795BC                 test    rcx, rcx
+  .text:0000000180B795BF                 jz      short loc_180B795FC
+  .text:0000000180B795C1                 mov     edx, [rcx+10h]
+  .text:0000000180B795C4                 mov     r8d, edx
+  .text:0000000180B795C7                 mov     eax, [rcx+30h]
+  .text:0000000180B795CA                 mov     ecx, 7FFFh
+  .text:0000000180B795CF                 shr     r8d, 0Fh
+  .text:0000000180B795D3                 and     eax, 1
+  .text:0000000180B795D6                 sub     r8d, eax
+  .text:0000000180B795D9                 mov     eax, edx
+  .text:0000000180B795DB                 and     eax, 7FFFh
+  .text:0000000180B795E0                 shl     r8d, 0Fh
+  .text:0000000180B795E4                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180B795E7                 cmovnz  ecx, eax
+  .text:0000000180B795EA                 or      r8d, ecx
+  .text:0000000180B795ED                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180B795F1                 jz      short loc_180B795FC
+  .text:0000000180B795F3                 and     r8d, 7FFFh
+  .text:0000000180B795FA                 jmp     short loc_180B79602
+  .text:0000000180B795FC                 mov     r8d, 7FFFh
+  .text:0000000180B79602                 mov     ecx, cs:dword_181F5FE24
+  .text:0000000180B79608                 mov     edx, 1
+  .text:0000000180B7960D                 mov     [rsp+68h+var_38], r9
+  .text:0000000180B79612                 lea     r9, aSv; "SV"
+  .text:0000000180B79619                 mov     [rsp+68h+var_40], rdi
+  .text:0000000180B7961E                 mov     dword ptr [rsp+68h+var_48], r8d
+  .text:0000000180B79623                 lea     r8, aSAddedGlobalEn; "%s:  added global entity %d %s (%s)\n"
+  .text:0000000180B7962A                 call    cs:LoggingSystem_Log
+  .text:0000000180B79630                 lea     r11, [rsp+68h+var_8]
+  .text:0000000180B79635                 xor     eax, eax
+  .text:0000000180B79637                 mov     rbx, [r11+20h]
+  .text:0000000180B7963B                 mov     rbp, [r11+28h]
+  .text:0000000180B7963F                 mov     rsp, r11
+  .text:0000000180B79642                 pop     rdi
+  .text:0000000180B79643                 retn
+procedure: |-
+  __int64 __fastcall CEntitySaveRestoreBlockHandler_RestoreEntity(__int64 a1, __int64 *a2, __int64 a3)
+  {
+    int v4; // eax
+    __int64 v5; // r9
+    unsigned int v6; // ebp
+    __int64 v7; // rdx
+    const char *v8; // rdi
+    __int64 v9; // rcx
+    const char *v10; // r9
+    unsigned int v11; // edx
+    int v12; // eax
+    int v13; // ecx
+    int v14; // r8d
+    __int64 v16; // rax
+    unsigned __int8 *v17; // rdx
+    __int64 v18; // r8
+    int v19; // eax
+    int v20; // ecx
+    const char *v21; // rdi
+    __int64 v22; // rcx
+    const char *v23; // r14
+    unsigned int v24; // edx
+    int v25; // eax
+    int v26; // ecx
+    int v27; // esi
+    const char *v28; // rax
+    const char *v29; // rdi
+    void (__fastcall *v30)(_UNKNOWN ***, char *, _QWORD, __int64); // r10
+    char *v31; // rdx
+    const char *v32; // r9
+    __int64 v33; // rcx
+    unsigned int v34; // edx
+    int v35; // eax
+    int v36; // ecx
+    int v37; // r8d
+    __int64 *v38; // [rsp+50h] [rbp-18h] BYREF
+    char v39; // [rsp+58h] [rbp-10h]
+
+    if ( !CEntitySaveRestoreBlockHandler_DoRestoreEntity(a1, a2, a3) || !a2 || !a2[105] )
+      return 0;
+    v4 = ((__int64 (__fastcall *)(_UNKNOWN ***))(*off_181C46F88)[4])(off_181C46F88);
+    v6 = v4;
+    v7 = (__int64)*off_181C46F88;
+    if ( v4 < 0 )
+    {
+      v29 = byte_18159B990;
+      v30 = *(void (__fastcall **)(_UNKNOWN ***, char *, _QWORD, __int64))(v7 + 16);
+      LOBYTE(v5) = 1;
+      v31 = byte_18159B990;
+      if ( a2[105] )
+        v31 = (char *)a2[105];
+      v30(off_181C46F88, v31, *((_QWORD *)off_181C47C28 + 12), v5);
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F5FE24, 1) )
+      {
+        v32 = byte_18159B990;
+        v33 = a2[2];
+        if ( a2[105] )
+          v32 = (const char *)a2[105];
+        if ( *(_QWORD *)(v33 + 32) )
+          v29 = *(const char **)(v33 + 32);
+        if ( !v33 )
+          goto LABEL_52;
+        v34 = *(_DWORD *)(v33 + 16);
+        v35 = *(_DWORD *)(v33 + 48);
+        v36 = 0x7FFF;
+        if ( v34 != -1 )
+          v36 = v34 & 0x7FFF;
+        if ( (v36 | (((v34 >> 15) - (v35 & 1)) << 15)) == 0xFFFFFFFF )
+  LABEL_52:
+          v37 = 0x7FFF;
+        else
+          v37 = v36 & 0x7FFF;
+        LoggingSystem_Log((unsigned int)dword_181F5FE24, 1, "%s:  added global entity %d %s (%s)\n", "SV", v37, v29, v32);
+      }
+      return 0;
+    }
+    if ( (*(unsigned __int8 (__fastcall **)(_UNKNOWN ***, _QWORD))(v7 + 40))(off_181C46F88, (unsigned int)v4) != 2 )
+    {
+      v16 = ((__int64 (__fastcall *)(_UNKNOWN ***, _QWORD))(*off_181C46F88)[6])(off_181C46F88, v6);
+      v17 = *((unsigned __int8 **)off_181C47C28 + 12);
+      if ( v17 != (unsigned __int8 *)v16 )
+      {
+        if ( !v17 || !v16 )
+          goto LABEL_26;
+        v18 = v16 - (_QWORD)v17;
+        do
+        {
+          v19 = v17[v18];
+          v20 = *v17 - v19;
+          if ( v20 )
+            break;
+          ++v17;
+        }
+        while ( v19 );
+        if ( v20 )
+        {
+  LABEL_26:
+          if ( (*(_DWORD *)(a2[2] + 48) & 0x80) == 0 )
+          {
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F5FE24, 1) )
+            {
+              v21 = byte_18159B990;
+              v22 = a2[2];
+              v23 = byte_18159B990;
+              if ( a2[105] )
+                v23 = (const char *)a2[105];
+              if ( *(_QWORD *)(v22 + 32) )
+                v21 = *(const char **)(v22 + 32);
+              if ( !v22 )
+                goto LABEL_37;
+              v24 = *(_DWORD *)(v22 + 16);
+              v25 = *(_DWORD *)(v22 + 48);
+              v26 = 0x7FFF;
+              if ( v24 != -1 )
+                v26 = v24 & 0x7FFF;
+              if ( (v26 | (((v24 >> 15) - (v25 & 1)) << 15)) == 0xFFFFFFFF )
+  LABEL_37:
+                v27 = 0x7FFF;
+              else
+                v27 = v26 & 0x7FFF;
+              v28 = (const char *)((__int64 (__fastcall *)(_UNKNOWN ***, _QWORD))(*off_181C46F88)[6])(off_181C46F88, v6);
+              LoggingSystem_Log(
+                (unsigned int)dword_181F5FE24,
+                1,
+                "%s:  marking global entity dormant (current:'%s' vs last active in:'%s') %d %s (%s)\n",
+                "SV",
+                *((const char **)off_181C47C28 + 12),
+                v28,
+                v27,
+                v21,
+                v23);
+            }
+            v38 = a2;
+            v39 = 0;
+            CEntitySystem_SetInPVS(g_pGameEntitySystem, 1, &v38);
+          }
+        }
+      }
+      return 0;
+    }
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F5FE24, 1) )
+    {
+      v8 = byte_18159B990;
+      v9 = a2[2];
+      v10 = byte_18159B990;
+      if ( a2[105] )
+        v10 = (const char *)a2[105];
+      if ( *(_QWORD *)(v9 + 32) )
+        v8 = *(const char **)(v9 + 32);
+      if ( !v9 )
+        goto LABEL_16;
+      v11 = *(_DWORD *)(v9 + 16);
+      v12 = *(_DWORD *)(v9 + 48);
+      v13 = 0x7FFF;
+      if ( v11 != -1 )
+        v13 = v11 & 0x7FFF;
+      if ( (v13 | (((v11 >> 15) - (v12 & 1)) << 15)) == 0xFFFFFFFF )
+  LABEL_16:
+        v14 = 0x7FFF;
+      else
+        v14 = v13 & 0x7FFF;
+      LoggingSystem_Log(
+        (unsigned int)dword_181F5FE24,
+        1,
+        "%s:  removing GLOBAL_DEAD global entity %d %s (%s)\n",
+        "SV",
+        v14,
+        v8,
+        v10);
+    }
+    return 0xFFFFFFFFLL;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_SaveInitEntities.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_SaveInitEntities.linux.yaml
@@ -1,0 +1,238 @@
+func_name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+func_va: '0x15510e0'
+disasm_code: |-
+  .text:00000000015510B8                 mov     rdi, rbx
+  .text:00000000015510BB                 mov     [rbp+var_34], esi
+  .text:00000000015510BE                 call    sub_FA2930
+  .text:00000000015510C3                 mov     esi, [rbp+var_34]
+  .text:00000000015510C6                 mov     [rax], esi
+  .text:00000000015510C8                 mov     rax, qword ptr ds:dword_0
+  .text:00000000015510D0                 ud2
+  .text:00000000015510E0                 push    rbp
+  .text:00000000015510E1                 mov     rbp, rsp
+  .text:00000000015510E4                 push    r15
+  .text:00000000015510E6                 push    r14
+  .text:00000000015510E8                 push    r13
+  .text:00000000015510EA                 mov     r13, rdx
+  .text:00000000015510ED                 push    r12
+  .text:00000000015510EF                 push    rbx
+  .text:00000000015510F0                 lea     rbx, [rsi+18h]
+  .text:00000000015510F4                 sub     rsp, 18h
+  .text:00000000015510F8                 mov     esi, [rdx]
+  .text:00000000015510FA                 mov     rdi, rbx
+  .text:00000000015510FD                 call    sub_FABAC0
+  .text:0000000001551102                 mov     eax, [r13+0]
+  .text:0000000001551106                 test    eax, eax
+  .text:0000000001551108                 jle     loc_15512B8
+  .text:000000000155110E                 xor     r12d, r12d
+  .text:0000000001551111                 jmp     loc_15511BC
+  .text:0000000001551120                 mov     eax, [rdx+10h]
+  .text:0000000001551123                 mov     ecx, [rdx+30h]
+  .text:0000000001551126                 shr     eax, 0Fh
+  .text:0000000001551129                 and     ecx, 1
+  .text:000000000155112C                 sub     eax, ecx
+  .text:000000000155112E                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001551132                 jz      loc_15512D8
+  .text:0000000001551138                 movzx   edx, word ptr [rdx+10h]
+  .text:000000000155113C                 and     dx, 7FFFh
+  .text:0000000001551141                 shl     eax, 0Fh
+  .text:0000000001551144                 movzx   edx, dx
+  .text:0000000001551147                 or      eax, edx
+  .text:0000000001551149                 cmp     eax, 0FFFFFFFFh
+  .text:000000000155114C                 jz      loc_1551248
+  .text:0000000001551152                 mov     [r15+8], edx
+  .text:0000000001551156                 mov     rdx, [r14+10h]
+  .text:000000000155115A                 test    rdx, rdx
+  .text:000000000155115D                 jz      loc_155125E
+  .text:0000000001551163                 mov     eax, [rdx+10h]
+  .text:0000000001551166                 mov     ecx, [rdx+30h]
+  .text:0000000001551169                 shr     eax, 0Fh
+  .text:000000000155116C                 and     ecx, 1
+  .text:000000000155116F                 sub     eax, ecx
+  .text:0000000001551171                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001551175                 jz      loc_15512E8
+  .text:000000000155117B                 movzx   edx, word ptr [rdx+10h]
+  .text:000000000155117F                 and     dx, 7FFFh
+  .text:0000000001551184                 shl     eax, 0Fh
+  .text:0000000001551187                 movzx   edx, dx
+  .text:000000000155118A                 or      eax, edx
+  .text:000000000155118C                 mov     [r15+10h], eax
+  .text:0000000001551190                 mov     r14, [r14+20h]
+  .text:0000000001551194                 test    r14, r14
+  .text:0000000001551197                 jz      short loc_15511AE
+  .text:0000000001551199                 mov     [r15+48h], r14
+  .text:000000000155119D                 add     word ptr [r14+20h], 1
+  .text:00000000015511A3                 cmp     byte ptr [r14+24h], 0
+  .text:00000000015511A8                 jnz     loc_1551270
+  .text:00000000015511AE                 add     r12, 1
+  .text:00000000015511B2                 cmp     [r13+0], r12d
+  .text:00000000015511B6                 jle     loc_15512B8
+  .text:00000000015511BC                 mov     rax, [r13+8]
+  .text:00000000015511C0                 mov     esi, r12d
+  .text:00000000015511C3                 lea     rax, [rax+r12*4]
+  .text:00000000015511C7                 mov     ecx, [rax]
+  .text:00000000015511C9                 cmp     ecx, 0FFFFFFFFh
+  .text:00000000015511CC                 jz      loc_15510B8
+  .text:00000000015511D2                 mov     rdi, cs:qword_2566120
+  .text:00000000015511D9                 test    rdi, rdi
+  .text:00000000015511DC                 jz      loc_15510B8
+  .text:00000000015511E2                 cmp     ecx, 0FFFFFFFEh
+  .text:00000000015511E5                 jz      loc_15510B8
+  .text:00000000015511EB                 movzx   eax, word ptr [rax]
+  .text:00000000015511EE                 mov     rdx, rax
+  .text:00000000015511F1                 shr     rdx, 9
+  .text:00000000015511F5                 and     edx, 3Fh
+  .text:00000000015511F8                 mov     rdx, [rdi+rdx*8]
+  .text:00000000015511FC                 test    rdx, rdx
+  .text:00000000015511FF                 jz      loc_15510B8
+  .text:0000000001551205                 and     eax, 1FFh
+  .text:000000000155120A                 imul    rax, 70h ; 'p'
+  .text:000000000155120E                 add     rax, rdx
+  .text:0000000001551211                 cmp     ecx, [rax+10h]
+  .text:0000000001551214                 jnz     loc_15510B8
+  .text:000000000155121A                 mov     r14, [rax]
+  .text:000000000155121D                 mov     rdi, rbx
+  .text:0000000001551220                 call    sub_FA2930
+  .text:0000000001551225                 mov     r15, rax
+  .text:0000000001551228                 mov     [rax], r12d
+  .text:000000000155122B                 mov     rax, [r14]
+  .text:000000000155122E                 mov     rdi, r14
+  .text:0000000001551231                 ; 0xE0 = 224LL = CEntityInstance_RequiredEdictIndex
+  .text:0000000001551231                 call    qword ptr [rax+0E0h]; 0xE0 = 224LL = CEntityInstance_RequiredEdictIndex
+  .text:0000000001551237                 mov     [r15+4], eax
+  .text:000000000155123B                 mov     rdx, [r14+10h]
+  .text:000000000155123F                 test    rdx, rdx
+  .text:0000000001551242                 jnz     loc_1551120
+  .text:0000000001551248                 mov     edx, 7FFFh
+  .text:000000000155124D                 mov     [r15+8], edx
+  .text:0000000001551251                 mov     rdx, [r14+10h]
+  .text:0000000001551255                 test    rdx, rdx
+  .text:0000000001551258                 jnz     loc_1551163
+  .text:000000000155125E                 mov     dword ptr [r15+10h], 0FFFFFFFFh
+  .text:0000000001551266                 jmp     loc_1551190
+  .text:0000000001551270                 mov     r15, cs:LOG_GENERAL_ptr
+  .text:0000000001551277                 ; _QWORD
+  .text:0000000001551277                 mov     esi, 2; _QWORD
+  .text:000000000155127C                 ; _QWORD
+  .text:000000000155127C                 mov     edi, [r15]; _QWORD
+  .text:000000000155127F                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001551284                 test    al, al
+  .text:0000000001551286                 jz      loc_15511AE
+  .text:000000000155128C                 ; _QWORD
+  .text:000000000155128C                 mov     edi, [r15]; _QWORD
+  .text:000000000155128F                 mov     rcx, r14
+  .text:0000000001551292                 ; _QWORD
+  .text:0000000001551292                 mov     esi, 2; _QWORD
+  .text:0000000001551297                 xor     eax, eax
+  .text:0000000001551299                 movsx   r8d, word ptr [r14+20h]
+  .text:000000000155129E                 lea     rdx, aKv0xPAddrefRef; "kv 0x%p AddRef refcount == %d\n"
+  .text:00000000015512A5                 add     r12, 1
+  .text:00000000015512A9                 call    _LoggingSystem_Log
+  .text:00000000015512AE                 cmp     [r13+0], r12d
+  .text:00000000015512B2                 jg      loc_15511BC
+  .text:00000000015512B8                 mov     rdi, rbx
+  .text:00000000015512BB                 call    sub_FADC90
+  .text:00000000015512C0                 add     rsp, 18h
+  .text:00000000015512C4                 mov     eax, 1
+  .text:00000000015512C9                 pop     rbx
+  .text:00000000015512CA                 pop     r12
+  .text:00000000015512CC                 pop     r13
+  .text:00000000015512CE                 pop     r14
+  .text:00000000015512D0                 pop     r15
+  .text:00000000015512D2                 pop     rbp
+  .text:00000000015512D3                 retn
+  .text:00000000015512D8                 mov     edx, 7FFFh
+  .text:00000000015512DD                 jmp     loc_1551141
+  .text:00000000015512E8                 mov     edx, 7FFFh
+  .text:00000000015512ED                 jmp     loc_1551184
+procedure: |-
+  __int64 __fastcall CEntitySaveRestoreBlockHandler_SaveInitEntities(__int64 a1, __int64 a2, unsigned int *a3)
+  {
+    __int64 v4; // rbx
+    __int64 v5; // r12
+    int v6; // eax
+    unsigned __int16 v7; // dx
+    __int64 v8; // rdx
+    int v9; // eax
+    unsigned __int16 v10; // dx
+    __int64 v11; // r14
+    unsigned __int16 *v12; // rax
+    int v13; // ecx
+    unsigned __int64 v14; // rax
+    __int64 v15; // rdx
+    __int64 v16; // rax
+    _QWORD *v17; // r14
+    __int64 v18; // r15
+    __int64 v19; // rdx
+
+    v4 = a2 + 24;
+    sub_FABAC0(a2 + 24, *a3);
+    if ( (int)*a3 > 0 )
+    {
+      v5 = 0;
+      while ( 1 )
+      {
+        v12 = (unsigned __int16 *)(*((_QWORD *)a3 + 1) + 4 * v5);
+        v13 = *(_DWORD *)v12;
+        if ( *(_DWORD *)v12 == -1
+          || !qword_2566120
+          || v13 == -2
+          || (v14 = *v12, (v15 = *(_QWORD *)(qword_2566120 + 8 * ((v14 >> 9) & 0x3F))) == 0)
+          || (v16 = v15 + 112 * (v14 & 0x1FF), v13 != *(_DWORD *)(v16 + 16)) )
+        {
+          *(_DWORD *)sub_FA2930(v4, (unsigned int)v5) = v5;
+          BUG();
+        }
+        v17 = *(_QWORD **)v16;
+        v18 = sub_FA2930(v4, (unsigned int)v5);
+        *(_DWORD *)v18 = v5;
+        *(_DWORD *)(v18 + 4) = (*(__int64 (__fastcall **)(_QWORD *))(*v17 + 224LL))(v17);// 0xE0 = 224LL = CEntityInstance_RequiredEdictIndex
+        v19 = v17[2];
+        if ( !v19
+          || ((v6 = (*(_DWORD *)(v19 + 16) >> 15) - (*(_DWORD *)(v19 + 48) & 1), *(_DWORD *)(v19 + 16) == -1)
+            ? (v7 = 0x7FFF)
+            : (v7 = *(_WORD *)(v19 + 16) & 0x7FFF),
+              (v7 | (v6 << 15)) == 0xFFFFFFFF) )
+        {
+          *(_DWORD *)(v18 + 8) = 0x7FFF;
+          v8 = v17[2];
+          if ( v8 )
+          {
+  LABEL_7:
+            v9 = (*(_DWORD *)(v8 + 16) >> 15) - (*(_DWORD *)(v8 + 48) & 1);
+            if ( *(_DWORD *)(v8 + 16) == -1 )
+              v10 = 0x7FFF;
+            else
+              v10 = *(_WORD *)(v8 + 16) & 0x7FFF;
+            *(_DWORD *)(v18 + 16) = v10 | (v9 << 15);
+            goto LABEL_10;
+          }
+        }
+        else
+        {
+          *(_DWORD *)(v18 + 8) = v7;
+          v8 = v17[2];
+          if ( v8 )
+            goto LABEL_7;
+        }
+        *(_DWORD *)(v18 + 16) = -1;
+  LABEL_10:
+        v11 = v17[4];
+        if ( v11
+          && (*(_QWORD *)(v18 + 72) = v11, ++*(_WORD *)(v11 + 32), *(_BYTE *)(v11 + 36))
+          && (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        {
+          ++v5;
+          LoggingSystem_Log(LOG_GENERAL, 2, "kv 0x%p AddRef refcount == %d\n", (const void *)v11, *(__int16 *)(v11 + 32));
+          if ( (int)*a3 <= (int)v5 )
+            break;
+        }
+        else if ( (int)*a3 <= (int)++v5 )
+        {
+          break;
+        }
+      }
+    }
+    sub_FADC90(v4);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_SaveInitEntities.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySaveRestoreBlockHandler_SaveInitEntities.windows.yaml
@@ -1,0 +1,251 @@
+func_name: CEntitySaveRestoreBlockHandler_SaveInitEntities
+func_va: '0x180b800f0'
+disasm_code: |-
+  .text:0000000180B800F0                 push    rbp
+  .text:0000000180B800F2                 push    rsi
+  .text:0000000180B800F3                 push    r12
+  .text:0000000180B800F5                 push    r15
+  .text:0000000180B800F7                 sub     rsp, 38h
+  .text:0000000180B800FB                 lea     rbp, [rdx+18h]
+  .text:0000000180B800FF                 mov     r15, r8
+  .text:0000000180B80102                 mov     edx, [r8]
+  .text:0000000180B80105                 mov     rcx, rbp
+  .text:0000000180B80108                 call    CGameSaveRestoreInfo__InitEntityTable
+  .text:0000000180B8010D                 xor     r12d, r12d
+  .text:0000000180B80110                 mov     esi, r12d
+  .text:0000000180B80113                 cmp     [r15], r12d
+  .text:0000000180B80116                 jle     loc_180B802BB
+  .text:0000000180B8011C                 mov     [rsp+58h+arg_0], rbx
+  .text:0000000180B80121                 mov     [rsp+58h+arg_10], rdi
+  .text:0000000180B80126                 mov     [rsp+58h+var_28], r14
+  .text:0000000180B8012B                 mov     r14d, r12d
+  .text:0000000180B8012E                 xchg    ax, ax
+  .text:0000000180B80130                 mov     rax, [r15+8]
+  .text:0000000180B80134                 mov     ecx, [r14+rax]
+  .text:0000000180B80138                 cmp     ecx, 0FFFFFFFFh
+  .text:0000000180B8013B                 jz      short loc_180B80189
+  .text:0000000180B8013D                 mov     r8, cs:qword_181D958F8
+  .text:0000000180B80144                 test    r8, r8
+  .text:0000000180B80147                 jz      short loc_180B80189
+  .text:0000000180B80149                 cmp     ecx, 0FFFFFFFEh
+  .text:0000000180B8014C                 jz      short loc_180B8017C
+  .text:0000000180B8014E                 mov     eax, ecx
+  .text:0000000180B80150                 and     eax, 7FFFh
+  .text:0000000180B80155                 mov     edx, eax
+  .text:0000000180B80157                 shr     rax, 9
+  .text:0000000180B8015B                 mov     r9, [r8+rax*8]
+  .text:0000000180B8015F                 test    r9, r9
+  .text:0000000180B80162                 jz      short loc_180B8017C
+  .text:0000000180B80164                 and     edx, 1FFh
+  .text:0000000180B8016A                 imul    rax, rdx, 70h ; 'p'
+  .text:0000000180B8016E                 add     rax, r9
+  .text:0000000180B80171                 jz      short loc_180B8017C
+  .text:0000000180B80173                 cmp     [rax+10h], ecx
+  .text:0000000180B80176                 cmovnz  rax, r12
+  .text:0000000180B8017A                 jmp     short loc_180B8017F
+  .text:0000000180B8017C                 mov     rax, r12
+  .text:0000000180B8017F                 test    rax, rax
+  .text:0000000180B80182                 jz      short loc_180B80189
+  .text:0000000180B80184                 mov     rbx, [rax]
+  .text:0000000180B80187                 jmp     short loc_180B8018C
+  .text:0000000180B80189                 mov     rbx, r12
+  .text:0000000180B8018C                 mov     edx, esi
+  .text:0000000180B8018E                 mov     rcx, rbp
+  .text:0000000180B80191                 call    CGameSaveRestoreInfo__GetEntityInfo
+  .text:0000000180B80196                 lea     rdx, [rsp+58h+arg_8]
+  .text:0000000180B8019B                 mov     rdi, rax
+  .text:0000000180B8019E                 mov     [rax], esi
+  .text:0000000180B801A0                 mov     rcx, [rbx]
+  .text:0000000180B801A3                 ; 0xD8 = 216LL = CEntityInstance_RequiredEdictIndex
+  .text:0000000180B801A3                 mov     r8, [rcx+0D8h]; 0xD8 = 216LL = CEntityInstance_RequiredEdictIndex
+  .text:0000000180B801AA                 mov     rcx, rbx
+  .text:0000000180B801AD                 call    r8
+  .text:0000000180B801B0                 mov     ecx, [rax]
+  .text:0000000180B801B2                 mov     [rdi+4], ecx
+  .text:0000000180B801B5                 mov     rcx, [rbx+10h]
+  .text:0000000180B801B9                 test    rcx, rcx
+  .text:0000000180B801BC                 jz      short loc_180B801EC
+  .text:0000000180B801BE                 mov     r8d, [rcx+10h]
+  .text:0000000180B801C2                 mov     edx, 7FFFh
+  .text:0000000180B801C7                 mov     ecx, [rcx+30h]
+  .text:0000000180B801CA                 mov     eax, r8d
+  .text:0000000180B801CD                 and     ecx, 1
+  .text:0000000180B801D0                 shr     eax, 0Fh
+  .text:0000000180B801D3                 sub     eax, ecx
+  .text:0000000180B801D5                 mov     ecx, r8d
+  .text:0000000180B801D8                 and     ecx, 7FFFh
+  .text:0000000180B801DE                 shl     eax, 0Fh
+  .text:0000000180B801E1                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180B801E5                 cmovnz  edx, ecx
+  .text:0000000180B801E8                 or      eax, edx
+  .text:0000000180B801EA                 jmp     short loc_180B801F1
+  .text:0000000180B801EC                 mov     eax, 0FFFFFFFFh
+  .text:0000000180B801F1                 mov     ecx, eax
+  .text:0000000180B801F3                 mov     edx, 7FFFh
+  .text:0000000180B801F8                 and     ecx, 7FFFh
+  .text:0000000180B801FE                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180B80201                 cmovnz  edx, ecx
+  .text:0000000180B80204                 mov     [rdi+8], edx
+  .text:0000000180B80207                 mov     rax, [rbx+10h]
+  .text:0000000180B8020B                 test    rax, rax
+  .text:0000000180B8020E                 jz      short loc_180B8023E
+  .text:0000000180B80210                 mov     edx, [rax+10h]
+  .text:0000000180B80213                 mov     ecx, 7FFFh
+  .text:0000000180B80218                 mov     eax, [rax+30h]
+  .text:0000000180B8021B                 mov     r8d, edx
+  .text:0000000180B8021E                 and     eax, 1
+  .text:0000000180B80221                 shr     r8d, 0Fh
+  .text:0000000180B80225                 sub     r8d, eax
+  .text:0000000180B80228                 mov     eax, edx
+  .text:0000000180B8022A                 and     eax, 7FFFh
+  .text:0000000180B8022F                 shl     r8d, 0Fh
+  .text:0000000180B80233                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180B80236                 cmovnz  ecx, eax
+  .text:0000000180B80239                 or      r8d, ecx
+  .text:0000000180B8023C                 jmp     short loc_180B80244
+  .text:0000000180B8023E                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180B80244                 mov     [rdi+10h], r8d
+  .text:0000000180B80248                 mov     rbx, [rbx+20h]
+  .text:0000000180B8024C                 test    rbx, rbx
+  .text:0000000180B8024F                 jz      short loc_180B8029D
+  .text:0000000180B80251                 mov     [rdi+48h], rbx
+  .text:0000000180B80255                 inc     word ptr [rbx+20h]
+  .text:0000000180B80259                 cmp     [rbx+24h], r12b
+  .text:0000000180B8025D                 jz      short loc_180B8029D
+  .text:0000000180B8025F                 mov     rcx, cs:LOG_GENERAL
+  .text:0000000180B80266                 mov     edx, 2
+  .text:0000000180B8026B                 mov     ecx, [rcx]
+  .text:0000000180B8026D                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B80273                 test    al, al
+  .text:0000000180B80275                 jz      short loc_180B8029D
+  .text:0000000180B80277                 mov     rcx, cs:LOG_GENERAL
+  .text:0000000180B8027E                 lea     r8, aKv0xPAddrefRef; "kv 0x%p AddRef refcount == %d\n"
+  .text:0000000180B80285                 movsx   eax, word ptr [rbx+20h]
+  .text:0000000180B80289                 mov     r9, rbx
+  .text:0000000180B8028C                 mov     edx, 2
+  .text:0000000180B80291                 mov     [rsp+58h+var_38], eax
+  .text:0000000180B80295                 mov     ecx, [rcx]
+  .text:0000000180B80297                 call    cs:LoggingSystem_Log
+  .text:0000000180B8029D                 inc     esi
+  .text:0000000180B8029F                 add     r14, 4
+  .text:0000000180B802A3                 cmp     esi, [r15]
+  .text:0000000180B802A6                 jl      loc_180B80130
+  .text:0000000180B802AC                 mov     r14, [rsp+58h+var_28]
+  .text:0000000180B802B1                 mov     rdi, [rsp+58h+arg_10]
+  .text:0000000180B802B6                 mov     rbx, [rsp+58h+arg_0]
+  .text:0000000180B802BB                 mov     rcx, rbp
+  .text:0000000180B802BE                 call    CGameSaveRestoreInfo__BuildEntityHash
+  .text:0000000180B802C3                 mov     al, 1
+  .text:0000000180B802C5                 add     rsp, 38h
+  .text:0000000180B802C9                 pop     r15
+  .text:0000000180B802CB                 pop     r12
+  .text:0000000180B802CD                 pop     rsi
+  .text:0000000180B802CE                 pop     rbp
+  .text:0000000180B802CF                 retn
+procedure: |-
+  char __fastcall CEntitySaveRestoreBlockHandler::SaveInitEntities(__int64 a1, __int64 a2, unsigned int *a3)
+  {
+    __int64 v3; // rbp
+    int v5; // esi
+    __int64 v6; // r14
+    int v7; // ecx
+    __int64 v8; // r9
+    __int64 v9; // rax
+    _QWORD *v10; // rbx
+    __int64 EntityInfo; // rdi
+    __int64 v12; // rcx
+    unsigned int v13; // r8d
+    int v14; // edx
+    int v15; // eax
+    int v16; // edx
+    __int64 v17; // rax
+    unsigned int v18; // edx
+    int v19; // ecx
+    int v20; // r8d
+    __int64 v21; // rbx
+
+    v3 = a2 + 24;
+    CGameSaveRestoreInfo::InitEntityTable(a2 + 24, *a3);
+    v5 = 0;
+    if ( (int)*a3 > 0 )
+    {
+      v6 = 0;
+      do
+      {
+        v7 = *(_DWORD *)(v6 + *((_QWORD *)a3 + 1));
+        if ( v7 == -1 || !qword_181D958F8 )
+          goto LABEL_14;
+        if ( v7 != -2
+          && (v8 = *(_QWORD *)(qword_181D958F8 + 8 * ((unsigned __int64)(v7 & 0x7FFF) >> 9))) != 0
+          && (v9 = v8 + 112LL * (v7 & 0x1FF)) != 0 )
+        {
+          if ( *(_DWORD *)(v9 + 16) != v7 )
+            v9 = 0;
+        }
+        else
+        {
+          v9 = 0;
+        }
+        if ( v9 )
+          v10 = *(_QWORD **)v9;
+        else
+  LABEL_14:
+          v10 = nullptr;
+        EntityInfo = CGameSaveRestoreInfo::GetEntityInfo(v3, v5);
+        *(_DWORD *)EntityInfo = v5;
+        *(_DWORD *)(EntityInfo + 4) = *(_DWORD *)(*(__int64 (__fastcall **)(_QWORD *))(*v10 + 216LL))(v10);// 0xD8 = 216LL = CEntityInstance_RequiredEdictIndex
+        v12 = v10[2];
+        if ( v12 )
+        {
+          v13 = *(_DWORD *)(v12 + 16);
+          v14 = 0x7FFF;
+          if ( v13 != -1 )
+            v14 = v13 & 0x7FFF;
+          v15 = v14 | (((v13 >> 15) - (*(_DWORD *)(v12 + 48) & 1)) << 15);
+        }
+        else
+        {
+          v15 = -1;
+        }
+        v16 = 0x7FFF;
+        if ( v15 != -1 )
+          v16 = v15 & 0x7FFF;
+        *(_DWORD *)(EntityInfo + 8) = v16;
+        v17 = v10[2];
+        if ( v17 )
+        {
+          v18 = *(_DWORD *)(v17 + 16);
+          v19 = 0x7FFF;
+          if ( v18 != -1 )
+            v19 = v18 & 0x7FFF;
+          v20 = v19 | (((v18 >> 15) - (*(_DWORD *)(v17 + 48) & 1)) << 15);
+        }
+        else
+        {
+          v20 = -1;
+        }
+        *(_DWORD *)(EntityInfo + 16) = v20;
+        v21 = v10[4];
+        if ( v21 )
+        {
+          *(_QWORD *)(EntityInfo + 72) = v21;
+          ++*(_WORD *)(v21 + 32);
+          if ( *(_BYTE *)(v21 + 36) )
+          {
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+              LoggingSystem_Log(
+                LOG_GENERAL,
+                2,
+                "kv 0x%p AddRef refcount == %d\n",
+                (const void *)v21,
+                *(__int16 *)(v21 + 32));
+          }
+        }
+        ++v5;
+        v6 += 4;
+      }
+      while ( v5 < (int)*a3 );
+    }
+    CGameSaveRestoreInfo::BuildEntityHash(v3);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.linux.yaml
@@ -1,48 +1,50 @@
 func_name: CEntitySystem_PostDataUpdate
-func_va: '0x1e50ae0'
+func_va: '0x1e502e0'
 disasm_code: |-
-  .text:0000000001E50AE0                 push    rbp
-  .text:0000000001E50AE1                 mov     rbp, rsp
-  .text:0000000001E50AE4                 push    r13
-  .text:0000000001E50AE6                 push    r12
-  .text:0000000001E50AE8                 movsxd  r12, esi
-  .text:0000000001E50AEB                 mov     esi, 80000001h
-  .text:0000000001E50AF0                 push    rbx
-  .text:0000000001E50AF1                 mov     rbx, rdx
-  .text:0000000001E50AF4                 sub     rsp, 8
-  .text:0000000001E50AF8                 mov     rax, [rdi+0C88h]
-  .text:0000000001E50AFF                 movss   xmm0, dword ptr [rdi+0BD4h]
-  .text:0000000001E50B07                 mov     rdx, [rax]
-  .text:0000000001E50B0A                 mov     rdi, rax
-  .text:0000000001E50B0D                 call    qword ptr [rdx+20h]
-  .text:0000000001E50B10                 test    r12d, r12d
-  .text:0000000001E50B13                 jle     short loc_1E50B5B
-  .text:0000000001E50B15                 shl     r12, 4
-  .text:0000000001E50B19                 lea     r13, byte_27BB9EB
-  .text:0000000001E50B20                 add     r12, rbx
-  .text:0000000001E50B23                 jmp     short loc_1E50B34
-  .text:0000000001E50B28                 call    qword ptr [rax+68h]
-  .text:0000000001E50B2B                 add     rbx, 10h
-  .text:0000000001E50B2F                 cmp     r12, rbx
-  .text:0000000001E50B32                 jz      short loc_1E50B5B
-  .text:0000000001E50B34                 mov     rax, [rbx]
-  .text:0000000001E50B37                 mov     byte ptr [r13+0], 0
-  .text:0000000001E50B3C                 and     dword ptr [rax+30h], 0FFFFFFF7h
-  .text:0000000001E50B40                 mov     rdi, [rax]
-  .text:0000000001E50B43                 mov     esi, [rbx+8]
-  .text:0000000001E50B46                 mov     rax, [rdi]
-  .text:0000000001E50B49                 test    sil, 4
-  .text:0000000001E50B4D                 jnz     short loc_1E50B28
-  .text:0000000001E50B4F                 call    qword ptr [rax+58h]      ; 58h = CBaseEntity_PostDataUpdate
-  .text:0000000001E50B52                 add     rbx, 10h
-  .text:0000000001E50B56                 cmp     r12, rbx
-  .text:0000000001E50B59                 jnz     short loc_1E50B34
-  .text:0000000001E50B5B                 add     rsp, 8
-  .text:0000000001E50B5F                 pop     rbx
-  .text:0000000001E50B60                 pop     r12
-  .text:0000000001E50B62                 pop     r13
-  .text:0000000001E50B64                 pop     rbp
-  .text:0000000001E50B65                 retn
+  .text:0000000001E502E0                 push    rbp
+  .text:0000000001E502E1                 mov     rbp, rsp
+  .text:0000000001E502E4                 push    r13
+  .text:0000000001E502E6                 push    r12
+  .text:0000000001E502E8                 movsxd  r12, esi
+  .text:0000000001E502EB                 mov     esi, 80000001h
+  .text:0000000001E502F0                 push    rbx
+  .text:0000000001E502F1                 mov     rbx, rdx
+  .text:0000000001E502F4                 sub     rsp, 8
+  .text:0000000001E502F8                 mov     rax, [rdi+0C88h]
+  .text:0000000001E502FF                 movss   xmm0, dword ptr [rdi+0BD4h]
+  .text:0000000001E50307                 mov     rdx, [rax]
+  .text:0000000001E5030A                 mov     rdi, rax
+  .text:0000000001E5030D                 call    qword ptr [rdx+20h]
+  .text:0000000001E50310                 test    r12d, r12d
+  .text:0000000001E50313                 jle     short loc_1E5035B
+  .text:0000000001E50315                 shl     r12, 4
+  .text:0000000001E50319                 lea     r13, byte_27BB16B
+  .text:0000000001E50320                 add     r12, rbx
+  .text:0000000001E50323                 jmp     short loc_1E50334
+  .text:0000000001E50328                 ; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
+  .text:0000000001E50328                 call    qword ptr [rax+68h]; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
+  .text:0000000001E5032B                 add     rbx, 10h
+  .text:0000000001E5032F                 cmp     r12, rbx
+  .text:0000000001E50332                 jz      short loc_1E5035B
+  .text:0000000001E50334                 mov     rax, [rbx]
+  .text:0000000001E50337                 mov     byte ptr [r13+0], 0
+  .text:0000000001E5033C                 and     dword ptr [rax+30h], 0FFFFFFF7h
+  .text:0000000001E50340                 mov     rdi, [rax]
+  .text:0000000001E50343                 mov     esi, [rbx+8]
+  .text:0000000001E50346                 mov     rax, [rdi]
+  .text:0000000001E50349                 test    sil, 4
+  .text:0000000001E5034D                 jnz     short loc_1E50328
+  .text:0000000001E5034F                 ; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
+  .text:0000000001E5034F                 call    qword ptr [rax+58h]; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
+  .text:0000000001E50352                 add     rbx, 10h
+  .text:0000000001E50356                 cmp     r12, rbx
+  .text:0000000001E50359                 jnz     short loc_1E50334
+  .text:0000000001E5035B                 add     rsp, 8
+  .text:0000000001E5035F                 pop     rbx
+  .text:0000000001E50360                 pop     r12
+  .text:0000000001E50362                 pop     r13
+  .text:0000000001E50364                 pop     rbp
+  .text:0000000001E50365                 retn
 procedure: |-
   __int64 __fastcall CEntitySystem_PostDataUpdate(__int64 a1, int a2, __int64 ***a3)
   {
@@ -63,17 +65,17 @@ procedure: |-
         while ( 1 )
         {
           v6 = *a3;
-          byte_27BB9EB = 0;
+          byte_27BB16B = 0;
           *((_DWORD *)v6 + 12) &= ~8u;
           v7 = **v6;
           if ( ((_DWORD)a3[1] & 4) == 0 )
             break;
-          result = (*(__int64 (**)(void))(v7 + 104))();
+          result = (*(__int64 (**)(void))(v7 + 104))();// 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
           a3 += 2;
           if ( v5 == a3 )
             return result;
         }
-        result = (*(__int64 (**)(void))(v7 + 88))();  // 88LL = 0x58 = CBaseEntity_PostDataUpdate
+        result = (*(__int64 (**)(void))(v7 + 88))();// 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
         a3 += 2;
       }
       while ( v5 != a3 );

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.windows.yaml
@@ -1,69 +1,71 @@
 func_name: CEntitySystem_PostDataUpdate
-func_va: '0x1811f4760'
+func_va: '0x1811f4700'
 disasm_code: |-
-  .text:00000001811F4760                 mov     [rsp+arg_0], rbx
-  .text:00000001811F4765                 push    rdi
-  .text:00000001811F4766                 sub     rsp, 20h
-  .text:00000001811F476A                 mov     rax, [rcx+0C80h]
-  .text:00000001811F4771                 mov     rdi, r8
-  .text:00000001811F4774                 movss   xmm2, dword ptr [rcx+0BD4h]
-  .text:00000001811F477C                 mov     rcx, rax
-  .text:00000001811F477F                 movsxd  rbx, edx
-  .text:00000001811F4782                 mov     edx, 80000001h
-  .text:00000001811F4787                 mov     r9, [rax]
-  .text:00000001811F478A                 call    qword ptr [r9+18h]
-  .text:00000001811F478E                 test    rbx, rbx
-  .text:00000001811F4791                 jle     short loc_1811F47D4
-  .text:00000001811F4793                 nop     dword ptr [rax+00h]
-  .text:00000001811F4797                 nop     word ptr [rax+rax+00000000h]
-  .text:00000001811F47A0                 mov     rax, [rdi]
-  .text:00000001811F47A3                 and     dword ptr [rax+30h], 0FFFFFFF7h
-  .text:00000001811F47A7                 mov     cs:byte_1820B15C6, 0
-  .text:00000001811F47AE                 mov     rcx, [rax]
-  .text:00000001811F47B1                 mov     edx, [rdi+8]
-  .text:00000001811F47B4                 mov     eax, edx
-  .text:00000001811F47B6                 shr     eax, 2
-  .text:00000001811F47B9                 mov     r8, [rcx]
-  .text:00000001811F47BC                 test    al, 1
-  .text:00000001811F47BE                 jz      short loc_1811F47C6
-  .text:00000001811F47C0                 call    qword ptr [r8+60h]
-  .text:00000001811F47C4                 jmp     short loc_1811F47CA
-  .text:00000001811F47C6                 call    qword ptr [r8+50h]       ; 50h = CBaseEntity_PostDataUpdate
-  .text:00000001811F47CA                 add     rdi, 10h
-  .text:00000001811F47CE                 sub     rbx, 1
-  .text:00000001811F47D2                 jnz     short loc_1811F47A0
-  .text:00000001811F47D4                 mov     rbx, [rsp+28h+arg_0]
-  .text:00000001811F47D9                 add     rsp, 20h
-  .text:00000001811F47DD                 pop     rdi
-  .text:00000001811F47DE                 retn
+  .text:00000001811F4700                 mov     [rsp+arg_0], rbx
+  .text:00000001811F4705                 push    rdi
+  .text:00000001811F4706                 sub     rsp, 20h
+  .text:00000001811F470A                 mov     rax, [rcx+0C80h]
+  .text:00000001811F4711                 mov     rdi, r8
+  .text:00000001811F4714                 movss   xmm2, dword ptr [rcx+0BD4h]
+  .text:00000001811F471C                 mov     rcx, rax
+  .text:00000001811F471F                 movsxd  rbx, edx
+  .text:00000001811F4722                 mov     edx, 80000001h
+  .text:00000001811F4727                 mov     r9, [rax]
+  .text:00000001811F472A                 call    qword ptr [r9+18h]
+  .text:00000001811F472E                 test    rbx, rbx
+  .text:00000001811F4731                 jle     short loc_1811F4774
+  .text:00000001811F4733                 nop     dword ptr [rax+00h]
+  .text:00000001811F4737                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811F4740                 mov     rax, [rdi]
+  .text:00000001811F4743                 and     dword ptr [rax+30h], 0FFFFFFF7h
+  .text:00000001811F4747                 mov     cs:g_bReceivedChainedPostDataUpdate, 0
+  .text:00000001811F474E                 mov     rcx, [rax]
+  .text:00000001811F4751                 mov     edx, [rdi+8]
+  .text:00000001811F4754                 mov     eax, edx
+  .text:00000001811F4756                 shr     eax, 2
+  .text:00000001811F4759                 mov     r8, [rcx]
+  .text:00000001811F475C                 test    al, 1
+  .text:00000001811F475E                 jz      short loc_1811F4766
+  .text:00000001811F4760                 ; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
+  .text:00000001811F4760                 call    qword ptr [r8+60h]; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
+  .text:00000001811F4764                 jmp     short loc_1811F476A
+  .text:00000001811F4766                 ; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+  .text:00000001811F4766                 call    qword ptr [r8+50h]; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+  .text:00000001811F476A                 add     rdi, 10h
+  .text:00000001811F476E                 sub     rbx, 1
+  .text:00000001811F4772                 jnz     short loc_1811F4740
+  .text:00000001811F4774                 mov     rbx, [rsp+28h+arg_0]
+  .text:00000001811F4779                 add     rsp, 20h
+  .text:00000001811F477D                 pop     rdi
+  .text:00000001811F477E                 retn
 procedure: |-
-  __int64 __fastcall sub_1811F4760(__int64 a1, int a2, __int64 ***a3)
+  void __fastcall CEntitySystem_PostDataUpdate(__int64 a1, int a2, __int64 a3)
   {
     __int64 v4; // rbx
-    __int64 result; // rax
-    __int64 **v6; // rax
-    __int64 v7; // r8
+    __int64 **v5; // rax
+    __int64 *pEntity; // rcx
+    int updateType; // edx
+    __int64 v8; // r8
 
     v4 = a2;
-    result = (*(__int64 (__fastcall **)(_QWORD, __int64))(**(_QWORD **)(a1 + 3200) + 24LL))(
-               *(_QWORD *)(a1 + 3200),
-               2147483649LL);
+    (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)(a1 + 3200) + 24LL))(*(_QWORD *)(a1 + 3200), 2147483649LL);
     if ( v4 > 0 )
     {
       do
       {
-        v6 = *a3;
-        *((_DWORD *)v6 + 12) &= ~8u;
-        byte_1820B15C6 = 0;
-        v7 = **v6;
-        if ( ((_DWORD)a3[1] & 4) != 0 )
-          result = (*(__int64 (**)(void))(v7 + 96))();
+        v5 = *(__int64 ***)a3;
+        *((_DWORD *)v5 + 12) &= ~8u;
+        g_bReceivedChainedPostDataUpdate = 0;
+        pEntity = *v5;
+        updateType = *(_DWORD *)(a3 + 8);
+        v8 = **v5;
+        if ( (updateType & 4) != 0 )
+          (*(void (__thiscall **)(__int64, int))(v8 + 96))((__int64)pEntity, updateType);// 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
         else
-          result = (*(__int64 (**)(void))(v7 + 80))();   // 80LL = 0x50 = CBaseEntity_PostDataUpdate
-        a3 += 2;
+          (*(void (__thiscall **)(__int64, int))(v8 + 80))((__int64)pEntity, updateType);// 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+        a3 += 16;
         --v4;
       }
       while ( v4 );
     }
-    return result;
   }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_SetInPVS.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_SetInPVS.linux.yaml
@@ -1,0 +1,449 @@
+func_name: CEntitySystem_SetInPVS
+func_va: '0x1e57ae0'
+disasm_code: |-
+  .text:0000000001E57AE0                 test    esi, esi
+  .text:0000000001E57AE2                 jz      locret_1E57CE0
+  .text:0000000001E57AE8                 push    rbp
+  .text:0000000001E57AE9                 mov     rbp, rsp
+  .text:0000000001E57AEC                 push    r15
+  .text:0000000001E57AEE                 mov     r15, rdi
+  .text:0000000001E57AF1                 push    r14
+  .text:0000000001E57AF3                 push    r13
+  .text:0000000001E57AF5                 push    r12
+  .text:0000000001E57AF7                 push    rbx
+  .text:0000000001E57AF8                 mov     ebx, esi
+  .text:0000000001E57AFA                 sub     rsp, 38h
+  .text:0000000001E57AFE                 mov     ecx, [rdi+0BC0h]
+  .text:0000000001E57B04                 test    ecx, ecx
+  .text:0000000001E57B06                 jg      loc_1E57C00
+  .text:0000000001E57B0C                 mov     eax, [rdi+0BB8h]
+  .text:0000000001E57B12                 test    eax, eax
+  .text:0000000001E57B14                 jg      loc_1E57C00
+  .text:0000000001E57B1A                 movsxd  r11, esi
+  .text:0000000001E57B1D                 shl     r11, 4
+  .text:0000000001E57B21                 lea     rcx, [r11+20h]
+  .text:0000000001E57B25                 sub     rsp, rcx
+  .text:0000000001E57B28                 lea     r12, [rsp+68h+var_59]
+  .text:0000000001E57B2D                 and     r12, 0FFFFFFFFFFFFFFF0h
+  .text:0000000001E57B31                 lea     rax, [r12+10h]
+  .text:0000000001E57B36                 mov     [rbp-58h], r12
+  .text:0000000001E57B3A                 mov     r13, r12
+  .text:0000000001E57B3D                 mov     [rbp-38h], rax
+  .text:0000000001E57B41                 test    esi, esi
+  .text:0000000001E57B43                 jle     loc_1E57DF8
+  .text:0000000001E57B49                 add     r11, rdx
+  .text:0000000001E57B4C                 xor     eax, eax
+  .text:0000000001E57B4E                 xor     r12d, r12d
+  .text:0000000001E57B51                 jmp     short loc_1E57B9D
+  .text:0000000001E57B58                 xor     ecx, ecx
+  .text:0000000001E57B5A                 test    sil, 80h
+  .text:0000000001E57B5E                 setz    cl
+  .text:0000000001E57B61                 add     ecx, 1
+  .text:0000000001E57B64                 test    r14b, r14b
+  .text:0000000001E57B67                 jz      short loc_1E57BBB
+  .text:0000000001E57B69                 mov     r8, [rbp-38h]
+  .text:0000000001E57B6D                 movsxd  rsi, eax
+  .text:0000000001E57B70                 xor     r14d, r14d
+  .text:0000000001E57B73                 add     eax, 1
+  .text:0000000001E57B76                 shl     rsi, 4
+  .text:0000000001E57B7A                 add     rsi, r8
+  .text:0000000001E57B7D                 movd    xmm0, ecx
+  .text:0000000001E57B81                 mov     [rsi], rdi
+  .text:0000000001E57B84                 pinsrd  xmm0, r14d, 1
+  .text:0000000001E57B8B                 movq    qword ptr [rsi+8], xmm0
+  .text:0000000001E57B90                 add     rdx, 10h
+  .text:0000000001E57B94                 cmp     r11, rdx
+  .text:0000000001E57B97                 jz      loc_1E57C38
+  .text:0000000001E57B9D                 mov     rcx, [rdx]
+  .text:0000000001E57BA0                 movzx   r14d, byte ptr [rdx+8]
+  .text:0000000001E57BA5                 mov     rdi, [rcx+10h]
+  .text:0000000001E57BA9                 mov     esi, [rdi+30h]
+  .text:0000000001E57BAC                 mov     ecx, esi
+  .text:0000000001E57BAE                 and     ecx, 2080h
+  .text:0000000001E57BB4                 jnz     short loc_1E57B58
+  .text:0000000001E57BB6                 test    r14b, r14b
+  .text:0000000001E57BB9                 jnz     short loc_1E57B90
+  .text:0000000001E57BBB                 mov     r14, [rdi+8]
+  .text:0000000001E57BBF                 test    byte ptr [r14+68h], 20h
+  .text:0000000001E57BC4                 setnz   r14b
+  .text:0000000001E57BC8                 movzx   r14d, r14b
+  .text:0000000001E57BCC                 add     r14d, 1
+  .text:0000000001E57BD0                 and     esi, 8000h
+  .text:0000000001E57BD6                 jz      short loc_1E57C20
+  .text:0000000001E57BD8                 mov     r14d, 2
+  .text:0000000001E57BDE                 cmp     ecx, 2
+  .text:0000000001E57BE1                 jz      short loc_1E57B90
+  .text:0000000001E57BE3                 mov     r10, [rbp-38h]
+  .text:0000000001E57BE7                 add     r12d, 1
+  .text:0000000001E57BEB                 mov     esi, ebx
+  .text:0000000001E57BED                 sub     esi, r12d
+  .text:0000000001E57BF0                 movsxd  rsi, esi
+  .text:0000000001E57BF3                 shl     rsi, 4
+  .text:0000000001E57BF7                 add     rsi, r10
+  .text:0000000001E57BFA                 jmp     short loc_1E57B7D
+  .text:0000000001E57C00                 mov     esi, ebx
+  .text:0000000001E57C02                 mov     rdi, r15
+  .text:0000000001E57C05                 call    sub_1E57760
+  .text:0000000001E57C0A                 lea     rsp, [rbp-28h]
+  .text:0000000001E57C0E                 pop     rbx
+  .text:0000000001E57C0F                 pop     r12
+  .text:0000000001E57C11                 pop     r13
+  .text:0000000001E57C13                 pop     r14
+  .text:0000000001E57C15                 pop     r15
+  .text:0000000001E57C17                 pop     rbp
+  .text:0000000001E57C18                 retn
+  .text:0000000001E57C20                 cmp     r14d, ecx
+  .text:0000000001E57C23                 jnz     short loc_1E57BE3
+  .text:0000000001E57C25                 add     rdx, 10h
+  .text:0000000001E57C29                 cmp     r11, rdx
+  .text:0000000001E57C2C                 jnz     loc_1E57B9D
+  .text:0000000001E57C32                 nop     word ptr [rax+rax+00h]
+  .text:0000000001E57C38                 mov     rdi, [rbp-38h]
+  .text:0000000001E57C3C                 sub     ebx, r12d
+  .text:0000000001E57C3F                 movsxd  rbx, ebx
+  .text:0000000001E57C42                 shl     rbx, 4
+  .text:0000000001E57C46                 add     rbx, rdi
+  .text:0000000001E57C49                 mov     [rbp-50h], rbx
+  .text:0000000001E57C4D                 test    r12d, r12d
+  .text:0000000001E57C50                 jnz     loc_1E57CE8
+  .text:0000000001E57C56                 mov     rcx, [rbp-50h]
+  .text:0000000001E57C5A                 lea     r14, [r15+10h]
+  .text:0000000001E57C5E                 mov     edx, r12d
+  .text:0000000001E57C61                 mov     rdi, r15
+  .text:0000000001E57C64                 mov     rsi, r14
+  .text:0000000001E57C67                 mov     [rbp-40h], eax
+  .text:0000000001E57C6A                 call    sub_1E57370
+  .text:0000000001E57C6F                 mov     rcx, [rbp-38h]
+  .text:0000000001E57C73                 mov     rsi, r14
+  .text:0000000001E57C76                 mov     rdi, r15
+  .text:0000000001E57C79                 mov     edx, [rbp-40h]
+  .text:0000000001E57C7C                 call    sub_1E57370
+  .text:0000000001E57C81                 mov     eax, [rbp-40h]
+  .text:0000000001E57C84                 test    eax, eax
+  .text:0000000001E57C86                 jz      short loc_1E57C0A
+  .text:0000000001E57C88                 mov     r12, [rbp-58h]
+  .text:0000000001E57C8C                 movsxd  rbx, eax
+  .text:0000000001E57C8F                 shl     rbx, 4
+  .text:0000000001E57C93                 add     rbx, r12
+  .text:0000000001E57C96                 jmp     short loc_1E57CB8
+  .text:0000000001E57CA0                 cmp     esi, 2
+  .text:0000000001E57CA3                 jnz     short loc_1E57CAB
+  .text:0000000001E57CA5                 or      dh, 20h
+  .text:0000000001E57CA8                 mov     [rcx+30h], edx
+  .text:0000000001E57CAB                 add     r12, 10h
+  .text:0000000001E57CAF                 cmp     rbx, r12
+  .text:0000000001E57CB2                 jz      loc_1E57DA0
+  .text:0000000001E57CB8                 mov     rcx, [r12+10h]
+  .text:0000000001E57CBD                 mov     edx, [rcx+30h]
+  .text:0000000001E57CC0                 and     edx, 0FFFFDF7Fh
+  .text:0000000001E57CC6                 mov     [rcx+30h], edx
+  .text:0000000001E57CC9                 mov     esi, [r12+1Ch]
+  .text:0000000001E57CCE                 cmp     esi, 1
+  .text:0000000001E57CD1                 jnz     short loc_1E57CA0
+  .text:0000000001E57CD3                 or      dl, 80h
+  .text:0000000001E57CD6                 mov     [rcx+30h], edx
+  .text:0000000001E57CD9                 jmp     short loc_1E57CAB
+  .text:0000000001E57CE0                 retn
+  .text:0000000001E57CE8                 movsxd  r14, r12d
+  .text:0000000001E57CEB                 mov     rsi, rbx
+  .text:0000000001E57CEE                 shl     r14, 4
+  .text:0000000001E57CF2                 add     r14, rbx
+  .text:0000000001E57CF5                 jmp     short loc_1E57D15
+  .text:0000000001E57D00                 cmp     r11d, 2
+  .text:0000000001E57D04                 jnz     short loc_1E57D0C
+  .text:0000000001E57D06                 or      dh, 20h
+  .text:0000000001E57D09                 mov     [rdi+30h], edx
+  .text:0000000001E57D0C                 add     rsi, 10h
+  .text:0000000001E57D10                 cmp     rsi, r14
+  .text:0000000001E57D13                 jz      short loc_1E57D40
+  .text:0000000001E57D15                 mov     rdi, [rsi]
+  .text:0000000001E57D18                 mov     edx, [rdi+30h]
+  .text:0000000001E57D1B                 and     edx, 0FFFFDF7Fh
+  .text:0000000001E57D21                 mov     [rdi+30h], edx
+  .text:0000000001E57D24                 mov     r11d, [rsi+0Ch]
+  .text:0000000001E57D28                 cmp     r11d, 1
+  .text:0000000001E57D2C                 jnz     short loc_1E57D00
+  .text:0000000001E57D2E                 or      dl, 80h
+  .text:0000000001E57D31                 mov     [rdi+30h], edx
+  .text:0000000001E57D34                 jmp     short loc_1E57D0C
+  .text:0000000001E57D40                 mov     rdx, [r15]
+  .text:0000000001E57D43                 ; 0xB8 = 184LL = CEntitySystem_OnSetDormant
+  .text:0000000001E57D43                 mov     r11, [rdx+0B8h]; 0xB8 = 184LL = CEntitySystem_OnSetDormant
+  .text:0000000001E57D4A                 lea     rdx, sub_1E50370
+  .text:0000000001E57D51                 cmp     r11, rdx
+  .text:0000000001E57D54                 jnz     loc_1E57E38
+  .text:0000000001E57D5A                 lea     rdi, byte_27BB168
+  .text:0000000001E57D61                 mov     [rbp-40h], rdi
+  .text:0000000001E57D65                 nop     dword ptr [rax]
+  .text:0000000001E57D68                 mov     rdx, [rbx]
+  .text:0000000001E57D6B                 mov     [rbp-44h], eax
+  .text:0000000001E57D6E                 add     rbx, 10h
+  .text:0000000001E57D72                 mov     rax, [rbp-40h]
+  .text:0000000001E57D76                 mov     esi, [rbx-8]
+  .text:0000000001E57D79                 mov     rdi, [rdx]
+  .text:0000000001E57D7C                 mov     byte ptr [rax], 0
+  .text:0000000001E57D7F                 mov     edx, [rbx-4]
+  .text:0000000001E57D82                 mov     r11, [rdi]
+  .text:0000000001E57D85                 call    qword ptr [r11+80h]
+  .text:0000000001E57D8C                 cmp     rbx, r14
+  .text:0000000001E57D8F                 mov     eax, [rbp-44h]
+  .text:0000000001E57D92                 jnz     short loc_1E57D68
+  .text:0000000001E57D94                 jmp     loc_1E57C56
+  .text:0000000001E57DA0                 mov     rdx, [r15]
+  .text:0000000001E57DA3                 ; 0xB8 = 184LL = CEntitySystem_OnSetDormant
+  .text:0000000001E57DA3                 mov     r9, [rdx+0B8h]; 0xB8 = 184LL = CEntitySystem_OnSetDormant
+  .text:0000000001E57DAA                 lea     rdx, sub_1E50370
+  .text:0000000001E57DB1                 cmp     r9, rdx
+  .text:0000000001E57DB4                 jnz     short loc_1E57E22
+  .text:0000000001E57DB6                 lea     rax, byte_27BB168
+  .text:0000000001E57DBD                 mov     [rbp-40h], rax
+  .text:0000000001E57DC1                 nop     dword ptr [rax+00000000h]
+  .text:0000000001E57DC8                 mov     rax, [r13+10h]
+  .text:0000000001E57DCC                 add     r13, 10h
+  .text:0000000001E57DD0                 mov     edx, [r13+0Ch]
+  .text:0000000001E57DD4                 mov     esi, [r13+8]
+  .text:0000000001E57DD8                 mov     rdi, [rax]
+  .text:0000000001E57DDB                 mov     rax, [rbp-40h]
+  .text:0000000001E57DDF                 mov     byte ptr [rax], 0
+  .text:0000000001E57DE2                 mov     rax, [rdi]
+  .text:0000000001E57DE5                 call    qword ptr [rax+80h]
+  .text:0000000001E57DEB                 cmp     rbx, r13
+  .text:0000000001E57DEE                 jnz     short loc_1E57DC8
+  .text:0000000001E57DF0                 jmp     loc_1E57C0A
+  .text:0000000001E57DF8                 lea     rbx, [rdi+10h]
+  .text:0000000001E57DFC                 mov     r14, rax
+  .text:0000000001E57DFF                 xor     edx, edx
+  .text:0000000001E57E01                 lea     rcx, [rax+r11]
+  .text:0000000001E57E05                 mov     rsi, rbx
+  .text:0000000001E57E08                 call    sub_1E57370
+  .text:0000000001E57E0D                 mov     rcx, r14
+  .text:0000000001E57E10                 xor     edx, edx
+  .text:0000000001E57E12                 mov     rsi, rbx
+  .text:0000000001E57E15                 mov     rdi, r15
+  .text:0000000001E57E18                 call    sub_1E57370
+  .text:0000000001E57E1D                 jmp     loc_1E57C0A
+  .text:0000000001E57E22                 mov     rdx, [rbp-38h]
+  .text:0000000001E57E26                 mov     ecx, 1
+  .text:0000000001E57E2B                 mov     esi, eax
+  .text:0000000001E57E2D                 mov     rdi, r15
+  .text:0000000001E57E30                 call    r9
+  .text:0000000001E57E33                 jmp     loc_1E57C0A
+  .text:0000000001E57E38                 mov     [rbp-40h], eax
+  .text:0000000001E57E3B                 mov     rdx, [rbp-50h]
+  .text:0000000001E57E3F                 xor     ecx, ecx
+  .text:0000000001E57E41                 mov     esi, r12d
+  .text:0000000001E57E44                 mov     rdi, r15
+  .text:0000000001E57E47                 call    r11
+  .text:0000000001E57E4A                 mov     eax, [rbp-40h]
+  .text:0000000001E57E4D                 jmp     loc_1E57C56
+procedure: |-
+  void __fastcall CEntitySystem_SetInPVS(int *a1, int a2, _BYTE *a3)
+  {
+    __int64 v5; // r11
+    void *v6; // rsp
+    __int64 *v7; // r13
+    _BYTE *v8; // r11
+    int v9; // eax
+    unsigned int v10; // r12d
+    unsigned int v11; // ecx
+    __int64 v12; // rsi
+    int v13; // r14d
+    _QWORD *v14; // rsi
+    char v15; // r14
+    __int64 v16; // rdi
+    int v17; // esi
+    _QWORD **v18; // rbx
+    unsigned int v19; // eax
+    __int64 *v20; // r12
+    __int64 *v21; // rbx
+    __int64 v22; // rcx
+    unsigned int v23; // edx
+    int v24; // esi
+    _DWORD *v25; // rsi
+    _DWORD *v26; // r14
+    __int64 v27; // rdi
+    unsigned int v28; // edx
+    int v29; // r11d
+    __int64 (__fastcall *v30)(); // r11
+    __int64 *v31; // rdx
+    __int64 v32; // rsi
+    __int64 v33; // rdi
+    __int64 (__fastcall *v34)(); // r9
+    __int64 *v35; // rax
+    __int64 v36; // rdx
+    __int64 v37; // rsi
+    __int64 v38; // rdi
+    __int64 v39; // [rsp-Eh] [rbp-68h] BYREF
+    __int64 *v40; // [rsp-6h] [rbp-60h]
+    _QWORD **v41; // [rsp+2h] [rbp-58h] BYREF
+    int v42; // [rsp+Eh] [rbp-4Ch]
+    char *v43; // [rsp+12h] [rbp-48h]
+    _QWORD *v44; // [rsp+1Ah] [rbp-40h]
+
+    if ( !a2 )
+      return;
+    if ( a1[752] > 0 || a1[750] > 0 )
+    {
+      sub_1E57760(a1, (unsigned int)a2);
+      return;
+    }
+    v5 = 16LL * a2;
+    v6 = alloca(v5 + 32);
+    v40 = &v39;
+    v7 = &v39;
+    v44 = &v41;
+    if ( a2 <= 0 )
+    {
+      sub_1E57370(a1, a1 + 4, 0, &(&v41)[(unsigned __int64)v5 / 8]);
+      sub_1E57370(a1, a1 + 4, 0, &v41);
+      return;
+    }
+    v8 = &a3[v5];
+    v9 = 0;
+    v10 = 0;
+    do
+    {
+      while ( 1 )
+      {
+        v15 = a3[8];
+        v16 = *(_QWORD *)(*(_QWORD *)a3 + 16LL);
+        v17 = *(_DWORD *)(v16 + 48);
+        v11 = v17 & 0x2080;
+        if ( (v17 & 0x2080) == 0 )
+          break;
+        v11 = ((v17 & 0x80u) == 0) + 1;
+        if ( !v15 )
+          goto LABEL_12;
+        v12 = v9;
+        v13 = 0;
+        ++v9;
+        v14 = &v44[2 * v12];
+  LABEL_8:
+        *v14 = v16;
+        v14[1] = _mm_insert_epi32(_mm_cvtsi32_si128(v11), v13, 1).m128i_u64[0];
+  LABEL_9:
+        a3 += 16;
+        if ( v8 == a3 )
+          goto LABEL_19;
+      }
+      if ( v15 )
+        goto LABEL_9;
+  LABEL_12:
+      v13 = ((*(_BYTE *)(*(_QWORD *)(v16 + 8) + 104LL) & 0x20) != 0) + 1;
+      if ( (v17 & 0x8000) != 0 )
+      {
+        v13 = 2;
+        if ( v11 == 2 )
+          goto LABEL_9;
+  LABEL_14:
+        ++v10;
+        v14 = &v44[2 * (int)(a2 - v10)];
+        goto LABEL_8;
+      }
+      if ( v13 != v11 )
+        goto LABEL_14;
+      a3 += 16;
+    }
+    while ( v8 != a3 );
+  LABEL_19:
+    v18 = (_QWORD **)&v44[2 * (int)(a2 - v10)];
+    v41 = v18;
+    if ( v10 )
+    {
+      v25 = v18;
+      v26 = &v18[2 * (int)v10];
+      do
+      {
+        v27 = *(_QWORD *)v25;
+        v28 = *(_DWORD *)(*(_QWORD *)v25 + 48LL) & 0xFFFFDF7F;
+        *(_DWORD *)(*(_QWORD *)v25 + 48LL) = v28;
+        v29 = v25[3];
+        if ( v29 == 1 )
+        {
+          LOBYTE(v28) = v28 | 0x80;
+          *(_DWORD *)(v27 + 48) = v28;
+        }
+        else if ( v29 == 2 )
+        {
+          BYTE1(v28) |= 0x20u;
+          *(_DWORD *)(v27 + 48) = v28;
+        }
+        v25 += 4;
+      }
+      while ( v25 != v26 );
+      v30 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 184LL);// 0xB8 = 184LL = CEntitySystem_OnSetDormant
+      if ( v30 == sub_1E50370 )
+      {
+        v43 = &byte_27BB168;
+        do
+        {
+          v31 = *v18;
+          v42 = v9;
+          v18 += 2;
+          v32 = *((unsigned int *)v18 - 2);
+          v33 = *v31;
+          *v43 = 0;
+          (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v33 + 128LL))(
+            v33,
+            v32,
+            *((unsigned int *)v18 - 1));
+          v9 = v42;
+        }
+        while ( v18 != (_QWORD **)v26 );
+      }
+      else
+      {
+        LODWORD(v43) = v9;
+        ((void (__fastcall *)(int *, _QWORD, _QWORD **, _QWORD))v30)(a1, v10, v41, 0);
+        v9 = (int)v43;
+      }
+    }
+    LODWORD(v43) = v9;
+    sub_1E57370(a1, a1 + 4, v10, v41);
+    sub_1E57370(a1, a1 + 4, (unsigned int)v43, v44);
+    v19 = (unsigned int)v43;
+    if ( (_DWORD)v43 )
+    {
+      v20 = v40;
+      v21 = &v40[2 * (int)v43];
+      do
+      {
+        v22 = v20[2];
+        v23 = *(_DWORD *)(v22 + 48) & 0xFFFFDF7F;
+        *(_DWORD *)(v22 + 48) = v23;
+        v24 = *((_DWORD *)v20 + 7);
+        if ( v24 == 1 )
+        {
+          LOBYTE(v23) = v23 | 0x80;
+          *(_DWORD *)(v22 + 48) = v23;
+        }
+        else if ( v24 == 2 )
+        {
+          BYTE1(v23) |= 0x20u;
+          *(_DWORD *)(v22 + 48) = v23;
+        }
+        v20 += 2;
+      }
+      while ( v21 != v20 );
+      v34 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 184LL);// 0xB8 = 184LL = CEntitySystem_OnSetDormant
+      if ( v34 == sub_1E50370 )
+      {
+        v43 = &byte_27BB168;
+        do
+        {
+          v35 = (__int64 *)v7[2];
+          v7 += 2;
+          v36 = *((unsigned int *)v7 + 3);
+          v37 = *((unsigned int *)v7 + 2);
+          v38 = *v35;
+          *v43 = 0;
+          (*(void (__fastcall **)(__int64, __int64, __int64))(*(_QWORD *)v38 + 128LL))(v38, v37, v36);
+        }
+        while ( v21 != v7 );
+      }
+      else
+      {
+        ((void (__fastcall *)(int *, _QWORD, _QWORD *, __int64))v34)(a1, v19, v44, 1);
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_SetInPVS.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_SetInPVS.windows.yaml
@@ -1,0 +1,343 @@
+func_name: CEntitySystem_SetInPVS
+func_va: '0x1811fa290'
+disasm_code: |-
+  .text:00000001811FA290                 mov     [rsp-8+arg_8], edx
+  .text:00000001811FA294                 mov     [rsp-8+arg_0], rcx
+  .text:00000001811FA299                 push    rbp
+  .text:00000001811FA29A                 push    rsi
+  .text:00000001811FA29B                 push    rdi
+  .text:00000001811FA29C                 push    r12
+  .text:00000001811FA29E                 push    r13
+  .text:00000001811FA2A0                 push    r14
+  .text:00000001811FA2A2                 push    r15
+  .text:00000001811FA2A4                 sub     rsp, 20h
+  .text:00000001811FA2A8                 lea     rbp, [rsp+20h]
+  .text:00000001811FA2AD                 mov     [rbp+30h+arg_10], rbx
+  .text:00000001811FA2B1                 mov     rdi, rcx
+  .text:00000001811FA2B4                 mov     r15d, edx
+  .text:00000001811FA2B7                 test    edx, edx
+  .text:00000001811FA2B9                 jz      loc_1811FA4D7
+  .text:00000001811FA2BF                 cmp     dword ptr [rcx+0BC0h], 0
+  .text:00000001811FA2C6                 jg      loc_1811FA4CF
+  .text:00000001811FA2CC                 cmp     dword ptr [rcx+0BB8h], 0
+  .text:00000001811FA2D3                 jg      loc_1811FA4CF
+  .text:00000001811FA2D9                 movsxd  rax, r15d
+  .text:00000001811FA2DC                 xor     r14d, r14d
+  .text:00000001811FA2DF                 shl     rax, 4
+  .text:00000001811FA2E3                 xor     r12d, r12d
+  .text:00000001811FA2E6                 add     rax, 1Fh
+  .text:00000001811FA2EA                 and     rax, 0FFFFFFFFFFFFFFF0h
+  .text:00000001811FA2EE                 lea     rcx, [rax+0Fh]
+  .text:00000001811FA2F2                 cmp     rcx, rax
+  .text:00000001811FA2F5                 ja      short loc_1811FA301
+  .text:00000001811FA2F7                 mov     rcx, 0FFFFFFFFFFFFFF0h
+  .text:00000001811FA301                 and     rcx, 0FFFFFFFFFFFFFFF0h
+  .text:00000001811FA305                 mov     rax, rcx
+  .text:00000001811FA308                 call    __alloca_probe
+  .text:00000001811FA30D                 sub     rsp, rcx
+  .text:00000001811FA310                 lea     r13, [rsp+50h+var_30]
+  .text:00000001811FA315                 add     r13, 10h
+  .text:00000001811FA319                 and     r13, 0FFFFFFFFFFFFFFF0h
+  .text:00000001811FA31D                 test    r15d, r15d
+  .text:00000001811FA320                 jle     loc_1811FA3C8
+  .text:00000001811FA326                 mov     ebx, r15d
+  .text:00000001811FA329                 mov     rsi, r15
+  .text:00000001811FA32C                 mov     r15d, 2
+  .text:00000001811FA332                 mov     rax, [r8]
+  .text:00000001811FA335                 mov     edi, r12d
+  .text:00000001811FA338                 mov     r11, [rax+10h]
+  .text:00000001811FA33C                 mov     r9d, [r11+30h]
+  .text:00000001811FA340                 test    r9d, 2080h
+  .text:00000001811FA347                 jnz     short loc_1811FA34D
+  .text:00000001811FA349                 xor     edx, edx
+  .text:00000001811FA34B                 jmp     short loc_1811FA35A
+  .text:00000001811FA34D                 movzx   eax, r9b
+  .text:00000001811FA351                 and     al, 80h
+  .text:00000001811FA353                 neg     al
+  .text:00000001811FA355                 sbb     edx, edx
+  .text:00000001811FA357                 add     edx, r15d
+  .text:00000001811FA35A                 movzx   r10d, byte ptr [r8+8]
+  .text:00000001811FA35F                 test    r10b, r10b
+  .text:00000001811FA362                 jz      short loc_1811FA368
+  .text:00000001811FA364                 xor     ecx, ecx
+  .text:00000001811FA366                 jmp     short loc_1811FA388
+  .text:00000001811FA368                 mov     rax, [r11+8]
+  .text:00000001811FA36C                 mov     ecx, 0
+  .text:00000001811FA371                 test    byte ptr [rax+68h], 20h
+  .text:00000001811FA375                 setnz   cl
+  .text:00000001811FA378                 inc     ecx
+  .text:00000001811FA37A                 test    r11, r11
+  .text:00000001811FA37D                 jz      short loc_1811FA388
+  .text:00000001811FA37F                 bt      r9d, 0Fh
+  .text:00000001811FA384                 cmovb   ecx, r15d
+  .text:00000001811FA388                 cmp     edx, ecx
+  .text:00000001811FA38A                 jz      short loc_1811FA3B2
+  .text:00000001811FA38C                 test    r10b, r10b
+  .text:00000001811FA38F                 jz      short loc_1811FA396
+  .text:00000001811FA391                 inc     r12d
+  .text:00000001811FA394                 jmp     short loc_1811FA39D
+  .text:00000001811FA396                 inc     r14d
+  .text:00000001811FA399                 dec     ebx
+  .text:00000001811FA39B                 mov     edi, ebx
+  .text:00000001811FA39D                 movsxd  rax, edi
+  .text:00000001811FA3A0                 add     rax, rax
+  .text:00000001811FA3A3                 mov     [r13+rax*8+0], r11
+  .text:00000001811FA3A8                 mov     [r13+rax*8+8], edx
+  .text:00000001811FA3AD                 mov     [r13+rax*8+0Ch], ecx
+  .text:00000001811FA3B2                 add     r8, 10h
+  .text:00000001811FA3B6                 sub     rsi, 1
+  .text:00000001811FA3BA                 jnz     loc_1811FA332
+  .text:00000001811FA3C0                 mov     r15d, [rbp+30h+arg_8]
+  .text:00000001811FA3C4                 mov     rdi, [rbp+30h+arg_0]
+  .text:00000001811FA3C8                 sub     r15d, r14d
+  .text:00000001811FA3CB                 test    r14d, r14d
+  .text:00000001811FA3CE                 jle     short loc_1811FA43E
+  .text:00000001811FA3D0                 movsxd  r11, r15d
+  .text:00000001811FA3D3                 shl     r11, 4
+  .text:00000001811FA3D7                 add     r11, r13
+  .text:00000001811FA3DA                 movsxd  r10, r14d
+  .text:00000001811FA3DD                 test    r14d, r14d
+  .text:00000001811FA3E0                 jle     short loc_1811FA429
+  .text:00000001811FA3E2                 mov     rdx, r11
+  .text:00000001811FA3E5                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811FA3F0                 mov     r9, [rdx]
+  .text:00000001811FA3F3                 mov     ecx, [r9+30h]
+  .text:00000001811FA3F7                 and     ecx, 0FFFFDF7Fh
+  .text:00000001811FA3FD                 mov     [r9+30h], ecx
+  .text:00000001811FA401                 mov     r8d, [rdx+0Ch]
+  .text:00000001811FA405                 sub     r8d, 1
+  .text:00000001811FA409                 jz      short loc_1811FA417
+  .text:00000001811FA40B                 cmp     r8d, 1
+  .text:00000001811FA40F                 jnz     short loc_1811FA41F
+  .text:00000001811FA411                 bts     ecx, 0Dh
+  .text:00000001811FA415                 jmp     short loc_1811FA41B
+  .text:00000001811FA417                 bts     ecx, 7
+  .text:00000001811FA41B                 mov     [r9+30h], ecx
+  .text:00000001811FA41F                 add     rdx, 10h
+  .text:00000001811FA423                 sub     r10, 1
+  .text:00000001811FA427                 jnz     short loc_1811FA3F0
+  .text:00000001811FA429                 mov     rax, [rdi]
+  .text:00000001811FA42C                 xor     r9d, r9d
+  .text:00000001811FA42F                 mov     r8, r11
+  .text:00000001811FA432                 mov     edx, r14d
+  .text:00000001811FA435                 mov     rcx, rdi
+  .text:00000001811FA438                 ; 0xB0 = 176LL = CEntitySystem_OnSetDormant
+  .text:00000001811FA438                 call    qword ptr [rax+0B0h]; 0xB0 = 176LL = CEntitySystem_OnSetDormant
+  .text:00000001811FA43E                 movsxd  r9, r15d
+  .text:00000001811FA441                 lea     rdx, [rdi+10h]
+  .text:00000001811FA445                 shl     r9, 4
+  .text:00000001811FA449                 mov     r8d, r14d
+  .text:00000001811FA44C                 add     r9, r13
+  .text:00000001811FA44F                 mov     rcx, rdi
+  .text:00000001811FA452                 call    sub_1811FC7A0
+  .text:00000001811FA457                 mov     r9, r13
+  .text:00000001811FA45A                 lea     rdx, [rdi+10h]
+  .text:00000001811FA45E                 mov     r8d, r12d
+  .text:00000001811FA461                 mov     rcx, rdi
+  .text:00000001811FA464                 call    sub_1811FC7A0
+  .text:00000001811FA469                 test    r12d, r12d
+  .text:00000001811FA46C                 jle     short loc_1811FA4D7
+  .text:00000001811FA46E                 movsxd  r10, r12d
+  .text:00000001811FA471                 mov     rdx, r13
+  .text:00000001811FA474                 nop     dword ptr [rax+00h]
+  .text:00000001811FA478                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811FA480                 mov     r9, [rdx]
+  .text:00000001811FA483                 mov     eax, [r9+30h]
+  .text:00000001811FA487                 and     eax, 0FFFFDF7Fh
+  .text:00000001811FA48C                 mov     [r9+30h], eax
+  .text:00000001811FA490                 mov     r8d, [rdx+0Ch]
+  .text:00000001811FA494                 sub     r8d, 1
+  .text:00000001811FA498                 jz      short loc_1811FA4A6
+  .text:00000001811FA49A                 cmp     r8d, 1
+  .text:00000001811FA49E                 jnz     short loc_1811FA4AE
+  .text:00000001811FA4A0                 bts     eax, 0Dh
+  .text:00000001811FA4A4                 jmp     short loc_1811FA4AA
+  .text:00000001811FA4A6                 bts     eax, 7
+  .text:00000001811FA4AA                 mov     [r9+30h], eax
+  .text:00000001811FA4AE                 add     rdx, 10h
+  .text:00000001811FA4B2                 sub     r10, 1
+  .text:00000001811FA4B6                 jnz     short loc_1811FA480
+  .text:00000001811FA4B8                 mov     rax, [rdi]
+  .text:00000001811FA4BB                 mov     r9b, 1
+  .text:00000001811FA4BE                 mov     r8, r13
+  .text:00000001811FA4C1                 mov     edx, r12d
+  .text:00000001811FA4C4                 mov     rcx, rdi
+  .text:00000001811FA4C7                 ; 0xB0 = 176LL = CEntitySystem_OnSetDormant
+  .text:00000001811FA4C7                 call    qword ptr [rax+0B0h]; 0xB0 = 176LL = CEntitySystem_OnSetDormant
+  .text:00000001811FA4CD                 jmp     short loc_1811FA4D7
+  .text:00000001811FA4CF                 mov     edx, r15d
+  .text:00000001811FA4D2                 call    sub_1811F4F30
+  .text:00000001811FA4D7                 mov     rbx, [rbp+30h+arg_10]
+  .text:00000001811FA4DB                 mov     rsp, rbp
+  .text:00000001811FA4DE                 pop     r15
+  .text:00000001811FA4E0                 pop     r14
+  .text:00000001811FA4E2                 pop     r13
+  .text:00000001811FA4E4                 pop     r12
+  .text:00000001811FA4E6                 pop     rdi
+  .text:00000001811FA4E7                 pop     rsi
+  .text:00000001811FA4E8                 pop     rbp
+  .text:00000001811FA4E9                 retn
+procedure: |-
+  void __fastcall CEntitySystem_SetInPVS(__int64 a1, int a2, _BYTE *a3)
+  {
+    __int64 v3; // rdi
+    int v4; // r15d
+    int v5; // r14d
+    int v6; // r12d
+    unsigned __int64 v7; // rax
+    __int64 v8; // rcx
+    void *v9; // rsp
+    void *v10; // rsp
+    int v11; // ebx
+    __int64 v12; // rsi
+    int v13; // edi
+    __int64 v14; // r11
+    int v15; // r9d
+    int v16; // edx
+    char v17; // r10
+    int v18; // ecx
+    __int64 v19; // rax
+    int v20; // r15d
+    __int64 v21; // r10
+    _DWORD *v22; // rdx
+    __int64 v23; // r9
+    unsigned int v24; // ecx
+    int v25; // ecx
+    __int64 v26; // r10
+    _DWORD *i; // rdx
+    __int64 v28; // r9
+    unsigned int v29; // eax
+    int v30; // eax
+    _QWORD v31[4]; // [rsp+30h] [rbp+10h] BYREF
+
+    v3 = a1;
+    v4 = a2;
+    if ( a2 )
+    {
+      if ( *(int *)(a1 + 3008) <= 0 && *(int *)(a1 + 3000) <= 0 )
+      {
+        v5 = 0;
+        v6 = 0;
+        v7 = (16LL * a2 + 31) & 0xFFFFFFFFFFFFFFF0uLL;
+        v8 = v7 + 15;
+        if ( v7 + 15 < v7 )
+          v8 = 0xFFFFFFFFFFFFFF0LL;
+        v9 = alloca(v8 & 0xFFFFFFFFFFFFFFF0uLL);
+        v10 = alloca(v8 & 0xFFFFFFFFFFFFFFF0uLL);
+        if ( a2 > 0 )
+        {
+          v11 = a2;
+          v12 = (unsigned int)a2;
+          do
+          {
+            v13 = v6;
+            v14 = *(_QWORD *)(*(_QWORD *)a3 + 16LL);
+            v15 = *(_DWORD *)(v14 + 48);
+            if ( (v15 & 0x2080) != 0 )
+              v16 = 2 - ((v15 & 0x80u) != 0);
+            else
+              v16 = 0;
+            v17 = a3[8];
+            if ( v17 )
+            {
+              v18 = 0;
+            }
+            else
+            {
+              v18 = ((*(_BYTE *)(*(_QWORD *)(v14 + 8) + 104LL) & 0x20) != 0) + 1;
+              if ( v14 && (v15 & 0x8000) != 0 )
+                v18 = 2;
+            }
+            if ( v16 != v18 )
+            {
+              if ( v17 )
+              {
+                ++v6;
+              }
+              else
+              {
+                ++v5;
+                v13 = --v11;
+              }
+              v19 = 2LL * v13;
+              v31[v19] = v14;
+              LODWORD(v31[v19 + 1]) = v16;
+              HIDWORD(v31[v19 + 1]) = v18;
+            }
+            a3 += 16;
+            --v12;
+          }
+          while ( v12 );
+          v4 = a2;
+          v3 = a1;
+        }
+        v20 = v4 - v5;
+        if ( v5 > 0 )
+        {
+          v21 = v5;
+          v22 = &v31[2 * v20];
+          while ( 1 )
+          {
+            v23 = *(_QWORD *)v22;
+            v24 = *(_DWORD *)(*(_QWORD *)v22 + 48LL) & 0xFFFFDF7F;
+            *(_DWORD *)(*(_QWORD *)v22 + 48LL) = v24;
+            if ( v22[3] == 1 )
+              break;
+            if ( v22[3] == 2 )
+            {
+              v25 = v24 | 0x2000;
+  LABEL_29:
+              *(_DWORD *)(v23 + 48) = v25;
+            }
+            v22 += 4;
+            if ( !--v21 )
+            {
+              (*(void (__fastcall **)(__int64, _QWORD, _QWORD *, _QWORD))(*(_QWORD *)v3
+                                                                        + 176LL))(// 0xB0 = 176LL = CEntitySystem_OnSetDormant
+                v3,
+                (unsigned int)v5,
+                &v31[2 * v20],
+                0);
+              goto LABEL_32;
+            }
+          }
+          v25 = v24 | 0x80;
+          goto LABEL_29;
+        }
+  LABEL_32:
+        sub_1811FC7A0(v3, v3 + 16, (unsigned int)v5, &v31[2 * v20]);
+        sub_1811FC7A0(v3, v3 + 16, (unsigned int)v6, v31);
+        if ( v6 <= 0 )
+          return;
+        v26 = v6;
+        for ( i = v31; ; i += 4 )
+        {
+          v28 = *(_QWORD *)i;
+          v29 = *(_DWORD *)(*(_QWORD *)i + 48LL) & 0xFFFFDF7F;
+          *(_DWORD *)(*(_QWORD *)i + 48LL) = v29;
+          if ( i[3] == 1 )
+            break;
+          if ( i[3] == 2 )
+          {
+            v30 = v29 | 0x2000;
+  LABEL_38:
+            *(_DWORD *)(v28 + 48) = v30;
+          }
+          if ( !--v26 )
+          {
+            LOBYTE(v28) = 1;
+            (*(void (__fastcall **)(__int64, _QWORD, _QWORD *, __int64))(*(_QWORD *)v3
+                                                                       + 176LL))(// 0xB0 = 176LL = CEntitySystem_OnSetDormant
+              v3,
+              (unsigned int)v6,
+              v31,
+              v28);
+            return;
+          }
+        }
+        v30 = v29 | 0x80;
+        goto LABEL_38;
+      }
+      sub_1811F4F30(a1, (unsigned int)a2);
+    }
+  }


### PR DESCRIPTION
## Summary

- Add preprocessor scripts for `CEntityInstance` virtual functions: `NetworkUpdateState`, `NetworkUpdateState_thunk`, `OnSetDormant`, `PreDataUpdate`, `PostDataUpdate`/`PostDataUpdateDelta`, `RequiredEdictIndex`, `DrawEntityDebugOverlays`
- Add preprocessor scripts for `CEntitySystem`: `OnSetDormant`, `SetInPVS`
- Add preprocessor scripts for `CEntitySaveRestoreBlockHandler`: `SaveInitEntities`, `RestoreEntity`
- Add preprocessor script for `CRagdollProp_DrawEntityDebugOverlays`
- Add preprocessor script for `CBaseModelEntity_SetRenderAttribute`
- Add C++ tests for `CEntityInstance`
- Fix pattern-C reference docs

## Test plan

- [ ] Run `uv run ida_analyze_bin.py -debug` to verify all new preprocessor scripts resolve correctly on both Windows and Linux binaries
- [ ] Confirm YAML output files are generated for each new script
- [ ] Verify no regressions in existing scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)