### PR TITLE
Add find-CEntitySystem_m_pCurrentManifest

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5135,6 +5135,12 @@ modules:
         expected_input:
           - CGameEntitySystem_vtable.{platform}.yaml
 
+      - name: find-CEntitySystem_m_pCurrentManifest
+        expected_output:
+          - CEntitySystem_m_pCurrentManifest.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.{platform}.yaml
+
       - name: find-CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
         expected_output:
           - CGameEntitySystem_BuildResourceManifest_KeyValuesVectors.{platform}.yaml
@@ -8172,6 +8178,11 @@ modules:
         category: vfunc
         alias:
           - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+
+      - name: CEntitySystem_m_pCurrentManifest
+        category: structmember
+        struct: CEntitySystem
+        member: m_pCurrentManifest
 
       - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4598,6 +4598,13 @@ modules:
         expected_output:
           - CEntitySystem_RegisterEntityClass.{platform}.yaml
 
+      - name: find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname
+        expected_output:
+          - CEntitySystem_m_entClassesByCPPClassname.{platform}.yaml
+          - CEntitySystem_m_entClassesByClassname.{platform}.yaml
+        expected_input:
+          - CEntitySystem_RegisterEntityClass.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntityByName
         expected_output:
           - CEntitySystem_CreateEntityByName.{platform}.yaml
@@ -7343,6 +7350,16 @@ modules:
         category: func
         alias:
           - CEntitySystem::RegisterEntityClass
+
+      - name: CEntitySystem_m_entClassesByCPPClassname
+        category: structmember
+        struct: CEntitySystem
+        member: m_entClassesByCPPClassname
+
+      - name: CEntitySystem_m_entClassesByClassname
+        category: structmember
+        struct: CEntitySystem
+        member: m_entClassesByClassname
 
       - name: CEntitySystem_CreateEntityByName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -4594,6 +4594,10 @@ modules:
         expected_output:
           - CEntitySystem_vtable.{platform}.yaml
 
+      - name: find-CEntitySystem_RegisterEntityClass
+        expected_output:
+          - CEntitySystem_RegisterEntityClass.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntityByName
         expected_output:
           - CEntitySystem_CreateEntityByName.{platform}.yaml
@@ -7334,6 +7338,11 @@ modules:
 
       - name: CEntitySystem_vtable
         category: vtable
+
+      - name: CEntitySystem_RegisterEntityClass
+        category: func
+        alias:
+          - CEntitySystem::RegisterEntityClass
 
       - name: CEntitySystem_CreateEntityByName
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_RegisterEntityClass.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RegisterEntityClass.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RegisterEntityClass skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RegisterEntityClass",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_RegisterEntityClass",
+        "xref_strings": [
+            'Multiple entity classes have the same designer name "%s" ( class %s and class %s )\n',
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": [], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_RegisterEntityClass",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_entClassesByCPPClassname",
+    "CEntitySystem_m_entClassesByClassname",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_entClassesByCPPClassname",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RegisterEntityClass.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_entClassesByClassname",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RegisterEntityClass.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_entClassesByCPPClassname",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_entClassesByClassname",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offsets and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_pCurrentManifest.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_pCurrentManifest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_pCurrentManifest skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_pCurrentManifest",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_pCurrentManifest",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_pCurrentManifest",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.linux.yaml
@@ -1,0 +1,252 @@
+func_name: CEntitySystem_RegisterEntityClass
+func_va: '0x1e67830'
+disasm_code: |-
+  .text:0000000001E67830                 test    rsi, rsi
+  .text:0000000001E67833                 jz      loc_1E67AA4
+  .text:0000000001E67839                 push    rbp
+  .text:0000000001E6783A                 mov     rbp, rsp
+  .text:0000000001E6783D                 push    r15
+  .text:0000000001E6783F                 push    r14
+  .text:0000000001E67841                 ; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:0000000001E67841                 lea     r14, [rdi+0A90h]; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:0000000001E67848                 push    r13
+  .text:0000000001E6784A                 lea     r13, [rbp-70h]
+  .text:0000000001E6784E                 push    r12
+  .text:0000000001E67850                 mov     r12, rsi
+  .text:0000000001E67853                 push    rbx
+  .text:0000000001E67854                 mov     rbx, rdi
+  .text:0000000001E67857                 lea     rdi, [rdi+0A98h]
+  .text:0000000001E6785E                 sub     rsp, 68h
+  .text:0000000001E67862                 mov     rax, [rsi+50h]
+  .text:0000000001E67866                 mov     rsi, r13
+  .text:0000000001E67869                 mov     rdx, [rax+8]
+  .text:0000000001E6786D                 mov     [rbp-80h], rdx
+  .text:0000000001E67871                 mov     rax, [rax]
+  .text:0000000001E67874                 mov     [rbp-70h], r14
+  .text:0000000001E67878                 mov     [rbp-60h], r14
+  .text:0000000001E6787C                 mov     [rbp-78h], rax
+  .text:0000000001E67880                 lea     rax, [rbp-80h]
+  .text:0000000001E67884                 mov     [rbp-68h], rax
+  .text:0000000001E67888                 call    sub_1E5FED0
+  .text:0000000001E6788D                 mov     rdx, rax
+  .text:0000000001E67890                 mov     [rbp-8Ch], ax
+  .text:0000000001E67897                 shr     rax, 20h
+  .text:0000000001E6789B                 shr     rdx, 10h
+  .text:0000000001E6789F                 mov     [rbp-88h], ax
+  .text:0000000001E678A6                 mov     [rbp-8Ah], dx
+  .text:0000000001E678AD                 cmp     dx, 0FFFFh
+  .text:0000000001E678B1                 jnz     loc_1E67969
+  .text:0000000001E678B7                 cmp     qword ptr [rbp-78h], 0
+  .text:0000000001E678BC                 jz      short loc_1E6790C
+  .text:0000000001E678BE                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E678BE                 lea     rax, [rbx+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E678C5                 mov     rsi, r13
+  .text:0000000001E678C8                 lea     rdx, [rbp-78h]
+  .text:0000000001E678CC                 mov     [rbp-70h], rax
+  .text:0000000001E678D0                 lea     rdi, [rbx+0AB8h]
+  .text:0000000001E678D7                 mov     [rbp-68h], rdx
+  .text:0000000001E678DB                 mov     [rbp-60h], rax
+  .text:0000000001E678DF                 call    sub_1E5FED0
+  .text:0000000001E678E4                 mov     r15, rax
+  .text:0000000001E678E7                 mov     [rbp-86h], ax
+  .text:0000000001E678EE                 shr     rax, 20h
+  .text:0000000001E678F2                 shr     r15, 10h
+  .text:0000000001E678F6                 mov     [rbp-82h], ax
+  .text:0000000001E678FD                 mov     [rbp-84h], r15w
+  .text:0000000001E67905                 cmp     r15w, 0FFFFh
+  .text:0000000001E6790A                 jnz     short loc_1E6798B
+  .text:0000000001E6790C                 mov     rdi, r12
+  .text:0000000001E6790F                 call    sub_1E3CF10
+  .text:0000000001E67914                 mov     rax, [rbp-78h]
+  .text:0000000001E67918                 test    rax, rax
+  .text:0000000001E6791B                 jz      short loc_1E6793C
+  .text:0000000001E6791D                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E6791D                 lea     rdi, [rbx+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E67924                 movq    xmm0, rax
+  .text:0000000001E67929                 mov     rsi, r13
+  .text:0000000001E6792C                 pinsrq  xmm0, r12, 1
+  .text:0000000001E67933                 movaps  xmmword ptr [rbp-70h], xmm0
+  .text:0000000001E67937                 call    sub_1E67440
+  .text:0000000001E6793C                 movq    xmm0, qword ptr [rbp-80h]
+  .text:0000000001E67941                 mov     rsi, r13
+  .text:0000000001E67944                 mov     rdi, r14
+  .text:0000000001E67947                 pinsrq  xmm0, r12, 1
+  .text:0000000001E6794E                 movaps  xmmword ptr [rbp-70h], xmm0
+  .text:0000000001E67952                 call    sub_1E67440
+  .text:0000000001E67957                 movzx   eax, ax
+  .text:0000000001E6795A                 lea     rsp, [rbp-28h]
+  .text:0000000001E6795E                 pop     rbx
+  .text:0000000001E6795F                 pop     r12
+  .text:0000000001E67961                 pop     r13
+  .text:0000000001E67963                 pop     r14
+  .text:0000000001E67965                 pop     r15
+  .text:0000000001E67967                 pop     rbp
+  .text:0000000001E67968                 retn
+  .text:0000000001E67969                 lea     rbx, dword_27BBCDC
+  .text:0000000001E67970                 ; _QWORD
+  .text:0000000001E67970                 mov     esi, 5; _QWORD
+  .text:0000000001E67975                 ; _QWORD
+  .text:0000000001E67975                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E67977                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E6797C                 test    al, al
+  .text:0000000001E6797E                 jnz     loc_1E67A3F
+  .text:0000000001E67984                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E67989                 jmp     short loc_1E6795A
+  .text:0000000001E6798B                 lea     r12, dword_27BBCDC
+  .text:0000000001E67992                 ; _QWORD
+  .text:0000000001E67992                 mov     esi, 5; _QWORD
+  .text:0000000001E67997                 ; _QWORD
+  .text:0000000001E67997                 mov     edi, [r12]; _QWORD
+  .text:0000000001E6799B                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E679A0                 test    al, al
+  .text:0000000001E679A2                 jz      short loc_1E67984
+  .text:0000000001E679A4                 xor     eax, eax
+  .text:0000000001E679A6                 test    word ptr [rbx+0ABAh], 7FFFh
+  .text:0000000001E679AF                 jz      short loc_1E679B8
+  .text:0000000001E679B1                 mov     rax, [rbx+0AC0h]
+  .text:0000000001E679B8                 movzx   r15d, r15w
+  .text:0000000001E679BC                 sub     rsp, 8
+  .text:0000000001E679C0                 ; _QWORD
+  .text:0000000001E679C0                 mov     edi, [r12]; _QWORD
+  .text:0000000001E679C4                 ; _QWORD
+  .text:0000000001E679C4                 mov     esi, 5; _QWORD
+  .text:0000000001E679C9                 lea     rdx, [r15+r15*2]
+  .text:0000000001E679CD                 mov     rax, [rax+rdx*8+10h]
+  .text:0000000001E679D2                 lea     rcx, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E679D9                 ; _QWORD
+  .text:0000000001E679D9                 mov     rdx, r13; _QWORD
+  .text:0000000001E679DC                 mov     rax, [rax+50h]
+  .text:0000000001E679E0                 mov     rax, [rax+8]
+  .text:0000000001E679E4                 mov     [rbp-70h], rcx
+  .text:0000000001E679E8                 lea     rcx, aRegisterentity; "RegisterEntityClass"
+  .text:0000000001E679EF                 mov     [rbp-60h], rcx
+  .text:0000000001E679F3                 lea     rcx, aMultipleEntity; "Multiple entity classes have the same d"...
+  .text:0000000001E679FA                 mov     dword ptr [rbp-68h], 27Fh
+  .text:0000000001E67A01                 mov     qword ptr [rbp-58h], 0
+  .text:0000000001E67A09                 mov     qword ptr [rbp-50h], 0
+  .text:0000000001E67A11                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E67A19                 mov     qword ptr [rbp-40h], 0
+  .text:0000000001E67A21                 mov     dword ptr [rbp-38h], 0
+  .text:0000000001E67A28                 push    rax
+  .text:0000000001E67A29                 mov     r9, [rbp-80h]
+  .text:0000000001E67A2D                 xor     eax, eax
+  .text:0000000001E67A2F                 mov     r8, [rbp-78h]
+  .text:0000000001E67A33                 call    __Z17LoggingSystem_Logi17LoggingSeverity_tRK20LoggingRareOptions_tPKcz; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const&,char const*,...)
+  .text:0000000001E67A38                 pop     rax
+  .text:0000000001E67A39                 pop     rdx
+  .text:0000000001E67A3A                 jmp     loc_1E67984
+  .text:0000000001E67A3F                 ; _QWORD
+  .text:0000000001E67A3F                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E67A41                 ; _QWORD
+  .text:0000000001E67A41                 mov     rdx, r13; _QWORD
+  .text:0000000001E67A44                 ; _QWORD
+  .text:0000000001E67A44                 mov     esi, 5; _QWORD
+  .text:0000000001E67A49                 mov     dword ptr [rbp-68h], 276h
+  .text:0000000001E67A50                 mov     r8, [rbp-80h]
+  .text:0000000001E67A54                 lea     rax, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E67A5B                 mov     qword ptr [rbp-58h], 0
+  .text:0000000001E67A63                 mov     [rbp-70h], rax
+  .text:0000000001E67A67                 lea     rax, aRegisterentity; "RegisterEntityClass"
+  .text:0000000001E67A6E                 mov     [rbp-60h], rax
+  .text:0000000001E67A72                 lea     rcx, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:0000000001E67A79                 xor     eax, eax
+  .text:0000000001E67A7B                 mov     qword ptr [rbp-50h], 0
+  .text:0000000001E67A83                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E67A8B                 mov     qword ptr [rbp-40h], 0
+  .text:0000000001E67A93                 mov     dword ptr [rbp-38h], 0
+  .text:0000000001E67A9A                 call    __Z17LoggingSystem_Logi17LoggingSeverity_tRK20LoggingRareOptions_tPKcz; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const&,char const*,...)
+  .text:0000000001E67A9F                 jmp     loc_1E67984
+  .text:0000000001E67AA4                 or      eax, 0FFFFFFFFh
+  .text:0000000001E67AA7                 retn
+procedure: |-
+  __int64 __fastcall sub_1E67830(__int64 a1, signed __int64 a2)
+  {
+    __int64 *v2; // rax
+    __int64 v3; // rax
+    unsigned __int64 v4; // rax
+    unsigned __int64 v5; // r15
+    __int64 v7; // rax
+    const char *v8; // rax
+    __m128i v9; // [rsp-88h] [rbp-88h] BYREF
+    __m128i inserted; // [rsp-78h] [rbp-78h] BYREF
+    const char *v11; // [rsp-68h] [rbp-68h]
+    __int64 v12; // [rsp-60h] [rbp-60h]
+    __int64 v13; // [rsp-58h] [rbp-58h]
+    __int64 v14; // [rsp-50h] [rbp-50h]
+    __int64 v15; // [rsp-48h] [rbp-48h]
+    int v16; // [rsp-40h] [rbp-40h]
+
+    if ( !a2 )
+      return 0xFFFFFFFFLL;
+    v2 = *(__int64 **)(a2 + 80);
+    v9.m128i_i64[0] = v2[1];
+    v3 = *v2;
+    inserted.m128i_i64[0] = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v11 = (const char *)(a1 + 2704);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v9.m128i_i64[1] = v3;
+    inserted.m128i_i64[1] = (__int64)&v9;
+    if ( (unsigned int)sub_1E5FED0(a1 + 2712, &inserted) >> 16 != 0xFFFF )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27BBCDC, 5) )
+      {
+        inserted.m128i_i32[2] = 630;
+        v12 = 0;
+        inserted.m128i_i64[0] = (__int64)"entitysystem.cpp";
+        v11 = "RegisterEntityClass";
+        v13 = 0;
+        v14 = 0;
+        v15 = 0;
+        v16 = 0;
+        LoggingSystem_Log(
+          (unsigned int)dword_27BBCDC,
+          5,
+          &inserted,
+          "Multiple registration of class %s\n",
+          (const char *)v9.m128i_i64[0]);
+      }
+      return 0xFFFFFFFFLL;
+    }
+    if ( v9.m128i_i64[1] )
+    {
+      inserted.m128i_i64[0] = a1 + 2736;// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      inserted.m128i_i64[1] = (__int64)&v9.m128i_i64[1];
+      v11 = (const char *)(a1 + 2736);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v4 = sub_1E5FED0(a1 + 2744, &inserted);
+      v5 = v4 >> 16;
+      if ( WORD1(v4) != 0xFFFF )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27BBCDC, 5) )
+        {
+          v7 = 0;
+          if ( (*(_WORD *)(a1 + 2746) & 0x7FFF) != 0 )
+            v7 = *(_QWORD *)(a1 + 2752);
+          v8 = *(const char **)(*(_QWORD *)(*(_QWORD *)(v7 + 24LL * (unsigned __int16)v5 + 16) + 80LL) + 8LL);
+          inserted.m128i_i64[0] = (__int64)"entitysystem.cpp";
+          v11 = "RegisterEntityClass";
+          inserted.m128i_i32[2] = 639;
+          v12 = 0;
+          v13 = 0;
+          v14 = 0;
+          v15 = 0;
+          v16 = 0;
+          LoggingSystem_Log(
+            (unsigned int)dword_27BBCDC,
+            5,
+            &inserted,
+            "Multiple entity classes have the same designer name \"%s\" ( class %s and class %s )\n",
+            (const char *)v9.m128i_i64[1],
+            (const char *)v9.m128i_i64[0],
+            v8);
+        }
+        return 0xFFFFFFFFLL;
+      }
+    }
+    sub_1E3CF10(a2);
+    if ( v9.m128i_i64[1] )
+    {
+      inserted = _mm_insert_epi64((__m128i)v9.m128i_u64[1], a2, 1);
+      sub_1E67440(a1 + 2736, &inserted);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+    }
+    inserted = _mm_insert_epi64(_mm_loadl_epi64(&v9), a2, 1);
+    return (unsigned __int16)sub_1E67440(a1 + 2704, &inserted);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.windows.yaml
@@ -1,0 +1,223 @@
+func_name: CEntitySystem_RegisterEntityClass
+func_va: '0x1811f56c0'
+disasm_code: |-
+  .text:00000001811F56C0                 push    rbp
+  .text:00000001811F56C2                 push    rbx
+  .text:00000001811F56C3                 push    rsi
+  .text:00000001811F56C4                 push    rdi
+  .text:00000001811F56C5                 push    r12
+  .text:00000001811F56C7                 push    r14
+  .text:00000001811F56C9                 push    r15
+  .text:00000001811F56CB                 lea     rbp, [rsp-27h]
+  .text:00000001811F56D0                 sub     rsp, 0A0h
+  .text:00000001811F56D7                 mov     rbx, rdx
+  .text:00000001811F56DA                 mov     rdi, rcx
+  .text:00000001811F56DD                 test    rdx, rdx
+  .text:00000001811F56E0                 jz      loc_1811F57A0
+  .text:00000001811F56E6                 mov     r8, [rdx+50h]
+  .text:00000001811F56EA                 ; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:00000001811F56EA                 lea     r14, [rcx+0A90h]; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:00000001811F56F1                 lea     rcx, [r14+8]
+  .text:00000001811F56F5                 mov     [rbp+57h+var_90], r14
+  .text:00000001811F56F9                 lea     rdx, [rbp+57h+arg_8]
+  .text:00000001811F56FD                 mov     [rbp+57h+var_80], r14
+  .text:00000001811F5701                 mov     rax, [r8+8]
+  .text:00000001811F5705                 mov     [rbp+57h+arg_18], rax
+  .text:00000001811F5709                 mov     rax, [r8]
+  .text:00000001811F570C                 lea     r8, [rbp+57h+var_90]
+  .text:00000001811F5710                 mov     [rbp+57h+arg_10], rax
+  .text:00000001811F5714                 lea     rax, [rbp+57h+arg_18]
+  .text:00000001811F5718                 mov     [rbp+57h+var_88], rax
+  .text:00000001811F571C                 call    sub_1811E2BC0
+  .text:00000001811F5721                 mov     r12d, 0FFFFh
+  .text:00000001811F5727                 cmp     [rax+2], r12w
+  .text:00000001811F572C                 jz      loc_1811F57B7
+  .text:00000001811F5732                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F5738                 mov     edx, 5
+  .text:00000001811F573D                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F5743                 test    al, al
+  .text:00000001811F5745                 jz      short loc_1811F57A0
+  .text:00000001811F5747                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F574B                 lea     rcx, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F5752                 mov     [rbp+57h+var_78], rcx
+  .text:00000001811F5756                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:00000001811F575D                 lea     rcx, aCentitysystemR_1; "CEntitySystem::RegisterEntityClass"
+  .text:00000001811F5764                 mov     [rbp+57h+var_70], 276h
+  .text:00000001811F576B                 mov     [rbp+57h+var_68], rcx
+  .text:00000001811F576F                 lea     r8, [rbp+57h+var_78]
+  .text:00000001811F5773                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F5779                 xorps   xmm0, xmm0
+  .text:00000001811F577C                 xorps   xmm1, xmm1
+  .text:00000001811F577F                 mov     [rbp+57h+var_40], 0
+  .text:00000001811F5786                 mov     edx, 5
+  .text:00000001811F578B                 mov     [rsp+0D0h+var_B0], rax
+  .text:00000001811F5790                 movdqu  [rbp+57h+var_60], xmm0
+  .text:00000001811F5795                 movdqu  [rbp+57h+var_50], xmm1
+  .text:00000001811F579A                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F57A0                 mov     eax, 0FFFFFFFFh
+  .text:00000001811F57A5                 add     rsp, 0A0h
+  .text:00000001811F57AC                 pop     r15
+  .text:00000001811F57AE                 pop     r14
+  .text:00000001811F57B0                 pop     r12
+  .text:00000001811F57B2                 pop     rdi
+  .text:00000001811F57B3                 pop     rsi
+  .text:00000001811F57B4                 pop     rbx
+  .text:00000001811F57B5                 pop     rbp
+  .text:00000001811F57B6                 retn
+  .text:00000001811F57B7                 cmp     [rbp+57h+arg_10], 0
+  .text:00000001811F57BC                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:00000001811F57BC                 lea     rsi, [rdi+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:00000001811F57C3                 jz      loc_1811F58A4
+  .text:00000001811F57C9                 lea     rax, [rbp+57h+arg_10]
+  .text:00000001811F57CD                 mov     [rbp+57h+var_90], rsi
+  .text:00000001811F57D1                 lea     rcx, [rsi+8]
+  .text:00000001811F57D5                 mov     [rbp+57h+var_88], rax
+  .text:00000001811F57D9                 lea     r8, [rbp+57h+var_90]
+  .text:00000001811F57DD                 mov     [rbp+57h+var_80], rsi
+  .text:00000001811F57E1                 lea     rdx, [rbp+57h+arg_8]
+  .text:00000001811F57E5                 call    sub_1811E2BC0
+  .text:00000001811F57EA                 movzx   r15d, word ptr [rax+2]
+  .text:00000001811F57EF                 cmp     r15w, r12w
+  .text:00000001811F57F3                 jz      loc_1811F58A4
+  .text:00000001811F57F9                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F57FF                 mov     edx, 5
+  .text:00000001811F5804                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F580A                 test    al, al
+  .text:00000001811F580C                 jz      short loc_1811F57A0
+  .text:00000001811F580E                 mov     eax, 7FFFh
+  .text:00000001811F5813                 test    [rdi+0ABAh], ax
+  .text:00000001811F581A                 jnz     short loc_1811F5820
+  .text:00000001811F581C                 xor     edx, edx
+  .text:00000001811F581E                 jmp     short loc_1811F5827
+  .text:00000001811F5820                 mov     rdx, [rdi+0AC0h]
+  .text:00000001811F5827                 lea     rcx, [r15+r15*2]
+  .text:00000001811F582B                 xorps   xmm0, xmm0
+  .text:00000001811F582E                 mov     rax, [rdx+rcx*8+10h]
+  .text:00000001811F5833                 lea     r9, aMultipleEntity_0; "Multiple entity classes have the same d"...
+  .text:00000001811F583A                 xorps   xmm1, xmm1
+  .text:00000001811F583D                 lea     r8, [rbp+57h+var_78]
+  .text:00000001811F5841                 mov     edx, 5
+  .text:00000001811F5846                 mov     rcx, [rax+50h]
+  .text:00000001811F584A                 mov     rax, [rcx+8]
+  .text:00000001811F584E                 lea     rcx, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F5855                 mov     [rsp+0D0h+var_A0], rax
+  .text:00000001811F585A                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F585E                 mov     [rbp+57h+var_78], rcx
+  .text:00000001811F5862                 lea     rcx, aCentitysystemR_1; "CEntitySystem::RegisterEntityClass"
+  .text:00000001811F5869                 mov     [rsp+0D0h+var_A8], rax
+  .text:00000001811F586E                 mov     rax, [rbp+57h+arg_10]
+  .text:00000001811F5872                 mov     [rbp+57h+var_68], rcx
+  .text:00000001811F5876                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F587C                 mov     [rsp+0D0h+var_B0], rax
+  .text:00000001811F5881                 mov     [rbp+57h+var_70], 280h
+  .text:00000001811F5888                 movdqu  [rbp+57h+var_60], xmm0
+  .text:00000001811F588D                 mov     [rbp+57h+var_40], 0
+  .text:00000001811F5894                 movdqu  [rbp+57h+var_50], xmm1
+  .text:00000001811F5899                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F589F                 jmp     loc_1811F57A0
+  .text:00000001811F58A4                 mov     rcx, rbx
+  .text:00000001811F58A7                 call    sub_1811E0050
+  .text:00000001811F58AC                 mov     rax, [rbp+57h+arg_10]
+  .text:00000001811F58B0                 test    rax, rax
+  .text:00000001811F58B3                 jz      short loc_1811F58C9
+  .text:00000001811F58B5                 lea     rdx, [rbp+57h+var_90]
+  .text:00000001811F58B9                 mov     [rbp+57h+var_90], rax
+  .text:00000001811F58BD                 mov     rcx, rsi
+  .text:00000001811F58C0                 mov     [rbp+57h+var_88], rbx
+  .text:00000001811F58C4                 call    sub_1811F16D0
+  .text:00000001811F58C9                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F58CD                 lea     rdx, [rbp+57h+var_90]
+  .text:00000001811F58D1                 mov     rcx, r14
+  .text:00000001811F58D4                 mov     [rbp+57h+var_90], rax
+  .text:00000001811F58D8                 mov     [rbp+57h+var_88], rbx
+  .text:00000001811F58DC                 call    sub_1811F16D0
+  .text:00000001811F58E1                 movzx   eax, ax
+  .text:00000001811F58E4                 jmp     loc_1811F57A5
+procedure: |-
+  __int64 __fastcall CEntitySystem_RegisterEntityClass(__int64 a1, __int64 a2)
+  {
+    __int64 v4; // r8
+    __int64 v5; // r14
+    __int64 v7; // r15
+    __int64 v8; // rdx
+    const char *v9; // [rsp+30h] [rbp-49h]
+    const char *v10; // [rsp+40h] [rbp-39h] BYREF
+    const char **v11; // [rsp+48h] [rbp-31h]
+    __int64 v12; // [rsp+50h] [rbp-29h]
+    const char *v13; // [rsp+58h] [rbp-21h] BYREF
+    int v14; // [rsp+60h] [rbp-19h]
+    const char *v15; // [rsp+68h] [rbp-11h]
+    __int128 v16; // [rsp+70h] [rbp-9h]
+    __int128 v17; // [rsp+80h] [rbp+7h]
+    int v18; // [rsp+90h] [rbp+17h]
+    char v19; // [rsp+E8h] [rbp+6Fh] BYREF
+    const char *v20; // [rsp+F0h] [rbp+77h] BYREF
+    const char *v21; // [rsp+F8h] [rbp+7Fh] BYREF
+
+    if ( !a2 )
+      return 0xFFFFFFFFLL;
+    v4 = *(_QWORD *)(a2 + 80);
+    v5 = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v10 = (const char *)(a1 + 2704);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v12 = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v21 = *(const char **)(v4 + 8);
+    v20 = *(const char **)v4;
+    v11 = &v21;
+    if ( *(_WORD *)(sub_1811E2BC0(a1 + 2712, &v19, &v10) + 2) != 0xFFFF )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
+      {
+        v13 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+        v14 = 630;
+        v15 = "CEntitySystem::RegisterEntityClass";
+        v18 = 0;
+        v16 = 0;
+        v17 = 0;
+        LoggingSystem_Log((unsigned int)dword_1820B1848, 5, &v13, "Multiple registration of class %s\n", v21);
+      }
+      return 0xFFFFFFFFLL;
+    }
+    if ( v20 )
+    {
+      v10 = (const char *)(a1 + 2736);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v11 = &v20;
+      v12 = a1 + 2736;// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v7 = *(unsigned __int16 *)(sub_1811E2BC0(a1 + 2744, &v19, &v10) + 2);
+      if ( (_WORD)v7 != 0xFFFF )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
+        {
+          if ( (*(_WORD *)(a1 + 2746) & 0x7FFF) != 0 )
+            v8 = *(_QWORD *)(a1 + 2752);
+          else
+            v8 = 0;
+          v9 = *(const char **)(*(_QWORD *)(*(_QWORD *)(v8 + 24 * v7 + 16) + 80LL) + 8LL);
+          v13 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+          v15 = "CEntitySystem::RegisterEntityClass";
+          v14 = 640;
+          v16 = 0;
+          v18 = 0;
+          v17 = 0;
+          LoggingSystem_Log(
+            (unsigned int)dword_1820B1848,
+            5,
+            &v13,
+            "Multiple entity classes have the same designer name \"%s\" ( class %s and class %s )\n",
+            v20,
+            v21,
+            v9);
+        }
+        return 0xFFFFFFFFLL;
+      }
+    }
+    sub_1811E0050(a2);
+    if ( v20 )
+    {
+      v10 = v20;
+      v11 = (const char **)a2;
+      sub_1811F16D0(a1 + 2736, &v10);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+    }
+    v10 = v21;
+    v11 = (const char **)a2;
+    return (unsigned __int16)sub_1811F16D0(v5, &v10);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.linux.yaml
@@ -1,0 +1,126 @@
+func_name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+func_va: '0x1529420'
+disasm_code: |-
+  .text:0000000001529420                 push    rbp
+  .text:0000000001529421                 mov     rbp, rsp
+  .text:0000000001529424                 push    r15
+  .text:0000000001529426                 mov     r15, rdx
+  .text:0000000001529429                 push    r14
+  .text:000000000152942B                 mov     r14, rcx
+  .text:000000000152942E                 push    r13
+  .text:0000000001529430                 mov     r13, rdi
+  .text:0000000001529433                 push    r12
+  .text:0000000001529435                 mov     r12, rsi
+  .text:0000000001529438                 push    rbx
+  .text:0000000001529439                 sub     rsp, 28h
+  .text:000000000152943D                 call    sub_C7BDE0
+  .text:0000000001529442                 mov     edi, 1
+  .text:0000000001529447                 mov     ebx, eax
+  .text:0000000001529449                 call    sub_C7BDF0
+  .text:000000000152944E                 mov     rsi, r12
+  .text:0000000001529451                 mov     rdi, r13
+  .text:0000000001529454                 mov     rcx, r14
+  .text:0000000001529457                 mov     rdx, r15
+  .text:000000000152945A                 call    sub_1E50DD0
+  .text:000000000152945F                 lea     rsi, aGamesessionman; "GameSessionManifest.vrgrp"
+  .text:0000000001529466                 ; _QWORD
+  .text:0000000001529466                 mov     rdi, r12; _QWORD
+  .text:0000000001529469                 call    _V_stricmp_fast
+  .text:000000000152946E                 test    eax, eax
+  .text:0000000001529470                 jz      short loc_1529490
+  .text:0000000001529472                 add     rsp, 28h
+  .text:0000000001529476                 movzx   edi, bl
+  .text:0000000001529479                 pop     rbx
+  .text:000000000152947A                 pop     r12
+  .text:000000000152947C                 pop     r13
+  .text:000000000152947E                 pop     r14
+  .text:0000000001529480                 pop     r15
+  .text:0000000001529482                 pop     rbp
+  .text:0000000001529483                 jmp     sub_C7BDF0
+  .text:0000000001529490                 mov     edi, cs:dword_246EC68
+  .text:0000000001529496                 mov     [rbp+var_48], r14
+  .text:000000000152949A                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:000000000152949A                 mov     r12, [r13+8]; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:000000000152949E                 mov     [r13+8], r14; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294A2                 test    edi, edi
+  .text:00000000015294A4                 js      short loc_15294C0
+  .text:00000000015294A6                 lea     rcx, [rbp+var_48]
+  .text:00000000015294AA                 mov     esi, 39h ; '9'
+  .text:00000000015294AF                 xor     edx, edx
+  .text:00000000015294B1                 call    sub_DEF550
+  .text:00000000015294B6                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294B6                 mov     [r13+8], r12; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294BA                 jmp     short loc_1529472
+  .text:00000000015294C0                 lea     r15, off_2288CD8
+  .text:00000000015294C7                 mov     [rbp+var_38], 0
+  .text:00000000015294CF                 mov     [rbp+var_40], r15
+  .text:00000000015294D3                 movzx   eax, cs:byte_25EFB20
+  .text:00000000015294DA                 test    al, al
+  .text:00000000015294DC                 jz      short loc_1529510
+  .text:00000000015294DE                 mov     rax, cs:qword_25EFB28
+  .text:00000000015294E5                 lea     r14, [rbp+var_40]
+  .text:00000000015294E9                 mov     rdi, r14
+  .text:00000000015294EC                 mov     [rbp+var_40], rax
+  .text:00000000015294F0                 call    qword ptr [rax+38h]
+  .text:00000000015294F3                 mov     rdi, r14
+  .text:00000000015294F6                 mov     [rbp+var_40], r15
+  .text:00000000015294FA                 mov     cs:dword_246EC68, eax
+  .text:0000000001529500                 call    nullsub_503
+  .text:0000000001529505                 mov     edi, cs:dword_246EC68
+  .text:000000000152950B                 jmp     short loc_15294A6
+  .text:0000000001529510                 lea     r14, byte_25EFB20
+  .text:0000000001529517                 ; _QWORD
+  .text:0000000001529517                 mov     rdi, r14; _QWORD
+  .text:000000000152951A                 call    ___cxa_guard_acquire
+  .text:000000000152951F                 test    eax, eax
+  .text:0000000001529521                 jz      short loc_15294DE
+  .text:0000000001529523                 mov     rax, cs:off_246E630
+  .text:000000000152952A                 ; _QWORD
+  .text:000000000152952A                 mov     rdi, r14; _QWORD
+  .text:000000000152952D                 mov     cs:qword_25EFB28, rax
+  .text:0000000001529534                 call    ___cxa_guard_release
+  .text:0000000001529539                 jmp     short loc_15294DE
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName(
+          __int64 a1,
+          __int64 a2,
+          __int64 a3,
+          __int64 a4)
+  {
+    unsigned __int8 v7; // bl
+    __int64 v9; // rdi
+    __int64 v10; // r12
+    int v11; // eax
+    __int64 v12; // [rsp+8h] [rbp-48h] BYREF
+    _QWORD v13[8]; // [rsp+10h] [rbp-40h] BYREF
+
+    v7 = sub_C7BDE0();
+    sub_C7BDF0(1);
+    sub_1E50DD0(a1, a2, a3, a4);
+    if ( !(unsigned int)V_stricmp_fast(a2, "GameSessionManifest.vrgrp") )
+    {
+      v9 = (unsigned int)dword_246EC68;
+      v12 = a4;
+      v10 = *(_QWORD *)(a1 + 8);// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      *(_QWORD *)(a1 + 8) = a4;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      if ( (int)v9 < 0 )
+      {
+        v13[1] = 0;
+        v13[0] = off_2288CD8;
+        if ( !(_BYTE)byte_25EFB20 && (unsigned int)__cxa_guard_acquire(&byte_25EFB20) )
+        {
+          qword_25EFB28 = (__int64)off_246E630[0];
+          __cxa_guard_release(&byte_25EFB20);
+        }
+        v13[0] = qword_25EFB28;
+        v11 = (*(__int64 (__fastcall **)(_QWORD *))(qword_25EFB28 + 56))(v13);
+        v13[0] = off_2288CD8;
+        dword_246EC68 = v11;
+        nullsub_503(v13);
+        v9 = (unsigned int)dword_246EC68;
+      }
+      sub_DEF550(v9, 57, 0, &v12);
+      *(_QWORD *)(a1 + 8) = v10;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+    }
+    return sub_C7BDF0(v7);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.windows.yaml
@@ -1,0 +1,133 @@
+func_name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+func_va: '0x180b42fc0'
+disasm_code: |-
+  .text:0000000180B42FC0                 mov     [rsp+arg_0], rbx
+  .text:0000000180B42FC5                 mov     [rsp+arg_8], rbp
+  .text:0000000180B42FCA                 mov     [rsp+arg_10], rsi
+  .text:0000000180B42FCF                 mov     [rsp+arg_18], rdi
+  .text:0000000180B42FD4                 push    r14
+  .text:0000000180B42FD6                 sub     rsp, 40h
+  .text:0000000180B42FDA                 mov     rbp, r9
+  .text:0000000180B42FDD                 mov     rbx, r8
+  .text:0000000180B42FE0                 mov     rdi, rdx
+  .text:0000000180B42FE3                 mov     rsi, rcx
+  .text:0000000180B42FE6                 call    sub_1803DE7B0
+  .text:0000000180B42FEB                 mov     cl, 1
+  .text:0000000180B42FED                 movzx   r14d, al
+  .text:0000000180B42FF1                 call    sub_1803E9060
+  .text:0000000180B42FF6                 mov     r9, rbp
+  .text:0000000180B42FF9                 mov     r8, rbx
+  .text:0000000180B42FFC                 mov     rdx, rdi
+  .text:0000000180B42FFF                 mov     rcx, rsi
+  .text:0000000180B43002                 call    sub_1811E82E0
+  .text:0000000180B43007                 lea     rdx, aGamesessionman; "GameSessionManifest.vrgrp"
+  .text:0000000180B4300E                 mov     rcx, rdi
+  .text:0000000180B43011                 call    cs:V_stricmp_fast
+  .text:0000000180B43017                 test    eax, eax
+  .text:0000000180B43019                 jnz     loc_180B430B9
+  .text:0000000180B4301F                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B4301F                 mov     rdi, [rsi+8]; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B43023                 mov     [rsi+8], rbp; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B43027                 mov     ecx, cs:dword_181B9ADC8
+  .text:0000000180B4302D                 mov     [rsp+48h+var_28], rbp
+  .text:0000000180B43032                 test    ecx, ecx
+  .text:0000000180B43034                 jns     short loc_180B430A4
+  .text:0000000180B43036                 mov     ecx, cs:TlsIndex
+  .text:0000000180B4303C                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180B43043                 mov     [rsp+48h+var_20], rax
+  .text:0000000180B43048                 mov     rax, gs:58h
+  .text:0000000180B43051                 mov     edx, 218h
+  .text:0000000180B43056                 mov     [rsp+48h+var_18], 0
+  .text:0000000180B4305F                 mov     rax, [rax+rcx*8]
+  .text:0000000180B43063                 mov     eax, [rdx+rax]
+  .text:0000000180B43066                 cmp     cs:dword_181E14850, eax
+  .text:0000000180B4306C                 jg      short loc_180B430DC
+  .text:0000000180B4306E                 mov     rax, cs:qword_181E14848
+  .text:0000000180B43075                 lea     rcx, [rsp+48h+var_20]
+  .text:0000000180B4307A                 mov     rbx, [rsp+48h+var_20]
+  .text:0000000180B4307F                 mov     [rsp+48h+var_20], rax
+  .text:0000000180B43084                 call    sub_1805087D0
+  .text:0000000180B43089                 lea     rcx, [rsp+48h+var_20]
+  .text:0000000180B4308E                 mov     [rsp+48h+var_20], rbx
+  .text:0000000180B43093                 mov     cs:dword_181B9ADC8, eax
+  .text:0000000180B43099                 call    sub_180507F80
+  .text:0000000180B4309E                 mov     ecx, cs:dword_181B9ADC8
+  .text:0000000180B430A4                 lea     r8, [rsp+48h+var_28]
+  .text:0000000180B430A9                 lea     rdx, sub_1805087D0
+  .text:0000000180B430B0                 call    sub_180512270
+  .text:0000000180B430B5                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B430B5                 mov     [rsi+8], rdi; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B430B9                 movzx   ecx, r14b
+  .text:0000000180B430BD                 mov     rbx, [rsp+48h+arg_0]
+  .text:0000000180B430C2                 mov     rbp, [rsp+48h+arg_8]
+  .text:0000000180B430C7                 mov     rsi, [rsp+48h+arg_10]
+  .text:0000000180B430CC                 mov     rdi, [rsp+48h+arg_18]
+  .text:0000000180B430D1                 add     rsp, 40h
+  .text:0000000180B430D5                 pop     r14
+  .text:0000000180B430D7                 jmp     sub_1803E9060
+  .text:0000000180B430DC                 lea     rcx, dword_181E14850
+  .text:0000000180B430E3                 call    sub_1814F7664
+  .text:0000000180B430E8                 cmp     cs:dword_181E14850, 0FFFFFFFFh
+  .text:0000000180B430EF                 jnz     loc_180B4306E
+  .text:0000000180B430F5                 mov     rax, cs:off_181B9AEE0
+  .text:0000000180B430FC                 lea     rcx, dword_181E14850
+  .text:0000000180B43103                 mov     cs:qword_181E14848, rax
+  .text:0000000180B4310A                 call    sub_1814F75F8
+  .text:0000000180B4310F                 jmp     loc_180B4306E
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName(
+          __int64 a1,
+          __int64 a2,
+          __int64 a3,
+          __int64 a4)
+  {
+    unsigned __int8 v8; // al
+    __int64 v9; // rcx
+    unsigned __int8 v10; // r14
+    __int64 v11; // r8
+    __int64 v12; // rdi
+    __int64 v13; // rcx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v15; // rbx
+    int v16; // eax
+    __int64 v18; // [rsp+20h] [rbp-28h] BYREF
+    _QWORD v19[4]; // [rsp+28h] [rbp-20h] BYREF
+
+    v8 = sub_1803DE7B0();
+    LOBYTE(v9) = 1;
+    v10 = v8;
+    sub_1803E9060(v9);
+    sub_1811E82E0(a1, a2, a3, a4);
+    if ( !(unsigned int)V_stricmp_fast(a2, "GameSessionManifest.vrgrp", v11) )
+    {
+      v12 = *(_QWORD *)(a1 + 8);// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      *(_QWORD *)(a1 + 8) = a4;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      v13 = (unsigned int)dword_181B9ADC8;
+      v18 = a4;
+      if ( dword_181B9ADC8 < 0 )
+      {
+        v19[0] = &CDontUseThisGameSystem::`vftable';
+        ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+        v19[1] = 0;
+        if ( dword_181E14850 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 536LL) )
+        {
+          sub_1814F7664(&dword_181E14850);
+          if ( dword_181E14850 == -1 )
+          {
+            qword_181E14848 = (__int64)off_181B9AEE0[0];
+            sub_1814F75F8(&dword_181E14850);
+          }
+        }
+        v15 = v19[0];
+        v19[0] = qword_181E14848;
+        v16 = sub_1805087D0(v19);
+        v19[0] = v15;
+        dword_181B9ADC8 = v16;
+        sub_180507F80(v19);
+        v13 = (unsigned int)dword_181B9ADC8;
+      }
+      sub_180512270(v13, sub_1805087D0, &v18);
+      *(_QWORD *)(a1 + 8) = v12;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+    }
+    return sub_1803E9060(v10);
+  }


### PR DESCRIPTION
## Summary
- Add `find-CEntitySystem_m_pCurrentManifest` preprocessor script (Pattern E: struct member via LLM_DECOMPILE)
- LLM_DECOMPILE predecessor: `CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName`
- `m_pCurrentManifest` is at offset `0x8` in `CEntitySystem`
- Adds annotated reference YAMLs for both Windows and Linux

## Test plan
- [ ] `ida_analyze_bin.py -debug` shows `find-CEntitySystem_m_pCurrentManifest` skipped with "all outputs exist" on both platforms