### PR TITLE
Add find-CEntityInstance_ValidatePrivateScriptScope preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -987,6 +987,16 @@ modules:
         expected_input:
           - CLoopTypeSimple_FrameUpdate.{platform}.yaml
 
+      - name: find-SetInfo_CommandHandler
+        expected_output:
+          - SetInfo_CommandHandler.{platform}.yaml
+
+      - name: find-INetworkClientService_IsConnected
+        expected_output:
+          - INetworkClientService_IsConnected.{platform}.yaml
+        expected_input:
+          - SetInfo_CommandHandler.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1170,6 +1180,15 @@ modules:
         alias:
           - INetworkClientService::IsActive
         shared: true
+
+      - name: INetworkClientService_IsConnected
+        category: vfunc
+        alias:
+          - INetworkClientService::IsConnected
+        shared: true
+
+      - name: SetInfo_CommandHandler
+        category: func
 
       - name: CNetworkClientService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -2964,6 +2964,10 @@ modules:
           - CEntitySystem_PrecacheEntity.{platform}.yaml
           - CEntitySystem_vtable.{platform}.yaml
 
+      - name: find-CEntitySystem_DoConstructEntity
+        expected_output:
+          - CEntitySystem_DoConstructEntity.{platform}.yaml
+
       - name: find-CEntityInstance_Disconnect-AND-CEntityComponentHelperT_Free
         expected_output:
           - CEntityInstance_Disconnect.{platform}.yaml
@@ -3628,6 +3632,16 @@ modules:
           - IGameTypes_CreateWorkshopMapGroup.{platform}.yaml
         expected_input:
           - CDedicatedServerWorkshopManager_SwitchToWorkshopMapGroup.{platform}.yaml
+
+      - name: find-CLoadingSpawnGroup_vtable
+        expected_output:
+          - CLoadingSpawnGroup_vtable.{platform}.yaml
+
+      - name: find-CLoadingSpawnGroup_CreateEntityToSpawn
+        expected_output:
+          - CLoadingSpawnGroup_CreateEntityToSpawn.{platform}.yaml
+        expected_input:
+          - CLoadingSpawnGroup_vtable.{platform}.yaml
 
       - name: find-CSpawnGroupMgrGameSystem_vtable
         expected_output:
@@ -5171,6 +5185,11 @@ modules:
         alias:
           - CEntitySystem::ConstructEntity
 
+      - name: CEntitySystem_DoConstructEntity
+        category: func
+        alias:
+          - CEntitySystem::DoConstructEntity
+
       - name: CEntitySystem_GetSpawnGroupWorldId
         category: vfunc
         alias:
@@ -5869,6 +5888,14 @@ modules:
         category: vfunc
         alias:
           - IGameSystem::OnPostSpawnGroupUnload
+
+      - name: CLoadingSpawnGroup_vtable
+        category: vtable
+
+      - name: CLoadingSpawnGroup_CreateEntityToSpawn
+        category: vfunc
+        alias:
+          - CLoadingSpawnGroup::CreateEntityToSpawn
 
       - name: CSpawnGroupMgrGameSystem_OnSpawnGroupPrecache
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -3923,6 +3923,10 @@ modules:
         expected_input:
           - CBaseEntity_ReloadPrivateScripts.{platform}.yaml
 
+      - name: find-CEntityInstance_ValidatePrivateScriptScope
+        expected_output:
+          - CEntityInstance_ValidatePrivateScriptScope.{platform}.yaml
+
       - name: find-CEntityInstance_NetworkStateChanged
         expected_output:
           - CEntityInstance_NetworkStateChanged.{platform}.yaml
@@ -6122,6 +6126,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::ReloadPrivateScripts
+
+      - name: CEntityInstance_ValidatePrivateScriptScope
+        category: func
+        alias:
+          - CEntityInstance::ValidatePrivateScriptScope
 
       - name: CEntityInstance_NetworkStateChanged
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -634,6 +634,12 @@ modules:
           - CNetworkGameServerBase_ServerSimulateInternal.{platform}.yaml
           - CNetworkGameServerBase_vtable.{platform}.yaml
 
+      - name: find-INetworkClientService_IsActive
+        expected_output:
+          - INetworkClientService_IsActive.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_ServerSimulate.{platform}.yaml
+
       - name: find-CNetworkGameServer_GetFreeClient
         expected_output:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
@@ -1157,6 +1163,12 @@ modules:
         category: vfunc
         alias:
           - INetworkMessages::FindNetworkGroup
+        shared: true
+
+      - name: INetworkClientService_IsActive
+        category: vfunc
+        alias:
+          - INetworkClientService::IsActive
         shared: true
 
       - name: CNetworkClientService_vtable

--- a/config.yaml
+++ b/config.yaml
@@ -610,6 +610,30 @@ modules:
         expected_output:
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
 
+      - name: find-CNetworkGameServerBase_vtable
+        expected_output:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+
+      - name: find-CNetworkGameServerBase_ServerSimulate-windows
+        platform: windows
+        expected_output:
+          - CNetworkGameServerBase_ServerSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+
+      - name: find-CNetworkGameServerBase_ServerSimulateInternal-linux
+        platform: linux
+        expected_output:
+          - CNetworkGameServerBase_ServerSimulateInternal.{platform}.yaml
+
+      - name: find-CNetworkGameServerBase_ServerSimulate-linux
+        platform: linux
+        expected_output:
+          - CNetworkGameServerBase_ServerSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_ServerSimulateInternal.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+
       - name: find-CNetworkGameServer_GetFreeClient
         expected_output:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
@@ -1033,6 +1057,19 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::ConnectClient
+
+      - name: CNetworkGameServerBase_vtable
+        category: vtable
+
+      - name: CNetworkGameServerBase_ServerSimulateInternal
+        category: func
+        alias:
+          - CNetworkGameServerBase::ServerSimulateInternal
+
+      - name: CNetworkGameServerBase_ServerSimulate
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::ServerSimulate
 
       - name: CNetworkGameServer_GetFreeClient
         category: func

--- a/ida_preprocessor_scripts/find-CEntityInstance_ValidatePrivateScriptScope.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_ValidatePrivateScriptScope.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_ValidatePrivateScriptScope skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_ValidatePrivateScriptScope",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntityInstance_ValidatePrivateScriptScope",
+        "xref_strings": [
+            "thisEntity",
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": ["InputRunPrivateScript"], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntityInstance_ValidatePrivateScriptScope",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_DoConstructEntity.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_DoConstructEntity.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_DoConstructEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_DoConstructEntity",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_DoConstructEntity",
+        "xref_strings": [
+            "GetDesignerNameForScriptClass",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_DoConstructEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoadingSpawnGroup_CreateEntityToSpawn.py
+++ b/ida_preprocessor_scripts/find-CLoadingSpawnGroup_CreateEntityToSpawn.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoadingSpawnGroup_CreateEntityToSpawn skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoadingSpawnGroup_CreateEntityToSpawn",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoadingSpawnGroup_CreateEntityToSpawn",
+        "xref_strings": [
+            "CGameEntitySystem::CreateEntities: NULL binding for entity %s.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CLoadingSpawnGroup_CreateEntityToSpawn", "CLoadingSpawnGroup"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoadingSpawnGroup_CreateEntityToSpawn",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoadingSpawnGroup_vtable.py
+++ b/ida_preprocessor_scripts/find-CLoadingSpawnGroup_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoadingSpawnGroup_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CLoadingSpawnGroup"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoadingSpawnGroup",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CLoadingSpawnGroup vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulate-linux.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulate-linux.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerSimulate-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ServerSimulate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ServerSimulate",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameServerBase_ServerSimulateInternal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_ServerSimulate", "CNetworkGameServerBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerSimulate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulate-windows.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulate-windows.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerSimulate-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ServerSimulate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ServerSimulate",
+        "xref_strings": [
+            "FULLMATCH:ServerGameFrame",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_ServerSimulate", "CNetworkGameServerBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerSimulate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulateInternal-linux.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerSimulateInternal-linux.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerSimulateInternal-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ServerSimulateInternal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ServerSimulateInternal",
+        "xref_strings": [
+            "FULLMATCH:ServerGameFrame",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerSimulateInternal",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_vtable.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CNetworkGameServerBase"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CNetworkGameServerBase vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-INetworkClientService_IsActive.py
+++ b/ida_preprocessor_scripts/find-INetworkClientService_IsActive.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkClientService_IsActive skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkClientService_IsActive",
+]
+
+# Windows: found in CNetworkGameServerBase_ServerSimulate (the vfunc itself)
+LLM_DECOMPILE_WINDOWS = [
+    (
+        "INetworkClientService_IsActive",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkGameServerBase_ServerSimulate.{platform}.yaml",
+    ),
+]
+
+# Linux: found in CNetworkGameServerBase_ServerSimulateInternal (internal helper)
+LLM_DECOMPILE_LINUX = [
+    (
+        "INetworkClientService_IsActive",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkGameServerBase_ServerSimulateInternal.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkClientService_IsActive", "INetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: INetworkClientService_IsActive is not a downstream predecessor.
+    (
+        "INetworkClientService_IsActive",
+        [
+            "func_name",
+            "vfunc_sig",    # REQUIRED for Pattern C
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Locate INetworkClientService_IsActive vfunc via LLM decompile of predecessor."""
+    llm_decompile = LLM_DECOMPILE_WINDOWS if platform == "windows" else LLM_DECOMPILE_LINUX
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=llm_decompile,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-INetworkClientService_IsConnected.py
+++ b/ida_preprocessor_scripts/find-INetworkClientService_IsConnected.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkClientService_IsConnected skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkClientService_IsConnected",
+]
+
+LLM_DECOMPILE = [
+    (
+        "INetworkClientService_IsConnected",
+        "prompt/call_llm_decompile.md",
+        "references/engine/SetInfo_CommandHandler.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkClientService_IsConnected", "INetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only: INetworkClientService is an abstract interface class with no
+    # concrete body in engine binary to sign.
+    (
+        "INetworkClientService_IsConnected",
+        [
+            "func_name",
+            "vfunc_sig",    # REQUIRED for Pattern C
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Locate INetworkClientService_IsConnected vfunc slot via LLM decompile of SetInfo_CommandHandler."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SetInfo_CommandHandler.py
+++ b/ida_preprocessor_scripts/find-SetInfo_CommandHandler.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SetInfo_CommandHandler skill."""
+
+from ida_preprocessor_scripts._registerconcommand import (
+    preprocess_registerconcommand_skill,
+)
+
+
+TARGET_FUNCTION_NAMES = [
+    "SetInfo_CommandHandler",
+]
+
+COMMAND_NAME = "setinfo"
+HELP_STRING = "Adds a new user info value"
+SEARCH_WINDOW_BEFORE_CALL = 96
+SEARCH_WINDOW_AFTER_XREF = 96
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "SetInfo_CommandHandler",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_registerconcommand_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        command_name=COMMAND_NAME,
+        help_string=HELP_STRING,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        search_window_before_call=SEARCH_WINDOW_BEFORE_CALL,
+        search_window_after_xref=SEARCH_WINDOW_AFTER_XREF,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerSimulate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerSimulate.windows.yaml
@@ -1,0 +1,333 @@
+func_name: CNetworkGameServerBase_ServerSimulate
+func_va: '0x1800b5910'
+disasm_code: |-
+  .text:00000001800B5910                 push    rbx
+  .text:00000001800B5912                 push    rbp
+  .text:00000001800B5913                 sub     rsp, 98h
+  .text:00000001800B591A                 cmp     dword ptr [rcx+38h], 1
+  .text:00000001800B591E                 mov     rbp, rdx
+  .text:00000001800B5921                 mov     rbx, rcx
+  .text:00000001800B5924                 jbe     loc_1800B5C72
+  .text:00000001800B592A                 mov     rax, [rcx]
+  .text:00000001800B592D                 call    qword ptr [rax+148h]
+  .text:00000001800B5933                 test    al, al
+  .text:00000001800B5935                 jnz     loc_1800B5C72
+  .text:00000001800B593B                 mov     [rsp+0A8h+var_18], r14
+  .text:00000001800B5943                 movaps  [rsp+0A8h+var_38], xmm7
+  .text:00000001800B5948                 call    sub_180412040
+  .text:00000001800B594D                 xor     r14d, r14d
+  .text:00000001800B5950                 xorps   xmm7, xmm7
+  .text:00000001800B5953                 test    al, al
+  .text:00000001800B5955                 jz      loc_1800B5A17
+  .text:00000001800B595B                 mov     rax, [rbx+3B8h]
+  .text:00000001800B5962                 movss   xmm0, dword ptr [rax]
+  .text:00000001800B5966                 ucomiss xmm0, xmm7
+  .text:00000001800B5969                 jp      short loc_1800B596D
+  .text:00000001800B596B                 jz      short loc_1800B597D
+  .text:00000001800B596D                 mov     rax, [rbx]
+  .text:00000001800B5970                 mov     rcx, rbx
+  .text:00000001800B5973                 call    qword ptr [rax+170h]
+  .text:00000001800B5979                 test    al, al
+  .text:00000001800B597B                 jz      short loc_1800B59B1
+  .text:00000001800B597D                 mov     rax, [rbx+3B8h]
+  .text:00000001800B5984                 mov     rcx, cs:g_pNetworkSystem
+  .text:00000001800B598B                 movaps  [rsp+0A8h+var_28], xmm6
+  .text:00000001800B5993                 movss   xmm6, dword ptr [rax]
+  .text:00000001800B5997                 mov     rax, [rcx]
+  .text:00000001800B599A                 cvtps2pd xmm6, xmm6
+  .text:00000001800B599D                 call    qword ptr [rax+0D8h]
+  .text:00000001800B59A3                 comisd  xmm0, xmm6
+  .text:00000001800B59A7                 movaps  xmm6, [rsp+0A8h+var_28]
+  .text:00000001800B59AF                 jbe     short loc_1800B59C3
+  .text:00000001800B59B1                 mov     rax, [rbx+3B8h]
+  .text:00000001800B59B8                 mov     rcx, rbx
+  .text:00000001800B59BB                 mov     [rax], r14d
+  .text:00000001800B59BE                 call    sub_1800B0E20
+  .text:00000001800B59C3                 mov     rax, [rbx+3A8h]
+  .text:00000001800B59CA                 movss   xmm0, dword ptr [rax]
+  .text:00000001800B59CE                 ucomiss xmm0, cs:dword_180582450
+  .text:00000001800B59D5                 jp      short loc_1800B59D9
+  .text:00000001800B59D7                 jz      short loc_1800B59E1
+  .text:00000001800B59D9                 mov     rcx, rbx
+  .text:00000001800B59DC                 call    sub_1800B0E20
+  .text:00000001800B59E1                 cmp     [rbx+2C3h], r14b
+  .text:00000001800B59E8                 jz      short loc_1800B5A17
+  .text:00000001800B59EA                 mov     rcx, rbx
+  .text:00000001800B59ED                 call    sub_1800A85A0
+  .text:00000001800B59F2                 mov     rax, [rbx]
+  .text:00000001800B59F5                 mov     rcx, rbx
+  .text:00000001800B59F8                 call    qword ptr [rax+178h]
+  .text:00000001800B59FE                 test    al, al
+  .text:00000001800B5A00                 jz      loc_1800B5C65
+  .text:00000001800B5A06                 lea     rcx, off_18060EF80
+  .text:00000001800B5A0D                 call    sub_1800FAB20
+  .text:00000001800B5A12                 jmp     loc_1800B5C65
+  .text:00000001800B5A17                 mov     eax, [rbx+38h]
+  .text:00000001800B5A1A                 cmp     eax, 3
+  .text:00000001800B5A1D                 jl      loc_1800B5C65
+  .text:00000001800B5A23                 mov     [rsp+0A8h+arg_8], rsi
+  .text:00000001800B5A2B                 mov     [rsp+0A8h+arg_10], rdi
+  .text:00000001800B5A33                 cmp     eax, 4
+  .text:00000001800B5A36                 jnz     short loc_1800B5A3D
+  .text:00000001800B5A38                 xor     dil, dil
+  .text:00000001800B5A3B                 jmp     short loc_1800B5A60
+  .text:00000001800B5A3D                 mov     rax, [rbx]
+  .text:00000001800B5A40                 mov     rcx, rbx
+  .text:00000001800B5A43                 call    qword ptr [rax+178h]
+  .text:00000001800B5A49                 test    al, al
+  .text:00000001800B5A4B                 jnz     short loc_1800B5A5D
+  .text:00000001800B5A4D                 mov     rcx, cs:g_pNetworkClientService
+  .text:00000001800B5A54                 mov     rax, [rcx]
+  .text:00000001800B5A57                 ; 0xF8 = 248LL = INetworkClientService_IsActive
+  .text:00000001800B5A57                 call    qword ptr [rax+0F8h]; 0xF8 = 248LL = INetworkClientService_IsActive
+  .text:00000001800B5A5D                 mov     dil, 1
+  .text:00000001800B5A60                 cmp     [rbx+250h], r14d
+  .text:00000001800B5A67                 jnz     short loc_1800B5A82
+  .text:00000001800B5A69                 mov     rax, [rbx]
+  .text:00000001800B5A6C                 mov     rcx, rbx
+  .text:00000001800B5A6F                 call    qword ptr [rax+178h]
+  .text:00000001800B5A75                 test    al, al
+  .text:00000001800B5A77                 jz      short loc_1800B5A82
+  .text:00000001800B5A79                 call    sub_180412040
+  .text:00000001800B5A7E                 test    al, al
+  .text:00000001800B5A80                 jz      short loc_1800B5AB0
+  .text:00000001800B5A82                 test    dil, dil
+  .text:00000001800B5A85                 jz      short loc_1800B5AB0
+  .text:00000001800B5A87                 mov     rax, [rbx]
+  .text:00000001800B5A8A                 mov     rcx, rbx
+  .text:00000001800B5A8D                 call    qword ptr [rax+178h]
+  .text:00000001800B5A93                 test    al, al
+  .text:00000001800B5A95                 jnz     short loc_1800B5AAB
+  .text:00000001800B5A97                 mov     rcx, cs:g_pNetworkClientService
+  .text:00000001800B5A9E                 mov     rax, [rcx]
+  .text:00000001800B5AA1                 ; 0xF8 = 248LL = INetworkClientService_IsActive
+  .text:00000001800B5AA1                 call    qword ptr [rax+0F8h]; 0xF8 = 248LL = INetworkClientService_IsActive
+  .text:00000001800B5AA7                 test    al, al
+  .text:00000001800B5AA9                 jz      short loc_1800B5AB0
+  .text:00000001800B5AAB                 mov     dil, 1
+  .text:00000001800B5AAE                 jmp     short loc_1800B5AB3
+  .text:00000001800B5AB0                 xor     dil, dil
+  .text:00000001800B5AB3                 mov     rcx, cs:g_pPulseSystem
+  .text:00000001800B5ABA                 mov     rax, [rcx]
+  .text:00000001800B5ABD                 call    qword ptr [rax+250h]
+  .text:00000001800B5AC3                 mov     edx, 0FFFFFFFFh
+  .text:00000001800B5AC8                 lea     rcx, sv_tick_parallel_with_client
+  .text:00000001800B5ACF                 movzx   esi, al
+  .text:00000001800B5AD2                 call    sub_1803FB9B0
+  .text:00000001800B5AD7                 test    rax, rax
+  .text:00000001800B5ADA                 jnz     short loc_1800B5AE7
+  .text:00000001800B5ADC                 mov     rax, cs:qword_1808C82D8
+  .text:00000001800B5AE3                 mov     rax, [rax+8]
+  .text:00000001800B5AE7                 cmp     [rax], r14b
+  .text:00000001800B5AEA                 jz      loc_1800B5BF4
+  .text:00000001800B5AF0                 cmp     [rbp+29h], r14b
+  .text:00000001800B5AF4                 jz      loc_1800B5BF4
+  .text:00000001800B5AFA                 test    sil, sil
+  .text:00000001800B5AFD                 jnz     loc_1800B5BF4
+  .text:00000001800B5B03                 mov     rcx, cs:g_pNetworkServerService
+  .text:00000001800B5B0A                 mov     dl, 1
+  .text:00000001800B5B0C                 mov     rax, [rcx]
+  .text:00000001800B5B0F                 call    qword ptr [rax+190h]
+  .text:00000001800B5B15                 mov     rax, cs:g_pThreadPool
+  .text:00000001800B5B1C                 mov     edx, 60h ; '`'
+  .text:00000001800B5B21                 mov     qword ptr [rsp+0A8h+var_78], rbx
+  .text:00000001800B5B26                 mov     byte ptr [rsp+0A8h+var_78+8], dil
+  .text:00000001800B5B2B                 mov     rsi, [rax]
+  .text:00000001800B5B2E                 movzx   eax, byte ptr [rbp+28h]
+  .text:00000001800B5B32                 mov     byte ptr [rsp+0A8h+var_78+9], al
+  .text:00000001800B5B36                 movzx   eax, byte ptr [rbp+29h]
+  .text:00000001800B5B3A                 mov     byte ptr [rsp+0A8h+var_78+0Ah], al
+  .text:00000001800B5B3E                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800B5B45                 mov     rcx, [rax]
+  .text:00000001800B5B48                 mov     rax, [rcx]
+  .text:00000001800B5B4B                 call    qword ptr [rax+8]
+  .text:00000001800B5B4E                 mov     rdi, rax
+  .text:00000001800B5B51                 test    rax, rax
+  .text:00000001800B5B54                 jz      short loc_1800B5BAD
+  .text:00000001800B5B56                 movups  xmm0, [rsp+0A8h+var_78]
+  .text:00000001800B5B5B                 mov     dword ptr [rax+8], 1
+  .text:00000001800B5B62                 lea     rcx, [rax+30h]
+  .text:00000001800B5B66                 mov     dword ptr [rax+10h], 4
+  .text:00000001800B5B6D                 lea     rdx, aServergamefram; "ServerGameFrame"
+  .text:00000001800B5B74                 mov     [rax+20h], r14
+  .text:00000001800B5B78                 mov     r8d, 20h ; ' '
+  .text:00000001800B5B7E                 mov     [rax+28h], r14
+  .text:00000001800B5B82                 mov     word ptr [rax+15h], 3
+  .text:00000001800B5B88                 mov     [rax+18h], r14
+  .text:00000001800B5B8C                 lea     rax, ??_7CLambdaJob@?1???$QueueJobWithFlags@V_lambda_1_@?BK@??ServerBeginSimulate@CNetworkGameServerBase@@UEAAXAEBUEventServerBeginSimulate_t@@@Z@@IThreadPool@@QEAA?AV?$CSmartPtr@VCThreadedJob@@VCRefCountAccessor@@@@PEBDW4JobPriority_t@@I$$QEAV_lambda_1_@?BK@??ServerBeginSimulate@CNetworkGameServerBase@@UEAAXAEBUEventServerBeginSimulate_t@@@Z@@Z@6B@; const `IThreadPool::QueueJobWithFlags<`CNetworkGameServerBase::ServerBeginSimulate(EventServerBeginSimulate_t const &)'::`26'::_lambda_1_>(char const *,JobPriority_t,uint,`CNetworkGameServerBase::ServerBeginSimulate(EventServerBeginSimulate_t const &)'::`26'::_lambda_1_ &&)'::`2'::CLambdaJob::`vftable'
+  .text:00000001800B5B93                 mov     [rcx], r14b
+  .text:00000001800B5B96                 movups  xmmword ptr [rdi+50h], xmm0
+  .text:00000001800B5B9A                 mov     [rdi], rax
+  .text:00000001800B5B9D                 mov     byte ptr [rdi+14h], 2
+  .text:00000001800B5BA1                 call    cs:_V_strncpy
+  .text:00000001800B5BA7                 mov     byte ptr [rdi+16h], 1
+  .text:00000001800B5BAB                 jmp     short loc_1800B5BB0
+  .text:00000001800B5BAD                 mov     rdi, r14
+  .text:00000001800B5BB0                 mov     [rdi+18h], rsi
+  .text:00000001800B5BB4                 mov     rdx, rdi
+  .text:00000001800B5BB7                 mov     rax, [rsi]
+  .text:00000001800B5BBA                 mov     rcx, rsi
+  .text:00000001800B5BBD                 call    qword ptr [rax+80h]
+  .text:00000001800B5BC3                 lea     rcx, [rbx+6F0h]
+  .text:00000001800B5BCA                 mov     [rsp+0A8h+arg_0], rdi
+  .text:00000001800B5BD2                 lea     rdx, [rsp+0A8h+arg_0]
+  .text:00000001800B5BDA                 call    sub_1800B6FE0
+  .text:00000001800B5BDF                 mov     rcx, [rsp+0A8h+arg_0]
+  .text:00000001800B5BE7                 test    rcx, rcx
+  .text:00000001800B5BEA                 jz      short loc_1800B5C55
+  .text:00000001800B5BEC                 mov     rax, [rcx]
+  .text:00000001800B5BEF                 call    qword ptr [rax+10h]
+  .text:00000001800B5BF2                 jmp     short loc_1800B5C55
+  .text:00000001800B5BF4                 test    dil, dil
+  .text:00000001800B5BF7                 jz      short loc_1800B5C03
+  .text:00000001800B5BF9                 movss   xmm0, cs:dword_1805821C8
+  .text:00000001800B5C01                 jmp     short loc_1800B5C06
+  .text:00000001800B5C03                 xorps   xmm0, xmm0
+  .text:00000001800B5C06                 mov     r9d, [rbx+44h]
+  .text:00000001800B5C0A                 lea     r8, [rbx+58h]
+  .text:00000001800B5C0E                 mov     [rsp+0A8h+var_80], 1
+  .text:00000001800B5C16                 lea     rdx, aCBuildworkerCs_24; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001800B5C1D                 lea     rcx, [rsp+0A8h+var_68]
+  .text:00000001800B5C22                 movss   [rsp+0A8h+var_88], xmm0
+  .text:00000001800B5C28                 call    sub_18005F390
+  .text:00000001800B5C2D                 mov     rcx, cs:g_pSource2Server
+  .text:00000001800B5C34                 movzx   edx, dil
+  .text:00000001800B5C38                 movzx   r9d, byte ptr [rbp+29h]
+  .text:00000001800B5C3D                 movzx   r8d, byte ptr [rbp+28h]
+  .text:00000001800B5C42                 mov     rax, [rcx]
+  .text:00000001800B5C45                 call    qword ptr [rax+98h]
+  .text:00000001800B5C4B                 lea     rcx, [rsp+0A8h+var_68]
+  .text:00000001800B5C50                 call    sub_18005F430
+  .text:00000001800B5C55                 mov     rdi, [rsp+0A8h+arg_10]
+  .text:00000001800B5C5D                 mov     rsi, [rsp+0A8h+arg_8]
+  .text:00000001800B5C65                 mov     r14, [rsp+0A8h+var_18]
+  .text:00000001800B5C6D                 movaps  xmm7, [rsp+0A8h+var_38]
+  .text:00000001800B5C72                 add     rsp, 98h
+  .text:00000001800B5C79                 pop     rbp
+  .text:00000001800B5C7A                 pop     rbx
+  .text:00000001800B5C7B                 retn
+procedure: |-
+  void __fastcall CNetworkGameServerBase_ServerSimulate(__int64 a1, __int64 a2)
+  {
+    __int64 v4; // rdx
+    __int64 v5; // r8
+    __int64 v6; // r9
+    double v7; // xmm6_8
+    int v8; // eax
+    char v9; // di
+    bool v10; // di
+    char v11; // si
+    _BYTE *v12; // rax
+    __int64 v13; // rdx
+    __int64 v14; // rax
+    __int64 v15; // rdi
+    int v16; // xmm0_4
+    __int128 v17; // [rsp+30h] [rbp-78h]
+    _BYTE v18[48]; // [rsp+40h] [rbp-68h] BYREF
+    __int64 v19; // [rsp+B0h] [rbp+8h] BYREF
+
+    if ( *(_DWORD *)(a1 + 56) > 1u && !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 328LL))(a1) )
+    {
+      if ( !(unsigned __int8)sub_180412040() )
+        goto LABEL_13;
+      if ( **(float **)(a1 + 952) != 0.0 && !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 368LL))(a1)
+        || (v7 = **(float **)(a1 + 952), (*(double (**)(void))(*(_QWORD *)g_pNetworkSystem + 216LL))() > v7) )
+      {
+        **(_DWORD **)(a1 + 952) = 0;
+        sub_1800B0E20(a1, v4, v5, v6);
+      }
+      if ( **(float **)(a1 + 936) != -1.0 )
+        sub_1800B0E20(a1, v4, v5, v6);
+      if ( *(_BYTE *)(a1 + 707) )
+      {
+        sub_1800A85A0(a1);
+        if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+          sub_1800FAB20((__int64)&off_18060EF80);
+      }
+      else
+      {
+  LABEL_13:
+        v8 = *(_DWORD *)(a1 + 56);
+        if ( v8 >= 3 )
+        {
+          if ( v8 == 4 )
+          {
+            v9 = 0;
+          }
+          else
+          {
+            if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+              (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkClientService + 248LL))(g_pNetworkClientService);// 0xF8 = 248LL = INetworkClientService_IsActive
+            v9 = 1;
+          }
+          v10 = (*(_DWORD *)(a1 + 592)
+              || !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1)
+              || (unsigned __int8)sub_180412040())
+             && v9
+             && ((*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1)
+              || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkClientService + 248LL))(g_pNetworkClientService));// 0xF8 = 248LL = INetworkClientService_IsActive
+          v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pPulseSystem + 592LL))(g_pPulseSystem);
+          v12 = (_BYTE *)sub_1803FB9B0((__int64)&sv_tick_parallel_with_client, -1);
+          if ( !v12 )
+            v12 = *(_BYTE **)(qword_1808C82D8 + 8);
+          if ( *v12 && *(_BYTE *)(a2 + 41) && !v11 )
+          {
+            LOBYTE(v13) = 1;
+            (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pNetworkServerService + 400LL))(
+              g_pNetworkServerService,
+              v13);
+            *(_QWORD *)&v17 = a1;
+            BYTE8(v17) = v10;
+            *(_WORD *)((char *)&v17 + 9) = *(_WORD *)(a2 + 40);
+            v14 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 96);
+            v15 = v14;
+            if ( v14 )
+            {
+              *(_DWORD *)(v14 + 8) = 1;
+              *(_DWORD *)(v14 + 16) = 4;
+              *(_QWORD *)(v14 + 32) = 0;
+              *(_QWORD *)(v14 + 40) = 0;
+              *(_WORD *)(v14 + 21) = 3;
+              *(_QWORD *)(v14 + 24) = 0;
+              *(_BYTE *)(v14 + 48) = 0;
+              *(_OWORD *)(v14 + 80) = v17;
+              *(_QWORD *)v14 = &`Z::QueueJobWithFlags<`CNetworkGameServerBase::ServerBeginSimulate'::`26'::_lambda_1_,EAAXAEBUEventServerBeginSimulate_t>'::`2'::CLambdaJob::`vftable';
+              *(_BYTE *)(v14 + 20) = 2;
+              V_strncpy(v14 + 48, "ServerGameFrame", 32);
+              *(_BYTE *)(v15 + 22) = 1;
+            }
+            else
+            {
+              v15 = 0;
+            }
+            *(_QWORD *)(v15 + 24) = g_pThreadPool;
+            (*(void (__fastcall **)(_QWORD, __int64))(*g_pThreadPool + 128LL))(g_pThreadPool, v15);
+            v19 = v15;
+            sub_1800B6FE0(a1 + 1776, &v19);
+            if ( v19 )
+              (*(void (__fastcall **)(__int64))(*(_QWORD *)v19 + 16LL))(v19);
+          }
+          else
+          {
+            if ( v10 )
+              v16 = 1015021568;
+            else
+              v16 = 0;
+            sub_18005F390(
+              (unsigned int)v18,
+              (unsigned int)"C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\networkgameserverbase.cpp:5838",
+              a1 + 88,
+              *(_DWORD *)(a1 + 68),
+              v16,
+              1);
+            (*(void (__fastcall **)(__int64, bool, _QWORD, _QWORD))(*(_QWORD *)g_pSource2Server + 152LL))(
+              g_pSource2Server,
+              v10,
+              *(unsigned __int8 *)(a2 + 40),
+              *(unsigned __int8 *)(a2 + 41));
+            sub_18005F430((__int64)v18);
+          }
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerSimulateInternal.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerSimulateInternal.linux.yaml
@@ -1,0 +1,557 @@
+func_name: CNetworkGameServerBase_ServerSimulateInternal
+func_va: '0x698380'
+disasm_code: |-
+  .text:0000000000698380                 push    rbp
+  .text:0000000000698381                 mov     rbp, rsp
+  .text:0000000000698384                 push    r15
+  .text:0000000000698386                 push    r14
+  .text:0000000000698388                 push    r13
+  .text:000000000069838A                 push    r12
+  .text:000000000069838C                 mov     r12, rsi
+  .text:000000000069838F                 push    rbx
+  .text:0000000000698390                 mov     rbx, rdi
+  .text:0000000000698393                 sub     rsp, 28h
+  .text:0000000000698397                 call    sub_861CC0
+  .text:000000000069839C                 test    al, al
+  .text:000000000069839E                 jnz     short loc_6983C0
+  .text:00000000006983A0                 mov     eax, [rbx+38h]
+  .text:00000000006983A3                 cmp     eax, 2
+  .text:00000000006983A6                 jg      loc_698470
+  .text:00000000006983AC                 add     rsp, 28h
+  .text:00000000006983B0                 pop     rbx
+  .text:00000000006983B1                 pop     r12
+  .text:00000000006983B3                 pop     r13
+  .text:00000000006983B5                 pop     r14
+  .text:00000000006983B7                 pop     r15
+  .text:00000000006983B9                 pop     rbp
+  .text:00000000006983BA                 retn
+  .text:00000000006983C0                 mov     rax, [rbx+3B8h]
+  .text:00000000006983C7                 pxor    xmm1, xmm1
+  .text:00000000006983CB                 movss   xmm0, dword ptr [rax]
+  .text:00000000006983CF                 ucomiss xmm0, xmm1
+  .text:00000000006983D2                 jp      loc_698510
+  .text:00000000006983D8                 jnz     loc_698510
+  .text:00000000006983DE                 mov     rdi, cs:qword_97C190
+  .text:00000000006983E5                 pxor    xmm3, xmm3
+  .text:00000000006983E9                 cvtss2sd xmm3, xmm0
+  .text:00000000006983ED                 movsd   [rbp+var_38], xmm3
+  .text:00000000006983F2                 mov     rax, [rdi]
+  .text:00000000006983F5                 call    qword ptr [rax+0D8h]
+  .text:00000000006983FB                 comisd  xmm0, [rbp+var_38]
+  .text:0000000000698400                 ja      loc_698550
+  .text:0000000000698406                 mov     rax, [rbx+3A8h]
+  .text:000000000069840D                 movss   xmm0, cs:dword_255714
+  .text:0000000000698415                 ucomiss xmm0, dword ptr [rax]
+  .text:0000000000698418                 jp      loc_6986C0
+  .text:000000000069841E                 jnz     loc_6986C0
+  .text:0000000000698424                 cmp     byte ptr [rbx+2C3h], 0
+  .text:000000000069842B                 jz      loc_6983A0
+  .text:0000000000698431                 mov     rdi, rbx
+  .text:0000000000698434                 call    sub_6903C0
+  .text:0000000000698439                 mov     rax, [rbx]
+  .text:000000000069843C                 mov     rdi, rbx
+  .text:000000000069843F                 call    qword ptr [rax+178h]
+  .text:0000000000698445                 test    al, al
+  .text:0000000000698447                 jz      loc_6983AC
+  .text:000000000069844D                 lea     rdi, qword_9C5760
+  .text:0000000000698454                 add     rsp, 28h
+  .text:0000000000698458                 pop     rbx
+  .text:0000000000698459                 pop     r12
+  .text:000000000069845B                 pop     r13
+  .text:000000000069845D                 pop     r14
+  .text:000000000069845F                 pop     r15
+  .text:0000000000698461                 pop     rbp
+  .text:0000000000698462                 jmp     sub_6EA5A0
+  .text:0000000000698470                 cmp     eax, 4
+  .text:0000000000698473                 jz      loc_6986E0
+  .text:0000000000698479                 mov     rax, [rbx]
+  .text:000000000069847C                 mov     rdi, rbx
+  .text:000000000069847F                 call    qword ptr [rax+178h]
+  .text:0000000000698485                 test    al, al
+  .text:0000000000698487                 jnz     short loc_6984AA
+  .text:0000000000698489                 mov     rdi, cs:g_pNetworkClientService
+  .text:0000000000698490                 lea     rdx, sub_5C5210
+  .text:0000000000698497                 mov     rax, [rdi]
+  .text:000000000069849A                 ; 0x100 = 256LL = INetworkClientService_IsActive
+  .text:000000000069849A                 mov     rax, [rax+100h]; 0x100 = 256LL = INetworkClientService_IsActive
+  .text:00000000006984A1                 cmp     rax, rdx
+  .text:00000000006984A4                 jnz     loc_698710
+  .text:00000000006984AA                 mov     eax, [rbx+250h]
+  .text:00000000006984B0                 test    eax, eax
+  .text:00000000006984B2                 jz      loc_698560
+  .text:00000000006984B8                 mov     rax, [rbx]
+  .text:00000000006984BB                 mov     rdi, rbx
+  .text:00000000006984BE                 call    qword ptr [rax+178h]
+  .text:00000000006984C4                 mov     r13d, eax
+  .text:00000000006984C7                 test    al, al
+  .text:00000000006984C9                 jnz     loc_698584
+  .text:00000000006984CF                 mov     rdi, cs:g_pNetworkClientService
+  .text:00000000006984D6                 lea     rdx, sub_5C5210
+  .text:00000000006984DD                 mov     rax, [rdi]
+  .text:00000000006984E0                 ; 0x100 = 256LL = INetworkClientService_IsActive
+  .text:00000000006984E0                 mov     rax, [rax+100h]; 0x100 = 256LL = INetworkClientService_IsActive
+  .text:00000000006984E7                 cmp     rax, rdx
+  .text:00000000006984EA                 jnz     loc_698930
+  .text:00000000006984F0                 mov     rax, [rdi+0A0h]
+  .text:00000000006984F7                 test    rax, rax
+  .text:00000000006984FA                 jz      loc_698581
+  .text:0000000000698500                 cmp     dword ptr [rax+240h], 5
+  .text:0000000000698507                 setnle  r13b
+  .text:000000000069850B                 jmp     short loc_698584
+  .text:0000000000698510                 mov     rdx, [rbx]
+  .text:0000000000698513                 lea     rcx, sub_67B0C0
+  .text:000000000069851A                 mov     rdx, [rdx+170h]
+  .text:0000000000698521                 cmp     rdx, rcx
+  .text:0000000000698524                 jnz     loc_698828
+  .text:000000000069852A                 mov     rdx, [rbx+3A0h]
+  .text:0000000000698531                 cmp     qword ptr [rdx], 0
+  .text:0000000000698535                 jnz     loc_6983DE
+  .text:000000000069853B                 mov     dword ptr [rax], 0
+  .text:0000000000698541                 mov     rdi, rbx
+  .text:0000000000698544                 call    sub_68E1A0
+  .text:0000000000698549                 jmp     loc_698406
+  .text:0000000000698550                 mov     rax, [rbx+3B8h]
+  .text:0000000000698557                 jmp     short loc_69853B
+  .text:0000000000698560                 mov     rax, [rbx]
+  .text:0000000000698563                 mov     rdi, rbx
+  .text:0000000000698566                 call    qword ptr [rax+178h]
+  .text:000000000069856C                 test    al, al
+  .text:000000000069856E                 jz      loc_6984B8
+  .text:0000000000698574                 call    sub_861CC0
+  .text:0000000000698579                 test    al, al
+  .text:000000000069857B                 jnz     loc_6984B8
+  .text:0000000000698581                 xor     r13d, r13d
+  .text:0000000000698584                 mov     rdi, cs:g_pPulseSystem
+  .text:000000000069858B                 mov     rax, [rdi]
+  .text:000000000069858E                 call    qword ptr [rax+250h]
+  .text:0000000000698594                 mov     rdi, cs:qword_9CFB88
+  .text:000000000069859B                 mov     esi, 0FFFFFFFFh
+  .text:00000000006985A0                 mov     r14d, eax
+  .text:00000000006985A3                 call    sub_910520
+  .text:00000000006985A8                 test    rax, rax
+  .text:00000000006985AB                 jz      loc_6986D0
+  .text:00000000006985B1                 movzx   r15d, byte ptr [rax]
+  .text:00000000006985B5                 test    r15b, r15b
+  .text:00000000006985B8                 jz      short loc_6985CB
+  .text:00000000006985BA                 cmp     byte ptr [r12+29h], 1
+  .text:00000000006985C0                 jnz     short loc_6985CB
+  .text:00000000006985C2                 test    r14b, r14b
+  .text:00000000006985C5                 jz      loc_698720
+  .text:00000000006985CB                 test    r13b, r13b
+  .text:00000000006985CE                 jnz     loc_6986A8
+  .text:00000000006985D4                 movss   xmm1, cs:dword_255A8C
+  .text:00000000006985DC                 pxor    xmm2, xmm2
+  .text:00000000006985E0                 mov     r15d, [rbx+44h]
+  .text:00000000006985E4                 pxor    xmm0, xmm0
+  .text:00000000006985E8                 cvtsi2ss xmm0, r15d
+  .text:00000000006985ED                 mulss   xmm0, xmm1
+  .text:00000000006985F1                 unpcklps xmm0, xmm2
+  .text:00000000006985F4                 movlps  [rbp+var_48], xmm0
+  .text:00000000006985F8                 call    _ThreadGetCurrentId
+  .text:00000000006985FD                 mov     rdi, cs:qword_97CA38
+  .text:0000000000698604                 movzx   esi, r13b
+  .text:0000000000698608                 movq    xmm0, [rbp+var_48]
+  .text:000000000069860D                 mov     r14, [rbx+88h]
+  .text:0000000000698614                 mov     r8d, [rbx+9Ch]
+  .text:000000000069861B                 movlps  qword ptr [rbx+88h], xmm0
+  .text:0000000000698622                 mov     [rbx+9Ch], r15d
+  .text:0000000000698629                 mov     r10, [rbx+0B0h]
+  .text:0000000000698630                 movss   xmm1, dword ptr [rbx+0A8h]
+  .text:0000000000698638                 mov     [rbx+0B0h], rax
+  .text:000000000069863F                 mov     dword ptr [rbx+0A8h], 0
+  .text:0000000000698649                 mov     r9, [rdi]
+  .text:000000000069864C                 mov     [rbp+var_40], r8d
+  .text:0000000000698650                 movzx   ecx, byte ptr [r12+29h]
+  .text:0000000000698656                 movss   [rbp+var_3C], xmm1
+  .text:000000000069865B                 movzx   edx, byte ptr [r12+28h]
+  .text:0000000000698661                 mov     [rbp+var_38], r10
+  .text:0000000000698665                 call    qword ptr [r9+98h]
+  .text:000000000069866C                 mov     r8d, [rbp+var_40]
+  .text:0000000000698670                 mov     [rbx+88h], r14
+  .text:0000000000698677                 mov     r10, [rbp+var_38]
+  .text:000000000069867B                 movss   xmm1, [rbp+var_3C]
+  .text:0000000000698680                 mov     [rbx+9Ch], r8d
+  .text:0000000000698687                 movss   dword ptr [rbx+0A8h], xmm1
+  .text:000000000069868F                 mov     [rbx+0B0h], r10
+  .text:0000000000698696                 add     rsp, 28h
+  .text:000000000069869A                 pop     rbx
+  .text:000000000069869B                 pop     r12
+  .text:000000000069869D                 pop     r13
+  .text:000000000069869F                 pop     r14
+  .text:00000000006986A1                 pop     r15
+  .text:00000000006986A3                 pop     rbp
+  .text:00000000006986A4                 retn
+  .text:00000000006986A8                 movss   xmm1, cs:dword_255A8C
+  .text:00000000006986B0                 movaps  xmm2, xmm1
+  .text:00000000006986B3                 jmp     loc_6985E0
+  .text:00000000006986C0                 mov     rdi, rbx
+  .text:00000000006986C3                 call    sub_68E1A0
+  .text:00000000006986C8                 jmp     loc_698424
+  .text:00000000006986D0                 mov     rax, cs:qword_9CFB88
+  .text:00000000006986D7                 mov     rax, [rax+8]
+  .text:00000000006986DB                 jmp     loc_6985B1
+  .text:00000000006986E0                 mov     edx, [rbx+250h]
+  .text:00000000006986E6                 test    edx, edx
+  .text:00000000006986E8                 jnz     loc_698581
+  .text:00000000006986EE                 mov     rax, [rbx]
+  .text:00000000006986F1                 mov     rdi, rbx
+  .text:00000000006986F4                 call    qword ptr [rax+178h]
+  .text:00000000006986FA                 test    al, al
+  .text:00000000006986FC                 jz      loc_698581
+  .text:0000000000698702                 call    sub_861CC0
+  .text:0000000000698707                 jmp     loc_698581
+  .text:0000000000698710                 call    rax
+  .text:0000000000698712                 jmp     loc_6984AA
+  .text:0000000000698720                 mov     rdi, cs:g_pNetworkServerService
+  .text:0000000000698727                 lea     rdx, sub_5A74C0
+  .text:000000000069872E                 mov     rax, [rdi]
+  .text:0000000000698731                 mov     rax, [rax+198h]
+  .text:0000000000698738                 cmp     rax, rdx
+  .text:000000000069873B                 jnz     loc_69893A
+  .text:0000000000698741                 mov     rax, [rdi+150h]
+  .text:0000000000698748                 test    rax, rax
+  .text:000000000069874B                 jz      loc_698856
+  .text:0000000000698751                 mov     rdx, [rax+258h]
+  .text:0000000000698758                 movsxd  rax, dword ptr [rax+250h]
+  .text:000000000069875F                 lea     rax, [rdx+rax*8]
+  .text:0000000000698763                 cmp     rdx, rax
+  .text:0000000000698766                 jz      loc_698856
+  .text:000000000069876C                 mov     r15, rdx
+  .text:000000000069876F                 jmp     short loc_69878D
+  .text:0000000000698780                 add     r15, 8
+  .text:0000000000698784                 cmp     rax, r15
+  .text:0000000000698787                 jz      loc_698850
+  .text:000000000069878D                 mov     r14, [r15]
+  .text:0000000000698790                 cmp     byte ptr [r14+61h], 0
+  .text:0000000000698795                 jnz     short loc_698780
+  .text:0000000000698797                 mov     rdx, [r14]
+  .text:000000000069879A                 mov     [rbp+var_38], rax
+  .text:000000000069879E                 mov     rdi, r14
+  .text:00000000006987A1                 call    qword ptr [rdx+270h]
+  .text:00000000006987A7                 mov     rax, [rbp+var_38]
+  .text:00000000006987AB                 mov     byte ptr [r14+61h], 2
+  .text:00000000006987B0                 mov     edx, [r14+0B44h]
+  .text:00000000006987B7                 mov     ecx, [r14+0B5Ch]
+  .text:00000000006987BE                 mov     [r14+0B5Ch], edx
+  .text:00000000006987C5                 mov     rdx, [r14+0B38h]
+  .text:00000000006987CC                 mov     [r14+0B44h], ecx
+  .text:00000000006987D3                 mov     rcx, [r14+0B50h]
+  .text:00000000006987DA                 mov     [r14+0B50h], rdx
+  .text:00000000006987E1                 mov     edx, [r14+0B40h]
+  .text:00000000006987E8                 mov     [r14+0B38h], rcx
+  .text:00000000006987EF                 mov     ecx, [r14+0B58h]
+  .text:00000000006987F6                 mov     [r14+0B58h], edx
+  .text:00000000006987FD                 mov     edx, [r14+0B30h]
+  .text:0000000000698804                 mov     [r14+0B40h], ecx
+  .text:000000000069880B                 mov     ecx, [r14+0B48h]
+  .text:0000000000698812                 mov     [r14+0B48h], edx
+  .text:0000000000698819                 mov     [r14+0B30h], ecx
+  .text:0000000000698820                 jmp     loc_698780
+  .text:0000000000698828                 mov     rdi, rbx
+  .text:000000000069882B                 call    rdx
+  .text:000000000069882D                 mov     edx, eax
+  .text:000000000069882F                 mov     rax, [rbx+3B8h]
+  .text:0000000000698836                 test    dl, dl
+  .text:0000000000698838                 jz      loc_69853B
+  .text:000000000069883E                 movss   xmm0, dword ptr [rax]
+  .text:0000000000698842                 jmp     loc_6983DE
+  .text:0000000000698850                 movzx   r15d, byte ptr [r12+29h]
+  .text:0000000000698856                 mov     cs:byte_9C2EF0, 0
+  .text:000000000069885D                 mov     rax, cs:g_pThreadPool_ptr
+  .text:0000000000698864                 movzx   edx, r13b
+  .text:0000000000698868                 ; _QWORD
+  .text:0000000000698868                 mov     edi, 60h ; '`'; _QWORD
+  .text:000000000069886D                 mov     r14, [rax]
+  .text:0000000000698870                 mov     rax, r12
+  .text:0000000000698873                 mov     dh, [rax+28h]
+  .text:0000000000698876                 mov     word ptr [rbp+var_38], dx
+  .text:000000000069887A                 call    __Znwm; operator new(ulong)
+  .text:000000000069887F                 movzx   edx, word ptr [rbp+var_38]
+  .text:0000000000698883                 pxor    xmm0, xmm0
+  .text:0000000000698887                 lea     rsi, aServergamefram; "ServerGameFrame"
+  .text:000000000069888E                 mov     r12, rax
+  .text:0000000000698891                 mov     rax, 400000001h
+  .text:000000000069889B                 mov     [r12+8], rax
+  .text:00000000006988A0                 lea     rax, off_9562B8
+  .text:00000000006988A7                 mov     qword ptr [r12+10h], 300h
+  .text:00000000006988B0                 ; _QWORD
+  .text:00000000006988B0                 lea     rdi, [r12+30h]; _QWORD
+  .text:00000000006988B5                 movups  xmmword ptr [r12+18h], xmm0
+  .text:00000000006988BB                 mov     [r12], rax
+  .text:00000000006988BF                 mov     [r12+58h], dx
+  .text:00000000006988C5                 ; _QWORD
+  .text:00000000006988C5                 mov     edx, 20h ; ' '; _QWORD
+  .text:00000000006988CA                 mov     qword ptr [r12+28h], 0
+  .text:00000000006988D3                 mov     qword ptr [r12+30h], 0
+  .text:00000000006988DC                 mov     [r12+50h], rbx
+  .text:00000000006988E1                 mov     [r12+5Ah], r15b
+  .text:00000000006988E6                 mov     byte ptr [r12+10h], 2
+  .text:00000000006988EC                 call    __V_strncpy
+  .text:00000000006988F1                 mov     [r12+18h], r14
+  .text:00000000006988F6                 mov     rdi, r14
+  .text:00000000006988F9                 mov     rsi, r12
+  .text:00000000006988FC                 mov     byte ptr [r12+12h], 1
+  .text:0000000000698902                 mov     rax, [r14]
+  .text:0000000000698905                 call    qword ptr [rax+88h]
+  .text:000000000069890B                 mov     rdi, [rbx+6F0h]
+  .text:0000000000698912                 test    rdi, rdi
+  .text:0000000000698915                 jz      short loc_69891D
+  .text:0000000000698917                 mov     rax, [rdi]
+  .text:000000000069891A                 call    qword ptr [rax+18h]
+  .text:000000000069891D                 mov     [rbx+6F0h], r12
+  .text:0000000000698924                 jmp     loc_6983AC
+  .text:0000000000698930                 call    rax
+  .text:0000000000698932                 mov     r13d, eax
+  .text:0000000000698935                 jmp     loc_698584
+  .text:000000000069893A                 mov     esi, 1
+  .text:000000000069893F                 call    rax
+  .text:0000000000698941                 movzx   r15d, byte ptr [r12+29h]
+  .text:0000000000698947                 jmp     loc_69885D
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_ServerSimulate(__int64 a1, __int64 a2)
+  {
+    __int64 result; // rax
+    float *v4; // rax
+    float v5; // xmm0_4
+    void (*v6)(void); // rax
+    unsigned __int8 v7; // r13
+    __int64 (*v8)(void); // rax
+    __int64 v9; // rax
+    __int64 (__fastcall *v10)(); // rdx
+    char v11; // r14
+    char *v12; // rax
+    char v13; // r15
+    __m128 v14; // xmm2
+    int v15; // r15d
+    __m128 v16; // xmm0
+    __int64 CurrentId; // rax
+    __int64 *v18; // rdi
+    __int64 v19; // r14
+    unsigned int v20; // r8d
+    double v21; // r10
+    unsigned int v22; // xmm1_4
+    __int64 v23; // r9
+    __int64 v24; // rcx
+    __int64 v25; // rdx
+    __int32 v26; // r8d
+    double v27; // r10
+    __int32 v28; // xmm1_4
+    __int64 (__fastcall *v29)(); // rax
+    __int64 v30; // rax
+    __int64 *v31; // rdx
+    double v32; // rax
+    __int64 *v33; // r15
+    __int64 *v34; // r14
+    __int64 v35; // rdx
+    int v36; // ecx
+    __int64 v37; // rdx
+    __int64 v38; // rcx
+    char v39; // dl
+    __int16 v40; // dx
+    _QWORD *v41; // r14
+    __int64 v42; // rax
+    __int16 v43; // dx
+    __int64 v44; // r12
+    __int64 v45; // rdi
+    __m128i v46; // [rsp+8h] [rbp-48h] BYREF
+    double v47; // [rsp+18h] [rbp-38h]
+
+    if ( !(unsigned __int8)sub_861CC0() )
+      goto LABEL_2;
+    v4 = *(float **)(a1 + 952);
+    v5 = *v4;
+    if ( *v4 != 0.0 )
+    {
+      v10 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 368LL);
+      if ( v10 == sub_67B0C0 )
+      {
+        if ( !**(_QWORD **)(a1 + 928) )
+          goto LABEL_22;
+      }
+      else
+      {
+        v39 = ((__int64 (__fastcall *)(__int64))v10)(a1);
+        v4 = *(float **)(a1 + 952);
+        if ( !v39 )
+          goto LABEL_22;
+        v5 = *v4;
+      }
+    }
+    v47 = v5;
+    if ( (*(double (__fastcall **)(__int64))(*(_QWORD *)qword_97C190 + 216LL))(qword_97C190) <= v5 )
+      goto LABEL_6;
+    v4 = *(float **)(a1 + 952);
+  LABEL_22:
+    *v4 = 0.0;
+    sub_68E1A0(a1);
+  LABEL_6:
+    if ( **(float **)(a1 + 936) != -1.0 )
+      sub_68E1A0(a1);
+    if ( !*(_BYTE *)(a1 + 707) )
+    {
+  LABEL_2:
+      result = *(unsigned int *)(a1 + 56);
+      if ( (int)result <= 2 )
+        return result;
+      if ( (_DWORD)result == 4 )
+      {
+        if ( !*(_DWORD *)(a1 + 592) && (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+          sub_861CC0();
+      }
+      else
+      {
+        if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+        {
+          v6 = *(void (**)(void))(*(_QWORD *)g_pNetworkClientService + 256LL);// 0x100 = 256LL = INetworkClientService_IsActive
+          if ( (char *)v6 != (char *)sub_5C5210 )
+            v6();
+        }
+        if ( *(_DWORD *)(a1 + 592)
+          || !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1)
+          || (unsigned __int8)sub_861CC0() )
+        {
+          v7 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1);
+          if ( !v7 )
+          {
+            v8 = *(__int64 (**)(void))(*(_QWORD *)g_pNetworkClientService + 256LL);// 0x100 = 256LL = INetworkClientService_IsActive
+            if ( v8 != sub_5C5210 )
+            {
+              v7 = v8();
+              goto LABEL_27;
+            }
+            v9 = *(_QWORD *)(g_pNetworkClientService + 160);
+            if ( !v9 )
+              goto LABEL_26;
+            v7 = *(_DWORD *)(v9 + 576) > 5;
+          }
+  LABEL_27:
+          v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pPulseSystem + 592LL))(g_pPulseSystem);
+          v12 = (char *)sub_910520(qword_9CFB88, 0xFFFFFFFFLL);
+          if ( !v12 )
+            v12 = *(char **)(qword_9CFB88 + 8);
+          v13 = *v12;
+          if ( *v12 && *(_BYTE *)(a2 + 41) == 1 && !v11 )
+          {
+            v29 = *(__int64 (__fastcall **)())(*(_QWORD *)g_pNetworkServerService + 408LL);
+            if ( v29 == sub_5A74C0 )
+            {
+              v30 = *(_QWORD *)(g_pNetworkServerService + 336);
+              if ( v30 )
+              {
+                v31 = *(__int64 **)(v30 + 600);
+                *(_QWORD *)&v32 = &v31[*(int *)(v30 + 592)];
+                if ( v31 != *(__int64 **)&v32 )
+                {
+                  v33 = v31;
+                  do
+                  {
+                    v34 = (__int64 *)*v33;
+                    if ( !*(_BYTE *)(*v33 + 97) )
+                    {
+                      v35 = *v34;
+                      v47 = v32;
+                      (*(void (__fastcall **)(__int64 *))(v35 + 624))(v34);
+                      v32 = v47;
+                      *((_BYTE *)v34 + 97) = 2;
+                      v36 = *((_DWORD *)v34 + 727);
+                      *((_DWORD *)v34 + 727) = *((_DWORD *)v34 + 721);
+                      v37 = v34[359];
+                      *((_DWORD *)v34 + 721) = v36;
+                      v38 = v34[362];
+                      v34[362] = v37;
+                      LODWORD(v37) = *((_DWORD *)v34 + 720);
+                      v34[359] = v38;
+                      LODWORD(v38) = *((_DWORD *)v34 + 726);
+                      *((_DWORD *)v34 + 726) = v37;
+                      LODWORD(v37) = *((_DWORD *)v34 + 716);
+                      *((_DWORD *)v34 + 720) = v38;
+                      LODWORD(v38) = *((_DWORD *)v34 + 722);
+                      *((_DWORD *)v34 + 722) = v37;
+                      *((_DWORD *)v34 + 716) = v38;
+                    }
+                    ++v33;
+                  }
+                  while ( *(__int64 **)&v32 != v33 );
+                  v13 = *(_BYTE *)(a2 + 41);
+                }
+              }
+              byte_9C2EF0 = 0;
+            }
+            else
+            {
+              ((void (__fastcall *)(__int64, __int64))v29)(g_pNetworkServerService, 1);
+              v13 = *(_BYTE *)(a2 + 41);
+            }
+            LOBYTE(v40) = v7;
+            v41 = g_pThreadPool;
+            HIBYTE(v40) = *(_BYTE *)(a2 + 40);
+            LOWORD(v47) = v40;
+            v42 = operator new(96);
+            v43 = LOWORD(v47);
+            v44 = v42;
+            *(_QWORD *)(v42 + 8) = 0x400000001LL;
+            *(_QWORD *)(v42 + 16) = 768;
+            *(_OWORD *)(v42 + 24) = 0;
+            *(_QWORD *)v42 = &off_9562B8;
+            *(_WORD *)(v42 + 88) = v43;
+            *(_QWORD *)(v42 + 40) = 0;
+            *(_QWORD *)(v42 + 48) = 0;
+            *(_QWORD *)(v42 + 80) = a1;
+            *(_BYTE *)(v42 + 90) = v13;
+            *(_BYTE *)(v42 + 16) = 2;
+            _V_strncpy(v42 + 48, "ServerGameFrame", 32);
+            *(_QWORD *)(v44 + 24) = v41;
+            *(_BYTE *)(v44 + 18) = 1;
+            result = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*v41 + 136LL))(v41, v44);
+            v45 = *(_QWORD *)(a1 + 1776);
+            if ( v45 )
+              result = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v45 + 24LL))(v45);
+            *(_QWORD *)(a1 + 1776) = v44;
+          }
+          else
+          {
+            if ( v7 )
+              v14 = (__m128)0x3C800000u;
+            else
+              v14 = 0;
+            v15 = *(_DWORD *)(a1 + 68);
+            v16 = 0;
+            v16.m128_f32[0] = (float)v15 * 0.015625;
+            _mm_storel_ps((double *)v46.m128i_i64, _mm_unpacklo_ps(v16, v14));
+            CurrentId = ThreadGetCurrentId();
+            v18 = (__int64 *)qword_97CA38;
+            v19 = *(_QWORD *)(a1 + 136);
+            v20 = *(_DWORD *)(a1 + 156);
+            _mm_storel_ps((double *)(a1 + 136), (__m128)_mm_loadl_epi64(&v46));
+            *(_DWORD *)(a1 + 156) = v15;
+            v21 = *(double *)(a1 + 176);
+            v22 = *(_DWORD *)(a1 + 168);
+            *(_QWORD *)(a1 + 176) = CurrentId;
+            *(_DWORD *)(a1 + 168) = 0;
+            v23 = *v18;
+            v46.m128i_i64[1] = __PAIR64__(v22, v20);
+            v24 = *(unsigned __int8 *)(a2 + 41);
+            v25 = *(unsigned __int8 *)(a2 + 40);
+            v47 = v21;
+            result = (*(__int64 (__fastcall **)(__int64 *, _QWORD, __int64, __int64))(v23 + 152))(v18, v7, v25, v24);
+            v26 = v46.m128i_i32[2];
+            *(_QWORD *)(a1 + 136) = v19;
+            v27 = v47;
+            v28 = v46.m128i_i32[3];
+            *(_DWORD *)(a1 + 156) = v26;
+            *(_DWORD *)(a1 + 168) = v28;
+            *(double *)(a1 + 176) = v27;
+          }
+          return result;
+        }
+      }
+  LABEL_26:
+      v7 = 0;
+      goto LABEL_27;
+    }
+    sub_6903C0(a1);
+    result = (*(__int64 (__fastcall **)(__int64, double))(*(_QWORD *)a1 + 376LL))(a1, COERCE_DOUBLE(3212836864LL));
+    if ( (_BYTE)result )
+      return sub_6EA5A0(&qword_9C5760);
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/SetInfo_CommandHandler.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/SetInfo_CommandHandler.linux.yaml
@@ -1,0 +1,320 @@
+func_name: SetInfo_CommandHandler
+func_va: '0x7010a0'
+disasm_code: |-
+  .text:00000000007010A0                 cmp     dword ptr [rsi+438h], 3
+  .text:00000000007010A7                 jnz     loc_7012F8
+  .text:00000000007010AD                 push    rbp
+  .text:00000000007010AE                 xor     edx, edx
+  .text:00000000007010B0                 mov     rbp, rsp
+  .text:00000000007010B3                 push    r15
+  .text:00000000007010B5                 push    r14
+  .text:00000000007010B7                 push    r13
+  .text:00000000007010B9                 push    r12
+  .text:00000000007010BB                 push    rbx
+  .text:00000000007010BC                 sub     rsp, 0A8h
+  .text:00000000007010C3                 mov     rax, [rsi+440h]
+  .text:00000000007010CA                 mov     rdi, cs:qword_97B050
+  .text:00000000007010D1                 mov     r12, [rax+8]
+  .text:00000000007010D5                 mov     r13, [rax+10h]
+  .text:00000000007010D9                 mov     rax, [rdi]
+  .text:00000000007010DC                 mov     rsi, r12
+  .text:00000000007010DF                 call    qword ptr [rax+88h]
+  .text:00000000007010E5                 cmp     rax, 0FFFFh
+  .text:00000000007010EB                 jnz     loc_7012D0
+  .text:00000000007010F1                 mov     rdi, cs:qword_97B050
+  .text:00000000007010F8                 mov     edx, 1
+  .text:00000000007010FD                 mov     rsi, r12
+  .text:0000000000701100                 lea     r14, [rbp-0C0h]
+  .text:0000000000701107                 mov     rax, [rdi]
+  .text:000000000070110A                 call    qword ptr [rax+58h]
+  .text:000000000070110D                 mov     rdi, r14
+  .text:0000000000701110                 mov     rsi, rax
+  .text:0000000000701113                 call    sub_8FDAE0
+  .text:0000000000701118                 mov     rax, [rbp-0B8h]
+  .text:000000000070111F                 test    rax, rax
+  .text:0000000000701122                 jz      short loc_701131
+  .text:0000000000701124                 mov     rax, [rax+30h]
+  .text:0000000000701128                 test    ah, 4
+  .text:000000000070112B                 jz      loc_701310
+  .text:0000000000701131                 mov     rdi, r12
+  .text:0000000000701134                 call    _MemAlloc_StrDupFunc
+  .text:0000000000701139                 ; _QWORD
+  .text:0000000000701139                 mov     edi, 10h; _QWORD
+  .text:000000000070113E                 mov     r15, rax
+  .text:0000000000701141                 call    __Znwm; operator new(ulong)
+  .text:0000000000701146                 mov     rdi, cs:qword_97B050
+  .text:000000000070114D                 mov     edx, 9
+  .text:0000000000701152                 mov     esi, 0FFFFFFFFh
+  .text:0000000000701157                 mov     rbx, rax
+  .text:000000000070115A                 xor     eax, eax
+  .text:000000000070115C                 pxor    xmm0, xmm0
+  .text:0000000000701160                 mov     dword ptr [rbp-0B0h], 0
+  .text:000000000070116A                 mov     [rbp-0ACh], ax
+  .text:0000000000701171                 mov     byte ptr [rbp-0AAh], 0
+  .text:0000000000701178                 movups  xmmword ptr [rbp-0A9h], xmm0
+  .text:000000000070117F                 movups  xmmword ptr [rbp-99h], xmm0
+  .text:0000000000701186                 movups  xmmword ptr [rbp-89h], xmm0
+  .text:000000000070118D                 mov     qword ptr [rbp-78h], 0
+  .text:0000000000701195                 mov     qword ptr [rbp-70h], 0
+  .text:000000000070119D                 mov     qword ptr [rbp-68h], 0
+  .text:00000000007011A5                 mov     qword ptr [rbp-60h], 0
+  .text:00000000007011AD                 mov     qword ptr [rbp-58h], 0
+  .text:00000000007011B5                 mov     byte ptr [rbp-40h], 0
+  .text:00000000007011B9                 mov     qword ptr [rbp-48h], 0
+  .text:00000000007011C1                 mov     [rbp-50h], dx
+  .text:00000000007011C5                 mov     [rbx], rsi
+  .text:00000000007011C8                 mov     qword ptr [rbx+8], 0
+  .text:00000000007011D0                 test    rdi, rdi
+  .text:00000000007011D3                 jz      loc_701440
+  .text:00000000007011D9                 mov     rax, [rdi]
+  .text:00000000007011DC                 call    qword ptr [rax+158h]
+  .text:00000000007011E2                 mov     [rbx+8], rax
+  .text:00000000007011E6                 test    rax, rax
+  .text:00000000007011E9                 jz      loc_701440
+  .text:00000000007011EF                 mov     eax, 0FFFFFFFFh
+  .text:00000000007011F4                 mov     byte ptr [rbp-0ACh], 1
+  .text:00000000007011FB                 lea     r8, [rbp-0B0h]
+  .text:0000000000701202                 mov     [rbx], rax
+  .text:0000000000701205                 ; this
+  .text:0000000000701205                 lea     rdi, [rbp-0A9h]; this
+  .text:000000000070120C                 mov     [rbp-0C8h], r8
+  .text:0000000000701213                 ; char *
+  .text:0000000000701213                 lea     rsi, s1; char *
+  .text:000000000070121A                 mov     qword ptr [rbp-0A9h], 0
+  .text:0000000000701225                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:000000000070122A                 mov     rdi, rbx
+  .text:000000000070122D                 mov     edx, 200h
+  .text:0000000000701232                 mov     rsi, r15
+  .text:0000000000701235                 mov     r8, [rbp-0C8h]
+  .text:000000000070123C                 lea     rcx, aCustomUserInfo; "Custom user info value"
+  .text:0000000000701243                 call    sub_753170
+  .text:0000000000701248                 movdqu  xmm0, xmmword ptr [rbx]
+  .text:000000000070124C                 movaps  xmmword ptr [rbp-0C0h], xmm0
+  .text:0000000000701253                 mov     rdi, [rbp-0B8h]
+  .text:000000000070125A                 mov     esi, 0FFFFFFFFh
+  .text:000000000070125F                 call    sub_910520
+  .text:0000000000701264                 mov     rdx, r13
+  .text:0000000000701267                 mov     rdi, r14
+  .text:000000000070126A                 xor     r8d, r8d
+  .text:000000000070126D                 mov     rcx, rax
+  .text:0000000000701270                 mov     esi, 0FFFFFFFFh
+  .text:0000000000701275                 call    sub_753590
+  .text:000000000070127A                 mov     rdi, cs:g_pNetworkClientService
+  .text:0000000000701281                 lea     rdx, sub_5C51E0
+  .text:0000000000701288                 mov     rax, [rdi]
+  .text:000000000070128B                 mov     rax, [rax+108h]  ; 0x108 = INetworkClientService_IsConnected (slot-only: abstract interface vfunc, no func_va)
+  .text:0000000000701292                 cmp     rax, rdx
+  .text:0000000000701295                 jnz     loc_701370
+  .text:000000000070129B                 mov     rax, [rdi+0A0h]
+  .text:00000000007012A2                 test    rax, rax
+  .text:00000000007012A5                 jz      short loc_7012B4
+  .text:00000000007012A7                 cmp     dword ptr [rax+240h], 1
+  .text:00000000007012AE                 jg      loc_70137A
+  .text:00000000007012B4                 add     rsp, 0A8h
+  .text:00000000007012BB                 pop     rbx
+  .text:00000000007012BC                 pop     r12
+  .text:00000000007012BE                 pop     r13
+  .text:00000000007012C0                 pop     r14
+  .text:00000000007012C2                 pop     r15
+  .text:00000000007012C4                 pop     rbp
+  .text:00000000007012C5                 retn
+  .text:00000000007012D0                 add     rsp, 0A8h
+  .text:00000000007012D7                 mov     rsi, r12
+  .text:00000000007012DA                 xor     eax, eax
+  .text:00000000007012DC                 pop     rbx
+  .text:00000000007012DD                 lea     rdi, aNameSIsAlready; "Name %s is already registered as consol"...
+  .text:00000000007012E4                 pop     r12
+  .text:00000000007012E6                 pop     r13
+  .text:00000000007012E8                 pop     r14
+  .text:00000000007012EA                 pop     r15
+  .text:00000000007012EC                 pop     rbp
+  .text:00000000007012ED                 jmp     _Msg
+  .text:00000000007012F8                 lea     rdi, aSyntaxSetinfoK; "Syntax: setinfo <key> <value>\n"
+  .text:00000000007012FF                 xor     eax, eax
+  .text:0000000000701301                 jmp     _Msg
+  .text:0000000000701310                 test    ah, 2
+  .text:0000000000701313                 jz      loc_701460
+  .text:0000000000701319                 call    sub_503D40
+  .text:000000000070131E                 mov     rdi, [rbp-0B8h]
+  .text:0000000000701325                 sub     eax, 2
+  .text:0000000000701328                 and     eax, 0FFFFFFFDh
+  .text:000000000070132B                 mov     rdx, [rdi+30h]
+  .text:000000000070132F                 jz      short loc_70133A
+  .text:0000000000701331                 test    dl, 2
+  .text:0000000000701334                 jnz     loc_7012B4
+  .text:000000000070133A                 and     dh, 40h
+  .text:000000000070133D                 jz      loc_70125A
+  .text:0000000000701343                 lea     rdi, qword_981180
+  .text:000000000070134A                 mov     esi, 0FFFFFFFFh
+  .text:000000000070134F                 call    sub_4FB750
+  .text:0000000000701354                 test    al, al
+  .text:0000000000701356                 jz      loc_701476
+  .text:000000000070135C                 mov     rdi, [rbp-0B8h]
+  .text:0000000000701363                 jmp     loc_70125A
+  .text:0000000000701370                 call    rax
+  .text:0000000000701372                 test    al, al
+  .text:0000000000701374                 jz      loc_7012B4
+  .text:000000000070137A                 mov     r14, qword ptr cs:xmmword_97C2D8+8
+  .text:0000000000701381                 lea     rbx, [rbp-0B0h]
+  .text:0000000000701388                 mov     rdx, r13
+  .text:000000000070138B                 mov     rsi, r12
+  .text:000000000070138E                 mov     rdi, rbx
+  .text:0000000000701391                 pxor    xmm0, xmm0
+  .text:0000000000701395                 mov     rax, 0FF00000000h
+  .text:000000000070139F                 movaps  xmmword ptr [rbp-70h], xmm0
+  .text:00000000007013A3                 mov     [rbp-0A0h], rax
+  .text:00000000007013AA                 mov     eax, 0BF800000h
+  .text:00000000007013AF                 mov     [rbp-90h], rax
+  .text:00000000007013B6                 lea     rax, off_953160
+  .text:00000000007013BD                 mov     [rbp-0B0h], rax
+  .text:00000000007013C4                 add     rax, 40h ; '@'
+  .text:00000000007013C8                 mov     [rbp-80h], rax
+  .text:00000000007013CC                 mov     qword ptr [rbp-0A8h], 0
+  .text:00000000007013D7                 mov     qword ptr [rbp-98h], 0FFFFFFFFFFFFFFFFh
+  .text:00000000007013E2                 mov     qword ptr [rbp-88h], 0FFFFFFFFFFFFFFFFh
+  .text:00000000007013ED                 mov     qword ptr [rbp-78h], 0
+  .text:00000000007013F5                 call    sub_699920
+  .text:00000000007013FA                 mov     rdi, [r14+0F0h]
+  .text:0000000000701401                 mov     edx, 0FFFFFFFFh
+  .text:0000000000701406                 mov     rsi, rbx
+  .text:0000000000701409                 mov     rax, [rdi]
+  .text:000000000070140C                 call    qword ptr [rax+140h]
+  .text:0000000000701412                 lea     rax, off_942D50
+  .text:0000000000701419                 mov     [rbp-0B0h], rax
+  .text:0000000000701420                 lea     rdi, [rbp-80h]
+  .text:0000000000701424                 add     rax, 40h ; '@'
+  .text:0000000000701428                 mov     [rbp-80h], rax
+  .text:000000000070142C                 call    sub_4A8730
+  .text:0000000000701431                 jmp     loc_7012B4
+  .text:0000000000701440                 mov     edi, 9
+  .text:0000000000701445                 call    sub_752D20
+  .text:000000000070144A                 mov     rax, [rax+50h]
+  .text:000000000070144E                 mov     [rbx+8], rax
+  .text:0000000000701452                 jmp     loc_7011EF
+  .text:0000000000701460                 lea     rdi, aConvarSIsAlrea; "Convar %s is already registered but not"...
+  .text:0000000000701467                 mov     rsi, r12
+  .text:000000000070146A                 xor     eax, eax
+  .text:000000000070146C                 call    _Msg
+  .text:0000000000701471                 jmp     loc_7012B4
+  .text:0000000000701476                 lea     rdi, aConvarSIsMarke; "Convar %s is marked as cheat and cheats"...
+  .text:000000000070147D                 mov     rsi, r12
+  .text:0000000000701480                 xor     eax, eax
+  .text:0000000000701482                 call    _Msg
+  .text:0000000000701487                 jmp     loc_7012B4
+procedure: |-
+  __int64 __fastcall SetInfo_CommandHandler(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // rax
+    const char *v3; // r12
+    __int64 v4; // r13
+    __int64 v5; // rsi
+    __int64 v6; // rax
+    __int64 v7; // r15
+    __m128i *v8; // rax
+    __int64 v9; // rdi
+    __m128i *v10; // rbx
+    __int64 v11; // rax
+    __int64 v12; // rdi
+    __int64 v13; // rax
+    __int64 (*v14)(void); // rax
+    __int64 result; // rax
+    int v16; // eax
+    __int64 v17; // rdx
+    __int64 v18; // r14
+    __m128i v19; // [rsp-C8h] [rbp-C8h] BYREF
+    _BYTE v20[56]; // [rsp-B8h] [rbp-B8h] BYREF
+    __int64 v21; // [rsp-80h] [rbp-80h]
+    __int128 v22; // [rsp-78h] [rbp-78h]
+    __int64 v23; // [rsp-68h] [rbp-68h]
+    __int64 v24; // [rsp-60h] [rbp-60h]
+    __int16 v25; // [rsp-58h] [rbp-58h]
+    __int64 v26; // [rsp-50h] [rbp-50h]
+    char v27; // [rsp-48h] [rbp-48h]
+
+    if ( *(_DWORD *)(a2 + 1080) != 3 )
+      return Msg("Syntax: setinfo <key> <value>\n");
+    v2 = *(_QWORD *)(a2 + 1088);
+    v3 = *(const char **)(v2 + 8);
+    v4 = *(_QWORD *)(v2 + 16);
+    if ( (*(__int64 (__fastcall **)(__int64, const char *, _QWORD))(*(_QWORD *)qword_97B050 + 136LL))(qword_97B050, v3, 0) != 0xFFFF )
+      return Msg("Name %s is already registered as console command\n", v3);
+    v5 = (*(__int64 (__fastcall **)(__int64, const char *, __int64))(*(_QWORD *)qword_97B050 + 88LL))(qword_97B050, v3, 1);
+    sub_8FDAE0(&v19, v5);
+    if ( !v19.m128i_i64[1] || (v6 = *(_QWORD *)(v19.m128i_i64[1] + 48), (v6 & 0x400) != 0) )
+    {
+      v7 = MemAlloc_StrDupFunc(v3);
+      v8 = (__m128i *)operator new(16);
+      v9 = qword_97B050;
+      v10 = v8;
+      memset(v20, 0, 55);
+      v21 = 0;
+      v22 = 0u;
+      v23 = 0;
+      v24 = 0;
+      v27 = 0;
+      v26 = 0;
+      v25 = 9;
+      v8->m128i_i64[0] = 0xFFFFFFFFLL;
+      v8->m128i_i64[1] = 0;
+      if ( !v9 || (v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v9 + 344LL))(v9), (v10->m128i_i64[1] = v11) == 0) )
+        v10->m128i_i64[1] = *(_QWORD *)(sub_752D20(9) + 80);
+      v20[4] = 1;
+      v10->m128i_i64[0] = 0xFFFFFFFFLL;
+      *(_QWORD *)&v20[7] = 0;
+      CUtlString::Set((CUtlString *)&v20[7], (const char *)&s1);
+      sub_753170(v10, v7, 512, "Custom user info value", v20);
+      v19 = _mm_loadu_si128(v10);
+      v12 = v19.m128i_i64[1];
+      goto LABEL_8;
+    }
+    if ( (v6 & 0x200) == 0 )
+      return Msg("Convar %s is already registered but not as user info value\n", v3);
+    v16 = sub_503D40();
+    v12 = v19.m128i_i64[1];
+    result = (v16 - 2) & 0xFFFFFFFD;
+    v17 = *(_QWORD *)(v19.m128i_i64[1] + 48);
+    if ( !(_DWORD)result || (v17 & 2) == 0 )
+    {
+      if ( (v17 & 0x4000) != 0 )
+      {
+        if ( !(unsigned __int8)sub_4FB750(&qword_981180, 0xFFFFFFFFLL) )
+          return Msg("Convar %s is marked as cheat and cheats are off\n", v3);
+        v12 = v19.m128i_i64[1];
+      }
+  LABEL_8:
+      v13 = sub_910520(v12, 0xFFFFFFFFLL);
+      sub_753590(&v19, 0xFFFFFFFFLL, v4, v13, 0);
+      v14 = *(__int64 (**)(void))(*(_QWORD *)g_pNetworkClientService + 264LL);  // 0x108 = 264LL = INetworkClientService_IsConnected (slot-only: abstract interface vfunc, no func_va - sub_5C51E0 is NOT INetworkClientService_IsConnected)
+      if ( v14 == sub_5C51E0 )
+      {
+        result = *(_QWORD *)(g_pNetworkClientService + 160);
+        if ( !result || *(int *)(result + 576) <= 1 )
+          return result;
+      }
+      else
+      {
+        result = v14();
+        if ( !(_BYTE)result )
+          return result;
+      }
+      v18 = *((_QWORD *)&xmmword_97C2D8 + 1);
+      v22 = 0;
+      *(_QWORD *)&v20[16] = 0xFF00000000LL;
+      *(_QWORD *)&v20[32] = 3212836864LL;
+      *(_QWORD *)v20 = &off_953160;
+      *(_QWORD *)&v20[48] = off_9531A0;
+      *(_QWORD *)&v20[8] = 0;
+      *(_QWORD *)&v20[24] = -1;
+      *(_QWORD *)&v20[40] = -1;
+      v21 = 0;
+      sub_699920(v20, v3, v4);
+      (*(void (__fastcall **)(_QWORD, _BYTE *, __int64))(**(_QWORD **)(v18 + 240) + 320LL))(
+        *(_QWORD *)(v18 + 240),
+        v20,
+        0xFFFFFFFFLL);
+      *(_QWORD *)v20 = &off_942D50;
+      *(_QWORD *)&v20[48] = off_942D90;
+      return sub_4A8730(&v20[48]);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/SetInfo_CommandHandler.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/SetInfo_CommandHandler.windows.yaml
@@ -1,0 +1,300 @@
+func_name: SetInfo_CommandHandler
+func_va: '0x180103e90'
+disasm_code: |-
+  .text:0000000180103E90                 push    rbp
+  .text:0000000180103E92                 push    r15
+  .text:0000000180103E94                 lea     rbp, [rsp-4Fh]
+  .text:0000000180103E99                 sub     rsp, 0D8h
+  .text:0000000180103EA0                 xor     r15d, r15d
+  .text:0000000180103EA3                 cmp     dword ptr [rdx+438h], 3
+  .text:0000000180103EAA                 jz      short loc_180103EC4
+  .text:0000000180103EAC                 lea     rcx, aSyntaxSetinfoK; "Syntax: setinfo <key> <value>\n"
+  .text:0000000180103EB3                 call    cs:Msg
+  .text:0000000180103EB9                 add     rsp, 0D8h
+  .text:0000000180103EC0                 pop     r15
+  .text:0000000180103EC2                 pop     rbp
+  .text:0000000180103EC3                 retn
+  .text:0000000180103EC4                 mov     rax, [rdx+440h]
+  .text:0000000180103ECB                 xor     r9d, r9d
+  .text:0000000180103ECE                 mov     rcx, cs:qword_1806845B8
+  .text:0000000180103ED5                 lea     rdx, [rbp+57h+arg_8]
+  .text:0000000180103ED9                 mov     [rsp+0E0h+var_18], rdi
+  .text:0000000180103EE1                 mov     [rsp+0E0h+var_20], r14
+  .text:0000000180103EE9                 mov     rdi, [rax+8]
+  .text:0000000180103EED                 mov     r14, [rax+10h]
+  .text:0000000180103EF1                 mov     r8, rdi
+  .text:0000000180103EF4                 mov     rax, [rcx]
+  .text:0000000180103EF7                 call    qword ptr [rax+88h]
+  .text:0000000180103EFD                 cmp     qword ptr [rax], 0FFFFh
+  .text:0000000180103F04                 jz      short loc_180103F1B
+  .text:0000000180103F06                 mov     rdx, rdi
+  .text:0000000180103F09                 lea     rcx, aNameSIsAlready; "Name %s is already registered as consol"...
+  .text:0000000180103F10                 call    cs:Msg
+  .text:0000000180103F16                 jmp     loc_18010418C
+  .text:0000000180103F1B                 mov     rcx, cs:qword_1806845B8
+  .text:0000000180103F22                 lea     rdx, [rbp+57h+arg_10]
+  .text:0000000180103F26                 mov     r9d, 1
+  .text:0000000180103F2C                 mov     [rsp+0E0h+arg_0], rbx
+  .text:0000000180103F34                 mov     r8, rdi
+  .text:0000000180103F37                 mov     rax, [rcx]
+  .text:0000000180103F3A                 call    qword ptr [rax+58h]
+  .text:0000000180103F3D                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180103F43                 lea     rcx, [rbp+57h+var_B0]
+  .text:0000000180103F47                 mov     rdx, [rax]
+  .text:0000000180103F4A                 call    sub_1803FB340
+  .text:0000000180103F4F                 mov     rax, qword ptr [rbp+57h+var_B0+8]
+  .text:0000000180103F53                 test    rax, rax
+  .text:0000000180103F56                 jz      loc_180103FF7
+  .text:0000000180103F5C                 mov     rax, [rax+30h]
+  .text:0000000180103F60                 bt      rax, 0Ah
+  .text:0000000180103F65                 jb      loc_180103FF7
+  .text:0000000180103F6B                 shr     rax, 9
+  .text:0000000180103F6F                 test    al, 1
+  .text:0000000180103F71                 jnz     short loc_180103F88
+  .text:0000000180103F73                 mov     rdx, rdi
+  .text:0000000180103F76                 lea     rcx, aConvarSIsAlrea; "Convar %s is already registered but not"...
+  .text:0000000180103F7D                 call    cs:Msg
+  .text:0000000180103F83                 jmp     loc_18010417B
+  .text:0000000180103F88                 call    sub_180073C10
+  .text:0000000180103F8D                 mov     rcx, qword ptr [rbp+57h+var_B0+8]
+  .text:0000000180103F91                 add     eax, 0FFFFFFFEh
+  .text:0000000180103F94                 test    eax, 0FFFFFFFDh
+  .text:0000000180103F99                 jz      short loc_180103FA9
+  .text:0000000180103F9B                 movzx   eax, byte ptr [rcx+30h]
+  .text:0000000180103F9F                 shr     al, 1
+  .text:0000000180103FA1                 test    al, 1
+  .text:0000000180103FA3                 jnz     loc_18010417B
+  .text:0000000180103FA9                 mov     eax, [rcx+30h]
+  .text:0000000180103FAC                 shr     rax, 0Eh
+  .text:0000000180103FB0                 test    al, 1
+  .text:0000000180103FB2                 jz      loc_1801040CD
+  .text:0000000180103FB8                 mov     edx, 0FFFFFFFFh
+  .text:0000000180103FBD                 lea     rcx, unk_180689E38
+  .text:0000000180103FC4                 call    sub_1803FB9B0
+  .text:0000000180103FC9                 test    rax, rax
+  .text:0000000180103FCC                 jnz     short loc_180103FD9
+  .text:0000000180103FCE                 mov     rax, cs:qword_180689E40
+  .text:0000000180103FD5                 mov     rax, [rax+8]
+  .text:0000000180103FD9                 cmp     [rax], r15b
+  .text:0000000180103FDC                 jnz     loc_1801040CD
+  .text:0000000180103FE2                 mov     rdx, rdi
+  .text:0000000180103FE5                 lea     rcx, aConvarSIsMarke; "Convar %s is marked as cheat and cheats"...
+  .text:0000000180103FEC                 call    cs:Msg
+  .text:0000000180103FF2                 jmp     loc_18010417B
+  .text:0000000180103FF7                 mov     rcx, rdi
+  .text:0000000180103FFA                 mov     [rsp+0E0h+var_10], rsi
+  .text:0000000180104002                 call    cs:MemAlloc_StrDupFunc
+  .text:0000000180104008                 mov     rcx, cs:g_pMemAlloc
+  .text:000000018010400F                 mov     rsi, rax
+  .text:0000000180104012                 mov     rcx, [rcx]
+  .text:0000000180104015                 mov     rdx, [rcx]
+  .text:0000000180104018                 mov     r8, [rdx+8]
+  .text:000000018010401C                 mov     edx, 10h
+  .text:0000000180104021                 call    r8
+  .text:0000000180104024                 mov     rbx, rax
+  .text:0000000180104027                 test    rax, rax
+  .text:000000018010402A                 jz      loc_1801040BB
+  .text:0000000180104030                 xorps   xmm0, xmm0
+  .text:0000000180104033                 mov     dword ptr [rbp+57h+var_A0], r15d
+  .text:0000000180104037                 xorps   xmm1, xmm1
+  .text:000000018010403A                 mov     word ptr [rbp+57h+var_A0+5], r15w
+  .text:000000018010403F                 mov     r8d, 9
+  .text:0000000180104045                 mov     [rbp+57h+var_68], r15
+  .text:0000000180104049                 mov     edx, 0FFFFFFFFh
+  .text:000000018010404E                 mov     [rbp+57h+var_40], r8w
+  .text:0000000180104053                 mov     rcx, rax
+  .text:0000000180104056                 mov     [rbp+57h+var_60], r15
+  .text:000000018010405A                 movups  xmmword ptr [rbp+57h+var_A0+7], xmm0
+  .text:000000018010405E                 mov     [rbp+57h+var_58], r15
+  .text:0000000180104062                 movups  [rbp+57h+var_89], xmm1
+  .text:0000000180104066                 mov     [rbp+57h+var_50], r15
+  .text:000000018010406A                 movups  xmmword ptr [rbp+57h+var_79], xmm0
+  .text:000000018010406E                 mov     [rbp+57h+var_48], r15
+  .text:0000000180104072                 mov     [rbp+57h+var_30], r15b
+  .text:0000000180104076                 mov     [rbp+57h+var_38], r15
+  .text:000000018010407A                 call    sub_1803FB340
+  .text:000000018010407F                 lea     rdx, unk_180523F9F
+  .text:0000000180104086                 mov     byte ptr [rbp+57h+var_A0+4], 1
+  .text:000000018010408A                 lea     rcx, [rbp+57h+var_A0+7]
+  .text:000000018010408E                 mov     [rbp+57h+var_A0+7], r15
+  .text:0000000180104092                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180104098                 lea     rax, [rbp+57h+var_A0]
+  .text:000000018010409C                 mov     r8d, 200h
+  .text:00000001801040A2                 lea     r9, aCustomUserInfo; "Custom user info value"
+  .text:00000001801040A9                 mov     [rsp+0E0h+var_C0], rax
+  .text:00000001801040AE                 mov     rdx, rsi
+  .text:00000001801040B1                 mov     rcx, rbx
+  .text:00000001801040B4                 call    sub_1803FBBD0
+  .text:00000001801040B9                 jmp     short loc_1801040BE
+  .text:00000001801040BB                 mov     rbx, r15
+  .text:00000001801040BE                 movups  xmm0, xmmword ptr [rbx]
+  .text:00000001801040C1                 mov     rsi, [rsp+0E0h+var_10]
+  .text:00000001801040C9                 movups  [rbp+57h+var_B0], xmm0
+  .text:00000001801040CD                 mov     r8, r14
+  .text:00000001801040D0                 lea     rcx, [rbp+57h+var_B0]
+  .text:00000001801040D4                 mov     edx, 0FFFFFFFFh
+  .text:00000001801040D9                 call    sub_1803FC920
+  .text:00000001801040DE                 mov     rcx, cs:g_pNetworkClientService
+  .text:00000001801040E5                 mov     rax, [rcx]
+  .text:00000001801040E8                 ; 0x100 = 256LL = INetworkClientService_IsConnected
+  .text:00000001801040E8                 call    qword ptr [rax+100h]; 0x100 = 256LL = INetworkClientService_IsConnected
+  .text:00000001801040EE                 test    al, al
+  .text:00000001801040F0                 jz      loc_18010417B
+  .text:00000001801040F6                 mov     rbx, cs:qword_1809090C0
+  .text:00000001801040FD                 lea     rcx, [rbp+57h+var_A0]
+  .text:0000000180104101                 xor     eax, eax
+  .text:0000000180104103                 mov     [rbp-39h], r15d
+  .text:0000000180104107                 mov     [rbp+57h+var_60], rax
+  .text:000000018010410B                 xorps   xmm0, xmm0
+  .text:000000018010410E                 lea     rax, ??_7CNETMsg_SetConVar_t@@6B@; const CNETMsg_SetConVar_t::`vftable'
+  .text:0000000180104115                 movsd   qword ptr [rbp-41h], xmm0
+  .text:000000018010411A                 mov     [rbp+57h+var_A0], rax
+  .text:000000018010411E                 mov     r8, r14
+  .text:0000000180104121                 lea     rax, ??_7CNETMsg_SetConVar_t@@6B@_0; const CNETMsg_SetConVar_t::`vftable'
+  .text:0000000180104128                 mov     [rbp+57h+var_8C], 0FFh
+  .text:000000018010412C                 mov     rdx, rdi
+  .text:000000018010412F                 mov     qword ptr [rbp+57h+var_79+9], rax
+  .text:0000000180104133                 mov     qword ptr [rbp+57h+var_89+1], 0FFFFFFFFFFFFFFFFh
+  .text:000000018010413B                 mov     dword ptr [rbp+57h+var_89+9], 0BF800000h
+  .text:0000000180104142                 mov     qword ptr [rbp+57h+var_79+1], 0FFFFFFFFFFFFFFFFh
+  .text:000000018010414A                 mov     [rbp+57h+var_68], r15
+  .text:000000018010414E                 mov     dword ptr [rbp+57h+var_60+4], r15d
+  .text:0000000180104152                 mov     [rbp+57h+var_58], r15
+  .text:0000000180104156                 call    sub_18009BFA0
+  .text:000000018010415B                 mov     rcx, [rbx+0F0h]
+  .text:0000000180104162                 lea     rdx, [rbp+57h+var_A0]
+  .text:0000000180104166                 mov     r8b, 0FFh
+  .text:0000000180104169                 mov     rax, [rcx]
+  .text:000000018010416C                 call    qword ptr [rax+138h]
+  .text:0000000180104172                 lea     rcx, [rbp+57h+var_A0]
+  .text:0000000180104176                 call    sub_18005F7E0
+  .text:000000018010417B                 lea     rcx, [rbp+57h+var_B0]
+  .text:000000018010417F                 call    _guard_check_icall_nop
+  .text:0000000180104184                 mov     rbx, [rsp+0E0h+arg_0]
+  .text:000000018010418C                 mov     rdi, [rsp+0E0h+var_18]
+  .text:0000000180104194                 mov     r14, [rsp+0E0h+var_20]
+  .text:000000018010419C                 add     rsp, 0D8h
+  .text:00000001801041A3                 pop     r15
+  .text:00000001801041A5                 pop     rbp
+  .text:00000001801041A6                 retn
+procedure: |-
+  char __fastcall sub_180103E90(__int64 a1, __int64 a2)
+  {
+    char result; // al
+    __int64 v3; // rax
+    const char *v4; // rdi
+    __int64 v5; // r14
+    _QWORD *v6; // rax
+    __int64 v7; // rax
+    _BYTE *v8; // rax
+    int v9; // esi
+    __int64 v10; // rax
+    __int128 *v11; // rbx
+    __int64 v12; // rbx
+    __int64 v13; // r8
+    __int128 v14; // [rsp+30h] [rbp-59h] BYREF
+    _BYTE v15[23]; // [rsp+40h] [rbp-49h] BYREF
+    __int128 v16; // [rsp+57h] [rbp-32h]
+    _BYTE v17[17]; // [rsp+67h] [rbp-22h]
+    __int64 v18; // [rsp+78h] [rbp-11h]
+    __int64 v19; // [rsp+80h] [rbp-9h]
+    __int64 v20; // [rsp+88h] [rbp-1h]
+    __int64 v21; // [rsp+90h] [rbp+7h]
+    __int64 v22; // [rsp+98h] [rbp+Fh]
+    __int16 v23; // [rsp+A0h] [rbp+17h]
+    __int64 v24; // [rsp+A8h] [rbp+1Fh]
+    char v25; // [rsp+B0h] [rbp+27h]
+    char v26; // [rsp+F8h] [rbp+6Fh] BYREF
+    char v27; // [rsp+100h] [rbp+77h] BYREF
+
+    if ( *(_DWORD *)(a2 + 1080) != 3 )
+      return Msg("Syntax: setinfo <key> <value>\n");
+    v3 = *(_QWORD *)(a2 + 1088);
+    v4 = *(const char **)(v3 + 8);
+    v5 = *(_QWORD *)(v3 + 16);
+    if ( *(_QWORD *)(*(__int64 (__fastcall **)(__int64, char *, const char *, _QWORD))(*(_QWORD *)qword_1806845B8 + 136LL))(
+                      qword_1806845B8,
+                      &v26,
+                      v4,
+                      0) != 0xFFFF )
+      return Msg("Name %s is already registered as console command\n", v4);
+    v6 = (_QWORD *)(*(__int64 (__fastcall **)(__int64, char *, const char *, __int64))(*(_QWORD *)qword_1806845B8 + 88LL))(
+                     qword_1806845B8,
+                     &v27,
+                     v4,
+                     1);
+    sub_1803FB340(&v14, *v6);
+    if ( !*((_QWORD *)&v14 + 1) || (v7 = *(_QWORD *)(*((_QWORD *)&v14 + 1) + 48LL), (v7 & 0x400) != 0) )
+    {
+      v9 = MemAlloc_StrDupFunc(v4);
+      v10 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 16);
+      v11 = (__int128 *)v10;
+      if ( v10 )
+      {
+        *(_DWORD *)v15 = 0;
+        memset(&v15[5], 0, 18);
+        v18 = 0;
+        v23 = 9;
+        v19 = 0;
+        v20 = 0;
+        v16 = 0;
+        v21 = 0;
+        *(_OWORD *)v17 = 0;
+        v22 = 0;
+        v25 = 0;
+        v24 = 0;
+        sub_1803FB340(v10, 0xFFFFFFFFLL);
+        v15[4] = 1;
+        *(_QWORD *)&v15[7] = 0;
+        CUtlString::Set((CUtlString *)&v15[7], (const char *)&unk_180523F9F);
+        sub_1803FBBD0((_DWORD)v11, v9, 512, (unsigned int)"Custom user info value", (__int64)v15);
+      }
+      else
+      {
+        v11 = nullptr;
+      }
+      v14 = *v11;
+  LABEL_20:
+      sub_1803FC920(&v14, 0xFFFFFFFFLL, v5);
+      result = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkClientService + 256LL))(g_pNetworkClientService);// 0x100 = 256LL = INetworkClientService_IsConnected
+      if ( result )
+      {
+        v12 = qword_1809090C0;
+        *(_DWORD *)&v15[16] = 0;
+        v19 = 0;
+        *(_QWORD *)&v15[8] = 0;
+        *(_QWORD *)v15 = &CNETMsg_SetConVar_t::`vftable';
+        v15[20] = -1;
+        *(_QWORD *)&v17[9] = &CNETMsg_SetConVar_t::`vftable';
+        *(_QWORD *)((char *)&v16 + 1) = -1;
+        *(_DWORD *)((char *)&v16 + 9) = -1082130432;
+        *(_QWORD *)&v17[1] = -1;
+        v18 = 0;
+        v20 = 0;
+        sub_18009BFA0(v15, v4, v5);
+        LOBYTE(v13) = -1;
+        (*(void (__fastcall **)(_QWORD, _BYTE *, __int64))(**(_QWORD **)(v12 + 240) + 312LL))(
+          *(_QWORD *)(v12 + 240),
+          v15,
+          v13);
+        return sub_18005F7E0(v15);
+      }
+      return result;
+    }
+    if ( (v7 & 0x200) == 0 )
+      return Msg("Convar %s is already registered but not as user info value\n", v4);
+    if ( (((unsigned int)sub_180073C10() - 2) & 0xFFFFFFFD) == 0
+      || (result = *(_BYTE *)(*((_QWORD *)&v14 + 1) + 48LL) >> 1, (*(_BYTE *)(*((_QWORD *)&v14 + 1) + 48LL) & 2) == 0) )
+    {
+      if ( (*(_DWORD *)(*((_QWORD *)&v14 + 1) + 48LL) & 0x4000LL) != 0 )
+      {
+        v8 = (_BYTE *)sub_1803FB9B0(&unk_180689E38, 0xFFFFFFFFLL);
+        if ( !v8 )
+          v8 = *(_BYTE **)(qword_180689E40 + 8);
+        if ( !*v8 )
+          return Msg("Convar %s is marked as cheat and cheats are off\n", v4);
+      }
+      goto LABEL_20;
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary
- Adds `find-CEntityInstance_ValidatePrivateScriptScope.py` (Pattern A: regular function via xref string)
- Discovers `CEntityInstance_ValidatePrivateScriptScope` by xref-ing `"thisEntity"` and excluding functions that reference `"InputRunPrivateScript"`
- Updates `config.yaml` with skill entry and symbol entry (`category: func`)

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures (2 successful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)