### PR TITLE
Add find-CEntityInstance_m_iszPrivateVScripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3960,6 +3960,12 @@ modules:
         expected_input:
           - CBaseEntity_ReloadPrivateScripts.{platform}.yaml
 
+      - name: find-CEntityInstance_m_iszPrivateVScripts
+        expected_output:
+          - CEntityInstance_m_iszPrivateVScripts.{platform}.yaml
+        expected_input:
+          - CBaseEntity_ReloadPrivateScripts.{platform}.yaml
+
       - name: find-CEntityInstance_ValidatePrivateScriptScope
         expected_output:
           - CEntityInstance_ValidatePrivateScriptScope.{platform}.yaml
@@ -4538,6 +4544,13 @@ modules:
         member: m_pKeyValues
         alias:
           - CEntityInstance::m_pKeyValues
+
+      - name: CEntityInstance_m_iszPrivateVScripts
+        category: structmember
+        struct: CEntityInstance
+        member: m_iszPrivateVScripts
+        alias:
+          - CEntityInstance::m_iszPrivateVScripts
 
       - name: CBaseEntity_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEntityInstance_m_iszPrivateVScripts.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_m_iszPrivateVScripts.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_m_iszPrivateVScripts skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntityInstance_m_iszPrivateVScripts",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_m_iszPrivateVScripts",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBaseEntity_ReloadPrivateScripts.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_m_iszPrivateVScripts",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_ReloadPrivateScripts.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_ReloadPrivateScripts.linux.yaml
@@ -1,0 +1,198 @@
+func_name: CBaseEntity_ReloadPrivateScripts
+func_va: '0x1e48820'
+disasm_code: |-
+  .text:0000000001E48820                 mov     rsi, [rdi+8] ; 0x8 = 8 = CEntityInstance::m_iszPrivateVScripts (structmember, struct=CEntityInstance, member=m_iszPrivateVScripts)
+  .text:0000000001E48824                 test    rsi, rsi
+  .text:0000000001E48827                 jnz     short loc_1E48830
+  .text:0000000001E48829                 retn
+  .text:0000000001E48830                 push    rbp
+  .text:0000000001E48831                 lea     rax, delim; " "
+  .text:0000000001E48838                 ; bool
+  .text:0000000001E48838                 xor     r9d, r9d; bool
+  .text:0000000001E4883B                 ; int
+  .text:0000000001E4883B                 mov     edx, 0FFFFFFFFh; int
+  .text:0000000001E48840                 mov     rbp, rsp
+  .text:0000000001E48843                 push    r15
+  .text:0000000001E48845                 ; int
+  .text:0000000001E48845                 mov     r8d, 1; int
+  .text:0000000001E4884B                 push    r14
+  .text:0000000001E4884D                 ; char **
+  .text:0000000001E4884D                 lea     rcx, [rbp-68h]; char **
+  .text:0000000001E48851                 push    r13
+  .text:0000000001E48853                 push    r12
+  .text:0000000001E48855                 mov     r12, rdi
+  .text:0000000001E48858                 push    rbx
+  .text:0000000001E48859                 ; this
+  .text:0000000001E48859                 lea     rdi, [rbp-60h]; this
+  .text:0000000001E4885D                 sub     rsp, 58h
+  .text:0000000001E48861                 mov     [rbp-68h], rax
+  .text:0000000001E48865                 mov     qword ptr [rbp-60h], 0
+  .text:0000000001E4886D                 mov     qword ptr [rbp-58h], 0
+  .text:0000000001E48875                 mov     qword ptr [rbp-50h], 0
+  .text:0000000001E4887D                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E48885                 mov     dword ptr [rbp-40h], 0
+  .text:0000000001E4888C                 call    __ZN12CSplitString5SplitEPKciPS1_ib; CSplitString::Split(char const*,int,char const**,int,bool)
+  .text:0000000001E48891                 mov     eax, [rbp-60h]
+  .text:0000000001E48894                 test    eax, eax
+  .text:0000000001E48896                 jle     loc_1E48938
+  .text:0000000001E4889C                 lea     r13, dword_286DD84
+  .text:0000000001E488A3                 xor     ebx, ebx
+  .text:0000000001E488A5                 jmp     short loc_1E488E6
+  .text:0000000001E488B0                 mov     rax, [rbp-58h]
+  .text:0000000001E488B4                 mov     r8, [r12+18h]
+  .text:0000000001E488B9                 mov     r9, [rax+r15]
+  .text:0000000001E488BD                 test    r8, r8
+  .text:0000000001E488C0                 jz      loc_1E48990
+  .text:0000000001E488C6                 lea     rdi, xmmword_27BBFC0
+  .text:0000000001E488CD                 mov     ecx, 1
+  .text:0000000001E488D2                 mov     rdx, r8
+  .text:0000000001E488D5                 mov     rsi, r9
+  .text:0000000001E488D8                 add     rbx, 1
+  .text:0000000001E488DC                 call    sub_1E7D0F0
+  .text:0000000001E488E1                 cmp     [rbp-60h], ebx
+  .text:0000000001E488E4                 jle     short loc_1E48938
+  .text:0000000001E488E6                 ; _QWORD
+  .text:0000000001E488E6                 mov     edi, [r13+0]; _QWORD
+  .text:0000000001E488EA                 ; _QWORD
+  .text:0000000001E488EA                 mov     esi, 1; _QWORD
+  .text:0000000001E488EF                 lea     r15, ds:0[rbx*8]
+  .text:0000000001E488F7                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E488FC                 test    al, al
+  .text:0000000001E488FE                 jz      short loc_1E488B0
+  .text:0000000001E48900                 mov     rax, [rbp-58h]
+  .text:0000000001E48904                 mov     rdi, [r12+10h]
+  .text:0000000001E48909                 mov     r14, [rax+rbx*8]
+  .text:0000000001E4890D                 call    sub_1E45610
+  .text:0000000001E48912                 ; _QWORD
+  .text:0000000001E48912                 mov     edi, [r13+0]; _QWORD
+  .text:0000000001E48916                 ; _QWORD
+  .text:0000000001E48916                 mov     esi, 1; _QWORD
+  .text:0000000001E4891B                 lea     rdx, aSExecutingScri; "%s executing script: %s\n"
+  .text:0000000001E48922                 mov     rcx, rax
+  .text:0000000001E48925                 xor     eax, eax
+  .text:0000000001E48927                 mov     r8, r14
+  .text:0000000001E4892A                 call    _LoggingSystem_Log
+  .text:0000000001E4892F                 jmp     loc_1E488B0
+  .text:0000000001E48938                 mov     rdi, [rbp-48h]
+  .text:0000000001E4893C                 test    rdi, rdi
+  .text:0000000001E4893F                 jz      short loc_1E48946
+  .text:0000000001E48941                 call    __ZdaPv; operator delete[](void *)
+  .text:0000000001E48946                 cmp     dword ptr [rbp-4Ch], 3FFFFFFFh
+  .text:0000000001E4894D                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E48955                 mov     dword ptr [rbp-40h], 0
+  .text:0000000001E4895C                 mov     dword ptr [rbp-60h], 0
+  .text:0000000001E48963                 ja      short loc_1E4897E
+  .text:0000000001E48965                 mov     rsi, [rbp-58h]
+  .text:0000000001E48969                 test    rsi, rsi
+  .text:0000000001E4896C                 jz      short loc_1E4897E
+  .text:0000000001E4896E                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E48975                 mov     rdi, [rax]
+  .text:0000000001E48978                 mov     rax, [rdi]
+  .text:0000000001E4897B                 call    qword ptr [rax+20h]
+  .text:0000000001E4897E                 add     rsp, 58h
+  .text:0000000001E48982                 pop     rbx
+  .text:0000000001E48983                 pop     r12
+  .text:0000000001E48985                 pop     r13
+  .text:0000000001E48987                 pop     r14
+  .text:0000000001E48989                 pop     r15
+  .text:0000000001E4898B                 pop     rbp
+  .text:0000000001E4898C                 retn
+  .text:0000000001E48990                 lea     rax, qword_25F5128
+  .text:0000000001E48997                 mov     rdi, [rax]
+  .text:0000000001E4899A                 test    rdi, rdi
+  .text:0000000001E4899D                 jz      loc_1E488C6
+  .text:0000000001E489A3                 mov     rax, [rdi]
+  .text:0000000001E489A6                 mov     [rbp-80h], r8
+  .text:0000000001E489AA                 xor     edx, edx
+  .text:0000000001E489AC                 xor     esi, esi
+  .text:0000000001E489AE                 mov     [rbp-78h], r9
+  .text:0000000001E489B2                 call    qword ptr [rax+98h]
+  .text:0000000001E489B8                 mov     r9, [rbp-78h]
+  .text:0000000001E489BC                 test    rax, rax
+  .text:0000000001E489BF                 mov     r8, [rbp-80h]
+  .text:0000000001E489C3                 mov     [r12+18h], rax
+  .text:0000000001E489C8                 jz      loc_1E488C6
+  .text:0000000001E489CE                 mov     rdi, r12
+  .text:0000000001E489D1                 call    CEntityInstance_ValidatePrivateScriptScope
+  .text:0000000001E489D6                 mov     r8, [r12+18h]
+  .text:0000000001E489DB                 mov     r9, [rbp-78h]
+  .text:0000000001E489DF                 jmp     loc_1E488C6
+procedure: |-
+  void __fastcall CBaseEntity_ReloadPrivateScripts(_QWORD *a1)
+  {
+    const char *v1; // rsi
+    __int64 v2; // rbx
+    __int64 v3; // r8
+    __int64 v4; // r9
+    __int64 v5; // rax
+    __int64 v6; // rdx
+    __int64 v7; // rcx
+    __int64 v8; // [rsp-88h] [rbp-88h]
+    __int64 v9; // [rsp-80h] [rbp-80h]
+    const char *v10; // [rsp-70h] [rbp-70h] BYREF
+    __int64 v11; // [rsp-68h] [rbp-68h] BYREF
+    __int64 v12; // [rsp-60h] [rbp-60h]
+    __int64 v13; // [rsp-58h] [rbp-58h]
+    __int64 v14; // [rsp-50h] [rbp-50h]
+    int v15; // [rsp-48h] [rbp-48h]
+
+    v1 = (const char *)a1[1];                  // 0x8 = 8 = CEntityInstance::m_iszPrivateVScripts (structmember, struct=CEntityInstance, member=m_iszPrivateVScripts)
+    if ( v1 )
+    {
+      v10 = " ";
+      v11 = 0;
+      v12 = 0;
+      v13 = 0;
+      v14 = 0;
+      v15 = 0;
+      CSplitString::Split((CSplitString *)&v11, v1, -1, &v10, 1, 0);
+      if ( (int)v11 > 0 )
+      {
+        v2 = 0;
+        do
+        {
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_286DD84, 1) )
+          {
+            sub_1E45610(a1[2]);
+            LoggingSystem_Log((unsigned int)dword_286DD84, 1, "%s executing script: %s\n");
+          }
+          v3 = a1[3];
+          v4 = *(_QWORD *)(v12 + 8 * v2);
+          if ( !v3 )
+          {
+            if ( qword_25F5128 )
+            {
+              v8 = a1[3];
+              v9 = *(_QWORD *)(v12 + 8 * v2);
+              v5 = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)qword_25F5128 + 152LL))(
+                     qword_25F5128,
+                     0,
+                     0);
+              v4 = v9;
+              v3 = v8;
+              a1[3] = v5;
+              if ( v5 )
+              {
+                CEntityInstance_ValidatePrivateScriptScope(a1, 0, v6, v7, v8, v9);
+                v3 = a1[3];
+                v4 = v9;
+              }
+            }
+          }
+          ++v2;
+          sub_1E7D0F0(&xmmword_27BBFC0, v4, v3, 1);
+        }
+        while ( (int)v11 > (int)v2 );
+      }
+      if ( v14 )
+        operator delete[]();
+      v14 = 0;
+      v15 = 0;
+      LODWORD(v11) = 0;
+      if ( HIDWORD(v13) <= 0x3FFFFFFF )
+      {
+        if ( v12 )
+          (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_ReloadPrivateScripts.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_ReloadPrivateScripts.windows.yaml
@@ -1,0 +1,199 @@
+func_name: CBaseEntity_ReloadPrivateScripts
+func_va: '0x18120dbd0'
+disasm_code: |-
+  .text:000000018120DBD0                 push    rbp
+  .text:000000018120DBD2                 push    rdi
+  .text:000000018120DBD3                 mov     rbp, rsp
+  .text:000000018120DBD6                 sub     rsp, 68h
+  .text:000000018120DBDA                 mov     rdx, [rcx+8] ; 0x8 = 8 = CEntityInstance::m_iszPrivateVScripts (structmember, struct=CEntityInstance, member=m_iszPrivateVScripts)
+  .text:000000018120DBDE                 mov     rdi, rcx
+  .text:000000018120DBE1                 test    rdx, rdx
+  .text:000000018120DBE4                 jz      loc_18120DD8C
+  .text:000000018120DBEA                 lea     rax, asc_18159BEAC; " "
+  .text:000000018120DBF1                 mov     [rsp+68h+arg_18], r14
+  .text:000000018120DBF9                 mov     [rsp+68h+var_8], r15
+  .text:000000018120DBFE                 lea     r9, [rbp+arg_0]
+  .text:000000018120DC02                 xor     r15d, r15d
+  .text:000000018120DC05                 mov     [rbp+arg_0], rax
+  .text:000000018120DC09                 mov     [rsp+68h+var_40], r15b
+  .text:000000018120DC0E                 lea     rcx, [rbp+var_38]
+  .text:000000018120DC12                 mov     r8d, 0FFFFFFFFh
+  .text:000000018120DC18                 mov     dword ptr [rsp+68h+var_48], 1
+  .text:000000018120DC20                 mov     [rbp+var_30], r15
+  .text:000000018120DC24                 mov     [rbp+var_28], r15
+  .text:000000018120DC28                 mov     [rbp+var_38], r15d
+  .text:000000018120DC2C                 mov     [rbp+var_20], r15
+  .text:000000018120DC30                 mov     [rbp+var_18], r15d
+  .text:000000018120DC34                 call    cs:?Split@CSplitString@@AEAAXPEBDHPEAPEBDH_N@Z; CSplitString::Split(char const *,int,char const * *,int,bool)
+  .text:000000018120DC3A                 mov     r14d, r15d
+  .text:000000018120DC3D                 cmp     [rbp+var_38], r15d
+  .text:000000018120DC41                 jle     loc_18120DCEF
+  .text:000000018120DC47                 mov     [rsp+68h+arg_8], rbx
+  .text:000000018120DC4F                 mov     [rsp+68h+arg_10], rsi
+  .text:000000018120DC57                 mov     esi, r15d
+  .text:000000018120DC5A                 nop     word ptr [rax+rax+00h]
+  .text:000000018120DC60                 mov     ecx, cs:dword_1821189CC
+  .text:000000018120DC66                 mov     edx, 1
+  .text:000000018120DC6B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018120DC71                 test    al, al
+  .text:000000018120DC73                 jz      short loc_18120DCA6
+  .text:000000018120DC75                 mov     rax, [rbp+var_30]
+  .text:000000018120DC79                 mov     rcx, [rdi+10h]
+  .text:000000018120DC7D                 mov     rbx, [rsi+rax]
+  .text:000000018120DC81                 call    sub_18120FDE0
+  .text:000000018120DC86                 mov     ecx, cs:dword_1821189CC
+  .text:000000018120DC8C                 lea     r8, aSExecutingScri; "%s executing script: %s\n"
+  .text:000000018120DC93                 mov     r9, rax
+  .text:000000018120DC96                 mov     [rsp+68h+var_48], rbx
+  .text:000000018120DC9B                 mov     edx, 1
+  .text:000000018120DCA0                 call    cs:LoggingSystem_Log
+  .text:000000018120DCA6                 mov     rax, [rbp+var_30]
+  .text:000000018120DCAA                 mov     rbx, [rsi+rax]
+  .text:000000018120DCAE                 cmp     [rdi+18h], r15
+  .text:000000018120DCB2                 jnz     short loc_18120DCBC
+  .text:000000018120DCB4                 mov     rcx, rdi
+  .text:000000018120DCB7                 call    CEntityInstance_ValidatePrivateScriptScope
+  .text:000000018120DCBC                 mov     r8, [rdi+18h]
+  .text:000000018120DCC0                 lea     rcx, qword_1820B1900
+  .text:000000018120DCC7                 mov     r9b, 1
+  .text:000000018120DCCA                 mov     rdx, rbx
+  .text:000000018120DCCD                 call    sub_18121B640
+  .text:000000018120DCD2                 inc     r14d
+  .text:000000018120DCD5                 add     rsi, 8
+  .text:000000018120DCD9                 cmp     r14d, [rbp+var_38]
+  .text:000000018120DCDD                 jl      short loc_18120DC60
+  .text:000000018120DCDF                 mov     rsi, [rsp+68h+arg_10]
+  .text:000000018120DCE7                 mov     rbx, [rsp+68h+arg_8]
+  .text:000000018120DCEF                 mov     rcx, [rbp+var_20]
+  .text:000000018120DCF3                 call    sub_180E772F0
+  .text:000000018120DCF8                 mov     eax, dword ptr [rbp+var_28+4]
+  .text:000000018120DCFB                 mov     r14, [rsp+68h+arg_18]
+  .text:000000018120DD03                 mov     rdx, [rbp+var_30]
+  .text:000000018120DD07                 mov     [rbp+var_20], r15
+  .text:000000018120DD0B                 mov     [rbp+var_18], r15d
+  .text:000000018120DD0F                 mov     [rbp+var_38], r15d
+  .text:000000018120DD13                 test    eax, 0C0000000h
+  .text:000000018120DD18                 jnz     short loc_18120DD3D
+  .text:000000018120DD1A                 test    rdx, rdx
+  .text:000000018120DD1D                 jz      short loc_18120DD39
+  .text:000000018120DD1F                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120DD26                 mov     rcx, [rax]
+  .text:000000018120DD29                 mov     rax, [rcx]
+  .text:000000018120DD2C                 call    qword ptr [rax+18h]
+  .text:000000018120DD2F                 mov     eax, dword ptr [rbp+var_28+4]
+  .text:000000018120DD32                 mov     rdx, r15
+  .text:000000018120DD35                 mov     [rbp+var_30], rdx
+  .text:000000018120DD39                 mov     dword ptr [rbp+var_28], r15d
+  .text:000000018120DD3D                 mov     [rbp+var_38], r15d
+  .text:000000018120DD41                 test    eax, 0C0000000h
+  .text:000000018120DD46                 jnz     short loc_18120DD6B
+  .text:000000018120DD48                 test    rdx, rdx
+  .text:000000018120DD4B                 jz      short loc_18120DD67
+  .text:000000018120DD4D                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120DD54                 mov     rcx, [rax]
+  .text:000000018120DD57                 mov     rax, [rcx]
+  .text:000000018120DD5A                 call    qword ptr [rax+18h]
+  .text:000000018120DD5D                 mov     eax, dword ptr [rbp+var_28+4]
+  .text:000000018120DD60                 mov     rdx, r15
+  .text:000000018120DD63                 mov     [rbp+var_30], rdx
+  .text:000000018120DD67                 mov     dword ptr [rbp+var_28], r15d
+  .text:000000018120DD6B                 mov     r15, [rsp+68h+var_8]
+  .text:000000018120DD70                 test    eax, 0C0000000h
+  .text:000000018120DD75                 jnz     short loc_18120DD8C
+  .text:000000018120DD77                 test    rdx, rdx
+  .text:000000018120DD7A                 jz      short loc_18120DD8C
+  .text:000000018120DD7C                 mov     rax, cs:g_pMemAlloc
+  .text:000000018120DD83                 mov     rcx, [rax]
+  .text:000000018120DD86                 mov     rax, [rcx]
+  .text:000000018120DD89                 call    qword ptr [rax+18h]
+  .text:000000018120DD8C                 add     rsp, 68h
+  .text:000000018120DD90                 pop     rdi
+  .text:000000018120DD91                 pop     rbp
+  .text:000000018120DD92                 retn
+procedure: |-
+  void __fastcall CBaseEntity_ReloadPrivateScripts(_QWORD *a1)
+  {
+    const char *v1; // rdx
+    int v3; // r14d
+    __int64 v4; // rsi
+    __int64 v5; // r9
+    const char *v6; // rbx
+    const char *v7; // rax
+    __int64 v8; // rbx
+    int v9; // eax
+    __int64 v10; // rdx
+    int v11; // [rsp+30h] [rbp-38h] BYREF
+    __int64 v12; // [rsp+38h] [rbp-30h]
+    __int64 v13; // [rsp+40h] [rbp-28h]
+    __int64 v14; // [rsp+48h] [rbp-20h]
+    int v15; // [rsp+50h] [rbp-18h]
+    const char *v16; // [rsp+80h] [rbp+18h] BYREF
+
+    v1 = (const char *)a1[1];                     // 0x8 = 8 = CEntityInstance::m_iszPrivateVScripts (structmember, struct=CEntityInstance, member=m_iszPrivateVScripts)
+    if ( v1 )
+    {
+      v16 = " ";
+      v12 = 0;
+      v13 = 0;
+      v11 = 0;
+      v14 = 0;
+      v15 = 0;
+      CSplitString::Split((CSplitString *)&v11, v1, -1, &v16, 1, 0);
+      v3 = 0;
+      if ( v11 > 0 )
+      {
+        v4 = 0;
+        do
+        {
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1821189CC, 1) )
+          {
+            v6 = *(const char **)(v4 + v12);
+            v7 = (const char *)sub_18120FDE0(a1[2]);
+            LoggingSystem_Log((unsigned int)dword_1821189CC, 1, "%s executing script: %s\n", v7, v6);
+          }
+          v8 = *(_QWORD *)(v4 + v12);
+          if ( !a1[3] )
+            CEntityInstance_ValidatePrivateScriptScope((__int64)a1);
+          LOBYTE(v5) = 1;
+          sub_18121B640(&qword_1820B1900, v8, a1[3], v5);
+          ++v3;
+          v4 += 8;
+        }
+        while ( v3 < v11 );
+      }
+      sub_180E772F0(v14);
+      v9 = HIDWORD(v13);
+      v10 = v12;
+      v14 = 0;
+      v15 = 0;
+      v11 = 0;
+      if ( (v13 & 0xC000000000000000uLL) == 0 )
+      {
+        if ( v12 )
+        {
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v12);
+          v9 = HIDWORD(v13);
+          v10 = 0;
+          v12 = 0;
+        }
+        LODWORD(v13) = 0;
+      }
+      v11 = 0;
+      if ( (v9 & 0xC0000000) == 0 )
+      {
+        if ( v10 )
+        {
+          (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+          v9 = HIDWORD(v13);
+          v10 = 0;
+          v12 = 0;
+        }
+        LODWORD(v13) = 0;
+      }
+      if ( (v9 & 0xC0000000) == 0 )
+      {
+        if ( v10 )
+          (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+      }
+    }
+  }


### PR DESCRIPTION
## Summary

- **Pattern E** (struct member via LLM_DECOMPILE): finds `CEntityInstance::m_iszPrivateVScripts` offset by decompiling `CBaseEntity_ReloadPrivateScripts`
- Offset is `0x8` on both Windows and Linux (confirmed from IDA annotations)
- Adds reference YAMLs for `CBaseEntity_ReloadPrivateScripts` (Windows + Linux) annotated with the struct member access
- Adds `CEntityInstance_m_iszPrivateVScripts` symbol entry (`structmember`, `struct: CEntityInstance`, `member: m_iszPrivateVScripts`)

## Test plan

- [ ] Produces `CEntityInstance_m_iszPrivateVScripts.windows.yaml` with `offset: 0x8`, `offset_sig`, `offset_sig_disp`
- [ ] Produces `CEntityInstance_m_iszPrivateVScripts.linux.yaml` with `offset: 0x8`, `offset_sig`, `offset_sig_disp`