### PR TITLE
feat: add find-PolymorphicHelper_t__SetPolymorphicPointer preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4438,6 +4438,10 @@ modules:
         expected_output:
           - RegisterSchemaTypeOverride_CEntityHandle.{platform}.yaml
 
+      - name: find-PolymorphicHelper_t__SetPolymorphicPointer
+        expected_output:
+          - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
+
       - name: find-GetCSceneEntityScriptDesc
         expected_output:
           - GetCSceneEntityScriptDesc.{platform}.yaml
@@ -7243,6 +7247,11 @@ modules:
 
       - name: RegisterSchemaTypeOverride_CEntityHandle
         category: func
+
+      - name: PolymorphicHelper_t__SetPolymorphicPointer
+        category: func
+        alias:
+          - PolymorphicHelper_t::SetPolymorphicPointer
 
       - name: GetCSceneEntityScriptDesc
         category: func

--- a/ida_preprocessor_scripts/find-PolymorphicHelper_t__SetPolymorphicPointer.py
+++ b/ida_preprocessor_scripts/find-PolymorphicHelper_t__SetPolymorphicPointer.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-PolymorphicHelper_t__SetPolymorphicPointer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "PolymorphicHelper_t__SetPolymorphicPointer",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "PolymorphicHelper_t__SetPolymorphicPointer",
+        "xref_strings": [
+            "PolymorphicHelper_t::SetPolymorphicPointer",
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": [], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "PolymorphicHelper_t__SetPolymorphicPointer",
+        "xref_strings": [
+            "../../public/networksystem/polymorphicmetadatahelper.h",
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": [], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "PolymorphicHelper_t__SetPolymorphicPointer",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add Pattern A preprocessor script for `PolymorphicHelper_t__SetPolymorphicPointer` (regular function in `server`)
- Platform-specific xref strings: `"PolymorphicHelper_t::SetPolymorphicPointer"` (Windows) / `"../../public/networksystem/polymorphicmetadatahelper.h"` (Linux)
- Add config.yaml skill and symbol entries

## Test plan
- [x] Validated on both Windows and Linux (bin/14158) — both platforms succeeded