### PR TITLE
Add find-CEntityInstance_m_pEntity preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3578,6 +3578,12 @@ modules:
           - CPointTeleport_Activate.{platform}.yaml
           - CBaseEntity_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_m_pEntity
+        expected_output:
+          - CEntityInstance_m_pEntity.{platform}.yaml
+        expected_input:
+          - CBaseEntity_Activate.{platform}.yaml
+
       - name: find-CBaseEntity_CollisionRulesChanged
         expected_output:
           - CBaseEntity_CollisionRulesChanged.{platform}.yaml
@@ -4470,6 +4476,16 @@ modules:
 
       - name: CEntityInstance_vtable
         category: vtable
+
+      - name: CEntityInstance
+        category: struct
+
+      - name: CEntityInstance_m_pEntity
+        category: structmember
+        struct: CEntityInstance
+        member: m_pEntity
+        alias:
+          - CEntityInstance::m_pEntity
 
       - name: CBaseEntity_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_NetworkUpdateState.py
@@ -29,6 +29,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         [
             "func_name",
             "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/ida_preprocessor_scripts/find-CEntityInstance_m_pEntity.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_m_pEntity.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_m_pEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntityInstance_m_pEntity",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_m_pEntity",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBaseEntity_Activate.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_m_pEntity",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_Activate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_Activate.linux.yaml
@@ -1,0 +1,224 @@
+func_name: CBaseEntity_Activate
+func_va: '0x16ce380'
+disasm_code: |-
+  .text:00000000016CE380                 push    rbp
+  .text:00000000016CE381                 mov     rbp, rsp
+  .text:00000000016CE384                 push    r14
+  .text:00000000016CE386                 push    r13
+  .text:00000000016CE388                 push    r12
+  .text:00000000016CE38A                 mov     r12d, esi
+  .text:00000000016CE38D                 push    rbx
+  .text:00000000016CE38E                 mov     rbx, rdi
+  .text:00000000016CE391                 sub     rsp, 50h
+  .text:00000000016CE395                 call    sub_1E474C0
+  .text:00000000016CE39A                 mov     esi, [rbx+5FCh]
+  .text:00000000016CE3A0                 test    esi, esi
+  .text:00000000016CE3A2                 jz      short loc_16CE3C7
+  .text:00000000016CE3A4                 lea     rax, qword_25EFF48
+  .text:00000000016CE3AB                 mov     rdi, rbx
+  .text:00000000016CE3AE                 mov     r13, [rax]
+  .text:00000000016CE3B1                 mov     rax, [rbx]
+  .text:00000000016CE3B4                 call    qword ptr [rax+708h]
+  .text:00000000016CE3BA                 mov     rdx, rbx
+  .text:00000000016CE3BD                 mov     rdi, r13
+  .text:00000000016CE3C0                 mov     esi, eax
+  .text:00000000016CE3C2                 call    sub_E116A0
+  .text:00000000016CE3C7                 mov     esi, [rbx+758h]
+  .text:00000000016CE3CD                 test    esi, esi
+  .text:00000000016CE3CF                 jz      short loc_16CE3DD
+  .text:00000000016CE3D1                 mov     rax, [rbx]
+  .text:00000000016CE3D4                 mov     rdi, rbx
+  .text:00000000016CE3D7                 call    qword ptr [rax+330h]
+  .text:00000000016CE3DD                 mov     rax, [rbx+5F0h]
+  .text:00000000016CE3E4                 test    rax, rax
+  .text:00000000016CE3E7                 jnz     loc_16CE520
+  .text:00000000016CE3ED                 mov     rsi, [rbx+568h]
+  .text:00000000016CE3F4                 test    rsi, rsi
+  .text:00000000016CE3F7                 jz      short loc_16CE405
+  .text:00000000016CE3F9                 mov     rax, [rbx]
+  .text:00000000016CE3FC                 mov     rdi, rbx
+  .text:00000000016CE3FF                 call    qword ptr [rax+380h]
+  .text:00000000016CE405                 mov     rax, [rbx+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:00000000016CE409                 test    rax, rax
+  .text:00000000016CE40C                 jz      short loc_16CE41E
+  .text:00000000016CE40E                 lea     rdi, [rbx+38h]
+  .text:00000000016CE412                 mov     rsi, rbx
+  .text:00000000016CE415                 call    sub_9F7820
+  .text:00000000016CE41A                 mov     rax, [rbx+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:00000000016CE41E                 mov     edi, [rax+38h]
+  .text:00000000016CE421                 call    sub_11CF990
+  .text:00000000016CE426                 ucomiss xmm0, dword ptr [rbx+610h]
+  .text:00000000016CE42D                 jp      short loc_16CE490
+  .text:00000000016CE42F                 jnz     short loc_16CE490
+  .text:00000000016CE431                 lea     r13, off_24FB0A8
+  .text:00000000016CE438                 xor     esi, esi
+  .text:00000000016CE43A                 mov     rdi, rbx
+  .text:00000000016CE43D                 mov     rax, [r13+0]
+  .text:00000000016CE441                 movss   xmm0, dword ptr [rax+30h]
+  .text:00000000016CE446                 call    sub_C95FF0
+  .text:00000000016CE44B                 mov     rax, [r13+0]
+  .text:00000000016CE44F                 mov     rdi, rbx
+  .text:00000000016CE452                 movss   xmm0, dword ptr [rax+30h]
+  .text:00000000016CE457                 call    sub_C96E40
+  .text:00000000016CE45C                 mov     rdi, [rbx+780h]
+  .text:00000000016CE463                 test    rdi, rdi
+  .text:00000000016CE466                 jz      short loc_16CE480
+  .text:00000000016CE468                 lea     rsp, [rbp-20h]
+  .text:00000000016CE46C                 mov     esi, r12d
+  .text:00000000016CE46F                 pop     rbx
+  .text:00000000016CE470                 pop     r12
+  .text:00000000016CE472                 pop     r13
+  .text:00000000016CE474                 pop     r14
+  .text:00000000016CE476                 pop     rbp
+  .text:00000000016CE477                 jmp     sub_18BE290
+  .text:00000000016CE480                 lea     rsp, [rbp-20h]
+  .text:00000000016CE484                 pop     rbx
+  .text:00000000016CE485                 pop     r12
+  .text:00000000016CE487                 pop     r13
+  .text:00000000016CE489                 pop     r14
+  .text:00000000016CE48B                 pop     rbp
+  .text:00000000016CE48C                 retn
+  .text:00000000016CE490                 xor     eax, eax
+  .text:00000000016CE492                 mov     esi, 1
+  .text:00000000016CE497                 movss   [rbp+var_64], xmm0
+  .text:00000000016CE49C                 pxor    xmm1, xmm1
+  .text:00000000016CE4A0                 lea     rdi, [rbp+var_50]
+  .text:00000000016CE4A4                 movaps  [rbp+var_40], xmm1
+  .text:00000000016CE4A8                 mov     [rbp+var_24], ax
+  .text:00000000016CE4AC                 lea     r13, [rbp+var_60]
+  .text:00000000016CE4B0                 mov     [rbp+var_60], 1
+  .text:00000000016CE4B8                 mov     [rbp+var_58], 0
+  .text:00000000016CE4C0                 mov     [rbp+var_50], 0
+  .text:00000000016CE4C8                 mov     [rbp+var_48], 0
+  .text:00000000016CE4D0                 mov     [rbp+var_30], 0FFFFFFFFFFFFFFFFh
+  .text:00000000016CE4D8                 mov     [rbp+var_28], 0FFFFFFFFh
+  .text:00000000016CE4DF                 call    sub_9B9680
+  .text:00000000016CE4E4                 mov     rax, [rbp+var_50]
+  .text:00000000016CE4E8                 mov     rsi, r13
+  .text:00000000016CE4EB                 mov     rdi, rbx
+  .text:00000000016CE4EE                 add     dword ptr [rbp+var_58], 1
+  .text:00000000016CE4F2                 mov     dword ptr [rax], 610h
+  .text:00000000016CE4F8                 mov     rax, [rbx]
+  .text:00000000016CE4FB                 call    qword ptr [rax+0E8h]
+  .text:00000000016CE501                 lea     rdi, [rbp+var_58]
+  .text:00000000016CE505                 call    sub_9B9050
+  .text:00000000016CE50A                 movss   xmm0, [rbp+var_64]
+  .text:00000000016CE50F                 movss   dword ptr [rbx+610h], xmm0
+  .text:00000000016CE517                 jmp     loc_16CE431
+  .text:00000000016CE520                 lea     rdx, qword_26D7D30
+  .text:00000000016CE527                 sub     rsp, 8
+  .text:00000000016CE52B                 mov     rcx, rbx
+  .text:00000000016CE52E                 xor     esi, esi
+  .text:00000000016CE530                 mov     [rbp+var_60], rax
+  .text:00000000016CE534                 xor     r9d, r9d
+  .text:00000000016CE537                 xor     r8d, r8d
+  .text:00000000016CE53A                 mov     rdi, [rdx]
+  .text:00000000016CE53D                 push    0
+  .text:00000000016CE53F                 lea     rdx, [rbp+var_60]
+  .text:00000000016CE543                 call    sub_15549B0
+  .text:00000000016CE548                 lea     rdi, [rbx+5E8h]
+  .text:00000000016CE54F                 mov     rsi, rax
+  .text:00000000016CE552                 call    sub_1671820
+  .text:00000000016CE557                 call    sub_A41620
+  .text:00000000016CE55C                 pop     rdx
+  .text:00000000016CE55D                 pop     rcx
+  .text:00000000016CE55E                 test    rax, rax
+  .text:00000000016CE561                 jnz     loc_16CE3ED
+  .text:00000000016CE567                 mov     r13, [rbx+5F0h]
+  .text:00000000016CE56E                 mov     rdi, [rbx+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:00000000016CE572                 lea     r14, byte_8D7B10
+  .text:00000000016CE579                 test    r13, r13
+  .text:00000000016CE57C                 cmovz   r13, r14
+  .text:00000000016CE580                 call    sub_1E45610
+  .text:00000000016CE585                 lea     rdi, aSSWasUnableToF; "%s '%s' was unable to find a damage fil"...
+  .text:00000000016CE58C                 mov     rdx, rax
+  .text:00000000016CE58F                 mov     rax, [rbx+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:00000000016CE593                 mov     rcx, r13
+  .text:00000000016CE596                 mov     rsi, [rax+20h]
+  .text:00000000016CE59A                 test    rsi, rsi
+  .text:00000000016CE59D                 cmovz   rsi, r14
+  .text:00000000016CE5A1                 xor     eax, eax
+  .text:00000000016CE5A3                 call    sub_9846D0
+  .text:00000000016CE5A8                 jmp     loc_16CE3ED
+procedure: |-
+  __int64 __fastcall CBaseEntity_Activate(__int64 *a1, unsigned int a2)
+  {
+    __int64 v4; // r13
+    unsigned int v5; // eax
+    __int64 v6; // rax
+    double v7; // xmm0_8
+    __int64 result; // rax
+    __int64 v9; // rdi
+    __int64 v10; // rsi
+    const char *v11; // r13
+    __int64 v12; // rdi
+    __int64 v13; // rax
+    const char *v14; // rsi
+    __int64 v15; // [rsp+10h] [rbp-60h] BYREF
+    __int64 v16; // [rsp+18h] [rbp-58h] BYREF
+    _QWORD v17[2]; // [rsp+20h] [rbp-50h] BYREF
+    __int128 v18; // [rsp+30h] [rbp-40h]
+    __int64 v19; // [rsp+40h] [rbp-30h]
+    int v20; // [rsp+48h] [rbp-28h]
+    __int16 v21; // [rsp+4Ch] [rbp-24h]
+
+    sub_1E474C0();
+    if ( *((_DWORD *)a1 + 383) )
+    {
+      v4 = qword_25EFF48;
+      v5 = (*(__int64 (__fastcall **)(__int64 *))(*a1 + 1800))(a1);
+      sub_E116A0(v4, v5, a1);
+    }
+    if ( *((_DWORD *)a1 + 470) )
+      (*(void (__fastcall **)(__int64 *))(*a1 + 816))(a1);
+    if ( a1[190] )
+    {
+      v15 = a1[190];
+      v10 = sub_15549B0(qword_26D7D30, 0, (unsigned int)&v15, (_DWORD)a1, 0, 0, 0);
+      sub_1671820(a1 + 189, v10);
+      if ( !sub_A41620(a1 + 189, v10) )
+      {
+        v11 = (const char *)a1[190];
+        v12 = a1[2]; // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+        if ( !v11 )
+          v11 = &byte_8D7B10;
+        v13 = sub_1E45610(v12);
+        v14 = *(const char **)(a1[2] + 32); // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+        if ( !v14 )
+          v14 = &byte_8D7B10;
+        sub_9846D0("%s '%s' was unable to find a damage filter named '%s'.\n", v14, v13, v11);
+      }
+    }
+    if ( a1[173] )
+      (*(void (__fastcall **)(__int64 *))(*a1 + 896))(a1);
+    v6 = a1[2]; // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+    if ( v6 )
+    {
+      sub_9F7820(a1 + 7, a1);
+      v6 = a1[2]; // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+    }
+    v7 = sub_11CF990(*(unsigned int *)(v6 + 56));
+    if ( *(float *)&v7 != *((float *)a1 + 388) )
+    {
+      v18 = 0;
+      v21 = 0;
+      v15 = 1;
+      v16 = 0;
+      v17[0] = 0;
+      v17[1] = 0;
+      v19 = -1;
+      v20 = -1;
+      sub_9B9680(v17, 1);
+      LODWORD(v16) = v16 + 1;
+      *(_DWORD *)v17[0] = 1552;
+      (*(void (__fastcall **)(__int64 *, __int64 *))(*a1 + 232))(a1, &v15);
+      sub_9B9050(&v16);
+      *((_DWORD *)a1 + 388) = LODWORD(v7);
+    }
+    sub_C95FF0(a1, 0, *((float *)off_24FB0A8 + 12));
+    result = sub_C96E40(a1, *((float *)off_24FB0A8 + 12));
+    v9 = a1[240];
+    if ( v9 )
+      return sub_18BE290(v9, a2);
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_Activate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_Activate.windows.yaml
@@ -1,0 +1,235 @@
+func_name: CBaseEntity_Activate
+func_va: '0x180c21cb0'
+disasm_code: |-
+  .text:0000000180C21CB0                 push    rbp
+  .text:0000000180C21CB2                 sub     rsp, 60h
+  .text:0000000180C21CB6                 mov     [rsp+68h+arg_8], rbx
+  .text:0000000180C21CBB                 mov     ebp, edx
+  .text:0000000180C21CBD                 mov     [rsp+68h+var_10], rsi
+  .text:0000000180C21CC2                 mov     rsi, rcx
+  .text:0000000180C21CC5                 movaps  [rsp+68h+var_28], xmm6
+  .text:0000000180C21CCA                 call    sub_18120B450
+  .text:0000000180C21CCF                 cmp     dword ptr [rsi+31Ch], 0
+  .text:0000000180C21CD6                 jz      short loc_180C21CF5
+  .text:0000000180C21CD8                 mov     rax, [rsi]
+  .text:0000000180C21CDB                 mov     rcx, rsi
+  .text:0000000180C21CDE                 call    qword ptr [rax+710h]
+  .text:0000000180C21CE4                 mov     rcx, cs:qword_181E147C0
+  .text:0000000180C21CEB                 mov     r8, rsi
+  .text:0000000180C21CEE                 mov     edx, eax
+  .text:0000000180C21CF0                 call    sub_18052EA30
+  .text:0000000180C21CF5                 mov     edx, [rsi+478h]
+  .text:0000000180C21CFB                 test    edx, edx
+  .text:0000000180C21CFD                 jz      short loc_180C21D0B
+  .text:0000000180C21CFF                 mov     rax, [rsi]
+  .text:0000000180C21D02                 mov     rcx, rsi
+  .text:0000000180C21D05                 call    qword ptr [rax+338h]
+  .text:0000000180C21D0B                 mov     rax, [rsi+310h]
+  .text:0000000180C21D12                 test    rax, rax
+  .text:0000000180C21D15                 jz      loc_180C21E2D
+  .text:0000000180C21D1B                 mov     rcx, cs:qword_181F5CFB8
+  .text:0000000180C21D22                 lea     r8, [rsp+68h+arg_0]
+  .text:0000000180C21D27                 mov     [rsp+68h+arg_0], rax
+  .text:0000000180C21D2C                 mov     r9, rsi
+  .text:0000000180C21D2F                 xor     eax, eax
+  .text:0000000180C21D31                 xor     edx, edx
+  .text:0000000180C21D33                 mov     [rsp+68h+var_38], rax
+  .text:0000000180C21D38                 mov     [rsp+68h+var_40], rax
+  .text:0000000180C21D3D                 mov     [rsp+68h+var_48], rax
+  .text:0000000180C21D42                 call    sub_180B548B0
+  .text:0000000180C21D47                 test    rax, rax
+  .text:0000000180C21D4A                 jz      loc_180C21DD3
+  .text:0000000180C21D50                 mov     rax, [rax+10h]
+  .text:0000000180C21D54                 test    rax, rax
+  .text:0000000180C21D57                 jz      short loc_180C21DD3
+  .text:0000000180C21D59                 mov     edx, [rax+10h]
+  .text:0000000180C21D5C                 mov     r8d, edx
+  .text:0000000180C21D5F                 mov     eax, [rax+30h]
+  .text:0000000180C21D62                 mov     ecx, edx
+  .text:0000000180C21D64                 and     eax, 1
+  .text:0000000180C21D67                 shr     r8d, 0Fh
+  .text:0000000180C21D6B                 sub     r8d, eax
+  .text:0000000180C21D6E                 and     ecx, 7FFFh
+  .text:0000000180C21D74                 shl     r8d, 0Fh
+  .text:0000000180C21D78                 mov     eax, 7FFFh
+  .text:0000000180C21D7D                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180C21D80                 cmovnz  eax, ecx
+  .text:0000000180C21D83                 or      r8d, eax
+  .text:0000000180C21D86                 mov     [rsi+308h], r8d
+  .text:0000000180C21D8D                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180C21D91                 jz      short loc_180C21DDD
+  .text:0000000180C21D93                 mov     rdx, cs:qword_181D958F8
+  .text:0000000180C21D9A                 test    rdx, rdx
+  .text:0000000180C21D9D                 jz      short loc_180C21DDD
+  .text:0000000180C21D9F                 cmp     r8d, 0FFFFFFFEh
+  .text:0000000180C21DA3                 jz      short loc_180C21DDD
+  .text:0000000180C21DA5                 mov     eax, r8d
+  .text:0000000180C21DA8                 and     eax, 7FFFh
+  .text:0000000180C21DAD                 mov     ecx, eax
+  .text:0000000180C21DAF                 shr     rax, 9
+  .text:0000000180C21DB3                 mov     r9, [rdx+rax*8]
+  .text:0000000180C21DB7                 test    r9, r9
+  .text:0000000180C21DBA                 jz      short loc_180C21DDD
+  .text:0000000180C21DBC                 and     ecx, 1FFh
+  .text:0000000180C21DC2                 imul    rax, rcx, 70h ; 'p'
+  .text:0000000180C21DC6                 add     rax, r9
+  .text:0000000180C21DC9                 jz      short loc_180C21DDD
+  .text:0000000180C21DCB                 cmp     [rax+10h], r8d
+  .text:0000000180C21DCF                 jz      short loc_180C21E2D
+  .text:0000000180C21DD1                 jmp     short loc_180C21DDD
+  .text:0000000180C21DD3                 mov     dword ptr [rsi+308h], 0FFFFFFFFh
+  .text:0000000180C21DDD                 mov     rax, [rsi+310h]
+  .text:0000000180C21DE4                 mov     rcx, [rsi+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:0000000180C21DE8                 test    rax, rax
+  .text:0000000180C21DEB                 mov     [rsp+68h+var_18], rdi
+  .text:0000000180C21DF0                 lea     rdi, byte_18159B988
+  .text:0000000180C21DF7                 mov     rbx, rdi
+  .text:0000000180C21DFA                 cmovnz  rbx, rax
+  .text:0000000180C21DFE                 call    sub_18120FDE0
+  .text:0000000180C21E03                 mov     rcx, [rsi+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:0000000180C21E07                 mov     r9, rbx
+  .text:0000000180C21E0A                 mov     r8, [rcx+20h]
+  .text:0000000180C21E0E                 lea     rcx, aSSWasUnableToF; "%s '%s' was unable to find a damage fil"...
+  .text:0000000180C21E15                 test    r8, r8
+  .text:0000000180C21E18                 cmovnz  rdi, r8
+  .text:0000000180C21E1C                 mov     r8, rax
+  .text:0000000180C21E1F                 mov     rdx, rdi
+  .text:0000000180C21E22                 call    cs:Warning
+  .text:0000000180C21E28                 mov     rdi, [rsp+68h+var_18]
+  .text:0000000180C21E2D                 mov     rdx, [rsi+2A8h]
+  .text:0000000180C21E34                 test    rdx, rdx
+  .text:0000000180C21E37                 jz      short loc_180C21E45
+  .text:0000000180C21E39                 mov     rax, [rsi]
+  .text:0000000180C21E3C                 mov     rcx, rsi
+  .text:0000000180C21E3F                 call    qword ptr [rax+388h]
+  .text:0000000180C21E45                 cmp     qword ptr [rsi+10h], 0 ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:0000000180C21E4A                 jz      short loc_180C21E58
+  .text:0000000180C21E4C                 lea     rcx, [rsi+38h]
+  .text:0000000180C21E50                 mov     rdx, rsi
+  .text:0000000180C21E53                 call    sub_1801B9EE0
+  .text:0000000180C21E58                 mov     rdx, [rsi+10h] ; 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+  .text:0000000180C21E5C                 lea     rcx, [rsp+68h+arg_0]
+  .text:0000000180C21E61                 mov     edx, [rdx+38h]
+  .text:0000000180C21E64                 call    sub_1808AE1F0
+  .text:0000000180C21E69                 movss   xmm6, dword ptr [rsp+68h+arg_0]
+  .text:0000000180C21E6F                 lea     rdx, [rsp+68h+arg_10]
+  .text:0000000180C21E77                 lea     rcx, [rsi+330h]
+  .text:0000000180C21E7E                 movss   [rsp+68h+arg_10], xmm6
+  .text:0000000180C21E87                 call    sub_1801B3420
+  .text:0000000180C21E8C                 test    al, al
+  .text:0000000180C21E8E                 jz      short loc_180C21EAF
+  .text:0000000180C21E90                 mov     edx, 0FFFFFFFFh
+  .text:0000000180C21E95                 lea     rcx, [rsi+330h]
+  .text:0000000180C21E9C                 mov     r8d, 0FFFFFFFFh
+  .text:0000000180C21EA2                 call    sub_180C427D0
+  .text:0000000180C21EA7                 movss   dword ptr [rsi+330h], xmm6
+  .text:0000000180C21EAF                 mov     rax, cs:off_181C47BB8
+  .text:0000000180C21EB6                 xor     r8d, r8d
+  .text:0000000180C21EB9                 mov     rcx, rsi
+  .text:0000000180C21EBC                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180C21EC1                 call    sub_1803E9070
+  .text:0000000180C21EC6                 mov     rax, cs:off_181C47BB8
+  .text:0000000180C21ECD                 mov     rcx, rsi
+  .text:0000000180C21ED0                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180C21ED5                 call    sub_1803EC440
+  .text:0000000180C21EDA                 mov     rcx, [rsi+4A0h]
+  .text:0000000180C21EE1                 movaps  xmm6, [rsp+68h+var_28]
+  .text:0000000180C21EE6                 mov     rsi, [rsp+68h+var_10]
+  .text:0000000180C21EEB                 mov     rbx, [rsp+68h+arg_8]
+  .text:0000000180C21EF0                 test    rcx, rcx
+  .text:0000000180C21EF3                 jz      short loc_180C21F01
+  .text:0000000180C21EF5                 mov     edx, ebp
+  .text:0000000180C21EF7                 add     rsp, 60h
+  .text:0000000180C21EFB                 pop     rbp
+  .text:0000000180C21EFC                 jmp     sub_180DBD610
+  .text:0000000180C21F01                 add     rsp, 60h
+  .text:0000000180C21F05                 pop     rbp
+  .text:0000000180C21F06                 retn
+procedure: |-
+  __int64 __fastcall CBaseEntity_Activate(_DWORD *a1, unsigned int a2)
+  {
+    unsigned int v4; // eax
+    __int64 v5; // rax
+    __int64 v6; // rax
+    unsigned int v7; // edx
+    int v8; // r8d
+    int v9; // eax
+    int v10; // r8d
+    __int64 v11; // r9
+    __int64 v12; // rax
+    char *v13; // rdi
+    char *v14; // rbx
+    __int64 v15; // rax
+    int v16; // xmm6_4
+    __int64 v17; // rdx
+    __int64 result; // rax
+    __int64 v19; // rcx
+    __int64 v20; // [rsp+70h] [rbp+8h] BYREF
+    int v21; // [rsp+80h] [rbp+18h] BYREF
+
+    sub_18120B450();
+    if ( a1[199] )
+    {
+      v4 = (*(__int64 (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 1808LL))(a1);
+      sub_18052EA30(qword_181E147C0, v4, a1);
+    }
+    if ( a1[286] )
+      (*(void (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 824LL))(a1);
+    if ( *((_QWORD *)a1 + 98) )
+    {
+      v20 = *((_QWORD *)a1 + 98);
+      v5 = sub_180B548B0(qword_181F5CFB8, 0, (unsigned int)&v20, (_DWORD)a1, 0, 0, 0);
+      if ( !v5 || (v6 = *(_QWORD *)(v5 + 16)) == 0 )
+      {
+        a1[194] = -1;
+  LABEL_18:
+        v13 = byte_18159B988;
+        v14 = byte_18159B988;
+        if ( *((_QWORD *)a1 + 98) )
+          v14 = (char *)*((_QWORD *)a1 + 98);
+        v15 = sub_18120FDE0(*((_QWORD *)a1 + 2)); // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+        if ( *(_QWORD *)(*((_QWORD *)a1 + 2) + 32LL) ) // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+          v13 = *(char **)(*((_QWORD *)a1 + 2) + 32LL); // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+        Warning("%s '%s' was unable to find a damage filter named '%s'.\n", v13, v15, v14);
+        goto LABEL_23;
+      }
+      v7 = *(_DWORD *)(v6 + 16);
+      v8 = ((v7 >> 15) - (*(_DWORD *)(v6 + 48) & 1)) << 15;
+      v9 = 0x7FFF;
+      if ( v7 != -1 )
+        v9 = v7 & 0x7FFF;
+      v10 = v9 | v8;
+      a1[194] = v10;
+      if ( v10 == -1 )
+        goto LABEL_18;
+      if ( !qword_181D958F8 )
+        goto LABEL_18;
+      if ( v10 == -2 )
+        goto LABEL_18;
+      v11 = *(_QWORD *)(qword_181D958F8 + 8 * ((unsigned __int64)(v10 & 0x7FFF) >> 9));
+      if ( !v11 )
+        goto LABEL_18;
+      v12 = v11 + 112LL * (v10 & 0x1FF);
+      if ( !v12 || *(_DWORD *)(v12 + 16) != v10 )
+        goto LABEL_18;
+    }
+  LABEL_23:
+    if ( *((_QWORD *)a1 + 85) )
+      (*(void (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 904LL))(a1);
+    if ( *((_QWORD *)a1 + 2) )                    // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+      sub_1801B9EE0(a1 + 14, a1);
+    sub_1808AE1F0(&v20, *(unsigned int *)(*((_QWORD *)a1 + 2) + 56LL)); // 16 = 0x10 = CEntityInstance::m_pEntity (structmember, struct=CEntityInstance, member=m_pEntity)
+    v16 = v20;
+    v21 = v20;
+    if ( (unsigned __int8)sub_1801B3420(a1 + 204, &v21) )
+    {
+      sub_180C427D0(a1 + 204, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+      a1[204] = v16;
+    }
+    sub_1803E9070(a1, v17, 0);
+    result = sub_1803EC440(a1);
+    v19 = *((_QWORD *)a1 + 148);
+    if ( v19 )
+      return sub_180DBD610(v19, a2);
+    return result;
+  }


### PR DESCRIPTION
## Summary
- New Pattern E preprocessor script `find-CEntityInstance_m_pEntity` locates the `CEntityInstance::m_pEntity` struct member offset via LLM_DECOMPILE on `CBaseEntity_Activate`. Uses `offset_sig_allow_across_function_boundary:true` so the offset signature can extend past the access instruction''s containing function when the surrounding bytes are too short to disambiguate.
- Generated and annotated `CBaseEntity_Activate.{linux,windows}.yaml` reference YAMLs with all `m_pEntity` access sites in both `disasm_code` and `procedure`.
- Added `CEntityInstance` struct symbol and `CEntityInstance_m_pEntity` structmember symbol entries to `config.yaml`.
- Drive-by: enabled `vfunc_sig_allow_across_function_boundary:true` for `find-CEntityInstance_NetworkUpdateState` to fix the same signature-near-function-end issue.

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` completes and `bin/14158/server/CEntityInstance_m_pEntity.{windows,linux}.yaml` are produced
- [ ] Run on the next game version bump to confirm the signature reuses cleanly