### PR TITLE
Add find-CPhysExplosion_Activate and refactor UTIL_Remove discovery

### DIFF
--- a/.claude/skills/cleanup-workspace/SKILL.md
+++ b/.claude/skills/cleanup-workspace/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: cleanup-workspace
+description: |
+  Clean up the local workspace after a dev branch has been merged into main.
+  Verifies the current dev branch is fully merged into origin/main, then switches to main,
+  pulls the latest, deletes the local dev branch, and deletes the remote dev branch if it still exists.
+  STOPS and warns the user if the current branch is not yet merged.
+  Triggers: cleanup workspace, cleanup branch, delete merged branch, finish dev branch, post-merge cleanup
+---
+
+# Cleanup Workspace
+
+Post-merge housekeeping: verify the active dev branch landed in `main`, then prune it locally and on `origin`.
+
+## When to Use
+
+After a pull request authored on a `dev*` branch has been merged into `main` and the user wants to return the workspace to a clean state on the updated `main` branch.
+
+## Safety Rules
+
+- **NEVER** delete a branch that is not fully merged into `origin/main`. If the merge check fails, STOP immediately and report to the user — do not pass `-D` to force delete.
+- **NEVER** run on `main` itself. If the current branch is `main`, abort with a clear message.
+- **NEVER** discard uncommitted changes. If the working tree is dirty, abort and ask the user to commit or stash first.
+- The remote name is assumed to be `origin`. If `origin` is not present, abort and ask the user which remote to use.
+
+## Method
+
+### Step 1 — Capture state and validate preconditions
+
+Run these checks in parallel:
+
+```bash
+git rev-parse --abbrev-ref HEAD          # current branch name
+git status --porcelain                   # must be empty (clean working tree)
+git remote                               # must contain 'origin'
+```
+
+Abort with a clear message if:
+- Current branch is `main` (nothing to clean up).
+- `git status --porcelain` is non-empty (uncommitted changes).
+- `origin` remote does not exist.
+
+Save the current branch name as `DEV_BRANCH` for later steps.
+
+### Step 2 — Fetch latest refs and verify merge status
+
+```bash
+git fetch origin --prune
+```
+
+Then check whether every commit on `DEV_BRANCH` is reachable from `origin/main`:
+
+```bash
+git merge-base --is-ancestor <DEV_BRANCH> origin/main
+```
+
+- Exit code `0` → branch is fully merged. Proceed to Step 3.
+- Exit code `1` → branch has commits not in `origin/main`. **STOP** and report to the user:
+  - Show the unmerged commits: `git log --oneline origin/main..<DEV_BRANCH>`
+  - Tell the user the branch is not merged and the skill will not delete it.
+  - Do **not** continue to subsequent steps.
+
+### Step 3 — Switch to main and pull
+
+```bash
+git checkout main
+git pull origin main --ff-only
+```
+
+Use `--ff-only` so the pull aborts cleanly if something unexpected happened upstream rather than creating a merge commit silently.
+
+### Step 4 — Delete the local dev branch
+
+```bash
+git branch -d <DEV_BRANCH>
+```
+
+Use lowercase `-d` (safe delete). It refuses to delete if not merged — which should not happen since Step 2 already verified the merge, but the double-check is intentional. Do **not** fall back to `-D`.
+
+### Step 5 — Delete the remote dev branch if it still exists
+
+First check whether the remote branch is still present (the maintainer may have already deleted it after merging the PR):
+
+```bash
+git ls-remote --heads origin <DEV_BRANCH>
+```
+
+- Output empty → remote already deleted. Skip the delete and report "remote branch already removed".
+- Output non-empty → delete it:
+
+```bash
+git push origin --delete <DEV_BRANCH>
+```
+
+If the push fails (permission denied, protected branch, etc.), report the error to the user — do not retry with force.
+
+### Step 6 — Report final state
+
+Summarize what changed in a short message:
+- Current branch (should be `main`) and its short SHA.
+- Whether the local dev branch was deleted.
+- Whether the remote dev branch was deleted or was already gone.
+
+## Example Walk-through
+
+User finishes work on `dev-14156` which has been merged into `main` via PR:
+
+```
+Step 1: HEAD=dev-14156, working tree clean, origin present.        ✓
+Step 2: git fetch origin --prune
+        git merge-base --is-ancestor dev-14156 origin/main → 0     ✓ merged
+Step 3: git checkout main
+        git pull origin main --ff-only                              → main now at <sha>
+Step 4: git branch -d dev-14156                                     → deleted
+Step 5: git ls-remote --heads origin dev-14156 → non-empty
+        git push origin --delete dev-14156                          → deleted
+Step 6: Report: on main @ <sha>; local dev-14156 deleted; remote dev-14156 deleted.
+```
+
+## Notes
+
+- The skill is a pure git workflow — no IDA Pro MCP or codebase analysis is involved.
+- If the user wants to clean up a *different* branch than the one currently checked out, they should switch to it first; this skill only operates on `HEAD`.
+- The skill never force-deletes (`-D`) or force-pushes. If a step refuses, that is a signal to stop and surface the situation, not to override.

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ settings.local.json
 settings.json
 __pycache__
 .venv
+.pytest_cache
+.vscode
 .env
 .stignore
 cs2_depot

--- a/config.yaml
+++ b/config.yaml
@@ -3565,9 +3565,23 @@ modules:
         expected_output:
           - CInferno_InfernoThink.{platform}.yaml
 
-      - name: find-UTIL_Remove
+      - name: find-CPhysExplosion_vtable
         expected_output:
+          - CPhysExplosion_vtable.{platform}.yaml
+
+      - name: find-CPhysExplosion_Activate
+        expected_output:
+          - CPhysExplosion_Activate.{platform}.yaml
+        expected_input:
+          - CBaseEntity_Activate.{platform}.yaml
+          - CPhysExplosion_vtable.{platform}.yaml
+
+      - name: find-CPhysExplosion_Explode-AND-UTIL_Remove
+        expected_output:
+          - CPhysExplosion_Explode.{platform}.yaml
           - UTIL_Remove.{platform}.yaml
+        expected_input:
+          - CPhysExplosion_Activate.{platform}.yaml
 
       - name: find-Host_Say
         expected_output:
@@ -6044,6 +6058,20 @@ modules:
         category: func
         alias:
           - CInferno::InfernoThink
+
+      - name: CPhysExplosion_vtable
+        category: vtable
+        shared: true
+
+      - name: CPhysExplosion_Activate
+        category: vfunc
+        alias:
+          - CPhysExplosion::Activate
+
+      - name: CPhysExplosion_Explode
+        category: func
+        alias:
+          - CPhysExplosion::Explode
 
       - name: UTIL_Remove
         category: func

--- a/ida_preprocessor_scripts/find-CPhysExplosion_Activate.py
+++ b/ida_preprocessor_scripts/find-CPhysExplosion_Activate.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CPhysExplosion_Activate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS=[
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CPhysExplosion_Activate", "CPhysExplosion", "CBaseEntity_Activate", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CPhysExplosion_Activate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CPhysExplosion_Explode-AND-UTIL_Remove.py
+++ b/ida_preprocessor_scripts/find-CPhysExplosion_Explode-AND-UTIL_Remove.py
@@ -1,23 +1,39 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-UTIL_Remove skill."""
+"""Preprocess script for find-CPhysExplosion_Explode-AND-UTIL_Remove skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
+    "CPhysExplosion_Explode",
     "UTIL_Remove",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
+        "CPhysExplosion_Explode",
+        "prompt/call_llm_decompile.md",
+        "references/server/CPhysExplosion_Activate.{platform}.yaml",
+    ),
+    (
         "UTIL_Remove",
         "prompt/call_llm_decompile.md",
-        "references/server/CInferno_InfernoThink.{platform}.yaml",
+        "references/server/CPhysExplosion_Activate.{platform}.yaml",
     ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
+    (
+        "CPhysExplosion_Explode",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
     # No func_sig: UTIL_Remove is a tiny stub whose head bytes are not unique in the
     # binary. LLM_DECOMPILE is used to locate it each time.
     (

--- a/ida_preprocessor_scripts/find-CPhysExplosion_vtable.py
+++ b/ida_preprocessor_scripts/find-CPhysExplosion_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CPhysExplosion_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CPhysExplosion"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CPhysExplosion",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CPhysExplosion vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CPhysExplosion_Activate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CPhysExplosion_Activate.linux.yaml
@@ -1,0 +1,32 @@
+func_name: CPhysExplosion_Activate
+func_va: '0x183a4b0'
+disasm_code: |-
+  .text:000000000183A4B0                 push    rbp
+  .text:000000000183A4B1                 mov     rbp, rsp
+  .text:000000000183A4B4                 push    rbx
+  .text:000000000183A4B5                 mov     rbx, rdi
+  .text:000000000183A4B8                 sub     rsp, 8
+  .text:000000000183A4BC                 call    CBaseEntity_Activate
+  .text:000000000183A4C1                 cmp     byte ptr [rbx+788h], 0
+  .text:000000000183A4C8                 jnz     short loc_183A4D0
+  .text:000000000183A4CA                 mov     rbx, [rbp+var_8]
+  .text:000000000183A4CE                 leave
+  .text:000000000183A4CF                 retn
+  .text:000000000183A4D0                 mov     rdi, rbx
+  .text:000000000183A4D3                 mov     rdx, rbx
+  .text:000000000183A4D6                 mov     rsi, rbx
+  .text:000000000183A4D9                 call    CPhysExplosion_Explode
+  .text:000000000183A4DE                 mov     rdi, rbx
+  .text:000000000183A4E1                 mov     rbx, [rbp+var_8]
+  .text:000000000183A4E5                 leave
+  .text:000000000183A4E6                 jmp     UTIL_Remove
+procedure: |-
+  void __fastcall CPhysExplosion_Activate(__int64 a1, unsigned int a2)
+  {
+    CBaseEntity_Activate((__int64 *)a1, a2);
+    if ( *(_BYTE *)(a1 + 1928) )
+    {
+      CPhysExplosion_Explode(a1, a1, a1);
+      UTIL_Remove(a1);
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CPhysExplosion_Activate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CPhysExplosion_Activate.windows.yaml
@@ -1,0 +1,30 @@
+func_name: CPhysExplosion_Activate
+func_va: '0x180d76480'
+disasm_code: |-
+  .text:0000000180D76480                 push    rbx
+  .text:0000000180D76482                 sub     rsp, 20h
+  .text:0000000180D76486                 mov     rbx, rcx
+  .text:0000000180D76489                 call    CBaseEntity_Activate
+  .text:0000000180D7648E                 cmp     byte ptr [rbx+4A8h], 0
+  .text:0000000180D76495                 jz      short loc_180D764B2
+  .text:0000000180D76497                 mov     r8, rbx
+  .text:0000000180D7649A                 mov     rdx, rbx
+  .text:0000000180D7649D                 mov     rcx, rbx
+  .text:0000000180D764A0                 call    CPhysExplosion_Explode
+  .text:0000000180D764A5                 mov     rcx, rbx
+  .text:0000000180D764A8                 add     rsp, 20h
+  .text:0000000180D764AC                 pop     rbx
+  .text:0000000180D764AD                 jmp     UTIL_Remove
+  .text:0000000180D764B2                 add     rsp, 20h
+  .text:0000000180D764B6                 pop     rbx
+  .text:0000000180D764B7                 retn
+procedure: |-
+  void __fastcall CPhysExplosion_Activate(__int64 a1, unsigned int a2)
+  {
+    CBaseEntity_Activate((_DWORD *)a1, a2);
+    if ( *(_BYTE *)(a1 + 1192) )
+    {
+      CPhysExplosion_Explode(a1, a1, a1);
+      UTIL_Remove(a1);
+    }
+  }


### PR DESCRIPTION
## Summary
- Adds `find-CPhysExplosion_vtable` and `find-CPhysExplosion_Activate` (Pattern F INHERIT_VFUNCS from `CBaseEntity_Activate`, resolves to vtable slot 13 / offset 0x68).
- Adds `find-CPhysExplosion_Explode-AND-UTIL_Remove` (Pattern D LLM_DECOMPILE) using `CPhysExplosion_Activate` as the predecessor — a much smaller and more stable anchor than the previous `CInferno_InfernoThink`.
- Removes the deprecated standalone `find-UTIL_Remove`; `UTIL_Remove` is now co-located with `CPhysExplosion_Explode` in the new skill.
- Adds the `cleanup-workspace` skill doc and minor `.gitignore` updates picked up on the same branch.

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` — 0 failures on both Windows and Linux server binaries.
- [x] Output YAMLs verified for `CPhysExplosion_vtable`, `CPhysExplosion_Activate`, `CPhysExplosion_Explode`, and `UTIL_Remove` on both platforms.
- [x] Reference YAMLs for `CPhysExplosion_Activate` annotated with `CPhysExplosion_Explode` rename on both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)