### PR TITLE
Add CEntitySystem struct member skills

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5682,6 +5682,12 @@ modules:
         expected_output:
           - CEntitySystem_Init.{platform}.yaml
 
+      - name: find-CEntitySystem_m_sEntSystemName
+        expected_output:
+          - CEntitySystem_m_sEntSystemName.{platform}.yaml
+        expected_input:
+          - CEntitySystem_Init.{platform}.yaml
+
       - name: find-INetworkMessages_SetNetworkSerializationContextData-AND-IFlattenedSerializers_CreateFieldChangedEventQueue
         expected_output:
           - INetworkMessages_SetNetworkSerializationContextData.{platform}.yaml
@@ -8756,6 +8762,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::Init
+
+      - name: CEntitySystem_m_sEntSystemName
+        category: structmember
+        struct: CEntitySystem
+        member: m_sEntSystemName
 
       - name: CEntitySystem_ClearEntityDatabase
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -5135,6 +5135,12 @@ modules:
         expected_input:
           - CGameEntitySystem_vtable.{platform}.yaml
 
+      - name: find-CEntitySystem_m_pCurrentManifest
+        expected_output:
+          - CEntitySystem_m_pCurrentManifest.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.{platform}.yaml
+
       - name: find-CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
         expected_output:
           - CGameEntitySystem_BuildResourceManifest_KeyValuesVectors.{platform}.yaml
@@ -8172,6 +8178,11 @@ modules:
         category: vfunc
         alias:
           - CGameEntitySystem::BuildResourceManifest_ManifestNameOrGroupName
+
+      - name: CEntitySystem_m_pCurrentManifest
+        category: structmember
+        struct: CEntitySystem
+        member: m_pCurrentManifest
 
       - name: CGameEntitySystem_BuildResourceManifest_KeyValuesVectors
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4598,6 +4598,13 @@ modules:
         expected_output:
           - CEntitySystem_RegisterEntityClass.{platform}.yaml
 
+      - name: find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname
+        expected_output:
+          - CEntitySystem_m_entClassesByCPPClassname.{platform}.yaml
+          - CEntitySystem_m_entClassesByClassname.{platform}.yaml
+        expected_input:
+          - CEntitySystem_RegisterEntityClass.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntityByName
         expected_output:
           - CEntitySystem_CreateEntityByName.{platform}.yaml
@@ -7343,6 +7350,16 @@ modules:
         category: func
         alias:
           - CEntitySystem::RegisterEntityClass
+
+      - name: CEntitySystem_m_entClassesByCPPClassname
+        category: structmember
+        struct: CEntitySystem
+        member: m_entClassesByCPPClassname
+
+      - name: CEntitySystem_m_entClassesByClassname
+        category: structmember
+        struct: CEntitySystem
+        member: m_entClassesByClassname
 
       - name: CEntitySystem_CreateEntityByName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -4594,6 +4594,10 @@ modules:
         expected_output:
           - CEntitySystem_vtable.{platform}.yaml
 
+      - name: find-CEntitySystem_RegisterEntityClass
+        expected_output:
+          - CEntitySystem_RegisterEntityClass.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntityByName
         expected_output:
           - CEntitySystem_CreateEntityByName.{platform}.yaml
@@ -7334,6 +7338,11 @@ modules:
 
       - name: CEntitySystem_vtable
         category: vtable
+
+      - name: CEntitySystem_RegisterEntityClass
+        category: func
+        alias:
+          - CEntitySystem::RegisterEntityClass
 
       - name: CEntitySystem_CreateEntityByName
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_RegisterEntityClass.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RegisterEntityClass.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RegisterEntityClass skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RegisterEntityClass",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_RegisterEntityClass",
+        "xref_strings": [
+            'Multiple entity classes have the same designer name "%s" ( class %s and class %s )\n',
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": [], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_RegisterEntityClass",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_entClassesByCPPClassname",
+    "CEntitySystem_m_entClassesByClassname",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_entClassesByCPPClassname",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RegisterEntityClass.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_entClassesByClassname",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RegisterEntityClass.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_entClassesByCPPClassname",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_entClassesByClassname",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offsets and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_pCurrentManifest.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_pCurrentManifest.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_pCurrentManifest skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_pCurrentManifest",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_pCurrentManifest",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_pCurrentManifest",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_sEntSystemName.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_sEntSystemName.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_sEntSystemName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_sEntSystemName",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_sEntSystemName",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_sEntSystemName",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -1,540 +1,586 @@
 func_name: CEntitySystem_Init
-func_va: '0x1d85780'
+func_va: '0x1e73880'
 disasm_code: |-
-  .text:0000000001D85780                 push    rbp
-  .text:0000000001D85781                 mov     rbp, rsp
-  .text:0000000001D85784                 push    r15
-  .text:0000000001D85786                 push    r14
-  .text:0000000001D85788                 mov     r14d, r8d
-  .text:0000000001D8578B                 push    r13
-  .text:0000000001D8578D                 mov     r13d, ecx
-  .text:0000000001D85790                 push    r12
-  .text:0000000001D85792                 mov     r12d, edx
-  .text:0000000001D85795                 push    rbx
-  .text:0000000001D85796                 mov     rbx, rdi
-  .text:0000000001D85799                 add     rdi, 0A88h
-  .text:0000000001D857A0                 sub     rsp, 68h
-  .text:0000000001D857A4                 call    sub_97F150
-  .text:0000000001D857A9                 lea     rax, unk_2664201
-  .text:0000000001D857B0                 mov     [rbx+0BC4h], r13d
-  .text:0000000001D857B7                 mov     [rax], r14b
-  .text:0000000001D857BA                 cmp     r12d, 1
-  .text:0000000001D857BE                 jz      loc_1D85B08
-  .text:0000000001D857C4                 lea     r13, g_pNetworkMessages
-  .text:0000000001D857CB                 xor     eax, eax
-  .text:0000000001D857CD                 mov     [rbx+0BE2h], al
-  .text:0000000001D857D3                 xor     r8d, r8d
-  .text:0000000001D857D6                 xor     ecx, ecx
-  .text:0000000001D857D8                 xor     edx, edx
-  .text:0000000001D857DA                 lea     rdi, [rbx+0CC8h]
-  .text:0000000001D857E1                 mov     esi, 400h
-  .text:0000000001D857E6                 call    sub_97F670
-  .text:0000000001D857EB                 lea     r14, qword_2664108
-  .text:0000000001D857F2                 lea     rax, [rbx+10h]
-  .text:0000000001D857F6                 mov     cs:qword_24587A8, rbx
-  .text:0000000001D857FD                 mov     cs:qword_24587A0, rax
-  .text:0000000001D85804                 mov     r12, [r14]
-  .text:0000000001D85807                 test    r12, r12
-  .text:0000000001D8580A                 jz      short loc_1D85879
-  .text:0000000001D8580C                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85817                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85820                 test    byte ptr [r12+70h], 2
-  .text:0000000001D85826                 jz      loc_1D85A70
-  .text:0000000001D8582C                 mov     r12, [r12+128h]
-  .text:0000000001D85834                 test    r12, r12
-  .text:0000000001D85837                 jnz     short loc_1D85820
-  .text:0000000001D85839                 mov     r12, [r14]
-  .text:0000000001D8583C                 test    r12, r12
-  .text:0000000001D8583F                 jz      short loc_1D85879
-  .text:0000000001D85841                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D8584C                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85857                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85860                 test    byte ptr [r12+70h], 2
-  .text:0000000001D85866                 jnz     loc_1D85A48
-  .text:0000000001D8586C                 mov     r12, [r12+128h]
-  .text:0000000001D85874                 test    r12, r12
-  .text:0000000001D85877                 jnz     short loc_1D85860
-  .text:0000000001D85879                 mov     r12, cs:qword_245F230
-  .text:0000000001D85880                 xor     r14d, r14d
-  .text:0000000001D85883                 lea     r15, nullsub_2005
-  .text:0000000001D8588A                 test    r12, r12
-  .text:0000000001D8588D                 jz      short loc_1D858D6
-  .text:0000000001D8588F                 nop
-  .text:0000000001D85890                 mov     rsi, r12
-  .text:0000000001D85893                 mov     rdi, rbx
-  .text:0000000001D85896                 add     r14d, 1
-  .text:0000000001D8589A                 call    sub_1D85280
-  .text:0000000001D8589F                 mov     rdx, [r12+10h]
-  .text:0000000001D858A4                 mov     [rdx+20h], eax
-  .text:0000000001D858A7                 mov     rax, [r12+10h]
-  .text:0000000001D858AC                 test    byte ptr [rax+24h], 1
-  .text:0000000001D858B0                 jz      short loc_1D858BB
-  .text:0000000001D858B2                 or      dword ptr [r12+8], 20000h
-  .text:0000000001D858BB                 mov     rax, [r12]
-  .text:0000000001D858BF                 mov     rax, [rax+8]
-  .text:0000000001D858C3                 cmp     rax, r15
-  .text:0000000001D858C6                 jnz     loc_1D85A98
-  .text:0000000001D858CC                 mov     r12, [r12+20h]
-  .text:0000000001D858D1                 test    r12, r12
-  .text:0000000001D858D4                 jnz     short loc_1D85890
-  .text:0000000001D858D6                 lea     r15, qword_26640D0
-  .text:0000000001D858DD                 mov     eax, r14d
-  .text:0000000001D858E0                 sub     eax, [r15]
-  .text:0000000001D858E3                 test    eax, eax
-  .text:0000000001D858E5                 jg      loc_1D85A30
-  .text:0000000001D858EB                 jnz     loc_1D85A3D
-  .text:0000000001D858F1                 mov     r12, cs:qword_245F230
-  .text:0000000001D858F8                 test    r12, r12
-  .text:0000000001D858FB                 jz      short loc_1D85932
-  .text:0000000001D858FD                 nop     dword ptr [rax]
-  .text:0000000001D85900                 mov     rdi, [r13+0]
-  .text:0000000001D85904                 test    rdi, rdi
-  .text:0000000001D85907                 jz      short loc_1D85917
-  .text:0000000001D85909                 mov     rax, [rdi]
-  .text:0000000001D8590C                 mov     esi, [r12+18h]
-  .text:0000000001D85911                 call    qword ptr [rax+0F0h]
-  .text:0000000001D85917                 mov     rax, [r12+10h]
-  .text:0000000001D8591C                 mov     rdx, [r15+8]
-  .text:0000000001D85920                 movsxd  rcx, dword ptr [rax+20h]
-  .text:0000000001D85924                 mov     [rdx+rcx*8], rax
-  .text:0000000001D85928                 mov     r12, [r12+20h]
-  .text:0000000001D8592D                 test    r12, r12
-  .text:0000000001D85930                 jnz     short loc_1D85900
-  .text:0000000001D85932                 cmp     word ptr [rbx+0AAAh], 0
-  .text:0000000001D8593A                 jz      short loc_1D85975
-  .text:0000000001D8593C                 movzx   eax, word ptr [rbx+0AA8h]
-  .text:0000000001D85943                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001D8594C                 jz      loc_1D85AB0
-  .text:0000000001D85952                 cmp     ax, 0FFFFh
-  .text:0000000001D85956                 jnz     loc_1D85DBD
-  .text:0000000001D8595C                 mov     rcx, [rbx+0AA0h]
-  .text:0000000001D85963                 mov     edx, offset stru_17FFE8
-  .text:0000000001D85968                 mov     rsi, [rcx+rdx+10h]
-  .text:0000000001D8596D                 mov     rdi, rbx
-  .text:0000000001D85970                 call    sub_1D66C80
-  .text:0000000001D85975                 cmp     cs:byte_26642B0, 0
-  .text:0000000001D8597C                 jnz     short loc_1D85991
-  .text:0000000001D8597E                 movzx   r12d, word ptr [rbx+0AA8h]
-  .text:0000000001D85986                 cmp     r12w, 0FFFFh
-  .text:0000000001D8598B                 jnz     loc_1D85DFE
-  .text:0000000001D85991                 lea     rdi, aEntitysystemCl; "EntitySystem - Class Tables"
-  .text:0000000001D85998                 xor     eax, eax
-  .text:0000000001D8599A                 call    sub_9802C0
-  .text:0000000001D8599F                 mov     rdi, [r13+0]
-  .text:0000000001D859A3                 test    rdi, rdi
-  .text:0000000001D859A6                 jz      short loc_1D859F7
-  .text:0000000001D859A8                 mov     rax, [rdi]
-  .text:0000000001D859AB                 lea     rsi, aStringTTable; "string_t_table"
-  .text:0000000001D859B2                 mov     edx, [rbx+0BC4h]
-  .text:0000000001D859B8                 lea     rcx, [rbx+1ED8h]
-  .text:0000000001D859BF                 call    qword ptr [rax+0A8h]; g_pNetworkMessages->SetNetworkSerializationContextData(...), 0xA8 = INetworkMessages_SetNetworkSerializationContextData
-  .text:0000000001D859C5                 mov     rdi, [r13+0]
-  .text:0000000001D859C9                 lea     rsi, [rbp+var_50]
-  .text:0000000001D859CD                 mov     qword ptr [rbp+var_68], 119h
-  .text:0000000001D859D5                 mov     qword ptr [rbp+var_68+8], 0
-  .text:0000000001D859DD                 movdqu  xmm0, [rbp+var_68]
-  .text:0000000001D859E2                 mov     rax, [rdi]
-  .text:0000000001D859E5                 mov     [rbp+var_50], 0
-  .text:0000000001D859ED                 movups  [rbp+var_48], xmm0
-  .text:0000000001D859F1                 call    qword ptr [rax+0C0h]
-  .text:0000000001D859F7                 mov     rdi, rbx
-  .text:0000000001D859FA                 call    sub_1D84180
-  .text:0000000001D859FF                 cmp     byte ptr [rbx+0BE2h], 0
-  .text:0000000001D85A06                 jnz     loc_1D85B48
-  .text:0000000001D85A0C                 cmp     cs:byte_26642B0, 0
-  .text:0000000001D85A13                 jz      loc_1D85B20
-  .text:0000000001D85A19                 mov     cs:byte_26642B0, 1
-  .text:0000000001D85A20                 add     rsp, 68h
-  .text:0000000001D85A24                 pop     rbx
-  .text:0000000001D85A25                 pop     r12
-  .text:0000000001D85A27                 pop     r13
-  .text:0000000001D85A29                 pop     r14
-  .text:0000000001D85A2B                 pop     r15
-  .text:0000000001D85A2D                 pop     rbp
-  .text:0000000001D85A2E                 retn
-  .text:0000000001D85A30                 mov     edi, [r15+10h]
-  .text:0000000001D85A34                 cmp     r14d, edi
-  .text:0000000001D85A37                 jg      loc_1D85CF8
-  .text:0000000001D85A3D                 mov     [r15], r14d
-  .text:0000000001D85A40                 jmp     loc_1D858F1
-  .text:0000000001D85A48                 mov     rsi, r12
-  .text:0000000001D85A4B                 mov     rdi, rbx
-  .text:0000000001D85A4E                 call    sub_1D79600
-  .text:0000000001D85A53                 mov     r12, [r12+128h]
-  .text:0000000001D85A5B                 test    r12, r12
-  .text:0000000001D85A5E                 jnz     loc_1D85860
-  .text:0000000001D85A64                 jmp     loc_1D85879
-  .text:0000000001D85A70                 mov     rsi, r12
-  .text:0000000001D85A73                 mov     rdi, rbx
-  .text:0000000001D85A76                 call    sub_1D79370
-  .text:0000000001D85A7B                 mov     r12, [r12+128h]
-  .text:0000000001D85A83                 test    r12, r12
-  .text:0000000001D85A86                 jnz     loc_1D85820
-  .text:0000000001D85A8C                 jmp     loc_1D85839
-  .text:0000000001D85A98                 mov     rdi, r12
-  .text:0000000001D85A9B                 call    rax
-  .text:0000000001D85A9D                 mov     r12, [r12+20h]
-  .text:0000000001D85AA2                 test    r12, r12
-  .text:0000000001D85AA5                 jnz     loc_1D85890
-  .text:0000000001D85AAB                 jmp     loc_1D858D6
-  .text:0000000001D85AB0                 mov     edx, offset stru_17FFE8
-  .text:0000000001D85AB5                 xor     ecx, ecx
-  .text:0000000001D85AB7                 cmp     ax, 0FFFFh
-  .text:0000000001D85ABB                 jz      loc_1D85968
-  .text:0000000001D85AC1                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85ACC                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85AD7                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85AE0                 movzx   eax, ax
-  .text:0000000001D85AE3                 lea     rax, [rax+rax*2]
-  .text:0000000001D85AE7                 lea     rdx, ds:0[rax*8]
-  .text:0000000001D85AEF                 movzx   eax, word ptr ds:dword_0[rax*8]
-  .text:0000000001D85AF7                 cmp     ax, 0FFFFh
-  .text:0000000001D85AFB                 jnz     short loc_1D85AE0
-  .text:0000000001D85AFD                 xor     ecx, ecx
-  .text:0000000001D85AFF                 jmp     loc_1D85968
-  .text:0000000001D85B08                 lea     r13, g_pNetworkMessages
-  .text:0000000001D85B0F                 cmp     qword ptr [r13+0], 0
-  .text:0000000001D85B14                 setnz   al
-  .text:0000000001D85B17                 jmp     loc_1D857CD
-  .text:0000000001D85B20                 movzx   r12d, word ptr [rbx+0AA8h]
-  .text:0000000001D85B28                 cmp     r12w, 0FFFFh
-  .text:0000000001D85B2D                 jnz     loc_1D86077
-  .text:0000000001D85B33                 call    sub_1D9ED40
-  .text:0000000001D85B38                 mov     rdi, rbx
-  .text:0000000001D85B3B                 call    sub_1D71880
-  .text:0000000001D85B40                 jmp     loc_1D85A19
-  .text:0000000001D85B48                 mov     edi, 58h ; 'X'
-  .text:0000000001D85B4D                 call    sub_975B50
-  .text:0000000001D85B52                 mov     ecx, 1
-  .text:0000000001D85B57                 xor     esi, esi
-  .text:0000000001D85B59                 xor     edi, edi
-  .text:0000000001D85B5B                 mov     r12, rax
-  .text:0000000001D85B5E                 mov     edx, 4E200h
-  .text:0000000001D85B63                 lea     rax, off_2303720
-  .text:0000000001D85B6A                 mov     [rbx+0C98h], r12
-  .text:0000000001D85B71                 mov     [r12], rax
-  .text:0000000001D85B75                 mov     rax, 0C8000000000000h
-  .text:0000000001D85B7F                 mov     [r12+48h], rax
-  .text:0000000001D85B84                 lea     rax, dword_266453C
-  .text:0000000001D85B8B                 mov     qword ptr [r12+8], 0
-  .text:0000000001D85B94                 mov     qword ptr [r12+10h], 0
-  .text:0000000001D85B9D                 mov     qword ptr [r12+18h], 0
-  .text:0000000001D85BA6                 mov     dword ptr [r12+20h], 0
-  .text:0000000001D85BAF                 mov     r14d, [rax]
-  .text:0000000001D85BB2                 mov     qword ptr [r12+30h], 0
-  .text:0000000001D85BBB                 mov     dword ptr [r12+38h], 0
-  .text:0000000001D85BC4                 mov     dword ptr [r12+28h], 0
-  .text:0000000001D85BCD                 mov     qword ptr [r12+3Ch], 0
-  .text:0000000001D85BD6                 mov     qword ptr [r12+50h], 0
-  .text:0000000001D85BDF                 call    sub_980270
-  .text:0000000001D85BE4                 mov     r13d, eax
-  .text:0000000001D85BE7                 cmp     eax, 4E1FFh
-  .text:0000000001D85BEC                 jle     loc_1D85CF2
-  .text:0000000001D85BF2                 xor     esi, esi
-  .text:0000000001D85BF4                 movsxd  rcx, dword ptr [r12+18h]
-  .text:0000000001D85BF9                 movsxd  rdx, eax
-  .text:0000000001D85BFC                 cmp     dword ptr [r12+1Ch], 3FFFFFFFh
-  .text:0000000001D85C05                 mov     rdi, [r12+10h]
-  .text:0000000001D85C0A                 setbe   sil
-  .text:0000000001D85C0E                 call    sub_97FB10
-  .text:0000000001D85C13                 mov     [r12+10h], rax
-  .text:0000000001D85C18                 mov     eax, [r12+1Ch]
-  .text:0000000001D85C1D                 cmp     eax, 3FFFFFFFh
-  .text:0000000001D85C22                 jbe     short loc_1D85C2E
-  .text:0000000001D85C24                 and     eax, 3FFFFFFFh
-  .text:0000000001D85C29                 mov     [r12+1Ch], eax
-  .text:0000000001D85C2E                 mov     [r12+18h], r13d
-  .text:0000000001D85C33                 lea     rdx, [r12+20h]
-  .text:0000000001D85C38                 xor     eax, eax
-  .text:0000000001D85C3A                 mov     dword ptr [r12+8], 4E200h
-  .text:0000000001D85C43                 xchg    eax, [rdx]
-  .text:0000000001D85C45                 mov     edi, 50h ; 'P'
-  .text:0000000001D85C4A                 mov     [r12+44h], r14d
-  .text:0000000001D85C4F                 mov     eax, [r12+20h]
-  .text:0000000001D85C54                 mov     dword ptr [r12+40h], 10000h
-  .text:0000000001D85C5D                 call    sub_975B50
-  .text:0000000001D85C62                 mov     rdi, rax
-  .text:0000000001D85C65                 mov     r13, rax
-  .text:0000000001D85C68                 call    sub_97FC70
-  .text:0000000001D85C6D                 mov     edx, [r12+40h]
-  .text:0000000001D85C72                 mov     r9d, 10h
-  .text:0000000001D85C78                 mov     rdi, r13
-  .text:0000000001D85C7B                 mov     r8d, 1000h
-  .text:0000000001D85C81                 mov     ecx, 1000h
-  .text:0000000001D85C86                 lea     rsi, aCnetworkfields; "CNetworkFieldScratchData.m_MemoryStacks"...
-  .text:0000000001D85C8D                 call    sub_97F770
-  .text:0000000001D85C92                 test    al, al
-  .text:0000000001D85C94                 jz      loc_1D8617B
-  .text:0000000001D85C9A                 mov     r14d, [r12+28h]
-  .text:0000000001D85C9F                 mov     edi, [r12+38h]
-  .text:0000000001D85CA4                 cmp     r14d, edi
-  .text:0000000001D85CA7                 jz      loc_1D85FB7
-  .text:0000000001D85CAD                 mov     rax, [r12+30h]
-  .text:0000000001D85CB2                 mov     edx, r14d
-  .text:0000000001D85CB5                 add     edx, 1
-  .text:0000000001D85CB8                 mov     [r12+28h], edx
-  .text:0000000001D85CBD                 movsxd  rdx, r14d
-  .text:0000000001D85CC0                 mov     [rax+rdx*8], r13
-  .text:0000000001D85CC4                 lea     rax, g_pFlattenedSerializers
-  .text:0000000001D85CCB                 mov     rdx, [rbx+0CA0h]
-  .text:0000000001D85CD2                 mov     rsi, [rbx+0C98h]
-  .text:0000000001D85CD9                 mov     rdi, [rax]
-  .text:0000000001D85CDC                 mov     rax, [rdi]
-  .text:0000000001D85CDF                 call    qword ptr [rax+118h]; g_pFlattenedSerializers->CreateFieldChangedEventQueue(...), 0x118 = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:0000000001D85CE5                 mov     [rbx+0C90h], rax
-  .text:0000000001D85CEC                 jmp     loc_1D85A0C
-  .text:0000000001D85CF2                 jmp     short loc_1D85CF2
-  .text:0000000001D85CF8                 mov     esi, [r15+14h]
-  .text:0000000001D85CFC                 cmp     esi, 3FFFFFFFh
-  .text:0000000001D85D02                 jbe     short loc_1D85D16
-  .text:0000000001D85D04                 mov     eax, esi
-  .text:0000000001D85D06                 and     eax, 0C0000000h
-  .text:0000000001D85D0B                 cmp     eax, 80000000h
-  .text:0000000001D85D10                 jnz     loc_1D85A3D
-  .text:0000000001D85D16                 mov     r12d, r14d
-  .text:0000000001D85D19                 movsxd  rax, edi
-  .text:0000000001D85D1C                 sub     r12d, edi
-  .text:0000000001D85D1F                 movsxd  rdx, r12d
-  .text:0000000001D85D22                 add     rax, rdx
-  .text:0000000001D85D25                 mov     edx, r14d
-  .text:0000000001D85D28                 cmp     rax, 7FFFFFFFh
-  .text:0000000001D85D2E                 jg      loc_1D85F67
-  .text:0000000001D85D34                 and     esi, 3FFFFFFFh
-  .text:0000000001D85D3A                 mov     ecx, 8
-  .text:0000000001D85D3F                 mov     [rbp+var_78], edx
-  .text:0000000001D85D42                 call    sub_980270
-  .text:0000000001D85D47                 mov     edx, [rbp+var_78]
-  .text:0000000001D85D4A                 mov     r12d, eax
-  .text:0000000001D85D4D                 cmp     eax, edx
-  .text:0000000001D85D4F                 jge     short loc_1D85D76
-  .text:0000000001D85D51                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85D5C                 nop     dword ptr [rax+00h]
-  .text:0000000001D85D60                 lea     eax, [r12+rdx]
-  .text:0000000001D85D64                 mov     r12d, eax
-  .text:0000000001D85D67                 shr     r12d, 1Fh
-  .text:0000000001D85D6B                 add     r12d, eax
-  .text:0000000001D85D6E                 sar     r12d, 1
-  .text:0000000001D85D71                 cmp     r12d, edx
-  .text:0000000001D85D74                 jl      short loc_1D85D60
-  .text:0000000001D85D76                 movsxd  rcx, dword ptr [r15+10h]
-  .text:0000000001D85D7A                 movsxd  rdx, r12d
-  .text:0000000001D85D7D                 xor     esi, esi
-  .text:0000000001D85D7F                 shl     rdx, 3
-  .text:0000000001D85D83                 mov     rdi, [r15+8]
-  .text:0000000001D85D87                 shl     rcx, 3
-  .text:0000000001D85D8B                 cmp     dword ptr [r15+14h], 3FFFFFFFh
-  .text:0000000001D85D93                 setbe   sil
-  .text:0000000001D85D97                 call    sub_97FB10
-  .text:0000000001D85D9C                 mov     [r15+8], rax
-  .text:0000000001D85DA0                 mov     eax, [r15+14h]
-  .text:0000000001D85DA4                 cmp     eax, 3FFFFFFFh
-  .text:0000000001D85DA9                 jbe     short loc_1D85DB4
-  .text:0000000001D85DAB                 and     eax, 3FFFFFFFh
-  .text:0000000001D85DB0                 mov     [r15+14h], eax
-  .text:0000000001D85DB4                 mov     [r15+10h], r12d
-  .text:0000000001D85DB8                 jmp     loc_1D85A3D
-  .text:0000000001D85DBD                 mov     rcx, [rbx+0AA0h]
-  .text:0000000001D85DC4                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85DCF                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001D85DDA                 nop     word ptr [rax+rax+00h]
-  .text:0000000001D85DE0                 movzx   eax, ax
-  .text:0000000001D85DE3                 lea     rax, [rax+rax*2]
-  .text:0000000001D85DE7                 lea     rdx, ds:0[rax*8]
-  .text:0000000001D85DEF                 movzx   eax, word ptr [rcx+rax*8]
-  .text:0000000001D85DF3                 cmp     ax, 0FFFFh
-  .text:0000000001D85DF7                 jnz     short loc_1D85DE0
-  .text:0000000001D85DF9                 jmp     loc_1D85968
-  .text:0000000001D85DFE                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001D85E05                 mov     esi, ecx
-  .text:0000000001D85E07                 and     si, 7FFFh
-  .text:0000000001D85E0C                 jmp     short loc_1D85E57
-  .text:0000000001D85E40                 mov     rdi, [rbx+0AA0h]
-  .text:0000000001D85E47                 lea     rdx, [rdi+rdx*8]
-  .text:0000000001D85E4B                 movzx   edx, word ptr [rdx]
-  .text:0000000001D85E4E                 cmp     dx, 0FFFFh
-  .text:0000000001D85E52                 jz      short loc_1D85E72
-  .text:0000000001D85E54                 mov     r12d, edx
-  .text:0000000001D85E57                 movzx   eax, r12w
-  .text:0000000001D85E5B                 lea     rdx, [rax+rax*2]
-  .text:0000000001D85E5F                 test    si, si
-  .text:0000000001D85E62                 jnz     short loc_1D85E40
-  .text:0000000001D85E64                 movzx   edx, word ptr ds:dword_0[rdx*8]
-  .text:0000000001D85E6C                 cmp     dx, 0FFFFh
-  .text:0000000001D85E70                 jnz     short loc_1D85E54
-  .text:0000000001D85E72                 lea     rsi, [rbx+0A98h]
-  .text:0000000001D85E79                 mov     qword ptr [rbp+var_78], rsi
-  .text:0000000001D85E7D                 jmp     short loc_1D85EA9
-  .text:0000000001D85E80                 call    sub_1D73F80
-  .text:0000000001D85E85                 mov     rdi, qword ptr [rbp+var_78]
-  .text:0000000001D85E89                 movzx   esi, r12w
-  .text:0000000001D85E8D                 call    sub_1D6CA00
-  .text:0000000001D85E92                 mov     r12d, eax
-  .text:0000000001D85E95                 cmp     ax, 0FFFFh
-  .text:0000000001D85E99                 jz      loc_1D85991
-  .text:0000000001D85E9F                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001D85EA6                 movzx   eax, ax
-  .text:0000000001D85EA9                 movzx   edx, word ptr [rbx+0AEAh]
-  .text:0000000001D85EB0                 xor     esi, esi
-  .text:0000000001D85EB2                 and     cx, 7FFFh
-  .text:0000000001D85EB7                 mov     r15d, edx
-  .text:0000000001D85EBA                 jz      short loc_1D85EC3
-  .text:0000000001D85EBC                 mov     rsi, [rbx+0AA0h]
-  .text:0000000001D85EC3                 lea     r8, [rax+rax*2]
-  .text:0000000001D85EC7                 lea     r14, ds:0[r8*8]
-  .text:0000000001D85ECF                 mov     rax, [rsi+r14+10h]
-  .text:0000000001D85ED4                 mov     esi, edx
-  .text:0000000001D85ED6                 sub     esi, [rax+80h]
-  .text:0000000001D85EDC                 test    esi, esi
-  .text:0000000001D85EDE                 jg      loc_1D85F80
-  .text:0000000001D85EE4                 jz      short loc_1D85EF8
-  .text:0000000001D85EE6                 mov     [rax+80h], edx
-  .text:0000000001D85EEC                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001D85EF3                 and     cx, 7FFFh
-  .text:0000000001D85EF8                 movzx   edx, r15w
-  .text:0000000001D85EFC                 xor     eax, eax
-  .text:0000000001D85EFE                 add     rdx, rdx
-  .text:0000000001D85F01                 test    cx, cx
-  .text:0000000001D85F04                 jz      short loc_1D85F0D
-  .text:0000000001D85F06                 mov     rax, [rbx+0AA0h]
-  .text:0000000001D85F0D                 mov     rax, [rax+r14+10h]
-  .text:0000000001D85F12                 mov     esi, 0FFh
-  .text:0000000001D85F17                 mov     rdi, [rax+88h]
-  .text:0000000001D85F1E                 call    sub_9814F0
-  .text:0000000001D85F23                 xor     eax, eax
-  .text:0000000001D85F25                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001D85F2E                 jz      short loc_1D85F37
-  .text:0000000001D85F30                 mov     rax, [rbx+0AA0h]
-  .text:0000000001D85F37                 mov     r15, [rax+r14+10h]
-  .text:0000000001D85F3C                 call    sub_97F8A0
-  .text:0000000001D85F41                 mov     esi, 46F20F89h
-  .text:0000000001D85F46                 mov     rdi, rax
-  .text:0000000001D85F49                 mov     rax, [rax]
-  .text:0000000001D85F4C                 call    qword ptr [rax+20h]
-  .text:0000000001D85F4F                 mov     rsi, r15
-  .text:0000000001D85F52                 mov     rdi, rbx
-  .text:0000000001D85F55                 test    al, al
-  .text:0000000001D85F57                 jnz     loc_1D85E80
-  .text:0000000001D85F5D                 call    sub_1D73700
-  .text:0000000001D85F62                 jmp     loc_1D85E85
-  .text:0000000001D85F67                 mov     esi, r12d
-  .text:0000000001D85F6A                 call    sub_980B00
-  .text:0000000001D85F6F                 mov     edi, [r15+10h]
-  .text:0000000001D85F73                 mov     esi, [r15+14h]
-  .text:0000000001D85F77                 lea     edx, [r12+rdi]
-  .text:0000000001D85F7B                 jmp     loc_1D85D34
-  .text:0000000001D85F80                 mov     ecx, [rax+90h]
-  .text:0000000001D85F86                 cmp     edx, ecx
-  .text:0000000001D85F88                 jle     loc_1D85EE6
-  .text:0000000001D85F8E                 lea     rdi, [rax+88h]
-  .text:0000000001D85F95                 mov     esi, edx
-  .text:0000000001D85F97                 mov     [rbp+var_84], edx
-  .text:0000000001D85F9D                 sub     esi, ecx
-  .text:0000000001D85F9F                 mov     [rbp+var_80], rax
-  .text:0000000001D85FA3                 call    sub_1D785E0
-  .text:0000000001D85FA8                 mov     edx, [rbp+var_84]
-  .text:0000000001D85FAE                 mov     rax, [rbp+var_80]
-  .text:0000000001D85FB2                 jmp     loc_1D85EE6
-  .text:0000000001D85FB7                 mov     esi, [r12+3Ch]
-  .text:0000000001D85FBC                 cmp     esi, 3FFFFFFFh
-  .text:0000000001D85FC2                 jbe     short loc_1D85FD6
-  .text:0000000001D85FC4                 mov     eax, esi
-  .text:0000000001D85FC6                 and     eax, 0C0000000h
-  .text:0000000001D85FCB                 cmp     eax, 80000000h
-  .text:0000000001D85FD0                 jnz     loc_1D85CAD
-  .text:0000000001D85FD6                 cmp     edi, 7FFFFFFFh
-  .text:0000000001D85FDC                 jz      loc_1D86162
-  .text:0000000001D85FE2                 lea     r8d, [rdi+1]
-  .text:0000000001D85FE6                 and     esi, 3FFFFFFFh
-  .text:0000000001D85FEC                 mov     ecx, 8
-  .text:0000000001D85FF1                 mov     edx, r8d
-  .text:0000000001D85FF4                 mov     [rbp+var_78], r8d
-  .text:0000000001D85FF8                 call    sub_980270
-  .text:0000000001D85FFD                 mov     r8d, [rbp+var_78]
-  .text:0000000001D86001                 mov     r15d, eax
-  .text:0000000001D86004                 cmp     r8d, eax
-  .text:0000000001D86007                 jg      short loc_1D86060
-  .text:0000000001D86009                 movsxd  rcx, dword ptr [r12+38h]
-  .text:0000000001D8600E                 movsxd  rdx, r15d
-  .text:0000000001D86011                 xor     esi, esi
-  .text:0000000001D86013                 shl     rdx, 3
-  .text:0000000001D86017                 mov     rdi, [r12+30h]
-  .text:0000000001D8601C                 shl     rcx, 3
-  .text:0000000001D86020                 cmp     dword ptr [r12+3Ch], 3FFFFFFFh
-  .text:0000000001D86029                 setbe   sil
-  .text:0000000001D8602D                 call    sub_97FB10
-  .text:0000000001D86032                 mov     edx, [r12+3Ch]
-  .text:0000000001D86037                 mov     [r12+30h], rax
-  .text:0000000001D8603C                 cmp     edx, 3FFFFFFFh
-  .text:0000000001D86042                 jbe     short loc_1D8604F
-  .text:0000000001D86044                 and     edx, 3FFFFFFFh
-  .text:0000000001D8604A                 mov     [r12+3Ch], edx
-  .text:0000000001D8604F                 mov     edx, [r12+28h]
-  .text:0000000001D86054                 mov     [r12+38h], r15d
-  .text:0000000001D86059                 jmp     loc_1D85CB5
-  .text:0000000001D86060                 lea     edx, [r15+r8]
-  .text:0000000001D86064                 mov     eax, edx
-  .text:0000000001D86066                 shr     eax, 1Fh
-  .text:0000000001D86069                 add     eax, edx
-  .text:0000000001D8606B                 sar     eax, 1
-  .text:0000000001D8606D                 mov     r15d, eax
-  .text:0000000001D86070                 cmp     r8d, eax
-  .text:0000000001D86073                 jg      short loc_1D86060
-  .text:0000000001D86075                 jmp     short loc_1D86009
-  .text:0000000001D86077                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001D8607E                 and     cx, 7FFFh
-  .text:0000000001D86083                 jmp     short loc_1D860D5
-  .text:0000000001D860C0                 mov     rdx, [rbx+0AA0h]
-  .text:0000000001D860C7                 movzx   eax, word ptr [rdx+rax*8]
-  .text:0000000001D860CB                 cmp     ax, 0FFFFh
-  .text:0000000001D860CF                 jz      short loc_1D860FA
-  .text:0000000001D860D1                 movzx   r12d, ax
-  .text:0000000001D860D5                 movzx   eax, r12w
-  .text:0000000001D860D9                 lea     rax, [rax+rax*2]
-  .text:0000000001D860DD                 lea     rsi, ds:0[rax*8]
-  .text:0000000001D860E5                 test    cx, cx
-  .text:0000000001D860E8                 jnz     short loc_1D860C0
-  .text:0000000001D860EA                 movzx   eax, word ptr ds:dword_0[rax*8]
-  .text:0000000001D860F2                 cmp     ax, 0FFFFh
-  .text:0000000001D860F6                 jnz     short loc_1D860D1
-  .text:0000000001D860F8                 xor     edx, edx
-  .text:0000000001D860FA                 mov     r13, 0FFFFFFFF00000000h
-  .text:0000000001D86104                 mov     rdi, [rsi+rdx+10h]
-  .text:0000000001D86109                 jmp     short loc_1D86139
-  .text:0000000001D86110                 movzx   edx, ax
-  .text:0000000001D86113                 and     r12, r13
-  .text:0000000001D86116                 or      r12, rdx
-  .text:0000000001D86119                 xor     edx, edx
-  .text:0000000001D8611B                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001D86124                 jz      short loc_1D8612D
-  .text:0000000001D86126                 mov     rdx, [rbx+0AA0h]
-  .text:0000000001D8612D                 movzx   eax, ax
-  .text:0000000001D86130                 lea     rax, [rax+rax*2]
-  .text:0000000001D86134                 mov     rdi, [rdx+rax*8+10h]
-  .text:0000000001D86139                 test    rdi, rdi
-  .text:0000000001D8613C                 jz      loc_1D85B33
-  .text:0000000001D86142                 call    sub_1D51EE0
-  .text:0000000001D86147                 lea     rdi, [rbx+0A98h]
-  .text:0000000001D8614E                 movzx   esi, r12w
-  .text:0000000001D86152                 call    sub_1D6CA00
-  .text:0000000001D86157                 cmp     ax, 0FFFFh
-  .text:0000000001D8615B                 jnz     short loc_1D86110
-  .text:0000000001D8615D                 jmp     loc_1D85B33
-  .text:0000000001D86162                 mov     esi, 1
-  .text:0000000001D86167                 call    sub_980B00
-  .text:0000000001D8616C                 mov     edi, [r12+38h]
-  .text:0000000001D86171                 mov     esi, [r12+3Ch]
-  .text:0000000001D86176                 jmp     loc_1D85FE2
-  .text:0000000001D8617B                 mov     esi, [r12+40h]
-  .text:0000000001D86180                 lea     rdi, aCnetworkfields_0; "CNetworkFieldScratchData::Init failed o"...
-  .text:0000000001D86187                 call    sub_9803D0
+  .text:0000000001E73880                 push    rbp
+  .text:0000000001E73881                 mov     rbp, rsp
+  .text:0000000001E73884                 push    r15
+  .text:0000000001E73886                 push    r14
+  .text:0000000001E73888                 mov     r14d, r8d
+  .text:0000000001E7388B                 push    r13
+  .text:0000000001E7388D                 mov     r13d, ecx
+  .text:0000000001E73890                 push    r12
+  .text:0000000001E73892                 mov     r12d, edx
+  .text:0000000001E73895                 push    rbx
+  .text:0000000001E73896                 mov     rbx, rdi
+  .text:0000000001E73899                 ; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:0000000001E73899                 ; this
+  .text:0000000001E73899                 add     rdi, 0A88h; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:0000000001E738A0                 sub     rsp, 68h
+  .text:0000000001E738A4                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:0000000001E738A9                 lea     rax, unk_27BB9F1
+  .text:0000000001E738B0                 mov     [rbx+0BBCh], r13d
+  .text:0000000001E738B7                 mov     [rax], r14b
+  .text:0000000001E738BA                 cmp     r12d, 1
+  .text:0000000001E738BE                 jz      loc_1E73C08
+  .text:0000000001E738C4                 lea     r13, qword_2743670
+  .text:0000000001E738CB                 xor     eax, eax
+  .text:0000000001E738CD                 mov     [rbx+0BDAh], al
+  .text:0000000001E738D3                 ; bool
+  .text:0000000001E738D3                 xor     r8d, r8d; bool
+  .text:0000000001E738D6                 ; void *
+  .text:0000000001E738D6                 xor     ecx, ecx; void *
+  .text:0000000001E738D8                 ; unsigned int
+  .text:0000000001E738D8                 xor     edx, edx; unsigned int
+  .text:0000000001E738DA                 ; this
+  .text:0000000001E738DA                 lea     rdi, [rbx+0CC0h]; this
+  .text:0000000001E738E1                 ; unsigned int
+  .text:0000000001E738E1                 mov     esi, 400h; unsigned int
+  .text:0000000001E738E6                 call    __ZN21CUtlScratchMemoryPool4InitEjjPvb; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
+  .text:0000000001E738EB                 lea     r14, qword_27BB928
+  .text:0000000001E738F2                 lea     rax, [rbx+10h]
+  .text:0000000001E738F6                 mov     cs:qword_25669A8, rbx
+  .text:0000000001E738FD                 mov     cs:qword_25669A0, rax
+  .text:0000000001E73904                 mov     r12, [r14]
+  .text:0000000001E73907                 test    r12, r12
+  .text:0000000001E7390A                 jz      short loc_1E73979
+  .text:0000000001E7390C                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73917                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73920                 test    byte ptr [r12+68h], 2
+  .text:0000000001E73926                 jz      loc_1E73B70
+  .text:0000000001E7392C                 mov     r12, [r12+120h]
+  .text:0000000001E73934                 test    r12, r12
+  .text:0000000001E73937                 jnz     short loc_1E73920
+  .text:0000000001E73939                 mov     r12, [r14]
+  .text:0000000001E7393C                 test    r12, r12
+  .text:0000000001E7393F                 jz      short loc_1E73979
+  .text:0000000001E73941                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7394C                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73957                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73960                 test    byte ptr [r12+68h], 2
+  .text:0000000001E73966                 jnz     loc_1E73B48
+  .text:0000000001E7396C                 mov     r12, [r12+120h]
+  .text:0000000001E73974                 test    r12, r12
+  .text:0000000001E73977                 jnz     short loc_1E73960
+  .text:0000000001E73979                 mov     r12, cs:qword_256D370
+  .text:0000000001E73980                 xor     r14d, r14d
+  .text:0000000001E73983                 lea     r15, nullsub_1669
+  .text:0000000001E7398A                 test    r12, r12
+  .text:0000000001E7398D                 jz      short loc_1E739D6
+  .text:0000000001E7398F                 nop
+  .text:0000000001E73990                 mov     rsi, r12
+  .text:0000000001E73993                 mov     rdi, rbx
+  .text:0000000001E73996                 add     r14d, 1
+  .text:0000000001E7399A                 call    sub_1E73380
+  .text:0000000001E7399F                 mov     rdx, [r12+10h]
+  .text:0000000001E739A4                 mov     [rdx+20h], eax
+  .text:0000000001E739A7                 mov     rax, [r12+10h]
+  .text:0000000001E739AC                 test    byte ptr [rax+24h], 1
+  .text:0000000001E739B0                 jz      short loc_1E739BB
+  .text:0000000001E739B2                 or      dword ptr [r12+8], 20000h
+  .text:0000000001E739BB                 mov     rax, [r12]
+  .text:0000000001E739BF                 mov     rax, [rax+8]
+  .text:0000000001E739C3                 cmp     rax, r15
+  .text:0000000001E739C6                 jnz     loc_1E73B98
+  .text:0000000001E739CC                 mov     r12, [r12+20h]
+  .text:0000000001E739D1                 test    r12, r12
+  .text:0000000001E739D4                 jnz     short loc_1E73990
+  .text:0000000001E739D6                 lea     r15, qword_27BB8F0
+  .text:0000000001E739DD                 mov     eax, r14d
+  .text:0000000001E739E0                 sub     eax, [r15]
+  .text:0000000001E739E3                 test    eax, eax
+  .text:0000000001E739E5                 jg      loc_1E73B30
+  .text:0000000001E739EB                 jnz     loc_1E73B3D
+  .text:0000000001E739F1                 mov     r12, cs:qword_256D370
+  .text:0000000001E739F8                 test    r12, r12
+  .text:0000000001E739FB                 jz      short loc_1E73A32
+  .text:0000000001E739FD                 nop     dword ptr [rax]
+  .text:0000000001E73A00                 mov     rdi, [r13+0]
+  .text:0000000001E73A04                 test    rdi, rdi
+  .text:0000000001E73A07                 jz      short loc_1E73A17
+  .text:0000000001E73A09                 mov     rax, [rdi]
+  .text:0000000001E73A0C                 mov     esi, [r12+18h]
+  .text:0000000001E73A11                 call    qword ptr [rax+0E8h]
+  .text:0000000001E73A17                 mov     rax, [r12+10h]
+  .text:0000000001E73A1C                 mov     rdx, [r15+8]
+  .text:0000000001E73A20                 movsxd  rcx, dword ptr [rax+20h]
+  .text:0000000001E73A24                 mov     [rdx+rcx*8], rax
+  .text:0000000001E73A28                 mov     r12, [r12+20h]
+  .text:0000000001E73A2D                 test    r12, r12
+  .text:0000000001E73A30                 jnz     short loc_1E73A00
+  .text:0000000001E73A32                 cmp     word ptr [rbx+0AAAh], 0
+  .text:0000000001E73A3A                 jz      short loc_1E73A75
+  .text:0000000001E73A3C                 movzx   eax, word ptr [rbx+0AA8h]
+  .text:0000000001E73A43                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E73A4C                 jz      loc_1E73BB0
+  .text:0000000001E73A52                 cmp     ax, 0FFFFh
+  .text:0000000001E73A56                 jnz     loc_1E73EBD
+  .text:0000000001E73A5C                 mov     rcx, [rbx+0AA0h]
+  .text:0000000001E73A63                 mov     edx, offset stru_17FFE8
+  .text:0000000001E73A68                 mov     rsi, [rcx+rdx+10h]
+  .text:0000000001E73A6D                 mov     rdi, rbx
+  .text:0000000001E73A70                 call    sub_1E54FC0
+  .text:0000000001E73A75                 cmp     cs:byte_27BBA40, 0
+  .text:0000000001E73A7C                 jnz     short loc_1E73A91
+  .text:0000000001E73A7E                 movzx   r12d, word ptr [rbx+0AA8h]
+  .text:0000000001E73A86                 cmp     r12w, 0FFFFh
+  .text:0000000001E73A8B                 jnz     loc_1E73EFE
+  .text:0000000001E73A91                 lea     rdi, aEntitysystemCl; "EntitySystem - Class Tables"
+  .text:0000000001E73A98                 xor     eax, eax
+  .text:0000000001E73A9A                 call    _COM_TimestampedLog
+  .text:0000000001E73A9F                 mov     rdi, [r13+0]
+  .text:0000000001E73AA3                 test    rdi, rdi
+  .text:0000000001E73AA6                 jz      short loc_1E73AF7
+  .text:0000000001E73AA8                 mov     rax, [rdi]
+  .text:0000000001E73AAB                 lea     rsi, aStringTTable; "string_t_table"
+  .text:0000000001E73AB2                 mov     edx, [rbx+0BBCh]
+  .text:0000000001E73AB8                 lea     rcx, [rbx+1ED0h]
+  .text:0000000001E73ABF                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+  .text:0000000001E73ABF                 call    qword ptr [rax+0A0h]; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+  .text:0000000001E73AC5                 mov     rdi, [r13+0]
+  .text:0000000001E73AC9                 lea     rsi, [rbp+var_50]
+  .text:0000000001E73ACD                 mov     qword ptr [rbp+var_68], 121h
+  .text:0000000001E73AD5                 mov     qword ptr [rbp+var_68+8], 0
+  .text:0000000001E73ADD                 movdqu  xmm0, [rbp+var_68]
+  .text:0000000001E73AE2                 mov     rax, [rdi]
+  .text:0000000001E73AE5                 mov     [rbp+var_50], 0
+  .text:0000000001E73AED                 movups  [rbp+var_48], xmm0
+  .text:0000000001E73AF1                 call    qword ptr [rax+0B8h]
+  .text:0000000001E73AF7                 mov     rdi, rbx
+  .text:0000000001E73AFA                 call    sub_1E72200
+  .text:0000000001E73AFF                 cmp     byte ptr [rbx+0BDAh], 0
+  .text:0000000001E73B06                 jnz     loc_1E73C48
+  .text:0000000001E73B0C                 cmp     cs:byte_27BBA40, 0
+  .text:0000000001E73B13                 jz      loc_1E73C20
+  .text:0000000001E73B19                 mov     cs:byte_27BBA40, 1
+  .text:0000000001E73B20                 add     rsp, 68h
+  .text:0000000001E73B24                 pop     rbx
+  .text:0000000001E73B25                 pop     r12
+  .text:0000000001E73B27                 pop     r13
+  .text:0000000001E73B29                 pop     r14
+  .text:0000000001E73B2B                 pop     r15
+  .text:0000000001E73B2D                 pop     rbp
+  .text:0000000001E73B2E                 retn
+  .text:0000000001E73B30                 ; _QWORD
+  .text:0000000001E73B30                 mov     edi, [r15+10h]; _QWORD
+  .text:0000000001E73B34                 cmp     r14d, edi
+  .text:0000000001E73B37                 jg      loc_1E73DF8
+  .text:0000000001E73B3D                 mov     [r15], r14d
+  .text:0000000001E73B40                 jmp     loc_1E739F1
+  .text:0000000001E73B48                 mov     rsi, r12
+  .text:0000000001E73B4B                 mov     rdi, rbx
+  .text:0000000001E73B4E                 call    sub_1E67AC0
+  .text:0000000001E73B53                 mov     r12, [r12+120h]
+  .text:0000000001E73B5B                 test    r12, r12
+  .text:0000000001E73B5E                 jnz     loc_1E73960
+  .text:0000000001E73B64                 jmp     loc_1E73979
+  .text:0000000001E73B70                 mov     rsi, r12
+  .text:0000000001E73B73                 mov     rdi, rbx
+  .text:0000000001E73B76                 call    sub_1E67830
+  .text:0000000001E73B7B                 mov     r12, [r12+120h]
+  .text:0000000001E73B83                 test    r12, r12
+  .text:0000000001E73B86                 jnz     loc_1E73920
+  .text:0000000001E73B8C                 jmp     loc_1E73939
+  .text:0000000001E73B98                 mov     rdi, r12
+  .text:0000000001E73B9B                 call    rax
+  .text:0000000001E73B9D                 mov     r12, [r12+20h]
+  .text:0000000001E73BA2                 test    r12, r12
+  .text:0000000001E73BA5                 jnz     loc_1E73990
+  .text:0000000001E73BAB                 jmp     loc_1E739D6
+  .text:0000000001E73BB0                 mov     edx, offset stru_17FFE8
+  .text:0000000001E73BB5                 xor     ecx, ecx
+  .text:0000000001E73BB7                 cmp     ax, 0FFFFh
+  .text:0000000001E73BBB                 jz      loc_1E73A68
+  .text:0000000001E73BC1                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73BCC                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73BD7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73BE0                 movzx   eax, ax
+  .text:0000000001E73BE3                 lea     rax, [rax+rax*2]
+  .text:0000000001E73BE7                 lea     rdx, ds:0[rax*8]
+  .text:0000000001E73BEF                 movzx   eax, word ptr ds:dword_0[rax*8]
+  .text:0000000001E73BF7                 cmp     ax, 0FFFFh
+  .text:0000000001E73BFB                 jnz     short loc_1E73BE0
+  .text:0000000001E73BFD                 xor     ecx, ecx
+  .text:0000000001E73BFF                 jmp     loc_1E73A68
+  .text:0000000001E73C08                 lea     r13, qword_2743670
+  .text:0000000001E73C0F                 cmp     qword ptr [r13+0], 0
+  .text:0000000001E73C14                 setnz   al
+  .text:0000000001E73C17                 jmp     loc_1E738CD
+  .text:0000000001E73C20                 movzx   r12d, word ptr [rbx+0AA8h]
+  .text:0000000001E73C28                 cmp     r12w, 0FFFFh
+  .text:0000000001E73C2D                 jnz     loc_1E74177
+  .text:0000000001E73C33                 call    sub_1E8FFB0
+  .text:0000000001E73C38                 mov     rdi, rbx
+  .text:0000000001E73C3B                 call    sub_1E5FD40
+  .text:0000000001E73C40                 jmp     loc_1E73B19
+  .text:0000000001E73C48                 ; _QWORD
+  .text:0000000001E73C48                 mov     edi, 58h ; 'X'; _QWORD
+  .text:0000000001E73C4D                 call    __Znwm; operator new(ulong)
+  .text:0000000001E73C52                 ; _QWORD
+  .text:0000000001E73C52                 mov     ecx, 1; _QWORD
+  .text:0000000001E73C57                 ; _QWORD
+  .text:0000000001E73C57                 xor     esi, esi; _QWORD
+  .text:0000000001E73C59                 ; _QWORD
+  .text:0000000001E73C59                 xor     edi, edi; _QWORD
+  .text:0000000001E73C5B                 mov     r12, rax
+  .text:0000000001E73C5E                 ; _QWORD
+  .text:0000000001E73C5E                 mov     edx, 4E200h; _QWORD
+  .text:0000000001E73C63                 lea     rax, off_24156E8
+  .text:0000000001E73C6A                 mov     [rbx+0C90h], r12
+  .text:0000000001E73C71                 mov     [r12], rax
+  .text:0000000001E73C75                 mov     rax, 0C8000000000000h
+  .text:0000000001E73C7F                 mov     [r12+48h], rax
+  .text:0000000001E73C84                 lea     rax, dword_27BBCDC
+  .text:0000000001E73C8B                 mov     qword ptr [r12+8], 0
+  .text:0000000001E73C94                 mov     qword ptr [r12+10h], 0
+  .text:0000000001E73C9D                 mov     qword ptr [r12+18h], 0
+  .text:0000000001E73CA6                 mov     dword ptr [r12+20h], 0
+  .text:0000000001E73CAF                 mov     r14d, [rax]
+  .text:0000000001E73CB2                 mov     qword ptr [r12+30h], 0
+  .text:0000000001E73CBB                 mov     dword ptr [r12+38h], 0
+  .text:0000000001E73CC4                 mov     dword ptr [r12+28h], 0
+  .text:0000000001E73CCD                 mov     qword ptr [r12+3Ch], 0
+  .text:0000000001E73CD6                 mov     qword ptr [r12+50h], 0
+  .text:0000000001E73CDF                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E73CE4                 mov     r13d, eax
+  .text:0000000001E73CE7                 cmp     eax, 4E1FFh
+  .text:0000000001E73CEC                 jle     loc_1E73DF2
+  .text:0000000001E73CF2                 xor     esi, esi
+  .text:0000000001E73CF4                 ; _QWORD
+  .text:0000000001E73CF4                 movsxd  rcx, dword ptr [r12+18h]; _QWORD
+  .text:0000000001E73CF9                 ; _QWORD
+  .text:0000000001E73CF9                 movsxd  rdx, eax; _QWORD
+  .text:0000000001E73CFC                 cmp     dword ptr [r12+1Ch], 3FFFFFFFh
+  .text:0000000001E73D05                 ; _QWORD
+  .text:0000000001E73D05                 mov     rdi, [r12+10h]; _QWORD
+  .text:0000000001E73D0A                 ; _QWORD
+  .text:0000000001E73D0A                 setbe   sil; _QWORD
+  .text:0000000001E73D0E                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E73D13                 mov     [r12+10h], rax
+  .text:0000000001E73D18                 mov     eax, [r12+1Ch]
+  .text:0000000001E73D1D                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E73D22                 jbe     short loc_1E73D2E
+  .text:0000000001E73D24                 and     eax, 3FFFFFFFh
+  .text:0000000001E73D29                 mov     [r12+1Ch], eax
+  .text:0000000001E73D2E                 mov     [r12+18h], r13d
+  .text:0000000001E73D33                 lea     rdx, [r12+20h]
+  .text:0000000001E73D38                 xor     eax, eax
+  .text:0000000001E73D3A                 mov     dword ptr [r12+8], 4E200h
+  .text:0000000001E73D43                 xchg    eax, [rdx]
+  .text:0000000001E73D45                 ; _QWORD
+  .text:0000000001E73D45                 mov     edi, 50h ; 'P'; _QWORD
+  .text:0000000001E73D4A                 mov     [r12+44h], r14d
+  .text:0000000001E73D4F                 mov     eax, [r12+20h]
+  .text:0000000001E73D54                 mov     dword ptr [r12+40h], 10000h
+  .text:0000000001E73D5D                 call    __Znwm; operator new(ulong)
+  .text:0000000001E73D62                 ; this
+  .text:0000000001E73D62                 mov     rdi, rax; this
+  .text:0000000001E73D65                 mov     r13, rax
+  .text:0000000001E73D68                 call    __ZN12CMemoryStackC1Ev; CMemoryStack::CMemoryStack(void)
+  .text:0000000001E73D6D                 ; unsigned int
+  .text:0000000001E73D6D                 mov     edx, [r12+40h]; unsigned int
+  .text:0000000001E73D72                 ; unsigned int
+  .text:0000000001E73D72                 mov     r9d, 10h; unsigned int
+  .text:0000000001E73D78                 ; this
+  .text:0000000001E73D78                 mov     rdi, r13; this
+  .text:0000000001E73D7B                 ; unsigned int
+  .text:0000000001E73D7B                 mov     r8d, 1000h; unsigned int
+  .text:0000000001E73D81                 ; unsigned int
+  .text:0000000001E73D81                 mov     ecx, 1000h; unsigned int
+  .text:0000000001E73D86                 lea     rsi, aCnetworkfields; "CNetworkFieldScratchData.m_MemoryStacks"...
+  .text:0000000001E73D8D                 call    __ZN12CMemoryStack4InitEPKcjjjj; CMemoryStack::Init(char const*,uint,uint,uint,uint)
+  .text:0000000001E73D92                 test    al, al
+  .text:0000000001E73D94                 jz      loc_1E7427B
+  .text:0000000001E73D9A                 mov     r14d, [r12+28h]
+  .text:0000000001E73D9F                 ; _QWORD
+  .text:0000000001E73D9F                 mov     edi, [r12+38h]; _QWORD
+  .text:0000000001E73DA4                 cmp     r14d, edi
+  .text:0000000001E73DA7                 jz      loc_1E740B7
+  .text:0000000001E73DAD                 mov     rax, [r12+30h]
+  .text:0000000001E73DB2                 mov     edx, r14d
+  .text:0000000001E73DB5                 add     edx, 1
+  .text:0000000001E73DB8                 mov     [r12+28h], edx
+  .text:0000000001E73DBD                 movsxd  rdx, r14d
+  .text:0000000001E73DC0                 mov     [rax+rdx*8], r13
+  .text:0000000001E73DC4                 lea     rax, qword_2743668
+  .text:0000000001E73DCB                 mov     rdx, [rbx+0C98h]
+  .text:0000000001E73DD2                 mov     rsi, [rbx+0C90h]
+  .text:0000000001E73DD9                 mov     rdi, [rax]
+  .text:0000000001E73DDC                 mov     rax, [rdi]
+  .text:0000000001E73DDF                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+  .text:0000000001E73DDF                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+  .text:0000000001E73DE5                 mov     [rbx+0C88h], rax
+  .text:0000000001E73DEC                 jmp     loc_1E73B0C
+  .text:0000000001E73DF2                 jmp     short loc_1E73DF2
+  .text:0000000001E73DF8                 mov     esi, [r15+14h]
+  .text:0000000001E73DFC                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E73E02                 jbe     short loc_1E73E16
+  .text:0000000001E73E04                 mov     eax, esi
+  .text:0000000001E73E06                 and     eax, 0C0000000h
+  .text:0000000001E73E0B                 cmp     eax, 80000000h
+  .text:0000000001E73E10                 jnz     loc_1E73B3D
+  .text:0000000001E73E16                 mov     r12d, r14d
+  .text:0000000001E73E19                 movsxd  rax, edi
+  .text:0000000001E73E1C                 sub     r12d, edi
+  .text:0000000001E73E1F                 movsxd  rdx, r12d
+  .text:0000000001E73E22                 add     rax, rdx
+  .text:0000000001E73E25                 ; _QWORD
+  .text:0000000001E73E25                 mov     edx, r14d; _QWORD
+  .text:0000000001E73E28                 cmp     rax, 7FFFFFFFh
+  .text:0000000001E73E2E                 jg      loc_1E74061
+  .text:0000000001E73E34                 ; _QWORD
+  .text:0000000001E73E34                 and     esi, 3FFFFFFFh; _QWORD
+  .text:0000000001E73E3A                 ; _QWORD
+  .text:0000000001E73E3A                 mov     ecx, 8; _QWORD
+  .text:0000000001E73E3F                 mov     [rbp+var_78], edx
+  .text:0000000001E73E42                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E73E47                 mov     edx, [rbp+var_78]
+  .text:0000000001E73E4A                 mov     r12d, eax
+  .text:0000000001E73E4D                 cmp     eax, edx
+  .text:0000000001E73E4F                 jge     short loc_1E73E76
+  .text:0000000001E73E51                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73E5C                 nop     dword ptr [rax+00h]
+  .text:0000000001E73E60                 lea     eax, [r12+rdx]
+  .text:0000000001E73E64                 mov     r12d, eax
+  .text:0000000001E73E67                 shr     r12d, 1Fh
+  .text:0000000001E73E6B                 add     r12d, eax
+  .text:0000000001E73E6E                 sar     r12d, 1
+  .text:0000000001E73E71                 cmp     r12d, edx
+  .text:0000000001E73E74                 jl      short loc_1E73E60
+  .text:0000000001E73E76                 movsxd  rcx, dword ptr [r15+10h]
+  .text:0000000001E73E7A                 movsxd  rdx, r12d
+  .text:0000000001E73E7D                 xor     esi, esi
+  .text:0000000001E73E7F                 ; _QWORD
+  .text:0000000001E73E7F                 shl     rdx, 3; _QWORD
+  .text:0000000001E73E83                 ; _QWORD
+  .text:0000000001E73E83                 mov     rdi, [r15+8]; _QWORD
+  .text:0000000001E73E87                 ; _QWORD
+  .text:0000000001E73E87                 shl     rcx, 3; _QWORD
+  .text:0000000001E73E8B                 cmp     dword ptr [r15+14h], 3FFFFFFFh
+  .text:0000000001E73E93                 ; _QWORD
+  .text:0000000001E73E93                 setbe   sil; _QWORD
+  .text:0000000001E73E97                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E73E9C                 mov     [r15+8], rax
+  .text:0000000001E73EA0                 mov     eax, [r15+14h]
+  .text:0000000001E73EA4                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E73EA9                 jbe     short loc_1E73EB4
+  .text:0000000001E73EAB                 and     eax, 3FFFFFFFh
+  .text:0000000001E73EB0                 mov     [r15+14h], eax
+  .text:0000000001E73EB4                 mov     [r15+10h], r12d
+  .text:0000000001E73EB8                 jmp     loc_1E73B3D
+  .text:0000000001E73EBD                 mov     rcx, [rbx+0AA0h]
+  .text:0000000001E73EC4                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73ECF                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E73EDA                 nop     word ptr [rax+rax+00h]
+  .text:0000000001E73EE0                 movzx   eax, ax
+  .text:0000000001E73EE3                 lea     rax, [rax+rax*2]
+  .text:0000000001E73EE7                 lea     rdx, ds:0[rax*8]
+  .text:0000000001E73EEF                 movzx   eax, word ptr [rcx+rax*8]
+  .text:0000000001E73EF3                 cmp     ax, 0FFFFh
+  .text:0000000001E73EF7                 jnz     short loc_1E73EE0
+  .text:0000000001E73EF9                 jmp     loc_1E73A68
+  .text:0000000001E73EFE                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E73F05                 mov     esi, ecx
+  .text:0000000001E73F07                 and     si, 7FFFh
+  .text:0000000001E73F0C                 jmp     short loc_1E73F57
+  .text:0000000001E73F40                 mov     rdi, [rbx+0AA0h]
+  .text:0000000001E73F47                 lea     rdx, [rdi+rdx*8]
+  .text:0000000001E73F4B                 movzx   edx, word ptr [rdx]
+  .text:0000000001E73F4E                 cmp     dx, 0FFFFh
+  .text:0000000001E73F52                 jz      short loc_1E73F72
+  .text:0000000001E73F54                 mov     r12d, edx
+  .text:0000000001E73F57                 movzx   eax, r12w
+  .text:0000000001E73F5B                 lea     rdx, [rax+rax*2]
+  .text:0000000001E73F5F                 test    si, si
+  .text:0000000001E73F62                 jnz     short loc_1E73F40
+  .text:0000000001E73F64                 movzx   edx, word ptr ds:dword_0[rdx*8]
+  .text:0000000001E73F6C                 cmp     dx, 0FFFFh
+  .text:0000000001E73F70                 jnz     short loc_1E73F54
+  .text:0000000001E73F72                 lea     rsi, [rbx+0A98h]
+  .text:0000000001E73F79                 mov     qword ptr [rbp+var_78], rsi
+  .text:0000000001E73F7D                 jmp     short loc_1E73FA9
+  .text:0000000001E73F80                 call    sub_1E623C0
+  .text:0000000001E73F85                 mov     rdi, qword ptr [rbp+var_78]
+  .text:0000000001E73F89                 movzx   esi, r12w
+  .text:0000000001E73F8D                 call    sub_1E5ADC0
+  .text:0000000001E73F92                 mov     r12d, eax
+  .text:0000000001E73F95                 cmp     ax, 0FFFFh
+  .text:0000000001E73F99                 jz      loc_1E73A91
+  .text:0000000001E73F9F                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E73FA6                 movzx   eax, ax
+  .text:0000000001E73FA9                 movzx   edx, word ptr [rbx+0AEAh]
+  .text:0000000001E73FB0                 xor     esi, esi
+  .text:0000000001E73FB2                 and     cx, 7FFFh
+  .text:0000000001E73FB7                 mov     r15d, edx
+  .text:0000000001E73FBA                 jz      short loc_1E73FC3
+  .text:0000000001E73FBC                 mov     rsi, [rbx+0AA0h]
+  .text:0000000001E73FC3                 lea     r8, [rax+rax*2]
+  .text:0000000001E73FC7                 lea     r14, ds:0[r8*8]
+  .text:0000000001E73FCF                 mov     rax, [rsi+r14+10h]
+  .text:0000000001E73FD4                 mov     esi, edx
+  .text:0000000001E73FD6                 sub     esi, [rax+78h]
+  .text:0000000001E73FD9                 test    esi, esi
+  .text:0000000001E73FDB                 jg      loc_1E74080
+  .text:0000000001E73FE1                 jz      short loc_1E73FF2
+  .text:0000000001E73FE3                 mov     [rax+78h], edx
+  .text:0000000001E73FE6                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E73FED                 and     cx, 7FFFh
+  .text:0000000001E73FF2                 movzx   edx, r15w
+  .text:0000000001E73FF6                 xor     eax, eax
+  .text:0000000001E73FF8                 ; n
+  .text:0000000001E73FF8                 add     rdx, rdx; n
+  .text:0000000001E73FFB                 test    cx, cx
+  .text:0000000001E73FFE                 jz      short loc_1E74007
+  .text:0000000001E74000                 mov     rax, [rbx+0AA0h]
+  .text:0000000001E74007                 mov     rax, [rax+r14+10h]
+  .text:0000000001E7400C                 ; c
+  .text:0000000001E7400C                 mov     esi, 0FFh; c
+  .text:0000000001E74011                 ; s
+  .text:0000000001E74011                 mov     rdi, [rax+80h]; s
+  .text:0000000001E74018                 call    _memset
+  .text:0000000001E7401D                 xor     eax, eax
+  .text:0000000001E7401F                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E74028                 jz      short loc_1E74031
+  .text:0000000001E7402A                 mov     rax, [rbx+0AA0h]
+  .text:0000000001E74031                 mov     r15, [rax+r14+10h]
+  .text:0000000001E74036                 call    _CommandLine
+  .text:0000000001E7403B                 mov     esi, 46F20F89h
+  .text:0000000001E74040                 mov     rdi, rax
+  .text:0000000001E74043                 mov     rax, [rax]
+  .text:0000000001E74046                 call    qword ptr [rax+20h]
+  .text:0000000001E74049                 mov     rsi, r15
+  .text:0000000001E7404C                 mov     rdi, rbx
+  .text:0000000001E7404F                 test    al, al
+  .text:0000000001E74051                 jnz     loc_1E73F80
+  .text:0000000001E74057                 call    sub_1E61B40
+  .text:0000000001E7405C                 jmp     loc_1E73F85
+  .text:0000000001E74061                 ; _QWORD
+  .text:0000000001E74061                 mov     esi, r12d; _QWORD
+  .text:0000000001E74064                 call    _UtlVectorMemory_FailedAllocation
+  .text:0000000001E74069                 mov     edi, [r15+10h]
+  .text:0000000001E7406D                 mov     esi, [r15+14h]
+  .text:0000000001E74071                 lea     edx, [r12+rdi]
+  .text:0000000001E74075                 jmp     loc_1E73E34
+  .text:0000000001E74080                 mov     ecx, [rax+88h]
+  .text:0000000001E74086                 cmp     edx, ecx
+  .text:0000000001E74088                 jle     loc_1E73FE3
+  .text:0000000001E7408E                 lea     rdi, [rax+80h]
+  .text:0000000001E74095                 mov     esi, edx
+  .text:0000000001E74097                 mov     [rbp+var_84], edx
+  .text:0000000001E7409D                 sub     esi, ecx
+  .text:0000000001E7409F                 mov     [rbp+var_80], rax
+  .text:0000000001E740A3                 call    sub_1E66A60
+  .text:0000000001E740A8                 mov     edx, [rbp+var_84]
+  .text:0000000001E740AE                 mov     rax, [rbp+var_80]
+  .text:0000000001E740B2                 jmp     loc_1E73FE3
+  .text:0000000001E740B7                 mov     esi, [r12+3Ch]
+  .text:0000000001E740BC                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E740C2                 jbe     short loc_1E740D6
+  .text:0000000001E740C4                 mov     eax, esi
+  .text:0000000001E740C6                 and     eax, 0C0000000h
+  .text:0000000001E740CB                 cmp     eax, 80000000h
+  .text:0000000001E740D0                 jnz     loc_1E73DAD
+  .text:0000000001E740D6                 cmp     edi, 7FFFFFFFh
+  .text:0000000001E740DC                 jz      loc_1E74262
+  .text:0000000001E740E2                 lea     r8d, [rdi+1]
+  .text:0000000001E740E6                 ; _QWORD
+  .text:0000000001E740E6                 and     esi, 3FFFFFFFh; _QWORD
+  .text:0000000001E740EC                 ; _QWORD
+  .text:0000000001E740EC                 mov     ecx, 8; _QWORD
+  .text:0000000001E740F1                 ; _QWORD
+  .text:0000000001E740F1                 mov     edx, r8d; _QWORD
+  .text:0000000001E740F4                 mov     [rbp+var_78], r8d
+  .text:0000000001E740F8                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E740FD                 mov     r8d, [rbp+var_78]
+  .text:0000000001E74101                 mov     r15d, eax
+  .text:0000000001E74104                 cmp     r8d, eax
+  .text:0000000001E74107                 jg      short loc_1E74160
+  .text:0000000001E74109                 movsxd  rcx, dword ptr [r12+38h]
+  .text:0000000001E7410E                 movsxd  rdx, r15d
+  .text:0000000001E74111                 xor     esi, esi
+  .text:0000000001E74113                 ; _QWORD
+  .text:0000000001E74113                 shl     rdx, 3; _QWORD
+  .text:0000000001E74117                 ; _QWORD
+  .text:0000000001E74117                 mov     rdi, [r12+30h]; _QWORD
+  .text:0000000001E7411C                 ; _QWORD
+  .text:0000000001E7411C                 shl     rcx, 3; _QWORD
+  .text:0000000001E74120                 cmp     dword ptr [r12+3Ch], 3FFFFFFFh
+  .text:0000000001E74129                 ; _QWORD
+  .text:0000000001E74129                 setbe   sil; _QWORD
+  .text:0000000001E7412D                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E74132                 mov     edx, [r12+3Ch]
+  .text:0000000001E74137                 mov     [r12+30h], rax
+  .text:0000000001E7413C                 cmp     edx, 3FFFFFFFh
+  .text:0000000001E74142                 jbe     short loc_1E7414F
+  .text:0000000001E74144                 and     edx, 3FFFFFFFh
+  .text:0000000001E7414A                 mov     [r12+3Ch], edx
+  .text:0000000001E7414F                 mov     edx, [r12+28h]
+  .text:0000000001E74154                 mov     [r12+38h], r15d
+  .text:0000000001E74159                 jmp     loc_1E73DB5
+  .text:0000000001E74160                 lea     edx, [r15+r8]
+  .text:0000000001E74164                 mov     eax, edx
+  .text:0000000001E74166                 shr     eax, 1Fh
+  .text:0000000001E74169                 add     eax, edx
+  .text:0000000001E7416B                 sar     eax, 1
+  .text:0000000001E7416D                 mov     r15d, eax
+  .text:0000000001E74170                 cmp     r8d, eax
+  .text:0000000001E74173                 jg      short loc_1E74160
+  .text:0000000001E74175                 jmp     short loc_1E74109
+  .text:0000000001E74177                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E7417E                 and     cx, 7FFFh
+  .text:0000000001E74183                 jmp     short loc_1E741D5
+  .text:0000000001E741C0                 mov     rdx, [rbx+0AA0h]
+  .text:0000000001E741C7                 movzx   eax, word ptr [rdx+rax*8]
+  .text:0000000001E741CB                 cmp     ax, 0FFFFh
+  .text:0000000001E741CF                 jz      short loc_1E741FA
+  .text:0000000001E741D1                 movzx   r12d, ax
+  .text:0000000001E741D5                 movzx   eax, r12w
+  .text:0000000001E741D9                 lea     rax, [rax+rax*2]
+  .text:0000000001E741DD                 lea     rsi, ds:0[rax*8]
+  .text:0000000001E741E5                 test    cx, cx
+  .text:0000000001E741E8                 jnz     short loc_1E741C0
+  .text:0000000001E741EA                 movzx   eax, word ptr ds:dword_0[rax*8]
+  .text:0000000001E741F2                 cmp     ax, 0FFFFh
+  .text:0000000001E741F6                 jnz     short loc_1E741D1
+  .text:0000000001E741F8                 xor     edx, edx
+  .text:0000000001E741FA                 mov     r13, 0FFFFFFFF00000000h
+  .text:0000000001E74204                 mov     rdi, [rsi+rdx+10h]
+  .text:0000000001E74209                 jmp     short loc_1E74239
+  .text:0000000001E74210                 movzx   edx, ax
+  .text:0000000001E74213                 and     r12, r13
+  .text:0000000001E74216                 or      r12, rdx
+  .text:0000000001E74219                 xor     edx, edx
+  .text:0000000001E7421B                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E74224                 jz      short loc_1E7422D
+  .text:0000000001E74226                 mov     rdx, [rbx+0AA0h]
+  .text:0000000001E7422D                 movzx   eax, ax
+  .text:0000000001E74230                 lea     rax, [rax+rax*2]
+  .text:0000000001E74234                 mov     rdi, [rdx+rax*8+10h]
+  .text:0000000001E74239                 test    rdi, rdi
+  .text:0000000001E7423C                 jz      loc_1E73C33
+  .text:0000000001E74242                 call    sub_1E3FFE0
+  .text:0000000001E74247                 lea     rdi, [rbx+0A98h]
+  .text:0000000001E7424E                 movzx   esi, r12w
+  .text:0000000001E74252                 call    sub_1E5ADC0
+  .text:0000000001E74257                 cmp     ax, 0FFFFh
+  .text:0000000001E7425B                 jnz     short loc_1E74210
+  .text:0000000001E7425D                 jmp     loc_1E73C33
+  .text:0000000001E74262                 ; _QWORD
+  .text:0000000001E74262                 mov     esi, 1; _QWORD
+  .text:0000000001E74267                 call    _UtlVectorMemory_FailedAllocation
+  .text:0000000001E7426C                 mov     edi, [r12+38h]
+  .text:0000000001E74271                 mov     esi, [r12+3Ch]
+  .text:0000000001E74276                 jmp     loc_1E740E2
+  .text:0000000001E7427B                 mov     esi, [r12+40h]
+  .text:0000000001E74280                 lea     rdi, aCnetworkfields_0; "CNetworkFieldScratchData::Init failed o"...
+  .text:0000000001E74287                 call    _Plat_FatalError
 procedure: |-
-  __int64 __fastcall CEntitySystem_Init(__int64 a1, __int64 a2, int a3, int a4, char a5)
+  __int64 __fastcall CEntitySystem_Init(__int64 a1, const char *a2, int a3, int a4, char a5)
   {
     bool v9; // al
     __int64 v10; // r12
     __int64 i; // r12
     __int64 v12; // r12
-    unsigned int j; // r14d
+    int j; // r14d
     __int64 (__fastcall *v14)(); // rax
     __int64 m; // r12
     unsigned __int16 v16; // ax
@@ -551,95 +597,93 @@ procedure: |-
     int v27; // eax
     int v28; // r13d
     unsigned int v29; // eax
-    __int64 v30; // r13
-    __int64 v31; // rdx
-    int v32; // r14d
-    __int64 v33; // rdi
-    __int64 v34; // rax
-    int v35; // edx
-    unsigned int v36; // esi
-    unsigned int v37; // r12d
-    __int64 v38; // rdx
+    CMemoryStack *v30; // r13
+    int v31; // r14d
+    __int64 v32; // rdi
+    __int64 v33; // rax
+    int v34; // edx
+    int v35; // esi
+    unsigned int v36; // r12d
+    __int64 v37; // rdx
     int k; // r12d
-    unsigned int v40; // eax
-    __int16 v41; // cx
-    unsigned __int16 v42; // dx
-    __int64 v43; // rax
-    int v44; // edx
-    __int64 v45; // rsi
-    __int16 v46; // cx
-    unsigned __int16 v47; // r15
-    __int64 v48; // r14
+    __int16 v39; // cx
+    unsigned __int16 v40; // dx
+    __int64 v41; // rax
+    int v42; // edx
+    __int64 v43; // rsi
+    __int16 v44; // cx
+    unsigned __int16 v45; // r15
+    __int64 v46; // r14
+    __int64 v47; // rax
+    __int64 v48; // rax
     __int64 v49; // rax
-    __int64 v50; // rax
+    __int64 v50; // r15
     __int64 v51; // rax
-    __int64 v52; // r15
-    __int64 v53; // rax
-    int v54; // ecx
-    unsigned int v55; // esi
-    int v56; // eax
-    int v57; // r8d
+    int v52; // ecx
+    unsigned int v53; // esi
+    int v54; // eax
+    int v55; // r8d
     int n; // r15d
-    unsigned int v59; // edx
-    __int64 v60; // rdx
-    unsigned __int16 v61; // ax
+    unsigned int v57; // edx
+    __int64 v58; // rdx
+    unsigned __int16 v59; // ax
     __int64 ii; // rdi
-    __int64 v63; // rdx
-    unsigned __int16 v64; // ax
-    int v65; // [rsp+Ch] [rbp-84h]
-    __int64 v66; // [rsp+10h] [rbp-80h]
-    int v67; // [rsp+18h] [rbp-78h]
-    __m128i v68; // [rsp+28h] [rbp-68h] BYREF
-    __int64 v69; // [rsp+40h] [rbp-50h] BYREF
-    __m128i v70; // [rsp+48h] [rbp-48h]
+    __int64 v61; // rdx
+    unsigned __int16 v62; // ax
+    int v63; // [rsp+Ch] [rbp-84h]
+    __int64 v64; // [rsp+10h] [rbp-80h]
+    int v65; // [rsp+18h] [rbp-78h]
+    __m128i v66; // [rsp+28h] [rbp-68h] BYREF
+    __int64 v67; // [rsp+40h] [rbp-50h] BYREF
+    __m128i v68; // [rsp+48h] [rbp-48h]
 
-    sub_97F150(a1 + 2696);
-    *(_DWORD *)(a1 + 3012) = a4;
-    unk_2664201 = a5;
-    v9 = a3 == 1 && g_pNetworkMessages != nullptr;
-    *(_BYTE *)(a1 + 3042) = v9;
-    sub_97F670(a1 + 3272, 1024, 0, 0, 0);
-    qword_24587A8 = a1;
-    qword_24587A0 = a1 + 16;
-    v10 = qword_2664108;
-    if ( qword_2664108 )
+    CUtlString::Set((CUtlString *)(a1 + 2696), a2);// 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+    *(_DWORD *)(a1 + 3004) = a4;
+    unk_27BB9F1 = a5;
+    v9 = a3 == 1 && qword_2743670 != nullptr;
+    *(_BYTE *)(a1 + 3034) = v9;
+    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3264), 0x400u, 0, nullptr, 0);
+    qword_25669A8 = a1;
+    qword_25669A0 = a1 + 16;
+    v10 = qword_27BB928;
+    if ( qword_27BB928 )
     {
       do
       {
-        while ( (*(_BYTE *)(v10 + 112) & 2) != 0 )
+        while ( (*(_BYTE *)(v10 + 104) & 2) != 0 )
         {
-          v10 = *(_QWORD *)(v10 + 296);
+          v10 = *(_QWORD *)(v10 + 288);
           if ( !v10 )
             goto LABEL_6;
         }
-        sub_1D79370(a1, v10);
-        v10 = *(_QWORD *)(v10 + 296);
+        sub_1E67830(a1, v10);
+        v10 = *(_QWORD *)(v10 + 288);
       }
       while ( v10 );
   LABEL_6:
-      for ( i = qword_2664108; i; i = *(_QWORD *)(i + 296) )
+      for ( i = qword_27BB928; i; i = *(_QWORD *)(i + 288) )
       {
-        while ( (*(_BYTE *)(i + 112) & 2) == 0 )
+        while ( (*(_BYTE *)(i + 104) & 2) == 0 )
         {
-          i = *(_QWORD *)(i + 296);
+          i = *(_QWORD *)(i + 288);
           if ( !i )
             goto LABEL_9;
         }
-        sub_1D79600(a1, i);
+        sub_1E67AC0(a1, i);
       }
     }
   LABEL_9:
-    v12 = qword_245F230;
+    v12 = qword_256D370;
     for ( j = 0; v12; v12 = *(_QWORD *)(v12 + 32) )
     {
       while ( 1 )
       {
         ++j;
-        *(_DWORD *)(*(_QWORD *)(v12 + 16) + 32LL) = sub_1D85280(a1, v12);
+        *(_DWORD *)(*(_QWORD *)(v12 + 16) + 32LL) = sub_1E73380(a1, v12);
         if ( (*(_BYTE *)(*(_QWORD *)(v12 + 16) + 36LL) & 1) != 0 )
           *(_DWORD *)(v12 + 8) |= 0x20000u;
         v14 = *(__int64 (__fastcall **)())(*(_QWORD *)v12 + 8LL);
-        if ( v14 != nullsub_2005 )
+        if ( v14 != nullsub_1669 )
           break;
         v12 = *(_QWORD *)(v12 + 32);
         if ( !v12 )
@@ -648,51 +692,48 @@ procedure: |-
       ((void (__fastcall *)(__int64))v14)(v12);
     }
   LABEL_14:
-    if ( (int)(j - qword_26640D0) > 0 )
+    if ( j - (int)qword_27BB8F0 > 0 )
     {
-      v23 = *((unsigned int *)&qword_26640D0 + 4);
-      if ( (int)j > (int)v23 )
+      v23 = (unsigned int)qword_27BB900;
+      if ( j > (int)qword_27BB900 )
       {
-        v36 = *((_DWORD *)&qword_26640D0 + 5);
-        if ( v36 <= 0x3FFFFFFF || (v36 & 0xC0000000) == 0x80000000 )
+        v35 = HIDWORD(qword_27BB900);
+        if ( HIDWORD(qword_27BB900) <= 0x3FFFFFFF || (HIDWORD(qword_27BB900) & 0xC0000000) == 0x80000000 )
         {
-          v37 = j - v23;
-          v38 = j;
-          if ( (int)(j - v23) + (__int64)(int)v23 > 0x7FFFFFFF )
+          v36 = j - qword_27BB900;
+          v37 = (unsigned int)j;
+          if ( j - (int)qword_27BB900 + (__int64)(int)qword_27BB900 > 0x7FFFFFFF )
           {
-            sub_980B00(v23, v37, j);
-            v23 = *((unsigned int *)&qword_26640D0 + 4);
-            v36 = *((_DWORD *)&qword_26640D0 + 5);
-            v38 = v37 + (unsigned int)v23;
+            UtlVectorMemory_FailedAllocation((unsigned int)qword_27BB900, v36);
+            v23 = (unsigned int)qword_27BB900;
+            v35 = HIDWORD(qword_27BB900);
+            v37 = v36 + (unsigned int)qword_27BB900;
           }
-          v67 = v38;
-          for ( k = sub_980270(v23, v36 & 0x3FFFFFFF, v38, 8); k < v67; k = (k + v67) / 2 )
+          v65 = v37;
+          for ( k = UtlVectorMemory_CalcNewAllocationCount(v23, v35 & 0x3FFFFFFF, v37, 8); k < v65; k = (k + v65) / 2 )
             ;
-          *(&qword_26640D0 + 1) = sub_97FB10(
-                                    *(&qword_26640D0 + 1),
-                                    *((_DWORD *)&qword_26640D0 + 5) <= 0x3FFFFFFFu,
-                                    8LL * k,
-                                    8LL * *((int *)&qword_26640D0 + 4));
-          v40 = *((_DWORD *)&qword_26640D0 + 5);
-          if ( v40 > 0x3FFFFFFF )
-            *((_DWORD *)&qword_26640D0 + 5) = v40 & 0x3FFFFFFF;
-          *((_DWORD *)&qword_26640D0 + 4) = k;
+          qword_27BB8F8 = UtlVectorMemory_Alloc(
+                            qword_27BB8F8,
+                            HIDWORD(qword_27BB900) <= 0x3FFFFFFF,
+                            8LL * k,
+                            8LL * (int)qword_27BB900);
+          if ( HIDWORD(qword_27BB900) > 0x3FFFFFFF )
+            HIDWORD(qword_27BB900) &= 0x3FFFFFFFu;
+          LODWORD(qword_27BB900) = k;
         }
       }
     }
-    else if ( j == (_DWORD)qword_26640D0 )
+    else if ( j == (_DWORD)qword_27BB8F0 )
     {
       goto LABEL_16;
     }
-    LODWORD(qword_26640D0) = j;
+    LODWORD(qword_27BB8F0) = j;
   LABEL_16:
-    for ( m = qword_245F230; m; m = *(_QWORD *)(m + 32) )
+    for ( m = qword_256D370; m; m = *(_QWORD *)(m + 32) )
     {
-      if ( g_pNetworkMessages )
-        (*(void (__fastcall **)(_QWORD *, _QWORD))(*g_pNetworkMessages + 240LL))(
-          g_pNetworkMessages,
-          *(unsigned int *)(m + 24));
-      *(_QWORD *)(*(&qword_26640D0 + 1) + 8LL * *(int *)(*(_QWORD *)(m + 16) + 32LL)) = *(_QWORD *)(m + 16);
+      if ( qword_2743670 )
+        (*(void (__fastcall **)(_QWORD *, _QWORD))(*qword_2743670 + 232LL))(qword_2743670, *(unsigned int *)(m + 24));
+      *(_QWORD *)(qword_27BB8F8 + 8LL * *(int *)(*(_QWORD *)(m + 16) + 32LL)) = *(_QWORD *)(m + 16);
     }
     if ( *(_WORD *)(a1 + 2730) )
     {
@@ -730,126 +771,125 @@ procedure: |-
           v17 = 0;
         }
       }
-      sub_1D66C80(a1, *(_QWORD *)(v17 + v18 + 16));
+      sub_1E54FC0(a1, *(_QWORD *)(v17 + v18 + 16));
     }
-    if ( !byte_26642B0 )
+    if ( !byte_27BBA40 )
     {
       v19 = *(_WORD *)(a1 + 2728);
       if ( v19 != 0xFFFF )
       {
-        v41 = *(_WORD *)(a1 + 2714);
+        v39 = *(_WORD *)(a1 + 2714);
         while ( 1 )
         {
-          v43 = v19;
+          v41 = v19;
           if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
           {
-            v42 = *(_WORD *)(*(_QWORD *)(a1 + 2720) + 24LL * v19);
-            if ( v42 == 0xFFFF )
+            v40 = *(_WORD *)(*(_QWORD *)(a1 + 2720) + 24LL * v19);
+            if ( v40 == 0xFFFF )
               goto LABEL_75;
           }
           else
           {
-            v42 = *(_WORD *)(24LL * v19);
-            if ( v42 == 0xFFFF )
+            v40 = *(_WORD *)(24LL * v19);
+            if ( v40 == 0xFFFF )
             {
               while ( 1 )
               {
   LABEL_75:
-                v44 = *(unsigned __int16 *)(a1 + 2794);
-                v45 = 0;
-                v46 = v41 & 0x7FFF;
-                v47 = *(_WORD *)(a1 + 2794);
-                if ( v46 )
-                  v45 = *(_QWORD *)(a1 + 2720);
-                v48 = 24 * v43;
-                v49 = *(_QWORD *)(v45 + 24 * v43 + 16);
-                if ( v44 - *(_DWORD *)(v49 + 128) > 0 )
+                v42 = *(unsigned __int16 *)(a1 + 2794);
+                v43 = 0;
+                v44 = v39 & 0x7FFF;
+                v45 = *(_WORD *)(a1 + 2794);
+                if ( v44 )
+                  v43 = *(_QWORD *)(a1 + 2720);
+                v46 = 24 * v41;
+                v47 = *(_QWORD *)(v43 + 24 * v41 + 16);
+                if ( v42 - *(_DWORD *)(v47 + 120) > 0 )
                 {
-                  v54 = *(_DWORD *)(v49 + 144);
-                  if ( v44 > v54 )
+                  v52 = *(_DWORD *)(v47 + 136);
+                  if ( v42 > v52 )
                   {
-                    v65 = *(unsigned __int16 *)(a1 + 2794);
-                    v66 = v49;
-                    sub_1D785E0(v49 + 136, (unsigned int)(v44 - v54));
-                    v44 = v65;
-                    v49 = v66;
+                    v63 = *(unsigned __int16 *)(a1 + 2794);
+                    v64 = v47;
+                    sub_1E66A60(v47 + 128, (unsigned int)(v42 - v52));
+                    v42 = v63;
+                    v47 = v64;
                   }
                 }
-                else if ( v44 == *(_DWORD *)(v49 + 128) )
+                else if ( v42 == *(_DWORD *)(v47 + 120) )
                 {
                   goto LABEL_80;
                 }
-                *(_DWORD *)(v49 + 128) = v44;
-                v46 = *(_WORD *)(a1 + 2714) & 0x7FFF;
+                *(_DWORD *)(v47 + 120) = v42;
+                v44 = *(_WORD *)(a1 + 2714) & 0x7FFF;
   LABEL_80:
-                v50 = 0;
-                if ( v46 )
-                  v50 = *(_QWORD *)(a1 + 2720);
-                sub_9814F0(*(_QWORD *)(*(_QWORD *)(v50 + v48 + 16) + 136LL), 255, 2LL * v47);
-                v51 = 0;
+                v48 = 0;
+                if ( v44 )
+                  v48 = *(_QWORD *)(a1 + 2720);
+                memset(*(void **)(*(_QWORD *)(v48 + v46 + 16) + 128LL), 255, 2LL * v45);
+                v49 = 0;
                 if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-                  v51 = *(_QWORD *)(a1 + 2720);
-                v52 = *(_QWORD *)(v51 + v48 + 16);
-                v53 = sub_97F8A0();
-                if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v53 + 32LL))(v53, 1190268809) )
-                  sub_1D73F80(a1, v52);
+                  v49 = *(_QWORD *)(a1 + 2720);
+                v50 = *(_QWORD *)(v49 + v46 + 16);
+                v51 = CommandLine();
+                if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v51 + 32LL))(v51, 1190268809) )
+                  sub_1E623C0(a1, v50);
                 else
-                  sub_1D73700(a1, v52);
-                LOWORD(v43) = sub_1D6CA00(a1 + 2712, v19);
-                v19 = v43;
-                if ( (_WORD)v43 == 0xFFFF )
+                  sub_1E61B40(a1, v50);
+                LOWORD(v41) = sub_1E5ADC0(a1 + 2712, v19);
+                v19 = v41;
+                if ( (_WORD)v41 == 0xFFFF )
                   goto LABEL_27;
-                v41 = *(_WORD *)(a1 + 2714);
-                v43 = (unsigned __int16)v43;
+                v39 = *(_WORD *)(a1 + 2714);
+                v41 = (unsigned __int16)v41;
               }
             }
           }
-          v19 = v42;
+          v19 = v40;
         }
       }
     }
   LABEL_27:
-    sub_9802C0("EntitySystem - Class Tables");
-    if ( g_pNetworkMessages )
+    COM_TimestampedLog("EntitySystem - Class Tables");
+    if ( qword_2743670 )
     {
-      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*g_pNetworkMessages
-                                                                      + 168LL))(// g_pNetworkMessages->SetNetworkSerializationContextData(...), 168LL = INetworkMessages_SetNetworkSerializationContextData
-        g_pNetworkMessages,
+      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))(
+        qword_2743670,
         "string_t_table",
-        *(unsigned int *)(a1 + 3012),
-        a1 + 7896);
-      v68 = (__m128i)0x119uLL;
-      v20 = _mm_loadu_si128(&v68);
-      v21 = *g_pNetworkMessages;
-      v69 = 0;
-      v70 = v20;
-      (*(void (__fastcall **)(_QWORD *, __int64 *))(v21 + 192))(g_pNetworkMessages, &v69);
+        *(unsigned int *)(a1 + 3004),
+        a1 + 7888);                               // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+      v66 = (__m128i)0x121uLL;
+      v20 = _mm_loadu_si128(&v66);
+      v21 = *qword_2743670;
+      v67 = 0;
+      v68 = v20;
+      (*(void (__fastcall **)(_QWORD *, __int64 *))(v21 + 184))(qword_2743670, &v67);
     }
-    result = sub_1D84180(a1);
-    if ( *(_BYTE *)(a1 + 3042) )
+    result = sub_1E72200(a1);
+    if ( *(_BYTE *)(a1 + 3034) )
     {
-      v25 = sub_975B50(88);
-      *(_QWORD *)(a1 + 3224) = v25;
-      *(_QWORD *)v25 = off_2303720;
+      v25 = operator new(88);
+      *(_QWORD *)(a1 + 3216) = v25;
+      *(_QWORD *)v25 = off_24156E8;
       *(_QWORD *)(v25 + 72) = 0xC8000000000000LL;
       *(_QWORD *)(v25 + 8) = 0;
       *(_QWORD *)(v25 + 16) = 0;
       *(_QWORD *)(v25 + 24) = 0;
       *(_DWORD *)(v25 + 32) = 0;
-      v26 = dword_266453C;
+      v26 = dword_27BBCDC;
       *(_QWORD *)(v25 + 48) = 0;
       *(_DWORD *)(v25 + 56) = 0;
       *(_DWORD *)(v25 + 40) = 0;
       *(_QWORD *)(v25 + 60) = 0;
       *(_QWORD *)(v25 + 80) = 0;
-      v27 = sub_980270(0, 0, 320000, 1);
+      v27 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 320000, 1);
       v28 = v27;
       if ( v27 <= 319999 )
       {
         while ( 1 )
           ;
       }
-      *(_QWORD *)(v25 + 16) = sub_97FB10(
+      *(_QWORD *)(v25 + 16) = UtlVectorMemory_Alloc(
                                 *(_QWORD *)(v25 + 16),
                                 *(_DWORD *)(v25 + 28) <= 0x3FFFFFFFu,
                                 v27,
@@ -862,89 +902,92 @@ procedure: |-
       _InterlockedExchange((volatile __int32 *)(v25 + 32), 0);
       *(_DWORD *)(v25 + 68) = v26;
       *(_DWORD *)(v25 + 64) = 0x10000;
-      v30 = sub_975B50(80);
-      sub_97FC70(v30);
-      if ( !(unsigned __int8)sub_97F770(
+      v30 = (CMemoryStack *)operator new(80);
+      CMemoryStack::CMemoryStack(v30);
+      if ( !(unsigned __int8)CMemoryStack::Init(
                                v30,
                                "CNetworkFieldScratchData.m_MemoryStacks[ 0 ]",
-                               *(unsigned int *)(v25 + 64),
-                               4096,
-                               4096,
-                               16) )
+                               *(_DWORD *)(v25 + 64),
+                               0x1000u,
+                               0x1000u,
+                               0x10u) )
       {
-        sub_9803D0("CNetworkFieldScratchData::Init failed on buffer of %u bytes.", *(_DWORD *)(v25 + 64));
-        JUMPOUT(0x1D8618C);
+        Plat_FatalError("CNetworkFieldScratchData::Init failed on buffer of %u bytes.", *(_DWORD *)(v25 + 64));
+        JUMPOUT(0x1E7428C);
       }
-      v32 = *(_DWORD *)(v25 + 40);
-      v33 = *(unsigned int *)(v25 + 56);
-      if ( v32 == (_DWORD)v33 && ((v55 = *(_DWORD *)(v25 + 60), v55 <= 0x3FFFFFFF) || (v55 & 0xC0000000) == 0x80000000) )
+      v31 = *(_DWORD *)(v25 + 40);
+      v32 = *(unsigned int *)(v25 + 56);
+      if ( v31 == (_DWORD)v32 && ((v53 = *(_DWORD *)(v25 + 60), v53 <= 0x3FFFFFFF) || (v53 & 0xC0000000) == 0x80000000) )
       {
-        if ( (_DWORD)v33 == 0x7FFFFFFF )
+        if ( (_DWORD)v32 == 0x7FFFFFFF )
         {
-          sub_980B00(v33, 1, v31);
-          v33 = *(unsigned int *)(v25 + 56);
-          v55 = *(_DWORD *)(v25 + 60);
+          UtlVectorMemory_FailedAllocation(v32, 1);
+          v32 = *(unsigned int *)(v25 + 56);
+          v53 = *(_DWORD *)(v25 + 60);
         }
-        v56 = sub_980270(v33, v55 & 0x3FFFFFFF, (unsigned int)(v33 + 1), 8);
-        v57 = v33 + 1;
-        for ( n = v56; v57 > n; n = (n + v57) / 2 )
+        v54 = UtlVectorMemory_CalcNewAllocationCount(v32, v53 & 0x3FFFFFFF, (unsigned int)(v32 + 1), 8);
+        v55 = v32 + 1;
+        for ( n = v54; v55 > n; n = (n + v55) / 2 )
           ;
-        v34 = sub_97FB10(*(_QWORD *)(v25 + 48), *(_DWORD *)(v25 + 60) <= 0x3FFFFFFFu, 8LL * n, 8LL * *(int *)(v25 + 56));
-        v59 = *(_DWORD *)(v25 + 60);
-        *(_QWORD *)(v25 + 48) = v34;
-        if ( v59 > 0x3FFFFFFF )
-          *(_DWORD *)(v25 + 60) = v59 & 0x3FFFFFFF;
-        v35 = *(_DWORD *)(v25 + 40);
+        v33 = UtlVectorMemory_Alloc(
+                *(_QWORD *)(v25 + 48),
+                *(_DWORD *)(v25 + 60) <= 0x3FFFFFFFu,
+                8LL * n,
+                8LL * *(int *)(v25 + 56));
+        v57 = *(_DWORD *)(v25 + 60);
+        *(_QWORD *)(v25 + 48) = v33;
+        if ( v57 > 0x3FFFFFFF )
+          *(_DWORD *)(v25 + 60) = v57 & 0x3FFFFFFF;
+        v34 = *(_DWORD *)(v25 + 40);
         *(_DWORD *)(v25 + 56) = n;
       }
       else
       {
-        v34 = *(_QWORD *)(v25 + 48);
-        v35 = *(_DWORD *)(v25 + 40);
+        v33 = *(_QWORD *)(v25 + 48);
+        v34 = *(_DWORD *)(v25 + 40);
       }
-      *(_DWORD *)(v25 + 40) = v35 + 1;
-      *(_QWORD *)(v34 + 8LL * v32) = v30;
-      result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pFlattenedSerializers
-                                                                   + 280LL))(// g_pFlattenedSerializers->CreateFieldChangedEventQueue(...), 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-                 g_pFlattenedSerializers,
-                 *(_QWORD *)(a1 + 3224),
-                 *(_QWORD *)(a1 + 3232));
-      *(_QWORD *)(a1 + 3216) = result;
+      *(_DWORD *)(v25 + 40) = v34 + 1;
+      *(_QWORD *)(v33 + 8LL * v31) = v30;
+      result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*qword_2743668 + 280LL))(
+                 qword_2743668,
+                 *(_QWORD *)(a1 + 3216),
+                 *(_QWORD *)(a1 + 3224));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+      *(_QWORD *)(a1 + 3208) = result;
     }
-    if ( byte_26642B0 )
+    if ( byte_27BBA40 )
       goto LABEL_31;
     v24 = *(_WORD *)(a1 + 2728);
     if ( v24 == 0xFFFF )
       goto LABEL_45;
     while ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
     {
-      v60 = *(_QWORD *)(a1 + 2720);
-      v61 = *(_WORD *)(v60 + 24LL * v24);
-      if ( v61 == 0xFFFF )
+      v58 = *(_QWORD *)(a1 + 2720);
+      v59 = *(_WORD *)(v58 + 24LL * v24);
+      if ( v59 == 0xFFFF )
         goto LABEL_104;
   LABEL_100:
-      v24 = v61;
+      v24 = v59;
     }
-    v61 = *(_WORD *)(24LL * v24);
-    if ( v61 != 0xFFFF )
+    v59 = *(_WORD *)(24LL * v24);
+    if ( v59 != 0xFFFF )
       goto LABEL_100;
-    v60 = 0;
+    v58 = 0;
   LABEL_104:
-    for ( ii = *(_QWORD *)(24LL * v24 + v60 + 16); ii; ii = *(_QWORD *)(v63 + 24LL * v64 + 16) )
+    for ( ii = *(_QWORD *)(24LL * v24 + v58 + 16); ii; ii = *(_QWORD *)(v61 + 24LL * v62 + 16) )
     {
-      sub_1D51EE0();
-      v64 = sub_1D6CA00(a1 + 2712, v24);
-      if ( v64 == 0xFFFF )
+      sub_1E3FFE0();
+      v62 = sub_1E5ADC0(a1 + 2712, v24);
+      if ( v62 == 0xFFFF )
         break;
-      v24 = v64;
-      v63 = 0;
+      v24 = v62;
+      v61 = 0;
       if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-        v63 = *(_QWORD *)(a1 + 2720);
+        v61 = *(_QWORD *)(a1 + 2720);
     }
   LABEL_45:
-    sub_1D9ED40();
-    result = sub_1D71880(a1);
+    sub_1E8FFB0();
+    result = sub_1E5FD40(a1);
   LABEL_31:
-    byte_26642B0 = 1;
+    byte_27BBA40 = 1;
     return result;
   }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -853,11 +853,11 @@ procedure: |-
     COM_TimestampedLog("EntitySystem - Class Tables");
     if ( qword_2743670 )
     {
-      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))(
+      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))( // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
         qword_2743670,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7888);                               // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+        a1 + 7888);
       v66 = (__m128i)0x121uLL;
       v20 = _mm_loadu_si128(&v66);
       v21 = *qword_2743670;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -1,436 +1,440 @@
 func_name: CEntitySystem_Init
-func_va: '0x1811886e0'
+func_va: '0x1811f0ad0'
 disasm_code: |-
-  .text:00000001811886E0                 mov     [rsp+arg_18], rbx
-  .text:00000001811886E5                 push    rsi
-  .text:00000001811886E6                 push    rdi
-  .text:00000001811886E7                 push    r12
-  .text:00000001811886E9                 push    r13
-  .text:00000001811886EB                 push    r15
-  .text:00000001811886ED                 sub     rsp, 0A0h
-  .text:00000001811886F4                 mov     rsi, rcx
-  .text:00000001811886F7                 mov     ebx, r9d
-  .text:00000001811886FA                 add     rcx, 0A88h
-  .text:0000000181188701                 mov     edi, r8d
-  .text:0000000181188704                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
-  .text:000000018118870A                 movzx   eax, [rsp+0C8h+arg_20]
-  .text:0000000181188712                 mov     cs:byte_181FF6F91, al
-  .text:0000000181188718                 mov     [rsi+0BC4h], ebx
-  .text:000000018118871E                 cmp     edi, 1
-  .text:0000000181188721                 jnz     short loc_181188733
-  .text:0000000181188723                 cmp     cs:g_pNetworkMessages, 0
-  .text:000000018118872B                 jz      short loc_181188733
-  .text:000000018118872D                 movzx   eax, dil
-  .text:0000000181188731                 jmp     short loc_181188735
-  .text:0000000181188733                 xor     al, al
-  .text:0000000181188735                 lea     rcx, [rsi+0CC0h]
-  .text:000000018118873C                 mov     [rsi+0BE2h], al
-  .text:0000000181188742                 xor     r9d, r9d
-  .text:0000000181188745                 mov     byte ptr [rsp+0C8h+var_A8], 0
-  .text:000000018118874A                 xor     r8d, r8d
-  .text:000000018118874D                 mov     edx, 400h
-  .text:0000000181188752                 call    cs:?Init@CUtlScratchMemoryPool@@QEAAXIIPEAX_N@Z; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
-  .text:0000000181188758                 mov     rbx, cs:qword_181FF6D90
-  .text:000000018118875F                 lea     rax, [rsi+10h]
-  .text:0000000181188763                 xor     r15d, r15d
-  .text:0000000181188766                 mov     cs:qword_181D8C650, rsi
-  .text:000000018118876D                 test    rsi, rsi
-  .text:0000000181188770                 cmovz   rax, r15
-  .text:0000000181188774                 mov     cs:qword_181D17000, rax
-  .text:000000018118877B                 test    rbx, rbx
-  .text:000000018118877E                 jz      short loc_1811887D0
-  .text:0000000181188780                 test    byte ptr [rbx+90h], 2
-  .text:0000000181188787                 jnz     short loc_181188794
-  .text:0000000181188789                 mov     rdx, rbx
-  .text:000000018118878C                 mov     rcx, rsi
-  .text:000000018118878F                 call    sub_18118D2A0
-  .text:0000000181188794                 mov     rbx, [rbx+148h]
-  .text:000000018118879B                 test    rbx, rbx
-  .text:000000018118879E                 jnz     short loc_181188780
-  .text:00000001811887A0                 mov     rbx, cs:qword_181FF6D90
-  .text:00000001811887A7                 test    rbx, rbx
-  .text:00000001811887AA                 jz      short loc_1811887D0
-  .text:00000001811887AC                 nop     dword ptr [rax+00h]
-  .text:00000001811887B0                 test    byte ptr [rbx+90h], 2
-  .text:00000001811887B7                 jz      short loc_1811887C4
-  .text:00000001811887B9                 mov     rdx, rbx
-  .text:00000001811887BC                 mov     rcx, rsi
-  .text:00000001811887BF                 call    sub_18118D030
-  .text:00000001811887C4                 mov     rbx, [rbx+148h]
-  .text:00000001811887CB                 test    rbx, rbx
-  .text:00000001811887CE                 jnz     short loc_1811887B0
-  .text:00000001811887D0                 mov     rbx, cs:qword_181D19B00
-  .text:00000001811887D7                 mov     edi, r15d
-  .text:00000001811887DA                 mov     [rsp+0C8h+arg_8], rbp
-  .text:00000001811887E2                 mov     r13d, 0FFFFh
-  .text:00000001811887E8                 mov     [rsp+0C8h+arg_10], r14
-  .text:00000001811887F0                 test    rbx, rbx
-  .text:00000001811887F3                 jz      loc_18118891E
-  .text:00000001811887F9                 lea     r14, aCBuildworkerCs_45; "C:\\buildworker\\csgo_rel_win64\\build"...
-  .text:0000000181188800                 lea     r12, aCentitysystemR; "CEntitySystem::RegisterComponentType"
-  .text:0000000181188807                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000181188810                 mov     rax, [rbx+10h]
-  .text:0000000181188814                 lea     rbp, [rsi+0AD0h]
-  .text:000000018118881B                 lea     r8, [rsp+0C8h+var_80]
-  .text:0000000181188820                 mov     [rsp+0C8h+var_80], rbp
-  .text:0000000181188825                 lea     rdx, [rsp+0C8h+arg_0]
-  .text:000000018118882D                 mov     [rsp+0C8h+var_70], rbp
-  .text:0000000181188832                 inc     edi
-  .text:0000000181188834                 mov     rcx, [rax]
-  .text:0000000181188837                 lea     rax, [rsp+0C8h+var_98]
-  .text:000000018118883C                 mov     [rsp+0C8h+var_98], rcx
-  .text:0000000181188841                 lea     rcx, [rbp+8]
-  .text:0000000181188845                 mov     [rsp+0C8h+var_78], rax
-  .text:000000018118884A                 call    sub_18117AA00
-  .text:000000018118884F                 cmp     [rax+2], r13w
-  .text:0000000181188854                 jz      short loc_1811888C8
-  .text:0000000181188856                 mov     ecx, cs:dword_181FF71B8
-  .text:000000018118885C                 mov     edx, 5
-  .text:0000000181188861                 call    cs:LoggingSystem_IsChannelEnabled
-  .text:0000000181188867                 test    al, al
-  .text:0000000181188869                 jz      short loc_1811888C1
-  .text:000000018118886B                 mov     rax, [rsp+0C8h+var_98]
-  .text:0000000181188870                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
-  .text:0000000181188877                 mov     ecx, cs:dword_181FF71B8
-  .text:000000018118887D                 lea     r8, [rsp+0C8h+var_68]
-  .text:0000000181188882                 xorps   xmm0, xmm0
-  .text:0000000181188885                 mov     [rsp+0C8h+var_A8], rax
-  .text:000000018118888A                 xorps   xmm1, xmm1
-  .text:000000018118888D                 mov     [rsp+0C8h+var_68], r14
-  .text:0000000181188892                 mov     edx, 5
-  .text:0000000181188897                 mov     [rsp+0C8h+var_60], 67Dh
-  .text:000000018118889F                 movdqu  [rsp+0C8h+var_50], xmm0
-  .text:00000001811888A5                 mov     [rsp+0C8h+var_58], r12
-  .text:00000001811888AA                 movdqu  [rsp+0C8h+var_40], xmm1
-  .text:00000001811888B3                 mov     [rsp+0C8h+var_30], r15d
-  .text:00000001811888BB                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
-  .text:00000001811888C1                 mov     ecx, 0FFFFFFFFh
-  .text:00000001811888C6                 jmp     short loc_1811888E7
-  .text:00000001811888C8                 mov     rax, [rsp+0C8h+var_98]
-  .text:00000001811888CD                 lea     rdx, [rsp+0C8h+var_90]
-  .text:00000001811888D2                 mov     rcx, rbp
-  .text:00000001811888D5                 mov     [rsp+0C8h+var_90], rax
-  .text:00000001811888DA                 mov     [rsp+0C8h+var_88], rbx
-  .text:00000001811888DF                 call    sub_181189470
-  .text:00000001811888E4                 movzx   ecx, ax
-  .text:00000001811888E7                 mov     r8d, 10h
-  .text:00000001811888ED                 mov     rdx, rbx
-  .text:00000001811888F0                 mov     rax, [rbx+r8]
-  .text:00000001811888F4                 mov     [rax+20h], ecx
-  .text:00000001811888F7                 mov     rax, [rbx+r8]
-  .text:00000001811888FB                 test    byte ptr [rax+24h], 1
-  .text:00000001811888FF                 jz      short loc_181188908
-  .text:0000000181188901                 or      dword ptr [rbx+8], 20000h
-  .text:0000000181188908                 mov     rax, [rbx]
-  .text:000000018118890B                 mov     rcx, rbx
-  .text:000000018118890E                 call    qword ptr [rax+8]
-  .text:0000000181188911                 mov     rbx, [rbx+20h]
-  .text:0000000181188915                 test    rbx, rbx
-  .text:0000000181188918                 jnz     loc_181188810
-  .text:000000018118891E                 mov     eax, cs:dword_181FF6DB8
-  .text:0000000181188924                 sub     edi, eax
-  .text:0000000181188926                 test    edi, edi
-  .text:0000000181188928                 jle     short loc_18118893D
-  .text:000000018118892A                 mov     r8d, edi
-  .text:000000018118892D                 lea     rcx, dword_181FF6DB8
-  .text:0000000181188934                 mov     edx, eax
-  .text:0000000181188936                 call    sub_1811895E0
-  .text:000000018118893B                 jmp     short loc_181188947
-  .text:000000018118893D                 jns     short loc_181188947
-  .text:000000018118893F                 add     eax, edi
-  .text:0000000181188941                 mov     cs:dword_181FF6DB8, eax
-  .text:0000000181188947                 mov     rbx, cs:qword_181D19B00
-  .text:000000018118894E                 test    rbx, rbx
-  .text:0000000181188951                 jz      short loc_181188987
-  .text:0000000181188953                 mov     rcx, cs:g_pNetworkMessages
-  .text:000000018118895A                 test    rcx, rcx
-  .text:000000018118895D                 jz      short loc_18118896B
-  .text:000000018118895F                 mov     rax, [rcx]
-  .text:0000000181188962                 mov     edx, [rbx+18h]
-  .text:0000000181188965                 call    qword ptr [rax+0F0h]
-  .text:000000018118896B                 mov     rdx, [rbx+10h]
-  .text:000000018118896F                 mov     rax, cs:qword_181FF6DC0
-  .text:0000000181188976                 movsxd  rcx, dword ptr [rdx+20h]
-  .text:000000018118897A                 mov     [rax+rcx*8], rdx
-  .text:000000018118897E                 mov     rbx, [rbx+20h]
-  .text:0000000181188982                 test    rbx, rbx
-  .text:0000000181188985                 jnz     short loc_181188953
-  .text:0000000181188987                 mov     r12d, 7FFFh
-  .text:000000018118898D                 cmp     [rsi+0AAAh], r15w
-  .text:0000000181188995                 jz      short loc_181188A10
-  .text:0000000181188997                 movzx   ebx, word ptr [rsi+0AEAh]
-  .text:000000018118899E                 mov     edx, cs:dword_181FF6DA0
-  .text:00000001811889A4                 mov     eax, ebx
-  .text:00000001811889A6                 sub     eax, edx
-  .text:00000001811889A8                 test    eax, eax
-  .text:00000001811889AA                 jle     short loc_1811889BD
-  .text:00000001811889AC                 mov     r8d, eax
-  .text:00000001811889AF                 lea     rcx, dword_181FF6DA0
-  .text:00000001811889B6                 call    sub_180891890
-  .text:00000001811889BB                 jmp     short loc_1811889C5
-  .text:00000001811889BD                 jns     short loc_1811889C5
-  .text:00000001811889BF                 mov     cs:dword_181FF6DA0, ebx
-  .text:00000001811889C5                 movzx   r8d, r15w
-  .text:00000001811889C9                 cmp     r15w, bx
-  .text:00000001811889CD                 jnb     short loc_181188A10
-  .text:00000001811889CF                 nop
-  .text:00000001811889D0                 mov     rcx, r15
-  .text:00000001811889D3                 test    [rsi+0ADAh], r12w
-  .text:00000001811889DB                 jz      short loc_1811889E4
-  .text:00000001811889DD                 mov     rcx, [rsi+0AE0h]
-  .text:00000001811889E4                 movzx   edx, r8w
-  .text:00000001811889E8                 inc     r8w
-  .text:00000001811889EC                 lea     rax, [rdx+rdx*2]
-  .text:00000001811889F0                 mov     rcx, [rcx+rax*8+10h]
-  .text:00000001811889F5                 mov     rax, [rcx+10h]
-  .text:00000001811889F9                 movzx   ecx, byte ptr [rax+24h]
-  .text:00000001811889FD                 mov     rax, cs:qword_181FF6DA8
-  .text:0000000181188A04                 and     cl, 1
-  .text:0000000181188A07                 mov     [rdx+rax], cl
-  .text:0000000181188A0A                 cmp     r8w, bx
-  .text:0000000181188A0E                 jb      short loc_1811889D0
-  .text:0000000181188A10                 cmp     cs:byte_181FF6EEC, r15b
-  .text:0000000181188A17                 jnz     loc_181188B41
-  .text:0000000181188A1D                 movzx   ebx, word ptr [rsi+0AA8h]
-  .text:0000000181188A24                 cmp     bx, r13w
-  .text:0000000181188A28                 jz      loc_181188B41
-  .text:0000000181188A2E                 mov     rdx, r15
-  .text:0000000181188A31                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188A39                 jz      short loc_181188A42
-  .text:0000000181188A3B                 mov     rdx, [rsi+0AA0h]
-  .text:0000000181188A42                 movzx   eax, bx
-  .text:0000000181188A45                 lea     rcx, [rax+rax*2]
-  .text:0000000181188A49                 movzx   eax, word ptr [rdx+rcx*8]
-  .text:0000000181188A4D                 cmp     ax, r13w
-  .text:0000000181188A51                 jz      short loc_181188A60
-  .text:0000000181188A53                 movzx   ebx, ax
-  .text:0000000181188A56                 jmp     short loc_181188A24
-  .text:0000000181188A60                 mov     rdx, r15
-  .text:0000000181188A63                 movzx   edi, word ptr [rsi+0AEAh]
-  .text:0000000181188A6A                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188A72                 jz      short loc_181188A7B
-  .text:0000000181188A74                 mov     rdx, [rsi+0AA0h]
-  .text:0000000181188A7B                 movzx   eax, bx
-  .text:0000000181188A7E                 lea     rcx, [rax+rax*2]
-  .text:0000000181188A82                 mov     eax, edi
-  .text:0000000181188A84                 lea     rbp, ds:0[rcx*8]
-  .text:0000000181188A8C                 mov     rcx, [rdx+rcx*8+10h]
-  .text:0000000181188A91                 add     rcx, 0A0h
-  .text:0000000181188A98                 mov     edx, [rcx]
-  .text:0000000181188A9A                 sub     eax, edx
-  .text:0000000181188A9C                 test    eax, eax
-  .text:0000000181188A9E                 jle     short loc_181188AAA
-  .text:0000000181188AA0                 mov     r8d, eax
-  .text:0000000181188AA3                 call    sub_181189880
-  .text:0000000181188AA8                 jmp     short loc_181188AAE
-  .text:0000000181188AAA                 jns     short loc_181188AAE
-  .text:0000000181188AAC                 mov     [rcx], edi
-  .text:0000000181188AAE                 mov     rcx, r15
-  .text:0000000181188AB1                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188AB9                 jz      short loc_181188AC2
-  .text:0000000181188ABB                 mov     rcx, [rsi+0AA0h]
-  .text:0000000181188AC2                 mov     rcx, [rcx+rbp+10h]
-  .text:0000000181188AC7                 mov     r8, rdi
-  .text:0000000181188ACA                 add     r8, r8; Size
-  .text:0000000181188ACD                 mov     edx, 0FFh; Val
-  .text:0000000181188AD2                 mov     rcx, [rcx+0A8h]; void *
-  .text:0000000181188AD9                 call    memset
-  .text:0000000181188ADE                 mov     rax, r15
-  .text:0000000181188AE1                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188AE9                 jz      short loc_181188AF2
-  .text:0000000181188AEB                 mov     rax, [rsi+0AA0h]
-  .text:0000000181188AF2                 mov     rdi, [rax+rbp+10h]
-  .text:0000000181188AF7                 call    cs:CommandLine
-  .text:0000000181188AFD                 mov     edx, 46F20F89h
-  .text:0000000181188B02                 mov     rcx, [rax]
-  .text:0000000181188B05                 mov     r8, [rcx+20h]
-  .text:0000000181188B09                 mov     rcx, rax
-  .text:0000000181188B0C                 call    r8
-  .text:0000000181188B0F                 mov     rdx, rdi
-  .text:0000000181188B12                 mov     rcx, rsi
-  .text:0000000181188B15                 test    al, al
-  .text:0000000181188B17                 jz      short loc_181188B20
-  .text:0000000181188B19                 call    sub_181190CE0
-  .text:0000000181188B1E                 jmp     short loc_181188B25
-  .text:0000000181188B20                 call    sub_181182FC0
-  .text:0000000181188B25                 movzx   edx, bx
-  .text:0000000181188B28                 lea     rcx, [rsi+0A98h]
-  .text:0000000181188B2F                 call    sub_18118BD20
-  .text:0000000181188B34                 movzx   ebx, ax
-  .text:0000000181188B37                 cmp     ax, r13w
-  .text:0000000181188B3B                 jnz     loc_181188A60
-  .text:0000000181188B41                 lea     rcx, aEntitysystemCl; "EntitySystem - Class Tables"
-  .text:0000000181188B48                 call    cs:COM_TimestampedLog
-  .text:0000000181188B4E                 mov     rcx, cs:g_pNetworkMessages
-  .text:0000000181188B55                 mov     r14, [rsp+0C8h+arg_10]
-  .text:0000000181188B5D                 test    rcx, rcx
-  .text:0000000181188B60                 jz      short loc_181188BA6
-  .text:0000000181188B62                 mov     rax, [rcx]
-  .text:0000000181188B65                 lea     r9, [rsi+1ED0h]
-  .text:0000000181188B6C                 mov     r8d, [rsi+0BC4h]
-  .text:0000000181188B73                 lea     rdx, aStringTTable; "string_t_table"
-  .text:0000000181188B7A                 call    qword ptr [rax+0A8h]; g_pNetworkMessages->SetNetworkSerializationContextData(...), 0xA8 = INetworkMessages_SetNetworkSerializationContextData
-  .text:0000000181188B80                 mov     rcx, cs:g_pNetworkMessages
-  .text:0000000181188B87                 lea     rdx, sub_18117CC90
-  .text:0000000181188B8E                 mov     rax, [rcx]
-  .text:0000000181188B91                 mov     [rsp+0C8h+var_88], rdx
-  .text:0000000181188B96                 lea     rdx, [rsp+0C8h+var_90]
-  .text:0000000181188B9B                 mov     [rsp+0C8h+var_90], r15
-  .text:0000000181188BA0                 call    qword ptr [rax+0C0h]
-  .text:0000000181188BA6                 mov     rcx, rsi
-  .text:0000000181188BA9                 call    sub_181182850
-  .text:0000000181188BAE                 cmp     [rsi+0BE2h], r15b
-  .text:0000000181188BB5                 jz      loc_181188C47
-  .text:0000000181188BBB                 mov     ecx, 58h ; 'X'
-  .text:0000000181188BC0                 call    sub_180E35430
-  .text:0000000181188BC5                 mov     rcx, rax
-  .text:0000000181188BC8                 test    rax, rax
-  .text:0000000181188BCB                 jz      short loc_181188C06
-  .text:0000000181188BCD                 lea     rax, ??_7CNetworkFieldScratchData@@6B@; const CNetworkFieldScratchData::`vftable'
-  .text:0000000181188BD4                 mov     [rcx], rax
-  .text:0000000181188BD7                 xor     eax, eax
-  .text:0000000181188BD9                 mov     [rcx+10h], r15
-  .text:0000000181188BDD                 mov     [rcx+18h], r15
-  .text:0000000181188BE1                 mov     [rcx+8], r15d
-  .text:0000000181188BE5                 mov     [rcx+20h], r15d
-  .text:0000000181188BE9                 mov     [rcx+30h], r15
-  .text:0000000181188BED                 mov     [rcx+38h], r15
-  .text:0000000181188BF1                 mov     [rcx+28h], r15d
-  .text:0000000181188BF5                 mov     [rcx+40h], r15d
-  .text:0000000181188BF9                 mov     [rcx+48h], eax
-  .text:0000000181188BFC                 mov     qword ptr [rcx+4Ch], 0C80000h
-  .text:0000000181188C04                 jmp     short loc_181188C09
-  .text:0000000181188C06                 mov     rcx, r15
-  .text:0000000181188C09                 mov     [rsi+0C90h], rcx
-  .text:0000000181188C10                 mov     edx, 10000h
-  .text:0000000181188C15                 mov     rax, [rcx]
-  .text:0000000181188C18                 mov     r8d, cs:dword_181FF71B8
-  .text:0000000181188C1F                 call    qword ptr [rax+8]
-  .text:0000000181188C22                 mov     rcx, cs:g_pFlattenedSerializers
-  .text:0000000181188C29                 mov     r8, [rsi+0C98h]
-  .text:0000000181188C30                 mov     rdx, [rsi+0C90h]
-  .text:0000000181188C37                 mov     rax, [rcx]
-  .text:0000000181188C3A                 call    qword ptr [rax+118h]; g_pFlattenedSerializers->CreateFieldChangedEventQueue(...), 0x118 = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:0000000181188C40                 mov     [rsi+0C88h], rax
-  .text:0000000181188C47                 cmp     cs:byte_181FF6EEC, r15b
-  .text:0000000181188C4E                 jnz     loc_181188DFE
-  .text:0000000181188C54                 movzx   ecx, word ptr [rsi+0AA8h]
-  .text:0000000181188C5B                 nop     dword ptr [rax+rax+00h]
-  .text:0000000181188C60                 cmp     cx, r13w
-  .text:0000000181188C64                 jz      loc_181188D02
-  .text:0000000181188C6A                 mov     rdx, r15
-  .text:0000000181188C6D                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188C75                 jz      short loc_181188C7E
-  .text:0000000181188C77                 mov     rdx, [rsi+0AA0h]
-  .text:0000000181188C7E                 movzx   r8d, cx
-  .text:0000000181188C82                 lea     rax, [r8+r8*2]
-  .text:0000000181188C86                 movzx   r9d, word ptr [rdx+rax*8]
-  .text:0000000181188C8B                 cmp     r9w, r13w
-  .text:0000000181188C8F                 jz      short loc_181188C97
-  .text:0000000181188C91                 movzx   ecx, r9w
-  .text:0000000181188C95                 jmp     short loc_181188C60
-  .text:0000000181188C97                 movzx   ebx, cx
-  .text:0000000181188C9A                 mov     rcx, r15
-  .text:0000000181188C9D                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188CA5                 jz      short loc_181188CAE
-  .text:0000000181188CA7                 mov     rcx, [rsi+0AA0h]
-  .text:0000000181188CAE                 lea     rax, [r8+r8*2]
-  .text:0000000181188CB2                 mov     rcx, [rcx+rax*8+10h]
-  .text:0000000181188CB7                 test    rcx, rcx
-  .text:0000000181188CBA                 jz      short loc_181188D02
-  .text:0000000181188CBC                 nop     dword ptr [rax+00h]
-  .text:0000000181188CC0                 call    sub_181175930
-  .text:0000000181188CC5                 movzx   edx, bx
-  .text:0000000181188CC8                 lea     rcx, [rsi+0A98h]
-  .text:0000000181188CCF                 call    sub_18118BD20
-  .text:0000000181188CD4                 cmp     ax, r13w
-  .text:0000000181188CD8                 jz      short loc_181188D02
-  .text:0000000181188CDA                 mov     rdx, r15
-  .text:0000000181188CDD                 movzx   ebx, ax
-  .text:0000000181188CE0                 test    [rsi+0A9Ah], r12w
-  .text:0000000181188CE8                 jz      short loc_181188CF1
-  .text:0000000181188CEA                 mov     rdx, [rsi+0AA0h]
-  .text:0000000181188CF1                 movzx   eax, ax
-  .text:0000000181188CF4                 lea     rcx, [rax+rax*2]
-  .text:0000000181188CF8                 mov     rcx, [rdx+rcx*8+10h]
-  .text:0000000181188CFD                 test    rcx, rcx
-  .text:0000000181188D00                 jnz     short loc_181188CC0
-  .text:0000000181188D02                 call    sub_1811B2CE0
-  .text:0000000181188D07                 mov     rbx, cs:qword_181FF6DE8
-  .text:0000000181188D0E                 test    rbx, rbx
-  .text:0000000181188D11                 jz      loc_181188DF7
-  .text:0000000181188D17                 lea     rbp, [rsi+2080h]
-  .text:0000000181188D1E                 xchg    ax, ax
-  .text:0000000181188D20                 call    qword ptr [rbx]
-  .text:0000000181188D22                 lea     rdx, byte_18152DF88
-  .text:0000000181188D29                 mov     r9d, 811C9DC5h
-  .text:0000000181188D2F                 mov     rsi, rax
-  .text:0000000181188D32                 mov     rcx, [rax+10h]
-  .text:0000000181188D36                 test    rcx, rcx
-  .text:0000000181188D39                 cmovnz  rdx, rcx
-  .text:0000000181188D3D                 movzx   ecx, byte ptr [rdx]
-  .text:0000000181188D40                 test    cl, cl
-  .text:0000000181188D42                 jz      short loc_181188D68
-  .text:0000000181188D44                 nop     dword ptr [rax+00h]
-  .text:0000000181188D48                 nop     dword ptr [rax+rax+00000000h]
-  .text:0000000181188D50                 movzx   eax, cl
-  .text:0000000181188D53                 lea     rdx, [rdx+1]
-  .text:0000000181188D57                 movzx   ecx, byte ptr [rdx]
-  .text:0000000181188D5A                 xor     eax, r9d
-  .text:0000000181188D5D                 imul    r9d, eax, 1000193h
-  .text:0000000181188D64                 test    cl, cl
-  .text:0000000181188D66                 jnz     short loc_181188D50
-  .text:0000000181188D68                 mov     r8d, r9d
-  .text:0000000181188D6B                 lea     rdx, [rsi+10h]
-  .text:0000000181188D6F                 shl     r8d, 11h
-  .text:0000000181188D73                 mov     rcx, rbp
-  .text:0000000181188D76                 xor     r8d, r9d
-  .text:0000000181188D79                 shr     r9d, 15h
-  .text:0000000181188D7D                 add     r8d, r9d
-  .text:0000000181188D80                 xor     r9d, r9d
-  .text:0000000181188D83                 call    sub_181179840
-  .text:0000000181188D88                 cmp     eax, 0FFFFFFFFh
-  .text:0000000181188D8B                 jnz     short loc_181188DEA
-  .text:0000000181188D8D                 mov     rax, [rsi+10h]
-  .text:0000000181188D91                 lea     rcx, byte_18152DF88
-  .text:0000000181188D98                 test    rax, rax
-  .text:0000000181188D9B                 mov     edx, 811C9DC5h
-  .text:0000000181188DA0                 cmovnz  rcx, rax
-  .text:0000000181188DA4                 movzx   eax, byte ptr [rcx]
-  .text:0000000181188DA7                 test    al, al
-  .text:0000000181188DA9                 jz      short loc_181188DC6
-  .text:0000000181188DAB                 nop     dword ptr [rax+rax+00h]
-  .text:0000000181188DB0                 movzx   eax, al
-  .text:0000000181188DB3                 lea     rcx, [rcx+1]
-  .text:0000000181188DB7                 xor     eax, edx
-  .text:0000000181188DB9                 imul    edx, eax, 1000193h
-  .text:0000000181188DBF                 movzx   eax, byte ptr [rcx]
-  .text:0000000181188DC2                 test    al, al
-  .text:0000000181188DC4                 jnz     short loc_181188DB0
-  .text:0000000181188DC6                 mov     r9d, edx
-  .text:0000000181188DC9                 mov     [rsp+0C8h+var_A8], r15
-  .text:0000000181188DCE                 shl     r9d, 11h
-  .text:0000000181188DD2                 mov     r8, rsi
-  .text:0000000181188DD5                 xor     r9d, edx
-  .text:0000000181188DD8                 mov     rcx, rbp
-  .text:0000000181188DDB                 shr     edx, 15h
-  .text:0000000181188DDE                 add     r9d, edx
-  .text:0000000181188DE1                 lea     rdx, [rsi+10h]
-  .text:0000000181188DE5                 call    sub_1811794F0
-  .text:0000000181188DEA                 mov     rbx, [rbx+8]
-  .text:0000000181188DEE                 test    rbx, rbx
-  .text:0000000181188DF1                 jnz     loc_181188D20
-  .text:0000000181188DF7                 mov     cs:qword_181FF6DE8, r15
-  .text:0000000181188DFE                 mov     rbp, [rsp+0C8h+arg_8]
-  .text:0000000181188E06                 mov     rbx, [rsp+0C8h+arg_18]
-  .text:0000000181188E0E                 mov     cs:byte_181FF6EEC, 1
-  .text:0000000181188E15                 add     rsp, 0A0h
-  .text:0000000181188E1C                 pop     r15
-  .text:0000000181188E1E                 pop     r13
-  .text:0000000181188E20                 pop     r12
-  .text:0000000181188E22                 pop     rdi
-  .text:0000000181188E23                 pop     rsi
-  .text:0000000181188E24                 retn
+  .text:00000001811F0AD0                 mov     [rsp+arg_18], rbx
+  .text:00000001811F0AD5                 push    rsi
+  .text:00000001811F0AD6                 push    rdi
+  .text:00000001811F0AD7                 push    r12
+  .text:00000001811F0AD9                 push    r13
+  .text:00000001811F0ADB                 push    r15
+  .text:00000001811F0ADD                 sub     rsp, 0A0h
+  .text:00000001811F0AE4                 mov     rsi, rcx
+  .text:00000001811F0AE7                 mov     ebx, r9d
+  .text:00000001811F0AEA                 ; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:00000001811F0AEA                 add     rcx, 0A88h; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:00000001811F0AF1                 mov     edi, r8d
+  .text:00000001811F0AF4                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:00000001811F0AFA                 movzx   eax, [rsp+0C8h+arg_20]
+  .text:00000001811F0B02                 mov     cs:byte_1820B15C0, al
+  .text:00000001811F0B08                 mov     [rsi+0BBCh], ebx
+  .text:00000001811F0B0E                 cmp     edi, 1
+  .text:00000001811F0B11                 jnz     short loc_1811F0B23
+  .text:00000001811F0B13                 cmp     cs:qword_182117C88, 0
+  .text:00000001811F0B1B                 jz      short loc_1811F0B23
+  .text:00000001811F0B1D                 movzx   eax, dil
+  .text:00000001811F0B21                 jmp     short loc_1811F0B25
+  .text:00000001811F0B23                 xor     al, al
+  .text:00000001811F0B25                 lea     rcx, [rsi+0CB8h]
+  .text:00000001811F0B2C                 mov     [rsi+0BDAh], al
+  .text:00000001811F0B32                 xor     r9d, r9d
+  .text:00000001811F0B35                 mov     byte ptr [rsp+0C8h+var_A8], 0
+  .text:00000001811F0B3A                 xor     r8d, r8d
+  .text:00000001811F0B3D                 mov     edx, 400h
+  .text:00000001811F0B42                 call    cs:?Init@CUtlScratchMemoryPool@@QEAAXIIPEAX_N@Z; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
+  .text:00000001811F0B48                 mov     rbx, cs:qword_1820B13B8
+  .text:00000001811F0B4F                 lea     rax, [rsi+10h]
+  .text:00000001811F0B53                 xor     r15d, r15d
+  .text:00000001811F0B56                 mov     cs:qword_181E14800, rsi
+  .text:00000001811F0B5D                 test    rsi, rsi
+  .text:00000001811F0B60                 cmovz   rax, r15
+  .text:00000001811F0B64                 mov     cs:qword_181D958F8, rax
+  .text:00000001811F0B6B                 test    rbx, rbx
+  .text:00000001811F0B6E                 jz      short loc_1811F0BBD
+  .text:00000001811F0B70                 test    byte ptr [rbx+68h], 2
+  .text:00000001811F0B74                 jnz     short loc_1811F0B81
+  .text:00000001811F0B76                 mov     rdx, rbx
+  .text:00000001811F0B79                 mov     rcx, rsi
+  .text:00000001811F0B7C                 call    CEntitySystem_RegisterEntityClass
+  .text:00000001811F0B81                 mov     rbx, [rbx+120h]
+  .text:00000001811F0B88                 test    rbx, rbx
+  .text:00000001811F0B8B                 jnz     short loc_1811F0B70
+  .text:00000001811F0B8D                 mov     rbx, cs:qword_1820B13B8
+  .text:00000001811F0B94                 test    rbx, rbx
+  .text:00000001811F0B97                 jz      short loc_1811F0BBD
+  .text:00000001811F0B99                 nop     dword ptr [rax+00000000h]
+  .text:00000001811F0BA0                 test    byte ptr [rbx+68h], 2
+  .text:00000001811F0BA4                 jz      short loc_1811F0BB1
+  .text:00000001811F0BA6                 mov     rdx, rbx
+  .text:00000001811F0BA9                 mov     rcx, rsi
+  .text:00000001811F0BAC                 call    sub_1811F5460
+  .text:00000001811F0BB1                 mov     rbx, [rbx+120h]
+  .text:00000001811F0BB8                 test    rbx, rbx
+  .text:00000001811F0BBB                 jnz     short loc_1811F0BA0
+  .text:00000001811F0BBD                 mov     rbx, cs:qword_181D985D0
+  .text:00000001811F0BC4                 mov     edi, r15d
+  .text:00000001811F0BC7                 mov     [rsp+0C8h+arg_8], rbp
+  .text:00000001811F0BCF                 mov     r13d, 0FFFFh
+  .text:00000001811F0BD5                 mov     [rsp+0C8h+arg_10], r14
+  .text:00000001811F0BDD                 test    rbx, rbx
+  .text:00000001811F0BE0                 jz      loc_1811F0D0E
+  .text:00000001811F0BE6                 lea     r14, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F0BED                 lea     r12, aCentitysystemR; "CEntitySystem::RegisterComponentType"
+  .text:00000001811F0BF4                 nop     dword ptr [rax+00h]
+  .text:00000001811F0BF8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811F0C00                 mov     rax, [rbx+10h]
+  .text:00000001811F0C04                 lea     rbp, [rsi+0AD0h]
+  .text:00000001811F0C0B                 lea     r8, [rsp+0C8h+var_80]
+  .text:00000001811F0C10                 mov     [rsp+0C8h+var_80], rbp
+  .text:00000001811F0C15                 lea     rdx, [rsp+0C8h+arg_0]
+  .text:00000001811F0C1D                 mov     [rsp+0C8h+var_70], rbp
+  .text:00000001811F0C22                 inc     edi
+  .text:00000001811F0C24                 mov     rcx, [rax]
+  .text:00000001811F0C27                 lea     rax, [rsp+0C8h+var_98]
+  .text:00000001811F0C2C                 mov     [rsp+0C8h+var_98], rcx
+  .text:00000001811F0C31                 lea     rcx, [rbp+8]
+  .text:00000001811F0C35                 mov     [rsp+0C8h+var_78], rax
+  .text:00000001811F0C3A                 call    sub_1811E2D10
+  .text:00000001811F0C3F                 cmp     [rax+2], r13w
+  .text:00000001811F0C44                 jz      short loc_1811F0CB8
+  .text:00000001811F0C46                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F0C4C                 mov     edx, 5
+  .text:00000001811F0C51                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F0C57                 test    al, al
+  .text:00000001811F0C59                 jz      short loc_1811F0CB1
+  .text:00000001811F0C5B                 mov     rax, [rsp+0C8h+var_98]
+  .text:00000001811F0C60                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:00000001811F0C67                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F0C6D                 lea     r8, [rsp+0C8h+var_68]
+  .text:00000001811F0C72                 xorps   xmm0, xmm0
+  .text:00000001811F0C75                 mov     [rsp+0C8h+var_A8], rax
+  .text:00000001811F0C7A                 xorps   xmm1, xmm1
+  .text:00000001811F0C7D                 mov     [rsp+0C8h+var_68], r14
+  .text:00000001811F0C82                 mov     edx, 5
+  .text:00000001811F0C87                 mov     [rsp+0C8h+var_60], 67Dh
+  .text:00000001811F0C8F                 movdqu  [rsp+0C8h+var_50], xmm0
+  .text:00000001811F0C95                 mov     [rsp+0C8h+var_58], r12
+  .text:00000001811F0C9A                 movdqu  [rsp+0C8h+var_40], xmm1
+  .text:00000001811F0CA3                 mov     [rsp+0C8h+var_30], r15d
+  .text:00000001811F0CAB                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F0CB1                 mov     ecx, 0FFFFFFFFh
+  .text:00000001811F0CB6                 jmp     short loc_1811F0CD7
+  .text:00000001811F0CB8                 mov     rax, [rsp+0C8h+var_98]
+  .text:00000001811F0CBD                 lea     rdx, [rsp+0C8h+var_90]
+  .text:00000001811F0CC2                 mov     rcx, rbp
+  .text:00000001811F0CC5                 mov     [rsp+0C8h+var_90], rax
+  .text:00000001811F0CCA                 mov     [rsp+0C8h+var_88], rbx
+  .text:00000001811F0CCF                 call    sub_1811F1870
+  .text:00000001811F0CD4                 movzx   ecx, ax
+  .text:00000001811F0CD7                 mov     r8d, 10h
+  .text:00000001811F0CDD                 mov     rdx, rbx
+  .text:00000001811F0CE0                 mov     rax, [rbx+r8]
+  .text:00000001811F0CE4                 mov     [rax+20h], ecx
+  .text:00000001811F0CE7                 mov     rax, [rbx+r8]
+  .text:00000001811F0CEB                 test    byte ptr [rax+24h], 1
+  .text:00000001811F0CEF                 jz      short loc_1811F0CF8
+  .text:00000001811F0CF1                 or      dword ptr [rbx+8], 20000h
+  .text:00000001811F0CF8                 mov     rax, [rbx]
+  .text:00000001811F0CFB                 mov     rcx, rbx
+  .text:00000001811F0CFE                 call    qword ptr [rax+8]
+  .text:00000001811F0D01                 mov     rbx, [rbx+20h]
+  .text:00000001811F0D05                 test    rbx, rbx
+  .text:00000001811F0D08                 jnz     loc_1811F0C00
+  .text:00000001811F0D0E                 mov     eax, cs:dword_1820B13E0
+  .text:00000001811F0D14                 sub     edi, eax
+  .text:00000001811F0D16                 test    edi, edi
+  .text:00000001811F0D18                 jle     short loc_1811F0D2D
+  .text:00000001811F0D1A                 mov     r8d, edi
+  .text:00000001811F0D1D                 lea     rcx, dword_1820B13E0
+  .text:00000001811F0D24                 mov     edx, eax
+  .text:00000001811F0D26                 call    sub_1811F1A10
+  .text:00000001811F0D2B                 jmp     short loc_1811F0D37
+  .text:00000001811F0D2D                 jns     short loc_1811F0D37
+  .text:00000001811F0D2F                 add     eax, edi
+  .text:00000001811F0D31                 mov     cs:dword_1820B13E0, eax
+  .text:00000001811F0D37                 mov     rbx, cs:qword_181D985D0
+  .text:00000001811F0D3E                 test    rbx, rbx
+  .text:00000001811F0D41                 jz      short loc_1811F0D77
+  .text:00000001811F0D43                 mov     rcx, cs:qword_182117C88
+  .text:00000001811F0D4A                 test    rcx, rcx
+  .text:00000001811F0D4D                 jz      short loc_1811F0D5B
+  .text:00000001811F0D4F                 mov     rax, [rcx]
+  .text:00000001811F0D52                 mov     edx, [rbx+18h]
+  .text:00000001811F0D55                 call    qword ptr [rax+0E8h]
+  .text:00000001811F0D5B                 mov     rdx, [rbx+10h]
+  .text:00000001811F0D5F                 mov     rax, cs:qword_1820B13E8
+  .text:00000001811F0D66                 movsxd  rcx, dword ptr [rdx+20h]
+  .text:00000001811F0D6A                 mov     [rax+rcx*8], rdx
+  .text:00000001811F0D6E                 mov     rbx, [rbx+20h]
+  .text:00000001811F0D72                 test    rbx, rbx
+  .text:00000001811F0D75                 jnz     short loc_1811F0D43
+  .text:00000001811F0D77                 mov     r12d, 7FFFh
+  .text:00000001811F0D7D                 cmp     [rsi+0AAAh], r15w
+  .text:00000001811F0D85                 jz      short loc_1811F0E00
+  .text:00000001811F0D87                 movzx   ebx, word ptr [rsi+0AEAh]
+  .text:00000001811F0D8E                 mov     edx, cs:dword_1820B13C8
+  .text:00000001811F0D94                 mov     eax, ebx
+  .text:00000001811F0D96                 sub     eax, edx
+  .text:00000001811F0D98                 test    eax, eax
+  .text:00000001811F0D9A                 jle     short loc_1811F0DAD
+  .text:00000001811F0D9C                 mov     r8d, eax
+  .text:00000001811F0D9F                 lea     rcx, dword_1820B13C8
+  .text:00000001811F0DA6                 call    sub_1808C4180
+  .text:00000001811F0DAB                 jmp     short loc_1811F0DB5
+  .text:00000001811F0DAD                 jns     short loc_1811F0DB5
+  .text:00000001811F0DAF                 mov     cs:dword_1820B13C8, ebx
+  .text:00000001811F0DB5                 movzx   r8d, r15w
+  .text:00000001811F0DB9                 cmp     r15w, bx
+  .text:00000001811F0DBD                 jnb     short loc_1811F0E00
+  .text:00000001811F0DBF                 nop
+  .text:00000001811F0DC0                 mov     rcx, r15
+  .text:00000001811F0DC3                 test    [rsi+0ADAh], r12w
+  .text:00000001811F0DCB                 jz      short loc_1811F0DD4
+  .text:00000001811F0DCD                 mov     rcx, [rsi+0AE0h]
+  .text:00000001811F0DD4                 movzx   edx, r8w
+  .text:00000001811F0DD8                 inc     r8w
+  .text:00000001811F0DDC                 lea     rax, [rdx+rdx*2]
+  .text:00000001811F0DE0                 mov     rcx, [rcx+rax*8+10h]
+  .text:00000001811F0DE5                 mov     rax, [rcx+10h]
+  .text:00000001811F0DE9                 movzx   ecx, byte ptr [rax+24h]
+  .text:00000001811F0DED                 mov     rax, cs:qword_1820B13D0
+  .text:00000001811F0DF4                 and     cl, 1
+  .text:00000001811F0DF7                 mov     [rdx+rax], cl
+  .text:00000001811F0DFA                 cmp     r8w, bx
+  .text:00000001811F0DFE                 jb      short loc_1811F0DC0
+  .text:00000001811F0E00                 cmp     cs:byte_1820B151C, r15b
+  .text:00000001811F0E07                 jnz     loc_1811F0F2F
+  .text:00000001811F0E0D                 movzx   ebx, word ptr [rsi+0AA8h]
+  .text:00000001811F0E14                 cmp     bx, r13w
+  .text:00000001811F0E18                 jz      loc_1811F0F2F
+  .text:00000001811F0E1E                 mov     rdx, r15
+  .text:00000001811F0E21                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F0E29                 jz      short loc_1811F0E32
+  .text:00000001811F0E2B                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F0E32                 movzx   eax, bx
+  .text:00000001811F0E35                 lea     rcx, [rax+rax*2]
+  .text:00000001811F0E39                 movzx   eax, word ptr [rdx+rcx*8]
+  .text:00000001811F0E3D                 cmp     ax, r13w
+  .text:00000001811F0E41                 jz      short loc_1811F0E50
+  .text:00000001811F0E43                 movzx   ebx, ax
+  .text:00000001811F0E46                 jmp     short loc_1811F0E14
+  .text:00000001811F0E50                 mov     rdx, r15
+  .text:00000001811F0E53                 movzx   edi, word ptr [rsi+0AEAh]
+  .text:00000001811F0E5A                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F0E62                 jz      short loc_1811F0E6B
+  .text:00000001811F0E64                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F0E6B                 movzx   eax, bx
+  .text:00000001811F0E6E                 lea     rcx, [rax+rax*2]
+  .text:00000001811F0E72                 mov     eax, edi
+  .text:00000001811F0E74                 lea     rbp, ds:0[rcx*8]
+  .text:00000001811F0E7C                 mov     rcx, [rdx+rcx*8+10h]
+  .text:00000001811F0E81                 mov     edx, [rcx+78h]
+  .text:00000001811F0E84                 add     rcx, 78h ; 'x'
+  .text:00000001811F0E88                 sub     eax, edx
+  .text:00000001811F0E8A                 test    eax, eax
+  .text:00000001811F0E8C                 jle     short loc_1811F0E98
+  .text:00000001811F0E8E                 mov     r8d, eax
+  .text:00000001811F0E91                 call    sub_1811F1CB0
+  .text:00000001811F0E96                 jmp     short loc_1811F0E9C
+  .text:00000001811F0E98                 jns     short loc_1811F0E9C
+  .text:00000001811F0E9A                 mov     [rcx], edi
+  .text:00000001811F0E9C                 mov     rcx, r15
+  .text:00000001811F0E9F                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F0EA7                 jz      short loc_1811F0EB0
+  .text:00000001811F0EA9                 mov     rcx, [rsi+0AA0h]
+  .text:00000001811F0EB0                 mov     rcx, [rcx+rbp+10h]
+  .text:00000001811F0EB5                 mov     r8, rdi
+  .text:00000001811F0EB8                 add     r8, r8
+  .text:00000001811F0EBB                 mov     edx, 0FFh
+  .text:00000001811F0EC0                 mov     rcx, [rcx+80h]
+  .text:00000001811F0EC7                 call    sub_18154A730
+  .text:00000001811F0ECC                 mov     rax, r15
+  .text:00000001811F0ECF                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F0ED7                 jz      short loc_1811F0EE0
+  .text:00000001811F0ED9                 mov     rax, [rsi+0AA0h]
+  .text:00000001811F0EE0                 mov     rdi, [rax+rbp+10h]
+  .text:00000001811F0EE5                 call    cs:CommandLine
+  .text:00000001811F0EEB                 mov     edx, 46F20F89h
+  .text:00000001811F0EF0                 mov     rcx, [rax]
+  .text:00000001811F0EF3                 mov     r8, [rcx+20h]
+  .text:00000001811F0EF7                 mov     rcx, rax
+  .text:00000001811F0EFA                 call    r8
+  .text:00000001811F0EFD                 mov     rdx, rdi
+  .text:00000001811F0F00                 mov     rcx, rsi
+  .text:00000001811F0F03                 test    al, al
+  .text:00000001811F0F05                 jz      short loc_1811F0F0E
+  .text:00000001811F0F07                 call    sub_1811F9240
+  .text:00000001811F0F0C                 jmp     short loc_1811F0F13
+  .text:00000001811F0F0E                 call    sub_1811EB3C0
+  .text:00000001811F0F13                 movzx   edx, bx
+  .text:00000001811F0F16                 lea     rcx, [rsi+0A98h]
+  .text:00000001811F0F1D                 call    sub_1811F4150
+  .text:00000001811F0F22                 movzx   ebx, ax
+  .text:00000001811F0F25                 cmp     ax, r13w
+  .text:00000001811F0F29                 jnz     loc_1811F0E50
+  .text:00000001811F0F2F                 lea     rcx, aEntitysystemCl; "EntitySystem - Class Tables"
+  .text:00000001811F0F36                 call    cs:COM_TimestampedLog
+  .text:00000001811F0F3C                 mov     rcx, cs:qword_182117C88
+  .text:00000001811F0F43                 mov     r14, [rsp+0C8h+arg_10]
+  .text:00000001811F0F4B                 test    rcx, rcx
+  .text:00000001811F0F4E                 jz      short loc_1811F0F94
+  .text:00000001811F0F50                 mov     rax, [rcx]
+  .text:00000001811F0F53                 lea     r9, [rsi+1EC8h]
+  .text:00000001811F0F5A                 mov     r8d, [rsi+0BBCh]
+  .text:00000001811F0F61                 lea     rdx, aStringTTable; "string_t_table"
+  .text:00000001811F0F68                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+  .text:00000001811F0F68                 call    qword ptr [rax+0A0h]; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+  .text:00000001811F0F6E                 mov     rcx, cs:qword_182117C88
+  .text:00000001811F0F75                 lea     rdx, sub_1811E4FA0
+  .text:00000001811F0F7C                 mov     rax, [rcx]
+  .text:00000001811F0F7F                 mov     [rsp+0C8h+var_88], rdx
+  .text:00000001811F0F84                 lea     rdx, [rsp+0C8h+var_90]
+  .text:00000001811F0F89                 mov     [rsp+0C8h+var_90], r15
+  .text:00000001811F0F8E                 call    qword ptr [rax+0B8h]
+  .text:00000001811F0F94                 mov     rcx, rsi
+  .text:00000001811F0F97                 call    sub_1811EAC10
+  .text:00000001811F0F9C                 cmp     [rsi+0BDAh], r15b
+  .text:00000001811F0FA3                 jz      loc_1811F1035
+  .text:00000001811F0FA9                 mov     ecx, 58h ; 'X'
+  .text:00000001811F0FAE                 call    sub_180E77230
+  .text:00000001811F0FB3                 mov     rcx, rax
+  .text:00000001811F0FB6                 test    rax, rax
+  .text:00000001811F0FB9                 jz      short loc_1811F0FF4
+  .text:00000001811F0FBB                 lea     rax, ??_7CNetworkFieldScratchData@@6B@; const CNetworkFieldScratchData::`vftable'
+  .text:00000001811F0FC2                 mov     [rcx], rax
+  .text:00000001811F0FC5                 xor     eax, eax
+  .text:00000001811F0FC7                 mov     [rcx+10h], r15
+  .text:00000001811F0FCB                 mov     [rcx+18h], r15
+  .text:00000001811F0FCF                 mov     [rcx+8], r15d
+  .text:00000001811F0FD3                 mov     [rcx+20h], r15d
+  .text:00000001811F0FD7                 mov     [rcx+30h], r15
+  .text:00000001811F0FDB                 mov     [rcx+38h], r15
+  .text:00000001811F0FDF                 mov     [rcx+28h], r15d
+  .text:00000001811F0FE3                 mov     [rcx+40h], r15d
+  .text:00000001811F0FE7                 mov     [rcx+48h], eax
+  .text:00000001811F0FEA                 mov     qword ptr [rcx+4Ch], 0C80000h
+  .text:00000001811F0FF2                 jmp     short loc_1811F0FF7
+  .text:00000001811F0FF4                 mov     rcx, r15
+  .text:00000001811F0FF7                 mov     [rsi+0C88h], rcx
+  .text:00000001811F0FFE                 mov     edx, 10000h
+  .text:00000001811F1003                 mov     rax, [rcx]
+  .text:00000001811F1006                 mov     r8d, cs:dword_1820B1848
+  .text:00000001811F100D                 call    qword ptr [rax+8]
+  .text:00000001811F1010                 mov     rcx, cs:qword_182117C90
+  .text:00000001811F1017                 mov     r8, [rsi+0C90h]
+  .text:00000001811F101E                 mov     rdx, [rsi+0C88h]
+  .text:00000001811F1025                 mov     rax, [rcx]
+  .text:00000001811F1028                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+  .text:00000001811F1028                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+  .text:00000001811F102E                 mov     [rsi+0C80h], rax
+  .text:00000001811F1035                 cmp     cs:byte_1820B151C, r15b
+  .text:00000001811F103C                 jnz     loc_1811F11EE
+  .text:00000001811F1042                 movzx   ecx, word ptr [rsi+0AA8h]
+  .text:00000001811F1049                 nop     dword ptr [rax+00000000h]
+  .text:00000001811F1050                 cmp     cx, r13w
+  .text:00000001811F1054                 jz      loc_1811F10F2
+  .text:00000001811F105A                 mov     rdx, r15
+  .text:00000001811F105D                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F1065                 jz      short loc_1811F106E
+  .text:00000001811F1067                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F106E                 movzx   r8d, cx
+  .text:00000001811F1072                 lea     rax, [r8+r8*2]
+  .text:00000001811F1076                 movzx   r9d, word ptr [rdx+rax*8]
+  .text:00000001811F107B                 cmp     r9w, r13w
+  .text:00000001811F107F                 jz      short loc_1811F1087
+  .text:00000001811F1081                 movzx   ecx, r9w
+  .text:00000001811F1085                 jmp     short loc_1811F1050
+  .text:00000001811F1087                 movzx   ebx, cx
+  .text:00000001811F108A                 mov     rcx, r15
+  .text:00000001811F108D                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F1095                 jz      short loc_1811F109E
+  .text:00000001811F1097                 mov     rcx, [rsi+0AA0h]
+  .text:00000001811F109E                 lea     rax, [r8+r8*2]
+  .text:00000001811F10A2                 mov     rcx, [rcx+rax*8+10h]
+  .text:00000001811F10A7                 test    rcx, rcx
+  .text:00000001811F10AA                 jz      short loc_1811F10F2
+  .text:00000001811F10AC                 nop     dword ptr [rax+00h]
+  .text:00000001811F10B0                 call    sub_1811DDA40
+  .text:00000001811F10B5                 movzx   edx, bx
+  .text:00000001811F10B8                 lea     rcx, [rsi+0A98h]
+  .text:00000001811F10BF                 call    sub_1811F4150
+  .text:00000001811F10C4                 cmp     ax, r13w
+  .text:00000001811F10C8                 jz      short loc_1811F10F2
+  .text:00000001811F10CA                 mov     rdx, r15
+  .text:00000001811F10CD                 movzx   ebx, ax
+  .text:00000001811F10D0                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F10D8                 jz      short loc_1811F10E1
+  .text:00000001811F10DA                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F10E1                 movzx   eax, ax
+  .text:00000001811F10E4                 lea     rcx, [rax+rax*2]
+  .text:00000001811F10E8                 mov     rcx, [rdx+rcx*8+10h]
+  .text:00000001811F10ED                 test    rcx, rcx
+  .text:00000001811F10F0                 jnz     short loc_1811F10B0
+  .text:00000001811F10F2                 call    sub_18121DD60
+  .text:00000001811F10F7                 mov     rbx, cs:qword_1820B1498
+  .text:00000001811F10FE                 test    rbx, rbx
+  .text:00000001811F1101                 jz      loc_1811F11E7
+  .text:00000001811F1107                 lea     rbp, [rsi+2070h]
+  .text:00000001811F110E                 xchg    ax, ax
+  .text:00000001811F1110                 call    qword ptr [rbx]
+  .text:00000001811F1112                 lea     rdx, byte_18159B988
+  .text:00000001811F1119                 mov     r9d, 811C9DC5h
+  .text:00000001811F111F                 mov     rsi, rax
+  .text:00000001811F1122                 mov     rcx, [rax+10h]
+  .text:00000001811F1126                 test    rcx, rcx
+  .text:00000001811F1129                 cmovnz  rdx, rcx
+  .text:00000001811F112D                 movzx   ecx, byte ptr [rdx]
+  .text:00000001811F1130                 test    cl, cl
+  .text:00000001811F1132                 jz      short loc_1811F1158
+  .text:00000001811F1134                 nop     dword ptr [rax+00h]
+  .text:00000001811F1138                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811F1140                 movzx   eax, cl
+  .text:00000001811F1143                 lea     rdx, [rdx+1]
+  .text:00000001811F1147                 movzx   ecx, byte ptr [rdx]
+  .text:00000001811F114A                 xor     eax, r9d
+  .text:00000001811F114D                 imul    r9d, eax, 1000193h
+  .text:00000001811F1154                 test    cl, cl
+  .text:00000001811F1156                 jnz     short loc_1811F1140
+  .text:00000001811F1158                 mov     r8d, r9d
+  .text:00000001811F115B                 lea     rdx, [rsi+10h]
+  .text:00000001811F115F                 shl     r8d, 11h
+  .text:00000001811F1163                 mov     rcx, rbp
+  .text:00000001811F1166                 xor     r8d, r9d
+  .text:00000001811F1169                 shr     r9d, 15h
+  .text:00000001811F116D                 add     r8d, r9d
+  .text:00000001811F1170                 xor     r9d, r9d
+  .text:00000001811F1173                 call    sub_1811E1B50
+  .text:00000001811F1178                 cmp     eax, 0FFFFFFFFh
+  .text:00000001811F117B                 jnz     short loc_1811F11DA
+  .text:00000001811F117D                 mov     rax, [rsi+10h]
+  .text:00000001811F1181                 lea     rcx, byte_18159B988
+  .text:00000001811F1188                 test    rax, rax
+  .text:00000001811F118B                 mov     edx, 811C9DC5h
+  .text:00000001811F1190                 cmovnz  rcx, rax
+  .text:00000001811F1194                 movzx   eax, byte ptr [rcx]
+  .text:00000001811F1197                 test    al, al
+  .text:00000001811F1199                 jz      short loc_1811F11B6
+  .text:00000001811F119B                 nop     dword ptr [rax+rax+00h]
+  .text:00000001811F11A0                 movzx   eax, al
+  .text:00000001811F11A3                 lea     rcx, [rcx+1]
+  .text:00000001811F11A7                 xor     eax, edx
+  .text:00000001811F11A9                 imul    edx, eax, 1000193h
+  .text:00000001811F11AF                 movzx   eax, byte ptr [rcx]
+  .text:00000001811F11B2                 test    al, al
+  .text:00000001811F11B4                 jnz     short loc_1811F11A0
+  .text:00000001811F11B6                 mov     r9d, edx
+  .text:00000001811F11B9                 mov     [rsp+0C8h+var_A8], r15
+  .text:00000001811F11BE                 shl     r9d, 11h
+  .text:00000001811F11C2                 mov     r8, rsi
+  .text:00000001811F11C5                 xor     r9d, edx
+  .text:00000001811F11C8                 mov     rcx, rbp
+  .text:00000001811F11CB                 shr     edx, 15h
+  .text:00000001811F11CE                 add     r9d, edx
+  .text:00000001811F11D1                 lea     rdx, [rsi+10h]
+  .text:00000001811F11D5                 call    sub_1811E1800
+  .text:00000001811F11DA                 mov     rbx, [rbx+8]
+  .text:00000001811F11DE                 test    rbx, rbx
+  .text:00000001811F11E1                 jnz     loc_1811F1110
+  .text:00000001811F11E7                 mov     cs:qword_1820B1498, r15
+  .text:00000001811F11EE                 mov     rbp, [rsp+0C8h+arg_8]
+  .text:00000001811F11F6                 mov     rbx, [rsp+0C8h+arg_18]
+  .text:00000001811F11FE                 mov     cs:byte_1820B151C, 1
+  .text:00000001811F1205                 add     rsp, 0A0h
+  .text:00000001811F120C                 pop     r15
+  .text:00000001811F120E                 pop     r13
+  .text:00000001811F1210                 pop     r12
+  .text:00000001811F1212                 pop     rdi
+  .text:00000001811F1213                 pop     rsi
+  .text:00000001811F1214                 retn
 procedure: |-
   __int64 __fastcall CEntitySystem_Init(__int64 a1, const char *a2, int a3, int a4, char a5)
   {
@@ -453,100 +457,101 @@ procedure: |-
     __int64 v24; // rdx
     __int64 v25; // rdi
     __int64 v26; // rbp
-    _DWORD *v27; // rcx
+    __int64 v27; // rcx
     __int64 v28; // rdx
-    int v29; // eax
-    __int64 v30; // rcx
-    __int64 v31; // rax
-    __int64 v32; // rdi
-    __int64 v33; // rax
+    _DWORD *v29; // rcx
+    int v30; // eax
+    __int64 v31; // rcx
+    __int64 v32; // rax
+    __int64 v33; // rdi
     __int64 v34; // rax
+    __int64 v35; // rax
     __int64 result; // rax
-    __int64 v36; // rax
-    __int64 v37; // rcx
+    __int64 v37; // rax
+    __int64 v38; // rcx
     unsigned __int16 ii; // cx
-    __int64 v39; // rdx
-    __int64 v40; // r8
-    unsigned __int16 v41; // bx
-    __int64 v42; // rcx
-    unsigned __int16 v43; // ax
-    __int64 v44; // rdx
-    __int64 v45; // rbx
-    __int64 v46; // rbp
-    __int64 v47; // rax
-    unsigned __int8 *v48; // rdx
-    unsigned int v49; // r9d
-    __int64 v50; // rsi
+    __int64 v40; // rdx
+    __int64 v41; // r8
+    unsigned __int16 v42; // bx
+    __int64 v43; // rcx
+    unsigned __int16 v44; // ax
+    __int64 v45; // rdx
+    __int64 v46; // rbx
+    __int64 v47; // rbp
+    __int64 v48; // rax
+    char *v49; // rdx
+    unsigned int v50; // r9d
+    __int64 v51; // rsi
     unsigned __int8 jj; // cl
-    int v52; // eax
-    unsigned __int8 *v53; // rcx
-    unsigned int v54; // edx
+    int v53; // eax
+    char *v54; // rcx
+    unsigned int v55; // edx
     unsigned __int8 kk; // al
-    const char *v56; // [rsp+30h] [rbp-98h] BYREF
-    const char *v57; // [rsp+38h] [rbp-90h] BYREF
-    __int64 (__fastcall *v58)(); // [rsp+40h] [rbp-88h]
-    _QWORD v59[3]; // [rsp+48h] [rbp-80h] BYREF
-    const char *v60; // [rsp+60h] [rbp-68h] BYREF
-    int v61; // [rsp+68h] [rbp-60h]
-    const char *v62; // [rsp+70h] [rbp-58h]
-    __int128 v63; // [rsp+78h] [rbp-50h]
-    __int128 v64; // [rsp+88h] [rbp-40h]
-    int v65; // [rsp+98h] [rbp-30h]
-    char v66; // [rsp+D0h] [rbp+8h] BYREF
+    const char *v57; // [rsp+30h] [rbp-98h] BYREF
+    const char *v58; // [rsp+38h] [rbp-90h] BYREF
+    __int64 (__fastcall *v59)(); // [rsp+40h] [rbp-88h]
+    _QWORD v60[3]; // [rsp+48h] [rbp-80h] BYREF
+    const char *v61; // [rsp+60h] [rbp-68h] BYREF
+    int v62; // [rsp+68h] [rbp-60h]
+    const char *v63; // [rsp+70h] [rbp-58h]
+    __int128 v64; // [rsp+78h] [rbp-50h]
+    __int128 v65; // [rsp+88h] [rbp-40h]
+    int v66; // [rsp+98h] [rbp-30h]
+    char v67; // [rsp+D0h] [rbp+8h] BYREF
 
-    CUtlString::Set((CUtlString *)(a1 + 2696), a2);
-    byte_181FF6F91 = a5;
-    *(_DWORD *)(a1 + 3012) = a4;
-    v8 = a3 == 1 && g_pNetworkMessages;
-    *(_BYTE *)(a1 + 3042) = v8;
-    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3264), 0x400u, 0, nullptr, 0);
-    v11 = qword_181FF6D90;
+    CUtlString::Set((CUtlString *)(a1 + 2696), a2);// 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+    byte_1820B15C0 = a5;
+    *(_DWORD *)(a1 + 3004) = a4;
+    v8 = a3 == 1 && qword_182117C88;
+    *(_BYTE *)(a1 + 3034) = v8;
+    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);
+    v11 = qword_1820B13B8;
     v12 = a1 + 16;
-    qword_181D8C650 = a1;
+    qword_181E14800 = a1;
     if ( !a1 )
       v12 = 0;
-    qword_181D17000 = v12;
-    if ( qword_181FF6D90 )
+    qword_181D958F8 = v12;
+    if ( qword_1820B13B8 )
     {
       do
       {
-        if ( (*(_BYTE *)(v11 + 144) & 2) == 0 )
-          sub_18118D2A0(a1, v11);
-        v11 = *(_QWORD *)(v11 + 328);
+        if ( (*(_BYTE *)(v11 + 104) & 2) == 0 )
+          CEntitySystem_RegisterEntityClass(a1, v11);
+        v11 = *(_QWORD *)(v11 + 288);
       }
       while ( v11 );
-      for ( i = qword_181FF6D90; i; i = *(_QWORD *)(i + 328) )
+      for ( i = qword_1820B13B8; i; i = *(_QWORD *)(i + 288) )
       {
-        if ( (*(_BYTE *)(i + 144) & 2) != 0 )
-          sub_18118D030(a1, i);
+        if ( (*(_BYTE *)(i + 104) & 2) != 0 )
+          sub_1811F5460(a1, i);
       }
     }
-    v14 = qword_181D19B00;
+    v14 = qword_181D985D0;
     for ( j = 0; v14; v14 = *(_QWORD *)(v14 + 32) )
     {
       v16 = *(const char ***)(v14 + 16);
-      v59[0] = a1 + 2768;
-      v59[2] = a1 + 2768;
+      v60[0] = a1 + 2768;
+      v60[2] = a1 + 2768;
       ++j;
-      v56 = *v16;
-      v59[1] = &v56;
-      if ( *(_WORD *)(sub_18117AA00(a1 + 2776, &v66, v59) + 2) == 0xFFFF )
+      v57 = *v16;
+      v60[1] = &v57;
+      if ( *(_WORD *)(sub_1811E2D10(a1 + 2776, &v67, v60) + 2) == 0xFFFF )
       {
-        v57 = v56;
-        v58 = (__int64 (__fastcall *)())v14;
-        v17 = (unsigned __int16)sub_181189470(a1 + 2768, &v57);
+        v58 = v57;
+        v59 = (__int64 (__fastcall *)())v14;
+        v17 = (unsigned __int16)sub_1811F1870(a1 + 2768, &v58);
       }
       else
       {
-        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181FF71B8, 5) )
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
         {
-          v60 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
-          v61 = 1661;
-          v63 = 0;
-          v62 = "CEntitySystem::RegisterComponentType";
+          v61 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+          v62 = 1661;
           v64 = 0;
+          v63 = "CEntitySystem::RegisterComponentType";
           v65 = 0;
-          LoggingSystem_Log((unsigned int)dword_181FF71B8, 5, &v60, "Multiple registration of class %s\n", v56);
+          v66 = 0;
+          LoggingSystem_Log((unsigned int)dword_1820B1848, 5, &v61, "Multiple registration of class %s\n", v57);
         }
         v17 = -1;
       }
@@ -555,42 +560,42 @@ procedure: |-
         *(_DWORD *)(v14 + 8) |= 0x20000u;
       (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v14 + 8LL))(v14, v14);
     }
-    v18 = j - dword_181FF6DB8;
+    v18 = j - dword_1820B13E0;
     if ( v18 <= 0 )
     {
       if ( v18 < 0 )
-        dword_181FF6DB8 += v18;
+        dword_1820B13E0 += v18;
     }
     else
     {
-      sub_1811895E0(&dword_181FF6DB8, (unsigned int)dword_181FF6DB8, (unsigned int)v18);
+      sub_1811F1A10(&dword_1820B13E0, (unsigned int)dword_1820B13E0, (unsigned int)v18);
     }
-    for ( k = qword_181D19B00; k; k = *(_QWORD *)(k + 32) )
+    for ( k = qword_181D985D0; k; k = *(_QWORD *)(k + 32) )
     {
-      if ( g_pNetworkMessages )
-        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pNetworkMessages + 240LL))(
-          g_pNetworkMessages,
+      if ( qword_182117C88 )
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)qword_182117C88 + 232LL))(
+          qword_182117C88,
           *(unsigned int *)(k + 24));
       v9 = *(_QWORD *)(k + 16);
-      *(_QWORD *)(qword_181FF6DC0 + 8LL * *(int *)(v9 + 32)) = v9;
+      *(_QWORD *)(qword_1820B13E8 + 8LL * *(int *)(v9 + 32)) = v9;
     }
     if ( *(_WORD *)(a1 + 2730) )
     {
       v20 = *(_WORD *)(a1 + 2794);
-      v9 = (unsigned int)dword_181FF6DA0;
-      v21 = v20 - dword_181FF6DA0;
+      v9 = (unsigned int)dword_1820B13C8;
+      v21 = v20 - dword_1820B13C8;
       if ( v21 <= 0 )
       {
         if ( v21 < 0 )
-          dword_181FF6DA0 = *(unsigned __int16 *)(a1 + 2794);
+          dword_1820B13C8 = *(unsigned __int16 *)(a1 + 2794);
       }
       else
       {
-        sub_180891890(&dword_181FF6DA0, (unsigned int)dword_181FF6DA0, (unsigned int)v21);
+        sub_1808C4180(&dword_1820B13C8, (unsigned int)dword_1820B13C8, (unsigned int)v21);
       }
       for ( m = 0;
             (unsigned __int16)m < v20;
-            *(_BYTE *)(v9 + qword_181FF6DA8) = *(_BYTE *)(*(_QWORD *)(*(_QWORD *)(v22 + 24 * v9 + 16) + 16LL) + 36LL) & 1 )
+            *(_BYTE *)(v9 + qword_1820B13D0) = *(_BYTE *)(*(_QWORD *)(*(_QWORD *)(v22 + 24 * v9 + 16) + 16LL) + 36LL) & 1 )
       {
         v22 = 0;
         if ( (*(_WORD *)(a1 + 2778) & 0x7FFF) != 0 )
@@ -599,7 +604,7 @@ procedure: |-
         LOWORD(m) = m + 1;
       }
     }
-    if ( !byte_181FF6EEC )
+    if ( !byte_1820B151C )
     {
       for ( n = *(_WORD *)(a1 + 2728); n != 0xFFFF; n = *(_WORD *)(v9 + 24LL * n) )
       {
@@ -615,32 +620,33 @@ procedure: |-
             if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
               v24 = *(_QWORD *)(a1 + 2720);
             v26 = 24LL * n;
-            v27 = (_DWORD *)(*(_QWORD *)(v24 + v26 + 16) + 160LL);
-            v28 = (unsigned int)*v27;
-            v29 = v25 - v28;
+            v27 = *(_QWORD *)(v24 + v26 + 16);
+            v28 = *(unsigned int *)(v27 + 120);
+            v29 = (_DWORD *)(v27 + 120);
+            v30 = v25 - v28;
             if ( (int)v25 - (int)v28 <= 0 )
             {
-              if ( v29 < 0 )
-                *v27 = v25;
+              if ( v30 < 0 )
+                *v29 = v25;
             }
             else
             {
-              sub_181189880(v27, v28, (unsigned int)v29);
+              sub_1811F1CB0(v29, v28, (unsigned int)v30);
             }
-            v30 = 0;
-            if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-              v30 = *(_QWORD *)(a1 + 2720);
-            memset(*(_QWORD *)(*(_QWORD *)(v30 + v26 + 16) + 168LL), 255, 2 * v25);
             v31 = 0;
             if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
               v31 = *(_QWORD *)(a1 + 2720);
-            v32 = *(_QWORD *)(v31 + v26 + 16);
-            v33 = CommandLine();
-            if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v33 + 32LL))(v33, 1190268809) )
-              sub_181190CE0(a1, v32);
+            sub_18154A730(*(_QWORD *)(*(_QWORD *)(v31 + v26 + 16) + 128LL), 255, 2 * v25);
+            v32 = 0;
+            if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
+              v32 = *(_QWORD *)(a1 + 2720);
+            v33 = *(_QWORD *)(v32 + v26 + 16);
+            v34 = CommandLine();
+            if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v34 + 32LL))(v34, 1190268809) )
+              sub_1811F9240(a1, v33);
             else
-              sub_181182FC0(a1, v32);
-            n = sub_18118BD20(a1 + 2712, n);
+              sub_1811EB3C0(a1, v33);
+            n = sub_1811F4150(a1 + 2712, n);
           }
           while ( n != 0xFFFF );
           break;
@@ -648,124 +654,122 @@ procedure: |-
       }
     }
     COM_TimestampedLog("EntitySystem - Class Tables", v9, m);
-    if ( g_pNetworkMessages )
+    if ( qword_182117C88 )
     {
-      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)g_pNetworkMessages
-                                                                     + 168LL))(// g_pNetworkMessages->SetNetworkSerializationContextData(...), 168LL = INetworkMessages_SetNetworkSerializationContextData
-        g_pNetworkMessages,
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))(
+        qword_182117C88,
         "string_t_table",
-        *(unsigned int *)(a1 + 3012),
-        a1 + 7888);
-      v34 = *(_QWORD *)g_pNetworkMessages;
-      v58 = sub_18117CC90;
-      v57 = nullptr;
-      (*(void (__fastcall **)(__int64, const char **))(v34 + 192))(g_pNetworkMessages, &v57);
+        *(unsigned int *)(a1 + 3004),
+        a1 + 7880);                               // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+      v35 = *(_QWORD *)qword_182117C88;
+      v59 = sub_1811E4FA0;
+      v58 = nullptr;
+      (*(void (__fastcall **)(__int64, const char **))(v35 + 184))(qword_182117C88, &v58);
     }
-    result = sub_181182850(a1);
-    if ( *(_BYTE *)(a1 + 3042) )
+    result = sub_1811EAC10(a1);
+    if ( *(_BYTE *)(a1 + 3034) )
     {
-      v36 = sub_180E35430(88);
-      v37 = v36;
-      if ( v36 )
+      v37 = sub_180E77230(88);
+      v38 = v37;
+      if ( v37 )
       {
-        *(_QWORD *)v36 = &CNetworkFieldScratchData::`vftable';
-        *(_QWORD *)(v36 + 16) = 0;
-        *(_QWORD *)(v36 + 24) = 0;
-        *(_DWORD *)(v36 + 8) = 0;
-        *(_DWORD *)(v36 + 32) = 0;
-        *(_QWORD *)(v36 + 48) = 0;
-        *(_QWORD *)(v36 + 56) = 0;
-        *(_DWORD *)(v36 + 40) = 0;
-        *(_DWORD *)(v36 + 64) = 0;
-        *(_DWORD *)(v36 + 72) = 0;
-        *(_QWORD *)(v36 + 76) = 13107200;
+        *(_QWORD *)v37 = &CNetworkFieldScratchData::`vftable';
+        *(_QWORD *)(v37 + 16) = 0;
+        *(_QWORD *)(v37 + 24) = 0;
+        *(_DWORD *)(v37 + 8) = 0;
+        *(_DWORD *)(v37 + 32) = 0;
+        *(_QWORD *)(v37 + 48) = 0;
+        *(_QWORD *)(v37 + 56) = 0;
+        *(_DWORD *)(v37 + 40) = 0;
+        *(_DWORD *)(v37 + 64) = 0;
+        *(_DWORD *)(v37 + 72) = 0;
+        *(_QWORD *)(v37 + 76) = 13107200;
       }
       else
       {
-        v37 = 0;
+        v38 = 0;
       }
-      *(_QWORD *)(a1 + 3216) = v37;
-      (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v37 + 8LL))(
-        v37,
+      *(_QWORD *)(a1 + 3208) = v38;
+      (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v38 + 8LL))(
+        v38,
         0x10000,
-        (unsigned int)dword_181FF71B8);
-      result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)g_pFlattenedSerializers
-                                                                  + 280LL))(// g_pFlattenedSerializers->CreateFieldChangedEventQueue(...), 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-                 g_pFlattenedSerializers,
-                 *(_QWORD *)(a1 + 3216),
-                 *(_QWORD *)(a1 + 3224));
-      *(_QWORD *)(a1 + 3208) = result;
+        (unsigned int)dword_1820B1848);
+      result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)qword_182117C90 + 280LL))(
+                 qword_182117C90,
+                 *(_QWORD *)(a1 + 3208),
+                 *(_QWORD *)(a1 + 3216));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+      *(_QWORD *)(a1 + 3200) = result;
     }
-    if ( !byte_181FF6EEC )
+    if ( !byte_1820B151C )
     {
-      for ( ii = *(_WORD *)(a1 + 2728); ii != 0xFFFF; ii = *(_WORD *)(v39 + 24LL * ii) )
+      for ( ii = *(_WORD *)(a1 + 2728); ii != 0xFFFF; ii = *(_WORD *)(v40 + 24LL * ii) )
       {
-        v39 = 0;
+        v40 = 0;
         if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-          v39 = *(_QWORD *)(a1 + 2720);
-        v40 = ii;
-        if ( *(_WORD *)(v39 + 24LL * ii) == 0xFFFF )
+          v40 = *(_QWORD *)(a1 + 2720);
+        v41 = ii;
+        if ( *(_WORD *)(v40 + 24LL * ii) == 0xFFFF )
         {
-          v41 = ii;
-          v42 = 0;
+          v42 = ii;
+          v43 = 0;
           if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-            v42 = *(_QWORD *)(a1 + 2720);
-          if ( *(_QWORD *)(v42 + 24 * v40 + 16) )
+            v43 = *(_QWORD *)(a1 + 2720);
+          if ( *(_QWORD *)(v43 + 24 * v41 + 16) )
           {
             do
             {
-              sub_181175930();
-              v43 = sub_18118BD20(a1 + 2712, v41);
-              if ( v43 == 0xFFFF )
+              sub_1811DDA40();
+              v44 = sub_1811F4150(a1 + 2712, v42);
+              if ( v44 == 0xFFFF )
                 break;
-              v44 = 0;
-              v41 = v43;
+              v45 = 0;
+              v42 = v44;
               if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-                v44 = *(_QWORD *)(a1 + 2720);
+                v45 = *(_QWORD *)(a1 + 2720);
             }
-            while ( *(_QWORD *)(v44 + 24LL * v43 + 16) );
+            while ( *(_QWORD *)(v45 + 24LL * v44 + 16) );
           }
           break;
         }
       }
-      result = sub_1811B2CE0();
-      v45 = qword_181FF6DE8;
-      if ( qword_181FF6DE8 )
+      result = sub_18121DD60();
+      v46 = qword_1820B1498;
+      if ( qword_1820B1498 )
       {
-        v46 = a1 + 8320;
+        v47 = a1 + 8304;
         do
         {
-          v47 = (*(__int64 (**)(void))v45)();
-          v48 = (unsigned __int8 *)byte_18152DF88;
-          v49 = -2128831035;
-          v50 = v47;
-          if ( *(_QWORD *)(v47 + 16) )
-            v48 = *(unsigned __int8 **)(v47 + 16);
-          for ( jj = *v48; *v48; v49 = 16777619 * (v49 ^ v52) )
+          v48 = (*(__int64 (**)(void))v46)();
+          v49 = byte_18159B988;
+          v50 = -2128831035;
+          v51 = v48;
+          if ( *(_QWORD *)(v48 + 16) )
+            v49 = *(char **)(v48 + 16);
+          for ( jj = *v49; *v49; v50 = 16777619 * (v50 ^ v53) )
           {
-            v52 = jj;
-            jj = *++v48;
+            v53 = jj;
+            jj = *++v49;
           }
-          result = sub_181179840(v46, v50 + 16, (v49 >> 21) + (v49 ^ (v49 << 17)), 0);
+          result = sub_1811E1B50(v47, v51 + 16, (v50 >> 21) + (v50 ^ (v50 << 17)), 0);
           if ( (_DWORD)result == -1 )
           {
-            v53 = (unsigned __int8 *)byte_18152DF88;
-            v54 = -2128831035;
-            if ( *(_QWORD *)(v50 + 16) )
-              v53 = *(unsigned __int8 **)(v50 + 16);
-            for ( kk = *v53; *v53; kk = *v53 )
+            v54 = byte_18159B988;
+            v55 = -2128831035;
+            if ( *(_QWORD *)(v51 + 16) )
+              v54 = *(char **)(v51 + 16);
+            for ( kk = *v54; *v54; kk = *v54 )
             {
-              ++v53;
-              v54 = 16777619 * (v54 ^ kk);
+              ++v54;
+              v55 = 16777619 * (v55 ^ kk);
             }
-            result = sub_1811794F0(v46, (int)v50 + 16, v50, (v54 >> 21) + (v54 ^ (v54 << 17)), 0);
+            result = sub_1811E1800(v47, (int)v51 + 16, v51, (v55 >> 21) + (v55 ^ (v55 << 17)), 0);
           }
-          v45 = *(_QWORD *)(v45 + 8);
+          v46 = *(_QWORD *)(v46 + 8);
         }
-        while ( v45 );
+        while ( v46 );
       }
-      qword_181FF6DE8 = 0;
+      qword_1820B1498 = 0;
     }
-    byte_181FF6EEC = 1;
+    byte_1820B151C = 1;
     return result;
   }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -656,11 +656,11 @@ procedure: |-
     COM_TimestampedLog("EntitySystem - Class Tables", v9, m);
     if ( qword_182117C88 )
     {
-      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))(
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))( // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
         qword_182117C88,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7880);                               // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+        a1 + 7880);
       v35 = *(_QWORD *)qword_182117C88;
       v59 = sub_1811E4FA0;
       v58 = nullptr;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.linux.yaml
@@ -1,0 +1,252 @@
+func_name: CEntitySystem_RegisterEntityClass
+func_va: '0x1e67830'
+disasm_code: |-
+  .text:0000000001E67830                 test    rsi, rsi
+  .text:0000000001E67833                 jz      loc_1E67AA4
+  .text:0000000001E67839                 push    rbp
+  .text:0000000001E6783A                 mov     rbp, rsp
+  .text:0000000001E6783D                 push    r15
+  .text:0000000001E6783F                 push    r14
+  .text:0000000001E67841                 ; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:0000000001E67841                 lea     r14, [rdi+0A90h]; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:0000000001E67848                 push    r13
+  .text:0000000001E6784A                 lea     r13, [rbp-70h]
+  .text:0000000001E6784E                 push    r12
+  .text:0000000001E67850                 mov     r12, rsi
+  .text:0000000001E67853                 push    rbx
+  .text:0000000001E67854                 mov     rbx, rdi
+  .text:0000000001E67857                 lea     rdi, [rdi+0A98h]
+  .text:0000000001E6785E                 sub     rsp, 68h
+  .text:0000000001E67862                 mov     rax, [rsi+50h]
+  .text:0000000001E67866                 mov     rsi, r13
+  .text:0000000001E67869                 mov     rdx, [rax+8]
+  .text:0000000001E6786D                 mov     [rbp-80h], rdx
+  .text:0000000001E67871                 mov     rax, [rax]
+  .text:0000000001E67874                 mov     [rbp-70h], r14
+  .text:0000000001E67878                 mov     [rbp-60h], r14
+  .text:0000000001E6787C                 mov     [rbp-78h], rax
+  .text:0000000001E67880                 lea     rax, [rbp-80h]
+  .text:0000000001E67884                 mov     [rbp-68h], rax
+  .text:0000000001E67888                 call    sub_1E5FED0
+  .text:0000000001E6788D                 mov     rdx, rax
+  .text:0000000001E67890                 mov     [rbp-8Ch], ax
+  .text:0000000001E67897                 shr     rax, 20h
+  .text:0000000001E6789B                 shr     rdx, 10h
+  .text:0000000001E6789F                 mov     [rbp-88h], ax
+  .text:0000000001E678A6                 mov     [rbp-8Ah], dx
+  .text:0000000001E678AD                 cmp     dx, 0FFFFh
+  .text:0000000001E678B1                 jnz     loc_1E67969
+  .text:0000000001E678B7                 cmp     qword ptr [rbp-78h], 0
+  .text:0000000001E678BC                 jz      short loc_1E6790C
+  .text:0000000001E678BE                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E678BE                 lea     rax, [rbx+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E678C5                 mov     rsi, r13
+  .text:0000000001E678C8                 lea     rdx, [rbp-78h]
+  .text:0000000001E678CC                 mov     [rbp-70h], rax
+  .text:0000000001E678D0                 lea     rdi, [rbx+0AB8h]
+  .text:0000000001E678D7                 mov     [rbp-68h], rdx
+  .text:0000000001E678DB                 mov     [rbp-60h], rax
+  .text:0000000001E678DF                 call    sub_1E5FED0
+  .text:0000000001E678E4                 mov     r15, rax
+  .text:0000000001E678E7                 mov     [rbp-86h], ax
+  .text:0000000001E678EE                 shr     rax, 20h
+  .text:0000000001E678F2                 shr     r15, 10h
+  .text:0000000001E678F6                 mov     [rbp-82h], ax
+  .text:0000000001E678FD                 mov     [rbp-84h], r15w
+  .text:0000000001E67905                 cmp     r15w, 0FFFFh
+  .text:0000000001E6790A                 jnz     short loc_1E6798B
+  .text:0000000001E6790C                 mov     rdi, r12
+  .text:0000000001E6790F                 call    sub_1E3CF10
+  .text:0000000001E67914                 mov     rax, [rbp-78h]
+  .text:0000000001E67918                 test    rax, rax
+  .text:0000000001E6791B                 jz      short loc_1E6793C
+  .text:0000000001E6791D                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E6791D                 lea     rdi, [rbx+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:0000000001E67924                 movq    xmm0, rax
+  .text:0000000001E67929                 mov     rsi, r13
+  .text:0000000001E6792C                 pinsrq  xmm0, r12, 1
+  .text:0000000001E67933                 movaps  xmmword ptr [rbp-70h], xmm0
+  .text:0000000001E67937                 call    sub_1E67440
+  .text:0000000001E6793C                 movq    xmm0, qword ptr [rbp-80h]
+  .text:0000000001E67941                 mov     rsi, r13
+  .text:0000000001E67944                 mov     rdi, r14
+  .text:0000000001E67947                 pinsrq  xmm0, r12, 1
+  .text:0000000001E6794E                 movaps  xmmword ptr [rbp-70h], xmm0
+  .text:0000000001E67952                 call    sub_1E67440
+  .text:0000000001E67957                 movzx   eax, ax
+  .text:0000000001E6795A                 lea     rsp, [rbp-28h]
+  .text:0000000001E6795E                 pop     rbx
+  .text:0000000001E6795F                 pop     r12
+  .text:0000000001E67961                 pop     r13
+  .text:0000000001E67963                 pop     r14
+  .text:0000000001E67965                 pop     r15
+  .text:0000000001E67967                 pop     rbp
+  .text:0000000001E67968                 retn
+  .text:0000000001E67969                 lea     rbx, dword_27BBCDC
+  .text:0000000001E67970                 ; _QWORD
+  .text:0000000001E67970                 mov     esi, 5; _QWORD
+  .text:0000000001E67975                 ; _QWORD
+  .text:0000000001E67975                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E67977                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E6797C                 test    al, al
+  .text:0000000001E6797E                 jnz     loc_1E67A3F
+  .text:0000000001E67984                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E67989                 jmp     short loc_1E6795A
+  .text:0000000001E6798B                 lea     r12, dword_27BBCDC
+  .text:0000000001E67992                 ; _QWORD
+  .text:0000000001E67992                 mov     esi, 5; _QWORD
+  .text:0000000001E67997                 ; _QWORD
+  .text:0000000001E67997                 mov     edi, [r12]; _QWORD
+  .text:0000000001E6799B                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E679A0                 test    al, al
+  .text:0000000001E679A2                 jz      short loc_1E67984
+  .text:0000000001E679A4                 xor     eax, eax
+  .text:0000000001E679A6                 test    word ptr [rbx+0ABAh], 7FFFh
+  .text:0000000001E679AF                 jz      short loc_1E679B8
+  .text:0000000001E679B1                 mov     rax, [rbx+0AC0h]
+  .text:0000000001E679B8                 movzx   r15d, r15w
+  .text:0000000001E679BC                 sub     rsp, 8
+  .text:0000000001E679C0                 ; _QWORD
+  .text:0000000001E679C0                 mov     edi, [r12]; _QWORD
+  .text:0000000001E679C4                 ; _QWORD
+  .text:0000000001E679C4                 mov     esi, 5; _QWORD
+  .text:0000000001E679C9                 lea     rdx, [r15+r15*2]
+  .text:0000000001E679CD                 mov     rax, [rax+rdx*8+10h]
+  .text:0000000001E679D2                 lea     rcx, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E679D9                 ; _QWORD
+  .text:0000000001E679D9                 mov     rdx, r13; _QWORD
+  .text:0000000001E679DC                 mov     rax, [rax+50h]
+  .text:0000000001E679E0                 mov     rax, [rax+8]
+  .text:0000000001E679E4                 mov     [rbp-70h], rcx
+  .text:0000000001E679E8                 lea     rcx, aRegisterentity; "RegisterEntityClass"
+  .text:0000000001E679EF                 mov     [rbp-60h], rcx
+  .text:0000000001E679F3                 lea     rcx, aMultipleEntity; "Multiple entity classes have the same d"...
+  .text:0000000001E679FA                 mov     dword ptr [rbp-68h], 27Fh
+  .text:0000000001E67A01                 mov     qword ptr [rbp-58h], 0
+  .text:0000000001E67A09                 mov     qword ptr [rbp-50h], 0
+  .text:0000000001E67A11                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E67A19                 mov     qword ptr [rbp-40h], 0
+  .text:0000000001E67A21                 mov     dword ptr [rbp-38h], 0
+  .text:0000000001E67A28                 push    rax
+  .text:0000000001E67A29                 mov     r9, [rbp-80h]
+  .text:0000000001E67A2D                 xor     eax, eax
+  .text:0000000001E67A2F                 mov     r8, [rbp-78h]
+  .text:0000000001E67A33                 call    __Z17LoggingSystem_Logi17LoggingSeverity_tRK20LoggingRareOptions_tPKcz; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const&,char const*,...)
+  .text:0000000001E67A38                 pop     rax
+  .text:0000000001E67A39                 pop     rdx
+  .text:0000000001E67A3A                 jmp     loc_1E67984
+  .text:0000000001E67A3F                 ; _QWORD
+  .text:0000000001E67A3F                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E67A41                 ; _QWORD
+  .text:0000000001E67A41                 mov     rdx, r13; _QWORD
+  .text:0000000001E67A44                 ; _QWORD
+  .text:0000000001E67A44                 mov     esi, 5; _QWORD
+  .text:0000000001E67A49                 mov     dword ptr [rbp-68h], 276h
+  .text:0000000001E67A50                 mov     r8, [rbp-80h]
+  .text:0000000001E67A54                 lea     rax, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E67A5B                 mov     qword ptr [rbp-58h], 0
+  .text:0000000001E67A63                 mov     [rbp-70h], rax
+  .text:0000000001E67A67                 lea     rax, aRegisterentity; "RegisterEntityClass"
+  .text:0000000001E67A6E                 mov     [rbp-60h], rax
+  .text:0000000001E67A72                 lea     rcx, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:0000000001E67A79                 xor     eax, eax
+  .text:0000000001E67A7B                 mov     qword ptr [rbp-50h], 0
+  .text:0000000001E67A83                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E67A8B                 mov     qword ptr [rbp-40h], 0
+  .text:0000000001E67A93                 mov     dword ptr [rbp-38h], 0
+  .text:0000000001E67A9A                 call    __Z17LoggingSystem_Logi17LoggingSeverity_tRK20LoggingRareOptions_tPKcz; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const&,char const*,...)
+  .text:0000000001E67A9F                 jmp     loc_1E67984
+  .text:0000000001E67AA4                 or      eax, 0FFFFFFFFh
+  .text:0000000001E67AA7                 retn
+procedure: |-
+  __int64 __fastcall sub_1E67830(__int64 a1, signed __int64 a2)
+  {
+    __int64 *v2; // rax
+    __int64 v3; // rax
+    unsigned __int64 v4; // rax
+    unsigned __int64 v5; // r15
+    __int64 v7; // rax
+    const char *v8; // rax
+    __m128i v9; // [rsp-88h] [rbp-88h] BYREF
+    __m128i inserted; // [rsp-78h] [rbp-78h] BYREF
+    const char *v11; // [rsp-68h] [rbp-68h]
+    __int64 v12; // [rsp-60h] [rbp-60h]
+    __int64 v13; // [rsp-58h] [rbp-58h]
+    __int64 v14; // [rsp-50h] [rbp-50h]
+    __int64 v15; // [rsp-48h] [rbp-48h]
+    int v16; // [rsp-40h] [rbp-40h]
+
+    if ( !a2 )
+      return 0xFFFFFFFFLL;
+    v2 = *(__int64 **)(a2 + 80);
+    v9.m128i_i64[0] = v2[1];
+    v3 = *v2;
+    inserted.m128i_i64[0] = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v11 = (const char *)(a1 + 2704);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v9.m128i_i64[1] = v3;
+    inserted.m128i_i64[1] = (__int64)&v9;
+    if ( (unsigned int)sub_1E5FED0(a1 + 2712, &inserted) >> 16 != 0xFFFF )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27BBCDC, 5) )
+      {
+        inserted.m128i_i32[2] = 630;
+        v12 = 0;
+        inserted.m128i_i64[0] = (__int64)"entitysystem.cpp";
+        v11 = "RegisterEntityClass";
+        v13 = 0;
+        v14 = 0;
+        v15 = 0;
+        v16 = 0;
+        LoggingSystem_Log(
+          (unsigned int)dword_27BBCDC,
+          5,
+          &inserted,
+          "Multiple registration of class %s\n",
+          (const char *)v9.m128i_i64[0]);
+      }
+      return 0xFFFFFFFFLL;
+    }
+    if ( v9.m128i_i64[1] )
+    {
+      inserted.m128i_i64[0] = a1 + 2736;// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      inserted.m128i_i64[1] = (__int64)&v9.m128i_i64[1];
+      v11 = (const char *)(a1 + 2736);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v4 = sub_1E5FED0(a1 + 2744, &inserted);
+      v5 = v4 >> 16;
+      if ( WORD1(v4) != 0xFFFF )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27BBCDC, 5) )
+        {
+          v7 = 0;
+          if ( (*(_WORD *)(a1 + 2746) & 0x7FFF) != 0 )
+            v7 = *(_QWORD *)(a1 + 2752);
+          v8 = *(const char **)(*(_QWORD *)(*(_QWORD *)(v7 + 24LL * (unsigned __int16)v5 + 16) + 80LL) + 8LL);
+          inserted.m128i_i64[0] = (__int64)"entitysystem.cpp";
+          v11 = "RegisterEntityClass";
+          inserted.m128i_i32[2] = 639;
+          v12 = 0;
+          v13 = 0;
+          v14 = 0;
+          v15 = 0;
+          v16 = 0;
+          LoggingSystem_Log(
+            (unsigned int)dword_27BBCDC,
+            5,
+            &inserted,
+            "Multiple entity classes have the same designer name \"%s\" ( class %s and class %s )\n",
+            (const char *)v9.m128i_i64[1],
+            (const char *)v9.m128i_i64[0],
+            v8);
+        }
+        return 0xFFFFFFFFLL;
+      }
+    }
+    sub_1E3CF10(a2);
+    if ( v9.m128i_i64[1] )
+    {
+      inserted = _mm_insert_epi64((__m128i)v9.m128i_u64[1], a2, 1);
+      sub_1E67440(a1 + 2736, &inserted);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+    }
+    inserted = _mm_insert_epi64(_mm_loadl_epi64(&v9), a2, 1);
+    return (unsigned __int16)sub_1E67440(a1 + 2704, &inserted);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterEntityClass.windows.yaml
@@ -1,0 +1,223 @@
+func_name: CEntitySystem_RegisterEntityClass
+func_va: '0x1811f56c0'
+disasm_code: |-
+  .text:00000001811F56C0                 push    rbp
+  .text:00000001811F56C2                 push    rbx
+  .text:00000001811F56C3                 push    rsi
+  .text:00000001811F56C4                 push    rdi
+  .text:00000001811F56C5                 push    r12
+  .text:00000001811F56C7                 push    r14
+  .text:00000001811F56C9                 push    r15
+  .text:00000001811F56CB                 lea     rbp, [rsp-27h]
+  .text:00000001811F56D0                 sub     rsp, 0A0h
+  .text:00000001811F56D7                 mov     rbx, rdx
+  .text:00000001811F56DA                 mov     rdi, rcx
+  .text:00000001811F56DD                 test    rdx, rdx
+  .text:00000001811F56E0                 jz      loc_1811F57A0
+  .text:00000001811F56E6                 mov     r8, [rdx+50h]
+  .text:00000001811F56EA                 ; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:00000001811F56EA                 lea     r14, [rcx+0A90h]; 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+  .text:00000001811F56F1                 lea     rcx, [r14+8]
+  .text:00000001811F56F5                 mov     [rbp+57h+var_90], r14
+  .text:00000001811F56F9                 lea     rdx, [rbp+57h+arg_8]
+  .text:00000001811F56FD                 mov     [rbp+57h+var_80], r14
+  .text:00000001811F5701                 mov     rax, [r8+8]
+  .text:00000001811F5705                 mov     [rbp+57h+arg_18], rax
+  .text:00000001811F5709                 mov     rax, [r8]
+  .text:00000001811F570C                 lea     r8, [rbp+57h+var_90]
+  .text:00000001811F5710                 mov     [rbp+57h+arg_10], rax
+  .text:00000001811F5714                 lea     rax, [rbp+57h+arg_18]
+  .text:00000001811F5718                 mov     [rbp+57h+var_88], rax
+  .text:00000001811F571C                 call    sub_1811E2BC0
+  .text:00000001811F5721                 mov     r12d, 0FFFFh
+  .text:00000001811F5727                 cmp     [rax+2], r12w
+  .text:00000001811F572C                 jz      loc_1811F57B7
+  .text:00000001811F5732                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F5738                 mov     edx, 5
+  .text:00000001811F573D                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F5743                 test    al, al
+  .text:00000001811F5745                 jz      short loc_1811F57A0
+  .text:00000001811F5747                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F574B                 lea     rcx, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F5752                 mov     [rbp+57h+var_78], rcx
+  .text:00000001811F5756                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:00000001811F575D                 lea     rcx, aCentitysystemR_1; "CEntitySystem::RegisterEntityClass"
+  .text:00000001811F5764                 mov     [rbp+57h+var_70], 276h
+  .text:00000001811F576B                 mov     [rbp+57h+var_68], rcx
+  .text:00000001811F576F                 lea     r8, [rbp+57h+var_78]
+  .text:00000001811F5773                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F5779                 xorps   xmm0, xmm0
+  .text:00000001811F577C                 xorps   xmm1, xmm1
+  .text:00000001811F577F                 mov     [rbp+57h+var_40], 0
+  .text:00000001811F5786                 mov     edx, 5
+  .text:00000001811F578B                 mov     [rsp+0D0h+var_B0], rax
+  .text:00000001811F5790                 movdqu  [rbp+57h+var_60], xmm0
+  .text:00000001811F5795                 movdqu  [rbp+57h+var_50], xmm1
+  .text:00000001811F579A                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F57A0                 mov     eax, 0FFFFFFFFh
+  .text:00000001811F57A5                 add     rsp, 0A0h
+  .text:00000001811F57AC                 pop     r15
+  .text:00000001811F57AE                 pop     r14
+  .text:00000001811F57B0                 pop     r12
+  .text:00000001811F57B2                 pop     rdi
+  .text:00000001811F57B3                 pop     rsi
+  .text:00000001811F57B4                 pop     rbx
+  .text:00000001811F57B5                 pop     rbp
+  .text:00000001811F57B6                 retn
+  .text:00000001811F57B7                 cmp     [rbp+57h+arg_10], 0
+  .text:00000001811F57BC                 ; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:00000001811F57BC                 lea     rsi, [rdi+0AB0h]; 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+  .text:00000001811F57C3                 jz      loc_1811F58A4
+  .text:00000001811F57C9                 lea     rax, [rbp+57h+arg_10]
+  .text:00000001811F57CD                 mov     [rbp+57h+var_90], rsi
+  .text:00000001811F57D1                 lea     rcx, [rsi+8]
+  .text:00000001811F57D5                 mov     [rbp+57h+var_88], rax
+  .text:00000001811F57D9                 lea     r8, [rbp+57h+var_90]
+  .text:00000001811F57DD                 mov     [rbp+57h+var_80], rsi
+  .text:00000001811F57E1                 lea     rdx, [rbp+57h+arg_8]
+  .text:00000001811F57E5                 call    sub_1811E2BC0
+  .text:00000001811F57EA                 movzx   r15d, word ptr [rax+2]
+  .text:00000001811F57EF                 cmp     r15w, r12w
+  .text:00000001811F57F3                 jz      loc_1811F58A4
+  .text:00000001811F57F9                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F57FF                 mov     edx, 5
+  .text:00000001811F5804                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F580A                 test    al, al
+  .text:00000001811F580C                 jz      short loc_1811F57A0
+  .text:00000001811F580E                 mov     eax, 7FFFh
+  .text:00000001811F5813                 test    [rdi+0ABAh], ax
+  .text:00000001811F581A                 jnz     short loc_1811F5820
+  .text:00000001811F581C                 xor     edx, edx
+  .text:00000001811F581E                 jmp     short loc_1811F5827
+  .text:00000001811F5820                 mov     rdx, [rdi+0AC0h]
+  .text:00000001811F5827                 lea     rcx, [r15+r15*2]
+  .text:00000001811F582B                 xorps   xmm0, xmm0
+  .text:00000001811F582E                 mov     rax, [rdx+rcx*8+10h]
+  .text:00000001811F5833                 lea     r9, aMultipleEntity_0; "Multiple entity classes have the same d"...
+  .text:00000001811F583A                 xorps   xmm1, xmm1
+  .text:00000001811F583D                 lea     r8, [rbp+57h+var_78]
+  .text:00000001811F5841                 mov     edx, 5
+  .text:00000001811F5846                 mov     rcx, [rax+50h]
+  .text:00000001811F584A                 mov     rax, [rcx+8]
+  .text:00000001811F584E                 lea     rcx, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F5855                 mov     [rsp+0D0h+var_A0], rax
+  .text:00000001811F585A                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F585E                 mov     [rbp+57h+var_78], rcx
+  .text:00000001811F5862                 lea     rcx, aCentitysystemR_1; "CEntitySystem::RegisterEntityClass"
+  .text:00000001811F5869                 mov     [rsp+0D0h+var_A8], rax
+  .text:00000001811F586E                 mov     rax, [rbp+57h+arg_10]
+  .text:00000001811F5872                 mov     [rbp+57h+var_68], rcx
+  .text:00000001811F5876                 mov     ecx, cs:dword_1820B1848
+  .text:00000001811F587C                 mov     [rsp+0D0h+var_B0], rax
+  .text:00000001811F5881                 mov     [rbp+57h+var_70], 280h
+  .text:00000001811F5888                 movdqu  [rbp+57h+var_60], xmm0
+  .text:00000001811F588D                 mov     [rbp+57h+var_40], 0
+  .text:00000001811F5894                 movdqu  [rbp+57h+var_50], xmm1
+  .text:00000001811F5899                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F589F                 jmp     loc_1811F57A0
+  .text:00000001811F58A4                 mov     rcx, rbx
+  .text:00000001811F58A7                 call    sub_1811E0050
+  .text:00000001811F58AC                 mov     rax, [rbp+57h+arg_10]
+  .text:00000001811F58B0                 test    rax, rax
+  .text:00000001811F58B3                 jz      short loc_1811F58C9
+  .text:00000001811F58B5                 lea     rdx, [rbp+57h+var_90]
+  .text:00000001811F58B9                 mov     [rbp+57h+var_90], rax
+  .text:00000001811F58BD                 mov     rcx, rsi
+  .text:00000001811F58C0                 mov     [rbp+57h+var_88], rbx
+  .text:00000001811F58C4                 call    sub_1811F16D0
+  .text:00000001811F58C9                 mov     rax, [rbp+57h+arg_18]
+  .text:00000001811F58CD                 lea     rdx, [rbp+57h+var_90]
+  .text:00000001811F58D1                 mov     rcx, r14
+  .text:00000001811F58D4                 mov     [rbp+57h+var_90], rax
+  .text:00000001811F58D8                 mov     [rbp+57h+var_88], rbx
+  .text:00000001811F58DC                 call    sub_1811F16D0
+  .text:00000001811F58E1                 movzx   eax, ax
+  .text:00000001811F58E4                 jmp     loc_1811F57A5
+procedure: |-
+  __int64 __fastcall CEntitySystem_RegisterEntityClass(__int64 a1, __int64 a2)
+  {
+    __int64 v4; // r8
+    __int64 v5; // r14
+    __int64 v7; // r15
+    __int64 v8; // rdx
+    const char *v9; // [rsp+30h] [rbp-49h]
+    const char *v10; // [rsp+40h] [rbp-39h] BYREF
+    const char **v11; // [rsp+48h] [rbp-31h]
+    __int64 v12; // [rsp+50h] [rbp-29h]
+    const char *v13; // [rsp+58h] [rbp-21h] BYREF
+    int v14; // [rsp+60h] [rbp-19h]
+    const char *v15; // [rsp+68h] [rbp-11h]
+    __int128 v16; // [rsp+70h] [rbp-9h]
+    __int128 v17; // [rsp+80h] [rbp+7h]
+    int v18; // [rsp+90h] [rbp+17h]
+    char v19; // [rsp+E8h] [rbp+6Fh] BYREF
+    const char *v20; // [rsp+F0h] [rbp+77h] BYREF
+    const char *v21; // [rsp+F8h] [rbp+7Fh] BYREF
+
+    if ( !a2 )
+      return 0xFFFFFFFFLL;
+    v4 = *(_QWORD *)(a2 + 80);
+    v5 = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v10 = (const char *)(a1 + 2704);// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v12 = a1 + 2704;// 0xA90 = 2704 = CEntitySystem::m_entClassesByCPPClassname (structmember, struct=CEntitySystem, member=m_entClassesByCPPClassname)
+    v21 = *(const char **)(v4 + 8);
+    v20 = *(const char **)v4;
+    v11 = &v21;
+    if ( *(_WORD *)(sub_1811E2BC0(a1 + 2712, &v19, &v10) + 2) != 0xFFFF )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
+      {
+        v13 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+        v14 = 630;
+        v15 = "CEntitySystem::RegisterEntityClass";
+        v18 = 0;
+        v16 = 0;
+        v17 = 0;
+        LoggingSystem_Log((unsigned int)dword_1820B1848, 5, &v13, "Multiple registration of class %s\n", v21);
+      }
+      return 0xFFFFFFFFLL;
+    }
+    if ( v20 )
+    {
+      v10 = (const char *)(a1 + 2736);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v11 = &v20;
+      v12 = a1 + 2736;// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+      v7 = *(unsigned __int16 *)(sub_1811E2BC0(a1 + 2744, &v19, &v10) + 2);
+      if ( (_WORD)v7 != 0xFFFF )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
+        {
+          if ( (*(_WORD *)(a1 + 2746) & 0x7FFF) != 0 )
+            v8 = *(_QWORD *)(a1 + 2752);
+          else
+            v8 = 0;
+          v9 = *(const char **)(*(_QWORD *)(*(_QWORD *)(v8 + 24 * v7 + 16) + 80LL) + 8LL);
+          v13 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+          v15 = "CEntitySystem::RegisterEntityClass";
+          v14 = 640;
+          v16 = 0;
+          v18 = 0;
+          v17 = 0;
+          LoggingSystem_Log(
+            (unsigned int)dword_1820B1848,
+            5,
+            &v13,
+            "Multiple entity classes have the same designer name \"%s\" ( class %s and class %s )\n",
+            v20,
+            v21,
+            v9);
+        }
+        return 0xFFFFFFFFLL;
+      }
+    }
+    sub_1811E0050(a2);
+    if ( v20 )
+    {
+      v10 = v20;
+      v11 = (const char **)a2;
+      sub_1811F16D0(a1 + 2736, &v10);// 0xAB0 = 2736 = CEntitySystem::m_entClassesByClassname (structmember, struct=CEntitySystem, member=m_entClassesByClassname)
+    }
+    v10 = v21;
+    v11 = (const char **)a2;
+    return (unsigned __int16)sub_1811F16D0(v5, &v10);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.linux.yaml
@@ -1,0 +1,126 @@
+func_name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+func_va: '0x1529420'
+disasm_code: |-
+  .text:0000000001529420                 push    rbp
+  .text:0000000001529421                 mov     rbp, rsp
+  .text:0000000001529424                 push    r15
+  .text:0000000001529426                 mov     r15, rdx
+  .text:0000000001529429                 push    r14
+  .text:000000000152942B                 mov     r14, rcx
+  .text:000000000152942E                 push    r13
+  .text:0000000001529430                 mov     r13, rdi
+  .text:0000000001529433                 push    r12
+  .text:0000000001529435                 mov     r12, rsi
+  .text:0000000001529438                 push    rbx
+  .text:0000000001529439                 sub     rsp, 28h
+  .text:000000000152943D                 call    sub_C7BDE0
+  .text:0000000001529442                 mov     edi, 1
+  .text:0000000001529447                 mov     ebx, eax
+  .text:0000000001529449                 call    sub_C7BDF0
+  .text:000000000152944E                 mov     rsi, r12
+  .text:0000000001529451                 mov     rdi, r13
+  .text:0000000001529454                 mov     rcx, r14
+  .text:0000000001529457                 mov     rdx, r15
+  .text:000000000152945A                 call    sub_1E50DD0
+  .text:000000000152945F                 lea     rsi, aGamesessionman; "GameSessionManifest.vrgrp"
+  .text:0000000001529466                 ; _QWORD
+  .text:0000000001529466                 mov     rdi, r12; _QWORD
+  .text:0000000001529469                 call    _V_stricmp_fast
+  .text:000000000152946E                 test    eax, eax
+  .text:0000000001529470                 jz      short loc_1529490
+  .text:0000000001529472                 add     rsp, 28h
+  .text:0000000001529476                 movzx   edi, bl
+  .text:0000000001529479                 pop     rbx
+  .text:000000000152947A                 pop     r12
+  .text:000000000152947C                 pop     r13
+  .text:000000000152947E                 pop     r14
+  .text:0000000001529480                 pop     r15
+  .text:0000000001529482                 pop     rbp
+  .text:0000000001529483                 jmp     sub_C7BDF0
+  .text:0000000001529490                 mov     edi, cs:dword_246EC68
+  .text:0000000001529496                 mov     [rbp+var_48], r14
+  .text:000000000152949A                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:000000000152949A                 mov     r12, [r13+8]; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:000000000152949E                 mov     [r13+8], r14; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294A2                 test    edi, edi
+  .text:00000000015294A4                 js      short loc_15294C0
+  .text:00000000015294A6                 lea     rcx, [rbp+var_48]
+  .text:00000000015294AA                 mov     esi, 39h ; '9'
+  .text:00000000015294AF                 xor     edx, edx
+  .text:00000000015294B1                 call    sub_DEF550
+  .text:00000000015294B6                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294B6                 mov     [r13+8], r12; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:00000000015294BA                 jmp     short loc_1529472
+  .text:00000000015294C0                 lea     r15, off_2288CD8
+  .text:00000000015294C7                 mov     [rbp+var_38], 0
+  .text:00000000015294CF                 mov     [rbp+var_40], r15
+  .text:00000000015294D3                 movzx   eax, cs:byte_25EFB20
+  .text:00000000015294DA                 test    al, al
+  .text:00000000015294DC                 jz      short loc_1529510
+  .text:00000000015294DE                 mov     rax, cs:qword_25EFB28
+  .text:00000000015294E5                 lea     r14, [rbp+var_40]
+  .text:00000000015294E9                 mov     rdi, r14
+  .text:00000000015294EC                 mov     [rbp+var_40], rax
+  .text:00000000015294F0                 call    qword ptr [rax+38h]
+  .text:00000000015294F3                 mov     rdi, r14
+  .text:00000000015294F6                 mov     [rbp+var_40], r15
+  .text:00000000015294FA                 mov     cs:dword_246EC68, eax
+  .text:0000000001529500                 call    nullsub_503
+  .text:0000000001529505                 mov     edi, cs:dword_246EC68
+  .text:000000000152950B                 jmp     short loc_15294A6
+  .text:0000000001529510                 lea     r14, byte_25EFB20
+  .text:0000000001529517                 ; _QWORD
+  .text:0000000001529517                 mov     rdi, r14; _QWORD
+  .text:000000000152951A                 call    ___cxa_guard_acquire
+  .text:000000000152951F                 test    eax, eax
+  .text:0000000001529521                 jz      short loc_15294DE
+  .text:0000000001529523                 mov     rax, cs:off_246E630
+  .text:000000000152952A                 ; _QWORD
+  .text:000000000152952A                 mov     rdi, r14; _QWORD
+  .text:000000000152952D                 mov     cs:qword_25EFB28, rax
+  .text:0000000001529534                 call    ___cxa_guard_release
+  .text:0000000001529539                 jmp     short loc_15294DE
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName(
+          __int64 a1,
+          __int64 a2,
+          __int64 a3,
+          __int64 a4)
+  {
+    unsigned __int8 v7; // bl
+    __int64 v9; // rdi
+    __int64 v10; // r12
+    int v11; // eax
+    __int64 v12; // [rsp+8h] [rbp-48h] BYREF
+    _QWORD v13[8]; // [rsp+10h] [rbp-40h] BYREF
+
+    v7 = sub_C7BDE0();
+    sub_C7BDF0(1);
+    sub_1E50DD0(a1, a2, a3, a4);
+    if ( !(unsigned int)V_stricmp_fast(a2, "GameSessionManifest.vrgrp") )
+    {
+      v9 = (unsigned int)dword_246EC68;
+      v12 = a4;
+      v10 = *(_QWORD *)(a1 + 8);// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      *(_QWORD *)(a1 + 8) = a4;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      if ( (int)v9 < 0 )
+      {
+        v13[1] = 0;
+        v13[0] = off_2288CD8;
+        if ( !(_BYTE)byte_25EFB20 && (unsigned int)__cxa_guard_acquire(&byte_25EFB20) )
+        {
+          qword_25EFB28 = (__int64)off_246E630[0];
+          __cxa_guard_release(&byte_25EFB20);
+        }
+        v13[0] = qword_25EFB28;
+        v11 = (*(__int64 (__fastcall **)(_QWORD *))(qword_25EFB28 + 56))(v13);
+        v13[0] = off_2288CD8;
+        dword_246EC68 = v11;
+        nullsub_503(v13);
+        v9 = (unsigned int)dword_246EC68;
+      }
+      sub_DEF550(v9, 57, 0, &v12);
+      *(_QWORD *)(a1 + 8) = v10;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+    }
+    return sub_C7BDF0(v7);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName.windows.yaml
@@ -1,0 +1,133 @@
+func_name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
+func_va: '0x180b42fc0'
+disasm_code: |-
+  .text:0000000180B42FC0                 mov     [rsp+arg_0], rbx
+  .text:0000000180B42FC5                 mov     [rsp+arg_8], rbp
+  .text:0000000180B42FCA                 mov     [rsp+arg_10], rsi
+  .text:0000000180B42FCF                 mov     [rsp+arg_18], rdi
+  .text:0000000180B42FD4                 push    r14
+  .text:0000000180B42FD6                 sub     rsp, 40h
+  .text:0000000180B42FDA                 mov     rbp, r9
+  .text:0000000180B42FDD                 mov     rbx, r8
+  .text:0000000180B42FE0                 mov     rdi, rdx
+  .text:0000000180B42FE3                 mov     rsi, rcx
+  .text:0000000180B42FE6                 call    sub_1803DE7B0
+  .text:0000000180B42FEB                 mov     cl, 1
+  .text:0000000180B42FED                 movzx   r14d, al
+  .text:0000000180B42FF1                 call    sub_1803E9060
+  .text:0000000180B42FF6                 mov     r9, rbp
+  .text:0000000180B42FF9                 mov     r8, rbx
+  .text:0000000180B42FFC                 mov     rdx, rdi
+  .text:0000000180B42FFF                 mov     rcx, rsi
+  .text:0000000180B43002                 call    sub_1811E82E0
+  .text:0000000180B43007                 lea     rdx, aGamesessionman; "GameSessionManifest.vrgrp"
+  .text:0000000180B4300E                 mov     rcx, rdi
+  .text:0000000180B43011                 call    cs:V_stricmp_fast
+  .text:0000000180B43017                 test    eax, eax
+  .text:0000000180B43019                 jnz     loc_180B430B9
+  .text:0000000180B4301F                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B4301F                 mov     rdi, [rsi+8]; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B43023                 mov     [rsi+8], rbp; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B43027                 mov     ecx, cs:dword_181B9ADC8
+  .text:0000000180B4302D                 mov     [rsp+48h+var_28], rbp
+  .text:0000000180B43032                 test    ecx, ecx
+  .text:0000000180B43034                 jns     short loc_180B430A4
+  .text:0000000180B43036                 mov     ecx, cs:TlsIndex
+  .text:0000000180B4303C                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180B43043                 mov     [rsp+48h+var_20], rax
+  .text:0000000180B43048                 mov     rax, gs:58h
+  .text:0000000180B43051                 mov     edx, 218h
+  .text:0000000180B43056                 mov     [rsp+48h+var_18], 0
+  .text:0000000180B4305F                 mov     rax, [rax+rcx*8]
+  .text:0000000180B43063                 mov     eax, [rdx+rax]
+  .text:0000000180B43066                 cmp     cs:dword_181E14850, eax
+  .text:0000000180B4306C                 jg      short loc_180B430DC
+  .text:0000000180B4306E                 mov     rax, cs:qword_181E14848
+  .text:0000000180B43075                 lea     rcx, [rsp+48h+var_20]
+  .text:0000000180B4307A                 mov     rbx, [rsp+48h+var_20]
+  .text:0000000180B4307F                 mov     [rsp+48h+var_20], rax
+  .text:0000000180B43084                 call    sub_1805087D0
+  .text:0000000180B43089                 lea     rcx, [rsp+48h+var_20]
+  .text:0000000180B4308E                 mov     [rsp+48h+var_20], rbx
+  .text:0000000180B43093                 mov     cs:dword_181B9ADC8, eax
+  .text:0000000180B43099                 call    sub_180507F80
+  .text:0000000180B4309E                 mov     ecx, cs:dword_181B9ADC8
+  .text:0000000180B430A4                 lea     r8, [rsp+48h+var_28]
+  .text:0000000180B430A9                 lea     rdx, sub_1805087D0
+  .text:0000000180B430B0                 call    sub_180512270
+  .text:0000000180B430B5                 ; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B430B5                 mov     [rsi+8], rdi; 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+  .text:0000000180B430B9                 movzx   ecx, r14b
+  .text:0000000180B430BD                 mov     rbx, [rsp+48h+arg_0]
+  .text:0000000180B430C2                 mov     rbp, [rsp+48h+arg_8]
+  .text:0000000180B430C7                 mov     rsi, [rsp+48h+arg_10]
+  .text:0000000180B430CC                 mov     rdi, [rsp+48h+arg_18]
+  .text:0000000180B430D1                 add     rsp, 40h
+  .text:0000000180B430D5                 pop     r14
+  .text:0000000180B430D7                 jmp     sub_1803E9060
+  .text:0000000180B430DC                 lea     rcx, dword_181E14850
+  .text:0000000180B430E3                 call    sub_1814F7664
+  .text:0000000180B430E8                 cmp     cs:dword_181E14850, 0FFFFFFFFh
+  .text:0000000180B430EF                 jnz     loc_180B4306E
+  .text:0000000180B430F5                 mov     rax, cs:off_181B9AEE0
+  .text:0000000180B430FC                 lea     rcx, dword_181E14850
+  .text:0000000180B43103                 mov     cs:qword_181E14848, rax
+  .text:0000000180B4310A                 call    sub_1814F75F8
+  .text:0000000180B4310F                 jmp     loc_180B4306E
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName(
+          __int64 a1,
+          __int64 a2,
+          __int64 a3,
+          __int64 a4)
+  {
+    unsigned __int8 v8; // al
+    __int64 v9; // rcx
+    unsigned __int8 v10; // r14
+    __int64 v11; // r8
+    __int64 v12; // rdi
+    __int64 v13; // rcx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v15; // rbx
+    int v16; // eax
+    __int64 v18; // [rsp+20h] [rbp-28h] BYREF
+    _QWORD v19[4]; // [rsp+28h] [rbp-20h] BYREF
+
+    v8 = sub_1803DE7B0();
+    LOBYTE(v9) = 1;
+    v10 = v8;
+    sub_1803E9060(v9);
+    sub_1811E82E0(a1, a2, a3, a4);
+    if ( !(unsigned int)V_stricmp_fast(a2, "GameSessionManifest.vrgrp", v11) )
+    {
+      v12 = *(_QWORD *)(a1 + 8);// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      *(_QWORD *)(a1 + 8) = a4;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+      v13 = (unsigned int)dword_181B9ADC8;
+      v18 = a4;
+      if ( dword_181B9ADC8 < 0 )
+      {
+        v19[0] = &CDontUseThisGameSystem::`vftable';
+        ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+        v19[1] = 0;
+        if ( dword_181E14850 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 536LL) )
+        {
+          sub_1814F7664(&dword_181E14850);
+          if ( dword_181E14850 == -1 )
+          {
+            qword_181E14848 = (__int64)off_181B9AEE0[0];
+            sub_1814F75F8(&dword_181E14850);
+          }
+        }
+        v15 = v19[0];
+        v19[0] = qword_181E14848;
+        v16 = sub_1805087D0(v19);
+        v19[0] = v15;
+        dword_181B9ADC8 = v16;
+        sub_180507F80(v19);
+        v13 = (unsigned int)dword_181B9ADC8;
+      }
+      sub_180512270(v13, sub_1805087D0, &v18);
+      *(_QWORD *)(a1 + 8) = v12;// 0x8 = 8 = CEntitySystem::m_pCurrentManifest (structmember, struct=CEntitySystem, member=m_pCurrentManifest)
+    }
+    return sub_1803E9060(v10);
+  }


### PR DESCRIPTION
## Summary
- Add `find-CEntitySystem_m_sEntSystemName` (Pattern E) -- CUtlString at offset 0xA88
- Add `find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname` (Pattern E) -- CUtlHashtable at 0xA90 and 0xAB0
- Add `find-CEntitySystem_RegisterEntityClass` (Pattern A) -- xref-based function discovery
- Add `find-CEntitySystem_m_pCurrentManifest` (Pattern E) -- struct member offset

## Test plan
- [ ] Validated all skills against gamever 14158 (Windows + Linux)
- [ ] All output YAMLs generated with correct offsets and unique signatures