### PR TITLE
feat(download): 仅下载 config.yaml 声明的模块并复用 DepotDownloader 重试

### DIFF
--- a/bump_download.py
+++ b/bump_download.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 import sys
 import tempfile
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -16,6 +15,13 @@ from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml.error import YAMLError
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString
 
+from depot_util import (
+    DEFAULT_DEPOTDOWNLOADER_ATTEMPTS,
+    DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS,
+    append_auth_args,
+    run_command,
+)
+
 
 DEFAULT_CONFIG_FILE = "download.yaml"
 DEFAULT_DEPOT_DIR = "cs2_depot"
@@ -23,8 +29,6 @@ DEFAULT_APP_ID = "730"
 DEFAULT_OS = "all-platform"
 STEAM_INF_PATH = r"game\csgo\steam.inf"
 DEFAULT_BRANCH_DEPOTS = ("2347771", "2347773")
-DEFAULT_DEPOTDOWNLOADER_ATTEMPTS = 3
-DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS = 30.0
 
 
 class BumpError(Exception):
@@ -68,66 +72,6 @@ def parse_patch_version(steam_inf_text: str) -> str:
     raise BumpError("PatchVersion not found in steam.inf")
 
 
-def _append_auth_args(
-    command: list[str],
-    username: str | None,
-    password: str | None,
-    remember_password: bool,
-) -> None:
-    if username:
-        command.extend(["-username", username])
-    if password:
-        command.extend(["-password", password])
-    if remember_password:
-        command.append("-remember-password")
-
-
-def _redact_command(command: list[str]) -> list[str]:
-    redacted: list[str] = []
-    skip_next = False
-    for part in command:
-        if skip_next:
-            redacted.append("<redacted>")
-            skip_next = False
-            continue
-        redacted.append(part)
-        if part == "-password":
-            skip_next = True
-    return redacted
-
-
-def run_command(
-    command: list[str],
-    *,
-    max_attempts: int = DEFAULT_DEPOTDOWNLOADER_ATTEMPTS,
-    retry_delay_seconds: float = DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS,
-) -> None:
-    """Run a subprocess command and let callers normalize errors."""
-    redacted_command = _redact_command(command)
-    attempt_count = max(1, max_attempts)
-
-    for attempt in range(1, attempt_count + 1):
-        if attempt == 1:
-            print(f"Running: {' '.join(redacted_command)}")
-        else:
-            print(
-                f"Retrying ({attempt}/{attempt_count}): "
-                f"{' '.join(redacted_command)}"
-            )
-
-        try:
-            subprocess.run(command, check=True)
-            return
-        except subprocess.CalledProcessError:
-            if attempt == attempt_count:
-                raise
-            print(
-                "Command failed; retrying in "
-                f"{retry_delay_seconds:g}s ({attempt}/{attempt_count})"
-            )
-            time.sleep(retry_delay_seconds)
-
-
 def fetch_manifest_id(
     depot: str,
     app: str,
@@ -150,7 +94,7 @@ def fetch_manifest_id(
         "-dir",
         str(output_dir),
     ]
-    _append_auth_args(command, username, password, remember_password)
+    append_auth_args(command, username, password, remember_password)
     command.append("-manifest-only")
     run_command(command)
     return find_manifest_id(output_dir, depot)
@@ -188,7 +132,7 @@ def download_and_parse_steam_inf(
             "-filelist",
             str(filelist_path),
         ]
-        _append_auth_args(command, username, password, remember_password)
+        append_auth_args(command, username, password, remember_password)
         run_command(command)
     finally:
         filelist_path.unlink(missing_ok=True)

--- a/depot_util.py
+++ b/depot_util.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Shared helpers for invoking DepotDownloader with retries and password redaction."""
+
+import subprocess
+import time
+
+
+DEFAULT_DEPOTDOWNLOADER_ATTEMPTS = 3
+DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS = 30.0
+
+
+def append_auth_args(
+    command: list[str],
+    username: str | None,
+    password: str | None,
+    remember_password: bool,
+) -> None:
+    """Append Steam auth arguments to a DepotDownloader command in place."""
+    if username:
+        command.extend(["-username", username])
+    if password:
+        command.extend(["-password", password])
+    if remember_password:
+        command.append("-remember-password")
+
+
+def redact_command(command: list[str]) -> list[str]:
+    """Return a copy of `command` with the value following `-password` redacted."""
+    redacted: list[str] = []
+    skip_next = False
+    for part in command:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        redacted.append(part)
+        if part == "-password":
+            skip_next = True
+    return redacted
+
+
+def run_command(
+    command: list[str],
+    *,
+    max_attempts: int = DEFAULT_DEPOTDOWNLOADER_ATTEMPTS,
+    retry_delay_seconds: float = DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS,
+) -> None:
+    """Run a subprocess command with bounded retries; callers normalize errors."""
+    redacted = redact_command(command)
+    attempt_count = max(1, max_attempts)
+
+    for attempt in range(1, attempt_count + 1):
+        if attempt == 1:
+            print(f"Running: {' '.join(redacted)}")
+        else:
+            print(
+                f"Retrying ({attempt}/{attempt_count}): "
+                f"{' '.join(redacted)}"
+            )
+
+        try:
+            subprocess.run(command, check=True)
+            return
+        except subprocess.CalledProcessError:
+            if attempt == attempt_count:
+                raise
+            print(
+                "Command failed; retrying in "
+                f"{retry_delay_seconds:g}s ({attempt}/{attempt_count})"
+            )
+            time.sleep(retry_delay_seconds)

--- a/download_depot.py
+++ b/download_depot.py
@@ -6,6 +6,7 @@ Download depot manifests by exact tag matching from download.yaml.
 import argparse
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 try:
@@ -15,8 +16,11 @@ except ImportError as exc:
     print("Please install required dependencies with: uv sync")
     sys.exit(1)
 
+from depot_util import append_auth_args, run_command
+
 
 DEFAULT_CONFIG_FILE = "download.yaml"
+DEFAULT_MODULES_CONFIG_FILE = "config.yaml"
 DEFAULT_DEPOT_DIR = "cs2_depot"
 DEFAULT_APP_ID = "730"
 DEFAULT_OS = "all-platform"
@@ -36,6 +40,14 @@ def parse_args() -> argparse.Namespace:
         "-config",
         default=DEFAULT_CONFIG_FILE,
         help=f"Path to download config file (default: {DEFAULT_CONFIG_FILE})",
+    )
+    parser.add_argument(
+        "-configyaml",
+        default=DEFAULT_MODULES_CONFIG_FILE,
+        help=(
+            f"Path to module config file used to build the DepotDownloader -filelist "
+            f"(default: {DEFAULT_MODULES_CONFIG_FILE})"
+        ),
     )
     parser.add_argument(
         "-depotdir",
@@ -103,43 +115,91 @@ def find_download_entry(downloads: list[dict], tag: str) -> dict:
     return entry
 
 
+def load_module_filelist(configyaml_path: str) -> list[str]:
+    """Collect sorted, de-duplicated path_windows/path_linux from config.yaml modules."""
+    path = Path(configyaml_path)
+    if not path.is_file():
+        raise ConfigError(f"Modules config file not found: {configyaml_path}")
+
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            config = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in modules config file: {configyaml_path}") from exc
+    except OSError as exc:
+        raise ConfigError(f"Failed to read modules config file: {configyaml_path}") from exc
+
+    if not isinstance(config, dict):
+        raise ConfigError("Modules config root must be a mapping/object")
+
+    modules = config.get("modules")
+    if not isinstance(modules, list):
+        raise ConfigError("Modules config field 'modules' must be a list")
+
+    paths: set[str] = set()
+    for index, module in enumerate(modules):
+        if not isinstance(module, dict):
+            raise ConfigError(f"Modules config field 'modules[{index}]' must be a mapping/object")
+        for key in ("path_windows", "path_linux"):
+            value = module.get(key)
+            if value is None:
+                continue
+            if not isinstance(value, str) or not value.strip():
+                raise ConfigError(
+                    f"Modules config 'modules[{index}].{key}' must be a non-empty string"
+                )
+            paths.add(value.strip())
+
+    if not paths:
+        raise ConfigError(
+            f"Modules config did not yield any path_windows/path_linux entries: {configyaml_path}"
+        )
+    return sorted(paths)
+
+
 def download_manifests(
     manifests: dict,
     app: str,
     os_name: str,
     depot_dir: str,
+    filelist: list[str],
     branch: str | None = None,
     username: str | None = None,
     password: str | None = None,
     remember_password: bool = False,
 ) -> None:
-    """Invoke DepotDownloader once per declared depot manifest."""
+    """Invoke DepotDownloader once per declared depot manifest, restricted by filelist."""
     if not isinstance(manifests, dict):
         raise ConfigError("Field 'manifests' must be a mapping of depot to manifest")
+    if not filelist:
+        raise ConfigError("Filelist must contain at least one path")
 
-    for depot, manifest in manifests.items():
-        command = [
-            "DepotDownloader",
-            "-app",
-            str(app),
-            "-depot",
-            str(depot),
-            "-os",
-            str(os_name),
-            "-dir",
-            str(depot_dir),
-        ]
-        if branch:
-            command.extend(["-branch", branch])
-        if username:
-            command.extend(["-username", username])
-        if password:
-            command.extend(["-password", password])
-        if remember_password:
-            command.append("-remember-password")
-        command.extend(["-manifest", str(manifest)])
-        print(f"Running: {' '.join(command)}")
-        subprocess.run(command, check=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", delete=False, suffix=".txt"
+    ) as handle:
+        handle.write("\n".join(filelist) + "\n")
+        filelist_path = Path(handle.name)
+    try:
+        for depot, manifest in manifests.items():
+            command = [
+                "DepotDownloader",
+                "-app",
+                str(app),
+                "-depot",
+                str(depot),
+                "-os",
+                str(os_name),
+                "-dir",
+                str(depot_dir),
+            ]
+            if branch:
+                command.extend(["-branch", branch])
+            append_auth_args(command, username, password, remember_password)
+            command.extend(["-manifest", str(manifest)])
+            command.extend(["-filelist", str(filelist_path)])
+            run_command(command)
+    finally:
+        filelist_path.unlink(missing_ok=True)
 
 
 def main() -> int:
@@ -154,18 +214,22 @@ def main() -> int:
         if branch is not None and not isinstance(branch, str):
             raise ConfigError(f"Download entry for tag '{args.tag}' field 'branch' must be a string")
 
+        filelist = load_module_filelist(args.configyaml)
+
         name = entry.get("name")
         if name:
             print(f"Matched tag '{args.tag}' ({name})")
         else:
             print(f"Matched tag '{args.tag}'")
         print(f"Manifest count: {len(manifests)}")
+        print(f"Filelist source: {args.configyaml} ({len(filelist)} paths)")
 
         download_manifests(
             manifests=manifests,
             app=args.app,
             os_name=args.os,
             depot_dir=args.depotdir,
+            filelist=filelist,
             branch=branch,
             username=args.username,
             password=args.password,

--- a/tests/test_bump_download.py
+++ b/tests/test_bump_download.py
@@ -76,7 +76,7 @@ class TestBumpDownload(unittest.TestCase):
             bump_download.parse_patch_version(text)
 
     @patch("builtins.print")
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.subprocess.run")
     def test_run_command_redacts_password_in_logs(self, mock_run, mock_print) -> None:
         command = ["DepotDownloader", "-app", "730", "-password", "secret"]
 
@@ -88,8 +88,8 @@ class TestBumpDownload(unittest.TestCase):
         mock_run.assert_called_once_with(command, check=True)
         self.assertEqual("secret", mock_run.call_args.args[0][4])
 
-    @patch("bump_download.time.sleep")
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.time.sleep")
+    @patch("depot_util.subprocess.run")
     def test_run_command_retries_after_subprocess_failure(
         self, mock_run, mock_sleep
     ) -> None:
@@ -107,8 +107,8 @@ class TestBumpDownload(unittest.TestCase):
         )
         mock_sleep.assert_called_once_with(0)
 
-    @patch("bump_download.time.sleep")
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.time.sleep")
+    @patch("depot_util.subprocess.run")
     def test_run_command_raises_after_retry_attempts_exhausted(
         self, mock_run, mock_sleep
     ) -> None:
@@ -126,7 +126,7 @@ class TestBumpDownload(unittest.TestCase):
         self.assertEqual(2, mock_run.call_count)
         mock_sleep.assert_called_once_with(0)
 
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.subprocess.run")
     def test_fetch_manifest_only_uses_isolated_directory(self, mock_run) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             isolated = Path(tmp) / "manifest"
@@ -163,7 +163,7 @@ class TestBumpDownload(unittest.TestCase):
         ]
         mock_run.assert_called_once_with(expected_command, check=True)
 
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.subprocess.run")
     def test_download_steam_inf_uses_manifest_and_filelist(self, mock_run) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             depot_dir = Path(tmp)
@@ -202,7 +202,7 @@ class TestBumpDownload(unittest.TestCase):
         mock_run.assert_called_once_with(expected_command, check=True)
         self.assertFalse(filelist_path.exists())
 
-    @patch("bump_download.subprocess.run")
+    @patch("depot_util.subprocess.run")
     def test_download_steam_inf_deletes_temporary_filelist(self, mock_run) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             depot_dir = Path(tmp)

--- a/tests/test_download_depot.py
+++ b/tests/test_download_depot.py
@@ -1,9 +1,13 @@
 import argparse
 import os
+import subprocess
 import tempfile
+import textwrap
 import unittest
-from unittest.mock import call, patch
+from pathlib import Path
+from unittest.mock import patch
 
+import depot_util
 import download_depot
 
 
@@ -84,100 +88,208 @@ downloads:
         finally:
             os.unlink(config_path)
 
+    def test_load_module_filelist_collects_windows_and_linux_paths(self) -> None:
+        config_path = self._write_yaml(
+            textwrap.dedent(
+                """
+                modules:
+                  - name: SDL3
+                    path_windows: game/bin/win64/SDL3.dll
+                    path_linux: game/bin/linuxsteamrt64/libSDL3.so.0
+                  - name: server
+                    path_windows: game/csgo/bin/win64/server.dll
+                """
+            )
+        )
+        try:
+            paths = download_depot.load_module_filelist(config_path)
+        finally:
+            os.unlink(config_path)
+
+        self.assertEqual(
+            [
+                "game/bin/linuxsteamrt64/libSDL3.so.0",
+                "game/bin/win64/SDL3.dll",
+                "game/csgo/bin/win64/server.dll",
+            ],
+            paths,
+        )
+
+    def test_load_module_filelist_raises_on_empty_modules(self) -> None:
+        config_path = self._write_yaml("modules: []\n")
+        try:
+            with self.assertRaises(download_depot.ConfigError):
+                download_depot.load_module_filelist(config_path)
+        finally:
+            os.unlink(config_path)
+
+    def test_load_module_filelist_raises_when_modules_missing(self) -> None:
+        config_path = self._write_yaml("other: value\n")
+        try:
+            with self.assertRaises(download_depot.ConfigError):
+                download_depot.load_module_filelist(config_path)
+        finally:
+            os.unlink(config_path)
+
+    def _filelist_capture_side_effect(self, captured: list[str]):
+        """Read the temp -filelist before DepotDownloader subprocess.run completes."""
+
+        def _side_effect(command, check=True):
+            self.assertTrue(check)
+            self.assertIn("-filelist", command)
+            filelist_path = Path(command[command.index("-filelist") + 1])
+            captured.append(filelist_path.read_text(encoding="utf-8"))
+            return None
+
+        return _side_effect
+
     def test_download_manifests_dispatches_declared_depots_only(self) -> None:
         manifests = {
             "2347771": "111",
             "2347773": "222",
         }
+        filelist = [
+            "game/bin/win64/SDL3.dll",
+            "game/bin/linuxsteamrt64/libSDL3.so.0",
+        ]
+        captured: list[str] = []
 
-        with patch("download_depot.subprocess.run") as mock_run:
+        with patch(
+            "depot_util.subprocess.run",
+            side_effect=self._filelist_capture_side_effect(captured),
+        ) as mock_run:
             download_depot.download_manifests(
                 manifests=manifests,
                 app="730",
                 os_name="all-platform",
                 depot_dir="cs2_depot",
+                filelist=filelist,
             )
 
-        self.assertEqual(
-            [
-                call(
-                    [
-                        "DepotDownloader",
-                        "-app",
-                        "730",
-                        "-depot",
-                        "2347771",
-                        "-os",
-                        "all-platform",
-                        "-dir",
-                        "cs2_depot",
-                        "-manifest",
-                        "111",
-                    ],
-                    check=True,
-                ),
-                call(
-                    [
-                        "DepotDownloader",
-                        "-app",
-                        "730",
-                        "-depot",
-                        "2347773",
-                        "-os",
-                        "all-platform",
-                        "-dir",
-                        "cs2_depot",
-                        "-manifest",
-                        "222",
-                    ],
-                    check=True,
-                ),
-            ],
-            mock_run.call_args_list,
-        )
+        self.assertEqual(2, mock_run.call_count)
+
+        observed_filelist_paths = set()
+        for call_args in mock_run.call_args_list:
+            command = call_args.args[0]
+            filelist_index = command.index("-filelist")
+            filelist_path = command[filelist_index + 1]
+            observed_filelist_paths.add(filelist_path)
+
+            self.assertEqual(
+                [
+                    "DepotDownloader",
+                    "-app",
+                    "730",
+                    "-os",
+                    "all-platform",
+                    "-dir",
+                    "cs2_depot",
+                ],
+                [command[0], command[1], command[2], command[5], command[6], command[7], command[8]],
+            )
+            self.assertEqual("-depot", command[3])
+            self.assertIn(command[4], manifests.keys())
+            self.assertEqual("-manifest", command[-4])
+            self.assertEqual(manifests[command[4]], command[-3])
+            self.assertEqual("-filelist", command[-2])
+
+        # All depots share the same temp filelist file path
+        self.assertEqual(1, len(observed_filelist_paths))
+        self.assertEqual(2, len(captured))
+        expected_contents = "\n".join(filelist) + "\n"
+        self.assertEqual([expected_contents, expected_contents], captured)
+        # Temp file is cleaned up afterwards
+        self.assertFalse(Path(next(iter(observed_filelist_paths))).exists())
 
     def test_download_manifests_adds_branch_when_configured(self) -> None:
-        manifests = {
-            "2347771": "111",
-        }
+        manifests = {"2347771": "111"}
+        filelist = ["game/bin/win64/SDL3.dll"]
 
-        with patch("download_depot.subprocess.run") as mock_run:
+        with patch(
+            "depot_util.subprocess.run",
+            side_effect=self._filelist_capture_side_effect([]),
+        ) as mock_run:
             download_depot.download_manifests(
                 manifests=manifests,
                 app="730",
                 os_name="all-platform",
                 depot_dir="cs2_depot",
+                filelist=filelist,
                 branch="animgraph_2_beta",
             )
 
-        self.assertEqual(
-            [
-                call(
-                    [
-                        "DepotDownloader",
-                        "-app",
-                        "730",
-                        "-depot",
-                        "2347771",
-                        "-os",
-                        "all-platform",
-                        "-dir",
-                        "cs2_depot",
-                        "-branch",
-                        "animgraph_2_beta",
-                        "-manifest",
-                        "111",
-                    ],
-                    check=True,
-                ),
-            ],
-            mock_run.call_args_list,
+        self.assertEqual(1, mock_run.call_count)
+        command = mock_run.call_args.args[0]
+        self.assertIn("-branch", command)
+        branch_index = command.index("-branch")
+        self.assertEqual("animgraph_2_beta", command[branch_index + 1])
+        self.assertIn("-manifest", command)
+        self.assertIn("-filelist", command)
+
+    def test_download_manifests_appends_auth_arguments(self) -> None:
+        manifests = {"2347771": "111"}
+        filelist = ["game/bin/win64/SDL3.dll"]
+
+        with patch(
+            "depot_util.subprocess.run",
+            side_effect=self._filelist_capture_side_effect([]),
+        ) as mock_run:
+            download_depot.download_manifests(
+                manifests=manifests,
+                app="730",
+                os_name="all-platform",
+                depot_dir="cs2_depot",
+                filelist=filelist,
+                username="user",
+                password="secret",
+                remember_password=True,
+            )
+
+        command = mock_run.call_args.args[0]
+        self.assertIn("-username", command)
+        self.assertEqual("user", command[command.index("-username") + 1])
+        self.assertIn("-password", command)
+        self.assertEqual("secret", command[command.index("-password") + 1])
+        self.assertIn("-remember-password", command)
+
+    def test_download_manifests_raises_when_filelist_empty(self) -> None:
+        with self.assertRaises(download_depot.ConfigError):
+            download_depot.download_manifests(
+                manifests={"2347771": "111"},
+                app="730",
+                os_name="all-platform",
+                depot_dir="cs2_depot",
+                filelist=[],
+            )
+
+    @patch("depot_util.time.sleep")
+    @patch("depot_util.subprocess.run")
+    def test_download_manifests_retries_on_subprocess_failure(self, mock_run, mock_sleep) -> None:
+        manifests = {"2347771": "111"}
+        filelist = ["game/bin/win64/SDL3.dll"]
+        mock_run.side_effect = [
+            subprocess.CalledProcessError(1, ["DepotDownloader"]),
+            None,
+        ]
+
+        download_depot.download_manifests(
+            manifests=manifests,
+            app="730",
+            os_name="all-platform",
+            depot_dir="cs2_depot",
+            filelist=filelist,
+        )
+
+        self.assertEqual(2, mock_run.call_count)
+        mock_sleep.assert_called_once_with(
+            depot_util.DEFAULT_DEPOTDOWNLOADER_RETRY_DELAY_SECONDS
         )
 
     def test_main_returns_nonzero_when_depotdownloader_missing(self) -> None:
         fake_args = argparse.Namespace(
             tag="alpha",
             config="download.yaml",
+            configyaml="config.yaml",
             depotdir="cs2_depot",
             app="730",
             os="all-platform",
@@ -193,7 +305,11 @@ downloads:
         with patch("download_depot.parse_args", return_value=fake_args), \
              patch("download_depot.load_downloads", return_value=[fake_entry]), \
              patch("download_depot.find_download_entry", return_value=fake_entry), \
-             patch("download_depot.subprocess.run", side_effect=FileNotFoundError("DepotDownloader")), \
+             patch(
+                 "download_depot.load_module_filelist",
+                 return_value=["game/bin/win64/SDL3.dll"],
+             ), \
+             patch("depot_util.subprocess.run", side_effect=FileNotFoundError("DepotDownloader")), \
              patch("builtins.print") as mock_print:
             exit_code = download_depot.main()
 


### PR DESCRIPTION
## Summary
- 把 `download_depot.py` 之前下载整套 manifest 内容的行为改成由 `config.yaml` 的 `modules[].path_windows` / `path_linux` 构造 `-filelist`，只拉取构建实际用到的二进制。
- 新增 `depot_util.py`，把 `bump_download.py` 已有的 DepotDownloader 重试 (`run_command`, 默认 3 次 / 30s) 与密码脱敏 (`redact_command`) 抽出来；`download_depot.py` 也走同一条重试路径。
- CLI 新增 `-configyaml`（默认 `config.yaml`），CI workflow 不需要改。

## Test plan
- [ ] `uv run python -m unittest tests.test_download_depot tests.test_bump_download`
- [ ] 端到端冒烟（需要 Steam 凭据/缓存）：`uv run download_depot.py -tag 14141 -depotdir cs2_depot -config download.yaml -configyaml config.yaml`，确认每次 DepotDownloader 命令都带上 `-filelist <tmp>` 并仅拉取 `config.yaml` 中声明的文件。
- [ ] 触发一次瞬时失败，确认日志输出 `Retrying (n/3): ...` 并最终成功；连续失败 3 次后整体退出。

🤖 Generated with [Claude Code](https://claude.com/claude-code)