### PR TITLE
Add find-CEntityInstance_m_CScriptComponent-AND-CEntityInstance_m_pKeyValues

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3585,6 +3585,13 @@ modules:
         expected_input:
           - CEntityInstance_ValidatePrivateScriptScope.{platform}.yaml
 
+      - name: find-CEntityInstance_m_CScriptComponent-AND-CEntityInstance_m_pKeyValues
+        expected_output:
+          - CEntityInstance_m_CScriptComponent.{platform}.yaml
+          - CEntityInstance_m_pKeyValues.{platform}.yaml
+        expected_input:
+          - CEntityInstance_UpdateOnRemove.{platform}.yaml
+
       - name: find-CBaseEntity_CollisionRulesChanged
         expected_output:
           - CBaseEntity_CollisionRulesChanged.{platform}.yaml
@@ -4494,6 +4501,20 @@ modules:
         member: m_hPrivateScope
         alias:
           - CEntityInstance::m_hPrivateScope
+
+      - name: CEntityInstance_m_CScriptComponent
+        category: structmember
+        struct: CEntityInstance
+        member: m_CScriptComponent
+        alias:
+          - CEntityInstance::m_CScriptComponent
+
+      - name: CEntityInstance_m_pKeyValues
+        category: structmember
+        struct: CEntityInstance
+        member: m_pKeyValues
+        alias:
+          - CEntityInstance::m_pKeyValues
 
       - name: CBaseEntity_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEntityInstance_m_CScriptComponent-AND-CEntityInstance_m_pKeyValues.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_m_CScriptComponent-AND-CEntityInstance_m_pKeyValues.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_m_CScriptComponent-AND-CEntityInstance_m_pKeyValues skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntityInstance_m_CScriptComponent",
+    "CEntityInstance_m_pKeyValues",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_m_CScriptComponent",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityInstance_UpdateOnRemove.{platform}.yaml",
+    ),
+    (
+        "CEntityInstance_m_pKeyValues",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityInstance_UpdateOnRemove.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_m_CScriptComponent",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "CEntityInstance_m_pKeyValues",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offsets and write YAMLs."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_UpdateOnRemove.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_UpdateOnRemove.linux.yaml
@@ -1,0 +1,227 @@
+func_name: CEntityInstance_UpdateOnRemove
+func_va: '0x1e47110'
+disasm_code: |-
+  .text:0000000001E47110                 push    rbp
+  .text:0000000001E47111                 mov     rbp, rsp
+  .text:0000000001E47114                 push    r13
+  .text:0000000001E47116                 push    r12
+  .text:0000000001E47118                 push    rbx
+  .text:0000000001E47119                 mov     rbx, rdi
+  .text:0000000001E4711C                 sub     rsp, 8
+  .text:0000000001E47120                 mov     rdi, [rdi+28h] ; 0x28 = 40 = CEntityInstance::m_CScriptComponent (structmember, struct=CEntityInstance, member=m_CScriptComponent)
+  .text:0000000001E47124                 mov     cs:byte_27BB9E9, 1
+  .text:0000000001E4712B                 test    rdi, rdi
+  .text:0000000001E4712E                 jz      short loc_1E47138
+  .text:0000000001E47130                 mov     rsi, rbx
+  .text:0000000001E47133                 call    sub_1E7C710
+  .text:0000000001E47138                 mov     rdx, [rbx+18h]
+  .text:0000000001E4713C                 test    rdx, rdx
+  .text:0000000001E4713F                 jz      loc_1E47240
+  .text:0000000001E47145                 lea     r13, qword_25F5128
+  .text:0000000001E4714C                 mov     ecx, 1
+  .text:0000000001E47151                 lea     rsi, aUpdateonremove; "UpdateOnRemove"
+  .text:0000000001E47158                 mov     rdi, [r13+0]
+  .text:0000000001E4715C                 mov     rax, [rdi]
+  .text:0000000001E4715F                 call    qword ptr [rax+0B0h]
+  .text:0000000001E47165                 mov     r12, rax
+  .text:0000000001E47168                 test    rax, rax
+  .text:0000000001E4716B                 jz      short loc_1E4719F
+  .text:0000000001E4716D                 mov     rdi, [r13+0]
+  .text:0000000001E47171                 sub     rsp, 8
+  .text:0000000001E47175                 xor     edx, edx
+  .text:0000000001E47177                 xor     r9d, r9d
+  .text:0000000001E4717A                 xor     r8d, r8d
+  .text:0000000001E4717D                 xor     ecx, ecx
+  .text:0000000001E4717F                 mov     rsi, r12
+  .text:0000000001E47182                 mov     rax, [rdi]
+  .text:0000000001E47185                 push    1
+  .text:0000000001E47187                 call    qword ptr [rax+0C0h]
+  .text:0000000001E4718D                 mov     rdi, [r13+0]
+  .text:0000000001E47191                 mov     rsi, r12
+  .text:0000000001E47194                 mov     rax, [rdi]
+  .text:0000000001E47197                 call    qword ptr [rax+0B8h]
+  .text:0000000001E4719D                 pop     rax
+  .text:0000000001E4719E                 pop     rdx
+  .text:0000000001E4719F                 mov     r12, [rbx+10h]
+  .text:0000000001E471A3                 test    r12, r12
+  .text:0000000001E471A6                 jz      short loc_1E471CD
+  .text:0000000001E471A8                 mov     rdx, [r12+28h]
+  .text:0000000001E471AD                 test    rdx, rdx
+  .text:0000000001E471B0                 jz      short loc_1E471CD
+  .text:0000000001E471B2                 lea     rdi, xmmword_27BBFC0
+  .text:0000000001E471B9                 mov     rsi, rbx
+  .text:0000000001E471BC                 call    sub_1E7B140
+  .text:0000000001E471C1                 mov     rax, [rbx+10h]
+  .text:0000000001E471C5                 mov     qword ptr [rax+28h], 0
+  .text:0000000001E471CD                 mov     rsi, [rbx+18h]
+  .text:0000000001E471D1                 test    rsi, rsi
+  .text:0000000001E471D4                 jz      short loc_1E471F6
+  .text:0000000001E471D6                 lea     rax, qword_25F5128
+  .text:0000000001E471DD                 mov     rdi, [rax]
+  .text:0000000001E471E0                 test    rdi, rdi
+  .text:0000000001E471E3                 jz      short loc_1E471EE
+  .text:0000000001E471E5                 mov     rax, [rdi]
+  .text:0000000001E471E8                 call    qword ptr [rax+0A8h]
+  .text:0000000001E471EE                 mov     qword ptr [rbx+18h], 0
+  .text:0000000001E471F6                 mov     r12, [rbx+10h]
+  .text:0000000001E471FA                 test    byte ptr [r12+31h], 40h
+  .text:0000000001E47200                 jz      short loc_1E47260
+  .text:0000000001E47202                 mov     r12, [rbx+20h] ; 0x20 = 32 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+  .text:0000000001E47206                 test    r12, r12
+  .text:0000000001E47209                 jz      short loc_1E47233
+  .text:0000000001E4720B                 cmp     byte ptr [r12+24h], 0
+  .text:0000000001E47211                 jnz     short loc_1E47290
+  .text:0000000001E47213                 movzx   eax, word ptr [r12+20h]
+  .text:0000000001E47219                 sub     eax, 1
+  .text:0000000001E4721C                 mov     [r12+20h], ax
+  .text:0000000001E47222                 test    ax, ax
+  .text:0000000001E47225                 jle     loc_1E472E0
+  .text:0000000001E4722B                 mov     qword ptr [rbx+20h], 0 ; 0x20 = 32 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+  .text:0000000001E47233                 lea     rsp, [rbp-18h]
+  .text:0000000001E47237                 pop     rbx
+  .text:0000000001E47238                 pop     r12
+  .text:0000000001E4723A                 pop     r13
+  .text:0000000001E4723C                 pop     rbp
+  .text:0000000001E4723D                 retn
+  .text:0000000001E47240                 mov     r12, [rbx+10h]
+  .text:0000000001E47244                 test    r12, r12
+  .text:0000000001E47247                 jz      short loc_1E471FA
+  .text:0000000001E47249                 mov     rdx, [r12+28h]
+  .text:0000000001E4724E                 test    rdx, rdx
+  .text:0000000001E47251                 jnz     loc_1E471B2
+  .text:0000000001E47257                 jmp     loc_1E471CD
+  .text:0000000001E47260                 lea     rax, qword_27BBC28
+  .text:0000000001E47267                 mov     rsi, r12
+  .text:0000000001E4726A                 mov     rdi, [rax]
+  .text:0000000001E4726D                 call    sub_1E644B0
+  .text:0000000001E47272                 mov     rax, [rbx+10h]
+  .text:0000000001E47276                 mov     rsi, r12
+  .text:0000000001E47279                 mov     rdi, [rax+8]
+  .text:0000000001E4727D                 call    sub_1E3D670
+  .text:0000000001E47282                 jmp     loc_1E47202
+  .text:0000000001E47290                 mov     r13, cs:LOG_GENERAL_ptr
+  .text:0000000001E47297                 ; _QWORD
+  .text:0000000001E47297                 mov     esi, 2; _QWORD
+  .text:0000000001E4729C                 ; _QWORD
+  .text:0000000001E4729C                 mov     edi, [r13+0]; _QWORD
+  .text:0000000001E472A0                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E472A5                 test    al, al
+  .text:0000000001E472A7                 jz      loc_1E47213
+  .text:0000000001E472AD                 movsx   eax, word ptr [r12+20h]
+  .text:0000000001E472B3                 mov     rcx, r12
+  .text:0000000001E472B6                 ; _QWORD
+  .text:0000000001E472B6                 mov     esi, 2; _QWORD
+  .text:0000000001E472BB                 ; _QWORD
+  .text:0000000001E472BB                 mov     edi, [r13+0]; _QWORD
+  .text:0000000001E472BF                 lea     rdx, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:0000000001E472C6                 lea     r8d, [rax-1]
+  .text:0000000001E472CA                 xor     eax, eax
+  .text:0000000001E472CC                 call    _LoggingSystem_Log
+  .text:0000000001E472D1                 jmp     loc_1E47213
+  .text:0000000001E472E0                 mov     rdi, r12
+  .text:0000000001E472E3                 call    sub_1E4EC50
+  .text:0000000001E472E8                 ; _QWORD
+  .text:0000000001E472E8                 mov     esi, 38h ; '8'; _QWORD
+  .text:0000000001E472ED                 ; _QWORD
+  .text:0000000001E472ED                 mov     rdi, r12; _QWORD
+  .text:0000000001E472F0                 call    __ZdlPvm; operator delete(void *,ulong)
+  .text:0000000001E472F5                 jmp     loc_1E4722B
+procedure: |-
+  void __fastcall CEntityInstance_UpdateOnRemove(_QWORD *a1, __int64 a2)
+  {
+    __int64 v3; // rdi
+    __int64 v4; // rdx
+    __int64 v5; // rax
+    __int64 v6; // r12
+    __int64 v7; // r12
+    __int64 v8; // r12
+    __int64 v9; // r12
+    __int16 v10; // ax
+    __int64 v11; // [rsp-8h] [rbp-28h]
+
+    v3 = a1[5];  // 5*8 = 40 = 0x28 = CEntityInstance::m_CScriptComponent (structmember, struct=CEntityInstance, member=m_CScriptComponent)
+    byte_27BB9E9 = 1;
+    if ( v3 )
+    {
+      a2 = (__int64)a1;
+      sub_1E7C710(v3, a1);
+    }
+    v4 = a1[3];
+    if ( v4 )
+    {
+      v5 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, __int64))(*(_QWORD *)qword_25F5128 + 176LL))(
+             qword_25F5128,
+             "UpdateOnRemove",
+             v4,
+             1);
+      v6 = v5;
+      if ( v5 )
+      {
+        (*(void (__fastcall **)(__int64, __int64, _QWORD, _QWORD, _QWORD, _QWORD, __int64))(*(_QWORD *)qword_25F5128
+                                                                                          + 192LL))(
+          qword_25F5128,
+          v5,
+          0,
+          0,
+          0,
+          0,
+          1);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_25F5128 + 184LL))(qword_25F5128, v6);
+        v4 = v11;
+      }
+      v7 = a1[2];
+      if ( !v7 )
+        goto LABEL_9;
+      v4 = *(_QWORD *)(v7 + 40);
+      if ( !v4 )
+        goto LABEL_9;
+      goto LABEL_8;
+    }
+    v8 = a1[2];
+    if ( !v8 )
+      goto LABEL_14;
+    v4 = *(_QWORD *)(v8 + 40);
+    if ( v4 )
+    {
+  LABEL_8:
+      sub_1E7B140(&xmmword_27BBFC0, a1);
+      *(_QWORD *)(a1[2] + 40LL) = 0;
+    }
+  LABEL_9:
+    a2 = a1[3];
+    if ( a2 )
+    {
+      if ( qword_25F5128 )
+        (*(void (__fastcall **)(__int64, __int64, __int64))(*(_QWORD *)qword_25F5128 + 168LL))(qword_25F5128, a2, v4);
+      a1[3] = 0;
+    }
+    v8 = a1[2];
+  LABEL_14:
+    if ( (*(_BYTE *)(v8 + 49) & 0x40) == 0 )
+    {
+      sub_1E644B0(qword_27BBC28, v8, v4);
+      a2 = v8;
+      sub_1E3D670(*(_QWORD *)(a1[2] + 8LL), v8);
+    }
+    v9 = a1[4];  // 4*8 = 32 = 0x20 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+    if ( v9 )
+    {
+      if ( *(_BYTE *)(v9 + 36) )
+      {
+        a2 = 2;
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        {
+          a2 = 2;
+          LoggingSystem_Log(LOG_GENERAL, 2, "kv 0x%p Release refcount == %d\n");
+        }
+      }
+      v10 = *(_WORD *)(v9 + 32) - 1;
+      *(_WORD *)(v9 + 32) = v10;
+      if ( v10 <= 0 )
+      {
+        sub_1E4EC50(v9, a2, v4);
+        operator delete(v9, 56);
+      }
+      a1[4] = 0;  // 4*8 = 32 = 0x20 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityInstance_UpdateOnRemove.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityInstance_UpdateOnRemove.windows.yaml
@@ -1,0 +1,204 @@
+func_name: CEntityInstance_UpdateOnRemove
+func_va: '0x18120e400'
+disasm_code: |-
+  .text:000000018120E400                 mov     [rsp+arg_0], rbx
+  .text:000000018120E405                 mov     [rsp+arg_8], rsi
+  .text:000000018120E40A                 push    rdi
+  .text:000000018120E40B                 sub     rsp, 40h
+  .text:000000018120E40F                 mov     rbx, rcx
+  .text:000000018120E412                 mov     cs:byte_1820B15C8, 1
+  .text:000000018120E419                 ; 0x28 = 40 = CEntityInstance::m_CScriptComponent (structmember, struct=CEntityInstance, member=m_CScriptComponent)
+  .text:000000018120E419                 mov     rcx, [rcx+28h]; 0x28 = 40 = CEntityInstance::m_CScriptComponent (structmember, struct=CEntityInstance, member=m_CScriptComponent)
+  .text:000000018120E41D                 test    rcx, rcx
+  .text:000000018120E420                 jz      short loc_18120E42A
+  .text:000000018120E422                 mov     rdx, rbx
+  .text:000000018120E425                 call    sub_18121BA10
+  .text:000000018120E42A                 mov     r8, [rbx+18h]
+  .text:000000018120E42E                 xor     esi, esi
+  .text:000000018120E430                 test    r8, r8
+  .text:000000018120E433                 jz      short loc_18120E496
+  .text:000000018120E435                 mov     rcx, cs:qword_181E16008
+  .text:000000018120E43C                 lea     rdx, aUpdateonremove; "UpdateOnRemove"
+  .text:000000018120E443                 mov     r9b, 1
+  .text:000000018120E446                 mov     rax, [rcx]
+  .text:000000018120E449                 call    qword ptr [rax+0A8h]
+  .text:000000018120E44F                 mov     rdi, rax
+  .text:000000018120E452                 test    rax, rax
+  .text:000000018120E455                 jz      short loc_18120E496
+  .text:000000018120E457                 mov     rcx, cs:qword_181E16008
+  .text:000000018120E45E                 xor     r9d, r9d
+  .text:000000018120E461                 mov     [rsp+48h+var_18], 1
+  .text:000000018120E466                 xor     r8d, r8d
+  .text:000000018120E469                 mov     [rsp+48h+var_20], rsi
+  .text:000000018120E46E                 mov     [rsp+48h+var_28], rsi
+  .text:000000018120E473                 mov     rdx, [rcx]
+  .text:000000018120E476                 mov     r10, [rdx+0B8h]
+  .text:000000018120E47D                 mov     rdx, rax
+  .text:000000018120E480                 call    r10
+  .text:000000018120E483                 mov     rcx, cs:qword_181E16008
+  .text:000000018120E48A                 mov     rdx, rdi
+  .text:000000018120E48D                 mov     rax, [rcx]
+  .text:000000018120E490                 call    qword ptr [rax+0B0h]
+  .text:000000018120E496                 mov     rdi, [rbx+10h]
+  .text:000000018120E49A                 test    rdi, rdi
+  .text:000000018120E49D                 jz      short loc_18120E4C3
+  .text:000000018120E49F                 mov     r8, [rdi+28h]
+  .text:000000018120E4A3                 test    r8, r8
+  .text:000000018120E4A6                 jz      short loc_18120E4C3
+  .text:000000018120E4A8                 mov     rdx, rbx
+  .text:000000018120E4AB                 lea     rcx, qword_1820B1900
+  .text:000000018120E4B2                 call    sub_181219C10
+  .text:000000018120E4B7                 mov     rax, [rbx+10h]
+  .text:000000018120E4BB                 mov     [rax+28h], rsi
+  .text:000000018120E4BF                 mov     rdi, [rbx+10h]
+  .text:000000018120E4C3                 mov     rdx, [rbx+18h]
+  .text:000000018120E4C7                 test    rdx, rdx
+  .text:000000018120E4CA                 jz      short loc_18120E4E9
+  .text:000000018120E4CC                 mov     rcx, cs:qword_181E16008
+  .text:000000018120E4D3                 test    rcx, rcx
+  .text:000000018120E4D6                 jz      short loc_18120E4E5
+  .text:000000018120E4D8                 mov     rax, [rcx]
+  .text:000000018120E4DB                 call    qword ptr [rax+0A0h]
+  .text:000000018120E4E1                 mov     rdi, [rbx+10h]
+  .text:000000018120E4E5                 mov     [rbx+18h], rsi
+  .text:000000018120E4E9                 mov     eax, [rdi+30h]
+  .text:000000018120E4EC                 shr     eax, 0Eh
+  .text:000000018120E4EF                 test    al, 1
+  .text:000000018120E4F1                 jnz     short loc_18120E512
+  .text:000000018120E4F3                 mov     rcx, cs:qword_1820B1418
+  .text:000000018120E4FA                 mov     rdx, rdi
+  .text:000000018120E4FD                 call    sub_1811F5B20
+  .text:000000018120E502                 mov     rcx, [rbx+10h]
+  .text:000000018120E506                 mov     rdx, rdi
+  .text:000000018120E509                 mov     rcx, [rcx+8]
+  .text:000000018120E50D                 call    sub_1811E0380
+  .text:000000018120E512                 ; 0x20 = 32 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+  .text:000000018120E512                 mov     rdi, [rbx+20h]; 0x20 = 32 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+  .text:000000018120E516                 test    rdi, rdi
+  .text:000000018120E519                 jz      short loc_18120E584
+  .text:000000018120E51B                 cmp     [rdi+24h], sil
+  .text:000000018120E51F                 jz      short loc_18120E561
+  .text:000000018120E521                 mov     rcx, cs:LOG_GENERAL
+  .text:000000018120E528                 mov     edx, 2
+  .text:000000018120E52D                 mov     ecx, [rcx]
+  .text:000000018120E52F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018120E535                 test    al, al
+  .text:000000018120E537                 jz      short loc_18120E561
+  .text:000000018120E539                 mov     rcx, cs:LOG_GENERAL
+  .text:000000018120E540                 lea     r8, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:000000018120E547                 movsx   eax, word ptr [rdi+20h]
+  .text:000000018120E54B                 mov     r9, rdi
+  .text:000000018120E54E                 dec     eax
+  .text:000000018120E550                 mov     edx, 2
+  .text:000000018120E555                 mov     dword ptr [rsp+48h+var_28], eax
+  .text:000000018120E559                 mov     ecx, [rcx]
+  .text:000000018120E55B                 call    cs:LoggingSystem_Log
+  .text:000000018120E561                 dec     word ptr [rdi+20h]
+  .text:000000018120E565                 cmp     [rdi+20h], si
+  .text:000000018120E569                 jg      short loc_18120E580
+  .text:000000018120E56B                 mov     rcx, rdi
+  .text:000000018120E56E                 call    sub_1811FF380
+  .text:000000018120E573                 mov     edx, 38h ; '8'
+  .text:000000018120E578                 mov     rcx, rdi
+  .text:000000018120E57B                 call    sub_180E77290
+  .text:000000018120E580                 mov     [rbx+20h], rsi
+  .text:000000018120E584                 mov     rbx, [rsp+48h+arg_0]
+  .text:000000018120E589                 mov     rsi, [rsp+48h+arg_8]
+  .text:000000018120E58E                 add     rsp, 40h
+  .text:000000018120E592                 pop     rdi
+  .text:000000018120E593                 retn
+procedure: |-
+  __int64 __fastcall CEntityInstance_UpdateOnRemove(__int64 a1, __int64 a2, __int64 a3, __int64 a4)
+  {
+    __int64 v5; // rcx
+    __int64 v6; // r8
+    __int64 v7; // rax
+    __int64 v8; // rdi
+    __int64 v9; // rdi
+    __int64 v10; // rdx
+    __int64 result; // rax
+    __int64 v12; // rdi
+    char v13; // [rsp+30h] [rbp-18h]
+
+    byte_1820B15C8 = 1;
+    v5 = *(_QWORD *)(a1 + 40);                    // 0x28 = 40 = CEntityInstance::m_CScriptComponent (structmember, struct=CEntityInstance, member=m_CScriptComponent)
+    if ( v5 )
+      sub_18121BA10(v5, a1);
+    v6 = *(_QWORD *)(a1 + 24);
+    if ( v6 )
+    {
+      LOBYTE(a4) = 1;
+      v7 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, __int64))(*(_QWORD *)qword_181E16008 + 168LL))(
+             qword_181E16008,
+             "UpdateOnRemove",
+             v6,
+             a4);
+      v8 = v7;
+      if ( v7 )
+      {
+        v13 = 1;
+        (*(void (__fastcall **)(__int64, __int64, _QWORD, _QWORD, _QWORD, _QWORD, char))(*(_QWORD *)qword_181E16008 + 184LL))(
+          qword_181E16008,
+          v7,
+          0,
+          0,
+          0,
+          0,
+          v13);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_181E16008 + 176LL))(qword_181E16008, v8);
+      }
+    }
+    v9 = *(_QWORD *)(a1 + 16);
+    if ( v9 )
+    {
+      v6 = *(_QWORD *)(v9 + 40);
+      if ( v6 )
+      {
+        sub_181219C10(&qword_1820B1900, a1);
+        *(_QWORD *)(*(_QWORD *)(a1 + 16) + 40LL) = 0;
+        v9 = *(_QWORD *)(a1 + 16);
+      }
+    }
+    v10 = *(_QWORD *)(a1 + 24);
+    if ( v10 )
+    {
+      if ( qword_181E16008 )
+      {
+        (*(void (__fastcall **)(__int64, __int64, __int64, __int64))(*(_QWORD *)qword_181E16008 + 160LL))(
+          qword_181E16008,
+          v10,
+          v6,
+          a4);
+        v9 = *(_QWORD *)(a1 + 16);
+      }
+      *(_QWORD *)(a1 + 24) = 0;
+    }
+    result = *(_DWORD *)(v9 + 48) >> 14;
+    if ( (*(_DWORD *)(v9 + 48) & 0x4000) == 0 )
+    {
+      sub_1811F5B20(qword_1820B1418, v9);
+      result = sub_1811E0380(*(_QWORD *)(*(_QWORD *)(a1 + 16) + 8LL), v9);
+    }
+    v12 = *(_QWORD *)(a1 + 32);                   // 0x20 = 32 = CEntityInstance::m_pKeyValues (structmember, struct=CEntityInstance, member=m_pKeyValues)
+    if ( v12 )
+    {
+      if ( *(_BYTE *)(v12 + 36) )
+      {
+        result = LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2);
+        if ( (_BYTE)result )
+          result = LoggingSystem_Log(
+                     LOG_GENERAL,
+                     2,
+                     "kv 0x%p Release refcount == %d\n",
+                     (const void *)v12,
+                     *(__int16 *)(v12 + 32) - 1);
+      }
+      if ( (__int16)--*(_WORD *)(v12 + 32) <= 0 )
+      {
+        sub_1811FF380(v12);
+        result = sub_180E77290(v12, 56);
+      }
+      *(_QWORD *)(a1 + 32) = 0;
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary

- Locate `CEntityInstance::m_CScriptComponent` (offset `0x28`) and `CEntityInstance::m_pKeyValues` (offset `0x20`) struct member offsets via LLM_DECOMPILE on `CEntityInstance_UpdateOnRemove`.
- Adds annotated reference YAMLs for both platforms (`references/server/CEntityInstance_UpdateOnRemove.{linux,windows}.yaml`).
- Adds `structmember` symbol entries next to the existing `m_pEntity` / `m_hPrivateScope` entries.

Mirrors the pattern from #363 (`m_pEntity-AND-m_hPrivateScope`).

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` produces `CEntityInstance_m_CScriptComponent.{platform}.yaml` and `CEntityInstance_m_pKeyValues.{platform}.yaml` for both windows and linux
- [ ] Output offsets: `m_CScriptComponent = 0x28`, `m_pKeyValues = 0x20`