### PR TITLE
Add find-CEntityInstance_ScriptAcceptInput (Windows + Linux)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2588,6 +2588,14 @@ modules:
         expected_input:
           - CEntityInstance_AcceptInput.{platform}.yaml
 
+      - name: find-CEntityInstance_ScriptAcceptInput-windows
+        platform: windows
+        expected_output:
+          - CEntityInstance_ScriptAcceptInput.{platform}.yaml
+        expected_input:
+          - CEntityIdentity_AcceptInput.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CEntityIdentity_SetEntityName
         expected_output:
           - CEntityIdentity_SetEntityName.{platform}.yaml
@@ -4860,6 +4868,11 @@ modules:
         category: func
         alias:
           - CEntityIdentity::AcceptInput
+
+      - name: CEntityInstance_ScriptAcceptInput
+        category: vfunc
+        alias:
+          - CEntityInstance::ScriptAcceptInput
 
       - name: CEntityIdentity_SetEntityName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2596,6 +2596,21 @@ modules:
           - CEntityIdentity_AcceptInput.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CEntityIdentity_AcceptInputInternal
+        platform: linux
+        expected_output:
+          - CEntityIdentity_AcceptInputInternal.{platform}.yaml
+        expected_input:
+          - CEntityIdentity_AcceptInput.{platform}.yaml
+
+      - name: find-CEntityInstance_ScriptAcceptInput-linux
+        platform: linux
+        expected_output:
+          - CEntityInstance_ScriptAcceptInput.{platform}.yaml
+        expected_input:
+          - CEntityIdentity_AcceptInputInternal.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CEntityIdentity_SetEntityName
         expected_output:
           - CEntityIdentity_SetEntityName.{platform}.yaml
@@ -4868,6 +4883,11 @@ modules:
         category: func
         alias:
           - CEntityIdentity::AcceptInput
+
+      - name: CEntityIdentity_AcceptInputInternal
+        category: func
+        alias:
+          - CEntityIdentity::AcceptInputInternal
 
       - name: CEntityInstance_ScriptAcceptInput
         category: vfunc

--- a/ida_preprocessor_scripts/find-CEntityIdentity_AcceptInputInternal.py
+++ b/ida_preprocessor_scripts/find-CEntityIdentity_AcceptInputInternal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityIdentity_AcceptInputInternal skill.
+
+CEntityIdentity_AcceptInputInternal only exists on Linux; on Windows it is
+inlined into CEntityIdentity_AcceptInput. Discovered via LLM_DECOMPILE on
+CEntityIdentity_AcceptInput, which tail-jumps to AcceptInputInternal after
+the early-exit hierarchy lookup.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityIdentity_AcceptInputInternal",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityIdentity_AcceptInputInternal",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityIdentity_AcceptInput.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityIdentity_AcceptInputInternal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_ScriptAcceptInput-linux.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_ScriptAcceptInput-linux.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_ScriptAcceptInput-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_ScriptAcceptInput",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_ScriptAcceptInput",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityIdentity_AcceptInputInternal.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_ScriptAcceptInput", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_ScriptAcceptInput",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_ScriptAcceptInput-windows.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_ScriptAcceptInput-windows.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_ScriptAcceptInput-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_ScriptAcceptInput",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_ScriptAcceptInput",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityIdentity_AcceptInput.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_ScriptAcceptInput", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_ScriptAcceptInput",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInput.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInput.linux.yaml
@@ -1,0 +1,90 @@
+func_name: CEntityIdentity_AcceptInput
+func_va: '0x1e45640'
+disasm_code: |-
+  .text:0000000001E45640                 push    rbp
+  .text:0000000001E45641                 mov     r11, rdx
+  .text:0000000001E45644                 mov     rbp, rsp
+  .text:0000000001E45647                 push    r15
+  .text:0000000001E45649                 mov     r15d, r9d
+  .text:0000000001E4564C                 push    r14
+  .text:0000000001E4564E                 push    r13
+  .text:0000000001E45650                 push    r12
+  .text:0000000001E45652                 mov     r12, rsi
+  .text:0000000001E45655                 push    rbx
+  .text:0000000001E45656                 mov     rbx, rdi
+  .text:0000000001E45659                 sub     rsp, 40h
+  .text:0000000001E4565D                 mov     rax, [rsi]
+  .text:0000000001E45660                 mov     [rbp+var_48], rdx
+  .text:0000000001E45664                 mov     r13, [rbp+arg_0]
+  .text:0000000001E45668                 mov     [rbp+var_50], rcx
+  .text:0000000001E4566C                 lea     rdx, [rbp+var_38]
+  .text:0000000001E45670                 mov     r14, [rbp+arg_8]
+  .text:0000000001E45674                 mov     [rbp+var_58], r8
+  .text:0000000001E45678                 mov     rdi, [rdi+8]
+  .text:0000000001E4567C                 mov     rsi, [rbx]
+  .text:0000000001E4567F                 mov     [rbp+var_38], rax
+  .text:0000000001E45683                 push    r14
+  .text:0000000001E45685                 push    r13
+  .text:0000000001E45687                 push    r9
+  .text:0000000001E45689                 mov     r9, r8
+  .text:0000000001E4568C                 mov     r8, rcx
+  .text:0000000001E4568F                 mov     rcx, r11
+  .text:0000000001E45692                 call    sub_1E3DAA0
+  .text:0000000001E45697                 add     rsp, 20h
+  .text:0000000001E4569B                 test    eax, eax
+  .text:0000000001E4569D                 jnz     short loc_1E456D0
+  .text:0000000001E4569F                 mov     [rbp+arg_8], r14
+  .text:0000000001E456A3                 mov     r8, [rbp+var_58]
+  .text:0000000001E456A7                 mov     r9d, r15d
+  .text:0000000001E456AA                 mov     rsi, r12
+  .text:0000000001E456AD                 mov     [rbp+arg_0], r13
+  .text:0000000001E456B1                 mov     rcx, [rbp+var_50]
+  .text:0000000001E456B5                 mov     rdi, rbx
+  .text:0000000001E456B8                 mov     rdx, [rbp+var_48]
+  .text:0000000001E456BC                 lea     rsp, [rbp-28h]
+  .text:0000000001E456C0                 pop     rbx
+  .text:0000000001E456C1                 pop     r12
+  .text:0000000001E456C3                 pop     r13
+  .text:0000000001E456C5                 pop     r14
+  .text:0000000001E456C7                 pop     r15
+  .text:0000000001E456C9                 pop     rbp
+  .text:0000000001E456CA                 jmp     CEntityIdentity_AcceptInputInternal
+  .text:0000000001E456D0                 cmp     eax, 2
+  .text:0000000001E456D3                 setz    al
+  .text:0000000001E456D6                 lea     rsp, [rbp-28h]
+  .text:0000000001E456DA                 pop     rbx
+  .text:0000000001E456DB                 pop     r12
+  .text:0000000001E456DD                 pop     r13
+  .text:0000000001E456DF                 pop     r14
+  .text:0000000001E456E1                 pop     r15
+  .text:0000000001E456E3                 pop     rbp
+  .text:0000000001E456E4                 retn
+procedure: |-
+  char __fastcall CEntityIdentity_AcceptInput(
+          __int64 *a1,
+          __int64 *a2,
+          int a3,
+          int a4,
+          int a5,
+          int a6,
+          __int64 a7,
+          __int64 a8)
+  {
+    int v9; // r12d
+    __int64 v11; // rax
+    __int64 v12; // rdi
+    __int64 v13; // rsi
+    int v14; // eax
+    __int64 v19; // [rsp+30h] [rbp-38h] BYREF
+
+    v9 = (int)a2;
+    v11 = *a2;
+    v12 = a1[1];
+    v13 = *a1;
+    v19 = v11;
+    v14 = sub_1E3DAA0(v12, v13, (unsigned int)&v19, a3, a4, a5, a6, a7, a8);
+    if ( v14 )
+      return v14 == 2;
+    else
+      return CEntityIdentity_AcceptInputInternal((_DWORD)a1, v9, a3, a4, a5, a6, a7, a8);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInput.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInput.windows.yaml
@@ -1,0 +1,494 @@
+func_name: CEntityIdentity_AcceptInput
+func_va: '0x18120f580'
+disasm_code: |-
+  .text:000000018120F580                 mov     [rsp-8+arg_10], rbx
+  .text:000000018120F585                 mov     [rsp-8+arg_8], rdx
+  .text:000000018120F58A                 mov     [rsp-8+arg_0], rcx
+  .text:000000018120F58F                 push    rbp
+  .text:000000018120F590                 push    rsi
+  .text:000000018120F591                 push    rdi
+  .text:000000018120F592                 push    r12
+  .text:000000018120F594                 push    r13
+  .text:000000018120F596                 push    r14
+  .text:000000018120F598                 push    r15
+  .text:000000018120F59A                 lea     rbp, [rsp-90h]
+  .text:000000018120F5A2                 sub     rsp, 190h
+  .text:000000018120F5A9                 mov     rax, [rdx]
+  .text:000000018120F5AC                 mov     r13, r9
+  .text:000000018120F5AF                 mov     r9, [rbp+0C0h+arg_20]
+  .text:000000018120F5B6                 mov     r14, rdx
+  .text:000000018120F5B9                 mov     rdx, [rcx]
+  .text:000000018120F5BC                 mov     r15, r8
+  .text:000000018120F5BF                 mov     rdi, [rbp+0C0h+arg_38]
+  .text:000000018120F5C6                 mov     rbx, rcx
+  .text:000000018120F5C9                 mov     rsi, [rbp+0C0h+arg_30]
+  .text:000000018120F5D0                 mov     r12d, [rbp+0C0h+arg_28]
+  .text:000000018120F5D7                 mov     rcx, [rcx+8]
+  .text:000000018120F5DB                 mov     [rsp+1C0h+var_180], rdi
+  .text:000000018120F5E0                 mov     [rsp+1C0h+var_188], rsi
+  .text:000000018120F5E5                 mov     dword ptr [rsp+1C0h+var_190], r12d
+  .text:000000018120F5EA                 mov     [rsp+1C0h+var_198], r9
+  .text:000000018120F5EF                 mov     r9, r8
+  .text:000000018120F5F2                 lea     r8, [rsp+1C0h+var_150]
+  .text:000000018120F5F7                 mov     [rsp+1C0h+var_150], rax
+  .text:000000018120F5FC                 mov     [rsp+1C0h+var_1A0], r13
+  .text:000000018120F601                 call    sub_1811DD410
+  .text:000000018120F606                 test    eax, eax
+  .text:000000018120F608                 jz      short loc_18120F615
+  .text:000000018120F60A                 cmp     eax, 2
+  .text:000000018120F60D                 setz    al
+  .text:000000018120F610                 jmp     loc_18120F9E2
+  .text:000000018120F615                 mov     rcx, [rbx]
+  .text:000000018120F618                 lea     rdx, [rsp+1C0h+var_150]
+  .text:000000018120F61D                 mov     [rsp+1C0h+var_188], rdi
+  .text:000000018120F622                 mov     r9, r13
+  .text:000000018120F625                 mov     [rsp+1C0h+var_190], rsi
+  .text:000000018120F62A                 mov     r8, r15
+  .text:000000018120F62D                 mov     dword ptr [rsp+1C0h+var_198], r12d
+  .text:000000018120F632                 mov     rax, [rcx]
+  .text:000000018120F635                 ; 0x88 = 136LL = CEntityInstance_ScriptAcceptInput
+  .text:000000018120F635                 mov     r10, [rax+88h]; 0x88 = 136LL = CEntityInstance_ScriptAcceptInput
+  .text:000000018120F63C                 mov     rax, [r14]
+  .text:000000018120F63F                 mov     [rsp+1C0h+var_150], rax
+  .text:000000018120F644                 mov     rax, [rbp+0C0h+arg_20]
+  .text:000000018120F64B                 mov     [rsp+1C0h+var_1A0], rax
+  .text:000000018120F650                 call    r10
+  .text:000000018120F653                 test    eax, eax
+  .text:000000018120F655                 jnz     short loc_18120F60A
+  .text:000000018120F657                 mov     r8, [rbx]
+  .text:000000018120F65A                 test    r8, r8
+  .text:000000018120F65D                 jnz     short loc_18120F66F
+  .text:000000018120F65F                 mov     rax, [r8+18h]
+  .text:000000018120F663                 xor     ebx, ebx
+  .text:000000018120F665                 mov     r14d, ebx
+  .text:000000018120F668                 mov     [rsp+1C0h+var_150], rax
+  .text:000000018120F66D                 jmp     short loc_18120F6A8
+  .text:000000018120F66F                 mov     rax, [rbx+8]
+  .text:000000018120F673                 xor     ebx, ebx
+  .text:000000018120F675                 movsxd  rdx, cs:dword_181CADFE0
+  .text:000000018120F67C                 mov     rcx, [rax+80h]
+  .text:000000018120F683                 movzx   eax, word ptr [rcx+rdx*2]
+  .text:000000018120F687                 mov     ecx, 0FFFFh
+  .text:000000018120F68C                 cmp     ax, cx
+  .text:000000018120F68F                 jz      short loc_18120F697
+  .text:000000018120F691                 mov     r14, [rax+r8]
+  .text:000000018120F695                 jmp     short loc_18120F69A
+  .text:000000018120F697                 mov     r14, rbx
+  .text:000000018120F69A                 mov     rax, [r8+18h]
+  .text:000000018120F69E                 mov     [rsp+1C0h+var_150], rax
+  .text:000000018120F6A3                 test    r14, r14
+  .text:000000018120F6A6                 jnz     short loc_18120F6B1
+  .text:000000018120F6A8                 test    rax, rax
+  .text:000000018120F6AB                 jz      loc_18120F9E2
+  .text:000000018120F6B1                 mov     rdi, cs:qword_181E16008
+  .text:000000018120F6B8                 lea     rdx, [rsp+1C0h+var_148]
+  .text:000000018120F6BD                 mov     [rbp+0C0h+var_13E], bx
+  .text:000000018120F6C1                 xor     sil, sil
+  .text:000000018120F6C4                 mov     [rbp+0C0h+var_140], sil
+  .text:000000018120F6C8                 mov     rcx, rdi
+  .text:000000018120F6CB                 mov     [rsp+1C0h+var_148], rbx
+  .text:000000018120F6D0                 mov     rax, [rdi]
+  .text:000000018120F6D3                 call    qword ptr [rax+120h]
+  .text:000000018120F6D9                 mov     rax, [rdi]
+  .text:000000018120F6DC                 mov     r12, [rsp+1C0h+var_148]
+  .text:000000018120F6E1                 mov     r10, [rax+108h]
+  .text:000000018120F6E8                 mov     [rsp+1C0h+var_160], r10
+  .text:000000018120F6ED                 test    r15, r15
+  .text:000000018120F6F0                 jz      short loc_18120F716
+  .text:000000018120F6F2                 mov     rax, [r15+10h]
+  .text:000000018120F6F6                 cmp     qword ptr [rax+28h], 0
+  .text:000000018120F6FB                 jnz     short loc_18120F70C
+  .text:000000018120F6FD                 xor     edx, edx
+  .text:000000018120F6FF                 mov     rcx, r15
+  .text:000000018120F702                 call    sub_18120C0D0
+  .text:000000018120F707                 mov     r10, [rsp+1C0h+var_160]
+  .text:000000018120F70C                 mov     rax, [r15+10h]
+  .text:000000018120F710                 mov     rcx, [rax+28h]
+  .text:000000018120F714                 jmp     short loc_18120F719
+  .text:000000018120F716                 mov     rcx, rbx
+  .text:000000018120F719                 mov     [rsp+1C0h+var_170], rcx
+  .text:000000018120F71E                 lea     r9, [rsp+1C0h+var_170]
+  .text:000000018120F723                 mov     rcx, rdi
+  .text:000000018120F726                 mov     [rsp+1C0h+var_168], 1Fh
+  .text:000000018120F72B                 lea     r8, aActivator; "activator"
+  .text:000000018120F732                 mov     [rsp+1C0h+var_166], bx
+  .text:000000018120F737                 mov     rdx, r12
+  .text:000000018120F73A                 call    r10
+  .text:000000018120F73D                 test    byte ptr [rsp+1C0h+var_166], 1
+  .text:000000018120F742                 jz      short loc_18120F759
+  .text:000000018120F744                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120F74B                 mov     rdx, [rsp+1C0h+var_170]
+  .text:000000018120F750                 mov     rcx, [rax]
+  .text:000000018120F753                 mov     rax, [rcx]
+  .text:000000018120F756                 call    qword ptr [rax+18h]
+  .text:000000018120F759                 mov     rax, [rdi]
+  .text:000000018120F75C                 mov     r15, [rax+108h]
+  .text:000000018120F763                 test    r13, r13
+  .text:000000018120F766                 jz      short loc_18120F787
+  .text:000000018120F768                 mov     rax, [r13+10h]
+  .text:000000018120F76C                 cmp     qword ptr [rax+28h], 0
+  .text:000000018120F771                 jnz     short loc_18120F77D
+  .text:000000018120F773                 xor     edx, edx
+  .text:000000018120F775                 mov     rcx, r13
+  .text:000000018120F778                 call    sub_18120C0D0
+  .text:000000018120F77D                 mov     rax, [r13+10h]
+  .text:000000018120F781                 mov     rcx, [rax+28h]
+  .text:000000018120F785                 jmp     short loc_18120F78A
+  .text:000000018120F787                 mov     rcx, rbx
+  .text:000000018120F78A                 mov     [rsp+1C0h+var_170], rcx
+  .text:000000018120F78F                 lea     r9, [rsp+1C0h+var_170]
+  .text:000000018120F794                 mov     rcx, rdi
+  .text:000000018120F797                 mov     [rsp+1C0h+var_168], 1Fh
+  .text:000000018120F79C                 lea     r8, aCaller; "caller"
+  .text:000000018120F7A3                 mov     [rsp+1C0h+var_166], bx
+  .text:000000018120F7A8                 mov     rdx, r12
+  .text:000000018120F7AB                 call    r15
+  .text:000000018120F7AE                 test    byte ptr [rsp+1C0h+var_166], 1
+  .text:000000018120F7B3                 jz      short loc_18120F7CA
+  .text:000000018120F7B5                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120F7BC                 mov     rdx, [rsp+1C0h+var_170]
+  .text:000000018120F7C1                 mov     rcx, [rax]
+  .text:000000018120F7C4                 mov     rax, [rcx]
+  .text:000000018120F7C7                 call    qword ptr [rax+18h]
+  .text:000000018120F7CA                 mov     rax, [rdi]
+  .text:000000018120F7CD                 lea     r8, aValue; "value"
+  .text:000000018120F7D4                 mov     r9, [rbp+0C0h+arg_20]
+  .text:000000018120F7DB                 mov     rdx, r12
+  .text:000000018120F7DE                 mov     rcx, rdi
+  .text:000000018120F7E1                 call    qword ptr [rax+108h]
+  .text:000000018120F7E7                 mov     eax, [rbp+0C0h+arg_28]
+  .text:000000018120F7ED                 lea     r9, [rsp+1C0h+var_170]
+  .text:000000018120F7F2                 mov     dword ptr [rsp+1C0h+var_170], eax
+  .text:000000018120F7F6                 lea     r8, aOutputid; "outputid"
+  .text:000000018120F7FD                 mov     rax, [rdi]
+  .text:000000018120F800                 mov     rdx, r12
+  .text:000000018120F803                 mov     rcx, rdi
+  .text:000000018120F806                 mov     [rsp+1C0h+var_168], 5
+  .text:000000018120F80B                 mov     [rsp+1C0h+var_166], bx
+  .text:000000018120F810                 call    qword ptr [rax+108h]
+  .text:000000018120F816                 test    byte ptr [rsp+1C0h+var_166], 1
+  .text:000000018120F81B                 jz      short loc_18120F832
+  .text:000000018120F81D                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120F824                 mov     rdx, [rsp+1C0h+var_170]
+  .text:000000018120F829                 mov     rcx, [rax]
+  .text:000000018120F82C                 mov     rax, [rcx]
+  .text:000000018120F82F                 call    qword ptr [rax+18h]
+  .text:000000018120F832                 mov     r15, [rbp+0C0h+arg_8]
+  .text:000000018120F839                 mov     r13d, 1
+  .text:000000018120F83F                 test    r14, r14
+  .text:000000018120F842                 jz      short loc_18120F86A
+  .text:000000018120F844                 mov     rax, [r15]
+  .text:000000018120F847                 lea     rdx, [rbp+0C0h+arg_8]
+  .text:000000018120F84E                 mov     r8, r12
+  .text:000000018120F851                 mov     [rbp+0C0h+arg_8], rax
+  .text:000000018120F858                 mov     rcx, r14
+  .text:000000018120F85B                 call    sub_181218D20
+  .text:000000018120F860                 test    al, al
+  .text:000000018120F862                 movzx   esi, sil
+  .text:000000018120F866                 cmovnz  esi, r13d
+  .text:000000018120F86A                 cmp     [rsp+1C0h+var_150], 0
+  .text:000000018120F870                 jz      loc_18120F9B2
+  .text:000000018120F876                 mov     r8d, 0FFh
+  .text:000000018120F87C                 lea     rdx, aInput_0; "Input"
+  .text:000000018120F883                 lea     rcx, [rbp+0C0h+var_130]
+  .text:000000018120F887                 call    cs:_V_strncpy
+  .text:000000018120F88D                 mov     rax, [r15]
+  .text:000000018120F890                 lea     rdx, byte_18159B988
+  .text:000000018120F897                 test    rax, rax
+  .text:000000018120F89A                 lea     rcx, [rbp+0C0h+var_130]
+  .text:000000018120F89E                 mov     r9d, 0FFFFFFFFh
+  .text:000000018120F8A4                 mov     r8d, 0FFh
+  .text:000000018120F8AA                 cmovnz  rdx, rax
+  .text:000000018120F8AE                 call    cs:_V_strncat
+  .text:000000018120F8B4                 mov     rcx, cs:qword_181E16008
+  .text:000000018120F8BB                 lea     rdx, [rbp+0C0h+var_130]
+  .text:000000018120F8BF                 mov     r8, [rbp+0C0h+arg_0]
+  .text:000000018120F8C6                 movzx   r9d, r13b
+  .text:000000018120F8CA                 mov     [rsp+1C0h+var_168], 0
+  .text:000000018120F8CF                 mov     [rsp+1C0h+var_166], bx
+  .text:000000018120F8D4                 mov     [rsp+1C0h+var_170], rbx
+  .text:000000018120F8D9                 mov     r8, [r8]
+  .text:000000018120F8DC                 mov     [rsp+1C0h+var_156], bx
+  .text:000000018120F8E1                 mov     [rsp+1C0h+var_158], 1Fh
+  .text:000000018120F8E6                 mov     [rsp+1C0h+var_160], r12
+  .text:000000018120F8EB                 mov     rax, [rcx]
+  .text:000000018120F8EE                 mov     r8, [r8+18h]
+  .text:000000018120F8F2                 call    qword ptr [rax+0A8h]
+  .text:000000018120F8F8                 mov     r15, rax
+  .text:000000018120F8FB                 test    rax, rax
+  .text:000000018120F8FE                 jnz     short loc_18120F922
+  .text:000000018120F900                 test    byte ptr [rsp+1C0h+var_156], r13b
+  .text:000000018120F905                 jz      loc_18120F991
+  .text:000000018120F90B                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120F912                 mov     rdx, [rsp+1C0h+var_160]
+  .text:000000018120F917                 mov     rcx, [rax]
+  .text:000000018120F91A                 mov     rax, [rcx]
+  .text:000000018120F91D                 call    qword ptr [rax+18h]
+  .text:000000018120F920                 jmp     short loc_18120F991
+  .text:000000018120F922                 mov     rcx, cs:qword_181E16008
+  .text:000000018120F929                 lea     rdx, [rsp+1C0h+var_170]
+  .text:000000018120F92E                 mov     byte ptr [rsp+1C0h+var_190], r13b
+  .text:000000018120F933                 lea     r8, [rsp+1C0h+var_160]
+  .text:000000018120F938                 mov     [rsp+1C0h+var_198], rbx
+  .text:000000018120F93D                 mov     r9d, r13d
+  .text:000000018120F940                 mov     [rsp+1C0h+var_1A0], rdx
+  .text:000000018120F945                 mov     rdx, r15
+  .text:000000018120F948                 mov     rax, [rcx]
+  .text:000000018120F94B                 call    qword ptr [rax+0B8h]
+  .text:000000018120F951                 mov     rcx, cs:qword_181E16008
+  .text:000000018120F958                 mov     rdx, r15
+  .text:000000018120F95B                 mov     r14d, eax
+  .text:000000018120F95E                 mov     r8, [rcx]
+  .text:000000018120F961                 call    qword ptr [r8+0B0h]
+  .text:000000018120F968                 test    byte ptr [rsp+1C0h+var_156], r13b
+  .text:000000018120F96D                 jz      short loc_18120F985
+  .text:000000018120F96F                 mov     rcx, cs:g_pMemAlloc
+  .text:000000018120F976                 mov     rdx, [rsp+1C0h+var_160]
+  .text:000000018120F97B                 mov     rcx, [rcx]
+  .text:000000018120F97E                 mov     r8, [rcx]
+  .text:000000018120F981                 call    qword ptr [r8+18h]
+  .text:000000018120F985                 cmp     r14d, 0FFFFFFFFh
+  .text:000000018120F989                 movzx   esi, sil
+  .text:000000018120F98D                 cmovnz  esi, r13d
+  .text:000000018120F991                 mov     [rsp+1C0h+var_158], 0
+  .text:000000018120F996                 test    byte ptr [rsp+1C0h+var_166], r13b
+  .text:000000018120F99B                 jz      short loc_18120F9B2
+  .text:000000018120F99D                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120F9A4                 mov     rdx, [rsp+1C0h+var_170]
+  .text:000000018120F9A9                 mov     rcx, [rax]
+  .text:000000018120F9AC                 mov     rax, [rcx]
+  .text:000000018120F9AF                 call    qword ptr [rax+18h]
+  .text:000000018120F9B2                 mov     r8, [rdi]
+  .text:000000018120F9B5                 mov     rdx, r12
+  .text:000000018120F9B8                 mov     rcx, rdi
+  .text:000000018120F9BB                 call    qword ptr [r8+0A0h]
+  .text:000000018120F9C2                 test    byte ptr [rbp+0C0h+var_13E], r13b
+  .text:000000018120F9C6                 jz      short loc_18120F9DE
+  .text:000000018120F9C8                 mov     rcx, cs:g_pMemAlloc
+  .text:000000018120F9CF                 mov     rdx, [rsp+1C0h+var_148]
+  .text:000000018120F9D4                 mov     rcx, [rcx]
+  .text:000000018120F9D7                 mov     r8, [rcx]
+  .text:000000018120F9DA                 call    qword ptr [r8+18h]
+  .text:000000018120F9DE                 movzx   eax, sil
+  .text:000000018120F9E2                 mov     rbx, [rsp+1C0h+arg_10]
+  .text:000000018120F9EA                 add     rsp, 190h
+  .text:000000018120F9F1                 pop     r15
+  .text:000000018120F9F3                 pop     r14
+  .text:000000018120F9F5                 pop     r13
+  .text:000000018120F9F7                 pop     r12
+  .text:000000018120F9F9                 pop     rdi
+  .text:000000018120F9FA                 pop     rsi
+  .text:000000018120F9FB                 pop     rbp
+  .text:000000018120F9FC                 retn
+procedure: |-
+  char __fastcall CEntityIdentity_AcceptInput(
+          _QWORD *a1,
+          void **a2,
+          __int64 a3,
+          __int64 a4,
+          __int64 a5,
+          int a6,
+          __int64 a7,
+          __int64 a8)
+  {
+    void *v8; // rax
+    __int64 v11; // rdx
+    __int64 v13; // rdi
+    __int64 v15; // rsi
+    int v16; // r12d
+    __int64 v17; // rcx
+    void *v18; // rax
+    __int64 v19; // rcx
+    __int64 (__fastcall *v20)(__int64, void **, __int64, __int64, __int64, int, __int64, __int64); // r10
+    __int64 v21; // r8
+    __int64 v22; // r14
+    __int64 v23; // rax
+    __int64 v24; // rdi
+    bool v25; // si
+    void (__fastcall *v26)(_QWORD, _QWORD, _QWORD, _QWORD); // r12
+    void (__fastcall *v27)(_QWORD, _QWORD, _QWORD, _QWORD); // r10
+    __int64 v28; // rcx
+    void (__fastcall *v29)(__int64, _QWORD, const char *, __int64 *); // r15
+    __int64 v30; // rcx
+    __int64 v31; // rax
+    char **v32; // r15
+    char *v33; // rdx
+    __int64 v34; // r8
+    __int64 v35; // rax
+    __int64 v36; // r15
+    int v37; // r14d
+    int v39; // [rsp+30h] [rbp-D0h]
+    __int64 v40; // [rsp+50h] [rbp-B0h] BYREF
+    char v41; // [rsp+58h] [rbp-A8h]
+    __int16 v42; // [rsp+5Ah] [rbp-A6h]
+    void (__fastcall *v43)(_QWORD, _QWORD, _QWORD, _QWORD); // [rsp+60h] [rbp-A0h] BYREF
+    char v44; // [rsp+68h] [rbp-98h]
+    __int16 v45; // [rsp+6Ah] [rbp-96h]
+    void *v46; // [rsp+70h] [rbp-90h] BYREF
+    void (__fastcall *v47)(_QWORD, _QWORD, _QWORD, _QWORD); // [rsp+78h] [rbp-88h] BYREF
+    char v48; // [rsp+80h] [rbp-80h]
+    __int16 v49; // [rsp+82h] [rbp-7Eh]
+    _BYTE v50[304]; // [rsp+90h] [rbp-70h] BYREF
+    void **v52; // [rsp+1D8h] [rbp+D8h] BYREF
+
+    v52 = a2;
+    v8 = *a2;
+    v11 = *a1;
+    v13 = a8;
+    v15 = a7;
+    v16 = a6;
+    v17 = a1[1];
+    v46 = v8;
+    LODWORD(v18) = sub_1811DD410(v17, v11, (unsigned int)&v46, a3, a4, a5, a6, a7, a8);
+    if ( (_DWORD)v18
+      || (v19 = *a1,
+          v20 = *(__int64 (__fastcall **)(__int64, void **, __int64, __int64, __int64, int, __int64, __int64))(*(_QWORD *)*a1 + 136LL),// 0x88 = 136LL = CEntityInstance_ScriptAcceptInput
+          v46 = *a2,
+          LODWORD(v18) = v20(v19, &v46, a3, a4, a5, v16, v15, v13),
+          (_DWORD)v18) )
+    {
+      LOBYTE(v18) = (_DWORD)v18 == 2;
+      return (char)v18;
+    }
+    v21 = *a1;
+    if ( !*a1 )
+    {
+      v18 = (void *)MEMORY[0x18];
+      v22 = 0;
+      v46 = (void *)MEMORY[0x18];
+      goto LABEL_10;
+    }
+    v23 = *(unsigned __int16 *)(*(_QWORD *)(a1[1] + 128LL) + 2LL * dword_181CADFE0);
+    if ( (_WORD)v23 == 0xFFFF )
+      v22 = 0;
+    else
+      v22 = *(_QWORD *)(v23 + v21);
+    v18 = *(void **)(v21 + 24);
+    v46 = v18;
+    if ( !v22 )
+    {
+  LABEL_10:
+      if ( !v18 )
+        return (char)v18;
+    }
+    v24 = qword_181E16008;
+    v49 = 0;
+    v25 = 0;
+    v48 = 0;
+    v47 = nullptr;
+    (*(void (__fastcall **)(__int64, void (__fastcall **)(_QWORD, _QWORD, _QWORD, _QWORD)))(*(_QWORD *)qword_181E16008
+                                                                                          + 288LL))(
+      qword_181E16008,
+      &v47);
+    v26 = v47;
+    v27 = *(void (__fastcall **)(_QWORD, _QWORD, _QWORD, _QWORD))(*(_QWORD *)v24 + 264LL);
+    v43 = v27;
+    if ( a3 )
+    {
+      if ( !*(_QWORD *)(*(_QWORD *)(a3 + 16) + 40LL) )
+      {
+        sub_18120C0D0(a3, 0);
+        v27 = v43;
+      }
+      v28 = *(_QWORD *)(*(_QWORD *)(a3 + 16) + 40LL);
+    }
+    else
+    {
+      v28 = 0;
+    }
+    v40 = v28;
+    v41 = 31;
+    v42 = 0;
+    v27(v24, v26, "activator", &v40);
+    if ( (v42 & 1) != 0 )
+      (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v40);
+    v29 = *(void (__fastcall **)(__int64, _QWORD, const char *, __int64 *))(*(_QWORD *)v24 + 264LL);
+    if ( a4 )
+    {
+      if ( !*(_QWORD *)(*(_QWORD *)(a4 + 16) + 40LL) )
+        sub_18120C0D0(a4, 0);
+      v30 = *(_QWORD *)(*(_QWORD *)(a4 + 16) + 40LL);
+    }
+    else
+    {
+      v30 = 0;
+    }
+    v40 = v30;
+    v41 = 31;
+    v42 = 0;
+    v29(v24, v26, "caller", &v40);
+    if ( (v42 & 1) != 0 )
+      (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v40);
+    (*(void (__fastcall **)(__int64, _QWORD, const char *, __int64))(*(_QWORD *)v24 + 264LL))(v24, v26, "value", a5);
+    LODWORD(v40) = a6;
+    v31 = *(_QWORD *)v24;
+    v41 = 5;
+    v42 = 0;
+    (*(void (__fastcall **)(__int64, _QWORD, const char *, __int64 *))(v31 + 264))(v24, v26, "outputid", &v40);
+    if ( (v42 & 1) != 0 )
+      (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v40);
+    v32 = (char **)v52;
+    if ( v22 )
+    {
+      v52 = (void **)*v52;
+      v25 = (unsigned __int8)sub_181218D20(v22, &v52, v26) != 0;
+    }
+    if ( v46 )
+    {
+      V_strncpy(v50, "Input", 255);
+      v33 = byte_18159B988;
+      if ( *v32 )
+        v33 = *v32;
+      V_strncat(v50, v33, 255, 0xFFFFFFFFLL);
+      v41 = 0;
+      v42 = 0;
+      v40 = 0;
+      v34 = *a1;
+      v45 = 0;
+      v44 = 31;
+      v43 = v26;
+      v35 = (*(__int64 (__fastcall **)(__int64, _BYTE *, _QWORD, __int64))(*(_QWORD *)qword_181E16008 + 168LL))(
+              qword_181E16008,
+              v50,
+              *(_QWORD *)(v34 + 24),
+              1);
+      v36 = v35;
+      if ( v35 )
+      {
+        LOBYTE(v39) = 1;
+        v37 = (*(__int64 (__fastcall **)(__int64, __int64, void (__fastcall **)(_QWORD, _QWORD, _QWORD, _QWORD), __int64, __int64 *, _QWORD, int))(*(_QWORD *)qword_181E16008 + 184LL))(
+                qword_181E16008,
+                v35,
+                &v43,
+                1,
+                &v40,
+                0,
+                v39);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_181E16008 + 176LL))(qword_181E16008, v36);
+        if ( (v45 & 1) != 0 )
+          (*(void (__fastcall **)(_QWORD, void (__fastcall *)(_QWORD, _QWORD, _QWORD, _QWORD)))(*g_pMemAlloc + 24LL))(
+            g_pMemAlloc,
+            v43);
+        if ( v37 != -1 )
+          v25 = 1;
+      }
+      else if ( (v45 & 1) != 0 )
+      {
+        (*(void (__fastcall **)(_QWORD, void (__fastcall *)(_QWORD, _QWORD, _QWORD, _QWORD)))(*g_pMemAlloc + 24LL))(
+          g_pMemAlloc,
+          v43);
+      }
+      v44 = 0;
+      if ( (v42 & 1) != 0 )
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v40);
+    }
+    (*(void (__fastcall **)(__int64, void (__fastcall *)(_QWORD, _QWORD, _QWORD, _QWORD)))(*(_QWORD *)v24 + 160LL))(
+      v24,
+      v26);
+    if ( (v49 & 1) != 0 )
+      (*(void (__fastcall **)(_QWORD, void (__fastcall *)(_QWORD, _QWORD, _QWORD, _QWORD)))(*g_pMemAlloc + 24LL))(
+        g_pMemAlloc,
+        v47);
+    LOBYTE(v18) = v25;
+    return (char)v18;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInputInternal.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityIdentity_AcceptInputInternal.linux.yaml
@@ -1,0 +1,474 @@
+func_name: CEntityIdentity_AcceptInputInternal
+func_va: '0x1e44330'
+disasm_code: |-
+  .text:0000000001E44330                 push    rbp
+  .text:0000000001E44331                 mov     rbp, rsp
+  .text:0000000001E44334                 push    r15
+  .text:0000000001E44336                 push    r14
+  .text:0000000001E44338                 push    r13
+  .text:0000000001E4433A                 mov     r13, rcx
+  .text:0000000001E4433D                 push    r12
+  .text:0000000001E4433F                 mov     r12, rsi
+  .text:0000000001E44342                 push    rbx
+  .text:0000000001E44343                 mov     rbx, rdi
+  .text:0000000001E44346                 sub     rsp, 168h
+  .text:0000000001E4434D                 mov     rdi, [rdi]
+  .text:0000000001E44350                 mov     [rbp+var_168], r8
+  .text:0000000001E44357                 mov     rcx, [rsi]
+  .text:0000000001E4435A                 mov     [rbp+var_16C], r9d
+  .text:0000000001E44361                 mov     rax, [rdi]
+  .text:0000000001E44364                 ; 0x90 = 144LL = CEntityInstance_ScriptAcceptInput
+  .text:0000000001E44364                 mov     rax, [rax+90h]; 0x90 = 144LL = CEntityInstance_ScriptAcceptInput
+  .text:0000000001E4436B                 mov     [rbp+var_130], rcx
+  .text:0000000001E44372                 lea     rcx, sub_1E442C0
+  .text:0000000001E44379                 cmp     rax, rcx
+  .text:0000000001E4437C                 jnz     loc_1E44618
+  .text:0000000001E44382                 mov     rax, [rbx+8]
+  .text:0000000001E44386                 lea     rcx, xmmword_27BBF40
+  .text:0000000001E4438D                 mov     rax, [rax+80h]
+  .text:0000000001E44394                 movsxd  rcx, dword ptr [rcx+20h]
+  .text:0000000001E44398                 movzx   eax, word ptr [rax+rcx*2]
+  .text:0000000001E4439C                 cmp     ax, 0FFFFh
+  .text:0000000001E443A0                 jz      short loc_1E443D8
+  .text:0000000001E443A2                 mov     rax, [rdi+rax]
+  .text:0000000001E443A6                 mov     [rbp+var_188], rax
+  .text:0000000001E443AD                 mov     rsi, [rdi+18h]
+  .text:0000000001E443B1                 xor     r15d, r15d
+  .text:0000000001E443B4                 or      rax, rsi
+  .text:0000000001E443B7                 mov     [rbp+var_190], rsi
+  .text:0000000001E443BE                 jnz     short loc_1E443F0
+  .text:0000000001E443C0                 lea     rsp, [rbp-28h]
+  .text:0000000001E443C4                 mov     eax, r15d
+  .text:0000000001E443C7                 pop     rbx
+  .text:0000000001E443C8                 pop     r12
+  .text:0000000001E443CA                 pop     r13
+  .text:0000000001E443CC                 pop     r14
+  .text:0000000001E443CE                 pop     r15
+  .text:0000000001E443D0                 pop     rbp
+  .text:0000000001E443D1                 retn
+  .text:0000000001E443D8                 mov     [rbp+var_188], 0
+  .text:0000000001E443E3                 xor     eax, eax
+  .text:0000000001E443E5                 jmp     short loc_1E443AD
+  .text:0000000001E443F0                 lea     rax, qword_25F5128
+  .text:0000000001E443F7                 mov     [rbp+var_180], rdx
+  .text:0000000001E443FE                 lea     rsi, [rbp+var_160]
+  .text:0000000001E44405                 mov     [rbp+var_160], 0
+  .text:0000000001E44410                 mov     [rbp+var_158], 0
+  .text:0000000001E4441A                 mov     r14, [rax]
+  .text:0000000001E4441D                 mov     rax, [r14]
+  .text:0000000001E44420                 mov     rdi, r14
+  .text:0000000001E44423                 call    qword ptr [rax+128h]
+  .text:0000000001E44429                 mov     rax, [rbp+var_160]
+  .text:0000000001E44430                 mov     rdx, [rbp+var_180]
+  .text:0000000001E44437                 mov     [rbp+var_178], rax
+  .text:0000000001E4443E                 mov     rax, [r14]
+  .text:0000000001E44441                 mov     r15, [rax+110h]
+  .text:0000000001E44448                 xor     eax, eax
+  .text:0000000001E4444A                 test    rdx, rdx
+  .text:0000000001E4444D                 jz      short loc_1E44460
+  .text:0000000001E4444F                 mov     rax, [rdx+10h]
+  .text:0000000001E44453                 mov     rax, [rax+28h]
+  .text:0000000001E44457                 test    rax, rax
+  .text:0000000001E4445A                 jz      loc_1E447C0
+  .text:0000000001E44460                 mov     [rbp+var_130], rax
+  .text:0000000001E44467                 lea     rax, [rbp+var_130]
+  .text:0000000001E4446E                 mov     rdi, r14
+  .text:0000000001E44471                 mov     rsi, [rbp+var_178]
+  .text:0000000001E44478                 mov     [rbp+var_128], 1Fh
+  .text:0000000001E44482                 mov     rcx, rax
+  .text:0000000001E44485                 mov     [rbp+var_180], rax
+  .text:0000000001E4448C                 lea     rdx, aActivator; "activator"
+  .text:0000000001E44493                 call    r15
+  .text:0000000001E44496                 test    byte ptr [rbp+var_128+2], 1
+  .text:0000000001E4449D                 jz      short loc_1E444B6
+  .text:0000000001E4449F                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E444A6                 mov     rsi, [rbp+var_130]
+  .text:0000000001E444AD                 mov     rdi, [rax]
+  .text:0000000001E444B0                 mov     rax, [rdi]
+  .text:0000000001E444B3                 call    qword ptr [rax+20h]
+  .text:0000000001E444B6                 mov     rax, [r14]
+  .text:0000000001E444B9                 mov     r15, [rax+110h]
+  .text:0000000001E444C0                 xor     eax, eax
+  .text:0000000001E444C2                 test    r13, r13
+  .text:0000000001E444C5                 jz      short loc_1E444D8
+  .text:0000000001E444C7                 mov     rax, [r13+10h]
+  .text:0000000001E444CB                 mov     rax, [rax+28h]
+  .text:0000000001E444CF                 test    rax, rax
+  .text:0000000001E444D2                 jz      loc_1E447E0
+  .text:0000000001E444D8                 mov     rcx, [rbp+var_180]
+  .text:0000000001E444DF                 mov     [rbp+var_130], rax
+  .text:0000000001E444E6                 mov     rdi, r14
+  .text:0000000001E444E9                 mov     rsi, [rbp+var_178]
+  .text:0000000001E444F0                 lea     rdx, aCaller; "caller"
+  .text:0000000001E444F7                 mov     [rbp+var_128], 1Fh
+  .text:0000000001E44501                 call    r15
+  .text:0000000001E44504                 test    byte ptr [rbp+var_128+2], 1
+  .text:0000000001E4450B                 jz      short loc_1E44524
+  .text:0000000001E4450D                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E44514                 mov     rsi, [rbp+var_130]
+  .text:0000000001E4451B                 mov     rdi, [rax]
+  .text:0000000001E4451E                 mov     rax, [rdi]
+  .text:0000000001E44521                 call    qword ptr [rax+20h]
+  .text:0000000001E44524                 mov     rax, [r14]
+  .text:0000000001E44527                 lea     rdx, aValue; "value"
+  .text:0000000001E4452E                 mov     rdi, r14
+  .text:0000000001E44531                 mov     r15, [rbp+var_178]
+  .text:0000000001E44538                 mov     rcx, [rbp+var_168]
+  .text:0000000001E4453F                 mov     rsi, r15
+  .text:0000000001E44542                 call    qword ptr [rax+110h]
+  .text:0000000001E44548                 mov     rax, [r14]
+  .text:0000000001E4454B                 mov     rsi, r15
+  .text:0000000001E4454E                 mov     rdi, r14
+  .text:0000000001E44551                 mov     edx, [rbp+var_16C]
+  .text:0000000001E44557                 mov     rcx, [rbp+var_180]
+  .text:0000000001E4455E                 mov     rax, [rax+110h]
+  .text:0000000001E44565                 mov     [rbp+var_128], 5
+  .text:0000000001E4456F                 mov     dword ptr [rbp+var_130], edx
+  .text:0000000001E44575                 lea     rdx, aOutputid; "outputid"
+  .text:0000000001E4457C                 call    rax
+  .text:0000000001E4457E                 test    byte ptr [rbp+var_128+2], 1
+  .text:0000000001E44585                 jz      short loc_1E4459E
+  .text:0000000001E44587                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E4458E                 mov     rsi, [rbp+var_130]
+  .text:0000000001E44595                 mov     rdi, [rax]
+  .text:0000000001E44598                 mov     rax, [rdi]
+  .text:0000000001E4459B                 call    qword ptr [rax+20h]
+  .text:0000000001E4459E                 mov     rdi, [rbp+var_188]
+  .text:0000000001E445A5                 test    rdi, rdi
+  .text:0000000001E445A8                 jz      loc_1E44650
+  .text:0000000001E445AE                 mov     rax, [r12]
+  .text:0000000001E445B2                 mov     rdx, [rbp+var_178]
+  .text:0000000001E445B9                 mov     rsi, [rbp+var_180]
+  .text:0000000001E445C0                 mov     [rbp+var_130], rax
+  .text:0000000001E445C7                 call    sub_1E7CAD0
+  .text:0000000001E445CC                 cmp     [rbp+var_190], 0
+  .text:0000000001E445D4                 mov     r15d, eax
+  .text:0000000001E445D7                 jnz     short loc_1E44653
+  .text:0000000001E445D9                 mov     rax, [r14]
+  .text:0000000001E445DC                 mov     rdi, r14
+  .text:0000000001E445DF                 mov     rsi, [rbp+var_178]
+  .text:0000000001E445E6                 call    qword ptr [rax+0A8h]
+  .text:0000000001E445EC                 test    byte ptr [rbp+var_158+2], 1
+  .text:0000000001E445F3                 jz      loc_1E443C0
+  .text:0000000001E445F9                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E44600                 mov     rsi, [rbp+var_160]
+  .text:0000000001E44607                 mov     rdi, [rax]
+  .text:0000000001E4460A                 mov     rax, [rdi]
+  .text:0000000001E4460D                 call    qword ptr [rax+20h]
+  .text:0000000001E44610                 jmp     loc_1E443C0
+  .text:0000000001E44618                 push    [rbp+arg_8]
+  .text:0000000001E4461B                 lea     rsi, [rbp+var_130]
+  .text:0000000001E44622                 mov     rcx, r13
+  .text:0000000001E44625                 push    [rbp+arg_0]
+  .text:0000000001E44628                 mov     [rbp+var_178], rdx
+  .text:0000000001E4462F                 call    rax
+  .text:0000000001E44631                 pop     rsi
+  .text:0000000001E44632                 test    eax, eax
+  .text:0000000001E44634                 pop     rdi
+  .text:0000000001E44635                 mov     rdx, [rbp+var_178]
+  .text:0000000001E4463C                 jz      loc_1E44798
+  .text:0000000001E44642                 cmp     eax, 2
+  .text:0000000001E44645                 setz    r15b
+  .text:0000000001E44649                 jmp     loc_1E443C0
+  .text:0000000001E44650                 xor     r15d, r15d
+  .text:0000000001E44653                 mov     r13, [rbp+var_180]
+  .text:0000000001E4465A                 ; _QWORD
+  .text:0000000001E4465A                 mov     edx, 0FFh; _QWORD
+  .text:0000000001E4465F                 lea     rsi, aInput_0; "Input"
+  .text:0000000001E44666                 ; _QWORD
+  .text:0000000001E44666                 mov     rdi, r13; _QWORD
+  .text:0000000001E44669                 call    __V_strncpy
+  .text:0000000001E4466E                 mov     rsi, [r12]
+  .text:0000000001E44672                 ; _QWORD
+  .text:0000000001E44672                 mov     ecx, 0FFFFFFFFh; _QWORD
+  .text:0000000001E44677                 ; _QWORD
+  .text:0000000001E44677                 mov     rdi, r13; _QWORD
+  .text:0000000001E4467A                 lea     rax, haystack
+  .text:0000000001E44681                 ; _QWORD
+  .text:0000000001E44681                 mov     edx, 0FFh; _QWORD
+  .text:0000000001E44686                 test    rsi, rsi
+  .text:0000000001E44689                 ; _QWORD
+  .text:0000000001E44689                 cmovz   rsi, rax; _QWORD
+  .text:0000000001E4468D                 call    __V_strncat
+  .text:0000000001E44692                 mov     rax, [rbx]
+  .text:0000000001E44695                 xor     ecx, ecx
+  .text:0000000001E44697                 mov     rsi, r13
+  .text:0000000001E4469A                 mov     rbx, [rbp+var_178]
+  .text:0000000001E446A1                 mov     [rbp+var_136], cx
+  .text:0000000001E446A8                 mov     ecx, 1
+  .text:0000000001E446AD                 mov     [rbp+var_150], 0
+  .text:0000000001E446B8                 mov     [rbp+var_148], 0
+  .text:0000000001E446C2                 mov     rdx, [rax+18h]
+  .text:0000000001E446C6                 mov     [rbp+var_138], 1Fh
+  .text:0000000001E446CD                 mov     [rbp+var_140], rbx
+  .text:0000000001E446D4                 lea     rbx, qword_25F5128
+  .text:0000000001E446DB                 mov     rdi, [rbx]
+  .text:0000000001E446DE                 mov     rax, [rdi]
+  .text:0000000001E446E1                 call    qword ptr [rax+0B0h]
+  .text:0000000001E446E7                 mov     r12, rax
+  .text:0000000001E446EA                 test    rax, rax
+  .text:0000000001E446ED                 jz      loc_1E447F7
+  .text:0000000001E446F3                 lea     rax, qword_25F5128
+  .text:0000000001E446FA                 sub     rsp, 8
+  .text:0000000001E446FE                 xor     r9d, r9d
+  .text:0000000001E44701                 mov     ecx, 1
+  .text:0000000001E44706                 lea     rdx, [rbp+var_140]
+  .text:0000000001E4470D                 mov     rsi, r12
+  .text:0000000001E44710                 lea     r8, [rbp+var_150]
+  .text:0000000001E44717                 mov     rdi, [rax]
+  .text:0000000001E4471A                 mov     rax, [rdi]
+  .text:0000000001E4471D                 push    1
+  .text:0000000001E4471F                 call    qword ptr [rax+0C0h]
+  .text:0000000001E44725                 mov     rsi, r12
+  .text:0000000001E44728                 mov     ebx, eax
+  .text:0000000001E4472A                 lea     rax, qword_25F5128
+  .text:0000000001E44731                 mov     rdi, [rax]
+  .text:0000000001E44734                 mov     rax, [rdi]
+  .text:0000000001E44737                 call    qword ptr [rax+0B8h]
+  .text:0000000001E4473D                 pop     rax
+  .text:0000000001E4473E                 pop     rdx
+  .text:0000000001E4473F                 test    byte ptr [rbp+var_136], 1
+  .text:0000000001E44746                 jz      short loc_1E4475F
+  .text:0000000001E44748                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E4474F                 mov     rsi, [rbp+var_140]
+  .text:0000000001E44756                 mov     rdi, [rax]
+  .text:0000000001E44759                 mov     rax, [rdi]
+  .text:0000000001E4475C                 call    qword ptr [rax+20h]
+  .text:0000000001E4475F                 cmp     ebx, 0FFFFFFFFh
+  .text:0000000001E44762                 setnz   al
+  .text:0000000001E44765                 or      r15d, eax
+  .text:0000000001E44768                 test    byte ptr [rbp+var_148+2], 1
+  .text:0000000001E4476F                 jz      loc_1E445D9
+  .text:0000000001E44775                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E4477C                 mov     rsi, [rbp+var_150]
+  .text:0000000001E44783                 mov     rdi, [rax]
+  .text:0000000001E44786                 mov     rax, [rdi]
+  .text:0000000001E44789                 call    qword ptr [rax+20h]
+  .text:0000000001E4478C                 jmp     loc_1E445D9
+  .text:0000000001E44798                 mov     rdi, [rbx]
+  .text:0000000001E4479B                 test    rdi, rdi
+  .text:0000000001E4479E                 jnz     loc_1E44382
+  .text:0000000001E447A4                 mov     [rbp+var_188], 0
+  .text:0000000001E447AF                 xor     eax, eax
+  .text:0000000001E447B1                 jmp     loc_1E443AD
+  .text:0000000001E447C0                 mov     rdi, rdx
+  .text:0000000001E447C3                 xor     esi, esi
+  .text:0000000001E447C5                 call    sub_1E48B40
+  .text:0000000001E447CA                 mov     rdx, [rbp+var_180]
+  .text:0000000001E447D1                 mov     rax, [rdx+10h]
+  .text:0000000001E447D5                 mov     rax, [rax+28h]
+  .text:0000000001E447D9                 jmp     loc_1E44460
+  .text:0000000001E447E0                 xor     esi, esi
+  .text:0000000001E447E2                 mov     rdi, r13
+  .text:0000000001E447E5                 call    sub_1E48B40
+  .text:0000000001E447EA                 mov     rax, [r13+10h]
+  .text:0000000001E447EE                 mov     rax, [rax+28h]
+  .text:0000000001E447F2                 jmp     loc_1E444D8
+  .text:0000000001E447F7                 test    byte ptr [rbp+var_136], 1
+  .text:0000000001E447FE                 jz      loc_1E44768
+  .text:0000000001E44804                 or      ebx, 0FFFFFFFFh
+  .text:0000000001E44807                 jmp     loc_1E44748
+procedure: |-
+  __int64 __fastcall sub_1E44330(
+          __int64 a1,
+          const bool **a2,
+          __int64 a3,
+          __int64 a4,
+          __int64 a5,
+          int a6,
+          __int64 a7,
+          __int64 a8)
+  {
+    unsigned int v8; // r15d
+    _QWORD *v12; // rdi
+    __int64 (__fastcall *v13)(); // rax
+    __int64 v14; // rax
+    __int64 v15; // rax
+    __int64 v17; // r14
+    void (__fastcall *v18)(__int64, __int64, const char *, const bool **); // r15
+    const bool *v19; // rax
+    void (__fastcall *v20)(__int64, __int64, const char *, const bool **); // r15
+    const bool *v21; // rax
+    void (__fastcall *v22)(__int64, __int64, const char *, const bool **); // rax
+    int v23; // eax
+    const bool *v24; // rsi
+    _QWORD *v25; // rax
+    __int64 v26; // rdx
+    __int64 v27; // rax
+    __int64 v28; // rdx
+    __int64 v29; // r12
+    int v30; // ebx
+    __int64 v31; // rax
+    int v32; // [rsp-10h] [rbp-1A0h]
+    __int64 v33; // [rsp-8h] [rbp-198h]
+    __int64 v34; // [rsp+0h] [rbp-190h]
+    __int64 v35; // [rsp+8h] [rbp-188h]
+    __int64 v36; // [rsp+10h] [rbp-180h]
+    __int64 v37; // [rsp+18h] [rbp-178h]
+    __int64 v38; // [rsp+18h] [rbp-178h]
+    __int64 v41; // [rsp+30h] [rbp-160h] BYREF
+    int v42; // [rsp+38h] [rbp-158h]
+    __int64 v43; // [rsp+40h] [rbp-150h] BYREF
+    int v44; // [rsp+48h] [rbp-148h]
+    __int64 v45; // [rsp+50h] [rbp-140h] BYREF
+    char v46; // [rsp+58h] [rbp-138h]
+    __int16 v47; // [rsp+5Ah] [rbp-136h]
+    const bool *v48; // [rsp+60h] [rbp-130h] BYREF
+    int v49; // [rsp+68h] [rbp-128h]
+
+    v12 = *(_QWORD **)a1;
+    v13 = *(__int64 (__fastcall **)())(*v12 + 144LL);// 0x90 = 144LL = CEntityInstance_ScriptAcceptInput
+    v48 = *a2;
+    if ( v13 == sub_1E442C0 )
+      goto LABEL_2;
+    v33 = a8;
+    v38 = a3;
+    v23 = ((__int64 (__fastcall *)(_QWORD *, const bool **, __int64, __int64))v13)(v12, &v48, a3, a4);
+    a3 = v38;
+    if ( v23 )
+    {
+      LOBYTE(v8) = v23 == 2;
+      return v8;
+    }
+    v12 = *(_QWORD **)a1;
+    if ( *(_QWORD *)a1 )
+    {
+  LABEL_2:
+      v14 = *(unsigned __int16 *)(*(_QWORD *)(*(_QWORD *)(a1 + 8) + 128LL) + 2LL * (int)qword_27BBF60);
+      if ( (_WORD)v14 == 0xFFFF )
+      {
+        v35 = 0;
+        v15 = 0;
+      }
+      else
+      {
+        v15 = *(_QWORD *)((char *)v12 + v14);
+        v35 = v15;
+      }
+    }
+    else
+    {
+      v35 = 0;
+      v15 = 0;
+    }
+    v8 = 0;
+    v34 = v12[3];
+    if ( v34 | v15 )
+    {
+      v36 = a3;
+      v41 = 0;
+      v42 = 0;
+      v17 = qword_25F5128;
+      (*(void (__fastcall **)(__int64, __int64 *))(*(_QWORD *)qword_25F5128 + 296LL))(qword_25F5128, &v41);
+      v37 = v41;
+      v18 = *(void (__fastcall **)(__int64, __int64, const char *, const bool **))(*(_QWORD *)v17 + 272LL);
+      v19 = nullptr;
+      if ( v36 )
+      {
+        v19 = *(const bool **)(*(_QWORD *)(v36 + 16) + 40LL);
+        if ( !v19 )
+        {
+          sub_1E48B40(v36, 0);
+          v19 = *(const bool **)(*(_QWORD *)(v36 + 16) + 40LL);
+        }
+      }
+      v48 = v19;
+      v49 = 31;
+      v18(v17, v37, "activator", &v48);
+      if ( (v49 & 0x10000) != 0 )
+        (*(void (__fastcall **)(_QWORD *, const bool *))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v48);
+      v20 = *(void (__fastcall **)(__int64, __int64, const char *, const bool **))(*(_QWORD *)v17 + 272LL);
+      v21 = nullptr;
+      if ( a4 )
+      {
+        v21 = *(const bool **)(*(_QWORD *)(a4 + 16) + 40LL);
+        if ( !v21 )
+        {
+          sub_1E48B40(a4, 0);
+          v21 = *(const bool **)(*(_QWORD *)(a4 + 16) + 40LL);
+        }
+      }
+      v48 = v21;
+      v49 = 31;
+      v20(v17, v37, "caller", &v48);
+      if ( (v49 & 0x10000) != 0 )
+        (*(void (__fastcall **)(_QWORD *, const bool *))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v48);
+      (*(void (__fastcall **)(__int64, __int64, const char *, __int64))(*(_QWORD *)v17 + 272LL))(v17, v37, "value", a5);
+      v22 = *(void (__fastcall **)(__int64, __int64, const char *, const bool **))(*(_QWORD *)v17 + 272LL);
+      v49 = 5;
+      LODWORD(v48) = a6;
+      v22(v17, v37, "outputid", &v48);
+      if ( (v49 & 0x10000) != 0 )
+        (*(void (__fastcall **)(_QWORD *, const bool *))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v48);
+      if ( v35 )
+      {
+        v48 = *a2;
+        v8 = sub_1E7CAD0(v35, &v48, v37);
+        if ( !v34 )
+        {
+  LABEL_21:
+          (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v17 + 168LL))(v17, v37);
+          if ( (v42 & 0x10000) != 0 )
+            (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v41);
+          return v8;
+        }
+      }
+      else
+      {
+        v8 = 0;
+      }
+      _V_strncpy(&v48, "Input", 255);
+      v24 = *a2;
+      if ( !*a2 )
+        v24 = &haystack;
+      _V_strncat(&v48, v24, 255, 0xFFFFFFFFLL);
+      v25 = *(_QWORD **)a1;
+      v47 = 0;
+      v43 = 0;
+      v44 = 0;
+      v26 = v25[3];
+      v46 = 31;
+      v45 = v37;
+      v27 = (*(__int64 (__fastcall **)(__int64, const bool **, __int64, __int64))(*(_QWORD *)qword_25F5128 + 176LL))(
+              qword_25F5128,
+              &v48,
+              v26,
+              1);
+      v29 = v27;
+      if ( v27 )
+      {
+        v30 = (*(__int64 (__fastcall **)(__int64, __int64, __int64 *, __int64, __int64 *, _QWORD, __int64))(*(_QWORD *)qword_25F5128 + 192LL))(
+                qword_25F5128,
+                v27,
+                &v45,
+                1,
+                &v43,
+                0,
+                1);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_25F5128 + 184LL))(qword_25F5128, v29);
+        LODWORD(v31) = v32;
+        v28 = v33;
+        if ( (v47 & 1) == 0 )
+        {
+  LABEL_31:
+          LOBYTE(v31) = v30 != -1;
+          v8 |= v31;
+          goto LABEL_32;
+        }
+      }
+      else
+      {
+        if ( (v47 & 1) == 0 )
+        {
+  LABEL_32:
+          if ( (v44 & 0x10000) != 0 )
+            (*(void (__fastcall **)(_QWORD *, __int64, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v43, v28);
+          goto LABEL_21;
+        }
+        v30 = -1;
+      }
+      v31 = (*(__int64 (__fastcall **)(_QWORD *, __int64, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v45, v28);
+      goto LABEL_31;
+    }
+    return v8;
+  }


### PR DESCRIPTION
## Summary

- **Windows**: `find-CEntityInstance_ScriptAcceptInput-windows` — Pattern C (vfunc via LLM_DECOMPILE) using `CEntityIdentity_AcceptInput` as predecessor; outputs `vfunc_offset: 0x88`, `vfunc_index: 17`
- **Linux**: Two-script chain because `CEntityIdentity_AcceptInputInternal` is inlined on Windows but a distinct function on Linux:
  - `find-CEntityIdentity_AcceptInputInternal` — Pattern D (func via LLM_DECOMPILE) using `CEntityIdentity_AcceptInput` as predecessor
  - `find-CEntityInstance_ScriptAcceptInput-linux` — Pattern C (vfunc via LLM_DECOMPILE) using `CEntityIdentity_AcceptInputInternal` as predecessor; outputs `vfunc_offset: 0x90`, `vfunc_index: 18`
- Adds `CEntityInstance_ScriptAcceptInput` (vfunc) and `CEntityIdentity_AcceptInputInternal` (func) symbol entries in `config.yaml`
- Adds reference YAMLs for `CEntityIdentity_AcceptInput` (Windows + Linux) and `CEntityIdentity_AcceptInputInternal` (Linux)

## Test plan

- [ ] Windows: produces `CEntityInstance_ScriptAcceptInput.windows.yaml` with `vfunc_sig`, `vfunc_offset: 0x88`, `vfunc_index: 17`
- [ ] Linux: produces `CEntityIdentity_AcceptInputInternal.linux.yaml` then `CEntityInstance_ScriptAcceptInput.linux.yaml` with `vfunc_sig`, `vfunc_offset: 0x90`, `vfunc_index: 18`