### PR TITLE
Add network client service preprocessor scripts and g_pInterfaceGlobals ppglobal support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -734,6 +734,24 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - ../client/INetworkClientService_SendNetMessage.{platform}.yaml
 
+      - name: find-CNetworkClientService_PrintSpawnGroupStatus
+        expected_output:
+          - CNetworkClientService_PrintSpawnGroupStatus.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
+      - name: find-CNetworkClientService_IsActive
+        expected_output:
+          - CNetworkClientService_IsActive.{platform}.yaml
+        expected_input:
+          - INetworkClientService_IsActive.{platform}.yaml
+
+      - name: find-CNetworkClientService_IsConnected
+        expected_output:
+          - CNetworkClientService_IsConnected.{platform}.yaml
+        expected_input:
+          - INetworkClientService_IsConnected.{platform}.yaml
+
       - name: find-CNetworkServerService_vtable
         expected_output:
           - CNetworkServerService_vtable.{platform}.yaml
@@ -1335,6 +1353,21 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::SendNetMessage
+
+      - name: CNetworkClientService_PrintSpawnGroupStatus
+        category: vfunc
+        alias:
+          - CNetworkClientService::PrintSpawnGroupStatus
+
+      - name: CNetworkClientService_IsActive
+        category: vfunc
+        alias:
+          - CNetworkClientService::IsActive
+
+      - name: CNetworkClientService_IsConnected
+        category: vfunc
+        alias:
+          - CNetworkClientService::IsConnected
 
       - name: CNetworkServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -799,6 +799,13 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnected.{platform}.yaml
 
+      - name: find-CNetworkClientService_ClockDriftAdjustFrameTime
+        expected_output:
+          - CNetworkClientService_ClockDriftAdjustFrameTime.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_ClockDrift_AdjustFrameTime.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_Init
         expected_output:
           - CNetworkClientService_Init.{platform}.yaml
@@ -1266,6 +1273,10 @@ modules:
         expected_output:
           - CNetworkGameClientBase_DeferActivate.{platform}.yaml
 
+      - name: find-CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+        expected_output:
+          - CNetworkGameClientBase_ClockDrift_AdjustFrameTime.{platform}.yaml
+
       - name: find-CNetworkGameClientBase_Connect
         expected_output:
           - CNetworkGameClientBase_Connect.{platform}.yaml
@@ -1546,6 +1557,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::IsConnected
+
+      - name: CNetworkClientService_ClockDriftAdjustFrameTime
+        category: vfunc
+        alias:
+          - CNetworkClientService::ClockDriftAdjustFrameTime
 
       - name: CNetworkClientService_Init
         category: vfunc
@@ -1940,6 +1956,11 @@ modules:
         category: func
         alias:
           - CNetworkGameClientBase::DeferActivate
+
+      - name: CNetworkGameClientBase_ClockDrift_AdjustFrameTime
+        category: func
+        alias:
+          - CNetworkGameClientBase::ClockDrift_AdjustFrameTime
 
       - name: CNetworkGameClientBase_Connect
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -881,6 +881,16 @@ modules:
         expected_input:
           - CNetworkServerService_Init.{platform}.yaml
 
+      - name: find-CNetworkGameClient_vtable
+        expected_output:
+          - CNetworkGameClient_vtable.{platform}.yaml
+
+      - name: find-CNetworkGameClient_DisconnectGame
+        expected_output:
+          - CNetworkGameClient_DisconnectGame.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+
       - name: find-INetworkMessages_FindNetworkGroup
         expected_output:
           - INetworkMessages_FindNetworkGroup.{platform}.yaml
@@ -1235,6 +1245,18 @@ modules:
         expected_output:
           - CNetworkGameClientBase_DeferActivate.{platform}.yaml
 
+      - name: find-CNetworkGameClientBase_Connect
+        expected_output:
+          - CNetworkGameClientBase_Connect.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_vtable.{platform}.yaml
+
+      - name: find-CNetworkGameClientBase_DisconnectGame
+        expected_output:
+          - CNetworkGameClientBase_DisconnectGame.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1406,6 +1428,14 @@ modules:
         alias:
           - CNetworkGameClient::RecordEntityBandwidth
           - RecordEntityBandwidth
+
+      - name: CNetworkGameClient_vtable
+        category: vtable
+
+      - name: CNetworkGameClient_DisconnectGame
+        category: vfunc
+        alias:
+          - CNetworkGameClient::DisconnectGame
 
       - name: INetworkMessages_FindNetworkGroup
         category: vfunc
@@ -1874,6 +1904,16 @@ modules:
         category: func
         alias:
           - CNetworkGameClientBase::DeferActivate
+
+      - name: CNetworkGameClientBase_Connect
+        category: vfunc
+        alias:
+          - CNetworkGameClientBase::Connect
+
+      - name: CNetworkGameClientBase_DisconnectGame
+        category: vfunc
+        alias:
+          - CNetworkGameClientBase::DisconnectGame
 
   - name: client
     path_windows: game/csgo/bin/win64/client.dll

--- a/config.yaml
+++ b/config.yaml
@@ -734,6 +734,13 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - ../client/INetworkClientService_SendNetMessage.{platform}.yaml
 
+      - name: find-CNetworkClientService_ServerCmd
+        platform: windows
+        expected_output:
+          - CNetworkClientService_ServerCmd.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_GetDisconnectReason
         expected_output:
           - CNetworkClientService_GetDisconnectReason.{platform}.yaml
@@ -1361,6 +1368,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::SendNetMessage
+
+      - name: CNetworkClientService_ServerCmd
+        category: vfunc
+        alias:
+          - CNetworkClientService::ServerCmd
 
       - name: CNetworkClientService_GetDisconnectReason
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2083,6 +2083,13 @@ modules:
         expected_output:
           - CUserMessage_ExtraUserData_vtable.{platform}.yaml
 
+      - name: find-SendViolationReport-windows
+        platform: windows
+        expected_output:
+          - SendViolationReport.{platform}.yaml
+        expected_input:
+          - CUserMessage_ExtraUserData_vtable.{platform}.yaml
+
     symbols:
       - name: CLoopModeGame_RegisterEventMapInternal
         category: func
@@ -2478,6 +2485,9 @@ modules:
 
       - name: CUserMessage_ExtraUserData_vtable
         category: vtable
+
+      - name: SendViolationReport
+        category: func
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/config.yaml
+++ b/config.yaml
@@ -1987,6 +1987,344 @@ modules:
       - name: ConnectInterfaces
         category: func
 
+      - name: g_pVApplication
+        category: gv
+
+      - name: g_pVEngineCvar
+        category: gv
+
+      - name: g_pVStringTokenSystem
+        category: gv
+
+      - name: g_pTestScriptMgr
+        category: gv
+
+      - name: g_pProcessUtils
+        category: gv
+
+      - name: g_pFileSystem
+        category: gv
+
+      - name: g_pAsyncFileSystem
+        category: gv
+
+      - name: g_pResourceSystem
+        category: gv
+
+      - name: g_pResourceManifestRegistry
+        category: gv
+
+      - name: g_pResourceHandleUtils
+        category: gv
+
+      - name: g_pSchemaSystem
+        category: gv
+
+      - name: g_pResourceCompilerSystem
+        category: gv
+
+      - name: g_pMaterialSystem2
+        category: gv
+
+      - name: g_pPostProcessingSystem
+        category: gv
+
+      - name: g_pInputSystem
+        category: gv
+
+      - name: g_pInputStackSystem
+        category: gv
+
+      - name: g_pRenderDeviceMgr
+        category: gv
+
+      - name: g_pRenderUtils
+        category: gv
+
+      - name: g_pSoundSystem
+        category: gv
+
+      - name: g_pSoundOpSystemEdit
+        category: gv
+
+      - name: g_pSoundOpSystem
+        category: gv
+
+      - name: g_pSteamAudio
+        category: gv
+
+      - name: g_pVP4
+        category: gv
+
+      - name: g_pLocalize
+        category: gv
+
+      - name: g_pMediaFoundation
+        category: gv
+
+      - name: g_pAVI
+        category: gv
+
+      - name: g_pWEBM
+        category: gv
+
+      - name: g_pBIK
+        category: gv
+
+      - name: g_pMeshSystem
+        category: gv
+
+      - name: g_pMeshUtils
+        category: gv
+
+      - name: g_pRenderDevice
+        category: gv
+
+      - name: g_pRenderDeviceSetup
+        category: gv
+
+      - name: g_pRenderHardwareConfig
+        category: gv
+
+      - name: g_pSceneSystem
+        category: gv
+
+      - name: g_pIPulseSystem
+        category: gv
+
+      - name: g_pSceneUtils
+        category: gv
+
+      - name: g_pWorldRendererMgr
+        category: gv
+
+      - name: g_pAssetSystem
+        category: gv
+
+      - name: g_pAssetSystemTest
+        category: gv
+
+      - name: g_pParticleSystemMgr
+        category: gv
+
+      - name: g_pScriptManager
+        category: gv
+
+      - name: g_pPropertyEditorSystem
+        category: gv
+
+      - name: g_pMatchFramework
+        category: gv
+
+      - name: g_pSource2V8System
+        category: gv
+
+      - name: g_pPanoramaUIEngine
+        category: gv
+
+      - name: g_pPanoramaUIClient
+        category: gv
+
+      - name: g_pPanoramaTextServices
+        category: gv
+
+      - name: g_pToolFramework2
+        category: gv
+
+      - name: g_pPhysicsBuilderMgr
+        category: gv
+
+      - name: g_pVisBuilder
+        category: gv
+
+      - name: g_pBakedLODBuilderMgr
+        category: gv
+
+      - name: g_pHelpSystem
+        category: gv
+
+      - name: g_pToolSceneNodeFactory
+        category: gv
+
+      - name: g_pEconItemToolModel
+        category: gv
+
+      - name: g_pSchemaTestExternalTwo
+        category: gv
+
+      - name: g_pSchemaTestExternalOne
+        category: gv
+
+      - name: g_pAnimationSystem
+        category: gv
+
+      - name: g_pAnimationSystemUtils
+        category: gv
+
+      - name: g_pHammerMapLoader
+        category: gv
+
+      - name: g_pMaterialUtils
+        category: gv
+
+      - name: g_pFontManager
+        category: gv
+
+      - name: g_pTextLayout
+        category: gv
+
+      - name: g_pAssetPreviewSystem
+        category: gv
+
+      - name: g_pAssetBrowserSystem
+        category: gv
+
+      - name: g_pAssetRenameSystem
+        category: gv
+
+      - name: g_pVConComm
+        category: gv
+
+      - name: g_pModelProcessingServices
+        category: gv
+
+      - name: g_pNetworkSystem
+        category: gv
+
+      - name: g_pNetworkMessages
+        category: gv
+
+      - name: g_pFlattenedSerializers
+        category: gv
+
+      - name: g_pSerializedEntities
+        category: gv
+
+      - name: g_pDemoUpconverter
+        category: gv
+
+      - name: g_pSource2Client
+        category: gv
+
+      - name: g_pSource2ClientUI
+        category: gv
+
+      - name: g_pSource2ClientPrediction
+        category: gv
+
+      - name: g_pSource2Server
+        category: gv
+
+      - name: g_pSource2Host
+        category: gv
+
+      - name: g_pSource2ModTools
+        category: gv
+
+      - name: g_pSource2GameClients
+        category: gv
+
+      - name: g_pSource2GameEntities
+        category: gv
+
+      - name: g_pEngineServiceMgr
+        category: gv
+
+      - name: g_pHostStateMgr
+        category: gv
+
+      - name: g_pNetworkService
+        category: gv
+
+      - name: g_pNetworkClientService
+        category: gv
+
+      - name: g_pNetworkP2PService
+        category: gv
+
+      - name: g_pNetworkServerService
+        category: gv
+
+      - name: g_pToolService
+        category: gv
+
+      - name: g_pRenderService
+        category: gv
+
+      - name: g_pStatsService
+        category: gv
+
+      - name: g_pVProfService
+        category: gv
+
+      - name: g_pInputService
+        category: gv
+
+      - name: g_pMapListService
+        category: gv
+
+      - name: g_pGameUIService
+        category: gv
+
+      - name: g_pSoundService
+        category: gv
+
+      - name: g_pBenchmarkService
+        category: gv
+
+      - name: g_pKeyValueCache
+        category: gv
+
+      - name: g_pClientServerSharedHandleSystem
+        category: gv
+
+      - name: g_pGameResourceServiceClient
+        category: gv
+
+      - name: g_pGameResourceServiceServer
+        category: gv
+
+      - name: g_pSource2EngineToClient
+        category: gv
+
+      - name: g_pSource2EngineToServer
+        category: gv
+
+      - name: g_pSource2EngineToServerStringTable
+        category: gv
+
+      - name: g_pSource2EngineToClientStringTable
+        category: gv
+
+      - name: g_pVPhysics2
+        category: gv
+
+      - name: g_pModelDocUtils
+        category: gv
+
+      - name: g_pAnimGraphEditorUtils
+        category: gv
+
+      - name: g_pExportSystem
+        category: gv
+
+      - name: g_pServerToolsInfo
+        category: gv
+
+      - name: g_pClientToolsInfo
+        category: gv
+
+      - name: g_pRAD3
+        category: gv
+
+      - name: g_pNavSystem
+        category: gv
+        platform: windows
+
+      - name: g_pNavGameTest
+        category: gv
+        platform: windows
+
       - name: g_pInterfaceGlobals
         category: gv
 
@@ -2447,6 +2785,124 @@ modules:
         expected_input:
           - ConnectInterfaces.{platform}.yaml
 
+      - name: find-g_pInterfaceGlobals_ppGlobal
+        expected_output:
+          - g_pVApplication.{platform}.yaml
+          - g_pVEngineCvar.{platform}.yaml
+          - g_pVStringTokenSystem.{platform}.yaml
+          - g_pTestScriptMgr.{platform}.yaml
+          - g_pProcessUtils.{platform}.yaml
+          - g_pFileSystem.{platform}.yaml
+          - g_pAsyncFileSystem.{platform}.yaml
+          - g_pResourceSystem.{platform}.yaml
+          - g_pResourceManifestRegistry.{platform}.yaml
+          - g_pResourceHandleUtils.{platform}.yaml
+          - g_pSchemaSystem.{platform}.yaml
+          - g_pResourceCompilerSystem.{platform}.yaml
+          - g_pMaterialSystem2.{platform}.yaml
+          - g_pPostProcessingSystem.{platform}.yaml
+          - g_pInputSystem.{platform}.yaml
+          - g_pInputStackSystem.{platform}.yaml
+          - g_pRenderDeviceMgr.{platform}.yaml
+          - g_pRenderUtils.{platform}.yaml
+          - g_pSoundSystem.{platform}.yaml
+          - g_pSoundOpSystemEdit.{platform}.yaml
+          - g_pSoundOpSystem.{platform}.yaml
+          - g_pSteamAudio.{platform}.yaml
+          - g_pVP4.{platform}.yaml
+          - g_pLocalize.{platform}.yaml
+          - g_pMediaFoundation.{platform}.yaml
+          - g_pAVI.{platform}.yaml
+          - g_pWEBM.{platform}.yaml
+          - g_pBIK.{platform}.yaml
+          - g_pMeshSystem.{platform}.yaml
+          - g_pMeshUtils.{platform}.yaml
+          - g_pRenderDevice.{platform}.yaml
+          - g_pRenderDeviceSetup.{platform}.yaml
+          - g_pRenderHardwareConfig.{platform}.yaml
+          - g_pSceneSystem.{platform}.yaml
+          - g_pIPulseSystem.{platform}.yaml
+          - g_pSceneUtils.{platform}.yaml
+          - g_pWorldRendererMgr.{platform}.yaml
+          - g_pAssetSystem.{platform}.yaml
+          - g_pAssetSystemTest.{platform}.yaml
+          - g_pParticleSystemMgr.{platform}.yaml
+          - g_pScriptManager.{platform}.yaml
+          - g_pPropertyEditorSystem.{platform}.yaml
+          - g_pMatchFramework.{platform}.yaml
+          - g_pSource2V8System.{platform}.yaml
+          - g_pPanoramaUIEngine.{platform}.yaml
+          - g_pPanoramaUIClient.{platform}.yaml
+          - g_pPanoramaTextServices.{platform}.yaml
+          - g_pToolFramework2.{platform}.yaml
+          - g_pPhysicsBuilderMgr.{platform}.yaml
+          - g_pVisBuilder.{platform}.yaml
+          - g_pBakedLODBuilderMgr.{platform}.yaml
+          - g_pHelpSystem.{platform}.yaml
+          - g_pToolSceneNodeFactory.{platform}.yaml
+          - g_pEconItemToolModel.{platform}.yaml
+          - g_pSchemaTestExternalTwo.{platform}.yaml
+          - g_pSchemaTestExternalOne.{platform}.yaml
+          - g_pAnimationSystem.{platform}.yaml
+          - g_pAnimationSystemUtils.{platform}.yaml
+          - g_pHammerMapLoader.{platform}.yaml
+          - g_pMaterialUtils.{platform}.yaml
+          - g_pFontManager.{platform}.yaml
+          - g_pTextLayout.{platform}.yaml
+          - g_pAssetPreviewSystem.{platform}.yaml
+          - g_pAssetBrowserSystem.{platform}.yaml
+          - g_pAssetRenameSystem.{platform}.yaml
+          - g_pVConComm.{platform}.yaml
+          - g_pModelProcessingServices.{platform}.yaml
+          - g_pNetworkSystem.{platform}.yaml
+          - g_pNetworkMessages.{platform}.yaml
+          - g_pFlattenedSerializers.{platform}.yaml
+          - g_pSerializedEntities.{platform}.yaml
+          - g_pDemoUpconverter.{platform}.yaml
+          - g_pSource2Client.{platform}.yaml
+          - g_pSource2ClientUI.{platform}.yaml
+          - g_pSource2ClientPrediction.{platform}.yaml
+          - g_pSource2Server.{platform}.yaml
+          - g_pSource2Host.{platform}.yaml
+          - g_pSource2ModTools.{platform}.yaml
+          - g_pSource2GameClients.{platform}.yaml
+          - g_pSource2GameEntities.{platform}.yaml
+          - g_pEngineServiceMgr.{platform}.yaml
+          - g_pHostStateMgr.{platform}.yaml
+          - g_pNetworkService.{platform}.yaml
+          - g_pNetworkClientService.{platform}.yaml
+          - g_pNetworkP2PService.{platform}.yaml
+          - g_pNetworkServerService.{platform}.yaml
+          - g_pToolService.{platform}.yaml
+          - g_pRenderService.{platform}.yaml
+          - g_pStatsService.{platform}.yaml
+          - g_pVProfService.{platform}.yaml
+          - g_pInputService.{platform}.yaml
+          - g_pMapListService.{platform}.yaml
+          - g_pGameUIService.{platform}.yaml
+          - g_pSoundService.{platform}.yaml
+          - g_pBenchmarkService.{platform}.yaml
+          - g_pKeyValueCache.{platform}.yaml
+          - g_pClientServerSharedHandleSystem.{platform}.yaml
+          - g_pGameResourceServiceClient.{platform}.yaml
+          - g_pGameResourceServiceServer.{platform}.yaml
+          - g_pSource2EngineToClient.{platform}.yaml
+          - g_pSource2EngineToServer.{platform}.yaml
+          - g_pSource2EngineToServerStringTable.{platform}.yaml
+          - g_pSource2EngineToClientStringTable.{platform}.yaml
+          - g_pVPhysics2.{platform}.yaml
+          - g_pModelDocUtils.{platform}.yaml
+          - g_pAnimGraphEditorUtils.{platform}.yaml
+          - g_pExportSystem.{platform}.yaml
+          - g_pServerToolsInfo.{platform}.yaml
+          - g_pClientToolsInfo.{platform}.yaml
+          - g_pRAD3.{platform}.yaml
+        expected_output_windows:
+          - g_pNavSystem.{platform}.yaml
+          - g_pNavGameTest.{platform}.yaml
+        expected_input:
+          - g_pInterfaceGlobals.{platform}.yaml
+
     symbols:
       - name: CLoopModeGame_RegisterEventMapInternal
         category: func
@@ -2868,6 +3324,344 @@ modules:
 
       - name: ConnectInterfaces
         category: func
+
+      - name: g_pVApplication
+        category: gv
+
+      - name: g_pVEngineCvar
+        category: gv
+
+      - name: g_pVStringTokenSystem
+        category: gv
+
+      - name: g_pTestScriptMgr
+        category: gv
+
+      - name: g_pProcessUtils
+        category: gv
+
+      - name: g_pFileSystem
+        category: gv
+
+      - name: g_pAsyncFileSystem
+        category: gv
+
+      - name: g_pResourceSystem
+        category: gv
+
+      - name: g_pResourceManifestRegistry
+        category: gv
+
+      - name: g_pResourceHandleUtils
+        category: gv
+
+      - name: g_pSchemaSystem
+        category: gv
+
+      - name: g_pResourceCompilerSystem
+        category: gv
+
+      - name: g_pMaterialSystem2
+        category: gv
+
+      - name: g_pPostProcessingSystem
+        category: gv
+
+      - name: g_pInputSystem
+        category: gv
+
+      - name: g_pInputStackSystem
+        category: gv
+
+      - name: g_pRenderDeviceMgr
+        category: gv
+
+      - name: g_pRenderUtils
+        category: gv
+
+      - name: g_pSoundSystem
+        category: gv
+
+      - name: g_pSoundOpSystemEdit
+        category: gv
+
+      - name: g_pSoundOpSystem
+        category: gv
+
+      - name: g_pSteamAudio
+        category: gv
+
+      - name: g_pVP4
+        category: gv
+
+      - name: g_pLocalize
+        category: gv
+
+      - name: g_pMediaFoundation
+        category: gv
+
+      - name: g_pAVI
+        category: gv
+
+      - name: g_pWEBM
+        category: gv
+
+      - name: g_pBIK
+        category: gv
+
+      - name: g_pMeshSystem
+        category: gv
+
+      - name: g_pMeshUtils
+        category: gv
+
+      - name: g_pRenderDevice
+        category: gv
+
+      - name: g_pRenderDeviceSetup
+        category: gv
+
+      - name: g_pRenderHardwareConfig
+        category: gv
+
+      - name: g_pSceneSystem
+        category: gv
+
+      - name: g_pIPulseSystem
+        category: gv
+
+      - name: g_pSceneUtils
+        category: gv
+
+      - name: g_pWorldRendererMgr
+        category: gv
+
+      - name: g_pAssetSystem
+        category: gv
+
+      - name: g_pAssetSystemTest
+        category: gv
+
+      - name: g_pParticleSystemMgr
+        category: gv
+
+      - name: g_pScriptManager
+        category: gv
+
+      - name: g_pPropertyEditorSystem
+        category: gv
+
+      - name: g_pMatchFramework
+        category: gv
+
+      - name: g_pSource2V8System
+        category: gv
+
+      - name: g_pPanoramaUIEngine
+        category: gv
+
+      - name: g_pPanoramaUIClient
+        category: gv
+
+      - name: g_pPanoramaTextServices
+        category: gv
+
+      - name: g_pToolFramework2
+        category: gv
+
+      - name: g_pPhysicsBuilderMgr
+        category: gv
+
+      - name: g_pVisBuilder
+        category: gv
+
+      - name: g_pBakedLODBuilderMgr
+        category: gv
+
+      - name: g_pHelpSystem
+        category: gv
+
+      - name: g_pToolSceneNodeFactory
+        category: gv
+
+      - name: g_pEconItemToolModel
+        category: gv
+
+      - name: g_pSchemaTestExternalTwo
+        category: gv
+
+      - name: g_pSchemaTestExternalOne
+        category: gv
+
+      - name: g_pAnimationSystem
+        category: gv
+
+      - name: g_pAnimationSystemUtils
+        category: gv
+
+      - name: g_pHammerMapLoader
+        category: gv
+
+      - name: g_pMaterialUtils
+        category: gv
+
+      - name: g_pFontManager
+        category: gv
+
+      - name: g_pTextLayout
+        category: gv
+
+      - name: g_pAssetPreviewSystem
+        category: gv
+
+      - name: g_pAssetBrowserSystem
+        category: gv
+
+      - name: g_pAssetRenameSystem
+        category: gv
+
+      - name: g_pVConComm
+        category: gv
+
+      - name: g_pModelProcessingServices
+        category: gv
+
+      - name: g_pNetworkSystem
+        category: gv
+
+      - name: g_pNetworkMessages
+        category: gv
+
+      - name: g_pFlattenedSerializers
+        category: gv
+
+      - name: g_pSerializedEntities
+        category: gv
+
+      - name: g_pDemoUpconverter
+        category: gv
+
+      - name: g_pSource2Client
+        category: gv
+
+      - name: g_pSource2ClientUI
+        category: gv
+
+      - name: g_pSource2ClientPrediction
+        category: gv
+
+      - name: g_pSource2Server
+        category: gv
+
+      - name: g_pSource2Host
+        category: gv
+
+      - name: g_pSource2ModTools
+        category: gv
+
+      - name: g_pSource2GameClients
+        category: gv
+
+      - name: g_pSource2GameEntities
+        category: gv
+
+      - name: g_pEngineServiceMgr
+        category: gv
+
+      - name: g_pHostStateMgr
+        category: gv
+
+      - name: g_pNetworkService
+        category: gv
+
+      - name: g_pNetworkClientService
+        category: gv
+
+      - name: g_pNetworkP2PService
+        category: gv
+
+      - name: g_pNetworkServerService
+        category: gv
+
+      - name: g_pToolService
+        category: gv
+
+      - name: g_pRenderService
+        category: gv
+
+      - name: g_pStatsService
+        category: gv
+
+      - name: g_pVProfService
+        category: gv
+
+      - name: g_pInputService
+        category: gv
+
+      - name: g_pMapListService
+        category: gv
+
+      - name: g_pGameUIService
+        category: gv
+
+      - name: g_pSoundService
+        category: gv
+
+      - name: g_pBenchmarkService
+        category: gv
+
+      - name: g_pKeyValueCache
+        category: gv
+
+      - name: g_pClientServerSharedHandleSystem
+        category: gv
+
+      - name: g_pGameResourceServiceClient
+        category: gv
+
+      - name: g_pGameResourceServiceServer
+        category: gv
+
+      - name: g_pSource2EngineToClient
+        category: gv
+
+      - name: g_pSource2EngineToServer
+        category: gv
+
+      - name: g_pSource2EngineToServerStringTable
+        category: gv
+
+      - name: g_pSource2EngineToClientStringTable
+        category: gv
+
+      - name: g_pVPhysics2
+        category: gv
+
+      - name: g_pModelDocUtils
+        category: gv
+
+      - name: g_pAnimGraphEditorUtils
+        category: gv
+
+      - name: g_pExportSystem
+        category: gv
+
+      - name: g_pServerToolsInfo
+        category: gv
+
+      - name: g_pClientToolsInfo
+        category: gv
+
+      - name: g_pRAD3
+        category: gv
+
+      - name: g_pNavSystem
+        category: gv
+        platform: windows
+
+      - name: g_pNavGameTest
+        category: gv
+        platform: windows
 
       - name: g_pInterfaceGlobals
         category: gv
@@ -5325,6 +6119,124 @@ modules:
           - g_pInterfaceGlobals.{platform}.yaml
         expected_input:
           - ConnectInterfaces.{platform}.yaml
+
+      - name: find-g_pInterfaceGlobals_ppGlobal
+        expected_output:
+          - g_pVApplication.{platform}.yaml
+          - g_pVEngineCvar.{platform}.yaml
+          - g_pVStringTokenSystem.{platform}.yaml
+          - g_pTestScriptMgr.{platform}.yaml
+          - g_pProcessUtils.{platform}.yaml
+          - g_pFileSystem.{platform}.yaml
+          - g_pAsyncFileSystem.{platform}.yaml
+          - g_pResourceSystem.{platform}.yaml
+          - g_pResourceManifestRegistry.{platform}.yaml
+          - g_pResourceHandleUtils.{platform}.yaml
+          - g_pSchemaSystem.{platform}.yaml
+          - g_pResourceCompilerSystem.{platform}.yaml
+          - g_pMaterialSystem2.{platform}.yaml
+          - g_pPostProcessingSystem.{platform}.yaml
+          - g_pInputSystem.{platform}.yaml
+          - g_pInputStackSystem.{platform}.yaml
+          - g_pRenderDeviceMgr.{platform}.yaml
+          - g_pRenderUtils.{platform}.yaml
+          - g_pSoundSystem.{platform}.yaml
+          - g_pSoundOpSystemEdit.{platform}.yaml
+          - g_pSoundOpSystem.{platform}.yaml
+          - g_pSteamAudio.{platform}.yaml
+          - g_pVP4.{platform}.yaml
+          - g_pLocalize.{platform}.yaml
+          - g_pMediaFoundation.{platform}.yaml
+          - g_pAVI.{platform}.yaml
+          - g_pWEBM.{platform}.yaml
+          - g_pBIK.{platform}.yaml
+          - g_pMeshSystem.{platform}.yaml
+          - g_pMeshUtils.{platform}.yaml
+          - g_pRenderDevice.{platform}.yaml
+          - g_pRenderDeviceSetup.{platform}.yaml
+          - g_pRenderHardwareConfig.{platform}.yaml
+          - g_pSceneSystem.{platform}.yaml
+          - g_pIPulseSystem.{platform}.yaml
+          - g_pSceneUtils.{platform}.yaml
+          - g_pWorldRendererMgr.{platform}.yaml
+          - g_pAssetSystem.{platform}.yaml
+          - g_pAssetSystemTest.{platform}.yaml
+          - g_pParticleSystemMgr.{platform}.yaml
+          - g_pScriptManager.{platform}.yaml
+          - g_pPropertyEditorSystem.{platform}.yaml
+          - g_pMatchFramework.{platform}.yaml
+          - g_pSource2V8System.{platform}.yaml
+          - g_pPanoramaUIEngine.{platform}.yaml
+          - g_pPanoramaUIClient.{platform}.yaml
+          - g_pPanoramaTextServices.{platform}.yaml
+          - g_pToolFramework2.{platform}.yaml
+          - g_pPhysicsBuilderMgr.{platform}.yaml
+          - g_pVisBuilder.{platform}.yaml
+          - g_pBakedLODBuilderMgr.{platform}.yaml
+          - g_pHelpSystem.{platform}.yaml
+          - g_pToolSceneNodeFactory.{platform}.yaml
+          - g_pEconItemToolModel.{platform}.yaml
+          - g_pSchemaTestExternalTwo.{platform}.yaml
+          - g_pSchemaTestExternalOne.{platform}.yaml
+          - g_pAnimationSystem.{platform}.yaml
+          - g_pAnimationSystemUtils.{platform}.yaml
+          - g_pHammerMapLoader.{platform}.yaml
+          - g_pMaterialUtils.{platform}.yaml
+          - g_pFontManager.{platform}.yaml
+          - g_pTextLayout.{platform}.yaml
+          - g_pAssetPreviewSystem.{platform}.yaml
+          - g_pAssetBrowserSystem.{platform}.yaml
+          - g_pAssetRenameSystem.{platform}.yaml
+          - g_pVConComm.{platform}.yaml
+          - g_pModelProcessingServices.{platform}.yaml
+          - g_pNetworkSystem.{platform}.yaml
+          - g_pNetworkMessages.{platform}.yaml
+          - g_pFlattenedSerializers.{platform}.yaml
+          - g_pSerializedEntities.{platform}.yaml
+          - g_pDemoUpconverter.{platform}.yaml
+          - g_pSource2Client.{platform}.yaml
+          - g_pSource2ClientUI.{platform}.yaml
+          - g_pSource2ClientPrediction.{platform}.yaml
+          - g_pSource2Server.{platform}.yaml
+          - g_pSource2Host.{platform}.yaml
+          - g_pSource2ModTools.{platform}.yaml
+          - g_pSource2GameClients.{platform}.yaml
+          - g_pSource2GameEntities.{platform}.yaml
+          - g_pEngineServiceMgr.{platform}.yaml
+          - g_pHostStateMgr.{platform}.yaml
+          - g_pNetworkService.{platform}.yaml
+          - g_pNetworkClientService.{platform}.yaml
+          - g_pNetworkP2PService.{platform}.yaml
+          - g_pNetworkServerService.{platform}.yaml
+          - g_pToolService.{platform}.yaml
+          - g_pRenderService.{platform}.yaml
+          - g_pStatsService.{platform}.yaml
+          - g_pVProfService.{platform}.yaml
+          - g_pInputService.{platform}.yaml
+          - g_pMapListService.{platform}.yaml
+          - g_pGameUIService.{platform}.yaml
+          - g_pSoundService.{platform}.yaml
+          - g_pBenchmarkService.{platform}.yaml
+          - g_pKeyValueCache.{platform}.yaml
+          - g_pClientServerSharedHandleSystem.{platform}.yaml
+          - g_pGameResourceServiceClient.{platform}.yaml
+          - g_pGameResourceServiceServer.{platform}.yaml
+          - g_pSource2EngineToClient.{platform}.yaml
+          - g_pSource2EngineToServer.{platform}.yaml
+          - g_pSource2EngineToServerStringTable.{platform}.yaml
+          - g_pSource2EngineToClientStringTable.{platform}.yaml
+          - g_pVPhysics2.{platform}.yaml
+          - g_pModelDocUtils.{platform}.yaml
+          - g_pAnimGraphEditorUtils.{platform}.yaml
+          - g_pExportSystem.{platform}.yaml
+          - g_pServerToolsInfo.{platform}.yaml
+          - g_pClientToolsInfo.{platform}.yaml
+          - g_pRAD3.{platform}.yaml
+        expected_output_windows:
+          - g_pNavSystem.{platform}.yaml
+          - g_pNavGameTest.{platform}.yaml
+        expected_input:
+          - g_pInterfaceGlobals.{platform}.yaml
 
     symbols:
       - name: CSource2Server_vtable
@@ -8041,6 +8953,344 @@ modules:
       - name: ConnectInterfaces
         category: func
 
+      - name: g_pVApplication
+        category: gv
+
+      - name: g_pVEngineCvar
+        category: gv
+
+      - name: g_pVStringTokenSystem
+        category: gv
+
+      - name: g_pTestScriptMgr
+        category: gv
+
+      - name: g_pProcessUtils
+        category: gv
+
+      - name: g_pFileSystem
+        category: gv
+
+      - name: g_pAsyncFileSystem
+        category: gv
+
+      - name: g_pResourceSystem
+        category: gv
+
+      - name: g_pResourceManifestRegistry
+        category: gv
+
+      - name: g_pResourceHandleUtils
+        category: gv
+
+      - name: g_pSchemaSystem
+        category: gv
+
+      - name: g_pResourceCompilerSystem
+        category: gv
+
+      - name: g_pMaterialSystem2
+        category: gv
+
+      - name: g_pPostProcessingSystem
+        category: gv
+
+      - name: g_pInputSystem
+        category: gv
+
+      - name: g_pInputStackSystem
+        category: gv
+
+      - name: g_pRenderDeviceMgr
+        category: gv
+
+      - name: g_pRenderUtils
+        category: gv
+
+      - name: g_pSoundSystem
+        category: gv
+
+      - name: g_pSoundOpSystemEdit
+        category: gv
+
+      - name: g_pSoundOpSystem
+        category: gv
+
+      - name: g_pSteamAudio
+        category: gv
+
+      - name: g_pVP4
+        category: gv
+
+      - name: g_pLocalize
+        category: gv
+
+      - name: g_pMediaFoundation
+        category: gv
+
+      - name: g_pAVI
+        category: gv
+
+      - name: g_pWEBM
+        category: gv
+
+      - name: g_pBIK
+        category: gv
+
+      - name: g_pMeshSystem
+        category: gv
+
+      - name: g_pMeshUtils
+        category: gv
+
+      - name: g_pRenderDevice
+        category: gv
+
+      - name: g_pRenderDeviceSetup
+        category: gv
+
+      - name: g_pRenderHardwareConfig
+        category: gv
+
+      - name: g_pSceneSystem
+        category: gv
+
+      - name: g_pIPulseSystem
+        category: gv
+
+      - name: g_pSceneUtils
+        category: gv
+
+      - name: g_pWorldRendererMgr
+        category: gv
+
+      - name: g_pAssetSystem
+        category: gv
+
+      - name: g_pAssetSystemTest
+        category: gv
+
+      - name: g_pParticleSystemMgr
+        category: gv
+
+      - name: g_pScriptManager
+        category: gv
+
+      - name: g_pPropertyEditorSystem
+        category: gv
+
+      - name: g_pMatchFramework
+        category: gv
+
+      - name: g_pSource2V8System
+        category: gv
+
+      - name: g_pPanoramaUIEngine
+        category: gv
+
+      - name: g_pPanoramaUIClient
+        category: gv
+
+      - name: g_pPanoramaTextServices
+        category: gv
+
+      - name: g_pToolFramework2
+        category: gv
+
+      - name: g_pPhysicsBuilderMgr
+        category: gv
+
+      - name: g_pVisBuilder
+        category: gv
+
+      - name: g_pBakedLODBuilderMgr
+        category: gv
+
+      - name: g_pHelpSystem
+        category: gv
+
+      - name: g_pToolSceneNodeFactory
+        category: gv
+
+      - name: g_pEconItemToolModel
+        category: gv
+
+      - name: g_pSchemaTestExternalTwo
+        category: gv
+
+      - name: g_pSchemaTestExternalOne
+        category: gv
+
+      - name: g_pAnimationSystem
+        category: gv
+
+      - name: g_pAnimationSystemUtils
+        category: gv
+
+      - name: g_pHammerMapLoader
+        category: gv
+
+      - name: g_pMaterialUtils
+        category: gv
+
+      - name: g_pFontManager
+        category: gv
+
+      - name: g_pTextLayout
+        category: gv
+
+      - name: g_pAssetPreviewSystem
+        category: gv
+
+      - name: g_pAssetBrowserSystem
+        category: gv
+
+      - name: g_pAssetRenameSystem
+        category: gv
+
+      - name: g_pVConComm
+        category: gv
+
+      - name: g_pModelProcessingServices
+        category: gv
+
+      - name: g_pNetworkSystem
+        category: gv
+
+      - name: g_pNetworkMessages
+        category: gv
+
+      - name: g_pFlattenedSerializers
+        category: gv
+
+      - name: g_pSerializedEntities
+        category: gv
+
+      - name: g_pDemoUpconverter
+        category: gv
+
+      - name: g_pSource2Client
+        category: gv
+
+      - name: g_pSource2ClientUI
+        category: gv
+
+      - name: g_pSource2ClientPrediction
+        category: gv
+
+      - name: g_pSource2Server
+        category: gv
+
+      - name: g_pSource2Host
+        category: gv
+
+      - name: g_pSource2ModTools
+        category: gv
+
+      - name: g_pSource2GameClients
+        category: gv
+
+      - name: g_pSource2GameEntities
+        category: gv
+
+      - name: g_pEngineServiceMgr
+        category: gv
+
+      - name: g_pHostStateMgr
+        category: gv
+
+      - name: g_pNetworkService
+        category: gv
+
+      - name: g_pNetworkClientService
+        category: gv
+
+      - name: g_pNetworkP2PService
+        category: gv
+
+      - name: g_pNetworkServerService
+        category: gv
+
+      - name: g_pToolService
+        category: gv
+
+      - name: g_pRenderService
+        category: gv
+
+      - name: g_pStatsService
+        category: gv
+
+      - name: g_pVProfService
+        category: gv
+
+      - name: g_pInputService
+        category: gv
+
+      - name: g_pMapListService
+        category: gv
+
+      - name: g_pGameUIService
+        category: gv
+
+      - name: g_pSoundService
+        category: gv
+
+      - name: g_pBenchmarkService
+        category: gv
+
+      - name: g_pKeyValueCache
+        category: gv
+
+      - name: g_pClientServerSharedHandleSystem
+        category: gv
+
+      - name: g_pGameResourceServiceClient
+        category: gv
+
+      - name: g_pGameResourceServiceServer
+        category: gv
+
+      - name: g_pSource2EngineToClient
+        category: gv
+
+      - name: g_pSource2EngineToServer
+        category: gv
+
+      - name: g_pSource2EngineToServerStringTable
+        category: gv
+
+      - name: g_pSource2EngineToClientStringTable
+        category: gv
+
+      - name: g_pVPhysics2
+        category: gv
+
+      - name: g_pModelDocUtils
+        category: gv
+
+      - name: g_pAnimGraphEditorUtils
+        category: gv
+
+      - name: g_pExportSystem
+        category: gv
+
+      - name: g_pServerToolsInfo
+        category: gv
+
+      - name: g_pClientToolsInfo
+        category: gv
+
+      - name: g_pRAD3
+        category: gv
+
+      - name: g_pNavSystem
+        category: gv
+        platform: windows
+
+      - name: g_pNavGameTest
+        category: gv
+        platform: windows
+
       - name: g_pInterfaceGlobals
         category: gv
 
@@ -8086,6 +9336,124 @@ modules:
           - g_pInterfaceGlobals.{platform}.yaml
         expected_input:
           - ConnectInterfaces.{platform}.yaml
+
+      - name: find-g_pInterfaceGlobals_ppGlobal
+        expected_output:
+          - g_pVApplication.{platform}.yaml
+          - g_pVEngineCvar.{platform}.yaml
+          - g_pVStringTokenSystem.{platform}.yaml
+          - g_pTestScriptMgr.{platform}.yaml
+          - g_pProcessUtils.{platform}.yaml
+          - g_pFileSystem.{platform}.yaml
+          - g_pAsyncFileSystem.{platform}.yaml
+          - g_pResourceSystem.{platform}.yaml
+          - g_pResourceManifestRegistry.{platform}.yaml
+          - g_pResourceHandleUtils.{platform}.yaml
+          - g_pSchemaSystem.{platform}.yaml
+          - g_pResourceCompilerSystem.{platform}.yaml
+          - g_pMaterialSystem2.{platform}.yaml
+          - g_pPostProcessingSystem.{platform}.yaml
+          - g_pInputSystem.{platform}.yaml
+          - g_pInputStackSystem.{platform}.yaml
+          - g_pRenderDeviceMgr.{platform}.yaml
+          - g_pRenderUtils.{platform}.yaml
+          - g_pSoundSystem.{platform}.yaml
+          - g_pSoundOpSystemEdit.{platform}.yaml
+          - g_pSoundOpSystem.{platform}.yaml
+          - g_pSteamAudio.{platform}.yaml
+          - g_pVP4.{platform}.yaml
+          - g_pLocalize.{platform}.yaml
+          - g_pMediaFoundation.{platform}.yaml
+          - g_pAVI.{platform}.yaml
+          - g_pWEBM.{platform}.yaml
+          - g_pBIK.{platform}.yaml
+          - g_pMeshSystem.{platform}.yaml
+          - g_pMeshUtils.{platform}.yaml
+          - g_pRenderDevice.{platform}.yaml
+          - g_pRenderDeviceSetup.{platform}.yaml
+          - g_pRenderHardwareConfig.{platform}.yaml
+          - g_pSceneSystem.{platform}.yaml
+          - g_pIPulseSystem.{platform}.yaml
+          - g_pSceneUtils.{platform}.yaml
+          - g_pWorldRendererMgr.{platform}.yaml
+          - g_pAssetSystem.{platform}.yaml
+          - g_pAssetSystemTest.{platform}.yaml
+          - g_pParticleSystemMgr.{platform}.yaml
+          - g_pScriptManager.{platform}.yaml
+          - g_pPropertyEditorSystem.{platform}.yaml
+          - g_pMatchFramework.{platform}.yaml
+          - g_pSource2V8System.{platform}.yaml
+          - g_pPanoramaUIEngine.{platform}.yaml
+          - g_pPanoramaUIClient.{platform}.yaml
+          - g_pPanoramaTextServices.{platform}.yaml
+          - g_pToolFramework2.{platform}.yaml
+          - g_pPhysicsBuilderMgr.{platform}.yaml
+          - g_pVisBuilder.{platform}.yaml
+          - g_pBakedLODBuilderMgr.{platform}.yaml
+          - g_pHelpSystem.{platform}.yaml
+          - g_pToolSceneNodeFactory.{platform}.yaml
+          - g_pEconItemToolModel.{platform}.yaml
+          - g_pSchemaTestExternalTwo.{platform}.yaml
+          - g_pSchemaTestExternalOne.{platform}.yaml
+          - g_pAnimationSystem.{platform}.yaml
+          - g_pAnimationSystemUtils.{platform}.yaml
+          - g_pHammerMapLoader.{platform}.yaml
+          - g_pMaterialUtils.{platform}.yaml
+          - g_pFontManager.{platform}.yaml
+          - g_pTextLayout.{platform}.yaml
+          - g_pAssetPreviewSystem.{platform}.yaml
+          - g_pAssetBrowserSystem.{platform}.yaml
+          - g_pAssetRenameSystem.{platform}.yaml
+          - g_pVConComm.{platform}.yaml
+          - g_pModelProcessingServices.{platform}.yaml
+          - g_pNetworkSystem.{platform}.yaml
+          - g_pNetworkMessages.{platform}.yaml
+          - g_pFlattenedSerializers.{platform}.yaml
+          - g_pSerializedEntities.{platform}.yaml
+          - g_pDemoUpconverter.{platform}.yaml
+          - g_pSource2Client.{platform}.yaml
+          - g_pSource2ClientUI.{platform}.yaml
+          - g_pSource2ClientPrediction.{platform}.yaml
+          - g_pSource2Server.{platform}.yaml
+          - g_pSource2Host.{platform}.yaml
+          - g_pSource2ModTools.{platform}.yaml
+          - g_pSource2GameClients.{platform}.yaml
+          - g_pSource2GameEntities.{platform}.yaml
+          - g_pEngineServiceMgr.{platform}.yaml
+          - g_pHostStateMgr.{platform}.yaml
+          - g_pNetworkService.{platform}.yaml
+          - g_pNetworkClientService.{platform}.yaml
+          - g_pNetworkP2PService.{platform}.yaml
+          - g_pNetworkServerService.{platform}.yaml
+          - g_pToolService.{platform}.yaml
+          - g_pRenderService.{platform}.yaml
+          - g_pStatsService.{platform}.yaml
+          - g_pVProfService.{platform}.yaml
+          - g_pInputService.{platform}.yaml
+          - g_pMapListService.{platform}.yaml
+          - g_pGameUIService.{platform}.yaml
+          - g_pSoundService.{platform}.yaml
+          - g_pBenchmarkService.{platform}.yaml
+          - g_pKeyValueCache.{platform}.yaml
+          - g_pClientServerSharedHandleSystem.{platform}.yaml
+          - g_pGameResourceServiceClient.{platform}.yaml
+          - g_pGameResourceServiceServer.{platform}.yaml
+          - g_pSource2EngineToClient.{platform}.yaml
+          - g_pSource2EngineToServer.{platform}.yaml
+          - g_pSource2EngineToServerStringTable.{platform}.yaml
+          - g_pSource2EngineToClientStringTable.{platform}.yaml
+          - g_pVPhysics2.{platform}.yaml
+          - g_pModelDocUtils.{platform}.yaml
+          - g_pAnimGraphEditorUtils.{platform}.yaml
+          - g_pExportSystem.{platform}.yaml
+          - g_pServerToolsInfo.{platform}.yaml
+          - g_pClientToolsInfo.{platform}.yaml
+          - g_pRAD3.{platform}.yaml
+        expected_output_windows:
+          - g_pNavSystem.{platform}.yaml
+          - g_pNavGameTest.{platform}.yaml
+        expected_input:
+          - g_pInterfaceGlobals.{platform}.yaml
 
   - name: networksystem # Execute skills for networksystem.dll again after server.dll
     path_windows: game/bin/win64/networksystem.dll

--- a/config.yaml
+++ b/config.yaml
@@ -734,6 +734,12 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - ../client/INetworkClientService_SendNetMessage.{platform}.yaml
 
+      - name: find-CNetworkClientService_GetDisconnectReason
+        expected_output:
+          - CNetworkClientService_GetDisconnectReason.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_PrintSpawnGroupStatus
         expected_output:
           - CNetworkClientService_PrintSpawnGroupStatus.{platform}.yaml
@@ -1355,6 +1361,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::SendNetMessage
+
+      - name: CNetworkClientService_GetDisconnectReason
+        category: vfunc
+        alias:
+          - CNetworkClientService::GetDisconnectReason
 
       - name: CNetworkClientService_PrintSpawnGroupStatus
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -744,12 +744,14 @@ modules:
         expected_output:
           - CNetworkClientService_IsActive.{platform}.yaml
         expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsActive.{platform}.yaml
 
       - name: find-CNetworkClientService_IsConnected
         expected_output:
           - CNetworkClientService_IsConnected.{platform}.yaml
         expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnected.{platform}.yaml
 
       - name: find-CNetworkServerService_vtable

--- a/config.yaml
+++ b/config.yaml
@@ -1289,6 +1289,10 @@ modules:
         expected_input:
           - CNetworkGameClientBase_vtable.{platform}.yaml
 
+      - name: find-CNetSupportImpl_vtable
+        expected_output:
+          - CNetSupportImpl_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1972,6 +1976,20 @@ modules:
         alias:
           - CNetworkGameClientBase::DisconnectGame
 
+      - name: CNetSupportImpl_vtable
+        category: vtable
+
+      - name: CNetSupportImpl_Connect
+        category: vfunc
+        alias:
+          - CNetSupportImpl::Connect
+
+      - name: ConnectInterfaces
+        category: func
+
+      - name: g_pInterfaceGlobals
+        category: gv
+
   - name: client
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so
@@ -2419,6 +2437,16 @@ modules:
         expected_input:
           - SendViolationReport.{platform}.yaml
 
+      - name: find-ConnectInterfaces
+        expected_output:
+          - ConnectInterfaces.{platform}.yaml
+
+      - name: find-g_pInterfaceGlobals
+        expected_output:
+          - g_pInterfaceGlobals.{platform}.yaml
+        expected_input:
+          - ConnectInterfaces.{platform}.yaml
+
     symbols:
       - name: CLoopModeGame_RegisterEventMapInternal
         category: func
@@ -2837,6 +2865,12 @@ modules:
         category: vfunc
         alias:
           - INetworkClientService::SendNetMessage
+
+      - name: ConnectInterfaces
+        category: func
+
+      - name: g_pInterfaceGlobals
+        category: gv
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll
@@ -3618,6 +3652,12 @@ modules:
           - CSource2Server_Connect.{platform}.yaml
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
+
+      - name: find-IAppSystem_Connect
+        expected_output:
+          - IAppSystem_Connect.{platform}.yaml
+        expected_input:
+          - CSource2Server_Connect.{platform}.yaml
 
       - name: find-CSource2Server_Init
         expected_output:
@@ -5276,6 +5316,16 @@ modules:
         expected_output:
           - CNavPhysicsInterface_vtable.{platform}.yaml
 
+      - name: find-ConnectInterfaces
+        expected_output:
+          - ConnectInterfaces.{platform}.yaml
+
+      - name: find-g_pInterfaceGlobals
+        expected_output:
+          - g_pInterfaceGlobals.{platform}.yaml
+        expected_input:
+          - ConnectInterfaces.{platform}.yaml
+
     symbols:
       - name: CSource2Server_vtable
         category: vtable
@@ -6240,6 +6290,11 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::Connect
+
+      - name: IAppSystem_Connect
+        category: vfunc
+        alias:
+          - IAppSystem::Connect
 
       - name: CSource2Server_GameFrame
         category: vfunc
@@ -7983,6 +8038,12 @@ modules:
       - name: CNavPhysicsInterface_vtable
         category: vtable
 
+      - name: ConnectInterfaces
+        category: func
+
+      - name: g_pInterfaceGlobals
+        category: gv
+
   - name: engine # Execute skills for engine2.dll again after client.dll
     path_windows: game/bin/win64/engine2.dll
     path_linux: game/bin/linuxsteamrt64/libengine2.so
@@ -8006,6 +8067,25 @@ modules:
           - CLoopTypeBase_GetClientServerMode.{platform}.yaml
         expected_input:
           - CEngineServiceMgr_GetActiveLoopClientServerMode.{platform}.yaml
+
+      - name: find-CNetSupportImpl_Connect
+        expected_output:
+          - CNetSupportImpl_Connect.{platform}.yaml
+        expected_input:
+          - ../server/IAppSystem_Connect.{platform}.yaml
+          - CNetSupportImpl_vtable.{platform}.yaml
+
+      - name: find-ConnectInterfaces
+        expected_output:
+          - ConnectInterfaces.{platform}.yaml
+        expected_input:
+          - CNetSupportImpl_Connect.{platform}.yaml
+
+      - name: find-g_pInterfaceGlobals
+        expected_output:
+          - g_pInterfaceGlobals.{platform}.yaml
+        expected_input:
+          - ConnectInterfaces.{platform}.yaml
 
   - name: networksystem # Execute skills for networksystem.dll again after server.dll
     path_windows: game/bin/win64/networksystem.dll

--- a/config.yaml
+++ b/config.yaml
@@ -799,6 +799,21 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnected.{platform}.yaml
 
+      - name: find-CNetworkClientService_Shutdown
+        expected_output:
+          - CNetworkClientService_Shutdown.{platform}.yaml
+        expected_input:
+          - IAppSystem_Shutdown.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
+      - name: find-CNetworkClientService_DisconnectGameNow
+        expected_output:
+          - CNetworkClientService_DisconnectGameNow.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_DisconnectGame.{platform}.yaml
+          - CNetworkClientService_Shutdown.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CGameClientConnectPrerequisite_vtable
         expected_output:
           - CGameClientConnectPrerequisite_vtable.{platform}.yaml
@@ -1525,6 +1540,16 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::IsConnected
+
+      - name: CNetworkClientService_Shutdown
+        category: vfunc
+        alias:
+          - CNetworkClientService::Shutdown
+
+      - name: CNetworkClientService_DisconnectGameNow
+        category: vfunc
+        alias:
+          - CNetworkClientService::DisconnectGameNow
 
       - name: CGameClientConnectPrerequisite_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -720,6 +720,20 @@ modules:
         expected_input:
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_SplitScreenConnect
+        expected_output:
+          - CNetworkClientService_SplitScreenConnect.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
+      - name: find-CNetworkClientService_SendNetMessage
+        platform: windows
+        expected_output:
+          - CNetworkClientService_SendNetMessage.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+          - ../client/INetworkClientService_SendNetMessage.{platform}.yaml
+
       - name: find-CNetworkServerService_vtable
         expected_output:
           - CNetworkServerService_vtable.{platform}.yaml
@@ -1311,6 +1325,16 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::ReceivedServerInfo
+
+      - name: CNetworkClientService_SplitScreenConnect
+        category: vfunc
+        alias:
+          - CNetworkClientService::SplitScreenConnect
+
+      - name: CNetworkClientService_SendNetMessage
+        category: vfunc
+        alias:
+          - CNetworkClientService::SendNetMessage
 
       - name: CNetworkServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -756,6 +756,12 @@ modules:
           - CNetworkGameClientBase_DeferActivate.{platform}.yaml
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_PrintConnectionStatus
+        expected_output:
+          - CNetworkClientService_PrintConnectionStatus.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_ServerCmd
         platform: windows
         expected_output:
@@ -1427,6 +1433,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::FinishChangeLevel
+
+      - name: CNetworkClientService_PrintConnectionStatus
+        category: vfunc
+        alias:
+          - CNetworkClientService::PrintConnectionStatus
 
       - name: CNetworkClientService_ServerCmd
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -799,6 +799,29 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnected.{platform}.yaml
 
+      - name: find-CGameClientConnectPrerequisite_vtable
+        expected_output:
+          - CGameClientConnectPrerequisite_vtable.{platform}.yaml
+
+      - name: find-CGameClientConnectPrerequisite_ctor
+        expected_output:
+          - CGameClientConnectPrerequisite_ctor.{platform}.yaml
+        expected_input:
+          - CGameClientConnectPrerequisite_vtable.{platform}.yaml
+
+      - name: find-CNetworkClientService_AddClientPrerequisites
+        expected_output:
+          - CNetworkClientService_AddClientPrerequisites.{platform}.yaml
+        expected_input:
+          - CGameClientConnectPrerequisite_ctor.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
+      - name: find-CNetworkClientService_AllocateRemoteConnectionClient
+        expected_output:
+          - CNetworkClientService_AllocateRemoteConnectionClient.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkServerService_vtable
         expected_output:
           - CNetworkServerService_vtable.{platform}.yaml
@@ -1472,6 +1495,24 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::IsConnected
+
+      - name: CGameClientConnectPrerequisite_vtable
+        category: vtable
+
+      - name: CGameClientConnectPrerequisite_ctor
+        category: func
+        alias:
+          - CGameClientConnectPrerequisite::CGameClientConnectPrerequisite
+
+      - name: CNetworkClientService_AddClientPrerequisites
+        category: vfunc
+        alias:
+          - CNetworkClientService::AddClientPrerequisites
+
+      - name: CNetworkClientService_AllocateRemoteConnectionClient
+        category: vfunc
+        alias:
+          - CNetworkClientService::AllocateRemoteConnectionClient
 
       - name: CNetworkServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -2079,6 +2079,10 @@ modules:
         expected_input:
           - CSkeletonInstance_PostDataUpdate.{platform}.yaml
 
+      - name: find-CUserMessage_ExtraUserData_vtable
+        expected_output:
+          - CUserMessage_ExtraUserData_vtable.{platform}.yaml
+
     symbols:
       - name: CLoopModeGame_RegisterEventMapInternal
         category: func
@@ -2471,6 +2475,9 @@ modules:
         member: m_modelState.m_hModel
         alias:
           - CSkeletonInstance::m_modelState.m_hModel
+
+      - name: CUserMessage_ExtraUserData_vtable
+        category: vtable
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/config.yaml
+++ b/config.yaml
@@ -714,6 +714,12 @@ modules:
         expected_output:
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_ProcessGameSessionManifest
+        expected_output:
+          - CNetworkClientService_ProcessGameSessionManifest.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkServerService_vtable
         expected_output:
           - CNetworkServerService_vtable.{platform}.yaml
@@ -1300,6 +1306,11 @@ modules:
 
       - name: CNetworkClientService_vtable
         category: vtable
+
+      - name: CNetworkClientService_ProcessGameSessionManifest
+        category: vfunc
+        alias:
+          - CNetworkClientService::ProcessGameSessionManifest
 
       - name: CNetworkServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -734,6 +734,13 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - ../client/INetworkClientService_SendNetMessage.{platform}.yaml
 
+      - name: find-CNetworkClientService_SendStringCmd
+        expected_output:
+          - CNetworkClientService_SendStringCmd.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_SendStringCmd.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_ServerCmd
         platform: windows
         expected_output:
@@ -1158,6 +1165,12 @@ modules:
         expected_input:
           - CNetworkGameClientBase_vtable.{platform}.yaml
 
+      - name: find-CNetworkGameClientBase_SendStringCmd
+        expected_output:
+          - CNetworkGameClientBase_SendStringCmd.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1368,6 +1381,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::SendNetMessage
+
+      - name: CNetworkClientService_SendStringCmd
+        category: vfunc
+        alias:
+          - CNetworkClientService::SendStringCmd
 
       - name: CNetworkClientService_ServerCmd
         category: vfunc
@@ -1734,6 +1752,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameClientBase::ProcessSetConVar
+
+      - name: CNetworkGameClientBase_SendStringCmd
+        category: vfunc
+        alias:
+          - CNetworkGameClientBase::SendStringCmd
 
   - name: client
     path_windows: game/csgo/bin/win64/client.dll

--- a/config.yaml
+++ b/config.yaml
@@ -762,6 +762,10 @@ modules:
         expected_input:
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_OnStatus
+        expected_output:
+          - CNetworkClientService_OnStatus.{platform}.yaml
+
       - name: find-CNetworkClientService_ServerCmd
         platform: windows
         expected_output:
@@ -1438,6 +1442,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::PrintConnectionStatus
+
+      - name: CNetworkClientService_OnStatus
+        category: func
+        alias:
+          - CNetworkClientService::OnStatus
 
       - name: CNetworkClientService_ServerCmd
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -799,6 +799,12 @@ modules:
           - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnected.{platform}.yaml
 
+      - name: find-CNetworkClientService_Init
+        expected_output:
+          - CNetworkClientService_Init.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_Shutdown
         expected_output:
           - CNetworkClientService_Shutdown.{platform}.yaml
@@ -1540,6 +1546,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::IsConnected
+
+      - name: CNetworkClientService_Init
+        category: vfunc
+        alias:
+          - CNetworkClientService::Init
 
       - name: CNetworkClientService_Shutdown
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2090,6 +2090,16 @@ modules:
         expected_input:
           - CUserMessage_ExtraUserData_vtable.{platform}.yaml
 
+      - name: find-IVEngineClient2_GetNetworkClient-AND-INetworkClient_GetLocalAddress-AND-INetworkClientService_IsConnected-AND-INetworkClientService_SendNetMessage
+        platform: windows
+        expected_output:
+          - IVEngineClient2_GetNetworkClient.{platform}.yaml
+          - INetworkClient_GetLocalAddress.{platform}.yaml
+          - INetworkClientService_IsConnected.{platform}.yaml
+          - INetworkClientService_SendNetMessage.{platform}.yaml
+        expected_input:
+          - SendViolationReport.{platform}.yaml
+
     symbols:
       - name: CLoopModeGame_RegisterEventMapInternal
         category: func
@@ -2488,6 +2498,26 @@ modules:
 
       - name: SendViolationReport
         category: func
+
+      - name: IVEngineClient2_GetNetworkClient
+        category: vfunc
+        alias:
+          - IVEngineClient2::GetNetworkClient
+
+      - name: INetworkClient_GetLocalAddress
+        category: vfunc
+        alias:
+          - INetworkClient::GetLocalAddress
+
+      - name: INetworkClientService_IsConnected
+        category: vfunc
+        alias:
+          - INetworkClientService::IsConnected
+
+      - name: INetworkClientService_SendNetMessage
+        category: vfunc
+        alias:
+          - INetworkClientService::SendNetMessage
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/config.yaml
+++ b/config.yaml
@@ -714,9 +714,9 @@ modules:
         expected_output:
           - CNetworkClientService_vtable.{platform}.yaml
 
-      - name: find-CNetworkClientService_ProcessGameSessionManifest
+      - name: find-CNetworkClientService_ReceivedServerInfo
         expected_output:
-          - CNetworkClientService_ProcessGameSessionManifest.{platform}.yaml
+          - CNetworkClientService_ReceivedServerInfo.{platform}.yaml
         expected_input:
           - CNetworkClientService_vtable.{platform}.yaml
 
@@ -1307,10 +1307,10 @@ modules:
       - name: CNetworkClientService_vtable
         category: vtable
 
-      - name: CNetworkClientService_ProcessGameSessionManifest
+      - name: CNetworkClientService_ReceivedServerInfo
         category: vfunc
         alias:
-          - CNetworkClientService::ProcessGameSessionManifest
+          - CNetworkClientService::ReceivedServerInfo
 
       - name: CNetworkServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -741,6 +741,13 @@ modules:
           - CNetworkGameClientBase_SendStringCmd.{platform}.yaml
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_StartChangeLevel
+        expected_output:
+          - CNetworkClientService_StartChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_StartChangeLevel.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_ServerCmd
         platform: windows
         expected_output:
@@ -1171,6 +1178,12 @@ modules:
         expected_input:
           - CNetworkGameClientBase_vtable.{platform}.yaml
 
+      - name: find-CNetworkGameClientBase_StartChangeLevel
+        expected_output:
+          - CNetworkGameClientBase_StartChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1386,6 +1399,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::SendStringCmd
+
+      - name: CNetworkClientService_StartChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkClientService::StartChangeLevel
 
       - name: CNetworkClientService_ServerCmd
         category: vfunc
@@ -1757,6 +1775,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameClientBase::SendStringCmd
+
+      - name: CNetworkGameClientBase_StartChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkGameClientBase::StartChangeLevel
 
   - name: client
     path_windows: game/csgo/bin/win64/client.dll

--- a/config.yaml
+++ b/config.yaml
@@ -748,6 +748,14 @@ modules:
           - CNetworkGameClientBase_StartChangeLevel.{platform}.yaml
           - CNetworkClientService_vtable.{platform}.yaml
 
+      - name: find-CNetworkClientService_FinishChangeLevel
+        expected_output:
+          - CNetworkClientService_FinishChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_FinishChangeLevel.{platform}.yaml
+          - CNetworkGameClientBase_DeferActivate.{platform}.yaml
+          - CNetworkClientService_vtable.{platform}.yaml
+
       - name: find-CNetworkClientService_ServerCmd
         platform: windows
         expected_output:
@@ -1184,6 +1192,16 @@ modules:
         expected_input:
           - CNetworkGameClientBase_vtable.{platform}.yaml
 
+      - name: find-CNetworkGameClientBase_FinishChangeLevel
+        expected_output:
+          - CNetworkGameClientBase_FinishChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameClientBase_vtable.{platform}.yaml
+
+      - name: find-CNetworkGameClientBase_DeferActivate
+        expected_output:
+          - CNetworkGameClientBase_DeferActivate.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1404,6 +1422,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkClientService::StartChangeLevel
+
+      - name: CNetworkClientService_FinishChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkClientService::FinishChangeLevel
 
       - name: CNetworkClientService_ServerCmd
         category: vfunc
@@ -1780,6 +1803,16 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameClientBase::StartChangeLevel
+
+      - name: CNetworkGameClientBase_FinishChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkGameClientBase::FinishChangeLevel
+
+      - name: CNetworkGameClientBase_DeferActivate
+        category: func
+        alias:
+          - CNetworkGameClientBase::DeferActivate
 
   - name: client
     path_windows: game/csgo/bin/win64/client.dll

--- a/docs/superpowers/plans/2026-05-20-g_pinterfaceglobals-ppglobal.md
+++ b/docs/superpowers/plans/2026-05-20-g_pinterfaceglobals-ppglobal.md
@@ -1,0 +1,784 @@
+# g_pInterfaceGlobals ppGlobal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `find-g_pInterfaceGlobals_ppGlobal` to derive all expected `g_pXXXX` global-variable pointer YAML files from the `g_pInterfaceGlobals` table.
+
+**Architecture:** Add one focused custom preprocessor script that reads `g_pInterfaceGlobals.{platform}.yaml`, scans IDA entries as `(interface_name_ptr, pp_global_ptr)` pairs, strictly validates expected interface-name coverage against the shared expected list without depending on order, then writes minimal `gv_name/gv_va/gv_rva` YAML for each expected pointer. Register the skill after the existing `find-g_pInterfaceGlobals` step for `client`, `server`, and the post-client `engine` skill chain, and register the produced GV symbols in the modules that own symbols.
+
+**Tech Stack:** Python 3, IDA MCP `py_eval`, PyYAML, `unittest`, `unittest.mock`, `config.yaml`
+
+---
+
+## File Map
+
+- Create: `ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py`
+  - Responsibility: strict table scan, expected-interface coverage validation, minimal GV YAML emission, optional best-effort IDB rename.
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+  - Responsibility: cover the custom script without IDA by mocking MCP `py_eval` and YAML writer behavior.
+- Modify: `config.yaml`
+  - Responsibility: register the new skill and all generated GV symbols for `client`, `server`, and `engine`.
+- Reference: `ida_preprocessor_scripts/find-g_pInterfaceGlobals.py`
+  - Responsibility: existing prerequisite script that generates `g_pInterfaceGlobals.{platform}.yaml`.
+- Reference: `ida_analyze_util.py`
+  - Responsibility: reuse `parse_mcp_result` and `write_gv_yaml`.
+- Reference: `docs/superpowers/specs/2026-05-20-g_pinterfaceglobals-ppglobal-design.md`
+  - Responsibility: accepted design and strict behavior contract.
+
+## Repository Constraints
+
+- Do not depend on `pp_global_ptr` having an IDA name.
+- Do not use per-module expected lists; `client`, `server`, and `engine` all use the same platform-specific expected sequence.
+- Windows `.dll` includes `("NavSystem001", "g_pNavSystem")` and `("NavGameTest001", "g_pNavGameTest")`; current Linux `.so` ends at `("Vrad3_001", "g_pRAD3")` for required outputs.
+- Do not run test or build commands unless explicitly requested by the user. Static import/YAML parse checks are allowed as targeted verification.
+- Do not create commits unless the user explicitly confirms git history operations.
+- The duplicate `engine` module near the end of `config.yaml` contains the existing `find-g_pInterfaceGlobals` skill and should receive the new follow-up skill. The primary `engine` module contains the `symbols` list and should receive the new GV symbols.
+
+## Shared Expected Entries
+
+Use this exact ordered list as the Windows list in the new script. Derive the Linux list with `EXPECTED_ENTRIES[:-1]`.
+
+```python
+EXPECTED_ENTRIES = [
+    ("VApplication001", "g_pVApplication"),
+    ("VEngineCvar007", "g_pVEngineCvar"),
+    ("VStringTokenSystem001", "g_pVStringTokenSystem"),
+    ("TestScriptMgr001", "g_pTestScriptMgr"),
+    ("VProcessUtils002", "g_pProcessUtils"),
+    ("VFileSystem017", "g_pFileSystem"),
+    ("VAsyncFileSystem2_001", "g_pAsyncFileSystem"),
+    ("ResourceSystem013", "g_pResourceSystem"),
+    ("ResourceManifestRegistry001", "g_pResourceManifestRegistry"),
+    ("ResourceHandleUtils001", "g_pResourceHandleUtils"),
+    ("SchemaSystem_001", "g_pSchemaSystem"),
+    ("ResourceCompilerSystem001", "g_pResourceCompilerSystem"),
+    ("VMaterialSystem2_001", "g_pMaterialSystem2"),
+    ("PostProcessingSystem_001", "g_pPostProcessingSystem"),
+    ("InputSystemVersion001", "g_pInputSystem"),
+    ("InputStackSystemVersion001", "g_pInputStackSystem"),
+    ("RenderDeviceMgr001", "g_pRenderDeviceMgr"),
+    ("RenderUtils_001", "g_pRenderUtils"),
+    ("SoundSystem001", "g_pSoundSystem"),
+    ("SoundOpSystemEdit001", "g_pSoundOpSystemEdit"),
+    ("SoundOpSystem001", "g_pSoundOpSystem"),
+    ("SteamAudio001", "g_pSteamAudio"),
+    ("VP4003", "g_pVP4"),
+    ("Localize_001", "g_pLocalize"),
+    ("VMediaFoundation001", "g_pMediaFoundation"),
+    ("VAvi001", "g_pAVI"),
+    ("VWebm001", "g_pWEBM"),
+    ("VBik001", "g_pBIK"),
+    ("MeshSystem001", "g_pMeshSystem"),
+    ("MeshUtils001", "g_pMeshUtils"),
+    ("RenderDevice003", "g_pRenderDevice"),
+    ("VRenderDeviceSetupV001", "g_pRenderDeviceSetup"),
+    ("RenderHardwareConfig002", "g_pRenderHardwareConfig"),
+    ("SceneSystem_002", "g_pSceneSystem"),
+    ("IPulseSystem_001", "g_pIPulseSystem"),
+    ("SceneUtils_001", "g_pSceneUtils"),
+    ("WorldRendererMgr001", "g_pWorldRendererMgr"),
+    ("AssetSystem001", "g_pAssetSystem"),
+    ("AssetSystemTest001", "g_pAssetSystemTest"),
+    ("ParticleSystemMgr003", "g_pParticleSystemMgr"),
+    ("VScriptManager010", "g_pScriptManager"),
+    ("PropertyEditorSystem_001", "g_pPropertyEditorSystem"),
+    ("MATCHFRAMEWORK_001", "g_pMatchFramework"),
+    ("Source2V8System001", "g_pSource2V8System"),
+    ("PanoramaUIEngine001", "g_pPanoramaUIEngine"),
+    ("PanoramaUIClient001", "g_pPanoramaUIClient"),
+    ("PanoramaTextServices001", "g_pPanoramaTextServices"),
+    ("ToolFramework2_002", "g_pToolFramework2"),
+    ("PhysicsBuilderMgr001", "g_pPhysicsBuilderMgr"),
+    ("VisBuilder_001", "g_pVisBuilder"),
+    ("BakedLODBuilderMgr001", "g_pBakedLODBuilderMgr"),
+    ("HelpSystem_001", "g_pHelpSystem"),
+    ("ToolSceneNodeFactory_001", "g_pToolSceneNodeFactory"),
+    ("EconItemToolModel_001", "g_pEconItemToolModel"),
+    ("SchemaTestExternal_Two_001", "g_pSchemaTestExternalTwo"),
+    ("SchemaTestExternal_One_001", "g_pSchemaTestExternalOne"),
+    ("AnimationSystem_001", "g_pAnimationSystem"),
+    ("AnimationSystemUtils_001", "g_pAnimationSystemUtils"),
+    ("HammerMapLoader001", "g_pHammerMapLoader"),
+    ("MaterialUtils_001", "g_pMaterialUtils"),
+    ("FontManager_001", "g_pFontManager"),
+    ("TextLayout_001", "g_pTextLayout"),
+    ("AssetPreviewSystem_001", "g_pAssetPreviewSystem"),
+    ("AssetBrowserSystem_001", "g_pAssetBrowserSystem"),
+    ("AssetRenameSystem_001", "g_pAssetRenameSystem"),
+    ("VConComm001", "g_pVConComm"),
+    ("MODEL_PROCESSING_SERVICES_INTERFACE_001", "g_pModelProcessingServices"),
+    ("NetworkSystemVersion001", "g_pNetworkSystem"),
+    ("NetworkMessagesVersion001", "g_pNetworkMessages"),
+    ("FlattenedSerializersVersion001", "g_pFlattenedSerializers"),
+    ("SerializedEntitiesVersion001", "g_pSerializedEntities"),
+    ("DemoUpconverterVersion001", "g_pDemoUpconverter"),
+    ("Source2Client002", "g_pSource2Client"),
+    ("Source2ClientUI001", "g_pSource2ClientUI"),
+    ("Source2ClientPrediction001", "g_pSource2ClientPrediction"),
+    ("Source2Server001", "g_pSource2Server"),
+    ("Source2Host001", "g_pSource2Host"),
+    ("Source2ModTools001", "g_pSource2ModTools"),
+    ("Source2GameClients001", "g_pSource2GameClients"),
+    ("Source2GameEntities001", "g_pSource2GameEntities"),
+    ("EngineServiceMgr001", "g_pEngineServiceMgr"),
+    ("HostStateMgr001", "g_pHostStateMgr"),
+    ("NetworkService_001", "g_pNetworkService"),
+    ("NetworkClientService_001", "g_pNetworkClientService"),
+    ("NetworkP2PService_001", "g_pNetworkP2PService"),
+    ("NetworkServerService_001", "g_pNetworkServerService"),
+    ("ToolService_001", "g_pToolService"),
+    ("RenderService_001", "g_pRenderService"),
+    ("StatsService_001", "g_pStatsService"),
+    ("VProfService_001", "g_pVProfService"),
+    ("InputService_001", "g_pInputService"),
+    ("MapListService_001", "g_pMapListService"),
+    ("GameUIService_001", "g_pGameUIService"),
+    ("SoundService_001", "g_pSoundService"),
+    ("BenchmarkService001", "g_pBenchmarkService"),
+    ("KeyValueCache001", "g_pKeyValueCache"),
+    ("ClientServerSharedHandleSystem001", "g_pClientServerSharedHandleSystem"),
+    ("GameResourceServiceClientV001", "g_pGameResourceServiceClient"),
+    ("GameResourceServiceServerV001", "g_pGameResourceServiceServer"),
+    ("Source2EngineToClient001", "g_pSource2EngineToClient"),
+    ("Source2EngineToServer001", "g_pSource2EngineToServer"),
+    ("Source2EngineToServerStringTable001", "g_pSource2EngineToServerStringTable"),
+    ("Source2EngineToClientStringTable001", "g_pSource2EngineToClientStringTable"),
+    ("VPhysics2_Interface_001", "g_pVPhysics2"),
+    ("ModelDocUtils001", "g_pModelDocUtils"),
+    ("AnimGraphEditorUtils001", "g_pAnimGraphEditorUtils"),
+    ("EXPORTSYSTEM_INTERFACE_VERSION_001", "g_pExportSystem"),
+    ("ServerToolsInfo_001", "g_pServerToolsInfo"),
+    ("ClientToolsInfo_001", "g_pClientToolsInfo"),
+    ("Vrad3_001", "g_pRAD3"),
+    ("NavSystem001", "g_pNavSystem"),
+    ("NavGameTest001", "g_pNavGameTest"),
+]
+```
+
+## Task 1: Add Custom Preprocessor Script
+
+**Files:**
+- Create: `ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py`
+
+- [ ] **Step 1: Create constants and basic helpers**
+
+Create the file with imports and constants:
+
+```python
+#!/usr/bin/env python3
+"""Preprocess script for g_pInterfaceGlobals ppGlobal entries."""
+
+import json
+import os
+
+import yaml
+
+from ida_analyze_util import parse_mcp_result, write_gv_yaml
+
+INTERFACE_GLOBALS_NAME = "g_pInterfaceGlobals"
+ENTRY_SIZE = 0x10
+MAX_SCAN_ENTRIES = 256
+EXPECTED_ENTRIES = [
+    # Paste the full ordered list from this plan.
+]
+WINDOWS_EXPECTED_ENTRIES = EXPECTED_ENTRIES
+LINUX_EXPECTED_ENTRIES = EXPECTED_ENTRIES[:-2]
+```
+
+Add:
+
+```python
+def _debug(debug, message):
+    if debug:
+        print(f"    Preprocess: {message}")
+```
+
+- [ ] **Step 2: Add YAML input loader**
+
+Add:
+
+```python
+def _parse_addr(value):
+    try:
+        return int(str(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_interface_globals_va(new_binary_dir, platform, debug=False):
+    yaml_path = os.path.join(new_binary_dir, f"{INTERFACE_GLOBALS_NAME}.{platform}.yaml")
+    if not os.path.exists(yaml_path):
+        _debug(debug, f"missing input YAML {yaml_path}")
+        return None
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:
+        _debug(debug, f"failed to read {yaml_path}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        _debug(debug, f"invalid YAML payload in {yaml_path}")
+        return None
+    gv_va = _parse_addr(data.get("gv_va"))
+    if gv_va is None:
+        _debug(debug, f"missing or invalid gv_va in {yaml_path}")
+    return gv_va
+```
+
+- [ ] **Step 3: Add IDA py_eval scanner**
+
+Add:
+
+```python
+def _build_scan_py_eval(table_va, expected_count):
+    max_entries = max(expected_count, MAX_SCAN_ENTRIES)
+    return f"""
+import ida_bytes
+import idc
+import json
+
+table_va = {table_va}
+entry_size = {ENTRY_SIZE}
+max_entries = {max_entries}
+entries = []
+
+def read_qword(ea):
+    value = ida_bytes.get_qword(ea)
+    if value in (None, idc.BADADDR):
+        return None
+    return int(value)
+
+for index in range(max_entries):
+    entry_va = table_va + index * entry_size
+    interface_name_va = read_qword(entry_va)
+    pp_global_va = read_qword(entry_va + 8)
+    if not interface_name_va or not pp_global_va:
+        break
+    interface_name = idc.get_strlit_contents(interface_name_va, -1, idc.STRTYPE_C)
+    if isinstance(interface_name, bytes):
+        interface_name = interface_name.decode("utf-8", errors="replace")
+    if not interface_name:
+        break
+    entries.append({{
+        "index": index,
+        "entry_va": hex(entry_va),
+        "interface_name": str(interface_name),
+        "interface_name_va": hex(interface_name_va),
+        "pp_global_va": hex(pp_global_va),
+    }})
+
+result = json.dumps(entries)
+"""
+```
+
+Add:
+
+```python
+async def _scan_entries_via_mcp(session, table_va, debug=False):
+    code = _build_scan_py_eval(table_va, len(EXPECTED_ENTRIES))
+    try:
+        result = await session.call_tool(name="py_eval", arguments={"code": code})
+    except Exception as exc:
+        _debug(debug, f"py_eval scan failed: {exc}")
+        return None
+    payload = parse_mcp_result(result)
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            _debug(debug, f"scan returned non-json payload: {payload}")
+            return None
+    if not isinstance(payload, list):
+        _debug(debug, f"scan returned invalid payload: {payload}")
+        return None
+    return payload
+```
+
+- [ ] **Step 4: Add expected-interface coverage validator**
+
+Add:
+
+```python
+def _match_expected_entries(actual_entries, debug=False):
+    expected_interfaces = {interface for interface, _ in EXPECTED_ENTRIES}
+    actual_by_interface = {}
+    for actual in actual_entries:
+        actual_interface = str(actual.get("interface_name", ""))
+        if actual_interface not in expected_interfaces:
+            continue
+        if actual_interface in actual_by_interface:
+            _debug(debug, f"duplicate interface entry: {actual_interface}")
+            return None
+        actual_by_interface[actual_interface] = actual
+
+    for expected_interface, expected_gv in EXPECTED_ENTRIES:
+        actual = actual_by_interface.get(expected_interface)
+        if actual is None:
+            _debug(debug, f"missing expected interface: {expected_interface}")
+            return None
+        pp_global_va = _parse_addr(actual.get("pp_global_va"))
+        if pp_global_va is None or pp_global_va == 0:
+            _debug(debug, f"invalid pp_global_va for {expected_gv}: {actual}")
+            return None
+
+    return actual_by_interface
+```
+
+- [ ] **Step 5: Add expected output mapping and writer**
+
+Add:
+
+```python
+def _build_output_map(expected_outputs, platform, debug=False):
+    output_map = {}
+    for path in expected_outputs or []:
+        output_map[os.path.basename(path)] = path
+
+    resolved = {}
+    for gv_name in EXPECTED_GV_NAMES:
+        filename = f"{gv_name}.{platform}.yaml"
+        output_path = output_map.get(filename)
+        if not output_path:
+            _debug(debug, f"missing expected output path for {filename}")
+            return None
+        resolved[gv_name] = output_path
+    return resolved
+
+
+def _build_gv_payloads(actual_by_interface, image_base):
+    payloads = {}
+    for interface_name, gv_name in EXPECTED_ENTRIES:
+        actual = actual_by_interface[interface_name]
+        gv_va = _parse_addr(actual.get("pp_global_va"))
+        payloads[gv_name] = {
+            "gv_name": gv_name,
+            "gv_va": hex(gv_va),
+            "gv_rva": hex(gv_va - image_base),
+        }
+    return payloads
+```
+
+- [ ] **Step 6: Add best-effort rename helper**
+
+Add:
+
+```python
+async def _rename_globals_best_effort(session, payloads, debug=False):
+    batch = {
+        "data": [
+            {"old": payload["gv_va"], "new": gv_name}
+            for gv_name, payload in payloads.items()
+        ]
+    }
+    try:
+        await session.call_tool(name="rename", arguments={"batch": batch})
+    except Exception as exc:
+        _debug(debug, f"best-effort gv rename failed: {exc}")
+```
+
+If the IDA MCP `rename` data mode requires old symbol names instead of addresses, replace this helper with a `py_eval` based `idc.set_name(int(gv_va, 16), gv_name, idc.SN_NOWARN)` implementation. The rename helper must remain non-fatal.
+
+- [ ] **Step 7: Add `preprocess_skill`**
+
+Add:
+
+```python
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    _ = skill_name, old_yaml_map, llm_config
+
+    table_va = _load_interface_globals_va(new_binary_dir, platform, debug=debug)
+    if table_va is None:
+        return False
+
+    output_map = _build_output_map(expected_outputs, platform, debug=debug)
+    if output_map is None:
+        return False
+
+    actual_entries = await _scan_entries_via_mcp(session, table_va, debug=debug)
+    if actual_entries is None:
+        return False
+
+    actual_by_interface = _match_expected_entries(actual_entries, debug=debug)
+    if actual_by_interface is None:
+        return False
+
+    payloads = _build_gv_payloads(actual_by_interface, image_base)
+    try:
+        for gv_name, payload in payloads.items():
+            write_gv_yaml(output_map[gv_name], payload)
+    except Exception as exc:
+        _debug(debug, f"failed to write gv YAML: {exc}")
+        return False
+
+    await _rename_globals_best_effort(session, payloads, debug=debug)
+    return True
+```
+
+## Task 2: Add Unit Tests For Custom Script
+
+**Files:**
+- Modify: `tests/test_ida_preprocessor_scripts.py`
+
+- [ ] **Step 1: Add script path constant**
+
+Near existing script path constants, add:
+
+```python
+INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH = (
+    PREPROCESSOR_SCRIPTS_DIR / "find-g_pInterfaceGlobals_ppGlobal.py"
+)
+```
+
+- [ ] **Step 2: Add fake MCP result helper if needed**
+
+If the file does not already have a reusable result class, add near the tests:
+
+```python
+class _TextResult:
+    def __init__(self, text):
+        self.content = [type("TextContent", (), {"text": text})()]
+```
+
+- [ ] **Step 3: Add success test**
+
+Add a new `unittest.IsolatedAsyncioTestCase` class:
+
+```python
+class TestFindGInterfaceGlobalsPpGlobal(unittest.IsolatedAsyncioTestCase):
+    async def test_preprocess_skill_writes_minimal_gv_yaml_from_interface_names(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal",
+        )
+        expected_entries = [
+            {
+                "index": index,
+                "entry_va": hex(0x180400000 + index * 0x10),
+                "interface_name": interface_name,
+                "interface_name_va": hex(0x180500000 + index * 0x20),
+                "pp_global_va": hex(0x180600000 + index * 0x8),
+            }
+            for index, (interface_name, _) in enumerate(module.EXPECTED_ENTRIES)
+        ]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = Path(temp_dir) / "g_pInterfaceGlobals.windows.yaml"
+            input_path.write_text(
+                "gv_name: g_pInterfaceGlobals\n"
+                "gv_va: '0x1804cd5c0'\n"
+                "gv_rva: '0x4cd5c0'\n",
+                encoding="utf-8",
+            )
+            expected_outputs = [
+                str(Path(temp_dir) / f"{gv_name}.windows.yaml")
+                for _, gv_name in module.EXPECTED_ENTRIES
+            ]
+            session = AsyncMock()
+            session.call_tool.side_effect = [
+                _TextResult(json.dumps(expected_entries)),
+                _TextResult("{}"),
+            ]
+
+            with patch.object(module, "write_gv_yaml") as mock_write:
+                result = await module.preprocess_skill(
+                    session=session,
+                    skill_name="find-g_pInterfaceGlobals_ppGlobal",
+                    expected_outputs=expected_outputs,
+                    old_yaml_map={},
+                    new_binary_dir=temp_dir,
+                    platform="windows",
+                    image_base=0x180000000,
+                    debug=True,
+                )
+
+        self.assertTrue(result)
+        self.assertEqual(len(module.EXPECTED_ENTRIES), mock_write.call_count)
+        first_path, first_payload = mock_write.call_args_list[0].args
+        self.assertTrue(first_path.endswith("g_pVApplication.windows.yaml"))
+        self.assertEqual(
+            {
+                "gv_name": "g_pVApplication",
+                "gv_va": "0x180600000",
+                "gv_rva": "0x600000",
+            },
+            first_payload,
+        )
+```
+
+- [ ] **Step 4: Add mismatch, trailing-extra, and out-of-order tests**
+
+Add tests for missing entries, trailing extra entries, out-of-order entries, and name mismatch:
+
+```python
+    async def test_preprocess_skill_fails_on_missing_entry(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_missing",
+        )
+        actual_entries = [
+            {
+                "index": index,
+                "entry_va": hex(0x180400000 + index * 0x10),
+                "interface_name": interface_name,
+                "interface_name_va": hex(0x180500000 + index * 0x20),
+                "pp_global_va": hex(0x180600000 + index * 0x8),
+            }
+            for index, (interface_name, _) in enumerate(module.EXPECTED_ENTRIES[:-1])
+        ]
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+        self.assertFalse(result)
+        mock_write.assert_not_called()
+
+    async def test_preprocess_skill_fails_on_interface_name_mismatch(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_mismatch",
+        )
+        actual_entries = [
+            {
+                "index": index,
+                "entry_va": hex(0x180400000 + index * 0x10),
+                "interface_name": interface_name,
+                "interface_name_va": hex(0x180500000 + index * 0x20),
+                "pp_global_va": hex(0x180600000 + index * 0x8),
+            }
+            for index, (interface_name, _) in enumerate(module.EXPECTED_ENTRIES)
+        ]
+        actual_entries[1]["interface_name"] = "WrongInterface001"
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+        self.assertFalse(result)
+        mock_write.assert_not_called()
+```
+
+Factor common setup into `_run_with_entries(...)` inside the test class if that keeps the tests short.
+
+- [ ] **Step 5: Add missing output test**
+
+Add:
+
+```python
+    async def test_preprocess_skill_fails_when_expected_output_is_missing(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_missing_output",
+        )
+        actual_entries = [
+            {
+                "index": index,
+                "entry_va": hex(0x180400000 + index * 0x10),
+                "interface_name": interface_name,
+                "interface_name_va": hex(0x180500000 + index * 0x20),
+                "pp_global_va": hex(0x180600000 + index * 0x8),
+            }
+            for index, (interface_name, _) in enumerate(module.EXPECTED_ENTRIES)
+        ]
+        result, mock_write = await self._run_with_entries(
+            module,
+            actual_entries,
+            drop_last_output=True,
+        )
+        self.assertFalse(result)
+        mock_write.assert_not_called()
+```
+
+## Task 3: Register Skill And GV Symbols In config.yaml
+
+**Files:**
+- Modify: `config.yaml`
+
+- [ ] **Step 1: Add skill to client**
+
+After the existing client skill:
+
+```yaml
+- name: find-g_pInterfaceGlobals
+  expected_output:
+    - g_pInterfaceGlobals.{platform}.yaml
+  expected_input:
+    - ConnectInterfaces.{platform}.yaml
+```
+
+add:
+
+```yaml
+- name: find-g_pInterfaceGlobals_ppGlobal
+  expected_output:
+    - g_pVApplication.{platform}.yaml
+    - g_pVEngineCvar.{platform}.yaml
+    # Add every gv name from EXPECTED_ENTRIES in order.
+  expected_output_windows:
+    - g_pNavSystem.{platform}.yaml
+    - g_pNavGameTest.{platform}.yaml
+  expected_input:
+    - g_pInterfaceGlobals.{platform}.yaml
+```
+
+- [ ] **Step 2: Add skill to server**
+
+Repeat the same skill block after the server `find-g_pInterfaceGlobals` block.
+
+- [ ] **Step 3: Add skill to engine post-client module**
+
+Repeat the same skill block after the duplicate post-client `engine` module's `find-g_pInterfaceGlobals` block near the end of `config.yaml`.
+
+- [ ] **Step 4: Add GV symbols to primary engine symbols**
+
+In the primary `engine` module's `symbols` list, before or after `g_pInterfaceGlobals`, add each `gv_name` from `EXPECTED_ENTRIES`:
+
+```yaml
+- name: g_pVApplication
+  category: gv
+- name: g_pVEngineCvar
+  category: gv
+```
+
+Do not duplicate names already present in that module.
+
+- [ ] **Step 5: Add GV symbols to client symbols**
+
+Repeat the same symbol additions in the `client` module's `symbols` list.
+
+- [ ] **Step 6: Add GV symbols to server symbols**
+
+Repeat the same symbol additions in the `server` module's `symbols` list.
+
+## Task 4: Static Verification
+
+**Files:**
+- Read: `ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py`
+- Read: `config.yaml`
+
+- [ ] **Step 1: Import the new script without running tests**
+
+Run only this static import command:
+
+```powershell
+uv run python -c "import importlib.util; p='ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py'; s=importlib.util.spec_from_file_location('ppg', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m); print(len(m.EXPECTED_ENTRIES)); print(m.EXPECTED_ENTRIES[0]); print(m.EXPECTED_ENTRIES[-1])"
+```
+
+Expected:
+
+```text
+112
+('VApplication001', 'g_pVApplication')
+('NavGameTest001', 'g_pNavGameTest')
+```
+
+Also verify the Linux list:
+
+```powershell
+uv run python -c "import importlib.util; p='ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py'; s=importlib.util.spec_from_file_location('ppg', p); m=importlib.util.module_from_spec(s); s.loader.exec_module(m); print(len(m.LINUX_EXPECTED_ENTRIES)); print(m.LINUX_EXPECTED_ENTRIES[-1])"
+```
+
+Expected:
+
+```text
+111
+('NavSystem001', 'g_pNavSystem')
+```
+
+- [ ] **Step 2: Parse config.yaml**
+
+Run:
+
+```powershell
+uv run python -c "import yaml; data=yaml.safe_load(open('config.yaml', encoding='utf-8')); print(len(data['modules']))"
+```
+
+Expected:
+
+```text
+prints a positive module count without exception
+```
+
+- [ ] **Step 3: Verify module registrations by script**
+
+Run:
+
+```powershell
+@'
+import yaml
+from pathlib import Path
+
+expected = [
+    "g_pVApplication",
+    "g_pVEngineCvar",
+    "g_pNavGameTest",
+]
+data = yaml.safe_load(Path("config.yaml").read_text(encoding="utf-8"))
+modules = data["modules"]
+for name in ("client", "server", "engine"):
+    matching = [m for m in modules if m.get("name") == name]
+    has_skill = any(
+        any(s.get("name") == "find-g_pInterfaceGlobals_ppGlobal" for s in m.get("skills", []))
+        for m in matching
+    )
+    has_symbols = {
+        sym.get("name")
+        for m in matching
+        for sym in m.get("symbols", []) or []
+        if sym.get("category") == "gv"
+    }
+    missing = [gv for gv in expected if gv not in has_symbols]
+    print(name, "skill=", has_skill, "missing_sample_symbols=", missing)
+'@ | uv run python -
+```
+
+Expected:
+
+```text
+client skill= True missing_sample_symbols= []
+server skill= True missing_sample_symbols= []
+engine skill= True missing_sample_symbols= []
+```
+
+- [ ] **Step 4: Optional focused unit tests only after user confirmation**
+
+If the user explicitly permits tests, run:
+
+```powershell
+uv run python -m unittest tests.test_ida_preprocessor_scripts.TestFindGInterfaceGlobalsPpGlobal -v
+```
+
+Expected:
+
+```text
+all tests in TestFindGInterfaceGlobalsPpGlobal pass
+```
+
+## Task 5: Completion Notes
+
+**Files:**
+- Read: `git status --short`
+
+- [ ] **Step 1: Inspect final git status**
+
+Run:
+
+```powershell
+git status --short
+```
+
+Expected:
+
+```text
+shows only the intended spec, plan, preprocessor script, tests, and config.yaml changes
+```
+
+- [ ] **Step 2: Do not commit unless confirmed**
+
+If the user explicitly requests a commit, use:
+
+```powershell
+git add docs/superpowers/specs/2026-05-20-g_pinterfaceglobals-ppglobal-design.md docs/superpowers/plans/2026-05-20-g_pinterfaceglobals-ppglobal.md ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py tests/test_ida_preprocessor_scripts.py config.yaml
+git commit -m "feat: 添加接口全局指针预处理"
+```
+
+Expected:
+
+```text
+commit is created only after explicit user confirmation
+```

--- a/docs/superpowers/specs/2026-05-20-g_pinterfaceglobals-ppglobal-design.md
+++ b/docs/superpowers/specs/2026-05-20-g_pinterfaceglobals-ppglobal-design.md
@@ -1,0 +1,282 @@
+# g_pInterfaceGlobals ppGlobal 预处理设计
+
+## 背景
+
+现有 `find-g_pInterfaceGlobals` 只定位 `g_pInterfaceGlobals` 表本身，并生成 `g_pInterfaceGlobals.{platform}.yaml`。IDA 中该表实际由连续的 16 字节 entry 组成：
+
+```text
+entry + 0x0: interface_name_ptr
+entry + 0x8: pp_global_ptr
+```
+
+每个 `interface_name_ptr` 指向稳定的接口版本字符串，例如 `VApplication001`；对应的 `pp_global_ptr` 是该接口全局变量指针的地址，例如 `g_pVApplication`。但实际 IDB 中 `pp_global_ptr` 不一定已经被重命名，因此不能把 IDA 名称作为定位依据。
+
+## 目标
+
+- 新增 `find-g_pInterfaceGlobals_ppGlobal` 预处理脚本。
+- 从 `g_pInterfaceGlobals` 表程序化定位 `g_pVApplication`、`g_pVEngineCvar` 等 `g_pXXXX` 全局变量指针。
+- 为每个目标输出最小 GV YAML 字段：
+  - `gv_name`
+  - `gv_va`
+  - `gv_rva`
+- 在 `config.yaml` 中为 `client`、`server`、`engine` 注册新 skill。
+- 在 `client`、`server`、`engine` 的 symbols 中注册这些 `g_pXXXX`，类别为 `gv`。
+- 强制要求三个模块的 `g_pInterfaceGlobals` entries 覆盖对应平台预期集合；允许实际表中存在额外 entries，且不为额外项生成 YAML。
+
+## 非目标
+
+- 不为这些 `g_pXXXX` 生成 `gv_sig`、`gv_sig_va`、`gv_inst_*` 字段。
+- 不依赖或信任 `pp_global_ptr` 当前 IDA 名称。
+- 不针对 `client`、`server`、`engine` 维护不同 expected list；只允许 Windows `.dll` 与 Linux `.so` 存在平台尾项差异。
+- 不调整 `find-g_pInterfaceGlobals` 的现有定位逻辑。
+- 不修改下游 gamedata 生成逻辑。
+
+## 方案比较
+
+### 方案 1：以 interface_name 集合为强约束
+
+脚本维护一份 `EXPECTED_ENTRIES = [(interface_name, gv_name), ...]`。运行时读取 `g_pInterfaceGlobals` 表中的实际 entries，按 `interface_name` 建立映射，并要求当前平台预期的每个 `interface_name` 都存在。通过校验后，用同一 entry 的 `pp_global_ptr` 地址生成对应 `gv_name` 的 YAML；实际表中多出的 entries 忽略。
+
+优点：
+
+- 不依赖 IDB 中 `pp_global_ptr` 是否已重命名。
+- 强校验能及时发现表结构或接口列表变化。
+- 三个模块使用同一份规则，行为一致；平台差异只由 `platform` 决定。
+
+缺点：
+
+- CS2 接口列表发生合法变化时，需要显式更新 expected list。
+
+### 方案 2：只按 interface_name 前缀匹配
+
+脚本扫描表项后要求 expected entries 按顺序出现在实际 entries 前缀中，不要求总数量完全一致。
+
+优点：
+
+- 对新增接口更宽容。
+
+缺点：
+
+- 无法处理合法的顺序调整。
+
+### 方案 3：按 pp_global_ptr IDA 名称匹配
+
+直接读取 `pp_global_ptr` 处的 IDA 名称并按 `g_pXXXX` 生成 YAML。
+
+优点：
+
+- 实现简单。
+
+缺点：
+
+- 实际 IDB 中该地址不一定被重命名，定位依据不可靠。
+- 与已确认约束冲突。
+
+## 选定方案
+
+采用方案 1：以 `interface_name` 序列为强约束。
+
+`interface_name_ptr` 是唯一可信 key。`pp_global_ptr` 只作为同一 entry 中待输出 GV 的地址来源；其 IDA 名称不参与定位和校验。Windows `.dll` 预期包含最后两项 `("NavSystem001", "g_pNavSystem")` 与 `("NavGameTest001", "g_pNavGameTest")`；当前 Linux `.so` 预期最后一项为 `("Vrad3_001", "g_pRAD3")`，不强制 `NavSystem001` 或 `NavGameTest001`。
+
+## 详细设计
+
+### 1. 新增预处理脚本
+
+新增文件：
+
+```text
+ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py
+```
+
+脚本入口仍使用现有约定：
+
+```python
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+```
+
+脚本内部维护 Windows 完整列表，并由平台派生实际 expected list：
+
+```python
+EXPECTED_ENTRIES = [
+    ("VApplication001", "g_pVApplication"),
+    ("VEngineCvar007", "g_pVEngineCvar"),
+    ...
+]
+WINDOWS_EXPECTED_ENTRIES = EXPECTED_ENTRIES
+LINUX_EXPECTED_ENTRIES = EXPECTED_ENTRIES[:-2]
+```
+
+### 2. 输入来源
+
+脚本读取当前模块目录下：
+
+```text
+g_pInterfaceGlobals.{platform}.yaml
+```
+
+并解析其中的 `gv_va`。该文件由现有 `find-g_pInterfaceGlobals` 生成，新 skill 在 `config.yaml` 中声明 `expected_input` 依赖它。
+
+如果输入 YAML 缺失、`gv_va` 缺失或地址不可解析，脚本返回 `False`。
+
+### 3. IDA 侧扫描
+
+通过 MCP `py_eval` 在 IDA 内完成表项扫描：
+
+1. 从 `g_pInterfaceGlobals.gv_va` 开始。
+2. 每 16 字节读取一个 entry。
+3. `entry + 0x0` 读取 `interface_name_ptr`。
+4. `entry + 0x8` 读取 `pp_global_ptr`。
+5. 对 `interface_name_ptr` 读取 C 字符串。
+6. 遇到空 `interface_name_ptr` 或空 `pp_global_ptr` 时停止。
+7. 设置合理上限，例如 `len(EXPECTED_ENTRIES) + 1` 或固定最大值，避免异常情况下无限扫描。
+
+扫描结果结构：
+
+```python
+[
+    {
+        "index": 0,
+        "entry_va": "0x...",
+        "interface_name": "VApplication001",
+        "interface_name_va": "0x...",
+        "pp_global_va": "0x...",
+    },
+]
+```
+
+### 4. 预期集合强校验规则
+
+实际 entries 必须覆盖当前平台 expected entries 的完整集合：
+
+- 每个 expected `interface_name` 都必须能在实际 entries 中找到。
+- 每个 expected `interface_name` 对应 entry 的 `pp_global_ptr` 必须是有效地址。
+- expected `interface_name` 在实际 entries 中重复出现时返回失败，避免地址歧义。
+- 实际表中的额外 entries 不参与 GV YAML 输出。
+- 实际 entries 的顺序不参与校验。
+
+不校验 `pp_global_ptr` 当前 IDA 名称，因为该名称不可靠。
+
+任一不一致时脚本返回 `False`，并在 debug 模式输出：
+
+- missing expected interface names
+- duplicated expected interface name
+- expected interface name
+- invalid `pp_global_ptr`
+
+### 5. YAML 输出
+
+只有在全量校验通过后，脚本才批量写出 YAML，避免半成品污染输出目录。
+
+每个 entry 按 expected 映射生成：
+
+```yaml
+gv_name: g_pVApplication
+gv_va: '0x...'
+gv_rva: '0x...'
+```
+
+其中：
+
+- `gv_name` 来自 `EXPECTED_ENTRIES` 的第二列。
+- `gv_va` 为同一 entry 的 `pp_global_ptr` 地址。
+- `gv_rva = gv_va - image_base`。
+
+写入使用现有 `ida_analyze_util.write_gv_yaml`，保持 GV YAML 的 key 顺序和格式一致。
+
+### 6. 可选 IDB 重命名
+
+校验和写 YAML 成功后，可尝试调用 `idc.set_name(pp_global_ptr, gv_name, idc.SN_NOWARN)`，提升后续 IDB 可读性。
+
+该重命名不能作为定位依据。若重命名失败，只在 debug 模式记录，不影响已经完成的 YAML 输出。
+
+### 7. config.yaml 注册
+
+在 `client`、`server`、`engine` 三个模块的 `find-g_pInterfaceGlobals` 后新增。公共 `expected_output` 只包含 Windows/Linux 共有项，Windows 专有的 `g_pNavSystem` 与 `g_pNavGameTest` 通过 `expected_output_windows` 注册：
+
+```yaml
+- name: find-g_pInterfaceGlobals_ppGlobal
+  expected_output:
+    - g_pVApplication.{platform}.yaml
+    - g_pVEngineCvar.{platform}.yaml
+    # ...
+  expected_output_windows:
+    - g_pNavSystem.{platform}.yaml
+    - g_pNavGameTest.{platform}.yaml
+  expected_input:
+    - g_pInterfaceGlobals.{platform}.yaml
+```
+
+并在三个模块的 `symbols` 中新增这些目标：
+
+```yaml
+- name: g_pVApplication
+  category: gv
+- name: g_pVEngineCvar
+  category: gv
+- name: g_pNavGameTest
+  category: gv
+  platform: windows
+```
+
+如某个 symbol 已存在于同一模块，则不重复注册。
+
+### 8. Expected entries 初始集合
+
+初始集合来自用户提供的 `g_pInterfaceGlobals` 表。实现时应完整转写为 `(interface_name, gv_name)` 列表，并保持顺序。
+
+前几项示例：
+
+```python
+("VApplication001", "g_pVApplication")
+("VEngineCvar007", "g_pVEngineCvar")
+("VStringTokenSystem001", "g_pVStringTokenSystem")
+("TestScriptMgr001", "g_pTestScriptMgr")
+("VProcessUtils002", "g_pProcessUtils")
+```
+
+该列表是 `client`、`server`、`engine` 的共同预期。任一模块缺少对应平台的 expected interface，都应视为失败。
+
+## 错误处理
+
+- 输入 `g_pInterfaceGlobals` YAML 不存在：返回 `False`。
+- `gv_va` 无法解析：返回 `False`。
+- IDA 读取 entry 失败：返回 `False`。
+- 缺少当前平台 expected interface：返回 `False`。
+- expected interface 重复出现：返回 `False`。
+- expected interface 对应的 `pp_global_ptr` 无效：返回 `False`。
+- 输出路径不在 `expected_outputs` 中或 expected output 缺失：返回 `False`。
+- YAML 写入异常：返回 `False`。
+
+## 验证方式
+
+本需求不要求默认执行测试或 build。实现完成后可做定向验证：
+
+1. 脚本可被 Python import。
+2. `config.yaml` 可被 PyYAML 解析。
+3. `client`、`server`、`engine` 都注册了 `find-g_pInterfaceGlobals_ppGlobal`。
+4. 三个模块的新 skill 都依赖 `g_pInterfaceGlobals.{platform}.yaml`。
+5. 三个模块都注册了 expected entries 对应的 `category: gv` symbols。
+6. 可用单元测试 mock MCP `py_eval`，覆盖：
+   - 完全匹配时写出全部 YAML。
+   - 实际表多出 entry 时成功，且只写出 expected entries 对应 YAML。
+   - 顺序调整时成功，并按 `interface_name` 绑定 `pp_global_ptr`。
+   - 缺少 entry 时失败。
+   - expected interface 被替换为未知 interface 时失败。
+   - `pp_global_ptr` 没有 IDA 名称时仍成功。
+
+## 交付边界
+
+本次交付包含：
+
+- 新增预处理脚本。
+- 更新 `config.yaml`。
+- 如有必要，新增轻量单元测试覆盖强校验逻辑。
+
+不包含：
+
+- 运行完整 IDA 分析。
+- 运行完整 build。
+- 修改 downstream dist 输出。

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -1159,6 +1159,8 @@ def parse_config(config_path):
                 skills.append({
                     "name": skill_name,
                     "expected_output": skill.get("expected_output", []) or [],
+                    "expected_output_windows": skill.get("expected_output_windows", []) or [],
+                    "expected_output_linux": skill.get("expected_output_linux", []) or [],
                     "optional_output": skill.get("optional_output", []) or [],
                     "expected_input": skill.get("expected_input", []),
                     "expected_input_windows": skill.get("expected_input_windows", []) or [],
@@ -1255,7 +1257,10 @@ def topological_sort_skills(skills):
     producers_by_output = {}
     for skill in skills:
         producer_name = skill["name"]
-        for output_path in skill.get("expected_output", []):
+        all_outputs = list(skill.get("expected_output", []) or [])
+        all_outputs += list(skill.get("expected_output_windows", []) or [])
+        all_outputs += list(skill.get("expected_output_linux", []) or [])
+        for output_path in all_outputs:
             if not output_path:
                 continue
             normalized_output = normalize_artifact_path(output_path)
@@ -1362,9 +1367,12 @@ def all_expected_outputs_exist(expected_outputs):
 
 def expand_skill_output_paths(binary_dir, skill, platform):
     """Return required, optional, and preprocessor output paths for one skill."""
+    platform_output_key = f"expected_output_{platform}"
+    combined_outputs = list(skill.get("expected_output", []) or [])
+    combined_outputs += list(skill.get(platform_output_key, []) or [])
     required_outputs = expand_expected_paths(
         binary_dir,
-        skill.get("expected_output", []) or [],
+        combined_outputs,
         platform,
     )
     optional_outputs = expand_expected_paths(
@@ -1416,9 +1424,12 @@ def _collect_post_process_yaml_mappings(
         if skill_platform and skill_platform != platform:
             continue
         try:
+            platform_output_key = f"expected_output_{platform}"
+            combined_outputs = list(skill.get("expected_output", []) or [])
+            combined_outputs += list(skill.get(platform_output_key, []) or [])
             expected_outputs = expand_expected_paths(
                 binary_dir,
-                skill.get("expected_output", []),
+                combined_outputs,
                 platform,
             )
         except ValueError as exc:

--- a/ida_preprocessor_scripts/find-CGameClientConnectPrerequisite_ctor.py
+++ b/ida_preprocessor_scripts/find-CGameClientConnectPrerequisite_ctor.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameClientConnectPrerequisite_ctor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameClientConnectPrerequisite_ctor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameClientConnectPrerequisite_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir, f"CGameClientConnectPrerequisite_vtable.{platform}.yaml"
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CGameClientConnectPrerequisite_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "CGameClientConnectPrerequisite_ctor",
+            "xref_strings": [
+                "FULLMATCH:levelname",
+                "FULLMATCH:remoteclient",
+            ],
+            "xref_gvs": [str(vtable_va)],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameClientConnectPrerequisite_vtable.py
+++ b/ida_preprocessor_scripts/find-CGameClientConnectPrerequisite_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameClientConnectPrerequisite_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CGameClientConnectPrerequisite"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameClientConnectPrerequisite",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CGameClientConnectPrerequisite vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetSupportImpl_Connect.py
+++ b/ida_preprocessor_scripts/find-CNetSupportImpl_Connect.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetSupportImpl_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    # base_vfunc is in the server module; use ../server/ prefix so the path resolves correctly
+    ("CNetSupportImpl_Connect", "CNetSupportImpl", "../server/IAppSystem_Connect", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetSupportImpl_Connect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig; fallback to inheriting slot index from IAppSystem_Connect."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetSupportImpl_vtable.py
+++ b/ida_preprocessor_scripts/find-CNetSupportImpl_vtable.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetSupportImpl_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CNetSupportImpl"]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetSupportImpl",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CNetSupportImpl vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_AddClientPrerequisites.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_AddClientPrerequisites.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_AddClientPrerequisites skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_AddClientPrerequisites",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_AddClientPrerequisites",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CGameClientConnectPrerequisite_ctor"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_AddClientPrerequisites", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_AddClientPrerequisites",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_AllocateRemoteConnectionClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_AllocateRemoteConnectionClient.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_AllocateRemoteConnectionClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_AllocateRemoteConnectionClient",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_AllocateRemoteConnectionClient",
+        "xref_strings": [
+            "FULLMATCH:loopback",
+            "FULLMATCH:address",
+            "FULLMATCH:reservationid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_AllocateRemoteConnectionClient", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_AllocateRemoteConnectionClient",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_ClockDriftAdjustFrameTime.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_ClockDriftAdjustFrameTime.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_ClockDriftAdjustFrameTime skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_ClockDriftAdjustFrameTime",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_ClockDriftAdjustFrameTime",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameClientBase_ClockDrift_AdjustFrameTime"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_ClockDriftAdjustFrameTime", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_ClockDriftAdjustFrameTime",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_DisconnectGameNow.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_DisconnectGameNow.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_DisconnectGameNow skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_DisconnectGameNow",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_DisconnectGameNow",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameClient_DisconnectGame"],
+        "exclude_funcs": ["CNetworkClientService_Shutdown"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_DisconnectGameNow", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_DisconnectGameNow",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_FinishChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_FinishChangeLevel.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_FinishChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_FinishChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_FinishChangeLevel",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CNetworkGameClientBase_FinishChangeLevel",
+            "CNetworkGameClientBase_DeferActivate",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_FinishChangeLevel", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_FinishChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_GetDisconnectReason.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_GetDisconnectReason.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_GetDisconnectReason skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_GetDisconnectReason",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_GetDisconnectReason",
+        "xref_strings": [
+            "Server Shutting Down",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_GetDisconnectReason", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # No func_sig: function body is a trivial one-liner returning a string literal.
+    (
+        "CNetworkClientService_GetDisconnectReason",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_Init.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_Init.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_Init",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_Init",
+        "xref_strings": [
+            "FULLMATCH:ClientToServer",
+            "FULLMATCH:Connectionless",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_Init", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_Init",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_IsActive.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_IsActive.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_IsActive skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CNetworkClientService_IsActive", "CNetworkClientService", "INetworkClientService_IsActive", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only: inherit vtable slot index from INetworkClientService_IsActive.
+    (
+        "CNetworkClientService_IsActive",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Inherit vtable slot index from INetworkClientService_IsActive for CNetworkClientService."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_IsActive.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_IsActive.py
@@ -10,11 +10,13 @@ INHERIT_VFUNCS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # Slot-only: inherit vtable slot index from INetworkClientService_IsActive.
     (
         "CNetworkClientService_IsActive",
         [
             "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
             "vtable_name",
             "vfunc_offset",
             "vfunc_index",

--- a/ida_preprocessor_scripts/find-CNetworkClientService_IsConnected.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_IsConnected.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_IsConnected skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CNetworkClientService_IsConnected", "CNetworkClientService", "INetworkClientService_IsConnected", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only: inherit vtable slot index from INetworkClientService_IsConnected.
+    (
+        "CNetworkClientService_IsConnected",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Inherit vtable slot index from INetworkClientService_IsConnected for CNetworkClientService."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_IsConnected.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_IsConnected.py
@@ -10,11 +10,13 @@ INHERIT_VFUNCS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # Slot-only: inherit vtable slot index from INetworkClientService_IsConnected.
     (
         "CNetworkClientService_IsConnected",
         [
             "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
             "vtable_name",
             "vfunc_offset",
             "vfunc_index",

--- a/ida_preprocessor_scripts/find-CNetworkClientService_OnStatus.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_OnStatus.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_OnStatus skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_OnStatus",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_OnStatus",
+        "xref_strings": [
+            "SystemLoad %.3f - %.3f, retrieval cost %sns",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_OnStatus",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_PrintConnectionStatus.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_PrintConnectionStatus.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_PrintConnectionStatus skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_PrintConnectionStatus",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_PrintConnectionStatus",
+        "xref_strings": [
+            "Connected [%s] [last packet %.3f sec ago]",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_PrintConnectionStatus", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_PrintConnectionStatus",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_PrintSpawnGroupStatus.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_PrintSpawnGroupStatus.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_PrintSpawnGroupStatus skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_PrintSpawnGroupStatus",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_PrintSpawnGroupStatus",
+        "xref_strings": [
+            "No client connection",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_PrintSpawnGroupStatus", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_PrintSpawnGroupStatus",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_ProcessGameSessionManifest.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_ProcessGameSessionManifest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_ProcessGameSessionManifest skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_ProcessGameSessionManifest",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_ProcessGameSessionManifest",
+        "xref_strings": [
+            "Client GameSessionManifest received from server",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_ProcessGameSessionManifest", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_ProcessGameSessionManifest",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_ReceivedServerInfo.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_ReceivedServerInfo.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkClientService_ProcessGameSessionManifest skill."""
+"""Preprocess script for find-CNetworkClientService_ReceivedServerInfo skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkClientService_ProcessGameSessionManifest",
+    "CNetworkClientService_ReceivedServerInfo",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkClientService_ProcessGameSessionManifest",
+        "func_name": "CNetworkClientService_ReceivedServerInfo",
         "xref_strings": [
             "Client GameSessionManifest received from server",
         ],
@@ -25,13 +25,13 @@ FUNC_XREFS = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CNetworkClientService_ProcessGameSessionManifest", "CNetworkClientService"),
+    ("CNetworkClientService_ReceivedServerInfo", "CNetworkClientService"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkClientService_ProcessGameSessionManifest",
+        "CNetworkClientService_ReceivedServerInfo",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CNetworkClientService_SendNetMessage.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_SendNetMessage.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_SendNetMessage skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkClientService_SendNetMessage",
+        "CNetworkClientService",
+        "../client/INetworkClientService_SendNetMessage",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_SendNetMessage",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_SendStringCmd.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_SendStringCmd.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_SendStringCmd skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_SendStringCmd",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_SendStringCmd",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameClientBase_SendStringCmd"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_SendStringCmd", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_SendStringCmd",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_ServerCmd.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_ServerCmd.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_ServerCmd skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_ServerCmd",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_ServerCmd",
+        "xref_strings": [
+            "ServerCmd called with %d bytes, cropping to %d",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_ServerCmd", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_ServerCmd",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_Shutdown.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_Shutdown.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CNetworkClientService_Shutdown", "CNetworkClientService", "IAppSystem_Shutdown", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_SplitScreenConnect.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_SplitScreenConnect.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_SplitScreenConnect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_SplitScreenConnect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_SplitScreenConnect",
+        "xref_strings": [
+            "Can't SplitScreenConnect, not connected",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_SplitScreenConnect", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_SplitScreenConnect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_StartChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_StartChangeLevel.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_StartChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_StartChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_StartChangeLevel",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameClientBase_StartChangeLevel"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkClientService_StartChangeLevel", "CNetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkClientService_StartChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_ClockDrift_AdjustFrameTime.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_ClockDrift_AdjustFrameTime.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_ClockDrift_AdjustFrameTime skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_ClockDrift_AdjustFrameTime",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_ClockDrift_AdjustFrameTime",
+        "xref_strings": [
+            "cl_clock_recvmargin: running at %.3f%% %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_ClockDrift_AdjustFrameTime",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_Connect.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_Connect.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_Connect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_Connect",
+        "xref_strings": [
+            "CL:  CNetworkGameClientBase::Connect() calling SetSignonState( SIGNONSTATE_CONNECTED )",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClientBase_Connect", "CNetworkGameClientBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_Connect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_DeferActivate.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_DeferActivate.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_DeferActivate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_DeferActivate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_DeferActivate",
+        "xref_strings": [
+            "CL:  Multiple calls to CNetworkGameClientBase::DeferActivate!!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_DeferActivate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_DisconnectGame.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_DisconnectGame.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_DisconnectGame skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_DisconnectGame",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_DisconnectGame",
+        "xref_strings": [
+            "Disconnecting from server: changelevel",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClientBase_DisconnectGame", "CNetworkGameClientBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_DisconnectGame",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_FinishChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_FinishChangeLevel.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_FinishChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_FinishChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_FinishChangeLevel",
+        "xref_strings": [
+            "CL:  CNetworkGameClientBase::FinishChangeLevel:  reconnecting client",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClientBase_FinishChangeLevel", "CNetworkGameClientBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_FinishChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_SendStringCmd.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_SendStringCmd.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_SendStringCmd skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_SendStringCmd",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_SendStringCmd",
+        "xref_strings": [
+            "CL:  SendStringCmd(disconnect)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClientBase_SendStringCmd", "CNetworkGameClientBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_SendStringCmd",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClientBase_StartChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClientBase_StartChangeLevel.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClientBase_StartChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClientBase_StartChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClientBase_StartChangeLevel",
+        "xref_strings": [
+            "CL:  CNetworkGameClientBase::StartChangeLevel",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClientBase_StartChangeLevel", "CNetworkGameClientBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClientBase_StartChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_DisconnectGame.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_DisconnectGame.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_DisconnectGame skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_DisconnectGame",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_DisconnectGame",
+        "xref_strings": [
+            "CL:  Disconnected - Client delta ticks out of order!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameClient_DisconnectGame", "CNetworkGameClient"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_DisconnectGame",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_vtable.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CNetworkGameClient"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CNetworkGameClient vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CUserMessage_ExtraUserData_vtable.py
+++ b/ida_preprocessor_scripts/find-CUserMessage_ExtraUserData_vtable.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CUserMessage_ExtraUserData_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CUserMessage_ExtraUserData"]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CUserMessage_ExtraUserData",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CUserMessage_ExtraUserData vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-ConnectInterfaces.py
+++ b/ida_preprocessor_scripts/find-ConnectInterfaces.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-ConnectInterfaces skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ConnectInterfaces",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "ConnectInterfaces",
+        "xref_strings": [
+            "APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": ["CNetSupportImpl_Connect"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "ConnectInterfaces",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IAppSystem_Connect.py
+++ b/ida_preprocessor_scripts/find-IAppSystem_Connect.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IAppSystem_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("IAppSystem_Connect", "IAppSystem", "CSource2Server_Connect", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
+    (
+        "IAppSystem_Connect",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CSource2Server_Connect."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IVEngineClient2_GetNetworkClient-AND-INetworkClient_GetLocalAddress-AND-INetworkClientService_IsConnected-AND-INetworkClientService_SendNetMessage.py
+++ b/ida_preprocessor_scripts/find-IVEngineClient2_GetNetworkClient-AND-INetworkClient_GetLocalAddress-AND-INetworkClientService_IsConnected-AND-INetworkClientService_SendNetMessage.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IVEngineClient2_GetNetworkClient-AND-INetworkClient_GetLocalAddress-AND-INetworkClientService_IsConnected-AND-INetworkClientService_SendNetMessage skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IVEngineClient2_GetNetworkClient",
+    "INetworkClient_GetLocalAddress",
+    "INetworkClientService_IsConnected",
+    "INetworkClientService_SendNetMessage",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IVEngineClient2_GetNetworkClient",
+        "prompt/call_llm_decompile.md",
+        "references/client/SendViolationReport.{platform}.yaml",
+    ),
+    (
+        "INetworkClient_GetLocalAddress",
+        "prompt/call_llm_decompile.md",
+        "references/client/SendViolationReport.{platform}.yaml",
+    ),
+    (
+        "INetworkClientService_IsConnected",
+        "prompt/call_llm_decompile.md",
+        "references/client/SendViolationReport.{platform}.yaml",
+    ),
+    (
+        "INetworkClientService_SendNetMessage",
+        "prompt/call_llm_decompile.md",
+        "references/client/SendViolationReport.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IVEngineClient2_GetNetworkClient", "IVEngineClient2"),
+    ("INetworkClient_GetLocalAddress", "INetworkClient"),
+    ("INetworkClientService_IsConnected", "INetworkClientService"),
+    ("INetworkClientService_SendNetMessage", "INetworkClientService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only: abstract interface vfuncs with no concrete body in client.dll
+    (
+        "IVEngineClient2_GetNetworkClient",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+    (
+        "INetworkClient_GetLocalAddress",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+    (
+        "INetworkClientService_IsConnected",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+    (
+        "INetworkClientService_SendNetMessage",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-SendViolationReport-windows.py
+++ b/ida_preprocessor_scripts/find-SendViolationReport-windows.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-SendViolationReport-windows skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "SendViolationReport",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "SendViolationReport",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir,
+        f"CUserMessage_ExtraUserData_vtable.{platform}.yaml",
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CUserMessage_ExtraUserData_vtable "
+                "vtable_va not found, cannot resolve xref_gvs"
+            )
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "SendViolationReport",
+            "xref_strings": [],
+            "xref_gvs": [str(vtable_va)],
+            "xref_signatures": ["BA A4 00 00 00", "00 00 80 BF"],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-g_pInterfaceGlobals.py
+++ b/ida_preprocessor_scripts/find-g_pInterfaceGlobals.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-g_pInterfaceGlobals skill."""
+
+import os
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_GLOBALVAR_NAMES = [
+    "g_pInterfaceGlobals",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "g_pInterfaceGlobals",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever gv_sig; fallback to LLM_DECOMPILE of ConnectInterfaces."""
+    module_name = os.path.basename(os.path.normpath(new_binary_dir)) if new_binary_dir else "server"
+
+    llm_decompile = [
+        (
+            "g_pInterfaceGlobals",
+            "prompt/call_llm_decompile.md",
+            f"references/{module_name}/ConnectInterfaces.{{platform}}.yaml",
+        ),
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        llm_decompile_specs=llm_decompile,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py
+++ b/ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Preprocess script for g_pInterfaceGlobals ppGlobal entries."""
+
+import json
+import os
+
+import yaml
+
+from ida_analyze_util import parse_mcp_result, write_gv_yaml
+
+INTERFACE_GLOBALS_NAME = "g_pInterfaceGlobals"
+ENTRY_SIZE = 0x10
+MAX_SCAN_ENTRIES = 256
+
+EXPECTED_ENTRIES = [
+    ('VApplication001', 'g_pVApplication'), ('VEngineCvar007', 'g_pVEngineCvar'), ('VStringTokenSystem001', 'g_pVStringTokenSystem'),
+    ('TestScriptMgr001', 'g_pTestScriptMgr'), ('VProcessUtils002', 'g_pProcessUtils'), ('VFileSystem017', 'g_pFileSystem'),
+    ('VAsyncFileSystem2_001', 'g_pAsyncFileSystem'), ('ResourceSystem013', 'g_pResourceSystem'), ('ResourceManifestRegistry001', 'g_pResourceManifestRegistry'),
+    ('ResourceHandleUtils001', 'g_pResourceHandleUtils'), ('SchemaSystem_001', 'g_pSchemaSystem'), ('ResourceCompilerSystem001', 'g_pResourceCompilerSystem'),
+    ('VMaterialSystem2_001', 'g_pMaterialSystem2'), ('PostProcessingSystem_001', 'g_pPostProcessingSystem'), ('InputSystemVersion001', 'g_pInputSystem'),
+    ('InputStackSystemVersion001', 'g_pInputStackSystem'), ('RenderDeviceMgr001', 'g_pRenderDeviceMgr'), ('RenderUtils_001', 'g_pRenderUtils'),
+    ('SoundSystem001', 'g_pSoundSystem'), ('SoundOpSystemEdit001', 'g_pSoundOpSystemEdit'), ('SoundOpSystem001', 'g_pSoundOpSystem'),
+    ('SteamAudio001', 'g_pSteamAudio'), ('VP4003', 'g_pVP4'), ('Localize_001', 'g_pLocalize'),
+    ('VMediaFoundation001', 'g_pMediaFoundation'), ('VAvi001', 'g_pAVI'), ('VWebm001', 'g_pWEBM'),
+    ('VBik001', 'g_pBIK'), ('MeshSystem001', 'g_pMeshSystem'), ('MeshUtils001', 'g_pMeshUtils'),
+    ('RenderDevice003', 'g_pRenderDevice'), ('VRenderDeviceSetupV001', 'g_pRenderDeviceSetup'), ('RenderHardwareConfig002', 'g_pRenderHardwareConfig'),
+    ('SceneSystem_002', 'g_pSceneSystem'), ('IPulseSystem_001', 'g_pIPulseSystem'), ('SceneUtils_001', 'g_pSceneUtils'),
+    ('WorldRendererMgr001', 'g_pWorldRendererMgr'), ('AssetSystem001', 'g_pAssetSystem'), ('AssetSystemTest001', 'g_pAssetSystemTest'),
+    ('ParticleSystemMgr003', 'g_pParticleSystemMgr'), ('VScriptManager010', 'g_pScriptManager'), ('PropertyEditorSystem_001', 'g_pPropertyEditorSystem'),
+    ('MATCHFRAMEWORK_001', 'g_pMatchFramework'), ('Source2V8System001', 'g_pSource2V8System'), ('PanoramaUIEngine001', 'g_pPanoramaUIEngine'),
+    ('PanoramaUIClient001', 'g_pPanoramaUIClient'), ('PanoramaTextServices001', 'g_pPanoramaTextServices'), ('ToolFramework2_002', 'g_pToolFramework2'),
+    ('PhysicsBuilderMgr001', 'g_pPhysicsBuilderMgr'), ('VisBuilder_001', 'g_pVisBuilder'), ('BakedLODBuilderMgr001', 'g_pBakedLODBuilderMgr'),
+    ('HelpSystem_001', 'g_pHelpSystem'), ('ToolSceneNodeFactory_001', 'g_pToolSceneNodeFactory'), ('EconItemToolModel_001', 'g_pEconItemToolModel'),
+    ('SchemaTestExternal_Two_001', 'g_pSchemaTestExternalTwo'), ('SchemaTestExternal_One_001', 'g_pSchemaTestExternalOne'), ('AnimationSystem_001', 'g_pAnimationSystem'),
+    ('AnimationSystemUtils_001', 'g_pAnimationSystemUtils'), ('HammerMapLoader001', 'g_pHammerMapLoader'), ('MaterialUtils_001', 'g_pMaterialUtils'),
+    ('FontManager_001', 'g_pFontManager'), ('TextLayout_001', 'g_pTextLayout'), ('AssetPreviewSystem_001', 'g_pAssetPreviewSystem'),
+    ('AssetBrowserSystem_001', 'g_pAssetBrowserSystem'), ('AssetRenameSystem_001', 'g_pAssetRenameSystem'), ('VConComm001', 'g_pVConComm'),
+    ('MODEL_PROCESSING_SERVICES_INTERFACE_001', 'g_pModelProcessingServices'), ('NetworkSystemVersion001', 'g_pNetworkSystem'), ('NetworkMessagesVersion001', 'g_pNetworkMessages'),
+    ('FlattenedSerializersVersion001', 'g_pFlattenedSerializers'), ('SerializedEntitiesVersion001', 'g_pSerializedEntities'), ('DemoUpconverterVersion001', 'g_pDemoUpconverter'),
+    ('Source2Client002', 'g_pSource2Client'), ('Source2ClientUI001', 'g_pSource2ClientUI'), ('Source2ClientPrediction001', 'g_pSource2ClientPrediction'),
+    ('Source2Server001', 'g_pSource2Server'), ('Source2Host001', 'g_pSource2Host'), ('Source2ModTools001', 'g_pSource2ModTools'),
+    ('Source2GameClients001', 'g_pSource2GameClients'), ('Source2GameEntities001', 'g_pSource2GameEntities'), ('EngineServiceMgr001', 'g_pEngineServiceMgr'),
+    ('HostStateMgr001', 'g_pHostStateMgr'), ('NetworkService_001', 'g_pNetworkService'), ('NetworkClientService_001', 'g_pNetworkClientService'),
+    ('NetworkP2PService_001', 'g_pNetworkP2PService'), ('NetworkServerService_001', 'g_pNetworkServerService'), ('ToolService_001', 'g_pToolService'),
+    ('RenderService_001', 'g_pRenderService'), ('StatsService_001', 'g_pStatsService'), ('VProfService_001', 'g_pVProfService'),
+    ('InputService_001', 'g_pInputService'), ('MapListService_001', 'g_pMapListService'), ('GameUIService_001', 'g_pGameUIService'),
+    ('SoundService_001', 'g_pSoundService'), ('BenchmarkService001', 'g_pBenchmarkService'), ('KeyValueCache001', 'g_pKeyValueCache'),
+    ('ClientServerSharedHandleSystem001', 'g_pClientServerSharedHandleSystem'), ('GameResourceServiceClientV001', 'g_pGameResourceServiceClient'), ('GameResourceServiceServerV001', 'g_pGameResourceServiceServer'),
+    ('Source2EngineToClient001', 'g_pSource2EngineToClient'), ('Source2EngineToServer001', 'g_pSource2EngineToServer'), ('Source2EngineToServerStringTable001', 'g_pSource2EngineToServerStringTable'),
+    ('Source2EngineToClientStringTable001', 'g_pSource2EngineToClientStringTable'), ('VPhysics2_Interface_001', 'g_pVPhysics2'), ('ModelDocUtils001', 'g_pModelDocUtils'),
+    ('AnimGraphEditorUtils001', 'g_pAnimGraphEditorUtils'), ('EXPORTSYSTEM_INTERFACE_VERSION_001', 'g_pExportSystem'), ('ServerToolsInfo_001', 'g_pServerToolsInfo'),
+    ('ClientToolsInfo_001', 'g_pClientToolsInfo'), ('Vrad3_001', 'g_pRAD3'), ('NavSystem001', 'g_pNavSystem'),
+    ('NavGameTest001', 'g_pNavGameTest'),
+]
+
+WINDOWS_EXPECTED_ENTRIES = EXPECTED_ENTRIES
+LINUX_EXPECTED_ENTRIES = EXPECTED_ENTRIES[:-2]
+
+
+def _expected_entries_for_platform(platform):
+    if platform == "linux":
+        return LINUX_EXPECTED_ENTRIES
+    return WINDOWS_EXPECTED_ENTRIES
+
+
+def _expected_gv_names_for_platform(platform):
+    return [gv_name for _, gv_name in _expected_entries_for_platform(platform)]
+
+
+def _debug(debug, message):
+    if debug:
+        print(f"    Preprocess: {message}")
+
+
+def _parse_addr(value):
+    try:
+        return int(str(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _load_interface_globals_va(new_binary_dir, platform, debug=False):
+    yaml_path = os.path.join(new_binary_dir, f"{INTERFACE_GLOBALS_NAME}.{platform}.yaml")
+    if not os.path.exists(yaml_path):
+        _debug(debug, f"missing input YAML {yaml_path}")
+        return None
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception as exc:
+        _debug(debug, f"failed to read {yaml_path}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        _debug(debug, f"invalid YAML payload in {yaml_path}")
+        return None
+    gv_va = _parse_addr(data.get("gv_va"))
+    if gv_va is None:
+        _debug(debug, f"missing or invalid gv_va in {yaml_path}")
+    return gv_va
+
+
+def _build_scan_py_eval(table_va, expected_count):
+    max_entries = max(expected_count, MAX_SCAN_ENTRIES)
+    return f"""
+import ida_bytes
+import idc
+import json
+
+table_va = {table_va}
+entry_size = {ENTRY_SIZE}
+max_entries = {max_entries}
+entries = []
+
+def read_qword(ea):
+    value = ida_bytes.get_qword(ea)
+    if value in (None, idc.BADADDR):
+        return None
+    return int(value)
+
+for index in range(max_entries):
+    entry_va = table_va + index * entry_size
+    interface_name_va = read_qword(entry_va)
+    pp_global_va = read_qword(entry_va + 8)
+    if not interface_name_va or not pp_global_va:
+        break
+    interface_name = idc.get_strlit_contents(interface_name_va, -1, idc.STRTYPE_C)
+    if isinstance(interface_name, bytes):
+        interface_name = interface_name.decode("utf-8", errors="replace")
+    if not interface_name:
+        break
+    entries.append({{
+        "index": index,
+        "entry_va": hex(entry_va),
+        "interface_name": str(interface_name),
+        "interface_name_va": hex(interface_name_va),
+        "pp_global_va": hex(pp_global_va),
+    }})
+
+result = json.dumps(entries)
+"""
+
+
+def _parse_py_eval_entries(payload, debug=False):
+    if isinstance(payload, dict) and "result" in payload:
+        payload = payload.get("result")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            _debug(debug, f"scan returned non-json payload: {payload}")
+            return None
+    if not isinstance(payload, list):
+        _debug(debug, f"scan returned invalid payload: {payload}")
+        return None
+    return payload
+
+
+async def _scan_entries_via_mcp(session, table_va, expected_entries, debug=False):
+    code = _build_scan_py_eval(table_va, len(expected_entries))
+    try:
+        result = await session.call_tool(name="py_eval", arguments={"code": code})
+    except Exception as exc:
+        _debug(debug, f"py_eval scan failed: {exc}")
+        return None
+    return _parse_py_eval_entries(parse_mcp_result(result), debug=debug)
+
+
+def _match_expected_entries(actual_entries, expected_entries, debug=False):
+    expected_interfaces = {interface for interface, _ in expected_entries}
+    actual_by_interface = {}
+    for actual in actual_entries:
+        actual_interface = str(actual.get("interface_name", ""))
+        if actual_interface not in expected_interfaces:
+            continue
+        if actual_interface in actual_by_interface:
+            _debug(debug, f"duplicate interface entry: {actual_interface}")
+            return None
+        actual_by_interface[actual_interface] = actual
+
+    if len(actual_by_interface) < len(expected_entries):
+        missing = [
+            interface
+            for interface, _ in expected_entries
+            if interface not in actual_by_interface
+        ]
+        _debug(
+            debug,
+            "missing expected interface entries: "
+            f"{', '.join(missing)}",
+        )
+        return None
+
+    for expected_interface, expected_gv in expected_entries:
+        actual = actual_by_interface[expected_interface]
+        pp_global_va = _parse_addr(actual.get("pp_global_va"))
+        if pp_global_va is None or pp_global_va == 0:
+            _debug(
+                debug,
+                f"invalid pp_global_va for {expected_interface} -> "
+                f"{expected_gv}: {actual}",
+            )
+            return None
+
+    return actual_by_interface
+
+
+def _build_output_map(expected_outputs, platform, expected_entries, debug=False):
+    output_map = {
+        os.path.basename(path): path
+        for path in (expected_outputs or [])
+    }
+    resolved = {}
+    for _, gv_name in expected_entries:
+        filename = f"{gv_name}.{platform}.yaml"
+        output_path = output_map.get(filename)
+        if not output_path:
+            _debug(debug, f"missing expected output path for {filename}")
+            return None
+        resolved[gv_name] = output_path
+    return resolved
+
+
+def _build_gv_payloads(actual_by_interface, image_base, expected_entries):
+    payloads = {}
+    for interface_name, gv_name in expected_entries:
+        actual = actual_by_interface[interface_name]
+        gv_va = _parse_addr(actual.get("pp_global_va"))
+        payloads[gv_name] = {
+            "gv_name": gv_name,
+            "gv_va": hex(gv_va),
+            "gv_rva": hex(gv_va - image_base),
+        }
+    return payloads
+
+
+def _build_rename_py_eval(payloads):
+    rename_items = [
+        {"addr": payload["gv_va"], "name": gv_name}
+        for gv_name, payload in payloads.items()
+    ]
+    rename_items_json = json.dumps(rename_items)
+    return f"""
+import idc
+import json
+
+rename_items = json.loads({rename_items_json!r})
+renamed = []
+for item in rename_items:
+    addr = int(item["addr"], 16)
+    name = item["name"]
+    ok = idc.set_name(addr, name, idc.SN_NOWARN)
+    renamed.append({{"addr": item["addr"], "name": name, "ok": bool(ok)}})
+
+result = json.dumps({{"renamed": renamed}})
+"""
+
+
+async def _rename_globals_best_effort(session, payloads, debug=False):
+    try:
+        await session.call_tool(
+            name="py_eval",
+            arguments={"code": _build_rename_py_eval(payloads)},
+        )
+    except Exception as exc:
+        _debug(debug, f"best-effort gv rename failed: {exc}")
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    _ = skill_name, old_yaml_map, llm_config
+    expected_entries = _expected_entries_for_platform(platform)
+
+    table_va = _load_interface_globals_va(new_binary_dir, platform, debug=debug)
+    if table_va is None:
+        return False
+
+    output_map = _build_output_map(
+        expected_outputs,
+        platform,
+        expected_entries,
+        debug=debug,
+    )
+    if output_map is None:
+        return False
+
+    actual_entries = await _scan_entries_via_mcp(
+        session,
+        table_va,
+        expected_entries,
+        debug=debug,
+    )
+    if actual_entries is None:
+        return False
+
+    actual_by_interface = _match_expected_entries(
+        actual_entries,
+        expected_entries,
+        debug=debug,
+    )
+    if actual_by_interface is None:
+        return False
+
+    payloads = _build_gv_payloads(
+        actual_by_interface,
+        image_base,
+        expected_entries,
+    )
+    try:
+        for gv_name, payload in payloads.items():
+            write_gv_yaml(output_map[gv_name], payload)
+    except Exception as exc:
+        _debug(debug, f"failed to write gv YAML: {exc}")
+        return False
+
+    await _rename_globals_best_effort(session, payloads, debug=debug)
+    return True

--- a/ida_preprocessor_scripts/references/client/ConnectInterfaces.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/ConnectInterfaces.linux.yaml
@@ -1,0 +1,236 @@
+func_name: ConnectInterfaces
+func_va: '0x1fa96a0'
+disasm_code: |-
+  .text:0000000001FA96A0                 push    rbp
+  .text:0000000001FA96A1                 movsxd  rax, esi
+  .text:0000000001FA96A4                 mov     rbp, rsp
+  .text:0000000001FA96A7                 push    r15
+  .text:0000000001FA96A9                 push    r14
+  .text:0000000001FA96AB                 push    r13
+  .text:0000000001FA96AD                 push    r12
+  .text:0000000001FA96AF                 push    rbx
+  .text:0000000001FA96B0                 sub     rsp, 18h
+  .text:0000000001FA96B4                 mov     esi, cs:dword_475B6E0
+  .text:0000000001FA96BA                 test    esi, esi
+  .text:0000000001FA96BC                 js      loc_1FA9867
+  .text:0000000001FA96C2                 mov     r12, rdi
+  .text:0000000001FA96C5                 jz      loc_1FA976C
+  .text:0000000001FA96CB                 test    eax, eax
+  .text:0000000001FA96CD                 jle     loc_1FA97FC
+  .text:0000000001FA96D3                 lea     rax, [rdi+rax*8]
+  .text:0000000001FA96D7                 mov     [rbp+var_38], rax
+  .text:0000000001FA96DB                 lea     rbx, off_4304490
+  .text:0000000001FA96E2                 lea     r13, unk_475AFE0
+  .text:0000000001FA96E9                 lea     r15, g_pInterfaceGlobals; "VApplication001"
+  .text:0000000001FA96F0                 lea     r14, qword_475BA78
+  .text:0000000001FA96F7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001FA9700                 mov     rdi, [r15]
+  .text:0000000001FA9703                 xor     esi, esi
+  .text:0000000001FA9705                 call    qword ptr [r12]
+  .text:0000000001FA9709                 movsxd  rdi, cs:dword_475B6E0
+  .text:0000000001FA9710                 mov     r10, rax
+  .text:0000000001FA9713                 mov     [r14], rax
+  .text:0000000001FA9716                 test    edi, edi
+  .text:0000000001FA9718                 jle     loc_1FA9820
+  .text:0000000001FA971E                 lea     rax, unk_475AFE0
+  .text:0000000001FA9725                 movsxd  rsi, edi
+  .text:0000000001FA9728                 xor     edx, edx
+  .text:0000000001FA972A                 shl     rsi, 4
+  .text:0000000001FA972E                 add     rsi, rax
+  .text:0000000001FA9731                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001FA973C                 nop     dword ptr [rax+00h]
+  .text:0000000001FA9740                 cmp     [rax], r14
+  .text:0000000001FA9743                 setz    cl
+  .text:0000000001FA9746                 add     rax, 10h
+  .text:0000000001FA974A                 or      edx, ecx
+  .text:0000000001FA974C                 cmp     rax, rsi
+  .text:0000000001FA974F                 jnz     short loc_1FA9740
+  .text:0000000001FA9751                 test    dl, dl
+  .text:0000000001FA9753                 jz      loc_1FA9820
+  .text:0000000001FA9759                 add     r15, 10h
+  .text:0000000001FA975D                 cmp     r15, rbx
+  .text:0000000001FA9760                 jz      loc_1FA9854
+  .text:0000000001FA9766                 mov     r14, [r15+8]
+  .text:0000000001FA976A                 jmp     short loc_1FA9700
+  .text:0000000001FA976C                 test    eax, eax
+  .text:0000000001FA976E                 jle     loc_1FA97FC
+  .text:0000000001FA9774                 lea     rax, [rdi+rax*8]
+  .text:0000000001FA9778                 mov     r13, rdi
+  .text:0000000001FA977B                 mov     [rbp+var_38], rax
+  .text:0000000001FA977F                 lea     rbx, off_4304490
+  .text:0000000001FA9786                 lea     r14, unk_475AFE0
+  .text:0000000001FA978D                 lea     r12, g_pInterfaceGlobals; "VApplication001"
+  .text:0000000001FA9794                 jmp     short loc_1FA97A9
+  .text:0000000001FA97A0                 add     r12, 10h
+  .text:0000000001FA97A4                 cmp     rbx, r12
+  .text:0000000001FA97A7                 jz      short loc_1FA97F2
+  .text:0000000001FA97A9                 mov     r15, [r12+8]
+  .text:0000000001FA97AE                 cmp     qword ptr [r15], 0
+  .text:0000000001FA97B2                 jnz     short loc_1FA97A0
+  .text:0000000001FA97B4                 mov     rdi, [r12]
+  .text:0000000001FA97B8                 xor     esi, esi
+  .text:0000000001FA97BA                 call    qword ptr [r13+0]
+  .text:0000000001FA97BE                 mov     [r15], rax
+  .text:0000000001FA97C1                 test    rax, rax
+  .text:0000000001FA97C4                 jz      short loc_1FA97A0
+  .text:0000000001FA97C6                 movsxd  rax, cs:dword_475B6E0
+  .text:0000000001FA97CD                 add     r12, 10h
+  .text:0000000001FA97D1                 mov     edx, cs:dword_475B6E4
+  .text:0000000001FA97D7                 lea     ecx, [rax+1]
+  .text:0000000001FA97DA                 shl     rax, 4
+  .text:0000000001FA97DE                 add     rax, r14
+  .text:0000000001FA97E1                 mov     cs:dword_475B6E0, ecx
+  .text:0000000001FA97E7                 mov     [rax], r15
+  .text:0000000001FA97EA                 mov     [rax+8], edx
+  .text:0000000001FA97ED                 cmp     rbx, r12
+  .text:0000000001FA97F0                 jnz     short loc_1FA97A9
+  .text:0000000001FA97F2                 add     r13, 8
+  .text:0000000001FA97F6                 cmp     [rbp+var_38], r13
+  .text:0000000001FA97FA                 jnz     short loc_1FA978D
+  .text:0000000001FA97FC                 add     cs:dword_475B6E4, 1
+  .text:0000000001FA9803                 add     rsp, 18h
+  .text:0000000001FA9807                 pop     rbx
+  .text:0000000001FA9808                 pop     r12
+  .text:0000000001FA980A                 pop     r13
+  .text:0000000001FA980C                 pop     r14
+  .text:0000000001FA980E                 pop     r15
+  .text:0000000001FA9810                 pop     rbp
+  .text:0000000001FA9811                 jmp     sub_1FA9560
+  .text:0000000001FA9820                 test    r10, r10
+  .text:0000000001FA9823                 jz      loc_1FA9759
+  .text:0000000001FA9829                 mov     edx, cs:dword_475B6E4
+  .text:0000000001FA982F                 lea     eax, [rdi+1]
+  .text:0000000001FA9832                 shl     rdi, 4
+  .text:0000000001FA9836                 add     r15, 10h
+  .text:0000000001FA983A                 mov     cs:dword_475B6E0, eax
+  .text:0000000001FA9840                 lea     rax, [r13+rdi+0]
+  .text:0000000001FA9845                 mov     [rax], r14
+  .text:0000000001FA9848                 mov     [rax+8], edx
+  .text:0000000001FA984B                 cmp     r15, rbx
+  .text:0000000001FA984E                 jnz     loc_1FA9766
+  .text:0000000001FA9854                 mov     rax, [rbp+var_38]
+  .text:0000000001FA9858                 add     r12, 8
+  .text:0000000001FA985C                 cmp     r12, rax
+  .text:0000000001FA985F                 jnz     loc_1FA96E9
+  .text:0000000001FA9865                 jmp     short loc_1FA97FC
+  .text:0000000001FA9867                 lea     rdi, aAppsystemInCon; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:0000000001FA986E                 xor     eax, eax
+  .text:0000000001FA9870                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall ConnectInterfaces(
+          __int64 (__fastcall **a1)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden this), _QWORD),
+          int a2)
+  {
+    __int64 (__fastcall **v2)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // r12
+    void (__fastcall ***v3)(__cxxabiv1::__class_type_info *__hidden); // r15
+    __int64 *i; // r14
+    __int64 v5; // rax
+    __int64 v6; // rdi
+    __int64 v7; // r10
+    char *v8; // rax
+    char v9; // dl
+    bool v10; // cl
+    __int64 (__fastcall **v11)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // r13
+    void (__fastcall ***v12)(__cxxabiv1::__class_type_info *__hidden); // r12
+    __int64 *v13; // r15
+    __int64 v14; // rax
+    int v15; // edx
+    char *v16; // rax
+    int v18; // edx
+    char *v19; // rax
+    __int64 (__fastcall **v20)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // [rsp+8h] [rbp-38h]
+
+    if ( dword_475B6E0 < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n", dword_475B6E0);
+      JUMPOUT(0x1FA9875);
+    }
+    v2 = a1;
+    if ( dword_475B6E0 )
+    {
+      if ( a2 > 0 )
+      {
+        v20 = &a1[a2];
+        do
+        {
+          v3 = (void (__fastcall ***)(__cxxabiv1::__class_type_info *__hidden))&g_pInterfaceGlobals;
+          for ( i = (__int64 *)&qword_475BA78; ; i = (__int64 *)v3[1] )
+          {
+            v5 = (*v2)(*v3, 0);
+            v6 = dword_475B6E0;
+            v7 = v5;
+            *i = v5;
+            if ( (int)v6 <= 0 )
+              goto LABEL_21;
+            v8 = (char *)&unk_475AFE0;
+            v9 = 0;
+            do
+            {
+              v10 = *(_QWORD *)v8 == (_QWORD)i;
+              v8 += 16;
+              v9 |= v10;
+            }
+            while ( v8 != (char *)&unk_475AFE0 + 16 * (int)v6 );
+            if ( !v9 )
+            {
+  LABEL_21:
+              if ( v7 )
+                break;
+            }
+            v3 += 2;
+            if ( v3 == &off_4304490 )
+              goto LABEL_23;
+  LABEL_11:
+            ;
+          }
+          v18 = dword_475B6E4;
+          v3 += 2;
+          dword_475B6E0 = v6 + 1;
+          v19 = (char *)&unk_475AFE0 + 16 * v6;
+          *(_QWORD *)v19 = i;
+          *((_DWORD *)v19 + 2) = v18;
+          if ( v3 != &off_4304490 )
+            goto LABEL_11;
+  LABEL_23:
+          ++v2;
+        }
+        while ( v2 != v20 );
+      }
+    }
+    else if ( a2 > 0 )
+    {
+      v11 = a1;
+      do
+      {
+        v12 = (void (__fastcall ***)(__cxxabiv1::__class_type_info *__hidden))&g_pInterfaceGlobals;
+        do
+        {
+          while ( 1 )
+          {
+            v13 = (__int64 *)v12[1];
+            if ( !*v13 )
+            {
+              v14 = (*v11)(*v12, 0);
+              *v13 = v14;
+              if ( v14 )
+                break;
+            }
+            v12 += 2;
+            if ( &off_4304490 == v12 )
+              goto LABEL_19;
+          }
+          v12 += 2;
+          v15 = dword_475B6E4;
+          v16 = (char *)&unk_475AFE0 + 16 * dword_475B6E0++;
+          *(_QWORD *)v16 = v13;
+          *((_DWORD *)v16 + 2) = v15;
+        }
+        while ( &off_4304490 != v12 );
+  LABEL_19:
+        ++v11;
+      }
+      while ( &a1[a2] != v11 );
+    }
+    ++dword_475B6E4;
+    return sub_1FA9560();
+  }

--- a/ida_preprocessor_scripts/references/client/ConnectInterfaces.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/ConnectInterfaces.windows.yaml
@@ -1,0 +1,231 @@
+func_name: ConnectInterfaces
+func_va: '0x18183cab0'
+disasm_code: |-
+  .text:000000018183CAB0                 push    r15
+  .text:000000018183CAB2                 sub     rsp, 40h
+  .text:000000018183CAB6                 mov     eax, cs:dword_18257D580
+  .text:000000018183CABC                 mov     r15, rcx
+  .text:000000018183CABF                 test    eax, eax
+  .text:000000018183CAC1                 jns     short loc_18183CAD3
+  .text:000000018183CAC3                 mov     edx, eax
+  .text:000000018183CAC5                 lea     rcx, aAppsystemInCon_1; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:000000018183CACC                 call    cs:Plat_FatalError
+  .text:000000018183CAD2                 ; Trap to Debugger
+  .text:000000018183CAD2                 int     3; Trap to Debugger
+  .text:000000018183CAD3                 mov     [rsp+48h+arg_0], rbx
+  .text:000000018183CAD8                 mov     [rsp+48h+arg_10], rsi
+  .text:000000018183CADD                 mov     [rsp+48h+var_10], rdi
+  .text:000000018183CAE2                 mov     [rsp+48h+var_18], r12
+  .text:000000018183CAE7                 mov     [rsp+48h+var_20], r13
+  .text:000000018183CAEC                 mov     [rsp+48h+var_28], r14
+  .text:000000018183CAF1                 movsxd  r12, edx
+  .text:000000018183CAF4                 test    eax, eax
+  .text:000000018183CAF6                 jnz     loc_18183CB8E
+  .text:000000018183CAFC                 test    edx, edx
+  .text:000000018183CAFE                 jle     short loc_18183CB7C
+  .text:000000018183CB00                 mov     [rsp+48h+arg_8], rbp
+  .text:000000018183CB05                 lea     r13, g_pInterfaceGlobals
+  .text:000000018183CB0C                 xor     ebp, ebp
+  .text:000000018183CB0E                 lea     r14, unk_18257D590
+  .text:000000018183CB15                 nop     word ptr [rax+rax+00000000h]
+  .text:000000018183CB20                 xor     esi, esi
+  .text:000000018183CB22                 mov     rbx, r13
+  .text:000000018183CB25                 mov     rdi, [rbx+8]
+  .text:000000018183CB29                 cmp     qword ptr [rdi], 0
+  .text:000000018183CB2D                 jnz     short loc_18183CB64
+  .text:000000018183CB2F                 mov     rcx, [rbx]
+  .text:000000018183CB32                 xor     edx, edx
+  .text:000000018183CB34                 call    qword ptr [r15+rbp*8]
+  .text:000000018183CB38                 mov     [rdi], rax
+  .text:000000018183CB3B                 test    rax, rax
+  .text:000000018183CB3E                 jz      short loc_18183CB64
+  .text:000000018183CB40                 movsxd  rax, cs:dword_18257D580
+  .text:000000018183CB47                 mov     rcx, rax
+  .text:000000018183CB4A                 add     rcx, rcx
+  .text:000000018183CB4D                 inc     eax
+  .text:000000018183CB4F                 mov     cs:dword_18257D580, eax
+  .text:000000018183CB55                 mov     eax, cs:dword_18257D57C
+  .text:000000018183CB5B                 mov     [r14+rcx*8+8], eax
+  .text:000000018183CB60                 mov     [r14+rcx*8], rdi
+  .text:000000018183CB64                 inc     esi
+  .text:000000018183CB66                 add     rbx, 10h
+  .text:000000018183CB6A                 cmp     esi, 70h ; 'p'
+  .text:000000018183CB6D                 jb      short loc_18183CB25
+  .text:000000018183CB6F                 inc     rbp
+  .text:000000018183CB72                 cmp     rbp, r12
+  .text:000000018183CB75                 jl      short loc_18183CB20
+  .text:000000018183CB77                 mov     rbp, [rsp+48h+arg_8]
+  .text:000000018183CB7C                 lea     rcx, cs:180000000h
+  .text:000000018183CB83                 call    cs:Plat_RegisterModule
+  .text:000000018183CB89                 jmp     loc_18183CC3B
+  .text:000000018183CB8E                 test    edx, edx
+  .text:000000018183CB90                 jle     loc_18183CC3B
+  .text:000000018183CB96                 lea     r13, g_pInterfaceGlobals
+  .text:000000018183CB9D                 lea     r14, unk_18257D590
+  .text:000000018183CBA4                 nop     dword ptr [rax+00h]
+  .text:000000018183CBA8                 nop     dword ptr [rax+rax+00000000h]
+  .text:000000018183CBB0                 xor     edi, edi
+  .text:000000018183CBB2                 mov     rsi, r13
+  .text:000000018183CBB5                 nop     word ptr [rax+rax+00000000h]
+  .text:000000018183CBC0                 mov     rax, [r15]
+  .text:000000018183CBC3                 xor     edx, edx
+  .text:000000018183CBC5                 mov     rcx, [rsi]
+  .text:000000018183CBC8                 mov     rbx, [rsi+8]
+  .text:000000018183CBCC                 call    rax
+  .text:000000018183CBCE                 movsxd  r8, cs:dword_18257D580
+  .text:000000018183CBD5                 xor     dl, dl
+  .text:000000018183CBD7                 mov     [rbx], rax
+  .text:000000018183CBDA                 test    r8d, r8d
+  .text:000000018183CBDD                 jle     short loc_18183CBFD
+  .text:000000018183CBDF                 mov     rax, r14
+  .text:000000018183CBE2                 mov     ecx, r8d
+  .text:000000018183CBE5                 cmp     [rax], rbx
+  .text:000000018183CBE8                 jnz     short loc_18183CBEF
+  .text:000000018183CBEA                 mov     [rax], rbx
+  .text:000000018183CBED                 mov     dl, 1
+  .text:000000018183CBEF                 add     rax, 10h
+  .text:000000018183CBF3                 sub     rcx, 1
+  .text:000000018183CBF7                 jnz     short loc_18183CBE5
+  .text:000000018183CBF9                 test    dl, dl
+  .text:000000018183CBFB                 jnz     short loc_18183CC22
+  .text:000000018183CBFD                 cmp     qword ptr [rbx], 0
+  .text:000000018183CC01                 jz      short loc_18183CC22
+  .text:000000018183CC03                 mov     eax, cs:dword_18257D57C
+  .text:000000018183CC09                 mov     rcx, r8
+  .text:000000018183CC0C                 add     rcx, rcx
+  .text:000000018183CC0F                 inc     r8d
+  .text:000000018183CC12                 mov     cs:dword_18257D580, r8d
+  .text:000000018183CC19                 mov     [r14+rcx*8], rbx
+  .text:000000018183CC1D                 mov     [r14+rcx*8+8], eax
+  .text:000000018183CC22                 inc     edi
+  .text:000000018183CC24                 add     rsi, 10h
+  .text:000000018183CC28                 cmp     edi, 70h ; 'p'
+  .text:000000018183CC2B                 jb      short loc_18183CBC0
+  .text:000000018183CC2D                 add     r15, 8
+  .text:000000018183CC31                 sub     r12, 1
+  .text:000000018183CC35                 jnz     loc_18183CBB0
+  .text:000000018183CC3B                 inc     cs:dword_18257D57C
+  .text:000000018183CC41                 mov     r14, [rsp+48h+var_28]
+  .text:000000018183CC46                 mov     r13, [rsp+48h+var_20]
+  .text:000000018183CC4B                 mov     r12, [rsp+48h+var_18]
+  .text:000000018183CC50                 mov     rdi, [rsp+48h+var_10]
+  .text:000000018183CC55                 mov     rsi, [rsp+48h+arg_10]
+  .text:000000018183CC5A                 mov     rbx, [rsp+48h+arg_0]
+  .text:000000018183CC5F                 add     rsp, 40h
+  .text:000000018183CC63                 pop     r15
+  .text:000000018183CC65                 jmp     sub_18183C930
+procedure: |-
+  __int64 __fastcall sub_18183CAB0(__int64 (__fastcall **a1)(char *, _QWORD), int a2)
+  {
+    __int64 v3; // r12
+    __int64 v4; // rbp
+    unsigned int v5; // esi
+    char **v6; // rbx
+    __int64 *v7; // rdi
+    __int64 v8; // rax
+    __int64 v9; // rcx
+    unsigned int v10; // edi
+    char **v11; // rsi
+    __int64 *v12; // rbx
+    __int64 v13; // rax
+    __int64 v14; // r8
+    char v15; // dl
+    __int64 **v16; // rax
+    __int64 v17; // rcx
+    int v18; // eax
+    __int64 v19; // rcx
+
+    if ( dword_18257D580 < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n", dword_18257D580);
+      __debugbreak();
+    }
+    v3 = a2;
+    if ( dword_18257D580 )
+    {
+      if ( a2 > 0 )
+      {
+        do
+        {
+          v10 = 0;
+          v11 = &g_pInterfaceGlobals;
+          do
+          {
+            v12 = (__int64 *)v11[1];
+            v13 = (*a1)(*v11, 0);
+            v14 = dword_18257D580;
+            v15 = 0;
+            *v12 = v13;
+            if ( (int)v14 <= 0 )
+              goto LABEL_28;
+            v16 = (__int64 **)&unk_18257D590;
+            v17 = (unsigned int)v14;
+            do
+            {
+              if ( *v16 == v12 )
+              {
+                *v16 = v12;
+                v15 = 1;
+              }
+              v16 += 2;
+              --v17;
+            }
+            while ( v17 );
+            if ( !v15 )
+            {
+  LABEL_28:
+              if ( *v12 )
+              {
+                v18 = dword_18257D57C;
+                v19 = 2 * v14;
+                dword_18257D580 = v14 + 1;
+                *((_QWORD *)&unk_18257D590 + v19) = v12;
+                *((_DWORD *)&unk_18257D590 + 2 * v19 + 2) = v18;
+              }
+            }
+            ++v10;
+            v11 += 2;
+          }
+          while ( v10 < 0x70 );
+          ++a1;
+          --v3;
+        }
+        while ( v3 );
+      }
+    }
+    else
+    {
+      if ( a2 > 0 )
+      {
+        v4 = 0;
+        do
+        {
+          v5 = 0;
+          v6 = &g_pInterfaceGlobals;
+          do
+          {
+            v7 = (__int64 *)v6[1];
+            if ( !*v7 )
+            {
+              v8 = a1[v4](*v6, 0);
+              *v7 = v8;
+              if ( v8 )
+              {
+                v9 = 2LL * dword_18257D580++;
+                *((_DWORD *)&unk_18257D590 + 2 * v9 + 2) = dword_18257D57C;
+                *((_QWORD *)&unk_18257D590 + v9) = v7;
+              }
+            }
+            ++v5;
+            v6 += 2;
+          }
+          while ( v5 < 112 );                     // NUM_INTERFACES
+          ++v4;
+        }
+        while ( v4 < v3 );
+      }
+      Plat_RegisterModule(0x180000000uLL);
+    }
+    ++dword_18257D57C;
+    return sub_18183C930();
+  }

--- a/ida_preprocessor_scripts/references/client/SendViolationReport.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/SendViolationReport.windows.yaml
@@ -1,0 +1,249 @@
+func_name: SendViolationReport
+func_va: '0x1800056f0'
+disasm_code: |-
+  .text:00000001800056F0                 mov     [rsp-8+arg_0], rbx
+  .text:00000001800056F5                 mov     [rsp-8+arg_8], rsi
+  .text:00000001800056FA                 mov     [rsp-8+arg_10], rdi
+  .text:00000001800056FF                 mov     [rsp-8+arg_18], r12
+  .text:0000000180005704                 push    rbp
+  .text:0000000180005705                 push    r14
+  .text:0000000180005707                 push    r15
+  .text:0000000180005709                 lea     rbp, [rsp-47h]
+  .text:000000018000570E                 sub     rsp, 100h
+  .text:0000000180005715                 mov     r15d, ecx
+  .text:0000000180005718                 movsxd  rbx, r9d
+  .text:000000018000571B                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180005722                 mov     rsi, rdx
+  .text:0000000180005725                 xor     edx, edx
+  .text:0000000180005727                 mov     rdi, r8
+  .text:000000018000572A                 mov     rax, [rcx]
+  .text:000000018000572D                 call    qword ptr [rax+148h]  ; 148h = IVEngineClient2_GetNetworkClient
+  .text:0000000180005733                 mov     r14, rax
+  .text:0000000180005736                 test    rax, rax
+  .text:0000000180005739                 jz      loc_1800058FC
+  .text:000000018000573F                 xor     edx, edx
+  .text:0000000180005741                 lea     rcx, [rsp+110h+var_F0]
+  .text:0000000180005746                 call    cs:?SetIP@netadr_t@@QEAAXI@Z; netadr_t::SetIP(uint)
+  .text:000000018000574C                 xor     edx, edx
+  .text:000000018000574E                 lea     rcx, [rsp+110h+var_F0]
+  .text:0000000180005753                 call    cs:?SetPort@netadr_t@@QEAAXG@Z; netadr_t::SetPort(ushort)
+  .text:0000000180005759                 mov     edx, 3
+  .text:000000018000575E                 lea     rcx, [rsp+110h+var_F0]
+  .text:0000000180005763                 call    cs:?SetType@netadr_t@@QEAAXW4netadrtype_t@@@Z; netadr_t::SetType(netadrtype_t)
+  .text:0000000180005769                 and     [rsp+110h+var_E0], 0FF0FFFFFh
+  .text:0000000180005771                 xor     r12d, r12d
+  .text:0000000180005774                 mov     rax, [r14]
+  .text:0000000180005777                 mov     rcx, r14
+  .text:000000018000577A                 mov     byte ptr [rsp+110h+var_E0+3], r12b
+  .text:000000018000577F                 and     [rsp+110h+var_E0], 0FFF00000h
+  .text:0000000180005787                 mov     [rsp+110h+var_E4], r12d
+  .text:000000018000578C                 mov     [rsp+110h+var_DC], r12
+  .text:0000000180005791                 mov     [rbp+57h+var_D4], r12d
+  .text:0000000180005795                 call    qword ptr [rax+8]  ; 8h = INetworkClient_GetLocalAddress
+  .text:0000000180005798                 xor     r8d, r8d
+  .text:000000018000579B                 lea     rcx, [rsp+110h+var_F0]
+  .text:00000001800057A0                 mov     rdx, rax
+  .text:00000001800057A3                 call    sub_180154C00
+  .text:00000001800057A8                 cmp     [rbp+57h+var_D4], 2
+  .text:00000001800057AC                 lea     rcx, [rsp+110h+var_F0]
+  .text:00000001800057B1                 mov     [rbp+57h+var_D4], r12d
+  .text:00000001800057B5                 jnz     loc_1800058F6
+  .text:00000001800057BB                 call    cs:?Clear@netadr_t@@QEAAXXZ; netadr_t::Clear(void)
+  .text:00000001800057C1                 xor     r8d, r8d
+  .text:00000001800057C4                 lea     rcx, [rbp+57h+var_70]
+  .text:00000001800057C8                 xor     edx, edx
+  .text:00000001800057CA                 call    sub_1806B88B0
+  .text:00000001800057CF                 or      [rbp+57h+var_60], 7
+  .text:00000001800057D3                 lea     rax, ??_7CUserMessage_ExtraUserData@@6B@; const CUserMessage_ExtraUserData::`vftable'
+  .text:00000001800057DA                 mov     [rbp+57h+var_70], rax
+  .text:00000001800057DE                 mov     [rbp+57h+var_18], r15d
+  .text:00000001800057E2                 mov     [rbp+57h+var_28], rsi
+  .text:00000001800057E6                 mov     [rbp+57h+var_20], rdi
+  .text:00000001800057EA                 test    ebx, ebx
+  .text:00000001800057EC                 jz      short loc_180005826
+  .text:00000001800057EE                 test    rsi, rsi
+  .text:00000001800057F1                 jz      short loc_18000580A
+  .text:00000001800057F3                 lea     rcx, [rbp+57h+var_58]
+  .text:00000001800057F7                 call    sub_181189700
+  .text:00000001800057FC                 mov     r8, rbx
+  .text:00000001800057FF                 mov     rdx, rsi
+  .text:0000000180005802                 mov     rcx, rax
+  .text:0000000180005805                 call    sub_180155060
+  .text:000000018000580A                 test    rdi, rdi
+  .text:000000018000580D                 jz      short loc_180005826
+  .text:000000018000580F                 lea     rcx, [rbp+57h+var_40]
+  .text:0000000180005813                 call    sub_181189700
+  .text:0000000180005818                 mov     r8, rbx
+  .text:000000018000581B                 mov     rdx, rdi
+  .text:000000018000581E                 mov     rcx, rax
+  .text:0000000180005821                 call    sub_180155060
+  .text:0000000180005826                 xorps   xmm0, xmm0
+  .text:0000000180005829                 mov     [rbp+57h+var_C0], r12d
+  .text:000000018000582D                 lea     rdi, ??_7CNetMessage@@6B@; const CNetMessage::`vftable'
+  .text:0000000180005834                 movsd   [rbp+57h+var_C8], xmm0
+  .text:0000000180005839                 xor     r8d, r8d
+  .text:000000018000583C                 mov     [rbp+57h+var_D0], rdi
+  .text:0000000180005840                 xor     edx, edx
+  .text:0000000180005842                 mov     [rbp+57h+var_BC], 0FFh
+  .text:0000000180005846                 lea     rcx, [rbp+57h+var_A0]
+  .text:000000018000584A                 mov     [rbp+57h+var_B8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180005852                 mov     [rbp+57h+var_B0], 0BF800000h
+  .text:0000000180005859                 mov     [rbp+57h+var_A8], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180005861                 call    sub_1806008E0
+  .text:0000000180005866                 lea     rax, ??_7CSVCMsg_UserMessage_t@@6B@; const CSVCMsg_UserMessage_t::`vftable'
+  .text:000000018000586D                 mov     edx, 0A4h
+  .text:0000000180005872                 mov     [rbp+57h+var_D0], rax
+  .text:0000000180005876                 lea     r8, [rbp+57h+var_70]
+  .text:000000018000587A                 lea     rax, ??_7CSVCMsg_UserMessage_t@@6B@_0; const CSVCMsg_UserMessage_t::`vftable'
+  .text:0000000180005881                 lea     rcx, [rbp+57h+var_A0]
+  .text:0000000180005885                 mov     [rbp+57h+var_A0], rax
+  .text:0000000180005889                 call    sub_180AF0040
+  .text:000000018000588E                 test    al, al
+  .text:0000000180005890                 jz      short loc_1800058C3
+  .text:0000000180005892                 mov     rcx, cs:g_pNetworkClientService
+  .text:0000000180005899                 mov     rax, [rcx]
+  .text:000000018000589C                 call    qword ptr [rax+100h]  ; 100h = INetworkClientService_IsConnected
+  .text:00000001800058A2                 test    al, al
+  .text:00000001800058A4                 jz      short loc_1800058BF
+  .text:00000001800058A6                 mov     rcx, cs:g_pNetworkClientService
+  .text:00000001800058AD                 lea     r8, [rbp+57h+var_D0]
+  .text:00000001800058B1                 xor     edx, edx
+  .text:00000001800058B3                 mov     r9b, 1
+  .text:00000001800058B6                 mov     rax, [rcx]
+  .text:00000001800058B9                 call    qword ptr [rax+190h]  ; 190h = INetworkClientService_SendNetMessage
+  .text:00000001800058BF                 mov     bl, 1
+  .text:00000001800058C1                 jmp     short loc_1800058C5
+  .text:00000001800058C3                 xor     bl, bl
+  .text:00000001800058C5                 lea     rax, ??_7?$CNetMessagePB@$0EI@VCSVCMsg_UserMessage@@$0N@$00$0A@@@6B@; const CNetMessagePB<72,CSVCMsg_UserMessage,13,1,0>::`vftable'
+  .text:00000001800058CC                 mov     [rbp+57h+var_D0], rax
+  .text:00000001800058D0                 lea     rcx, [rbp+57h+var_A0]
+  .text:00000001800058D4                 lea     rax, ??_7?$CNetMessagePB@$0EI@VCSVCMsg_UserMessage@@$0N@$00$0A@@@6B@_0; const CNetMessagePB<72,CSVCMsg_UserMessage,13,1,0>::`vftable'
+  .text:00000001800058DB                 mov     [rbp+57h+var_A0], rax
+  .text:00000001800058DF                 call    sub_180605CC0
+  .text:00000001800058E4                 lea     rcx, [rbp+57h+var_70]
+  .text:00000001800058E8                 mov     [rbp+57h+var_D0], rdi
+  .text:00000001800058EC                 call    sub_1806BE1B0
+  .text:00000001800058F1                 movzx   eax, bl
+  .text:00000001800058F4                 jmp     short loc_1800058FE
+  .text:00000001800058F6                 call    cs:?Clear@netadr_t@@QEAAXXZ; netadr_t::Clear(void)
+  .text:00000001800058FC                 xor     al, al
+  .text:00000001800058FE                 lea     r11, [rsp+110h+var_10]
+  .text:0000000180005906                 mov     rbx, [r11+20h]
+  .text:000000018000590A                 mov     rsi, [r11+28h]
+  .text:000000018000590E                 mov     rdi, [r11+30h]
+  .text:0000000180005912                 mov     r12, [r11+38h]
+  .text:0000000180005916                 mov     rsp, r11
+  .text:0000000180005919                 pop     r15
+  .text:000000018000591B                 pop     r14
+  .text:000000018000591D                 pop     rbp
+  .text:000000018000591E                 retn
+procedure: |-
+  char __fastcall SendViolationReport(int a1, __int64 a2, __int64 a3, int a4)
+  {
+    __int64 v5; // rbx
+    __int64 *v8; // r14
+    __int64 v9; // rax
+    const char *v10; // rax
+    bool v11; // zf
+    __int64 v12; // rax
+    __int64 v13; // rax
+    __int64 v14; // r9
+    char v15; // bl
+    _BYTE v17[12]; // [rsp+20h] [rbp-99h] BYREF
+    int v18; // [rsp+2Ch] [rbp-8Dh]
+    int v19; // [rsp+30h] [rbp-89h]
+    __int64 v20; // [rsp+34h] [rbp-85h]
+    int v21; // [rsp+3Ch] [rbp-7Dh]
+    _QWORD v22[2]; // [rsp+40h] [rbp-79h] BYREF
+    int v23; // [rsp+50h] [rbp-69h]
+    char v24; // [rsp+54h] [rbp-65h]
+    __int64 v25; // [rsp+58h] [rbp-61h]
+    unsigned int v26; // [rsp+60h] [rbp-59h]
+    __int64 v27; // [rsp+68h] [rbp-51h]
+    _QWORD v28[6]; // [rsp+70h] [rbp-49h] BYREF
+    _QWORD v29[2]; // [rsp+A0h] [rbp-19h] BYREF
+    int v30; // [rsp+B0h] [rbp-9h]
+    _BYTE v31[24]; // [rsp+B8h] [rbp-1h] BYREF
+    _BYTE v32[24]; // [rsp+D0h] [rbp+17h] BYREF
+    __int64 v33; // [rsp+E8h] [rbp+2Fh]
+    __int64 v34; // [rsp+F0h] [rbp+37h]
+    int v35; // [rsp+F8h] [rbp+3Fh]
+
+    v5 = a4;
+    v8 = (__int64 *)(*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pEngineClient + 328LL))(g_pEngineClient, 0);// 328LL = 0x148 = IVEngineClient2_GetNetworkClient
+    if ( !v8 )
+      return 0;
+    netadr_t::SetIP((netadr_t *)v17, 0);
+    netadr_t::SetPort((netadr_t *)v17, 0);
+    netadr_t::SetType(v17, 3);
+    v19 &= 0xFF0FFFFF;
+    v9 = *v8;
+    HIBYTE(v19) = 0;
+    v19 &= 0xFFF00000;
+    v18 = 0;
+    v20 = 0;
+    v21 = 0;
+    v10 = (const char *)(*(__int64 (__fastcall **)(__int64 *))(v9 + 8))(v8);// 8LL = 0x8 = INetworkClient_GetLocalAddress
+    sub_180154C00((__int64)v17, v10, 0);
+    v11 = v21 == 2;
+    v21 = 0;
+    if ( !v11 )
+    {
+      netadr_t::Clear((netadr_t *)v17);
+      return 0;
+    }
+    netadr_t::Clear((netadr_t *)v17);
+    sub_1806B88B0(v29, 0, 0);
+    v30 |= 7u;
+    v29[0] = &CUserMessage_ExtraUserData::`vftable';
+    v35 = a1;
+    v33 = a2;
+    v34 = a3;
+    if ( (_DWORD)v5 )
+    {
+      if ( a2 )
+      {
+        v12 = sub_181189700(v31);
+        sub_180155060(v12, a2, v5);
+      }
+      if ( a3 )
+      {
+        v13 = sub_181189700(v32);
+        sub_180155060(v13, a3, v5);
+      }
+    }
+    v23 = 0;
+    v22[1] = 0;
+    v22[0] = &CNetMessage::`vftable';
+    v24 = -1;
+    v25 = -1;
+    v26 = 0xBF800000;
+    v27 = -1;
+    sub_1806008E0(v28, 0, 0);
+    v22[0] = &CSVCMsg_UserMessage_t::`vftable';
+    v28[0] = &CSVCMsg_UserMessage_t::`vftable';
+    if ( (unsigned __int8)sub_180AF0040(v28, 164, v29) )
+    {
+      if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkClientService + 256LL))(g_pNetworkClientService) )// 256LL = 0x100 = INetworkClientService_IsConnected
+      {
+        LOBYTE(v14) = 1;
+        (*(void (__fastcall **)(__int64, _QWORD, _QWORD *, __int64))(*(_QWORD *)g_pNetworkClientService
+                                                                   + 400LL))(// 400LL = 0x190 = INetworkClientService_SendNetMessage
+          g_pNetworkClientService,
+          0,
+          v22,
+          v14);
+      }
+      v15 = 1;
+    }
+    else
+    {
+      v15 = 0;
+    }
+    v22[0] = &CNetMessagePB<72,CSVCMsg_UserMessage,13,1,0>::`vftable';
+    v28[0] = &CNetMessagePB<72,CSVCMsg_UserMessage,13,1,0>::`vftable';
+    sub_180605CC0(v28);
+    v22[0] = &CNetMessage::`vftable';
+    sub_1806BE1B0(v29);
+    return v15;
+  }

--- a/ida_preprocessor_scripts/references/engine/ConnectInterfaces.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/ConnectInterfaces.linux.yaml
@@ -1,0 +1,189 @@
+func_name: ConnectInterfaces
+func_va: '0x8fee80'
+disasm_code: |-
+  .text:00000000008FEE80                 push    rbp
+  .text:00000000008FEE81                 mov     rbp, rsp
+  .text:00000000008FEE84                 push    r15
+  .text:00000000008FEE86                 push    r14
+  .text:00000000008FEE88                 push    r13
+  .text:00000000008FEE8A                 push    r12
+  .text:00000000008FEE8C                 push    rbx
+  .text:00000000008FEE8D                 sub     rsp, 8
+  .text:00000000008FEE91                 mov     esi, cs:dword_97CC6C
+  .text:00000000008FEE97                 test    esi, esi
+  .text:00000000008FEE99                 js      loc_8FEFFA
+  .text:00000000008FEE9F                 mov     rbx, rdi
+  .text:00000000008FEEA2                 jz      loc_8FEF2D
+  .text:00000000008FEEA8                 lea     r15, g_pInterfaceGlobals
+  .text:00000000008FEEAF                 lea     r12, [r15+6F0h]
+  .text:00000000008FEEB6                 lea     r14, qword_97D470
+  .text:00000000008FEEBD                 lea     r13, unk_97CC80
+  .text:00000000008FEEC4                 nop     dword ptr [rax+00h]
+  .text:00000000008FEEC8                 mov     rdi, [r15]
+  .text:00000000008FEECB                 xor     esi, esi
+  .text:00000000008FEECD                 call    qword ptr [rbx]
+  .text:00000000008FEECF                 mov     r8d, cs:dword_97CC6C
+  .text:00000000008FEED6                 mov     [r14], rax
+  .text:00000000008FEED9                 test    r8d, r8d
+  .text:00000000008FEEDC                 jle     loc_8FEFCC
+  .text:00000000008FEEE2                 lea     rdx, unk_97CC80
+  .text:00000000008FEEE9                 movsxd  rdi, r8d
+  .text:00000000008FEEEC                 xor     ecx, ecx
+  .text:00000000008FEEEE                 shl     rdi, 4
+  .text:00000000008FEEF2                 add     rdi, rdx
+  .text:00000000008FEEF5                 nop     word ptr [rax+rax+00000000h]
+  .text:00000000008FEF00                 cmp     [rdx], r14
+  .text:00000000008FEF03                 setz    sil
+  .text:00000000008FEF07                 add     rdx, 10h
+  .text:00000000008FEF0B                 or      ecx, esi
+  .text:00000000008FEF0D                 cmp     rdi, rdx
+  .text:00000000008FEF10                 jnz     short loc_8FEF00
+  .text:00000000008FEF12                 test    cl, cl
+  .text:00000000008FEF14                 jz      loc_8FEFCC
+  .text:00000000008FEF1A                 add     r15, 10h
+  .text:00000000008FEF1E                 cmp     r15, r12
+  .text:00000000008FEF21                 jz      loc_8FEFB2
+  .text:00000000008FEF27                 mov     r14, [r15+8]
+  .text:00000000008FEF2B                 jmp     short loc_8FEEC8
+  .text:00000000008FEF2D                 lea     r12, g_pInterfaceGlobals
+  .text:00000000008FEF34                 lea     r15, [r12+6F0h]
+  .text:00000000008FEF3C                 lea     r14, unk_97CC80
+  .text:00000000008FEF43                 jmp     short loc_8FEF69
+  .text:00000000008FEF60                 add     r12, 10h
+  .text:00000000008FEF64                 cmp     r12, r15
+  .text:00000000008FEF67                 jz      short loc_8FEFB2
+  .text:00000000008FEF69                 mov     r13, [r12+8]
+  .text:00000000008FEF6E                 cmp     qword ptr [r13+0], 0
+  .text:00000000008FEF73                 jnz     short loc_8FEF60
+  .text:00000000008FEF75                 mov     rdi, [r12]
+  .text:00000000008FEF79                 xor     esi, esi
+  .text:00000000008FEF7B                 call    qword ptr [rbx]
+  .text:00000000008FEF7D                 mov     [r13+0], rax
+  .text:00000000008FEF81                 test    rax, rax
+  .text:00000000008FEF84                 jz      short loc_8FEF60
+  .text:00000000008FEF86                 movsxd  rax, cs:dword_97CC6C
+  .text:00000000008FEF8D                 add     r12, 10h
+  .text:00000000008FEF91                 lea     edx, [rax+1]
+  .text:00000000008FEF94                 shl     rax, 4
+  .text:00000000008FEF98                 mov     cs:dword_97CC6C, edx
+  .text:00000000008FEF9E                 mov     edx, cs:dword_97D380
+  .text:00000000008FEFA4                 add     rax, r14
+  .text:00000000008FEFA7                 mov     [rax], r13
+  .text:00000000008FEFAA                 mov     [rax+8], edx
+  .text:00000000008FEFAD                 cmp     r12, r15
+  .text:00000000008FEFB0                 jnz     short loc_8FEF69
+  .text:00000000008FEFB2                 add     cs:dword_97D380, 1
+  .text:00000000008FEFB9                 add     rsp, 8
+  .text:00000000008FEFBD                 pop     rbx
+  .text:00000000008FEFBE                 pop     r12
+  .text:00000000008FEFC0                 pop     r13
+  .text:00000000008FEFC2                 pop     r14
+  .text:00000000008FEFC4                 pop     r15
+  .text:00000000008FEFC6                 pop     rbp
+  .text:00000000008FEFC7                 jmp     sub_75B800
+  .text:00000000008FEFCC                 test    rax, rax
+  .text:00000000008FEFCF                 jz      loc_8FEF1A
+  .text:00000000008FEFD5                 lea     eax, [r8+1]
+  .text:00000000008FEFD9                 mov     edx, cs:dword_97D380
+  .text:00000000008FEFDF                 mov     cs:dword_97CC6C, eax
+  .text:00000000008FEFE5                 movsxd  rax, r8d
+  .text:00000000008FEFE8                 shl     rax, 4
+  .text:00000000008FEFEC                 add     rax, r13
+  .text:00000000008FEFEF                 mov     [rax], r14
+  .text:00000000008FEFF2                 mov     [rax+8], edx
+  .text:00000000008FEFF5                 jmp     loc_8FEF1A
+  .text:00000000008FEFFA                 lea     rdi, aAppsystemInCon; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:00000000008FF001                 xor     eax, eax
+  .text:00000000008FF003                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall sub_8FEE80(__int64 (__fastcall **a1)(char *, _QWORD))
+  {
+    char **v1; // r15
+    __int64 *i; // r14
+    __int64 v3; // rax
+    int v4; // r8d
+    char *v5; // rdx
+    char v6; // cl
+    bool v7; // si
+    char **v8; // r12
+    __int64 *v9; // r13
+    __int64 v10; // rax
+    __int64 v11; // rax
+    int v12; // edx
+    char *v13; // rax
+    int v15; // edx
+    char *v16; // rax
+
+    if ( dword_97CC6C < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n");
+      JUMPOUT(0x8FF008);
+    }
+    if ( dword_97CC6C )
+    {
+      v1 = &g_pInterfaceGlobals;
+      for ( i = &qword_97D470; ; i = (__int64 *)v1[1] )
+      {
+        v3 = (*a1)(*v1, 0);
+        v4 = dword_97CC6C;
+        *i = v3;
+        if ( v4 <= 0 )
+          goto LABEL_16;
+        v5 = (char *)&unk_97CC80;
+        v6 = 0;
+        do
+        {
+          v7 = *(_QWORD *)v5 == (_QWORD)i;
+          v5 += 16;
+          v6 |= v7;
+        }
+        while ( (char *)&unk_97CC80 + 16 * v4 != v5 );
+        if ( !v6 )
+        {
+  LABEL_16:
+          if ( v3 )
+          {
+            v15 = dword_97D380;
+            dword_97CC6C = v4 + 1;
+            v16 = (char *)&unk_97CC80 + 16 * v4;
+            *(_QWORD *)v16 = i;
+            *((_DWORD *)v16 + 2) = v15;
+          }
+        }
+        v1 += 2;
+        if ( v1 == &off_95B770 )
+          break;
+      }
+    }
+    else
+    {
+      v8 = &g_pInterfaceGlobals;
+      do
+      {
+        while ( 1 )
+        {
+          v9 = (__int64 *)v8[1];
+          if ( !*v9 )
+          {
+            v10 = (*a1)(*v8, 0);
+            *v9 = v10;
+            if ( v10 )
+              break;
+          }
+          v8 += 2;
+          if ( v8 == &off_95B770 )
+            goto LABEL_15;
+        }
+        v8 += 2;
+        v11 = 16LL * dword_97CC6C++;
+        v12 = dword_97D380;
+        v13 = (char *)&unk_97CC80 + v11;
+        *(_QWORD *)v13 = v9;
+        *((_DWORD *)v13 + 2) = v12;
+      }
+      while ( v8 != &off_95B770 );
+    }
+  LABEL_15:
+    ++dword_97D380;
+    return sub_75B800();
+  }

--- a/ida_preprocessor_scripts/references/engine/ConnectInterfaces.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/ConnectInterfaces.windows.yaml
@@ -1,0 +1,231 @@
+func_name: ConnectInterfaces
+func_va: '0x1803fbc90'
+disasm_code: |-
+  .text:00000001803FBC90                 push    r15
+  .text:00000001803FBC92                 sub     rsp, 40h
+  .text:00000001803FBC96                 mov     eax, cs:dword_180685A40
+  .text:00000001803FBC9C                 mov     r15, rcx
+  .text:00000001803FBC9F                 test    eax, eax
+  .text:00000001803FBCA1                 jns     short loc_1803FBCB3
+  .text:00000001803FBCA3                 mov     edx, eax
+  .text:00000001803FBCA5                 lea     rcx, aAppsystemInCon; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:00000001803FBCAC                 call    cs:Plat_FatalError
+  .text:00000001803FBCB2                 ; Trap to Debugger
+  .text:00000001803FBCB2                 int     3; Trap to Debugger
+  .text:00000001803FBCB3                 mov     [rsp+48h+arg_0], rbx
+  .text:00000001803FBCB8                 mov     [rsp+48h+arg_10], rsi
+  .text:00000001803FBCBD                 mov     [rsp+48h+var_10], rdi
+  .text:00000001803FBCC2                 mov     [rsp+48h+var_18], r12
+  .text:00000001803FBCC7                 mov     [rsp+48h+var_20], r13
+  .text:00000001803FBCCC                 mov     [rsp+48h+var_28], r14
+  .text:00000001803FBCD1                 movsxd  r12, edx
+  .text:00000001803FBCD4                 test    eax, eax
+  .text:00000001803FBCD6                 jnz     loc_1803FBD6E
+  .text:00000001803FBCDC                 test    edx, edx
+  .text:00000001803FBCDE                 jle     short loc_1803FBD5C
+  .text:00000001803FBCE0                 mov     [rsp+48h+arg_8], rbp
+  .text:00000001803FBCE5                 lea     r13, g_pInterfaceGlobals
+  .text:00000001803FBCEC                 xor     ebp, ebp
+  .text:00000001803FBCEE                 lea     r14, unk_180685A50
+  .text:00000001803FBCF5                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001803FBD00                 xor     esi, esi
+  .text:00000001803FBD02                 mov     rbx, r13
+  .text:00000001803FBD05                 mov     rdi, [rbx+8]
+  .text:00000001803FBD09                 cmp     qword ptr [rdi], 0
+  .text:00000001803FBD0D                 jnz     short loc_1803FBD44
+  .text:00000001803FBD0F                 mov     rcx, [rbx]
+  .text:00000001803FBD12                 xor     edx, edx
+  .text:00000001803FBD14                 call    qword ptr [r15+rbp*8]
+  .text:00000001803FBD18                 mov     [rdi], rax
+  .text:00000001803FBD1B                 test    rax, rax
+  .text:00000001803FBD1E                 jz      short loc_1803FBD44
+  .text:00000001803FBD20                 movsxd  rax, cs:dword_180685A40
+  .text:00000001803FBD27                 mov     rcx, rax
+  .text:00000001803FBD2A                 add     rcx, rcx
+  .text:00000001803FBD2D                 inc     eax
+  .text:00000001803FBD2F                 mov     cs:dword_180685A40, eax
+  .text:00000001803FBD35                 mov     eax, cs:dword_180685A3C
+  .text:00000001803FBD3B                 mov     [r14+rcx*8+8], eax
+  .text:00000001803FBD40                 mov     [r14+rcx*8], rdi
+  .text:00000001803FBD44                 inc     esi
+  .text:00000001803FBD46                 add     rbx, 10h
+  .text:00000001803FBD4A                 cmp     esi, 70h ; 'p'
+  .text:00000001803FBD4D                 jb      short loc_1803FBD05
+  .text:00000001803FBD4F                 inc     rbp
+  .text:00000001803FBD52                 cmp     rbp, r12
+  .text:00000001803FBD55                 jl      short loc_1803FBD00
+  .text:00000001803FBD57                 mov     rbp, [rsp+48h+arg_8]
+  .text:00000001803FBD5C                 lea     rcx, cs:180000000h
+  .text:00000001803FBD63                 call    cs:Plat_RegisterModule
+  .text:00000001803FBD69                 jmp     loc_1803FBE1B
+  .text:00000001803FBD6E                 test    edx, edx
+  .text:00000001803FBD70                 jle     loc_1803FBE1B
+  .text:00000001803FBD76                 lea     r13, g_pInterfaceGlobals
+  .text:00000001803FBD7D                 lea     r14, unk_180685A50
+  .text:00000001803FBD84                 nop     dword ptr [rax+00h]
+  .text:00000001803FBD88                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001803FBD90                 xor     edi, edi
+  .text:00000001803FBD92                 mov     rsi, r13
+  .text:00000001803FBD95                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001803FBDA0                 mov     rax, [r15]
+  .text:00000001803FBDA3                 xor     edx, edx
+  .text:00000001803FBDA5                 mov     rcx, [rsi]
+  .text:00000001803FBDA8                 mov     rbx, [rsi+8]
+  .text:00000001803FBDAC                 call    rax
+  .text:00000001803FBDAE                 movsxd  r8, cs:dword_180685A40
+  .text:00000001803FBDB5                 xor     dl, dl
+  .text:00000001803FBDB7                 mov     [rbx], rax
+  .text:00000001803FBDBA                 test    r8d, r8d
+  .text:00000001803FBDBD                 jle     short loc_1803FBDDD
+  .text:00000001803FBDBF                 mov     rax, r14
+  .text:00000001803FBDC2                 mov     ecx, r8d
+  .text:00000001803FBDC5                 cmp     [rax], rbx
+  .text:00000001803FBDC8                 jnz     short loc_1803FBDCF
+  .text:00000001803FBDCA                 mov     [rax], rbx
+  .text:00000001803FBDCD                 mov     dl, 1
+  .text:00000001803FBDCF                 add     rax, 10h
+  .text:00000001803FBDD3                 sub     rcx, 1
+  .text:00000001803FBDD7                 jnz     short loc_1803FBDC5
+  .text:00000001803FBDD9                 test    dl, dl
+  .text:00000001803FBDDB                 jnz     short loc_1803FBE02
+  .text:00000001803FBDDD                 cmp     qword ptr [rbx], 0
+  .text:00000001803FBDE1                 jz      short loc_1803FBE02
+  .text:00000001803FBDE3                 mov     eax, cs:dword_180685A3C
+  .text:00000001803FBDE9                 mov     rcx, r8
+  .text:00000001803FBDEC                 add     rcx, rcx
+  .text:00000001803FBDEF                 inc     r8d
+  .text:00000001803FBDF2                 mov     cs:dword_180685A40, r8d
+  .text:00000001803FBDF9                 mov     [r14+rcx*8], rbx
+  .text:00000001803FBDFD                 mov     [r14+rcx*8+8], eax
+  .text:00000001803FBE02                 inc     edi
+  .text:00000001803FBE04                 add     rsi, 10h
+  .text:00000001803FBE08                 cmp     edi, 70h ; 'p'
+  .text:00000001803FBE0B                 jb      short loc_1803FBDA0
+  .text:00000001803FBE0D                 add     r15, 8
+  .text:00000001803FBE11                 sub     r12, 1
+  .text:00000001803FBE15                 jnz     loc_1803FBD90
+  .text:00000001803FBE1B                 inc     cs:dword_180685A3C
+  .text:00000001803FBE21                 mov     r14, [rsp+48h+var_28]
+  .text:00000001803FBE26                 mov     r13, [rsp+48h+var_20]
+  .text:00000001803FBE2B                 mov     r12, [rsp+48h+var_18]
+  .text:00000001803FBE30                 mov     rdi, [rsp+48h+var_10]
+  .text:00000001803FBE35                 mov     rsi, [rsp+48h+arg_10]
+  .text:00000001803FBE3A                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001803FBE3F                 add     rsp, 40h
+  .text:00000001803FBE43                 pop     r15
+  .text:00000001803FBE45                 jmp     sub_1803FBB10
+procedure: |-
+  __int64 __fastcall ConnectInterfaces(__int64 (__fastcall **a1)(char *, _QWORD), int a2)
+  {
+    __int64 v3; // r12
+    __int64 v4; // rbp
+    unsigned int v5; // esi
+    char **v6; // rbx
+    __int64 *v7; // rdi
+    __int64 v8; // rax
+    __int64 v9; // rcx
+    unsigned int v10; // edi
+    char **v11; // rsi
+    __int64 *v12; // rbx
+    __int64 v13; // rax
+    __int64 v14; // r8
+    char v15; // dl
+    __int64 **v16; // rax
+    __int64 v17; // rcx
+    int v18; // eax
+    __int64 v19; // rcx
+
+    if ( dword_180685A40 < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n", dword_180685A40);
+      __debugbreak();
+    }
+    v3 = a2;
+    if ( dword_180685A40 )
+    {
+      if ( a2 > 0 )
+      {
+        do
+        {
+          v10 = 0;
+          v11 = &g_pInterfaceGlobals;
+          do
+          {
+            v12 = (__int64 *)v11[1];
+            v13 = (*a1)(*v11, 0);
+            v14 = dword_180685A40;
+            v15 = 0;
+            *v12 = v13;
+            if ( (int)v14 <= 0 )
+              goto LABEL_28;
+            v16 = (__int64 **)&unk_180685A50;
+            v17 = (unsigned int)v14;
+            do
+            {
+              if ( *v16 == v12 )
+              {
+                *v16 = v12;
+                v15 = 1;
+              }
+              v16 += 2;
+              --v17;
+            }
+            while ( v17 );
+            if ( !v15 )
+            {
+  LABEL_28:
+              if ( *v12 )
+              {
+                v18 = dword_180685A3C;
+                v19 = 2 * v14;
+                dword_180685A40 = v14 + 1;
+                *((_QWORD *)&unk_180685A50 + v19) = v12;
+                *((_DWORD *)&unk_180685A50 + 2 * v19 + 2) = v18;
+              }
+            }
+            ++v10;
+            v11 += 2;
+          }
+          while ( v10 < 112 );                    // NUM_INTERFACES
+          ++a1;
+          --v3;
+        }
+        while ( v3 );
+      }
+    }
+    else
+    {
+      if ( a2 > 0 )
+      {
+        v4 = 0;
+        do
+        {
+          v5 = 0;
+          v6 = &g_pInterfaceGlobals;
+          do
+          {
+            v7 = (__int64 *)v6[1];
+            if ( !*v7 )
+            {
+              v8 = a1[v4](*v6, 0);
+              *v7 = v8;
+              if ( v8 )
+              {
+                v9 = 2LL * dword_180685A40++;
+                *((_DWORD *)&unk_180685A50 + 2 * v9 + 2) = dword_180685A3C;
+                *((_QWORD *)&unk_180685A50 + v9) = v7;
+              }
+            }
+            ++v5;
+            v6 += 2;
+          }
+          while ( v5 < 0x70 );
+          ++v4;
+        }
+        while ( v4 < v3 );
+      }
+      Plat_RegisterModule(0x180000000uLL);
+    }
+    ++dword_180685A3C;
+    return sub_1803FBB10();
+  }

--- a/ida_preprocessor_scripts/references/server/ConnectInterfaces.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/ConnectInterfaces.linux.yaml
@@ -1,0 +1,236 @@
+func_name: ConnectInterfaces
+func_va: '0x1b5fbe0'
+disasm_code: |-
+  .text:0000000001B5FBE0                 push    rbp
+  .text:0000000001B5FBE1                 movsxd  rax, esi
+  .text:0000000001B5FBE4                 mov     rbp, rsp
+  .text:0000000001B5FBE7                 push    r15
+  .text:0000000001B5FBE9                 push    r14
+  .text:0000000001B5FBEB                 push    r13
+  .text:0000000001B5FBED                 push    r12
+  .text:0000000001B5FBEF                 push    rbx
+  .text:0000000001B5FBF0                 sub     rsp, 18h
+  .text:0000000001B5FBF4                 mov     esi, cs:dword_278B9A0
+  .text:0000000001B5FBFA                 test    esi, esi
+  .text:0000000001B5FBFC                 js      loc_1B5FDA7
+  .text:0000000001B5FC02                 mov     r12, rdi
+  .text:0000000001B5FC05                 jz      loc_1B5FCAC
+  .text:0000000001B5FC0B                 test    eax, eax
+  .text:0000000001B5FC0D                 jle     loc_1B5FD3C
+  .text:0000000001B5FC13                 lea     rax, [rdi+rax*8]
+  .text:0000000001B5FC17                 mov     [rbp+var_38], rax
+  .text:0000000001B5FC1B                 lea     rbx, off_24273F0
+  .text:0000000001B5FC22                 lea     r13, unk_278B2A0
+  .text:0000000001B5FC29                 lea     r15, g_pInterfaceGlobals; "VApplication001"
+  .text:0000000001B5FC30                 lea     r14, qword_278BD30
+  .text:0000000001B5FC37                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001B5FC40                 mov     rdi, [r15]
+  .text:0000000001B5FC43                 xor     esi, esi
+  .text:0000000001B5FC45                 call    qword ptr [r12]
+  .text:0000000001B5FC49                 movsxd  rdi, cs:dword_278B9A0
+  .text:0000000001B5FC50                 mov     r10, rax
+  .text:0000000001B5FC53                 mov     [r14], rax
+  .text:0000000001B5FC56                 test    edi, edi
+  .text:0000000001B5FC58                 jle     loc_1B5FD60
+  .text:0000000001B5FC5E                 lea     rax, unk_278B2A0
+  .text:0000000001B5FC65                 movsxd  rsi, edi
+  .text:0000000001B5FC68                 xor     edx, edx
+  .text:0000000001B5FC6A                 shl     rsi, 4
+  .text:0000000001B5FC6E                 add     rsi, rax
+  .text:0000000001B5FC71                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001B5FC7C                 nop     dword ptr [rax+00h]
+  .text:0000000001B5FC80                 cmp     [rax], r14
+  .text:0000000001B5FC83                 setz    cl
+  .text:0000000001B5FC86                 add     rax, 10h
+  .text:0000000001B5FC8A                 or      edx, ecx
+  .text:0000000001B5FC8C                 cmp     rax, rsi
+  .text:0000000001B5FC8F                 jnz     short loc_1B5FC80
+  .text:0000000001B5FC91                 test    dl, dl
+  .text:0000000001B5FC93                 jz      loc_1B5FD60
+  .text:0000000001B5FC99                 add     r15, 10h
+  .text:0000000001B5FC9D                 cmp     r15, rbx
+  .text:0000000001B5FCA0                 jz      loc_1B5FD94
+  .text:0000000001B5FCA6                 mov     r14, [r15+8]
+  .text:0000000001B5FCAA                 jmp     short loc_1B5FC40
+  .text:0000000001B5FCAC                 test    eax, eax
+  .text:0000000001B5FCAE                 jle     loc_1B5FD3C
+  .text:0000000001B5FCB4                 lea     rax, [rdi+rax*8]
+  .text:0000000001B5FCB8                 mov     r13, rdi
+  .text:0000000001B5FCBB                 mov     [rbp+var_38], rax
+  .text:0000000001B5FCBF                 lea     rbx, off_24273F0
+  .text:0000000001B5FCC6                 lea     r14, unk_278B2A0
+  .text:0000000001B5FCCD                 lea     r12, g_pInterfaceGlobals; "VApplication001"
+  .text:0000000001B5FCD4                 jmp     short loc_1B5FCE9
+  .text:0000000001B5FCE0                 add     r12, 10h
+  .text:0000000001B5FCE4                 cmp     rbx, r12
+  .text:0000000001B5FCE7                 jz      short loc_1B5FD32
+  .text:0000000001B5FCE9                 mov     r15, [r12+8]
+  .text:0000000001B5FCEE                 cmp     qword ptr [r15], 0
+  .text:0000000001B5FCF2                 jnz     short loc_1B5FCE0
+  .text:0000000001B5FCF4                 mov     rdi, [r12]
+  .text:0000000001B5FCF8                 xor     esi, esi
+  .text:0000000001B5FCFA                 call    qword ptr [r13+0]
+  .text:0000000001B5FCFE                 mov     [r15], rax
+  .text:0000000001B5FD01                 test    rax, rax
+  .text:0000000001B5FD04                 jz      short loc_1B5FCE0
+  .text:0000000001B5FD06                 movsxd  rax, cs:dword_278B9A0
+  .text:0000000001B5FD0D                 add     r12, 10h
+  .text:0000000001B5FD11                 mov     edx, cs:dword_278B9A4
+  .text:0000000001B5FD17                 lea     ecx, [rax+1]
+  .text:0000000001B5FD1A                 shl     rax, 4
+  .text:0000000001B5FD1E                 add     rax, r14
+  .text:0000000001B5FD21                 mov     cs:dword_278B9A0, ecx
+  .text:0000000001B5FD27                 mov     [rax], r15
+  .text:0000000001B5FD2A                 mov     [rax+8], edx
+  .text:0000000001B5FD2D                 cmp     rbx, r12
+  .text:0000000001B5FD30                 jnz     short loc_1B5FCE9
+  .text:0000000001B5FD32                 add     r13, 8
+  .text:0000000001B5FD36                 cmp     [rbp+var_38], r13
+  .text:0000000001B5FD3A                 jnz     short loc_1B5FCCD
+  .text:0000000001B5FD3C                 add     cs:dword_278B9A4, 1
+  .text:0000000001B5FD43                 add     rsp, 18h
+  .text:0000000001B5FD47                 pop     rbx
+  .text:0000000001B5FD48                 pop     r12
+  .text:0000000001B5FD4A                 pop     r13
+  .text:0000000001B5FD4C                 pop     r14
+  .text:0000000001B5FD4E                 pop     r15
+  .text:0000000001B5FD50                 pop     rbp
+  .text:0000000001B5FD51                 jmp     sub_1B5FAA0
+  .text:0000000001B5FD60                 test    r10, r10
+  .text:0000000001B5FD63                 jz      loc_1B5FC99
+  .text:0000000001B5FD69                 mov     edx, cs:dword_278B9A4
+  .text:0000000001B5FD6F                 lea     eax, [rdi+1]
+  .text:0000000001B5FD72                 shl     rdi, 4
+  .text:0000000001B5FD76                 add     r15, 10h
+  .text:0000000001B5FD7A                 mov     cs:dword_278B9A0, eax
+  .text:0000000001B5FD80                 lea     rax, [r13+rdi+0]
+  .text:0000000001B5FD85                 mov     [rax], r14
+  .text:0000000001B5FD88                 mov     [rax+8], edx
+  .text:0000000001B5FD8B                 cmp     r15, rbx
+  .text:0000000001B5FD8E                 jnz     loc_1B5FCA6
+  .text:0000000001B5FD94                 mov     rax, [rbp+var_38]
+  .text:0000000001B5FD98                 add     r12, 8
+  .text:0000000001B5FD9C                 cmp     r12, rax
+  .text:0000000001B5FD9F                 jnz     loc_1B5FC29
+  .text:0000000001B5FDA5                 jmp     short loc_1B5FD3C
+  .text:0000000001B5FDA7                 lea     rdi, aAppsystemInCon; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:0000000001B5FDAE                 xor     eax, eax
+  .text:0000000001B5FDB0                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall ConnectInterfaces(
+          __int64 (__fastcall **a1)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden this), _QWORD),
+          int a2)
+  {
+    __int64 (__fastcall **v2)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // r12
+    void (__fastcall ***v3)(__cxxabiv1::__class_type_info *__hidden); // r15
+    __int64 *i; // r14
+    __int64 v5; // rax
+    __int64 v6; // rdi
+    __int64 v7; // r10
+    char *v8; // rax
+    char v9; // dl
+    bool v10; // cl
+    __int64 (__fastcall **v11)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // r13
+    void (__fastcall ***v12)(__cxxabiv1::__class_type_info *__hidden); // r12
+    __int64 *v13; // r15
+    __int64 v14; // rax
+    int v15; // edx
+    char *v16; // rax
+    int v18; // edx
+    char *v19; // rax
+    __int64 (__fastcall **v20)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // [rsp+8h] [rbp-38h]
+
+    if ( dword_278B9A0 < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n", dword_278B9A0);
+      JUMPOUT(0x1B5FDB5);
+    }
+    v2 = a1;
+    if ( dword_278B9A0 )
+    {
+      if ( a2 > 0 )
+      {
+        v20 = &a1[a2];
+        do
+        {
+          v3 = (void (__fastcall ***)(__cxxabiv1::__class_type_info *__hidden))&g_pInterfaceGlobals;
+          for ( i = (__int64 *)&qword_278BD30; ; i = (__int64 *)v3[1] )
+          {
+            v5 = (*v2)(*v3, 0);
+            v6 = dword_278B9A0;
+            v7 = v5;
+            *i = v5;
+            if ( (int)v6 <= 0 )
+              goto LABEL_21;
+            v8 = (char *)&unk_278B2A0;
+            v9 = 0;
+            do
+            {
+              v10 = *(_QWORD *)v8 == (_QWORD)i;
+              v8 += 16;
+              v9 |= v10;
+            }
+            while ( v8 != (char *)&unk_278B2A0 + 16 * (int)v6 );
+            if ( !v9 )
+            {
+  LABEL_21:
+              if ( v7 )
+                break;
+            }
+            v3 += 2;
+            if ( v3 == &off_24273F0 )
+              goto LABEL_23;
+  LABEL_11:
+            ;
+          }
+          v18 = dword_278B9A4;
+          v3 += 2;
+          dword_278B9A0 = v6 + 1;
+          v19 = (char *)&unk_278B2A0 + 16 * v6;
+          *(_QWORD *)v19 = i;
+          *((_DWORD *)v19 + 2) = v18;
+          if ( v3 != &off_24273F0 )
+            goto LABEL_11;
+  LABEL_23:
+          ++v2;
+        }
+        while ( v2 != v20 );
+      }
+    }
+    else if ( a2 > 0 )
+    {
+      v11 = a1;
+      do
+      {
+        v12 = (void (__fastcall ***)(__cxxabiv1::__class_type_info *__hidden))&g_pInterfaceGlobals;
+        do
+        {
+          while ( 1 )
+          {
+            v13 = (__int64 *)v12[1];
+            if ( !*v13 )
+            {
+              v14 = (*v11)(*v12, 0);
+              *v13 = v14;
+              if ( v14 )
+                break;
+            }
+            v12 += 2;
+            if ( &off_24273F0 == v12 )
+              goto LABEL_19;
+          }
+          v12 += 2;
+          v15 = dword_278B9A4;
+          v16 = (char *)&unk_278B2A0 + 16 * dword_278B9A0++;
+          *(_QWORD *)v16 = v13;
+          *((_DWORD *)v16 + 2) = v15;
+        }
+        while ( &off_24273F0 != v12 );
+  LABEL_19:
+        ++v11;
+      }
+      while ( &a1[a2] != v11 );
+    }
+    ++dword_278B9A4;
+    return sub_1B5FAA0();
+  }

--- a/ida_preprocessor_scripts/references/server/ConnectInterfaces.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/ConnectInterfaces.windows.yaml
@@ -1,0 +1,231 @@
+func_name: ConnectInterfaces
+func_va: '0x1814f6b00'
+disasm_code: |-
+  .text:00000001814F6B00                 push    r15
+  .text:00000001814F6B02                 sub     rsp, 40h
+  .text:00000001814F6B06                 mov     eax, cs:dword_182156570
+  .text:00000001814F6B0C                 mov     r15, rcx
+  .text:00000001814F6B0F                 test    eax, eax
+  .text:00000001814F6B11                 jns     short loc_1814F6B23
+  .text:00000001814F6B13                 mov     edx, eax
+  .text:00000001814F6B15                 lea     rcx, aAppsystemInCon_1; "APPSYSTEM: In ConnectInterfaces(), s_nR"...
+  .text:00000001814F6B1C                 call    cs:Plat_FatalError
+  .text:00000001814F6B22                 ; Trap to Debugger
+  .text:00000001814F6B22                 int     3; Trap to Debugger
+  .text:00000001814F6B23                 mov     [rsp+48h+arg_0], rbx
+  .text:00000001814F6B28                 mov     [rsp+48h+arg_10], rsi
+  .text:00000001814F6B2D                 mov     [rsp+48h+var_10], rdi
+  .text:00000001814F6B32                 mov     [rsp+48h+var_18], r12
+  .text:00000001814F6B37                 mov     [rsp+48h+var_20], r13
+  .text:00000001814F6B3C                 mov     [rsp+48h+var_28], r14
+  .text:00000001814F6B41                 movsxd  r12, edx
+  .text:00000001814F6B44                 test    eax, eax
+  .text:00000001814F6B46                 jnz     loc_1814F6BDE
+  .text:00000001814F6B4C                 test    edx, edx
+  .text:00000001814F6B4E                 jle     short loc_1814F6BCC
+  .text:00000001814F6B50                 mov     [rsp+48h+arg_8], rbp
+  .text:00000001814F6B55                 lea     r13, g_pInterfaceGlobals
+  .text:00000001814F6B5C                 xor     ebp, ebp
+  .text:00000001814F6B5E                 lea     r14, unk_182156580
+  .text:00000001814F6B65                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001814F6B70                 xor     esi, esi
+  .text:00000001814F6B72                 mov     rbx, r13
+  .text:00000001814F6B75                 mov     rdi, [rbx+8]
+  .text:00000001814F6B79                 cmp     qword ptr [rdi], 0
+  .text:00000001814F6B7D                 jnz     short loc_1814F6BB4
+  .text:00000001814F6B7F                 mov     rcx, [rbx]
+  .text:00000001814F6B82                 xor     edx, edx
+  .text:00000001814F6B84                 call    qword ptr [r15+rbp*8]
+  .text:00000001814F6B88                 mov     [rdi], rax
+  .text:00000001814F6B8B                 test    rax, rax
+  .text:00000001814F6B8E                 jz      short loc_1814F6BB4
+  .text:00000001814F6B90                 movsxd  rax, cs:dword_182156570
+  .text:00000001814F6B97                 mov     rcx, rax
+  .text:00000001814F6B9A                 add     rcx, rcx
+  .text:00000001814F6B9D                 inc     eax
+  .text:00000001814F6B9F                 mov     cs:dword_182156570, eax
+  .text:00000001814F6BA5                 mov     eax, cs:dword_18215656C
+  .text:00000001814F6BAB                 mov     [r14+rcx*8+8], eax
+  .text:00000001814F6BB0                 mov     [r14+rcx*8], rdi
+  .text:00000001814F6BB4                 inc     esi
+  .text:00000001814F6BB6                 add     rbx, 10h
+  .text:00000001814F6BBA                 cmp     esi, 70h ; 'p'
+  .text:00000001814F6BBD                 jb      short loc_1814F6B75
+  .text:00000001814F6BBF                 inc     rbp
+  .text:00000001814F6BC2                 cmp     rbp, r12
+  .text:00000001814F6BC5                 jl      short loc_1814F6B70
+  .text:00000001814F6BC7                 mov     rbp, [rsp+48h+arg_8]
+  .text:00000001814F6BCC                 lea     rcx, cs:180000000h
+  .text:00000001814F6BD3                 call    cs:Plat_RegisterModule
+  .text:00000001814F6BD9                 jmp     loc_1814F6C8B
+  .text:00000001814F6BDE                 test    edx, edx
+  .text:00000001814F6BE0                 jle     loc_1814F6C8B
+  .text:00000001814F6BE6                 lea     r13, g_pInterfaceGlobals
+  .text:00000001814F6BED                 lea     r14, unk_182156580
+  .text:00000001814F6BF4                 nop     dword ptr [rax+00h]
+  .text:00000001814F6BF8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001814F6C00                 xor     edi, edi
+  .text:00000001814F6C02                 mov     rsi, r13
+  .text:00000001814F6C05                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001814F6C10                 mov     rax, [r15]
+  .text:00000001814F6C13                 xor     edx, edx
+  .text:00000001814F6C15                 mov     rcx, [rsi]
+  .text:00000001814F6C18                 mov     rbx, [rsi+8]
+  .text:00000001814F6C1C                 call    rax
+  .text:00000001814F6C1E                 movsxd  r8, cs:dword_182156570
+  .text:00000001814F6C25                 xor     dl, dl
+  .text:00000001814F6C27                 mov     [rbx], rax
+  .text:00000001814F6C2A                 test    r8d, r8d
+  .text:00000001814F6C2D                 jle     short loc_1814F6C4D
+  .text:00000001814F6C2F                 mov     rax, r14
+  .text:00000001814F6C32                 mov     ecx, r8d
+  .text:00000001814F6C35                 cmp     [rax], rbx
+  .text:00000001814F6C38                 jnz     short loc_1814F6C3F
+  .text:00000001814F6C3A                 mov     [rax], rbx
+  .text:00000001814F6C3D                 mov     dl, 1
+  .text:00000001814F6C3F                 add     rax, 10h
+  .text:00000001814F6C43                 sub     rcx, 1
+  .text:00000001814F6C47                 jnz     short loc_1814F6C35
+  .text:00000001814F6C49                 test    dl, dl
+  .text:00000001814F6C4B                 jnz     short loc_1814F6C72
+  .text:00000001814F6C4D                 cmp     qword ptr [rbx], 0
+  .text:00000001814F6C51                 jz      short loc_1814F6C72
+  .text:00000001814F6C53                 mov     eax, cs:dword_18215656C
+  .text:00000001814F6C59                 mov     rcx, r8
+  .text:00000001814F6C5C                 add     rcx, rcx
+  .text:00000001814F6C5F                 inc     r8d
+  .text:00000001814F6C62                 mov     cs:dword_182156570, r8d
+  .text:00000001814F6C69                 mov     [r14+rcx*8], rbx
+  .text:00000001814F6C6D                 mov     [r14+rcx*8+8], eax
+  .text:00000001814F6C72                 inc     edi
+  .text:00000001814F6C74                 add     rsi, 10h
+  .text:00000001814F6C78                 cmp     edi, 70h ; 'p'
+  .text:00000001814F6C7B                 jb      short loc_1814F6C10
+  .text:00000001814F6C7D                 add     r15, 8
+  .text:00000001814F6C81                 sub     r12, 1
+  .text:00000001814F6C85                 jnz     loc_1814F6C00
+  .text:00000001814F6C8B                 inc     cs:dword_18215656C
+  .text:00000001814F6C91                 mov     r14, [rsp+48h+var_28]
+  .text:00000001814F6C96                 mov     r13, [rsp+48h+var_20]
+  .text:00000001814F6C9B                 mov     r12, [rsp+48h+var_18]
+  .text:00000001814F6CA0                 mov     rdi, [rsp+48h+var_10]
+  .text:00000001814F6CA5                 mov     rsi, [rsp+48h+arg_10]
+  .text:00000001814F6CAA                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001814F6CAF                 add     rsp, 40h
+  .text:00000001814F6CB3                 pop     r15
+  .text:00000001814F6CB5                 jmp     sub_1814F6980
+procedure: |-
+  __int64 __fastcall sub_1814F6B00(__int64 (__fastcall **a1)(char *, _QWORD), int a2)
+  {
+    __int64 v3; // r12
+    __int64 v4; // rbp
+    unsigned int v5; // esi
+    char **v6; // rbx
+    __int64 *v7; // rdi
+    __int64 v8; // rax
+    __int64 v9; // rcx
+    unsigned int v10; // edi
+    char **v11; // rsi
+    __int64 *v12; // rbx
+    __int64 v13; // rax
+    __int64 v14; // r8
+    char v15; // dl
+    __int64 **v16; // rax
+    __int64 v17; // rcx
+    int v18; // eax
+    __int64 v19; // rcx
+
+    if ( dword_182156570 < 0 )
+    {
+      Plat_FatalError("APPSYSTEM: In ConnectInterfaces(), s_nRegistrationCount is %d!\n", dword_182156570);
+      __debugbreak();
+    }
+    v3 = a2;
+    if ( dword_182156570 )
+    {
+      if ( a2 > 0 )
+      {
+        do
+        {
+          v10 = 0;
+          v11 = &g_pInterfaceGlobals;
+          do
+          {
+            v12 = (__int64 *)v11[1];
+            v13 = (*a1)(*v11, 0);
+            v14 = dword_182156570;
+            v15 = 0;
+            *v12 = v13;
+            if ( (int)v14 <= 0 )
+              goto LABEL_28;
+            v16 = (__int64 **)&unk_182156580;
+            v17 = (unsigned int)v14;
+            do
+            {
+              if ( *v16 == v12 )
+              {
+                *v16 = v12;
+                v15 = 1;
+              }
+              v16 += 2;
+              --v17;
+            }
+            while ( v17 );
+            if ( !v15 )
+            {
+  LABEL_28:
+              if ( *v12 )
+              {
+                v18 = dword_18215656C;
+                v19 = 2 * v14;
+                dword_182156570 = v14 + 1;
+                *((_QWORD *)&unk_182156580 + v19) = v12;
+                *((_DWORD *)&unk_182156580 + 2 * v19 + 2) = v18;
+              }
+            }
+            ++v10;
+            v11 += 2;
+          }
+          while ( v10 < 0x70 );
+          ++a1;
+          --v3;
+        }
+        while ( v3 );
+      }
+    }
+    else
+    {
+      if ( a2 > 0 )
+      {
+        v4 = 0;
+        do
+        {
+          v5 = 0;
+          v6 = &g_pInterfaceGlobals;
+          do
+          {
+            v7 = (__int64 *)v6[1];
+            if ( !*v7 )
+            {
+              v8 = a1[v4](*v6, 0);
+              *v7 = v8;
+              if ( v8 )
+              {
+                v9 = 2LL * dword_182156570++;
+                *((_DWORD *)&unk_182156580 + 2 * v9 + 2) = dword_18215656C;
+                *((_QWORD *)&unk_182156580 + v9) = v7;
+              }
+            }
+            ++v5;
+            v6 += 2;
+          }
+          while ( v5 < 0x70 );
+          ++v4;
+        }
+        while ( v4 < v3 );
+      }
+      Plat_RegisterModule(0x180000000uLL);
+    }
+    ++dword_18215656C;
+    return sub_1814F6980();
+  }

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -230,6 +230,34 @@ class TestResolveArtifactPathIntegration(unittest.TestCase):
             ]
         )
 
+    def test_expand_skill_output_paths_includes_platform_expected_outputs(self) -> None:
+        binary_dir = str(Path("/tmp/bin/14141/engine"))
+        skill = {
+            "expected_output": ["Common.{platform}.yaml"],
+            "expected_output_windows": ["WindowsOnly.{platform}.yaml"],
+            "expected_output_linux": ["LinuxOnly.{platform}.yaml"],
+            "optional_output": ["Optional.{platform}.yaml"],
+        }
+
+        required, optional, preprocess = ida_analyze_bin.expand_skill_output_paths(
+            binary_dir,
+            skill,
+            "windows",
+        )
+
+        self.assertEqual(
+            [
+                str(Path("/tmp/bin/14141/engine/Common.windows.yaml").resolve()),
+                str(Path("/tmp/bin/14141/engine/WindowsOnly.windows.yaml").resolve()),
+            ],
+            required,
+        )
+        self.assertEqual(
+            [str(Path("/tmp/bin/14141/engine/Optional.windows.yaml").resolve())],
+            optional,
+        )
+        self.assertEqual(required + optional, preprocess)
+
 
 class TestParseConfig(unittest.TestCase):
     def test_parse_config_reads_skip_if_exists(self) -> None:
@@ -315,6 +343,41 @@ modules:
             modules[0]["skills"][0]["optional_output"],
         )
 
+    def test_parse_config_reads_platform_expected_outputs(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "config.yaml"
+            config_path.write_text(
+                """
+modules:
+  - name: engine
+    path_windows: game/bin/win64/engine2.dll
+    path_linux: game/bin/linuxsteamrt64/libengine2.so
+    skills:
+      - name: find-g_pInterfaceGlobals_ppGlobal
+        expected_output:
+          - Common.{platform}.yaml
+        expected_output_windows:
+          - WindowsOnly.{platform}.yaml
+        expected_output_linux:
+          - LinuxOnly.{platform}.yaml
+""".strip()
+                + "\n",
+                encoding="utf-8",
+            )
+
+            modules = ida_analyze_bin.parse_config(str(config_path))
+
+        skill = modules[0]["skills"][0]
+        self.assertEqual(["Common.{platform}.yaml"], skill["expected_output"])
+        self.assertEqual(
+            ["WindowsOnly.{platform}.yaml"],
+            skill["expected_output_windows"],
+        )
+        self.assertEqual(
+            ["LinuxOnly.{platform}.yaml"],
+            skill["expected_output_linux"],
+        )
+
     def test_parse_config_defaults_optional_output_to_empty_list(self) -> None:
         with TemporaryDirectory() as temp_dir:
             config_path = Path(temp_dir) / "config.yaml"
@@ -336,6 +399,8 @@ modules:
             modules = ida_analyze_bin.parse_config(str(config_path))
 
         self.assertEqual([], modules[0]["skills"][0]["optional_output"])
+        self.assertEqual([], modules[0]["skills"][0]["expected_output_windows"])
+        self.assertEqual([], modules[0]["skills"][0]["expected_output_linux"])
 
 
 class TestSkillOrdering(unittest.TestCase):

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -87,6 +87,9 @@ ON_EVENT_MAP_CALLBACKS_CLIENT_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CLoopModeGame_OnEventMapCallbacks-client.py"
 )
+INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py"
+)
 
 class _FakeStreamableHttpClient:
     async def __aenter__(self):
@@ -2778,6 +2781,202 @@ class TestFindCEngineServiceMgrDeactivateLoop(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertFalse(result)
+
+
+class TestFindGInterfaceGlobalsPpGlobal(unittest.IsolatedAsyncioTestCase):
+    def _build_entries(self, module, platform="windows"):
+        return [
+            {
+                "index": index,
+                "entry_va": hex(0x180400000 + index * 0x10),
+                "interface_name": interface_name,
+                "interface_name_va": hex(0x180500000 + index * 0x20),
+                "pp_global_va": hex(0x180600000 + index * 0x8),
+            }
+            for index, (interface_name, _) in enumerate(
+                module._expected_entries_for_platform(platform)
+            )
+        ]
+
+    async def _run_with_entries(
+        self,
+        module,
+        actual_entries,
+        drop_last_output=False,
+        platform="windows",
+    ):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = Path(temp_dir) / f"g_pInterfaceGlobals.{platform}.yaml"
+            input_path.write_text(
+                "gv_name: g_pInterfaceGlobals\n"
+                "gv_va: '0x1804cd5c0'\n"
+                "gv_rva: '0x4cd5c0'\n",
+                encoding="utf-8",
+            )
+            expected_outputs = [
+                str(Path(temp_dir) / f"{gv_name}.{platform}.yaml")
+                for gv_name in module._expected_gv_names_for_platform(platform)
+            ]
+            if drop_last_output:
+                expected_outputs = expected_outputs[:-1]
+
+            session = AsyncMock()
+            session.call_tool.side_effect = [
+                _py_eval_payload(actual_entries),
+                _py_eval_payload({"renamed": True}),
+            ]
+
+            with patch.object(module, "write_gv_yaml") as mock_write:
+                result = await module.preprocess_skill(
+                    session=session,
+                    skill_name="find-g_pInterfaceGlobals_ppGlobal",
+                    expected_outputs=expected_outputs,
+                    old_yaml_map={},
+                    new_binary_dir=temp_dir,
+                    platform=platform,
+                    image_base=0x180000000,
+                    debug=True,
+                )
+
+        return result, mock_write
+
+    async def test_preprocess_skill_writes_minimal_gv_yaml_from_interface_names(
+        self,
+    ) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal",
+        )
+        actual_entries = self._build_entries(module)
+
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+
+        self.assertTrue(result)
+        self.assertEqual(len(module.WINDOWS_EXPECTED_ENTRIES), mock_write.call_count)
+        first_path, first_payload = mock_write.call_args_list[0].args
+        self.assertTrue(first_path.endswith("g_pVApplication.windows.yaml"))
+        self.assertEqual(
+            {
+                "gv_name": "g_pVApplication",
+                "gv_va": "0x180600000",
+                "gv_rva": "0x600000",
+            },
+            first_payload,
+        )
+
+    async def test_preprocess_skill_excludes_nav_globals_on_linux(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_linux",
+        )
+        actual_entries = self._build_entries(module, platform="linux")
+
+        result, mock_write = await self._run_with_entries(
+            module,
+            actual_entries,
+            platform="linux",
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(len(module.LINUX_EXPECTED_ENTRIES), mock_write.call_count)
+        written_paths = [call_args.args[0] for call_args in mock_write.call_args_list]
+        self.assertFalse(
+            any(path.endswith("g_pNavGameTest.linux.yaml") for path in written_paths)
+        )
+        self.assertFalse(
+            any(path.endswith("g_pNavSystem.linux.yaml") for path in written_paths)
+        )
+        self.assertEqual(
+            ("Vrad3_001", "g_pRAD3"),
+            module.LINUX_EXPECTED_ENTRIES[-1],
+        )
+
+    async def test_preprocess_skill_fails_on_missing_entry(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_missing",
+        )
+        actual_entries = self._build_entries(module)[:-1]
+
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+
+        self.assertFalse(result)
+        mock_write.assert_not_called()
+
+    async def test_preprocess_skill_allows_trailing_extra_entries(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_extra",
+        )
+        actual_entries = self._build_entries(module)
+        actual_entries.append(
+            {
+                "index": len(actual_entries),
+                "entry_va": hex(0x180400000 + len(actual_entries) * 0x10),
+                "interface_name": "ExtraInterface001",
+                "interface_name_va": "0x180700000",
+                "pp_global_va": "0x180710000",
+            }
+        )
+
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+
+        self.assertTrue(result)
+        self.assertEqual(len(module.WINDOWS_EXPECTED_ENTRIES), mock_write.call_count)
+        written_paths = [call_args.args[0] for call_args in mock_write.call_args_list]
+        self.assertFalse(any("ExtraInterface001" in path for path in written_paths))
+
+    async def test_preprocess_skill_allows_entries_out_of_order(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_out_of_order",
+        )
+        actual_entries = self._build_entries(module)
+        actual_entries[-2], actual_entries[-1] = (
+            actual_entries[-1],
+            actual_entries[-2],
+        )
+
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+
+        self.assertTrue(result)
+        payloads = {
+            call_args.args[1]["gv_name"]: call_args.args[1]
+            for call_args in mock_write.call_args_list
+        }
+        self.assertEqual("0x180600370", payloads["g_pNavSystem"]["gv_va"])
+        self.assertEqual("0x180600378", payloads["g_pNavGameTest"]["gv_va"])
+
+    async def test_preprocess_skill_fails_on_interface_name_mismatch(self) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_mismatch",
+        )
+        actual_entries = self._build_entries(module)
+        actual_entries[1]["interface_name"] = "WrongInterface001"
+
+        result, mock_write = await self._run_with_entries(module, actual_entries)
+
+        self.assertFalse(result)
+        mock_write.assert_not_called()
+
+    async def test_preprocess_skill_fails_when_expected_output_is_missing(
+        self,
+    ) -> None:
+        module = _load_module(
+            INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH,
+            "find_g_pInterfaceGlobals_ppGlobal_missing_output",
+        )
+        actual_entries = self._build_entries(module)
+
+        result, mock_write = await self._run_with_entries(
+            module,
+            actual_entries,
+            drop_last_output=True,
+        )
+
+        self.assertFalse(result)
+        mock_write.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_update_gamedata.py
+++ b/tests/test_update_gamedata.py
@@ -1,0 +1,61 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import update_gamedata
+
+
+class TestLoadAllYamlData(unittest.TestCase):
+    def test_load_all_yaml_data_skips_symbol_on_non_matching_platform(self) -> None:
+        config = {
+            "modules": [
+                {
+                    "name": "engine",
+                    "symbols": [
+                        {"name": "CommonGlobal", "category": "gv"},
+                        {
+                            "name": "WindowsOnlyGlobal",
+                            "category": "gv",
+                            "platform": "windows",
+                        },
+                    ],
+                }
+            ]
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            engine_dir = Path(temp_dir) / "14141" / "engine"
+            engine_dir.mkdir(parents=True)
+            (engine_dir / "CommonGlobal.windows.yaml").write_text(
+                "gv_name: CommonGlobal\ngv_va: '0x180100000'\n",
+                encoding="utf-8",
+            )
+            (engine_dir / "CommonGlobal.linux.yaml").write_text(
+                "gv_name: CommonGlobal\ngv_va: '0x100000'\n",
+                encoding="utf-8",
+            )
+            (engine_dir / "WindowsOnlyGlobal.windows.yaml").write_text(
+                "gv_name: WindowsOnlyGlobal\ngv_va: '0x180200000'\n",
+                encoding="utf-8",
+            )
+
+            yaml_data, missing_symbols = update_gamedata.load_all_yaml_data(
+                config,
+                temp_dir,
+                "14141",
+                ["windows", "linux"],
+                debug=True,
+            )
+
+        self.assertIn("windows", yaml_data["WindowsOnlyGlobal"])
+        self.assertNotIn("linux", yaml_data["WindowsOnlyGlobal"])
+        self.assertFalse(
+            any(
+                item["name"] == "WindowsOnlyGlobal" and item["platform"] == "linux"
+                for item in missing_symbols
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/update_gamedata.py
+++ b/update_gamedata.py
@@ -370,6 +370,14 @@ def load_all_yaml_data(config, bin_dir, gamever, platforms, debug=False):
             if not func_name:
                 continue
 
+            symbol_platform = symbol.get("platform")
+            if symbol_platform:
+                target_platforms = [p for p in platforms if p == symbol_platform]
+                if not target_platforms:
+                    continue
+            else:
+                target_platforms = platforms
+
             category = symbol.get("category")
             aliases = symbol.get("alias", [])
             if isinstance(aliases, str):
@@ -396,7 +404,7 @@ def load_all_yaml_data(config, bin_dir, gamever, platforms, debug=False):
                     print(f"  Warning: structmember {func_name} missing struct or member field")
                     continue
 
-                for platform in platforms:
+                for platform in target_platforms:
                     member_yaml_path = os.path.join(
                         bin_dir, gamever, module_name, f"{func_name}.{platform}.yaml"
                     )
@@ -448,7 +456,7 @@ def load_all_yaml_data(config, bin_dir, gamever, platforms, debug=False):
                         print(f"  Warning: Struct member YAML not found: {member_yaml_path}")
             else:
                 # Original logic for func/vfunc/struct types, with patch alias fallback.
-                for platform in platforms:
+                for platform in target_platforms:
                     candidate_names = [func_name]
                     if category == "patch":
                         candidate_names.extend(aliases)


### PR DESCRIPTION
## Summary
- Add preprocessor scripts for `CNetworkClientService_*`, `CNetworkGameClientBase_*`, `CNetworkGameClient_*` family (Init/Shutdown, Connect/DisconnectGame, ChangeLevel, SendStringCmd/ServerCmd/SendNetMessage, IsActive/IsConnected, PrintConnectionStatus/PrintSpawnGroupStatus, OnStatus, GetDisconnectReason, ClockDrift_AdjustFrameTime, ReceivedServerInfo, SplitScreenConnect, AddClientPrerequisites/AllocateRemoteConnectionClient).
- Add `ConnectInterfaces` / `IAppSystem_Connect` / `g_pInterfaceGlobals` discovery plus the new `g_pInterfaceGlobals_ppGlobal` preprocessor, along with `CNetSupportImpl` and `CGameClientConnectPrerequisite` vtable/ctor finders.
- Misc: `CUserMessage_ExtraUserData_vtable`, `SendViolationReport-windows`, IVEngineClient2/INetworkClient(Service) finder; rename `ProcessGameSessionManifest` → `ReceivedServerInfo`; expose `func_va/rva/size` on IsActive/IsConnected outputs; bump `hl2sdk_cs2`.

## Test plan
- [x] `uv run ida_analyze_bin.py -debug`
- [x] Verify generated `config.yaml` entries resolve on client/server/engine binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)