### PR TITLE
Add 4 new targets to CEntitySystem_PrecacheEntity decompile script + optional-field support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4621,12 +4621,16 @@ modules:
         expected_output:
           - CEntitySystem_PrecacheEntity.{platform}.yaml
 
-      - name: find-CEntitySystem_DestroyEntity-AND-CEntitySystem_DoAllocateEntity-AND-CEntitySystem_ConstructEntity-AND-CEntitySystem_GetSpawnGroupWorldId
+      - name: find-CEntitySystem_PrecacheEntity-decompiles
         expected_output:
           - CEntitySystem_DestroyEntity.{platform}.yaml
-          - CEntitySystem_DoAllocateEntity.{platform}.yaml
+          - CConcreteEntityList_AllocEntity.{platform}.yaml
           - CEntitySystem_ConstructEntity.{platform}.yaml
           - CEntitySystem_GetSpawnGroupWorldId.{platform}.yaml
+          - CEntitySystem_FindClassByDesignName.{platform}.yaml
+          - CEntitySystem_m_EntityList.{platform}.yaml
+          - CEntityIdentity_FreeAttributes.{platform}.yaml
+          - CConcreteEntityList_FreeEntity.{platform}.yaml
         expected_input:
           - CEntitySystem_PrecacheEntity.{platform}.yaml
           - CEntitySystem_vtable.{platform}.yaml
@@ -7295,10 +7299,10 @@ modules:
         alias:
           - CEntitySystem::DestroyEntity
 
-      - name: CEntitySystem_DoAllocateEntity
+      - name: CConcreteEntityList_AllocEntity
         category: func
         alias:
-          - CEntitySystem::DoAllocateEntity
+          - CConcreteEntityList::AllocEntity
 
       - name: CEntitySystem_ConstructEntity
         category: func
@@ -7314,6 +7318,31 @@ modules:
         category: vfunc
         alias:
           - CEntitySystem::GetSpawnGroupWorldId
+
+      - name: CEntitySystem_FindClassByDesignName
+        category: func
+        alias:
+          - CEntitySystem::FindClassByDesignName
+
+      - name: CEntitySystem
+        category: struct
+
+      - name: CEntitySystem_m_EntityList
+        category: structmember
+        struct: CEntitySystem
+        member: m_EntityList
+        alias:
+          - CEntitySystem::m_EntityList
+
+      - name: CEntityIdentity_FreeAttributes
+        category: func
+        alias:
+          - CEntityIdentity::FreeAttributes
+
+      - name: CConcreteEntityList_FreeEntity
+        category: func
+        alias:
+          - CConcreteEntityList::FreeEntity
 
       - name: UTIL_CreateEntityByName
         category: func

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -458,6 +458,7 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
 
         desired_output_fields = []
         generation_options = {}
+        optional_fields = set()
 
         def _handle_true_directive(field_name, directive_name):
             if field_name == directive_name:
@@ -497,6 +498,13 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
                 if debug:
                     print(f"    Preprocess: invalid desired field list for {symbol_name}")
                 return None
+
+            # Optional-field marker: trailing "?" means the field is allowed to be
+            # missing from the candidate data (e.g. structmember `size?` when the
+            # access site is a `lea` with no natural operand size).
+            if field_name.endswith("?") and len(field_name) > 1:
+                field_name = field_name[:-1]
+                optional_fields.add(field_name)
 
             if field_name == "vfunc_sig_max_match":
                 if debug:
@@ -561,6 +569,7 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
         normalized[symbol_name] = {
             "desired_output_fields": desired_output_fields,
             "generation_options": generation_options,
+            "optional_fields": optional_fields,
         }
 
     return normalized
@@ -796,10 +805,18 @@ def _assemble_symbol_payload(symbol_name, target_kind, candidate_data, desired_f
             print(f"    Preprocess: missing desired-fields entry for {symbol_name}")
         return None
     desired_fields = desired_field_spec["desired_output_fields"]
+    optional_fields = desired_field_spec.get("optional_fields") or set()
 
     payload = {}
     for field_name in desired_fields:
         if field_name not in candidate_data:
+            if field_name in optional_fields:
+                if debug:
+                    print(
+                        f"    Preprocess: skipping missing optional field "
+                        f"{field_name} for {symbol_name}"
+                    )
+                continue
             if debug:
                 print(
                     f"    Preprocess: missing desired field {field_name} "

--- a/ida_preprocessor_scripts/find-CEntitySystem_PrecacheEntity-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_PrecacheEntity-decompiles.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CEntitySystem_DestroyEntity-AND-CEntitySystem_DoAllocateEntity-AND-CEntitySystem_ConstructEntity-AND-CEntitySystem_GetSpawnGroupWorldId skill."""
+"""Preprocess script for find-CEntitySystem_PrecacheEntity-decompiles skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "CEntitySystem_DestroyEntity",
-    "CEntitySystem_DoAllocateEntity",
+    "CConcreteEntityList_AllocEntity",
     "CEntitySystem_ConstructEntity",
     "CEntitySystem_GetSpawnGroupWorldId",
+    "CEntitySystem_FindClassByDesignName",
+    "CEntityIdentity_FreeAttributes",
+    "CConcreteEntityList_FreeEntity",
+]
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_EntityList",
 ]
 
 LLM_DECOMPILE = [
@@ -18,7 +25,7 @@ LLM_DECOMPILE = [
         "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
     ),
     (
-        "CEntitySystem_DoAllocateEntity",
+        "CConcreteEntityList_AllocEntity",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
     ),
@@ -29,6 +36,26 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_GetSpawnGroupWorldId",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_FindClassByDesignName",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_EntityList",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
+    ),
+    (
+        "CEntityIdentity_FreeAttributes",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
+    ),
+    (
+        "CConcreteEntityList_FreeEntity",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
     ),
@@ -52,7 +79,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CEntitySystem_DoAllocateEntity",
+        "CConcreteEntityList_AllocEntity",
         [
             "func_name",
             "func_sig",
@@ -84,13 +111,55 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vtable_name",
         ],
     ),
+    (
+        "CEntitySystem_FindClassByDesignName",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CEntitySystem_m_EntityList",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size?",  # lea-based access has no natural operand size
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "CEntityIdentity_FreeAttributes",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CConcreteEntityList_FreeEntity",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever func_sig/vfunc_sig to locate target function(s) and write YAML."""
+    """Reuse previous gamever func_sig/vfunc_sig/offset_sig to locate targets and write YAMLs."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -99,6 +168,7 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
         llm_decompile_specs=LLM_DECOMPILE,
         llm_config=llm_config,

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_CreateEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_CreateEntity.linux.yaml
@@ -54,7 +54,7 @@ disasm_code: |-
   .text:0000000001E688AE                 mov     edx, [rbp+var_34]
   .text:0000000001E688B1                 and     r9d, 1
   .text:0000000001E688B5                 mov     [rbp+var_44], r10d
-  .text:0000000001E688B9                 call    CEntitySystem_DoAllocateEntity
+  .text:0000000001E688B9                 call    CConcreteEntityList_AllocEntity
   .text:0000000001E688BE                 mov     r12, rax
   .text:0000000001E688C1                 test    rax, rax
   .text:0000000001E688C4                 jz      loc_1E6899B
@@ -312,7 +312,7 @@ procedure: |-
     if ( !*(_QWORD *)(a3 + 224) )
       return 0;
   LABEL_11:
-    EntityIdentity = CEntitySystem_DoAllocateEntity((__int64)a1, v14, v24, a7, a8, (*(_DWORD *)(a3 + 104) & 0x40) != 0);
+    EntityIdentity = CConcreteEntityList_AllocEntity((__int64)a1, v14, v24, a7, a8, (*(_DWORD *)(a3 + 104) & 0x40) != 0);
     v16 = (unsigned __int64)EntityIdentity;
     if ( !EntityIdentity )
       return 0;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.linux.yaml
@@ -1,168 +1,170 @@
 func_name: CEntitySystem_PrecacheEntity
-func_va: '0x1e68d20'
+func_va: '0x1eacd20'
 disasm_code: |-
-  .text:0000000001E68D20                 push    rbp
-  .text:0000000001E68D21                 lea     rax, aClassname; "classname"
-  .text:0000000001E68D28                 mov     rbp, rsp
-  .text:0000000001E68D2B                 push    r15
-  .text:0000000001E68D2D                 lea     r15, [rbp+var_40]
-  .text:0000000001E68D31                 push    r14
-  .text:0000000001E68D33                 mov     r14, rsi
-  .text:0000000001E68D36                 push    r13
-  .text:0000000001E68D38                 mov     rsi, r15
-  .text:0000000001E68D3B                 push    r12
-  .text:0000000001E68D3D                 mov     r12d, edx
-  .text:0000000001E68D40                 xor     edx, edx
-  .text:0000000001E68D42                 push    rbx
-  .text:0000000001E68D43                 mov     rbx, rdi
-  .text:0000000001E68D46                 mov     rdi, r14
-  .text:0000000001E68D49                 sub     rsp, 28h
-  .text:0000000001E68D4D                 mov     [rbp+var_40], 0FFFFFFFFC61B1C62h
-  .text:0000000001E68D55                 mov     [rbp+var_38], rax
-  .text:0000000001E68D59                 call    sub_1E4DC00
-  .text:0000000001E68D5E                 test    rax, rax
-  .text:0000000001E68D61                 jz      short loc_1E68D74
-  .text:0000000001E68D63                 mov     rdi, rax
-  .text:0000000001E68D66                 movzx   eax, word ptr [rax]
-  .text:0000000001E68D69                 shr     ax, 2
-  .text:0000000001E68D6D                 and     eax, 0Fh
-  .text:0000000001E68D70                 cmp     al, 6
-  .text:0000000001E68D72                 jz      short loc_1E68DA8
-  .text:0000000001E68D74                 lea     rbx, g_pLoggingChannelEntitySystem
-  .text:0000000001E68D7B                 ; _QWORD
-  .text:0000000001E68D7B                 mov     esi, 3; _QWORD
-  .text:0000000001E68D80                 ; _QWORD
-  .text:0000000001E68D80                 mov     edi, [rbx]; _QWORD
-  .text:0000000001E68D82                 call    _LoggingSystem_IsChannelEnabled
-  .text:0000000001E68D87                 test    al, al
-  .text:0000000001E68D89                 jnz     loc_1E68F00
-  .text:0000000001E68D8F                 xor     r12d, r12d
-  .text:0000000001E68D92                 add     rsp, 28h
-  .text:0000000001E68D96                 mov     rax, r12
-  .text:0000000001E68D99                 pop     rbx
-  .text:0000000001E68D9A                 pop     r12
-  .text:0000000001E68D9C                 pop     r13
-  .text:0000000001E68D9E                 pop     r14
-  .text:0000000001E68DA0                 pop     r15
-  .text:0000000001E68DA2                 pop     rbp
-  .text:0000000001E68DA3                 retn
-  .text:0000000001E68DA8                 lea     rsi, haystack
-  .text:0000000001E68DAF                 call    sub_1B086D0
-  .text:0000000001E68DB4                 mov     rsi, rax
-  .text:0000000001E68DB7                 test    rax, rax
-  .text:0000000001E68DBA                 jz      short loc_1E68D74
-  .text:0000000001E68DBC                 mov     rdx, r15
-  .text:0000000001E68DBF                 mov     rdi, rbx
-  .text:0000000001E68DC2                 mov     [rbp+var_40], 0
-  .text:0000000001E68DCA                 call    sub_1E5ECC0
-  .text:0000000001E68DCF                 test    rax, rax
-  .text:0000000001E68DD2                 mov     [rbp+var_48], rax
-  .text:0000000001E68DD6                 jz      loc_1E68ED0
-  .text:0000000001E68DDC                 xor     r9d, r9d
-  .text:0000000001E68DDF                 mov     r8d, 1
-  .text:0000000001E68DE5                 mov     ecx, 0FFFFFFFFh
-  .text:0000000001E68DEA                 mov     edx, 0FFFFFFFFh
-  .text:0000000001E68DEF                 xor     esi, esi
-  .text:0000000001E68DF1                 mov     rdi, rbx
-  .text:0000000001E68DF4                 call    CEntitySystem_DoAllocateEntity
-  .text:0000000001E68DF9                 mov     r10, [rbp+var_48]
-  .text:0000000001E68DFD                 mov     r13, rax
-  .text:0000000001E68E00                 mov     [rax+8], r10
-  .text:0000000001E68E04                 mov     eax, [r10+68h]
-  .text:0000000001E68E08                 test    al, 4
-  .text:0000000001E68E0A                 jnz     loc_1E68ED8
-  .text:0000000001E68E10                 cmp     r12d, 0FFFFFFFFh
-  .text:0000000001E68E14                 jnz     short loc_1E68E1D
-  .text:0000000001E68E16                 mov     r12d, [rbx+1F40h]
-  .text:0000000001E68E1D                 and     eax, 400h
-  .text:0000000001E68E22                 jnz     loc_1E68EE6
-  .text:0000000001E68E28                 mov     rdx, [rbx]
-  .text:0000000001E68E2B                 lea     rcx, sub_1E4F150
-  .text:0000000001E68E32                 mov     rdx, [rdx+90h]    ; 0x90 = CEntitySystem_GetSpawnGroupWorldId
-  .text:0000000001E68E39                 cmp     rdx, rcx
-  .text:0000000001E68E3C                 jnz     loc_1E68EF0
-  .text:0000000001E68E42                 movd    xmm0, r12d
-  .text:0000000001E68E47                 mov     rsi, r13
-  .text:0000000001E68E4A                 mov     rdi, rbx
-  .text:0000000001E68E4D                 pinsrd  xmm0, eax, 1
-  .text:0000000001E68E53                 movq    qword ptr [r13+34h], xmm0
-  .text:0000000001E68E59                 mov     rdx, [rbp+var_40]
-  .text:0000000001E68E5D                 lea     rax, haystack
-  .text:0000000001E68E64                 test    rdx, rdx
-  .text:0000000001E68E67                 cmovz   rdx, rax
-  .text:0000000001E68E6B                 call    CEntitySystem_ConstructEntity
-  .text:0000000001E68E70                 test    al, al
-  .text:0000000001E68E72                 jz      short loc_1E68EB5
-  .text:0000000001E68E74                 mov     rdx, r14
-  .text:0000000001E68E77                 mov     rsi, r13
-  .text:0000000001E68E7A                 mov     rdi, rbx
-  .text:0000000001E68E7D                 mov     r12, [r13+0]
-  .text:0000000001E68E81                 call    sub_1E68C50
-  .text:0000000001E68E86                 test    al, al
-  .text:0000000001E68E88                 jz      short loc_1E68EA8
-  .text:0000000001E68E8A                 cmp     [rbp+var_40], 0
-  .text:0000000001E68E8F                 jz      loc_1E68D92
-  .text:0000000001E68E95                 ; this
-  .text:0000000001E68E95                 mov     rdi, r15; this
-  .text:0000000001E68E98                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
-  .text:0000000001E68E9D                 jmp     loc_1E68D92
-  .text:0000000001E68EA8                 mov     rdi, r12
-  .text:0000000001E68EAB                 mov     r13, [r12+10h]
-  .text:0000000001E68EB0                 call    CEntitySystem_DestroyEntity
-  .text:0000000001E68EB5                 xor     esi, esi
-  .text:0000000001E68EB7                 mov     rdi, r13
-  .text:0000000001E68EBA                 call    sub_1E446E0
-  .text:0000000001E68EBF                 lea     rdi, [rbx+10h]
-  .text:0000000001E68EC3                 mov     edx, 1
-  .text:0000000001E68EC8                 mov     rsi, r13
-  .text:0000000001E68ECB                 call    sub_1E51E80
-  .text:0000000001E68ED0                 xor     r12d, r12d
-  .text:0000000001E68ED3                 jmp     short loc_1E68E8A
-  .text:0000000001E68ED8                 xor     r12d, r12d
-  .text:0000000001E68EDB                 and     eax, 400h
-  .text:0000000001E68EE0                 jz      loc_1E68E28
-  .text:0000000001E68EE6                 mov     eax, 1
-  .text:0000000001E68EEB                 jmp     loc_1E68E42
-  .text:0000000001E68EF0                 mov     esi, r12d
-  .text:0000000001E68EF3                 mov     rdi, rbx
-  .text:0000000001E68EF6                 call    rdx
-  .text:0000000001E68EF8                 jmp     loc_1E68E42
-  .text:0000000001E68F00                 ; _QWORD
-  .text:0000000001E68F00                 mov     edi, [rbx]; _QWORD
-  .text:0000000001E68F02                 lea     rdx, aCentitysystemP; "CEntitySystem::PrecacheEntity: Classnam"...
-  .text:0000000001E68F09                 ; _QWORD
-  .text:0000000001E68F09                 mov     esi, 3; _QWORD
-  .text:0000000001E68F0E                 xor     eax, eax
-  .text:0000000001E68F10                 call    _LoggingSystem_Log
-  .text:0000000001E68F15                 jmp     loc_1E68D8F
+  .text:0000000001EACD20                 push    rbp
+  .text:0000000001EACD21                 lea     rax, aClassname; "classname"
+  .text:0000000001EACD28                 mov     rbp, rsp
+  .text:0000000001EACD2B                 push    r15
+  .text:0000000001EACD2D                 lea     r15, [rbp+var_40]
+  .text:0000000001EACD31                 push    r14
+  .text:0000000001EACD33                 mov     r14, rsi
+  .text:0000000001EACD36                 push    r13
+  .text:0000000001EACD38                 mov     rsi, r15
+  .text:0000000001EACD3B                 push    r12
+  .text:0000000001EACD3D                 mov     r12d, edx
+  .text:0000000001EACD40                 xor     edx, edx
+  .text:0000000001EACD42                 push    rbx
+  .text:0000000001EACD43                 mov     rbx, rdi
+  .text:0000000001EACD46                 mov     rdi, r14
+  .text:0000000001EACD49                 sub     rsp, 28h
+  .text:0000000001EACD4D                 mov     [rbp+var_40], 0FFFFFFFFC61B1C62h
+  .text:0000000001EACD55                 mov     [rbp+var_38], rax
+  .text:0000000001EACD59                 call    sub_1E91C00
+  .text:0000000001EACD5E                 test    rax, rax
+  .text:0000000001EACD61                 jz      short loc_1EACD74
+  .text:0000000001EACD63                 mov     rdi, rax
+  .text:0000000001EACD66                 movzx   eax, word ptr [rax]
+  .text:0000000001EACD69                 shr     ax, 2
+  .text:0000000001EACD6D                 and     eax, 0Fh
+  .text:0000000001EACD70                 cmp     al, 6
+  .text:0000000001EACD72                 jz      short loc_1EACDA8
+  .text:0000000001EACD74                 lea     rbx, dword_280425C
+  .text:0000000001EACD7B                 ; _QWORD
+  .text:0000000001EACD7B                 mov     esi, 3; _QWORD
+  .text:0000000001EACD80                 ; _QWORD
+  .text:0000000001EACD80                 mov     edi, [rbx]; _QWORD
+  .text:0000000001EACD82                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001EACD87                 test    al, al
+  .text:0000000001EACD89                 jnz     loc_1EACF00
+  .text:0000000001EACD8F                 xor     r12d, r12d
+  .text:0000000001EACD92                 add     rsp, 28h
+  .text:0000000001EACD96                 mov     rax, r12
+  .text:0000000001EACD99                 pop     rbx
+  .text:0000000001EACD9A                 pop     r12
+  .text:0000000001EACD9C                 pop     r13
+  .text:0000000001EACD9E                 pop     r14
+  .text:0000000001EACDA0                 pop     r15
+  .text:0000000001EACDA2                 pop     rbp
+  .text:0000000001EACDA3                 retn
+  .text:0000000001EACDA8                 lea     rsi, haystack
+  .text:0000000001EACDAF                 call    sub_1B4CE50
+  .text:0000000001EACDB4                 mov     rsi, rax
+  .text:0000000001EACDB7                 test    rax, rax
+  .text:0000000001EACDBA                 jz      short loc_1EACD74
+  .text:0000000001EACDBC                 mov     rdx, r15
+  .text:0000000001EACDBF                 mov     rdi, rbx
+  .text:0000000001EACDC2                 mov     [rbp+var_40], 0
+  .text:0000000001EACDCA                 call    CEntitySystem_FindClassByDesignName
+  .text:0000000001EACDCF                 test    rax, rax
+  .text:0000000001EACDD2                 mov     [rbp+var_48], rax
+  .text:0000000001EACDD6                 jz      loc_1EACED0
+  .text:0000000001EACDDC                 xor     r9d, r9d
+  .text:0000000001EACDDF                 mov     r8d, 1
+  .text:0000000001EACDE5                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001EACDEA                 mov     edx, 0FFFFFFFFh
+  .text:0000000001EACDEF                 xor     esi, esi
+  .text:0000000001EACDF1                 mov     rdi, rbx
+  .text:0000000001EACDF4                 call    CConcreteEntityList_AllocEntity
+  .text:0000000001EACDF9                 mov     r10, [rbp+var_48]
+  .text:0000000001EACDFD                 mov     r13, rax
+  .text:0000000001EACE00                 mov     [rax+8], r10
+  .text:0000000001EACE04                 mov     eax, [r10+68h]
+  .text:0000000001EACE08                 test    al, 4
+  .text:0000000001EACE0A                 jnz     loc_1EACED8
+  .text:0000000001EACE10                 cmp     r12d, 0FFFFFFFFh
+  .text:0000000001EACE14                 jnz     short loc_1EACE1D
+  .text:0000000001EACE16                 mov     r12d, [rbx+1F40h]
+  .text:0000000001EACE1D                 and     eax, 400h
+  .text:0000000001EACE22                 jnz     loc_1EACEE6
+  .text:0000000001EACE28                 mov     rdx, [rbx]
+  .text:0000000001EACE2B                 lea     rcx, CEntitySystem_GetSpawnGroupWorldId
+  .text:0000000001EACE32                 ; 0x90 = 144LL = CEntitySystem_GetSpawnGroupWorldId
+  .text:0000000001EACE32                 mov     rdx, [rdx+90h]; 0x90 = 144LL = CEntitySystem_GetSpawnGroupWorldId
+  .text:0000000001EACE39                 cmp     rdx, rcx
+  .text:0000000001EACE3C                 jnz     loc_1EACEF0
+  .text:0000000001EACE42                 movd    xmm0, r12d
+  .text:0000000001EACE47                 mov     rsi, r13
+  .text:0000000001EACE4A                 mov     rdi, rbx
+  .text:0000000001EACE4D                 pinsrd  xmm0, eax, 1
+  .text:0000000001EACE53                 movq    qword ptr [r13+34h], xmm0
+  .text:0000000001EACE59                 mov     rdx, [rbp+var_40]
+  .text:0000000001EACE5D                 lea     rax, haystack
+  .text:0000000001EACE64                 test    rdx, rdx
+  .text:0000000001EACE67                 cmovz   rdx, rax
+  .text:0000000001EACE6B                 call    CEntitySystem_ConstructEntity
+  .text:0000000001EACE70                 test    al, al
+  .text:0000000001EACE72                 jz      short loc_1EACEB5
+  .text:0000000001EACE74                 mov     rdx, r14
+  .text:0000000001EACE77                 mov     rsi, r13
+  .text:0000000001EACE7A                 mov     rdi, rbx
+  .text:0000000001EACE7D                 mov     r12, [r13+0]
+  .text:0000000001EACE81                 call    sub_1EACC50
+  .text:0000000001EACE86                 test    al, al
+  .text:0000000001EACE88                 jz      short loc_1EACEA8
+  .text:0000000001EACE8A                 cmp     [rbp+var_40], 0
+  .text:0000000001EACE8F                 jz      loc_1EACD92
+  .text:0000000001EACE95                 ; this
+  .text:0000000001EACE95                 mov     rdi, r15; this
+  .text:0000000001EACE98                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:0000000001EACE9D                 jmp     loc_1EACD92
+  .text:0000000001EACEA8                 mov     rdi, r12
+  .text:0000000001EACEAB                 mov     r13, [r12+10h]
+  .text:0000000001EACEB0                 call    CEntitySystem_DestroyEntity
+  .text:0000000001EACEB5                 xor     esi, esi
+  .text:0000000001EACEB7                 mov     rdi, r13
+  .text:0000000001EACEBA                 call    CEntityIdentity_FreeAttributes
+  .text:0000000001EACEBF                 ; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:0000000001EACEBF                 lea     rdi, [rbx+10h]; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:0000000001EACEC3                 mov     edx, 1
+  .text:0000000001EACEC8                 mov     rsi, r13
+  .text:0000000001EACECB                 call    CConcreteEntityList_FreeEntity
+  .text:0000000001EACED0                 xor     r12d, r12d
+  .text:0000000001EACED3                 jmp     short loc_1EACE8A
+  .text:0000000001EACED8                 xor     r12d, r12d
+  .text:0000000001EACEDB                 and     eax, 400h
+  .text:0000000001EACEE0                 jz      loc_1EACE28
+  .text:0000000001EACEE6                 mov     eax, 1
+  .text:0000000001EACEEB                 jmp     loc_1EACE42
+  .text:0000000001EACEF0                 mov     esi, r12d
+  .text:0000000001EACEF3                 mov     rdi, rbx
+  .text:0000000001EACEF6                 call    rdx
+  .text:0000000001EACEF8                 jmp     loc_1EACE42
+  .text:0000000001EACF00                 ; _QWORD
+  .text:0000000001EACF00                 mov     edi, [rbx]; _QWORD
+  .text:0000000001EACF02                 lea     rdx, aCentitysystemP; "CEntitySystem::PrecacheEntity: Classnam"...
+  .text:0000000001EACF09                 ; _QWORD
+  .text:0000000001EACF09                 mov     esi, 3; _QWORD
+  .text:0000000001EACF0E                 xor     eax, eax
+  .text:0000000001EACF10                 call    _LoggingSystem_Log
+  .text:0000000001EACF15                 jmp     loc_1EACD8F
 procedure: |-
-  __int64 __fastcall CEntitySystem_PrecacheEntity(_DWORD *a1, _QWORD *a2, unsigned int a3)
+  __int64 __fastcall CEntitySystem_PrecacheEntity(_DWORD *a1, __int64 a2, unsigned int a3)
   {
     _WORD *v5; // rax
     __int64 v6; // r12
-    char *v8; // rsi
+    __int64 v8; // rsi
     __int64 *Entity; // r13
     int v10; // eax
     __int64 (__fastcall *v11)(); // rdx
-    char *v12; // rdx
+    bool *v12; // rdx
     __int64 v13; // [rsp+8h] [rbp-48h]
     _QWORD v14[8]; // [rsp+10h] [rbp-40h] BYREF
 
     v14[0] = -971301790;
     v14[1] = "classname";
-    v5 = (_WORD *)sub_1E4DC00(a2, (int *)v14, nullptr);
+    v5 = (_WORD *)sub_1E91C00(a2, v14, 0);
     if ( v5 )
     {
       if ( ((*v5 >> 2) & 0xF) == 6 )
       {
-        v8 = (char *)sub_1B086D0((__int64)v5, &haystack);
+        v8 = sub_1B4CE50(v5, &haystack);
         if ( v8 )
         {
           v14[0] = 0;
-          v13 = sub_1E5ECC0((__int64)a1, v8, (CUtlString *)v14);
+          v13 = CEntitySystem_FindClassByDesignName(a1, v8, v14);
           if ( !v13 )
             goto LABEL_23;
-          Entity = CEntitySystem_DoAllocateEntity((__int64)a1, 0, 0xFFFFFFFFLL, 0xFFFFFFFFLL, 1u, 0);
+          Entity = CConcreteEntityList_AllocEntity((__int64)a1, 0, 0xFFFFFFFFLL, 0xFFFFFFFFLL, 1u, 0);
           Entity[1] = v13;
           if ( (*(_DWORD *)(v13 + 104) & 4) != 0 )
           {
@@ -171,8 +173,8 @@ procedure: |-
             if ( !v10 )
             {
   LABEL_13:
-              v11 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 144LL); // 144LL = 0x90 = CEntitySystem_GetSpawnGroupWorldId
-              if ( v11 != sub_1E4F150 )
+              v11 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 144LL);// 0x90 = 144LL = CEntitySystem_GetSpawnGroupWorldId
+              if ( v11 != CEntitySystem_GetSpawnGroupWorldId )
                 v10 = ((__int64 (__fastcall *)(_DWORD *, _QWORD))v11)(a1, a3);
               goto LABEL_15;
             }
@@ -188,19 +190,19 @@ procedure: |-
           v10 = 1;
   LABEL_15:
           *(__int64 *)((char *)Entity + 52) = _mm_insert_epi32(_mm_cvtsi32_si128(a3), v10, 1).m128i_u64[0];
-          v12 = (char *)v14[0];
+          v12 = (bool *)v14[0];
           if ( !v14[0] )
-            v12 = (char *)&haystack;
+            v12 = (bool *)&haystack;
           if ( (unsigned __int8)CEntitySystem_ConstructEntity((__int64)a1, Entity, v12) )
           {
             v6 = *Entity;
-            if ( (unsigned __int8)sub_1E68C50((__int64)a1, Entity, (__int64)a2) )
+            if ( (unsigned __int8)sub_1EACC50(a1, Entity, a2) )
               goto LABEL_19;
             Entity = *(__int64 **)(v6 + 16);
             CEntitySystem_DestroyEntity(v6);
           }
-          sub_1E446E0(Entity, 0);
-          sub_1E51E80((__int64)(a1 + 4), (unsigned __int64)Entity, 1);
+          CEntityIdentity_FreeAttributes(Entity, 0);
+          CConcreteEntityList_FreeEntity(a1 + 4, Entity, 1);// a1 is _DWORD * so a1+4 = a1+0x10 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
   LABEL_23:
           v6 = 0;
   LABEL_19:
@@ -210,10 +212,7 @@ procedure: |-
         }
       }
     }
-    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)g_pLoggingChannelEntitySystem, 3) )
-      LoggingSystem_Log(
-        (unsigned int)g_pLoggingChannelEntitySystem,
-        3,
-        "CEntitySystem::PrecacheEntity: Classname missing from entity!\n");
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_280425C, 3) )
+      LoggingSystem_Log((unsigned int)dword_280425C, 3, "CEntitySystem::PrecacheEntity: Classname missing from entity!\n");
     return 0;
   }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.windows.yaml
@@ -1,189 +1,192 @@
 func_name: CEntitySystem_PrecacheEntity
-func_va: '0x1811e61f0'
+func_va: '0x1812143f0'
 disasm_code: |-
-  .text:00000001811E61F0                 push    rsi
-  .text:00000001811E61F2                 push    rdi
-  .text:00000001811E61F3                 push    r14
-  .text:00000001811E61F5                 push    r15
-  .text:00000001811E61F7                 sub     rsp, 98h
-  .text:00000001811E61FE                 mov     r15, rdx
-  .text:00000001811E6201                 mov     [rsp+0B8h+var_80], 0FFFFFFFFC61B1C62h
-  .text:00000001811E620A                 mov     esi, r8d
-  .text:00000001811E620D                 lea     rax, aClassname; "classname"
-  .text:00000001811E6214                 mov     rdi, rcx
-  .text:00000001811E6217                 mov     [rsp+0B8h+var_78], rax
-  .text:00000001811E621C                 mov     rcx, r15
-  .text:00000001811E621F                 lea     rdx, [rsp+0B8h+var_80]
-  .text:00000001811E6224                 xor     r8d, r8d
-  .text:00000001811E6227                 call    sub_1811FE7D0
-  .text:00000001811E622C                 test    rax, rax
-  .text:00000001811E622F                 jz      loc_1811E6470
-  .text:00000001811E6235                 movzx   ecx, byte ptr [rax]
-  .text:00000001811E6238                 shr     cl, 2
-  .text:00000001811E623B                 and     cl, 0Fh
-  .text:00000001811E623E                 cmp     cl, 6
-  .text:00000001811E6241                 jnz     loc_1811E6470
-  .text:00000001811E6247                 lea     r14, unk_18159A988
-  .text:00000001811E624E                 mov     rcx, rax
-  .text:00000001811E6251                 mov     rdx, r14
-  .text:00000001811E6254                 call    sub_1814D4DD0
-  .text:00000001811E6259                 test    rax, rax
-  .text:00000001811E625C                 jz      loc_1811E6470
-  .text:00000001811E6262                 mov     [rsp+0B8h+arg_8], rbp
-  .text:00000001811E626A                 lea     r8, [rsp+0B8h+var_88]
-  .text:00000001811E626F                 mov     [rsp+0B8h+arg_0], rbx
-  .text:00000001811E6277                 mov     rdx, rax
-  .text:00000001811E627A                 mov     rcx, rdi
-  .text:00000001811E627D                 mov     [rsp+0B8h+var_28], r12
-  .text:00000001811E6285                 mov     [rsp+0B8h+var_88], 0
-  .text:00000001811E628E                 call    sub_1811ED0E0
-  .text:00000001811E6293                 mov     rbp, rax
-  .text:00000001811E6296                 test    rax, rax
-  .text:00000001811E6299                 jz      loc_1811E6432
-  .text:00000001811E629F                 mov     [rsp+0B8h+var_90], 0
-  .text:00000001811E62A4                 lea     rcx, [rdi+10h]
-  .text:00000001811E62A8                 xor     edx, edx
-  .text:00000001811E62AA                 mov     byte ptr [rsp+0B8h+var_98], 1
-  .text:00000001811E62AF                 mov     r9d, 0FFFFFFFFh
-  .text:00000001811E62B5                 mov     r8d, 0FFFFFFFFh
-  .text:00000001811E62BB                 call    CEntitySystem_DoAllocateEntity
-  .text:00000001811E62C0                 mov     rbx, rax
-  .text:00000001811E62C3                 test    rax, rax
-  .text:00000001811E62C6                 jnz     short loc_1811E62FC
-  .text:00000001811E62C8                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E62CE                 mov     edx, 3
-  .text:00000001811E62D3                 call    cs:LoggingSystem_IsChannelEnabled
-  .text:00000001811E62D9                 test    al, al
-  .text:00000001811E62DB                 jz      short loc_1811E62F5
-  .text:00000001811E62DD                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E62E3                 lea     r8, aDoallocateenti; "DoAllocateEntity failed\n"
-  .text:00000001811E62EA                 mov     edx, 3
-  .text:00000001811E62EF                 call    cs:LoggingSystem_Log
-  .text:00000001811E62F5                 xor     ebx, ebx
-  .text:00000001811E62F7                 jmp     loc_1811E638C
-  .text:00000001811E62FC                 cmp     qword ptr [rax], 0
-  .text:00000001811E6300                 jz      short loc_1811E637D
-  .text:00000001811E6302                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E6308                 mov     edx, 5
-  .text:00000001811E630D                 call    cs:LoggingSystem_IsChannelEnabled
-  .text:00000001811E6313                 test    al, al
-  .text:00000001811E6315                 jz      short loc_1811E62F5
-  .text:00000001811E6317                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E631D                 lea     rax, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
-  .text:00000001811E6324                 mov     [rsp+0B8h+var_70], rax
-  .text:00000001811E6329                 lea     r9, aDoallocateenti_0; "DoAllocateEntity pEntity->m_pInstance !"...
-  .text:00000001811E6330                 lea     rax, aCentitysystemA_0; "CEntitySystem::AllocateEntityIdentity"
-  .text:00000001811E6337                 mov     [rsp+0B8h+var_68], 704h
-  .text:00000001811E633F                 xorps   xmm0, xmm0
-  .text:00000001811E6342                 mov     [rsp+0B8h+var_60], rax
-  .text:00000001811E6347                 xorps   xmm1, xmm1
-  .text:00000001811E634A                 mov     [rsp+0B8h+var_38], 0
-  .text:00000001811E6355                 lea     r8, [rsp+0B8h+var_70]
-  .text:00000001811E635A                 mov     [rsp+0B8h+var_98], 0FFFFFFFFh
-  .text:00000001811E6362                 mov     edx, 5
-  .text:00000001811E6367                 movdqu  [rsp+0B8h+var_58], xmm0
-  .text:00000001811E636D                 movdqu  [rsp+0B8h+var_48], xmm1
-  .text:00000001811E6373                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
-  .text:00000001811E6379                 xor     ebx, ebx
-  .text:00000001811E637B                 jmp     short loc_1811E638C
-  .text:00000001811E637D                 or      dword ptr [rax+30h], 100h
-  .text:00000001811E6384                 mov     qword ptr [rax+48h], 0
-  .text:00000001811E638C                 mov     [rbx+8], rbp
-  .text:00000001811E6390                 mov     ecx, [rbp+68h]
-  .text:00000001811E6393                 mov     eax, ecx
-  .text:00000001811E6395                 shr     eax, 2
-  .text:00000001811E6398                 test    al, 1
-  .text:00000001811E639A                 jz      short loc_1811E63A0
-  .text:00000001811E639C                 xor     esi, esi
-  .text:00000001811E639E                 jmp     short loc_1811E63AB
-  .text:00000001811E63A0                 cmp     esi, 0FFFFFFFFh
-  .text:00000001811E63A3                 jnz     short loc_1811E63AB
-  .text:00000001811E63A5                 mov     esi, [rdi+1F38h]
-  .text:00000001811E63AB                 shr     ecx, 0Ah
-  .text:00000001811E63AE                 test    cl, 1
-  .text:00000001811E63B1                 jnz     short loc_1811E63CE
-  .text:00000001811E63B3                 mov     rax, [rdi]
-  .text:00000001811E63B6                 lea     rdx, [rsp+0B8h+arg_18]
-  .text:00000001811E63BE                 mov     r8d, esi
-  .text:00000001811E63C1                 mov     rcx, rdi
-  .text:00000001811E63C4                 call    qword ptr [rax+88h]    ; 0x88 = CEntitySystem_GetSpawnGroupWorldId
-  .text:00000001811E63CA                 mov     ecx, [rax]
-  .text:00000001811E63CC                 jmp     short loc_1811E63D3
-  .text:00000001811E63CE                 mov     ecx, 1
-  .text:00000001811E63D3                 mov     [rbx+38h], ecx
-  .text:00000001811E63D6                 mov     rdx, rbx
-  .text:00000001811E63D9                 mov     [rbx+34h], esi
-  .text:00000001811E63DC                 mov     rcx, rdi
-  .text:00000001811E63DF                 mov     rax, [rsp+0B8h+var_88]
-  .text:00000001811E63E4                 test    rax, rax
-  .text:00000001811E63E7                 cmovnz  r14, rax
-  .text:00000001811E63EB                 mov     r8, r14
-  .text:00000001811E63EE                 call    CEntitySystem_ConstructEntity
-  .text:00000001811E63F3                 test    al, al
-  .text:00000001811E63F5                 jnz     short loc_1811E6412
-  .text:00000001811E63F7                 xor     edx, edx
-  .text:00000001811E63F9                 mov     rcx, rbx
-  .text:00000001811E63FC                 call    sub_18120E670
-  .text:00000001811E6401                 mov     r8b, 1
-  .text:00000001811E6404                 lea     rcx, [rdi+10h]
-  .text:00000001811E6408                 mov     rdx, rbx
-  .text:00000001811E640B                 call    sub_1811EE5A0
-  .text:00000001811E6410                 jmp     short loc_1811E6432
-  .text:00000001811E6412                 mov     rsi, [rbx]
-  .text:00000001811E6415                 mov     r8, r15
-  .text:00000001811E6418                 mov     rdx, rbx
-  .text:00000001811E641B                 mov     rcx, rdi
-  .text:00000001811E641E                 call    sub_1811FB030
-  .text:00000001811E6423                 test    al, al
-  .text:00000001811E6425                 jnz     short loc_1811E6434
-  .text:00000001811E6427                 mov     rdx, rsi
-  .text:00000001811E642A                 mov     rcx, rdi
-  .text:00000001811E642D                 call    CEntitySystem_DestroyEntity
-  .text:00000001811E6432                 xor     esi, esi
-  .text:00000001811E6434                 cmp     [rsp+0B8h+var_88], 0
-  .text:00000001811E643A                 mov     r12, [rsp+0B8h+var_28]
-  .text:00000001811E6442                 mov     rbp, [rsp+0B8h+arg_8]
-  .text:00000001811E644A                 mov     rbx, [rsp+0B8h+arg_0]
-  .text:00000001811E6452                 jz      short loc_1811E645F
-  .text:00000001811E6454                 lea     rcx, [rsp+0B8h+var_88]
-  .text:00000001811E6459                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
-  .text:00000001811E645F                 mov     rax, rsi
-  .text:00000001811E6462                 add     rsp, 98h
-  .text:00000001811E6469                 pop     r15
-  .text:00000001811E646B                 pop     r14
-  .text:00000001811E646D                 pop     rdi
-  .text:00000001811E646E                 pop     rsi
-  .text:00000001811E646F                 retn
-  .text:00000001811E6470                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E6476                 mov     edx, 3
-  .text:00000001811E647B                 call    cs:LoggingSystem_IsChannelEnabled
-  .text:00000001811E6481                 test    al, al
-  .text:00000001811E6483                 jz      short loc_1811E649D
-  .text:00000001811E6485                 mov     ecx, cs:dword_1820B0808
-  .text:00000001811E648B                 lea     r8, aCentitysystemP; "CEntitySystem::PrecacheEntity: Classnam"...
-  .text:00000001811E6492                 mov     edx, 3
-  .text:00000001811E6497                 call    cs:LoggingSystem_Log
-  .text:00000001811E649D                 xor     eax, eax
-  .text:00000001811E649F                 add     rsp, 98h
-  .text:00000001811E64A6                 pop     r15
-  .text:00000001811E64A8                 pop     r14
-  .text:00000001811E64AA                 pop     rdi
-  .text:00000001811E64AB                 pop     rsi
-  .text:00000001811E64AC                 retn
+  .text:00000001812143F0                 push    rsi
+  .text:00000001812143F2                 push    rdi
+  .text:00000001812143F3                 push    r14
+  .text:00000001812143F5                 push    r15
+  .text:00000001812143F7                 sub     rsp, 98h
+  .text:00000001812143FE                 mov     r15, rdx
+  .text:0000000181214401                 mov     [rsp+0B8h+var_80], 0FFFFFFFFC61B1C62h
+  .text:000000018121440A                 mov     esi, r8d
+  .text:000000018121440D                 lea     rax, aClassname; "classname"
+  .text:0000000181214414                 mov     rdi, rcx
+  .text:0000000181214417                 mov     [rsp+0B8h+var_78], rax
+  .text:000000018121441C                 mov     rcx, r15
+  .text:000000018121441F                 lea     rdx, [rsp+0B8h+var_80]
+  .text:0000000181214424                 xor     r8d, r8d
+  .text:0000000181214427                 call    sub_18122C9D0
+  .text:000000018121442C                 test    rax, rax
+  .text:000000018121442F                 jz      loc_181214670
+  .text:0000000181214435                 movzx   ecx, byte ptr [rax]
+  .text:0000000181214438                 shr     cl, 2
+  .text:000000018121443B                 and     cl, 0Fh
+  .text:000000018121443E                 cmp     cl, 6
+  .text:0000000181214441                 jnz     loc_181214670
+  .text:0000000181214447                 lea     r14, byte_1815C9988
+  .text:000000018121444E                 mov     rcx, rax
+  .text:0000000181214451                 mov     rdx, r14
+  .text:0000000181214454                 call    sub_181502AC0
+  .text:0000000181214459                 test    rax, rax
+  .text:000000018121445C                 jz      loc_181214670
+  .text:0000000181214462                 mov     [rsp+0B8h+arg_8], rbp
+  .text:000000018121446A                 lea     r8, [rsp+0B8h+var_88]
+  .text:000000018121446F                 mov     [rsp+0B8h+arg_0], rbx
+  .text:0000000181214477                 mov     rdx, rax
+  .text:000000018121447A                 mov     rcx, rdi
+  .text:000000018121447D                 mov     [rsp+0B8h+var_28], r12
+  .text:0000000181214485                 mov     [rsp+0B8h+var_88], 0
+  .text:000000018121448E                 call    CEntitySystem_FindClassByDesignName
+  .text:0000000181214493                 mov     rbp, rax
+  .text:0000000181214496                 test    rax, rax
+  .text:0000000181214499                 jz      loc_181214632
+  .text:000000018121449F                 mov     [rsp+0B8h+var_90], 0
+  .text:00000001812144A4                 ; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:00000001812144A4                 lea     rcx, [rdi+10h]; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:00000001812144A8                 xor     edx, edx
+  .text:00000001812144AA                 mov     byte ptr [rsp+0B8h+var_98], 1
+  .text:00000001812144AF                 mov     r9d, 0FFFFFFFFh
+  .text:00000001812144B5                 mov     r8d, 0FFFFFFFFh
+  .text:00000001812144BB                 call    CConcreteEntityList_AllocEntity
+  .text:00000001812144C0                 mov     rbx, rax
+  .text:00000001812144C3                 test    rax, rax
+  .text:00000001812144C6                 jnz     short loc_1812144FC
+  .text:00000001812144C8                 mov     ecx, cs:dword_1820EFF88
+  .text:00000001812144CE                 mov     edx, 3
+  .text:00000001812144D3                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001812144D9                 test    al, al
+  .text:00000001812144DB                 jz      short loc_1812144F5
+  .text:00000001812144DD                 mov     ecx, cs:dword_1820EFF88
+  .text:00000001812144E3                 lea     r8, aDoallocateenti; "DoAllocateEntity failed\n"
+  .text:00000001812144EA                 mov     edx, 3
+  .text:00000001812144EF                 call    cs:LoggingSystem_Log
+  .text:00000001812144F5                 xor     ebx, ebx
+  .text:00000001812144F7                 jmp     loc_18121458C
+  .text:00000001812144FC                 cmp     qword ptr [rax], 0
+  .text:0000000181214500                 jz      short loc_18121457D
+  .text:0000000181214502                 mov     ecx, cs:dword_1820EFF88
+  .text:0000000181214508                 mov     edx, 5
+  .text:000000018121450D                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000181214513                 test    al, al
+  .text:0000000181214515                 jz      short loc_1812144F5
+  .text:0000000181214517                 mov     ecx, cs:dword_1820EFF88
+  .text:000000018121451D                 lea     rax, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000181214524                 mov     [rsp+0B8h+var_70], rax
+  .text:0000000181214529                 lea     r9, aDoallocateenti_0; "DoAllocateEntity pEntity->m_pInstance !"...
+  .text:0000000181214530                 lea     rax, aCentitysystemA_0; "CEntitySystem::AllocateEntityIdentity"
+  .text:0000000181214537                 mov     [rsp+0B8h+var_68], 704h
+  .text:000000018121453F                 xorps   xmm0, xmm0
+  .text:0000000181214542                 mov     [rsp+0B8h+var_60], rax
+  .text:0000000181214547                 xorps   xmm1, xmm1
+  .text:000000018121454A                 mov     [rsp+0B8h+var_38], 0
+  .text:0000000181214555                 lea     r8, [rsp+0B8h+var_70]
+  .text:000000018121455A                 mov     [rsp+0B8h+var_98], 0FFFFFFFFh
+  .text:0000000181214562                 mov     edx, 5
+  .text:0000000181214567                 movdqu  [rsp+0B8h+var_58], xmm0
+  .text:000000018121456D                 movdqu  [rsp+0B8h+var_48], xmm1
+  .text:0000000181214573                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:0000000181214579                 xor     ebx, ebx
+  .text:000000018121457B                 jmp     short loc_18121458C
+  .text:000000018121457D                 or      dword ptr [rax+30h], 100h
+  .text:0000000181214584                 mov     qword ptr [rax+48h], 0
+  .text:000000018121458C                 mov     [rbx+8], rbp
+  .text:0000000181214590                 mov     ecx, [rbp+68h]
+  .text:0000000181214593                 mov     eax, ecx
+  .text:0000000181214595                 shr     eax, 2
+  .text:0000000181214598                 test    al, 1
+  .text:000000018121459A                 jz      short loc_1812145A0
+  .text:000000018121459C                 xor     esi, esi
+  .text:000000018121459E                 jmp     short loc_1812145AB
+  .text:00000001812145A0                 cmp     esi, 0FFFFFFFFh
+  .text:00000001812145A3                 jnz     short loc_1812145AB
+  .text:00000001812145A5                 mov     esi, [rdi+1F38h]
+  .text:00000001812145AB                 shr     ecx, 0Ah
+  .text:00000001812145AE                 test    cl, 1
+  .text:00000001812145B1                 jnz     short loc_1812145CE
+  .text:00000001812145B3                 mov     rax, [rdi]
+  .text:00000001812145B6                 lea     rdx, [rsp+0B8h+arg_18]
+  .text:00000001812145BE                 mov     r8d, esi
+  .text:00000001812145C1                 mov     rcx, rdi
+  .text:00000001812145C4                 ; 0x88 = 136LL = CEntitySystem_GetSpawnGroupWorldId
+  .text:00000001812145C4                 call    qword ptr [rax+88h]; 0x88 = 136LL = CEntitySystem_GetSpawnGroupWorldId
+  .text:00000001812145CA                 mov     ecx, [rax]
+  .text:00000001812145CC                 jmp     short loc_1812145D3
+  .text:00000001812145CE                 mov     ecx, 1
+  .text:00000001812145D3                 mov     [rbx+38h], ecx
+  .text:00000001812145D6                 mov     rdx, rbx
+  .text:00000001812145D9                 mov     [rbx+34h], esi
+  .text:00000001812145DC                 mov     rcx, rdi
+  .text:00000001812145DF                 mov     rax, [rsp+0B8h+var_88]
+  .text:00000001812145E4                 test    rax, rax
+  .text:00000001812145E7                 cmovnz  r14, rax
+  .text:00000001812145EB                 mov     r8, r14
+  .text:00000001812145EE                 call    CEntitySystem_ConstructEntity
+  .text:00000001812145F3                 test    al, al
+  .text:00000001812145F5                 jnz     short loc_181214612
+  .text:00000001812145F7                 xor     edx, edx
+  .text:00000001812145F9                 mov     rcx, rbx
+  .text:00000001812145FC                 call    CEntityIdentity_FreeAttributes
+  .text:0000000181214601                 mov     r8b, 1
+  .text:0000000181214604                 ; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:0000000181214604                 lea     rcx, [rdi+10h]; 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
+  .text:0000000181214608                 mov     rdx, rbx
+  .text:000000018121460B                 call    CConcreteEntityList_FreeEntity
+  .text:0000000181214610                 jmp     short loc_181214632
+  .text:0000000181214612                 mov     rsi, [rbx]
+  .text:0000000181214615                 mov     r8, r15
+  .text:0000000181214618                 mov     rdx, rbx
+  .text:000000018121461B                 mov     rcx, rdi
+  .text:000000018121461E                 call    sub_181229230
+  .text:0000000181214623                 test    al, al
+  .text:0000000181214625                 jnz     short loc_181214634
+  .text:0000000181214627                 mov     rdx, rsi
+  .text:000000018121462A                 mov     rcx, rdi
+  .text:000000018121462D                 call    CEntitySystem_DestroyEntity
+  .text:0000000181214632                 xor     esi, esi
+  .text:0000000181214634                 cmp     [rsp+0B8h+var_88], 0
+  .text:000000018121463A                 mov     r12, [rsp+0B8h+var_28]
+  .text:0000000181214642                 mov     rbp, [rsp+0B8h+arg_8]
+  .text:000000018121464A                 mov     rbx, [rsp+0B8h+arg_0]
+  .text:0000000181214652                 jz      short loc_18121465F
+  .text:0000000181214654                 lea     rcx, [rsp+0B8h+var_88]
+  .text:0000000181214659                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018121465F                 mov     rax, rsi
+  .text:0000000181214662                 add     rsp, 98h
+  .text:0000000181214669                 pop     r15
+  .text:000000018121466B                 pop     r14
+  .text:000000018121466D                 pop     rdi
+  .text:000000018121466E                 pop     rsi
+  .text:000000018121466F                 retn
+  .text:0000000181214670                 mov     ecx, cs:dword_1820EFF88
+  .text:0000000181214676                 mov     edx, 3
+  .text:000000018121467B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000181214681                 test    al, al
+  .text:0000000181214683                 jz      short loc_18121469D
+  .text:0000000181214685                 mov     ecx, cs:dword_1820EFF88
+  .text:000000018121468B                 lea     r8, aCentitysystemP; "CEntitySystem::PrecacheEntity: Classnam"...
+  .text:0000000181214692                 mov     edx, 3
+  .text:0000000181214697                 call    cs:LoggingSystem_Log
+  .text:000000018121469D                 xor     eax, eax
+  .text:000000018121469F                 add     rsp, 98h
+  .text:00000001812146A6                 pop     r15
+  .text:00000001812146A8                 pop     r14
+  .text:00000001812146AA                 pop     rdi
+  .text:00000001812146AB                 pop     rsi
+  .text:00000001812146AC                 retn
 procedure: |-
-  __int64 __fastcall CEntitySystem_PrecacheEntity(_DWORD *a1, __int64 a2, unsigned int a3)
+  __int64 __fastcall CEntitySystem_PrecacheEntity(__int64 a1, _QWORD *a2, unsigned int a3)
   {
     _BYTE *v6; // rax
-    void *v7; // r14
+    char *v7; // r14
     __int64 v8; // rax
     __int64 v9; // rbp
-    __int64 v10; // rax
-    __int64 v11; // rbx
+    unsigned __int64 v10; // rax
+    unsigned __int64 v11; // rbx
     int v12; // ecx
     int v13; // ecx
     __int64 v14; // r8
     __int64 v15; // rsi
-    void *v17; // [rsp+30h] [rbp-88h] BYREF
+    char *v17; // [rsp+30h] [rbp-88h] BYREF
     _QWORD v18[2]; // [rsp+38h] [rbp-80h] BYREF
     const char *v19; // [rsp+48h] [rbp-70h] BYREF
     int v20; // [rsp+50h] [rbp-68h]
@@ -195,30 +198,30 @@ procedure: |-
 
     v18[0] = -971301790;
     v18[1] = "classname";
-    v6 = (_BYTE *)sub_1811FE7D0(a2, v18, 0);
+    v6 = (_BYTE *)sub_18122C9D0(a2, (int *)v18, nullptr);
     if ( v6 )
     {
       if ( ((*v6 >> 2) & 0xF) == 6 )
       {
-        v7 = &unk_18159A988;
-        v8 = sub_1814D4DD0(v6, &unk_18159A988);
+        v7 = byte_1815C9988;
+        v8 = sub_181502AC0(v6, byte_1815C9988);
         if ( v8 )
         {
           v17 = nullptr;
-          v9 = sub_1811ED0E0(a1, v8, &v17);
+          v9 = CEntitySystem_FindClassByDesignName(a1, v8, &v17);
           if ( !v9 )
             goto LABEL_26;
-          v10 = CEntitySystem_DoAllocateEntity((int)a1 + 16, 0, -1, -1, 1, 0);
+          v10 = CConcreteEntityList_AllocEntity(a1 + 16, 0, -1, -1, 1u, 0);// 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
           v11 = v10;
           if ( !v10 )
           {
-            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B0808, 3) )
-              LoggingSystem_Log((unsigned int)dword_1820B0808, 3, "DoAllocateEntity failed\n");
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820EFF88, 3) )
+              LoggingSystem_Log((unsigned int)dword_1820EFF88, 3, "DoAllocateEntity failed\n");
             goto LABEL_8;
           }
           if ( *(_QWORD *)v10 )
           {
-            if ( !(unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B0808, 5) )
+            if ( !(unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820EFF88, 5) )
             {
   LABEL_8:
               v11 = 0;
@@ -231,7 +234,7 @@ procedure: |-
             v22 = 0;
             v23 = 0;
             LoggingSystem_Log(
-              (unsigned int)dword_1820B0808,
+              (unsigned int)dword_1820EFF88,
               5,
               &v19,
               "DoAllocateEntity pEntity->m_pInstance != NULL %d\n",
@@ -252,20 +255,20 @@ procedure: |-
           }
           else if ( a3 == -1 )
           {
-            a3 = a1[1998];
+            a3 = *(_DWORD *)(a1 + 7992);
           }
           if ( (v12 & 0x400) != 0 )
             v13 = 1;
           else
-            v13 = *(_DWORD *)(*(__int64 (__fastcall **)(_DWORD *, char *, _QWORD))(*(_QWORD *)a1 + 136LL))(a1, &v25, a3); // 136LL = 0x88 = CEntitySystem_GetSpawnGroupWorldId
+            v13 = *(_DWORD *)(*(__int64 (__fastcall **)(__int64, char *, _QWORD))(*(_QWORD *)a1 + 136LL))(a1, &v25, a3);// 0x88 = 136LL = CEntitySystem_GetSpawnGroupWorldId
           *(_DWORD *)(v11 + 56) = v13;
           *(_DWORD *)(v11 + 52) = a3;
           if ( v17 )
             v7 = v17;
-          if ( (unsigned __int8)CEntitySystem_ConstructEntity(a1, v11, v7) )
+          if ( (unsigned __int8)CEntitySystem_ConstructEntity(a1, (__int64 *)v11, v7) )
           {
             v15 = *(_QWORD *)v11;
-            if ( (unsigned __int8)sub_1811FB030(a1, v11, a2) )
+            if ( (unsigned __int8)sub_181229230(a1, v11, a2) )
             {
   LABEL_27:
               if ( v17 )
@@ -276,9 +279,9 @@ procedure: |-
           }
           else
           {
-            sub_18120E670(v11, 0);
+            CEntityIdentity_FreeAttributes(v11, 0);
             LOBYTE(v14) = 1;
-            sub_1811EE5A0(a1 + 4, v11, v14);
+            CConcreteEntityList_FreeEntity(a1 + 16, v11, v14);// 0x10 = 16 = CEntitySystem::m_EntityList (structmember, struct=CEntitySystem, member=m_EntityList)
           }
   LABEL_26:
           v15 = 0;
@@ -286,9 +289,9 @@ procedure: |-
         }
       }
     }
-    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B0808, 3) )
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820EFF88, 3) )
       LoggingSystem_Log(
-        (unsigned int)dword_1820B0808,
+        (unsigned int)dword_1820EFF88,
         3,
         "CEntitySystem::PrecacheEntity: Classname missing from entity!\n");
     return 0;


### PR DESCRIPTION
## Summary
- Rename `find-CEntitySystem_DestroyEntity-AND-CConcreteEntityList_AllocEntity-AND-CEntitySystem_ConstructEntity-AND-CEntitySystem_GetSpawnGroupWorldId` → `find-CEntitySystem_PrecacheEntity-decompiles`, expanded from 4 to 8 LLM_DECOMPILE targets sharing `CEntitySystem_PrecacheEntity` as the predecessor.
- New targets: `CEntitySystem_FindClassByDesignName`, `CEntitySystem_m_EntityList` (structmember), `CEntityIdentity_FreeAttributes`, `CConcreteEntityList_FreeEntity`.
- Add trailing-`?` optional-field marker in `_normalize_generate_yaml_desired_fields` / `_assemble_symbol_payload` so `lea`-based struct member accesses (no natural operand size) can emit YAML without `size`.
- Regenerate and annotate `CEntitySystem_PrecacheEntity.{linux,windows}.yaml` references; update `config.yaml` skill entry + add 5 new symbol entries (struct + funcs + structmember).

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` → Successful: 2, Failed: 0, Skipped: 1310
- [x] All 8 output YAMLs generated for both `windows` and `linux` platforms
- [x] `CEntitySystem_m_EntityList.{platform}.yaml` correctly omits `size` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)