### PR TITLE
Add PolymorphicHelper_t__SetPolymorphicPointer and CEntityInstance accessor path vfunc preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4869,6 +4869,14 @@ modules:
         expected_output:
           - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
 
+      - name: find-CEntityInstance_AddChangeAccessorPath-AND-CEntityInstance_AssignChangeAccessorPathIds
+        expected_output:
+          - CEntityInstance_AddChangeAccessorPath.{platform}.yaml
+          - CEntityInstance_AssignChangeAccessorPathIds.{platform}.yaml
+        expected_input:
+          - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CNavPhysicsInterface_vtable
         expected_output:
           - CNavPhysicsInterface_vtable.{platform}.yaml
@@ -5147,6 +5155,16 @@ modules:
         category: func
         alias:
           - PolymorphicHelper_t::SetPolymorphicPointer
+
+      - name: CEntityInstance_AddChangeAccessorPath
+        category: vfunc
+        alias:
+          - CEntityInstance::AddChangeAccessorPath
+
+      - name: CEntityInstance_AssignChangeAccessorPathIds
+        category: vfunc
+        alias:
+          - CEntityInstance::AssignChangeAccessorPathIds
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -4865,6 +4865,10 @@ modules:
           - CEntitySaveRestoreBlockHandler_SaveInternal.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-PolymorphicHelper_t__SetPolymorphicPointer
+        expected_output:
+          - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
+
       - name: find-CNavPhysicsInterface_vtable
         expected_output:
           - CNavPhysicsInterface_vtable.{platform}.yaml
@@ -5138,6 +5142,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::RequiredEdictIndex
+
+      - name: PolymorphicHelper_t__SetPolymorphicPointer
+        category: func
+        alias:
+          - PolymorphicHelper_t::SetPolymorphicPointer
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEntityInstance_AddChangeAccessorPath-AND-CEntityInstance_AssignChangeAccessorPathIds.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_AddChangeAccessorPath-AND-CEntityInstance_AssignChangeAccessorPathIds.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_AddChangeAccessorPath-AND-CEntityInstance_AssignChangeAccessorPathIds skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_AddChangeAccessorPath",
+    "CEntityInstance_AssignChangeAccessorPathIds",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntityInstance_AddChangeAccessorPath",
+        "prompt/call_llm_decompile.md",
+        "references/server/PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml",
+    ),
+    (
+        "CEntityInstance_AssignChangeAccessorPathIds",
+        "prompt/call_llm_decompile.md",
+        "references/server/PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEntityInstance_AddChangeAccessorPath", "CEntityInstance"),
+    ("CEntityInstance_AssignChangeAccessorPathIds", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntityInstance_AddChangeAccessorPath",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "CEntityInstance_AssignChangeAccessorPathIds",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target functions and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-PolymorphicHelper_t__SetPolymorphicPointer.py
+++ b/ida_preprocessor_scripts/find-PolymorphicHelper_t__SetPolymorphicPointer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-PolymorphicHelper_t__SetPolymorphicPointer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "PolymorphicHelper_t__SetPolymorphicPointer",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "PolymorphicHelper_t__SetPolymorphicPointer",
+        "xref_strings": [
+            "PolymorphicHelper_t::SetPolymorphicPointer",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "PolymorphicHelper_t__SetPolymorphicPointer",
+        "xref_strings": [
+            "../../public/networksystem/polymorphicmetadatahelper.h",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "PolymorphicHelper_t__SetPolymorphicPointer",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.linux.yaml
@@ -1,0 +1,610 @@
+func_name: PolymorphicHelper_t__SetPolymorphicPointer
+func_va: '0x11de2e0'
+disasm_code: |-
+  .text:00000000011DE2E0                 push    rbp
+  .text:00000000011DE2E1                 mov     rbp, rsp
+  .text:00000000011DE2E4                 push    r15
+  .text:00000000011DE2E6                 push    r14
+  .text:00000000011DE2E8                 mov     r14d, r9d
+  .text:00000000011DE2EB                 push    r13
+  .text:00000000011DE2ED                 mov     r13, rdx
+  .text:00000000011DE2F0                 push    r12
+  .text:00000000011DE2F2                 mov     r12, rcx
+  .text:00000000011DE2F5                 push    rbx
+  .text:00000000011DE2F6                 mov     rbx, rdi
+  .text:00000000011DE2F9                 sub     rsp, 88h
+  .text:00000000011DE300                 mov     rax, [rdi]
+  .text:00000000011DE303                 mov     [rbp+var_A0], rsi
+  .text:00000000011DE30A                 mov     r15d, [rbp+arg_0]
+  .text:00000000011DE30E                 mov     dword ptr [rbp+var_98], r8d
+  .text:00000000011DE315                 call    qword ptr [rax+118h]
+  .text:00000000011DE31B                 mov     rax, [r13+0]
+  .text:00000000011DE31F                 mov     [r13+0], r12
+  .text:00000000011DE323                 test    r12, r12
+  .text:00000000011DE326                 jz      loc_11DE720
+  .text:00000000011DE32C                 lea     rdi, [r12+8]
+  .text:00000000011DE331                 mov     rcx, r12
+  .text:00000000011DE334                 mov     rsi, rbx
+  .text:00000000011DE337                 mov     [rbp+var_A8], rax
+  .text:00000000011DE33E                 mov     edx, 1
+  .text:00000000011DE343                 call    sub_1E75E30
+  .text:00000000011DE348                 test    r14b, r14b
+  .text:00000000011DE34B                 jnz     loc_11DE480
+  .text:00000000011DE351                 mov     rax, [rbp+var_A8]
+  .text:00000000011DE358                 test    rax, rax
+  .text:00000000011DE35B                 jz      loc_11DE738
+  .text:00000000011DE361                 ; _QWORD
+  .text:00000000011DE361                 xor     esi, esi; _QWORD
+  .text:00000000011DE363                 ; _QWORD
+  .text:00000000011DE363                 xor     edi, edi; _QWORD
+  .text:00000000011DE365                 ; _QWORD
+  .text:00000000011DE365                 mov     ecx, 4; _QWORD
+  .text:00000000011DE36A                 mov     r14d, [rax+28h]
+  .text:00000000011DE36E                 ; _QWORD
+  .text:00000000011DE36E                 mov     edx, 1; _QWORD
+  .text:00000000011DE373                 mov     [rbp+var_70], 0
+  .text:00000000011DE37B                 mov     [rbp+var_70+8], 0
+  .text:00000000011DE383                 mov     [rbp+var_60], 0
+  .text:00000000011DE38B                 mov     [rbp+var_58], 0
+  .text:00000000011DE393                 mov     qword ptr [rbp+var_50], 0
+  .text:00000000011DE39B                 mov     qword ptr [rbp+var_50+8], 0
+  .text:00000000011DE3A3                 mov     dword ptr [rbp+var_40], 0
+  .text:00000000011DE3AA                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:00000000011DE3AF                 test    eax, eax
+  .text:00000000011DE3B1                 jle     loc_11DE47C
+  .text:00000000011DE3B7                 movsxd  rcx, dword ptr [rbp+var_60]
+  .text:00000000011DE3BB                 movsxd  rdx, eax
+  .text:00000000011DE3BE                 xor     esi, esi
+  .text:00000000011DE3C0                 mov     dword ptr [rbp+var_A8], eax
+  .text:00000000011DE3C6                 ; _QWORD
+  .text:00000000011DE3C6                 shl     rdx, 2; _QWORD
+  .text:00000000011DE3CA                 ; _QWORD
+  .text:00000000011DE3CA                 mov     rdi, [rbp+var_70+8]; _QWORD
+  .text:00000000011DE3CE                 ; _QWORD
+  .text:00000000011DE3CE                 shl     rcx, 2; _QWORD
+  .text:00000000011DE3D2                 cmp     dword ptr [rbp+var_60+4], 3FFFFFFFh
+  .text:00000000011DE3D9                 ; _QWORD
+  .text:00000000011DE3D9                 setbe   sil; _QWORD
+  .text:00000000011DE3DD                 call    _UtlVectorMemory_Alloc
+  .text:00000000011DE3E2                 mov     edx, dword ptr [rbp+var_60+4]
+  .text:00000000011DE3E5                 mov     r8d, dword ptr [rbp+var_A8]
+  .text:00000000011DE3EC                 mov     [rbp+var_70+8], rax
+  .text:00000000011DE3F0                 cmp     edx, 3FFFFFFFh
+  .text:00000000011DE3F6                 jbe     short loc_11DE401
+  .text:00000000011DE3F8                 and     edx, 3FFFFFFFh
+  .text:00000000011DE3FE                 mov     dword ptr [rbp+var_60+4], edx
+  .text:00000000011DE401                 add     dword ptr [rbp+var_70], 1
+  .text:00000000011DE405                 mov     dword ptr [rbp+var_60], r8d
+  .text:00000000011DE409                 mov     rdi, rbx
+  .text:00000000011DE40C                 mov     [rax], r14d
+  .text:00000000011DE40F                 mov     rax, [rbx]
+  .text:00000000011DE412                 lea     r14, [rbp+var_70]
+  .text:00000000011DE416                 mov     rsi, r14
+  .text:00000000011DE419                 ; 0xF8 = 248LL = CEntityInstance_AssignChangeAccessorPathIds
+  .text:00000000011DE419                 call    qword ptr [rax+0F8h]; 0xF8 = 248LL = CEntityInstance_AssignChangeAccessorPathIds
+  .text:00000000011DE41F                 cmp     dword ptr [rbp+var_50+0Ch], 3FFFFFFFh
+  .text:00000000011DE426                 mov     dword ptr [rbp+var_58], 0
+  .text:00000000011DE42D                 ja      short loc_11DE448
+  .text:00000000011DE42F                 mov     rsi, qword ptr [rbp+var_50]
+  .text:00000000011DE433                 test    rsi, rsi
+  .text:00000000011DE436                 jz      short loc_11DE448
+  .text:00000000011DE438                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000011DE43F                 mov     rdi, [rax]
+  .text:00000000011DE442                 mov     rax, [rdi]
+  .text:00000000011DE445                 call    qword ptr [rax+20h]
+  .text:00000000011DE448                 cmp     dword ptr [rbp+var_60+4], 3FFFFFFFh
+  .text:00000000011DE44F                 mov     dword ptr [rbp+var_70], 0
+  .text:00000000011DE456                 ja      short loc_11DE471
+  .text:00000000011DE458                 mov     rsi, [rbp+var_70+8]
+  .text:00000000011DE45C                 test    rsi, rsi
+  .text:00000000011DE45F                 jz      short loc_11DE471
+  .text:00000000011DE461                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000011DE468                 mov     rdi, [rax]
+  .text:00000000011DE46B                 mov     rax, [rdi]
+  .text:00000000011DE46E                 call    qword ptr [rax+20h]
+  .text:00000000011DE471                 test    r12, r12
+  .text:00000000011DE474                 jnz     loc_11DE73C
+  .text:00000000011DE47A                 jmp     short loc_11DE4F3
+  .text:00000000011DE47C                 jmp     short loc_11DE47C
+  .text:00000000011DE480                 mov     rax, [rbx]
+  .text:00000000011DE483                 lea     rcx, aPublicNetworks_0; "../../public/networksystem/polymorphicm"...
+  .text:00000000011DE48A                 xor     r10d, r10d
+  .text:00000000011DE48D                 mov     rdi, rbx
+  .text:00000000011DE490                 mov     rdx, cs:qword_86E980
+  .text:00000000011DE497                 lea     r14, [rbp+var_70]
+  .text:00000000011DE49B                 movq    xmm0, cs:off_22FD990; "SetPolymorphicPointer"
+  .text:00000000011DE4A3                 mov     rsi, r14
+  .text:00000000011DE4A6                 mov     rax, [rax+0E8h]
+  .text:00000000011DE4AD                 pinsrq  xmm0, rcx, 1
+  .text:00000000011DE4B4                 mov     [rbp+var_70], 0
+  .text:00000000011DE4BC                 mov     [rbp+var_70+8], 0
+  .text:00000000011DE4C4                 mov     [rbp+var_60], 0
+  .text:00000000011DE4CC                 mov     [rbp+var_58], 0
+  .text:00000000011DE4D4                 movaps  [rbp+var_50], xmm0
+  .text:00000000011DE4D8                 mov     [rbp+var_40], rdx
+  .text:00000000011DE4DC                 mov     [rbp+var_38], 0FFFFFFFFh
+  .text:00000000011DE4E3                 mov     [rbp+var_34], r10w
+  .text:00000000011DE4E8                 call    rax
+  .text:00000000011DE4EA                 lea     rdi, [rbp+var_70+8]
+  .text:00000000011DE4EE                 call    sub_9B9050
+  .text:00000000011DE4F3                 test    r15b, r15b
+  .text:00000000011DE4F6                 jz      loc_11DE70A
+  .text:00000000011DE4FC                 mov     rax, [r13+0]
+  .text:00000000011DE500                 test    rax, rax
+  .text:00000000011DE503                 jz      loc_11DE70A
+  .text:00000000011DE509                 mov     r12d, [rax+28h]
+  .text:00000000011DE50D                 test    r12d, r12d
+  .text:00000000011DE510                 js      loc_11DE872
+  .text:00000000011DE516                 lea     rax, qword_26F8388
+  .text:00000000011DE51D                 mov     rdi, rbx
+  .text:00000000011DE520                 mov     r13, [rax]
+  .text:00000000011DE523                 mov     rax, [rbx]
+  .text:00000000011DE526                 call    qword ptr [rax+138h]
+  .text:00000000011DE52C                 mov     edx, [rax+4]
+  .text:00000000011DE52F                 and     edx, 7FFFFFFFh
+  .text:00000000011DE535                 jz      loc_11DE830
+  .text:00000000011DE53B                 cmp     edx, 4
+  .text:00000000011DE53E                 ja      loc_11DE7A0
+  .text:00000000011DE544                 add     rax, 8
+  .text:00000000011DE548                 movsxd  rdx, r12d
+  .text:00000000011DE54B                 mov     esi, [rax+rdx*4]
+  .text:00000000011DE54E                 cmp     esi, 0FFFFFFFFh
+  .text:00000000011DE551                 jz      loc_11DE7F0
+  .text:00000000011DE557                 test    esi, esi
+  .text:00000000011DE559                 jz      loc_11DE810
+  .text:00000000011DE55F                 js      loc_11DE860
+  .text:00000000011DE565                 xor     edi, edi
+  .text:00000000011DE567                 xor     edx, edx
+  .text:00000000011DE569                 mov     eax, esi
+  .text:00000000011DE56B                 and     eax, cs:dword_77BA40
+  .text:00000000011DE571                 mov     word ptr [rbp+var_58], di
+  .text:00000000011DE575                 mov     byte ptr [rbp+var_58+2], 0
+  .text:00000000011DE579                 lea     r8, dword_77BA80
+  .text:00000000011DE580                 lea     rdi, unk_77BA44
+  .text:00000000011DE587                 jz      short loc_11DE5C0
+  .text:00000000011DE589                 nop     word ptr [rax+rax+00000000h]
+  .text:00000000011DE594                 nop     word ptr [rax+rax+00000000h]
+  .text:00000000011DE59F                 nop
+  .text:00000000011DE5A0                 mov     ecx, [r8+rdx*2]
+  .text:00000000011DE5A4                 sar     eax, cl
+  .text:00000000011DE5A6                 sub     eax, 1
+  .text:00000000011DE5A9                 mov     [r14+rdx], ax
+  .text:00000000011DE5AE                 mov     eax, [rdi+rdx*2]
+  .text:00000000011DE5B1                 add     rdx, 2
+  .text:00000000011DE5B5                 add     word ptr [rbp+var_58], 1
+  .text:00000000011DE5BA                 and     eax, esi
+  .text:00000000011DE5BC                 test    eax, eax
+  .text:00000000011DE5BE                 jnz     short loc_11DE5A0
+  .text:00000000011DE5C0                 mov     rdx, [rbx+10h]
+  .text:00000000011DE5C4                 mov     rax, [rdx+8]
+  .text:00000000011DE5C8                 mov     rcx, [rax+0D8h]
+  .text:00000000011DE5CF                 mov     rax, [rax+0E0h]
+  .text:00000000011DE5D6                 mov     [rbp+var_80], rcx
+  .text:00000000011DE5DA                 mov     [rbp+var_78], rax
+  .text:00000000011DE5DE                 lea     rax, qword_2743668
+  .text:00000000011DE5E5                 mov     ecx, [rdx+30h]
+  .text:00000000011DE5E8                 mov     rsi, [rax]
+  .text:00000000011DE5EB                 and     ecx, 1
+  .text:00000000011DE5EE                 mov     rax, [rsi]
+  .text:00000000011DE5F1                 mov     r10, [rax+8]
+  .text:00000000011DE5F5                 mov     eax, [rdx+10h]
+  .text:00000000011DE5F8                 shr     eax, 0Fh
+  .text:00000000011DE5FB                 sub     eax, ecx
+  .text:00000000011DE5FD                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:00000000011DE601                 jz      loc_11DE840
+  .text:00000000011DE607                 movzx   edx, word ptr [rdx+10h]
+  .text:00000000011DE60B                 and     dx, 7FFFh
+  .text:00000000011DE610                 shl     eax, 0Fh
+  .text:00000000011DE613                 movzx   r9d, dx
+  .text:00000000011DE617                 and     edx, 7FFFh
+  .text:00000000011DE61D                 or      edx, eax
+  .text:00000000011DE61F                 mov     eax, 7FFFh
+  .text:00000000011DE624                 mov     rcx, r14
+  .text:00000000011DE627                 lea     r13, haystack
+  .text:00000000011DE62E                 cmp     edx, 0FFFFFFFFh
+  .text:00000000011DE631                 mov     r8, rbx
+  .text:00000000011DE634                 cmovz   r9d, eax
+  .text:00000000011DE638                 lea     rax, [rbp+var_90]
+  .text:00000000011DE63F                 mov     [rbp+var_A0], rax
+  .text:00000000011DE646                 lea     rdx, [rbp+var_80]
+  .text:00000000011DE64A                 mov     rdi, rax
+  .text:00000000011DE64D                 push    1
+  .text:00000000011DE64F                 lea     r15, [rbp+var_88]
+  .text:00000000011DE656                 push    0
+  .text:00000000011DE658                 call    r10
+  .text:00000000011DE65B                 mov     r8, [rbp+var_90]
+  .text:00000000011DE662                 mov     rsi, r14
+  .text:00000000011DE665                 mov     rdi, r15
+  .text:00000000011DE668                 pop     rax
+  .text:00000000011DE669                 pop     rdx
+  .text:00000000011DE66A                 test    r8, r8
+  .text:00000000011DE66D                 cmovz   r8, r13
+  .text:00000000011DE671                 mov     [rbp+var_98], r8
+  .text:00000000011DE678                 call    sub_202BFD0
+  .text:00000000011DE67D                 mov     rcx, [rbp+var_88]
+  .text:00000000011DE684                 mov     rdx, [rbx+10h]
+  .text:00000000011DE688                 mov     r8, [rbp+var_98]
+  .text:00000000011DE68F                 test    rcx, rcx
+  .text:00000000011DE692                 cmovz   rcx, r13
+  .text:00000000011DE696                 test    rdx, rdx
+  .text:00000000011DE699                 jz      loc_11DE820
+  .text:00000000011DE69F                 mov     eax, [rdx+10h]
+  .text:00000000011DE6A2                 mov     esi, [rdx+30h]
+  .text:00000000011DE6A5                 shr     eax, 0Fh
+  .text:00000000011DE6A8                 and     esi, 1
+  .text:00000000011DE6AB                 sub     eax, esi
+  .text:00000000011DE6AD                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:00000000011DE6B1                 jz      loc_11DE850
+  .text:00000000011DE6B7                 movzx   esi, word ptr [rdx+10h]
+  .text:00000000011DE6BB                 and     si, 7FFFh
+  .text:00000000011DE6C0                 shl     eax, 0Fh
+  .text:00000000011DE6C3                 movzx   esi, si
+  .text:00000000011DE6C6                 or      eax, esi
+  .text:00000000011DE6C8                 cmp     eax, 0FFFFFFFFh
+  .text:00000000011DE6CB                 jz      loc_11DE820
+  .text:00000000011DE6D1                 lea     rdi, aDAssignedChang; "%d: assigned ChangeAccessorFieldPathInd"...
+  .text:00000000011DE6D8                 xor     eax, eax
+  .text:00000000011DE6DA                 mov     edx, r12d
+  .text:00000000011DE6DD                 call    _Msg
+  .text:00000000011DE6E2                 cmp     [rbp+var_88], 0
+  .text:00000000011DE6EA                 jz      short loc_11DE6F4
+  .text:00000000011DE6EC                 ; this
+  .text:00000000011DE6EC                 mov     rdi, r15; this
+  .text:00000000011DE6EF                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:00000000011DE6F4                 cmp     [rbp+var_90], 0
+  .text:00000000011DE6FC                 jz      short loc_11DE70A
+  .text:00000000011DE6FE                 ; this
+  .text:00000000011DE6FE                 mov     rdi, [rbp+var_A0]; this
+  .text:00000000011DE705                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:00000000011DE70A                 lea     rsp, [rbp-28h]
+  .text:00000000011DE70E                 pop     rbx
+  .text:00000000011DE70F                 pop     r12
+  .text:00000000011DE711                 pop     r13
+  .text:00000000011DE713                 pop     r14
+  .text:00000000011DE715                 pop     r15
+  .text:00000000011DE717                 pop     rbp
+  .text:00000000011DE718                 retn
+  .text:00000000011DE720                 test    r14b, r14b
+  .text:00000000011DE723                 jnz     loc_11DE480
+  .text:00000000011DE729                 test    rax, rax
+  .text:00000000011DE72C                 jnz     loc_11DE361
+  .text:00000000011DE732                 jmp     short loc_11DE70A
+  .text:00000000011DE738                 lea     r14, [rbp+var_70]
+  .text:00000000011DE73C                 mov     rax, [rbx+10h]
+  .text:00000000011DE740                 xor     r9d, r9d
+  .text:00000000011DE743                 mov     rcx, rbx
+  .text:00000000011DE746                 mov     rdi, r14
+  .text:00000000011DE749                 mov     r8, [rbp+var_A0]
+  .text:00000000011DE750                 mov     rax, [rax+8]
+  .text:00000000011DE754                 mov     rdx, [rax+0D8h]
+  .text:00000000011DE75B                 mov     rax, [rax+0E0h]
+  .text:00000000011DE762                 mov     [rbp+var_80], rdx
+  .text:00000000011DE766                 lea     rdx, [rbp+var_80]
+  .text:00000000011DE76A                 mov     [rbp+var_78], rax
+  .text:00000000011DE76E                 lea     rax, qword_2743668
+  .text:00000000011DE775                 mov     rsi, [rax]
+  .text:00000000011DE778                 mov     rax, [rsi]
+  .text:00000000011DE77B                 call    qword ptr [rax+0A0h]
+  .text:00000000011DE781                 cmp     dword ptr [rbp+var_98], 0FFFFFFFFh
+  .text:00000000011DE788                 jz      short loc_11DE7D2
+  .text:00000000011DE78A                 cmp     byte ptr [rbp+var_58+2], 0
+  .text:00000000011DE78E                 jz      short loc_11DE7B0
+  .text:00000000011DE790                 lea     rdi, aPathAddtotailF; "Path_AddToTail failed for read only CFi"...
+  .text:00000000011DE797                 xor     eax, eax
+  .text:00000000011DE799                 call    _Plat_FatalError
+  .text:00000000011DE79E                 xchg    ax, ax
+  .text:00000000011DE7A0                 mov     rax, [rax+8]
+  .text:00000000011DE7A4                 jmp     loc_11DE548
+  .text:00000000011DE7B0                 movsx   rax, word ptr [rbp+var_58]
+  .text:00000000011DE7B5                 cmp     ax, 9
+  .text:00000000011DE7B9                 jg      loc_11DE8CF
+  .text:00000000011DE7BF                 movzx   ecx, word ptr [rbp+var_98]
+  .text:00000000011DE7C6                 lea     edx, [rax+1]
+  .text:00000000011DE7C9                 mov     word ptr [rbp+var_58], dx
+  .text:00000000011DE7CD                 mov     word ptr [rbp+rax*2+var_70], cx
+  .text:00000000011DE7D2                 mov     rax, [rbx]
+  .text:00000000011DE7D5                 mov     rsi, r14
+  .text:00000000011DE7D8                 mov     rdi, rbx
+  .text:00000000011DE7DB                 ; 0xF0 = 240LL = CEntityInstance_AddChangeAccessorPath
+  .text:00000000011DE7DB                 call    qword ptr [rax+0F0h]; 0xF0 = 240LL = CEntityInstance_AddChangeAccessorPath
+  .text:00000000011DE7E1                 jmp     loc_11DE4F3
+  .text:00000000011DE7F0                 mov     r8d, 1
+  .text:00000000011DE7F6                 mov     r9d, 7FFFh
+  .text:00000000011DE7FC                 mov     byte ptr [rbp+var_58+2], 0
+  .text:00000000011DE800                 mov     word ptr [rbp+var_58], r8w
+  .text:00000000011DE805                 mov     word ptr [rbp+var_70], r9w
+  .text:00000000011DE80A                 jmp     loc_11DE5C0
+  .text:00000000011DE810                 xor     ecx, ecx
+  .text:00000000011DE812                 mov     byte ptr [rbp+var_58+2], 0
+  .text:00000000011DE816                 mov     word ptr [rbp+var_58], cx
+  .text:00000000011DE81A                 jmp     loc_11DE5C0
+  .text:00000000011DE820                 mov     esi, 7FFFh
+  .text:00000000011DE825                 jmp     loc_11DE6D1
+  .text:00000000011DE830                 xor     eax, eax
+  .text:00000000011DE832                 jmp     loc_11DE548
+  .text:00000000011DE840                 mov     edx, 7FFFh
+  .text:00000000011DE845                 jmp     loc_11DE610
+  .text:00000000011DE850                 mov     esi, 7FFFh
+  .text:00000000011DE855                 jmp     loc_11DE6C0
+  .text:00000000011DE860                 mov     edx, esi
+  .text:00000000011DE862                 mov     rdi, r14
+  .text:00000000011DE865                 mov     rsi, r13
+  .text:00000000011DE868                 call    sub_202CA00
+  .text:00000000011DE86D                 jmp     loc_11DE5C0
+  .text:00000000011DE872                 lea     rdi, aUnableToAssign; "unable to AssignChangeAccessorPathIds!!"...
+  .text:00000000011DE879                 xor     eax, eax
+  .text:00000000011DE87B                 call    _Msg
+  .text:00000000011DE880                 lea     rax, aSetpolymorphic; "SetPolymorphicPointer"
+  .text:00000000011DE887                 ; _QWORD
+  .text:00000000011DE887                 mov     rdi, r14; _QWORD
+  .text:00000000011DE88A                 movq    xmm0, cs:off_22FD998; "../../public/networksystem/polymorphicm"...
+  .text:00000000011DE892                 mov     dword ptr [rbp+var_58], 0E5h
+  .text:00000000011DE899                 pinsrq  xmm0, rax, 1
+  .text:00000000011DE8A0                 lea     rax, aIsvalidchangea; "IsValidChangeAccessorFieldPathIndex( pi"...
+  .text:00000000011DE8A7                 movaps  xmmword ptr [rbp+var_70], xmm0
+  .text:00000000011DE8AB                 mov     [rbp+var_60], rax
+  .text:00000000011DE8AF                 movzx   eax, byte ptr [rbp+var_58+4]
+  .text:00000000011DE8B3                 and     eax, 0FFFFFF80h
+  .text:00000000011DE8B6                 or      eax, 14h
+  .text:00000000011DE8B9                 mov     byte ptr [rbp+var_58+4], al
+  .text:00000000011DE8BC                 call    __Z22Assert_ConditionFailedRK34_AssertCompileTimeConstantStruct_t; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const&)
+  .text:00000000011DE8C1                 test    al, al
+  .text:00000000011DE8C3                 jz      loc_11DE70A
+  .text:00000000011DE8C9                 ; Trap to Debugger
+  .text:00000000011DE8C9                 int     3; Trap to Debugger
+  .text:00000000011DE8CA                 jmp     loc_11DE70A
+  .text:00000000011DE8CF                 lea     rdi, aPathAddtotailF_0; "Path_AddToTail failed, depth already =="...
+  .text:00000000011DE8D6                 mov     esi, 0Ah
+  .text:00000000011DE8DB                 xor     eax, eax
+  .text:00000000011DE8DD                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall sub_11DE2E0(_QWORD *a1, __int64 a2, __int64 *a3, __int64 a4, int a5, char a6, char a7)
+  {
+    __int64 result; // rax
+    int v11; // r14d
+    int v12; // eax
+    void (__fastcall *v13)(_QWORD *, __m128i *); // rax
+    __int64 v14; // rax
+    __int64 v15; // rax
+    int v16; // esi
+    __int64 v17; // rdx
+    int v18; // eax
+    int v19; // eax
+    __int64 v20; // rdx
+    __int64 v21; // rax
+    __int64 v22; // rcx
+    __int64 v23; // rax
+    int v24; // eax
+    unsigned __int16 v25; // dx
+    __int64 v26; // r9
+    const bool *v27; // r8
+    const char *v28; // rcx
+    __int64 v29; // rdx
+    int v30; // esi
+    __int64 v31; // rax
+    __int64 v32; // rdx
+    __int64 v33; // rax
+    __int64 v34; // rax
+    __int64 v35; // [rsp+8h] [rbp-A8h]
+    int v36; // [rsp+8h] [rbp-A8h]
+    const char *v38; // [rsp+18h] [rbp-98h]
+    const bool *v39; // [rsp+20h] [rbp-90h] BYREF
+    const char *v40; // [rsp+28h] [rbp-88h] BYREF
+    __int64 v41; // [rsp+30h] [rbp-80h] BYREF
+    __int64 v42; // [rsp+38h] [rbp-78h]
+    __m128i v43; // [rsp+40h] [rbp-70h] BYREF
+    const char *v44; // [rsp+50h] [rbp-60h]
+    __int64 v45; // [rsp+58h] [rbp-58h]
+    __m128i inserted; // [rsp+60h] [rbp-50h]
+    __int64 v47; // [rsp+70h] [rbp-40h]
+    int v48; // [rsp+78h] [rbp-38h]
+    __int16 v49; // [rsp+7Ch] [rbp-34h]
+
+    (*(void (__fastcall **)(_QWORD *))(*a1 + 280LL))(a1);
+    result = *a3;
+    *a3 = a4;
+    if ( !a4 )
+    {
+      if ( !a6 )
+      {
+        if ( !result )
+          return result;
+  LABEL_4:
+        v11 = *(_DWORD *)(result + 40);
+        v43 = 0u;
+        v44 = nullptr;
+        v45 = 0;
+        inserted = 0u;
+        LODWORD(v47) = 0;
+        v12 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4);
+        if ( v12 <= 0 )
+        {
+          while ( 1 )
+            ;
+        }
+        v36 = v12;
+        v43.m128i_i64[1] = UtlVectorMemory_Alloc(v43.m128i_i64[1], HIDWORD(v44) <= 0x3FFFFFFF, 4LL * v12, 4LL * (int)v44);
+        ++v43.m128i_i32[0];
+        LODWORD(v44) = v36;
+        *(_DWORD *)v43.m128i_i64[1] = v11;
+        result = (*(__int64 (__fastcall **)(_QWORD *, __m128i *))(*a1 + 248LL))(a1, &v43);// 0xF8 = 248LL = CEntityInstance_AssignChangeAccessorPathIds
+        LODWORD(v45) = 0;
+        if ( inserted.m128i_i32[3] <= 0x3FFFFFFFu && inserted.m128i_i64[0] )
+          result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+        v43.m128i_i32[0] = 0;
+        if ( HIDWORD(v44) <= 0x3FFFFFFF && v43.m128i_i64[1] )
+          result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+        if ( !a4 )
+          goto LABEL_15;
+        goto LABEL_46;
+      }
+  LABEL_14:
+      v13 = *(void (__fastcall **)(_QWORD *, __m128i *))(*a1 + 232LL);
+      v43 = 0u;
+      v44 = nullptr;
+      v45 = 0;
+      inserted = _mm_insert_epi64(
+                   _mm_loadl_epi64((const __m128i *)off_22FD990),
+                   (signed __int64)"../../public/networksystem/polymorphicmetadatahelper.h",
+                   1);
+      v47 = -4294967114LL;
+      v48 = -1;
+      v49 = 0;
+      v13(a1, &v43);
+      result = sub_9B9050(&v43.m128i_u64[1]);
+      goto LABEL_15;
+    }
+    v35 = result;
+    sub_1E75E30(a4 + 8, a1, 1, a4);
+    if ( a6 )
+      goto LABEL_14;
+    result = v35;
+    if ( v35 )
+      goto LABEL_4;
+  LABEL_46:
+    v31 = *(_QWORD *)(a1[2] + 8LL);
+    v32 = *(_QWORD *)(v31 + 216);
+    v33 = *(_QWORD *)(v31 + 224);
+    v41 = v32;
+    v42 = v33;
+    (*(void (__fastcall **)(__m128i *, _QWORD *, __int64 *, _QWORD *, __int64, _QWORD))(*qword_2743668 + 160LL))(
+      &v43,
+      qword_2743668,
+      &v41,
+      a1,
+      a2,
+      0);
+    if ( a5 != -1 )
+    {
+      if ( BYTE2(v45) )
+      {
+        v14 = Plat_FatalError("Path_AddToTail failed for read only CFieldPath");
+        goto LABEL_49;
+      }
+      v34 = (__int16)v45;
+      if ( (__int16)v45 > 9 )
+      {
+        Plat_FatalError("Path_AddToTail failed, depth already == DEFAULT_MAX_PATH_DEPTH(%d)", 10);
+        JUMPOUT(0x11DE8E2);
+      }
+      LOWORD(v45) = v45 + 1;
+      v43.m128i_i16[v34] = a5;
+    }
+    result = (*(__int64 (__fastcall **)(_QWORD *, __m128i *))(*a1 + 240LL))(a1, &v43);// 0xF0 = 240LL = CEntityInstance_AddChangeAccessorPath
+  LABEL_15:
+    if ( !a7 )
+      return result;
+    result = *a3;
+    if ( !*a3 )
+      return result;
+    LODWORD(a4) = *(_DWORD *)(result + 40);
+    if ( (int)a4 >= 0 )
+    {
+      a3 = (__int64 *)qword_26F8388;
+      v14 = (*(__int64 (__fastcall **)(_QWORD *))(*a1 + 312LL))(a1);
+      if ( (*(_DWORD *)(v14 + 4) & 0x7FFFFFFF) == 0 )
+      {
+        v15 = 0;
+        goto LABEL_21;
+      }
+      if ( (*(_DWORD *)(v14 + 4) & 0x7FFFFFFFu) <= 4 )
+      {
+        v15 = v14 + 8;
+  LABEL_21:
+        v16 = *(_DWORD *)(v15 + 4LL * (int)a4);
+        if ( v16 == -1 )
+        {
+          BYTE2(v45) = 0;
+          LOWORD(v45) = 1;
+          v43.m128i_i16[0] = 0x7FFF;
+        }
+        else if ( v16 )
+        {
+          if ( v16 < 0 )
+          {
+            sub_202CA00(&v43, a3, (unsigned int)v16);
+          }
+          else
+          {
+            v17 = 0;
+            v18 = v16 & 0x7FC00000;
+            LOWORD(v45) = 0;
+            BYTE2(v45) = 0;
+            if ( (v16 & 0x7FC00000) != 0 )
+            {
+              do
+              {
+                v43.m128i_i16[v17] = (v18 >> dword_77BA80[v17]) - 1;
+                v19 = *(_DWORD *)((char *)&unk_77BA44 + 1 * v17++);
+                LOWORD(v45) = v45 + 1;
+                v18 = v16 & v19;
+              }
+              while ( v18 );
+            }
+          }
+        }
+        else
+        {
+          BYTE2(v45) = 0;
+          LOWORD(v45) = 0;
+        }
+        v20 = a1[2];
+        v21 = *(_QWORD *)(v20 + 8);
+        v22 = *(_QWORD *)(v21 + 216);
+        v23 = *(_QWORD *)(v21 + 224);
+        v41 = v22;
+        v42 = v23;
+        v24 = (*(_DWORD *)(v20 + 16) >> 15) - (*(_DWORD *)(v20 + 48) & 1);
+        if ( *(_DWORD *)(v20 + 16) == -1 )
+          v25 = 0x7FFF;
+        else
+          v25 = *(_WORD *)(v20 + 16) & 0x7FFF;
+        v26 = v25;
+        if ( ((v24 << 15) | v25 & 0x7FFF) == 0xFFFFFFFF )
+          v26 = 0x7FFF;
+        (*(void (__fastcall **)(const bool **, _QWORD *, __int64 *, __m128i *, _QWORD *, __int64, _QWORD, __int64))(*qword_2743668 + 8LL))(
+          &v39,
+          qword_2743668,
+          &v41,
+          &v43,
+          a1,
+          v26,
+          0,
+          1);
+        v27 = v39;
+        if ( !v39 )
+          v27 = &haystack;
+        v38 = (const char *)v27;
+        sub_202BFD0(&v40, &v43);
+        v28 = v40;
+        v29 = a1[2];
+        if ( !v40 )
+          v28 = (const char *)&haystack;
+        if ( !v29
+          || (*(_DWORD *)(v29 + 16) == -1 ? (LOWORD(v30) = 0x7FFF) : (LOWORD(v30) = *(_WORD *)(v29 + 16) & 0x7FFF),
+              v30 = (unsigned __int16)v30,
+              ((unsigned __int16)v30 | (((*(_DWORD *)(v29 + 16) >> 15) - (*(_DWORD *)(v29 + 48) & 1)) << 15)) == 0xFFFFFFFF) )
+        {
+          v30 = 0x7FFF;
+        }
+        result = Msg("%d: assigned ChangeAccessorFieldPathIndex_t[ %d ] = '%s' for field %s\n", v30, a4, v28, v38);
+        if ( v40 )
+          result = CUtlString::FreeMemoryBlock((CUtlString *)&v40);
+        if ( v39 )
+          return CUtlString::FreeMemoryBlock((CUtlString *)&v39);
+        return result;
+      }
+  LABEL_49:
+      v15 = *(_QWORD *)(v14 + 8);
+      goto LABEL_21;
+    }
+    Msg("unable to AssignChangeAccessorPathIds!!!\n");
+    LODWORD(v45) = 229;
+    v43 = _mm_insert_epi64(_mm_loadl_epi64((const __m128i *)off_22FD998), (signed __int64)"SetPolymorphicPointer", 1);
+    v44 = "IsValidChangeAccessorFieldPathIndex( pi )";
+    BYTE4(v45) = BYTE4(v45) & 0x80 | 0x14;
+    result = Assert_ConditionFailed(&v43);
+    if ( (_BYTE)result )
+      __debugbreak();
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.windows.yaml
@@ -1,0 +1,721 @@
+func_name: PolymorphicHelper_t__SetPolymorphicPointer
+func_va: '0x180885530'
+disasm_code: |-
+  .text:0000000180885530                 push    rbp
+  .text:0000000180885532                 push    rsi
+  .text:0000000180885533                 push    r12
+  .text:0000000180885535                 push    r13
+  .text:0000000180885537                 push    r14
+  .text:0000000180885539                 push    r15
+  .text:000000018088553B                 lea     rbp, [rsp-0Fh]
+  .text:0000000180885540                 sub     rsp, 98h
+  .text:0000000180885547                 mov     rax, [rcx]
+  .text:000000018088554A                 mov     r12, r9
+  .text:000000018088554D                 mov     r13, r8
+  .text:0000000180885550                 mov     r14, rcx
+  .text:0000000180885553                 call    qword ptr [rax+110h]
+  .text:0000000180885559                 mov     r15, [rbp+37h+arg_20]
+  .text:000000018088555D                 mov     rax, [r12]
+  .text:0000000180885561                 mov     [rbp+37h+arg_18], rax
+  .text:0000000180885565                 mov     [r12], r15
+  .text:0000000180885569                 test    r15, r15
+  .text:000000018088556C                 jz      short loc_180885584
+  .text:000000018088556E                 lea     rcx, [r15+8]
+  .text:0000000180885572                 mov     r9, r15
+  .text:0000000180885575                 mov     r8b, 1
+  .text:0000000180885578                 mov     rdx, r14
+  .text:000000018088557B                 call    sub_18120F3C0
+  .text:0000000180885580                 mov     rax, [rbp+37h+arg_18]
+  .text:0000000180885584                 mov     [rsp+0C0h+arg_8], rbx
+  .text:000000018088558C                 lea     rsi, aPolymorphichel; "PolymorphicHelper_t::SetPolymorphicPoin"...
+  .text:0000000180885593                 mov     [rsp+0C0h+var_30], rdi
+  .text:000000018088559B                 lea     rcx, aCBuildworkerCs_26; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001808855A2                 xor     edi, edi
+  .text:00000001808855A4                 mov     edx, 1
+  .text:00000001808855A9                 cmp     [rbp+37h+arg_30], dil
+  .text:00000001808855AD                 jz      loc_18088564E
+  .text:00000001808855B3                 mov     rax, [r14]
+  .text:00000001808855B6                 lea     rdx, [rbp+37h+var_70]
+  .text:00000001808855BA                 mov     [rbp+37h+var_48], rcx
+  .text:00000001808855BE                 mov     rcx, r14
+  .text:00000001808855C1                 mov     dword ptr [rbp+37h+var_70], edi
+  .text:00000001808855C4                 mov     [rbp+37h+var_60], rdi
+  .text:00000001808855C8                 mov     [rbp+37h+var_58], rdi
+  .text:00000001808855CC                 mov     dword ptr [rbp+37h+var_68], edi
+  .text:00000001808855CF                 mov     [rbp+37h+var_50], rsi
+  .text:00000001808855D3                 mov     [rbp+37h+var_40], 0B6h
+  .text:00000001808855DA                 mov     [rbp+37h+var_3C], 0FFFFFFFFFFFFFFFFh
+  .text:00000001808855E2                 mov     [rbp+37h+var_34], di
+  .text:00000001808855E6                 call    qword ptr [rax+0E0h]
+  .text:00000001808855EC                 mov     eax, dword ptr [rbp+37h+var_58+4]
+  .text:00000001808855EF                 mov     rdx, [rbp+37h+var_60]
+  .text:00000001808855F3                 mov     dword ptr [rbp+37h+var_68], edi
+  .text:00000001808855F6                 test    eax, 0C0000000h
+  .text:00000001808855FB                 jnz     loc_180885824
+  .text:0000000180885601                 test    rdx, rdx
+  .text:0000000180885604                 jz      short loc_18088561F
+  .text:0000000180885606                 mov     rax, cs:g_pMemAlloc
+  .text:000000018088560D                 mov     rcx, [rax]
+  .text:0000000180885610                 mov     rax, [rcx]
+  .text:0000000180885613                 call    qword ptr [rax+18h]
+  .text:0000000180885616                 mov     eax, dword ptr [rbp+37h+var_58+4]
+  .text:0000000180885619                 mov     edx, edi
+  .text:000000018088561B                 mov     [rbp+37h+var_60], rdx
+  .text:000000018088561F                 mov     dword ptr [rbp+37h+var_58], edi
+  .text:0000000180885622                 test    eax, 0C0000000h
+  .text:0000000180885627                 jnz     loc_180885824
+  .text:000000018088562D                 test    rdx, rdx
+  .text:0000000180885630                 jz      short loc_180885646
+  .text:0000000180885632                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180885639                 mov     rcx, [rax]
+  .text:000000018088563C                 mov     rax, [rcx]
+  .text:000000018088563F                 call    qword ptr [rax+18h]
+  .text:0000000180885642                 mov     [rbp+37h+var_60], rdi
+  .text:0000000180885646                 mov     dword ptr [rbp+37h+var_58], edi
+  .text:0000000180885649                 jmp     loc_180885824
+  .text:000000018088564E                 test    rax, rax
+  .text:0000000180885651                 jz      loc_1808857A5
+  .text:0000000180885657                 mov     ebx, [rax+28h]
+  .text:000000018088565A                 mov     r8d, edx
+  .text:000000018088565D                 xor     edx, edx
+  .text:000000018088565F                 mov     [rbp+37h+var_68], rdi
+  .text:0000000180885663                 mov     r9d, 4
+  .text:0000000180885669                 mov     [rbp+37h+var_60], rdi
+  .text:000000018088566D                 xor     ecx, ecx
+  .text:000000018088566F                 mov     dword ptr [rbp+37h+var_70], edi
+  .text:0000000180885672                 mov     [rbp+37h+var_50], rdi
+  .text:0000000180885676                 mov     [rbp+37h+var_48], rdi
+  .text:000000018088567A                 mov     dword ptr [rbp+37h+var_58], edi
+  .text:000000018088567D                 mov     [rbp+37h+var_40], edi
+  .text:0000000180885680                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180885686                 mov     esi, eax
+  .text:0000000180885688                 cmp     eax, 1
+  .text:000000018088568B                 jge     short loc_18088569F
+  .text:000000018088568D                 nop     dword ptr [rax]
+  .text:0000000180885690                 lea     eax, [rsi+1]
+  .text:0000000180885693                 cdq
+  .text:0000000180885694                 sub     eax, edx
+  .text:0000000180885696                 sar     eax, 1
+  .text:0000000180885698                 mov     esi, eax
+  .text:000000018088569A                 cmp     eax, 1
+  .text:000000018088569D                 jl      short loc_180885690
+  .text:000000018088569F                 movsxd  r9, dword ptr [rbp+37h+var_60]
+  .text:00000001808856A3                 mov     rcx, [rbp+37h+var_68]
+  .text:00000001808856A7                 shl     r9, 2
+  .text:00000001808856AB                 test    dword ptr [rbp+37h+var_60+4], 0C0000000h
+  .text:00000001808856B2                 mov     r8d, esi
+  .text:00000001808856B5                 setz    dl
+  .text:00000001808856B8                 shl     r8, 2
+  .text:00000001808856BC                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001808856C2                 mov     ecx, dword ptr [rbp+37h+var_60+4]
+  .text:00000001808856C5                 mov     [rbp+37h+var_68], rax
+  .text:00000001808856C9                 test    ecx, 0C0000000h
+  .text:00000001808856CF                 jz      short loc_1808856DA
+  .text:00000001808856D1                 and     ecx, 3FFFFFFFh
+  .text:00000001808856D7                 mov     dword ptr [rbp+37h+var_60+4], ecx
+  .text:00000001808856DA                 inc     dword ptr [rbp+37h+var_70]
+  .text:00000001808856DD                 lea     rdx, [rbp+37h+var_70]
+  .text:00000001808856E1                 mov     dword ptr [rbp+37h+var_60], esi
+  .text:00000001808856E4                 mov     rcx, r14
+  .text:00000001808856E7                 mov     [rax], ebx
+  .text:00000001808856E9                 mov     rax, [r14]
+  .text:00000001808856EC                 ; 0xF0 = 240LL = CEntityInstance_AssignChangeAccessorPathIds
+  .text:00000001808856EC                 call    qword ptr [rax+0F0h]; 0xF0 = 240LL = CEntityInstance_AssignChangeAccessorPathIds
+  .text:00000001808856F2                 mov     eax, dword ptr [rbp+37h+var_48+4]
+  .text:00000001808856F5                 mov     rdx, [rbp+37h+var_50]
+  .text:00000001808856F9                 mov     dword ptr [rbp+37h+var_58], edi
+  .text:00000001808856FC                 test    eax, 0C0000000h
+  .text:0000000180885701                 jnz     short loc_180885748
+  .text:0000000180885703                 test    rdx, rdx
+  .text:0000000180885706                 jz      short loc_180885722
+  .text:0000000180885708                 mov     rax, cs:g_pMemAlloc
+  .text:000000018088570F                 mov     rcx, [rax]
+  .text:0000000180885712                 mov     rax, [rcx]
+  .text:0000000180885715                 call    qword ptr [rax+18h]
+  .text:0000000180885718                 mov     eax, dword ptr [rbp+37h+var_48+4]
+  .text:000000018088571B                 mov     rdx, rdi
+  .text:000000018088571E                 mov     [rbp+37h+var_50], rdx
+  .text:0000000180885722                 mov     dword ptr [rbp+37h+var_48], edi
+  .text:0000000180885725                 test    eax, 0C0000000h
+  .text:000000018088572A                 jnz     short loc_180885748
+  .text:000000018088572C                 test    rdx, rdx
+  .text:000000018088572F                 jz      short loc_180885745
+  .text:0000000180885731                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180885738                 mov     rcx, [rax]
+  .text:000000018088573B                 mov     rax, [rcx]
+  .text:000000018088573E                 call    qword ptr [rax+18h]
+  .text:0000000180885741                 mov     [rbp+37h+var_50], rdi
+  .text:0000000180885745                 mov     dword ptr [rbp+37h+var_48], edi
+  .text:0000000180885748                 mov     eax, dword ptr [rbp+37h+var_60+4]
+  .text:000000018088574B                 mov     rdx, [rbp+37h+var_68]
+  .text:000000018088574F                 mov     dword ptr [rbp+37h+var_70], edi
+  .text:0000000180885752                 test    eax, 0C0000000h
+  .text:0000000180885757                 jnz     short loc_18088579E
+  .text:0000000180885759                 test    rdx, rdx
+  .text:000000018088575C                 jz      short loc_180885778
+  .text:000000018088575E                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180885765                 mov     rcx, [rax]
+  .text:0000000180885768                 mov     rax, [rcx]
+  .text:000000018088576B                 call    qword ptr [rax+18h]
+  .text:000000018088576E                 mov     eax, dword ptr [rbp+37h+var_60+4]
+  .text:0000000180885771                 mov     rdx, rdi
+  .text:0000000180885774                 mov     [rbp+37h+var_68], rdx
+  .text:0000000180885778                 mov     dword ptr [rbp+37h+var_60], edi
+  .text:000000018088577B                 test    eax, 0C0000000h
+  .text:0000000180885780                 jnz     short loc_18088579E
+  .text:0000000180885782                 test    rdx, rdx
+  .text:0000000180885785                 jz      short loc_18088579B
+  .text:0000000180885787                 mov     rax, cs:g_pMemAlloc
+  .text:000000018088578E                 mov     rcx, [rax]
+  .text:0000000180885791                 mov     rax, [rcx]
+  .text:0000000180885794                 call    qword ptr [rax+18h]
+  .text:0000000180885797                 mov     [rbp+37h+var_68], rdi
+  .text:000000018088579B                 mov     dword ptr [rbp+37h+var_60], edi
+  .text:000000018088579E                 lea     rsi, aPolymorphichel; "PolymorphicHelper_t::SetPolymorphicPoin"...
+  .text:00000001808857A5                 test    r15, r15
+  .text:00000001808857A8                 jz      short loc_180885824
+  .text:00000001808857AA                 mov     rax, [r14+10h]
+  .text:00000001808857AE                 lea     r8, [rbp+37h+var_80]
+  .text:00000001808857B2                 mov     [rsp+0C0h+var_98], rdi
+  .text:00000001808857B7                 lea     rdx, [rbp+37h+var_70]
+  .text:00000001808857BB                 mov     r9, r14
+  .text:00000001808857BE                 mov     [rsp+0C0h+var_A0], r13
+  .text:00000001808857C3                 mov     rcx, [rax+8]
+  .text:00000001808857C7                 mov     rax, [rcx+0D8h]
+  .text:00000001808857CE                 mov     [rbp+37h+var_80], rax
+  .text:00000001808857D2                 mov     rax, [rcx+0E0h]
+  .text:00000001808857D9                 mov     rcx, cs:qword_182117C90
+  .text:00000001808857E0                 mov     [rbp+37h+var_78], rax
+  .text:00000001808857E4                 mov     rax, [rcx]
+  .text:00000001808857E7                 call    qword ptr [rax+0A0h]
+  .text:00000001808857ED                 mov     edx, [rbp+37h+arg_28]
+  .text:00000001808857F0                 cmp     edx, 0FFFFFFFFh
+  .text:00000001808857F3                 jz      short loc_180885814
+  .text:00000001808857F5                 cmp     byte ptr [rbp+37h+var_58+2], dil
+  .text:00000001808857F9                 jnz     short loc_180885876
+  .text:00000001808857FB                 movsx   rcx, word ptr [rbp+37h+var_58]
+  .text:0000000180885800                 cmp     ecx, 0Ah
+  .text:0000000180885803                 jge     short loc_180885863
+  .text:0000000180885805                 mov     rax, rcx
+  .text:0000000180885808                 inc     cx
+  .text:000000018088580B                 mov     word ptr [rbp+37h+var_58], cx
+  .text:000000018088580F                 mov     word ptr [rbp+rax*2+37h+var_70], dx
+  .text:0000000180885814                 mov     rax, [r14]
+  .text:0000000180885817                 lea     rdx, [rbp+37h+var_70]
+  .text:000000018088581B                 mov     rcx, r14
+  .text:000000018088581E                 ; 0xE8 = 232LL = CEntityInstance_AddChangeAccessorPath
+  .text:000000018088581E                 call    qword ptr [rax+0E8h]; 0xE8 = 232LL = CEntityInstance_AddChangeAccessorPath
+  .text:0000000180885824                 cmp     [rbp+37h+arg_38], 0
+  .text:0000000180885828                 jz      loc_180885AA4
+  .text:000000018088582E                 mov     rbx, [r12]
+  .text:0000000180885832                 test    rbx, rbx
+  .text:0000000180885835                 jz      loc_180885AA4
+  .text:000000018088583B                 movsxd  rbx, dword ptr [rbx+28h]
+  .text:000000018088583F                 test    ebx, ebx
+  .text:0000000180885841                 js      loc_180885A60
+  .text:0000000180885847                 mov     rax, [r14]
+  .text:000000018088584A                 mov     rcx, r14
+  .text:000000018088584D                 call    qword ptr [rax+138h]
+  .text:0000000180885853                 mov     ecx, [rax+4]
+  .text:0000000180885856                 and     ecx, 7FFFFFFFh
+  .text:000000018088585C                 jnz     short loc_180885884
+  .text:000000018088585E                 mov     r8, rdi
+  .text:0000000180885861                 jmp     short loc_180885890
+  .text:0000000180885863                 mov     edx, 0Ah
+  .text:0000000180885868                 lea     rcx, aPathAddtotailF; "Path_AddToTail failed, depth already =="...
+  .text:000000018088586F                 call    cs:Plat_FatalError
+  .text:0000000180885875                 ; Trap to Debugger
+  .text:0000000180885875                 int     3; Trap to Debugger
+  .text:0000000180885876                 lea     rcx, aPathAddtotailF_0; "Path_AddToTail failed for read only CFi"...
+  .text:000000018088587D                 call    cs:Plat_FatalError
+  .text:0000000180885883                 ; Trap to Debugger
+  .text:0000000180885883                 int     3; Trap to Debugger
+  .text:0000000180885884                 lea     r8, [rax+8]
+  .text:0000000180885888                 cmp     ecx, 4
+  .text:000000018088588B                 jbe     short loc_180885890
+  .text:000000018088588D                 mov     r8, [r8]
+  .text:0000000180885890                 mov     r8d, [r8+rbx*4]
+  .text:0000000180885894                 mov     esi, 7FFFh
+  .text:0000000180885899                 cmp     r8d, 0FFFFFFFFh
+  .text:000000018088589D                 jnz     short loc_1808858AE
+  .text:000000018088589F                 mov     eax, 1
+  .text:00000001808858A4                 mov     word ptr [rbp+37h+var_70], si
+  .text:00000001808858A8                 mov     word ptr [rbp+37h+var_58], ax
+  .text:00000001808858AC                 jmp     short loc_180885923
+  .text:00000001808858AE                 test    r8d, r8d
+  .text:00000001808858B1                 jz      short loc_18088591F
+  .text:00000001808858B3                 js      short loc_18088590D
+  .text:00000001808858B5                 mov     eax, r8d
+  .text:00000001808858B8                 mov     word ptr [rbp+37h+var_58], di
+  .text:00000001808858BC                 mov     byte ptr [rbp+37h+var_58+2], 0
+  .text:00000001808858C0                 lea     r9, [rbp+37h+var_70]
+  .text:00000001808858C4                 and     eax, 7FC00000h
+  .text:00000001808858C9                 jz      short loc_180885927
+  .text:00000001808858CB                 mov     rdx, rdi
+  .text:00000001808858CE                 lea     r10, cs:180000000h
+  .text:00000001808858D5                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001808858E0                 mov     ecx, [rdx+r10+15A1CE0h]
+  .text:00000001808858E8                 lea     rdx, [rdx+4]
+  .text:00000001808858EC                 sar     eax, cl
+  .text:00000001808858EE                 lea     r9, [r9+2]
+  .text:00000001808858F2                 dec     ax
+  .text:00000001808858F5                 mov     [r9-2], ax
+  .text:00000001808858FA                 inc     word ptr [rbp+37h+var_58]
+  .text:00000001808858FE                 mov     eax, [rdx+r10+15A1D08h]
+  .text:0000000180885906                 and     eax, r8d
+  .text:0000000180885909                 jnz     short loc_1808858E0
+  .text:000000018088590B                 jmp     short loc_180885927
+  .text:000000018088590D                 mov     rcx, cs:qword_181F78580
+  .text:0000000180885914                 lea     rdx, [rbp+37h+var_70]
+  .text:0000000180885918                 call    sub_1814F0DA0
+  .text:000000018088591D                 jmp     short loc_180885927
+  .text:000000018088591F                 mov     word ptr [rbp+37h+var_58], di
+  .text:0000000180885923                 mov     byte ptr [rbp+37h+var_58+2], 0
+  .text:0000000180885927                 mov     rdx, [r14+10h]
+  .text:000000018088592B                 mov     r10, cs:qword_182117C90
+  .text:0000000180885932                 mov     rcx, [rdx+8]
+  .text:0000000180885936                 mov     rax, [rcx+0D8h]
+  .text:000000018088593D                 mov     [rbp+37h+var_80], rax
+  .text:0000000180885941                 mov     rax, [rcx+0E0h]
+  .text:0000000180885948                 mov     [rbp+37h+var_78], rax
+  .text:000000018088594C                 mov     rax, [r10]
+  .text:000000018088594F                 mov     r11, [rax+8]
+  .text:0000000180885953                 test    rdx, rdx
+  .text:0000000180885956                 jz      short loc_18088597F
+  .text:0000000180885958                 mov     r8d, [rdx+10h]
+  .text:000000018088595C                 mov     eax, r8d
+  .text:000000018088595F                 mov     ecx, [rdx+30h]
+  .text:0000000180885962                 mov     edx, esi
+  .text:0000000180885964                 and     ecx, 1
+  .text:0000000180885967                 shr     eax, 0Fh
+  .text:000000018088596A                 sub     eax, ecx
+  .text:000000018088596C                 mov     ecx, r8d
+  .text:000000018088596F                 and     ecx, esi
+  .text:0000000180885971                 shl     eax, 0Fh
+  .text:0000000180885974                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180885978                 cmovnz  edx, ecx
+  .text:000000018088597B                 or      eax, edx
+  .text:000000018088597D                 jmp     short loc_180885984
+  .text:000000018088597F                 mov     eax, 0FFFFFFFFh
+  .text:0000000180885984                 mov     edx, eax
+  .text:0000000180885986                 mov     [rsp+0C0h+var_88], 1
+  .text:000000018088598B                 and     edx, esi
+  .text:000000018088598D                 mov     [rsp+0C0h+var_90], edi
+  .text:0000000180885991                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180885994                 lea     r9, [rbp+37h+var_70]
+  .text:0000000180885998                 mov     r8d, esi
+  .text:000000018088599B                 mov     rcx, r10
+  .text:000000018088599E                 cmovnz  r8d, edx
+  .text:00000001808859A2                 lea     rdx, [rbp+37h+arg_20]
+  .text:00000001808859A6                 mov     dword ptr [rsp+0C0h+var_98], r8d
+  .text:00000001808859AB                 lea     r8, [rbp+37h+var_80]
+  .text:00000001808859AF                 mov     [rsp+0C0h+var_A0], r14
+  .text:00000001808859B4                 call    r11
+  .text:00000001808859B7                 mov     rax, [rbp+37h+arg_20]
+  .text:00000001808859BB                 lea     rdi, byte_18159B988
+  .text:00000001808859C2                 test    rax, rax
+  .text:00000001808859C5                 lea     rdx, [rbp+37h+arg_0]
+  .text:00000001808859C9                 mov     r15, rdi
+  .text:00000001808859CC                 lea     rcx, [rbp+37h+var_70]
+  .text:00000001808859D0                 cmovnz  r15, rax
+  .text:00000001808859D4                 call    sub_1814EFE40
+  .text:00000001808859D9                 mov     rcx, [rax]
+  .text:00000001808859DC                 test    rcx, rcx
+  .text:00000001808859DF                 cmovnz  rdi, rcx
+  .text:00000001808859E3                 mov     rcx, [r14+10h]
+  .text:00000001808859E7                 test    rcx, rcx
+  .text:00000001808859EA                 jz      short loc_180885A13
+  .text:00000001808859EC                 mov     r8d, [rcx+10h]
+  .text:00000001808859F0                 mov     edx, esi
+  .text:00000001808859F2                 mov     ecx, [rcx+30h]
+  .text:00000001808859F5                 mov     eax, r8d
+  .text:00000001808859F8                 and     ecx, 1
+  .text:00000001808859FB                 shr     eax, 0Fh
+  .text:00000001808859FE                 sub     eax, ecx
+  .text:0000000180885A00                 mov     ecx, r8d
+  .text:0000000180885A03                 and     ecx, esi
+  .text:0000000180885A05                 shl     eax, 0Fh
+  .text:0000000180885A08                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180885A0C                 cmovnz  edx, ecx
+  .text:0000000180885A0F                 or      eax, edx
+  .text:0000000180885A11                 jmp     short loc_180885A18
+  .text:0000000180885A13                 mov     eax, 0FFFFFFFFh
+  .text:0000000180885A18                 mov     ecx, eax
+  .text:0000000180885A1A                 mov     [rsp+0C0h+var_A0], r15
+  .text:0000000180885A1F                 and     ecx, esi
+  .text:0000000180885A21                 mov     r9, rdi
+  .text:0000000180885A24                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180885A27                 mov     r8d, ebx
+  .text:0000000180885A2A                 cmovnz  esi, ecx
+  .text:0000000180885A2D                 lea     rcx, aDAssignedChang; "%d: assigned ChangeAccessorFieldPathInd"...
+  .text:0000000180885A34                 mov     edx, esi
+  .text:0000000180885A36                 call    cs:Msg
+  .text:0000000180885A3C                 cmp     [rbp+37h+arg_0], 0
+  .text:0000000180885A41                 jz      short loc_180885A4D
+  .text:0000000180885A43                 lea     rcx, [rbp+37h+arg_0]
+  .text:0000000180885A47                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180885A4D                 cmp     [rbp+37h+arg_20], 0
+  .text:0000000180885A52                 jz      short loc_180885AA4
+  .text:0000000180885A54                 lea     rcx, [rbp+37h+arg_20]
+  .text:0000000180885A58                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180885A5E                 jmp     short loc_180885AA4
+  .text:0000000180885A60                 lea     rcx, aUnableToAssign; "unable to AssignChangeAccessorPathIds!!"...
+  .text:0000000180885A67                 call    cs:Msg
+  .text:0000000180885A6D                 lea     rax, aCBuildworkerCs_26; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180885A74                 mov     [rbp+37h+var_68], rsi
+  .text:0000000180885A78                 mov     [rbp+37h+var_70], rax
+  .text:0000000180885A7C                 lea     rcx, [rbp+37h+var_70]
+  .text:0000000180885A80                 lea     rax, aIsvalidchangea; "IsValidChangeAccessorFieldPathIndex( pi"...
+  .text:0000000180885A87                 mov     dword ptr [rbp+37h+var_58], 0E5h
+  .text:0000000180885A8E                 mov     [rbp+37h+var_60], rax
+  .text:0000000180885A92                 mov     dword ptr [rbp+37h+var_58+4], 14h
+  .text:0000000180885A99                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@@Z; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &)
+  .text:0000000180885A9F                 test    al, al
+  .text:0000000180885AA1                 jz      short loc_180885AA4
+  .text:0000000180885AA3                 ; Trap to Debugger
+  .text:0000000180885AA3                 int     3; Trap to Debugger
+  .text:0000000180885AA4                 mov     rax, [rbp+37h+arg_18]
+  .text:0000000180885AA8                 mov     rdi, [rsp+0C0h+var_30]
+  .text:0000000180885AB0                 mov     rbx, [rsp+0C0h+arg_8]
+  .text:0000000180885AB8                 add     rsp, 98h
+  .text:0000000180885ABF                 pop     r15
+  .text:0000000180885AC1                 pop     r14
+  .text:0000000180885AC3                 pop     r13
+  .text:0000000180885AC5                 pop     r12
+  .text:0000000180885AC7                 pop     rsi
+  .text:0000000180885AC8                 pop     rbp
+  .text:0000000180885AC9                 retn
+procedure: |-
+  const char *__fastcall sub_180885530(
+          _QWORD *a1,
+          __int64 a2,
+          __int64 a3,
+          const char **a4,
+          const char *a5,
+          int a6,
+          char a7,
+          char a8)
+  {
+    __int64 v11; // r15
+    const char *v12; // rax
+    __int64 v13; // rdx
+    __int64 v14; // rax
+    int v15; // eax
+    int v16; // ebx
+    __int64 v17; // rdx
+    int i; // esi
+    int v19; // eax
+    const char *v20; // rdx
+    int v21; // eax
+    __int64 v22; // rcx
+    __int64 v23; // rax
+    __int64 v24; // rbx
+    __int64 v25; // rax
+    _QWORD *v26; // r8
+    int v27; // r8d
+    int v28; // esi
+    const char **v29; // r9
+    int v30; // eax
+    __int64 v31; // rdx
+    int v32; // ecx
+    __int64 v33; // rdx
+    __int64 v34; // rcx
+    unsigned int v35; // r8d
+    int v36; // ecx
+    int v37; // edx
+    int v38; // eax
+    int v39; // r8d
+    const char *v40; // rdi
+    const char *v41; // r15
+    const char **v42; // rax
+    __int64 v43; // rcx
+    unsigned int v44; // r8d
+    int v45; // edx
+    int v46; // eax
+    __int64 v48; // [rsp+40h] [rbp-49h] BYREF
+    __int64 v49; // [rsp+48h] [rbp-41h]
+    const char *v50; // [rsp+50h] [rbp-39h] BYREF
+    char *v51; // [rsp+58h] [rbp-31h]
+    const char *v52; // [rsp+60h] [rbp-29h]
+    __int64 v53; // [rsp+68h] [rbp-21h]
+    const char *v54; // [rsp+70h] [rbp-19h]
+    const char *v55; // [rsp+78h] [rbp-11h]
+    int v56; // [rsp+80h] [rbp-9h]
+    __int64 v57; // [rsp+84h] [rbp-5h]
+    __int16 v58; // [rsp+8Ch] [rbp+3h]
+    __int64 v59; // [rsp+D0h] [rbp+47h] BYREF
+    const char *v60; // [rsp+E8h] [rbp+5Fh]
+
+    (*(void (__fastcall **)(_QWORD *))(*a1 + 272LL))(a1);
+    v11 = (__int64)a5;
+    v12 = *a4;
+    v60 = *a4;
+    *a4 = a5;
+    if ( v11 )
+    {
+      sub_18120F3C0(v11 + 8, (__int64)a1, 1, v11);
+      v12 = v60;
+    }
+    v13 = 1;
+    if ( a7 )
+    {
+      v14 = *a1;
+      v55 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\public\\networksystem\\polymorphicmetadatahelper.h";
+      LODWORD(v50) = 0;
+      v52 = nullptr;
+      v53 = 0;
+      LODWORD(v51) = 0;
+      v54 = "PolymorphicHelper_t::SetPolymorphicPointer";
+      v56 = 182;
+      v57 = -1;
+      v58 = 0;
+      (*(void (__fastcall **)(_QWORD *, const char **))(v14 + 224))(a1, &v50);
+      v15 = HIDWORD(v53);
+      v13 = (__int64)v52;
+      LODWORD(v51) = 0;
+      if ( (v53 & 0xC000000000000000uLL) == 0 )
+      {
+        if ( v52 )
+        {
+          (*(void (__fastcall **)(_QWORD, const char *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v52);
+          v15 = HIDWORD(v53);
+          v13 = 0;
+          v52 = nullptr;
+        }
+        LODWORD(v53) = 0;
+        if ( (v15 & 0xC0000000) == 0 )
+        {
+          if ( v13 )
+          {
+            (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+            v52 = nullptr;
+          }
+          LODWORD(v53) = 0;
+        }
+      }
+    }
+    else
+    {
+      if ( v12 )
+      {
+        v16 = *((_DWORD *)v12 + 10);
+        v51 = nullptr;
+        v52 = nullptr;
+        LODWORD(v50) = 0;
+        v54 = nullptr;
+        v55 = nullptr;
+        LODWORD(v53) = 0;
+        v56 = 0;
+        for ( i = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4); i < 1; i = (i + 1) / 2 )
+          v17 = (unsigned int)((i + 1) >> 31);
+        LOBYTE(v17) = (HIDWORD(v52) & 0xC0000000) == 0;
+        v51 = (char *)UtlVectorMemory_Alloc(v51, v17, 4LL * (unsigned int)i, 4LL * (int)v52);
+        LODWORD(v50) = (_DWORD)v50 + 1;
+        LODWORD(v52) = i;
+        *(_DWORD *)v51 = v16;
+        (*(void (__fastcall **)(_QWORD *, const char **))(*a1 + 240LL))(a1, &v50);// 0xF0 = 240LL = CEntityInstance_AssignChangeAccessorPathIds
+        v19 = HIDWORD(v55);
+        v20 = v54;
+        LODWORD(v53) = 0;
+        if ( (HIDWORD(v55) & 0xC0000000) == 0 )
+        {
+          if ( v54 )
+          {
+            (*(void (__fastcall **)(_QWORD, const char *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v54);
+            v19 = HIDWORD(v55);
+            v20 = nullptr;
+            v54 = nullptr;
+          }
+          LODWORD(v55) = 0;
+          if ( (v19 & 0xC0000000) == 0 )
+          {
+            if ( v20 )
+            {
+              (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+              v54 = nullptr;
+            }
+            LODWORD(v55) = 0;
+          }
+        }
+        v21 = HIDWORD(v52);
+        v13 = (__int64)v51;
+        LODWORD(v50) = 0;
+        if ( (HIDWORD(v52) & 0xC0000000) == 0 )
+        {
+          if ( v51 )
+          {
+            (*(void (__fastcall **)(_QWORD, char *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v51);
+            v21 = HIDWORD(v52);
+            v13 = 0;
+            v51 = nullptr;
+          }
+          LODWORD(v52) = 0;
+          if ( (v21 & 0xC0000000) == 0 )
+          {
+            if ( v13 )
+            {
+              (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+              v51 = nullptr;
+            }
+            LODWORD(v52) = 0;
+          }
+        }
+      }
+      if ( v11 )
+      {
+        v22 = *(_QWORD *)(a1[2] + 8LL);
+        v48 = *(_QWORD *)(v22 + 216);
+        v49 = *(_QWORD *)(v22 + 224);
+        (*(void (__fastcall **)(__int64, const char **, __int64 *, _QWORD *, __int64, _QWORD))(*(_QWORD *)qword_182117C90
+                                                                                             + 160LL))(
+          qword_182117C90,
+          &v50,
+          &v48,
+          a1,
+          a3,
+          0);
+        if ( a6 != -1 )
+        {
+          if ( BYTE2(v53) )
+          {
+            Plat_FatalError("Path_AddToTail failed for read only CFieldPath");
+            __debugbreak();
+          }
+          if ( (__int16)v53 >= 10 )
+          {
+            Plat_FatalError("Path_AddToTail failed, depth already == DEFAULT_MAX_PATH_DEPTH(%d)", 10);
+            __debugbreak();
+          }
+          v23 = (__int16)v53;
+          LOWORD(v53) = v53 + 1;
+          *((_WORD *)&v50 + v23) = a6;
+        }
+        (*(void (__fastcall **)(_QWORD *, const char **))(*a1 + 232LL))(a1, &v50);// 0xE8 = 232LL = CEntityInstance_AddChangeAccessorPath
+      }
+    }
+    if ( a8 && *a4 )
+    {
+      v24 = *((int *)*a4 + 10);
+      if ( (int)v24 >= 0 )
+      {
+        v25 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*a1 + 312LL))(a1, v13);
+        if ( (*(_DWORD *)(v25 + 4) & 0x7FFFFFFF) != 0 )
+        {
+          v26 = (_QWORD *)(v25 + 8);
+          if ( (*(_DWORD *)(v25 + 4) & 0x7FFFFFFFu) > 4 )
+            v26 = (_QWORD *)*v26;
+        }
+        else
+        {
+          v26 = nullptr;
+        }
+        v27 = *((_DWORD *)v26 + v24);
+        v28 = 0x7FFF;
+        if ( v27 == -1 )
+        {
+          LOWORD(v50) = 0x7FFF;
+          LOWORD(v53) = 1;
+        }
+        else
+        {
+          if ( v27 )
+          {
+            if ( v27 < 0 )
+            {
+              sub_1814F0DA0(qword_181F78580, &v50);
+            }
+            else
+            {
+              LOWORD(v53) = 0;
+              BYTE2(v53) = 0;
+              v29 = &v50;
+              v30 = v27 & 0x7FC00000;
+              if ( (v27 & 0x7FC00000) != 0 )
+              {
+                v31 = 0;
+                do
+                {
+                  v32 = *(_DWORD *)((char *)&unk_1815A1CE0 + v31);
+                  v31 += 4;
+                  v29 = (const char **)((char *)v29 + 2);
+                  *((_WORD *)v29 - 1) = (v30 >> v32) - 1;
+                  LOWORD(v53) = v53 + 1;
+                  v30 = v27 & *(_DWORD *)((_BYTE *)&unk_1815A1D08 + v31);
+                }
+                while ( v30 );
+              }
+            }
+            goto LABEL_54;
+          }
+          LOWORD(v53) = 0;
+        }
+        BYTE2(v53) = 0;
+  LABEL_54:
+        v33 = a1[2];
+        v34 = *(_QWORD *)(v33 + 8);
+        v48 = *(_QWORD *)(v34 + 216);
+        v49 = *(_QWORD *)(v34 + 224);
+        if ( v33 )
+        {
+          v35 = *(_DWORD *)(v33 + 16);
+          v36 = *(_DWORD *)(v33 + 48);
+          v37 = 0x7FFF;
+          if ( v35 != -1 )
+            v37 = v35 & 0x7FFF;
+          v38 = v37 | (((v35 >> 15) - (v36 & 1)) << 15);
+        }
+        else
+        {
+          v38 = -1;
+        }
+        v39 = 0x7FFF;
+        if ( v38 != -1 )
+          v39 = v38 & 0x7FFF;
+        (*(void (__fastcall **)(__int64, const char **, __int64 *, const char **, _QWORD *, int, _DWORD, char))(*(_QWORD *)qword_182117C90 + 8LL))(
+          qword_182117C90,
+          &a5,
+          &v48,
+          &v50,
+          a1,
+          v39,
+          0,
+          1);
+        v40 = byte_18159B988;
+        v41 = byte_18159B988;
+        if ( a5 )
+          v41 = a5;
+        v42 = (const char **)sub_1814EFE40(&v50, &v59);
+        if ( *v42 )
+          v40 = *v42;
+        v43 = a1[2];
+        if ( v43 )
+        {
+          v44 = *(_DWORD *)(v43 + 16);
+          v45 = 0x7FFF;
+          if ( v44 != -1 )
+            v45 = v44 & 0x7FFF;
+          v46 = v45 | (((v44 >> 15) - (*(_DWORD *)(v43 + 48) & 1)) << 15);
+        }
+        else
+        {
+          v46 = -1;
+        }
+        if ( v46 != -1 )
+          v28 = v46 & 0x7FFF;
+        Msg("%d: assigned ChangeAccessorFieldPathIndex_t[ %d ] = '%s' for field %s\n", v28, v24, v40, v41);
+        if ( v59 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v59);
+        if ( a5 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&a5);
+        return v60;
+      }
+      Msg("unable to AssignChangeAccessorPathIds!!!\n", v13);
+      v51 = "PolymorphicHelper_t::SetPolymorphicPointer";
+      v50 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\public\\networksystem\\polymorphicmetadatahelper.h";
+      v53 = 0x14000000E5LL;
+      v52 = "IsValidChangeAccessorFieldPathIndex( pi )";
+      if ( Assert_ConditionFailed((const struct _AssertCompileTimeConstantStruct_t *)&v50) )
+        __debugbreak();
+    }
+    return v60;
+  }


### PR DESCRIPTION
## Summary

- Add `find-PolymorphicHelper_t__SetPolymorphicPointer` preprocessor script (Pattern A) using platform-specific xref strings (`PolymorphicHelper_t::SetPolymorphicPointer` on Windows, `../../public/networksystem/polymorphicmetadatahelper.h` on Linux)
- Add `find-CEntityInstance_AddChangeAccessorPath-AND-CEntityInstance_AssignChangeAccessorPathIds` preprocessor script (Pattern C, slim) using LLM_DECOMPILE on `PolymorphicHelper_t__SetPolymorphicPointer` to locate two slot-only vfuncs of `CEntityInstance`
- Add reference YAMLs for `PolymorphicHelper_t__SetPolymorphicPointer` (both platforms) with vfunc call offsets annotated
- Update `config.yaml` with skill entries, `expected_input` dependency chains, and symbol entries for all three targets

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug -modules server` passes with Failed: 0
- [ ] Output YAMLs contain `vfunc_sig`, `vfunc_offset`, `vfunc_index`, `vtable_name` for both CEntityInstance vfuncs
- [ ] Output YAML for `PolymorphicHelper_t__SetPolymorphicPointer` contains `func_sig`, `func_va`, `func_rva`, `func_size`