### PR TITLE
feat: bump-download

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - "*"
+  repository_dispatch:
+    types: [build-on-self-runner]
 
 permissions:
   contents: write
@@ -29,8 +31,12 @@ jobs:
         shell: pwsh
         run: |
           $tag = "${{ github.ref_name }}"
+          if ("${{ github.event_name }}" -eq "repository_dispatch") {
+            $tag = "${{ github.event.client_payload.tag }}"
+          }
+
           if ([string]::IsNullOrWhiteSpace($tag)) {
-            throw "github.ref_name is empty."
+            throw "Unable to determine tag for ${{ github.event_name }} event."
           }
 
           if ([string]::IsNullOrWhiteSpace($env:PERSISTED_WORKSPACE)) {
@@ -44,6 +50,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref }}
+          fetch-depth: 0
           submodules: true
 
       - name: Create persisted workspace links
@@ -156,8 +164,9 @@ jobs:
           & 7z @archiveArgs
 
       - name: Create release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'repository_dispatch'
         uses: softprops/action-gh-release@v1
         with:
-          name: gamedata-${{ github.ref_name }}
-          files: gamedata-${{ env.GAMEVER }}.7z
+          tag_name: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref_name }}
+          name: gamedata-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref_name }}
+          files: gamedata-${{ github.event_name == 'repository_dispatch' && github.event.client_payload.tag || github.ref_name }}.7z

--- a/.github/workflows/bump-download.yml
+++ b/.github/workflows/bump-download.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: bump-download-${{ github.repository }}
@@ -34,7 +35,7 @@ jobs:
         run: |
           $workspace = (Resolve-Path -LiteralPath $env:GITHUB_WORKSPACE).Path -replace '\\', '/'
           git config --global --add safe.directory "$workspace"
-          git fetch origin --prune --prune-tags --tags
+          git fetch origin --prune --prune-tags --tags "+refs/heads/*:refs/remotes/origin/*"
 
       - name: Configure git
         shell: pwsh
@@ -47,9 +48,119 @@ jobs:
         shell: pwsh
         run: uv run bump_download.py -config download.yaml -depotdir cs2_depot -username "$env:STEAM_USERNAME" -password "$env:STEAM_PASSWORD" -remember-password -github-output "$env:GITHUB_OUTPUT"
 
-      - name: Push bump commit and tag
-        if: steps.bump.outputs.updated == 'true'
+      - name: Push bump branch
+        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.repair_tag != 'true'
+        id: branch
         shell: pwsh
         run: |
-          git push origin HEAD:main
-          git push origin "${{ steps.bump.outputs.tag }}"
+          $tag = "${{ steps.bump.outputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw "steps.bump.outputs.tag is empty."
+          }
+
+          $branch = "bump-download/$tag"
+          git push --force-with-lease origin "HEAD:refs/heads/$branch"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to push bump branch $branch."
+          }
+
+          "branch=$branch" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Create or update bump pull request
+        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.repair_tag != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = '${{ steps.bump.outputs.tag }}';
+            const branch = '${{ steps.branch.outputs.branch }}';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              state: 'open',
+              head: `${owner}:${branch}`,
+              base: 'main',
+            });
+
+            if (pulls.length > 0) {
+              core.notice(`Bump pull request already exists: ${pulls[0].html_url}`);
+              return;
+            }
+
+            const { data: pull } = await github.rest.pulls.create({
+              owner,
+              repo,
+              base: 'main',
+              head: branch,
+              title: `chore(download): 更新 ${tag} 下载清单`,
+              body: [
+                `Automated download bump for tag \`${tag}\`.`,
+                '',
+                'After this PR is merged, the post-merge workflow will create the tag and dispatch `build-on-self-runner`.',
+                '',
+                `<!-- bump-download-tag: ${tag} -->`,
+              ].join('\n'),
+            });
+
+            core.notice(`Created bump pull request: ${pull.html_url}`);
+
+      - name: Push repaired tag and dispatch build
+        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.repair_tag == 'true'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $tag = "${{ steps.bump.outputs.tag }}"
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw "steps.bump.outputs.tag is empty."
+          }
+
+          $headSha = git rev-parse HEAD
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to resolve HEAD."
+          }
+
+          $existingTag = git ls-remote --tags origin "refs/tags/$tag"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to query remote tag $tag."
+          }
+
+          if ([string]::IsNullOrWhiteSpace($existingTag)) {
+            git push origin "refs/tags/$tag"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to push repaired tag $tag."
+            }
+          } else {
+            $existingSha = ($existingTag -split "\s+")[0]
+            if ($existingSha -ne $headSha) {
+              throw "Remote tag $tag already exists at $existingSha, expected $headSha."
+            }
+
+            Write-Host "Remote tag $tag already points to $headSha."
+          }
+
+          $payload = @{
+            event_type = "build-on-self-runner"
+            client_payload = @{
+              tag = $tag
+              merge_sha = $headSha
+              repair_tag = $true
+            }
+          } | ConvertTo-Json -Depth 5
+
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+
+          Invoke-RestMethod `
+            -Method Post `
+            -Uri "https://api.github.com/repos/${{ github.repository }}/dispatches" `
+            -Headers $headers `
+            -ContentType "application/json" `
+            -Body $payload
+
+          Write-Host "Dispatched build-on-self-runner for repaired tag $tag."

--- a/.github/workflows/tag-bump-after-merge.yml
+++ b/.github/workflows/tag-bump-after-merge.yml
@@ -1,0 +1,113 @@
+name: Tag Bump After Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  tag-and-dispatch:
+    if: >
+      (github.repository == 'HLND2T/CS2_VibeSignatures' || github.repository == 'hzqst/CS2_VibeSignatures') &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'bump-download/')
+    runs-on: [self-hosted, windows, x64]
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Create tag and dispatch build
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          $headRef = "${{ github.event.pull_request.head.ref }}"
+          $tag = $headRef.Substring("bump-download/".Length)
+          $mergeSha = "${{ github.event.pull_request.merge_commit_sha }}"
+
+          if ([string]::IsNullOrWhiteSpace($tag)) {
+            throw "Could not derive tag from pull request head ref: $headRef"
+          }
+
+          if ($tag -notmatch '^[A-Za-z0-9._-]+$') {
+            throw "Refusing to create unexpected tag name: $tag"
+          }
+
+          if ([string]::IsNullOrWhiteSpace($mergeSha)) {
+            throw "github.event.pull_request.merge_commit_sha is empty."
+          }
+
+          git config user.name "github-actions[bot]"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to configure git user.name."
+          }
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to configure git user.email."
+          }
+
+          git fetch origin "main:refs/remotes/origin/main" --tags --force
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to fetch origin main and tags."
+          }
+
+          git merge-base --is-ancestor $mergeSha origin/main
+          if ($LASTEXITCODE -ne 0) {
+            throw "Merge commit $mergeSha is not reachable from origin/main."
+          }
+
+          $existingTag = git ls-remote --tags origin "refs/tags/$tag"
+          if ($LASTEXITCODE -ne 0) {
+            throw "Failed to query remote tag $tag."
+          }
+
+          if ([string]::IsNullOrWhiteSpace($existingTag)) {
+            git tag $tag $mergeSha
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to create local tag $tag."
+            }
+
+            git push origin "refs/tags/$tag"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to push tag $tag."
+            }
+          } else {
+            $existingSha = ($existingTag -split "\s+")[0]
+            if ($existingSha -ne $mergeSha) {
+              throw "Remote tag $tag already exists at $existingSha, expected $mergeSha."
+            }
+
+            Write-Host "Remote tag $tag already points to $mergeSha."
+          }
+
+          $payload = @{
+            event_type = "build-on-self-runner"
+            client_payload = @{
+              tag = $tag
+              merge_sha = $mergeSha
+              pull_request = ${{ github.event.pull_request.number }}
+            }
+          } | ConvertTo-Json -Depth 5
+
+          $headers = @{
+            Authorization = "Bearer $env:GITHUB_TOKEN"
+            Accept = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+
+          Invoke-RestMethod `
+            -Method Post `
+            -Uri "https://api.github.com/repos/${{ github.repository }}/dispatches" `
+            -Headers $headers `
+            -ContentType "application/json" `
+            -Body $payload
+
+          Write-Host "Dispatched build-on-self-runner for tag $tag."

--- a/bump_download.py
+++ b/bump_download.py
@@ -265,13 +265,20 @@ def save_config(config_path: Path, data: dict[str, Any]) -> None:
         _yaml().dump(data, handle)
 
 
-def write_github_output(output_path: Path | None, updated: bool, tag: str | None) -> None:
+def write_github_output(
+    output_path: Path | None,
+    updated: bool,
+    tag: str | None,
+    repair_tag: bool = False,
+) -> None:
     """Write GitHub Actions step outputs when requested."""
     if output_path is None:
         return
     lines = [f"updated={'true' if updated else 'false'}"]
     if updated and tag:
         lines.append(f"tag={tag}")
+    if repair_tag:
+        lines.append("repair_tag=true")
     with output_path.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
 
@@ -494,7 +501,12 @@ def run(args: argparse.Namespace) -> int:
         append_download_entry(downloads, plan)
         save_config(config_path, data)
         create_commit_and_tag(config_path, plan.tag, plan.patch_version)
-    write_github_output(output_path, updated=True, tag=plan.tag)
+    write_github_output(
+        output_path,
+        updated=True,
+        tag=plan.tag,
+        repair_tag=plan.repair_tag,
+    )
     print(f"Prepared bump tag {plan.tag} for {patch_version}")
     return 0
 

--- a/docs/superpowers/specs/2026-05-17-bump-download-design.md
+++ b/docs/superpowers/specs/2026-05-17-bump-download-design.md
@@ -174,17 +174,20 @@ jobs:
         run: |
           uv run bump_download.py -config download.yaml -depotdir cs2_depot -username "$env:STEAM_USERNAME" -password "$env:STEAM_PASSWORD" -remember-password -github-output "$env:GITHUB_OUTPUT"
 
-      - name: Push bump commit and tag
+      - name: Push bump branch
         if: steps.bump.outputs.updated == 'true'
         shell: pwsh
         run: |
-          git push origin HEAD:main
-          git push origin "${{ steps.bump.outputs.tag }}"
+          git push origin "HEAD:refs/heads/bump-download/${{ steps.bump.outputs.tag }}"
+
+      - name: Create or update bump pull request
+        if: steps.bump.outputs.updated == 'true'
+        uses: actions/github-script@v7
 ```
 
-workflow 使用 `main` 作为固定目标分支。新 tag 推送后，现有 tag-triggered build workflow 会继续处理后续构建和 release。
+workflow 使用 `main` 作为固定目标分支，但不直接 push protected branch。新下载条目先进入 `bump-download/<tag>` 临时分支并创建 PR。PR 合并后，post-merge workflow 在合并后的 main commit 上创建 tag，并通过 `repository_dispatch` 触发 `build-on-self-runner`。
 
-push 顺序保持为先 `git push origin HEAD:main`，再 `git push origin <tag>`。如果 main push 失败，tag push 不执行；下一次 workflow 仍会基于旧 main 重新尝试。如果 main push 成功但 tag push 失败，下一次 workflow 会通过 tag 修复模式补推缺失 tag。
+如果配置已在 `main` 但远端 tag 缺失，脚本进入 tag 修复模式并写出 `repair_tag=true`。workflow 此时不创建 PR，而是补推缺失 tag，并通过 `repository_dispatch` 触发 `build-on-self-runner`。
 
 ## Output 与退出码
 
@@ -208,7 +211,7 @@ updated=true
 tag=14161
 ```
 
-tag 修复模式同样写入 `updated=true` 和 `tag=<missing_tag>`，让 workflow 执行 push step；此时 `git push origin HEAD:main` 应为 no-op，`git push origin <tag>` 会补齐缺失 tag。
+tag 修复模式同样写入 `updated=true` 和 `tag=<missing_tag>`，并额外写入 `repair_tag=true`，让 workflow 走补 tag 与 dispatch 构建路径。
 
 ## 错误处理
 
@@ -245,8 +248,8 @@ tag 修复模式同样写入 `updated=true` 和 `tag=<missing_tag>`，让 workfl
 - 下载 `steam.inf` 时使用 `2347770` 的 manifest id 和只包含 `game\csgo\steam.inf` 的 filelist。
 - `-dry-run` 不写文件、不执行 git。
 - 有更新时 Git 命令顺序为 `add -> commit -> tag`。
-- main push 已成功但 tag 缺失时，脚本进入 tag 修复模式并输出需要 push 的 tag。
-- `-github-output` 正确写入 `updated=false` 或 `updated=true/tag=...`。
+- 配置已在 main 但 tag 缺失时，脚本进入 tag 修复模式并输出需要补推的 tag。
+- `-github-output` 正确写入 `updated=false`、`updated=true/tag=...`，以及 tag 修复时的 `repair_tag=true`。
 - `ruamel.yaml` 写回后保留既有条目的行内注释。
 
 按仓库偏好，本任务属于有行为影响的新自动化功能，建议至少执行定向单测：

--- a/tests/test_bump_download.py
+++ b/tests/test_bump_download.py
@@ -481,6 +481,18 @@ class TestBumpDownload(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
             )
 
+            repair_output = Path(tmp) / "repair_out.txt"
+            bump_download.write_github_output(
+                repair_output,
+                updated=True,
+                tag="14161",
+                repair_tag=True,
+            )
+            self.assertEqual(
+                "updated=true\ntag=14161\nrepair_tag=true\n",
+                repair_output.read_text(encoding="utf-8"),
+            )
+
     @patch("bump_download.subprocess.run")
     def test_create_commit_and_tag_runs_expected_git_commands(self, mock_run) -> None:
         bump_download.create_commit_and_tag(
@@ -908,7 +920,7 @@ class TestBumpDownload(unittest.TestCase):
         ensure_local_tag_matches_head.assert_called_once_with("14161")
         create_repair_tag.assert_called_once_with("14161")
         create_commit_and_tag.assert_not_called()
-        self.assertEqual("updated=true\ntag=14161\n", output_text)
+        self.assertEqual("updated=true\ntag=14161\nrepair_tag=true\n", output_text)
 
     @patch("bump_download.parse_args", return_value=argparse.Namespace())
     def test_main_maps_known_errors_to_exit_codes(self, _parse_args) -> None:


### PR DESCRIPTION
bump-download 现在不再推 HEAD:main，而是推送 bump-download/<tag> 临时分支并创建 PR；PR 合并后由新增 workflow 创建 tag，再用 repository_dispatch 触发 build-on-self-runner。