### PR TITLE
Add preprocessor scripts for engine service, loop mode, and entity system symbols

### DIFF
--- a/.claude/agents/vtable-fixer.md
+++ b/.claude/agents/vtable-fixer.md
@@ -20,3 +20,4 @@ Rules:
 - YOU MUST ensure the new vtable layout after edit matches vfunc index from reference YAMLs.
 - If the prototype of new virtual functions are unknown, leave them `virtual void KnownFunctionName() = 0;`;
 - If there are gaps between known functions, leave the unkown functions `virtual void unk001() = 0;`, `virtual void unk002() = 0;` or something like that.
+- `YAML:[N]: XXXX_dtor` or `YAML:[N]: XXXX_vdtor` stands for virtual destructor of class `XXXX`

--- a/.claude/skills/create-preprocessor-scripts/references/pattern-B.md
+++ b/.claude/skills/create-preprocessor-scripts/references/pattern-B.md
@@ -76,11 +76,18 @@ async def preprocess_skill(
 
 When xref strings differ between Windows and Linux, use `FUNC_XREFS_WINDOWS` / `FUNC_XREFS_LINUX` and a ternary in `preprocess_skill`. See [Pattern A](pattern-A.md#platform-specific-xref-strings-variant) for the full example -- the same approach applies to Pattern B.
 
+## FUNC_VTABLE_RELATIONS: Class Name vs Artifact Stem
+
+If config.yaml `expected_input` includes an existing vtable YAML such as `{VTABLE_CLASS}_vtable.{platform}.yaml`, set the second value in `FUNC_VTABLE_RELATIONS` to the artifact stem (`"{VTABLE_CLASS}_vtable"`), not the bare class name. `preprocess_common_skill` only reads the local YAML when the value ends with `_vtable` / `_vtableN`; a bare class name triggers live IDA vtable lookup instead, which may fail for templated classes unless `mangled_class_names` aliases are also passed.
+
+Use a bare class name only when no vtable YAML should be read and the value is intended as metadata or for live lookup.
+
 ## Checklist
 
 - [ ] `TARGET_FUNCTION_NAMES` lists all functions the script should find
 - [ ] `FUNC_XREFS` xref strings match the user's specified debug strings
 - [ ] `FUNC_VTABLE_RELATIONS` lists correct vtable class for each target that has `vtable_name` or `vfunc_*` in its `GENERATE_YAML_DESIRED_FIELDS`
+- [ ] If config.yaml `expected_input` includes `{VTABLE_CLASS}_vtable.{platform}.yaml`, `FUNC_VTABLE_RELATIONS` uses `{VTABLE_CLASS}_vtable` as the second value
 - [ ] `preprocess_common_skill` call passes `func_names=`, `func_xrefs=`, and `func_vtable_relations=`
 - [ ] config.yaml `expected_input` includes the vtable YAML
 - [ ] No `LLM_DECOMPILE`, no `llm_config` parameter

--- a/.claude/skills/rename-preprocessor-scripts/SKILL.md
+++ b/.claude/skills/rename-preprocessor-scripts/SKILL.md
@@ -29,6 +29,9 @@ the Python script, `config.yaml`, and every per-gamever YAML output file under `
 > If only the symbol suffix changes (e.g. `Foo_Bar` → `Foo_Baz`) and the vtable class stays
 > the same, skip the class rename steps below.
 
+> **Multiple renames at once:** run all steps for every symbol in a single pass — batch the
+> `sed` calls with multiple `-e` flags rather than doing separate passes per symbol.
+
 ---
 
 ## Step 1: Find All Affected Files
@@ -45,8 +48,8 @@ Expected hits fall into these categories:
 |-----------|-------------|--------------|
 | Preprocessor script | `ida_preprocessor_scripts/find-OldName.py` | File renamed + content updated |
 | config.yaml | `config.yaml` | Skill name, `expected_output`, `skip_if_exists`, symbol `name` + `alias` |
-| Output YAMLs | `bin/*/engine/OldName.{platform}.yaml` | File renamed + `func_name` / `vtable_name` fields |
-| Reference YAMLs | `ida_preprocessor_scripts/references/**/*.yaml` | Comment strings updated |
+| Output YAMLs | `bin/*/client\|engine/OldName.{platform}.yaml` | File renamed + `func_name` / `vtable_name` fields |
+| Reference YAMLs | `ida_preprocessor_scripts/references/**/*.yaml` | File renamed (if named after symbol) or comment strings updated |
 | Test files | `tests/*.py` | Fixture data, assertions, class/method names updated |
 
 Also check whether any **other** scripts list `OldName.{platform}.yaml` as an `expected_input`
@@ -63,6 +66,11 @@ Use `git mv` to preserve history:
 git mv ida_preprocessor_scripts/find-OldName.py \
         ida_preprocessor_scripts/find-NewName.py
 ```
+
+> **Compound script names:** scripts may bundle multiple symbols with `-AND-` separators
+> (e.g. `find-IGameSystemFactory_Allocate-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName.py`)
+> or have an `-impl` suffix. Only rename the part that changed — leave unrelated symbol names
+> and suffixes intact.
 
 ---
 
@@ -88,7 +96,19 @@ Only touch fields that are actually present in the script; skip inapplicable row
 
 ## Step 4: Update config.yaml
 
-Four locations may need editing:
+Four locations may need editing. Use a single `sed` invocation with multiple `-e` flags to
+handle both the `_` symbol name and the `::` alias form in one pass:
+
+```bash
+sed -i \
+  -e 's/OldName/NewName/g' \
+  -e 's/OldClass::OldMethodSuffix/NewClass::NewMethodSuffix/g' \
+  config.yaml
+```
+
+> The `alias` field uses `::` notation (`IGameSystemFactory::Allocate`), which a plain
+> `s/OldName/NewName/` will **not** match because the symbol name uses `_` separators.
+> Always add a separate `-e` expression for the alias form when the method suffix changes.
 
 ### 4a. Skill entry (under `skills:`)
 
@@ -113,13 +133,13 @@ Four locations may need editing:
       - name: OldName
         category: vfunc          # (or func / structmember / vtable / gv)
         alias:
-          - OldClass::MethodName
+          - OldClass::OldMethodSuffix
 
 # After
       - name: NewName
         category: vfunc
         alias:
-          - NewClass::MethodName
+          - NewClass::NewMethodSuffix
 ```
 
 ### 4c. Downstream `expected_input` entries (if any)
@@ -135,25 +155,18 @@ If any skill has `skip_if_exists: - OldName.{platform}.yaml`, update to `NewName
 
 ## Step 5: Rename and Update Output YAML Files
 
-The output YAMLs under `bin/` are **not tracked by git**, so use regular `mv`:
+The output YAMLs under `bin/` are **not tracked by git**, so use regular `mv`.
+Adjust the subdirectory (`client` or `engine`) to match the module:
 
 ```bash
-for dir in bin/*/engine; do          # adjust subdirectory to match the module
+for dir in bin/*/client; do          # or bin/*/engine — check Step 1 grep output
   for platform in windows linux; do
-    mv "${dir}/OldName.${platform}.yaml" "${dir}/NewName.${platform}.yaml" 2>/dev/null || true
-  done
-done
-```
-
-Then update the `func_name` and (if applicable) `vtable_name` fields inside each renamed file:
-
-```bash
-for dir in bin/*/engine; do
-  for platform in windows linux; do
-    f="${dir}/NewName.${platform}.yaml"
-    [ -f "$f" ] || continue
-    sed -i "s/func_name: OldName/func_name: NewName/" "$f"
-    sed -i "s/vtable_name: OldClass/vtable_name: NewClass/" "$f"
+    old="${dir}/OldName.${platform}.yaml"
+    new="${dir}/NewName.${platform}.yaml"
+    [ -f "$old" ] || continue
+    mv "$old" "$new"
+    sed -i "s/func_name: OldName/func_name: NewName/" "$new"
+    sed -i "s/vtable_name: OldClass/vtable_name: NewClass/" "$new"
   done
 done
 ```
@@ -165,19 +178,28 @@ done
 
 ## Step 6: Update Reference YAMLs (if any)
 
-Reference YAMLs under `ida_preprocessor_scripts/references/` contain IDA disassembly /
-decompilation snippets that may include the old name in inline comments, e.g.:
+Reference YAMLs under `ida_preprocessor_scripts/references/` may need two kinds of treatment:
 
-```
-call qword ptr [rax+30h]; 0x30 = 48LL = OldName
+**A. Reference YAML named after the symbol** (e.g. `references/client/OldName.windows.yaml`):
+rename the file and update its contents:
+
+```bash
+mv ida_preprocessor_scripts/references/client/OldName.windows.yaml \
+   ida_preprocessor_scripts/references/client/NewName.windows.yaml
+mv ida_preprocessor_scripts/references/client/OldName.linux.yaml \
+   ida_preprocessor_scripts/references/client/NewName.linux.yaml
+sed -i "s/OldName/NewName/g" \
+  ida_preprocessor_scripts/references/client/NewName.windows.yaml \
+  ida_preprocessor_scripts/references/client/NewName.linux.yaml
 ```
 
-If the Step 1 grep found any of these files, update them with:
+**B. Reference YAML named after a different symbol** (e.g. `references/client/IGameSystem_AddByName.windows.yaml`
+contains inline comments referencing `OldName`): update contents only:
 
 ```bash
 sed -i "s/OldName/NewName/g" \
-  ida_preprocessor_scripts/references/engine/SomeFile.windows.yaml \
-  ida_preprocessor_scripts/references/engine/SomeFile.linux.yaml
+  ida_preprocessor_scripts/references/client/SomeFile.windows.yaml \
+  ida_preprocessor_scripts/references/client/SomeFile.linux.yaml
 ```
 
 ---
@@ -210,6 +232,11 @@ If any other preprocessor scripts reference `OldName` (e.g. in `INHERIT_VFUNCS` 
 `base_vfunc_name`, or in `LLM_DECOMPILE` as a predecessor), update those references to
 `NewName` in their `.py` source and in their `config.yaml` `expected_input` entries.
 
+> **`INHERIT_VFUNCS` `base_vfunc_name` gotcha:** the 3rd element of the tuple is a path like
+> `"../client/OldName"` (without `.yaml`). A grep on the full symbol name will find it, but
+> a sed that only matches `OldName.{platform}.yaml` will not. Make sure the plain
+> `s/OldName/NewName/g` pass covers it.
+
 ---
 
 ## Step 9: Verify
@@ -225,20 +252,34 @@ the old name for historical context.
 
 ---
 
+## Step 10: Commit
+
+Stage all tracked changes and commit:
+
+```bash
+git add <all modified/renamed tracked files>
+git commit -m "Rename OldName to NewName across preprocessor scripts"
+```
+
+> The `bin/` output YAMLs are untracked — they will not appear in the commit, which is expected.
+
+---
+
 ## Checklist
 
 - [ ] Old Python file removed / renamed via `git mv`
 - [ ] New Python file has all `OldName` / `OldClass` occurrences replaced
 - [ ] `config.yaml` skill `name` and `expected_output` updated
-- [ ] `config.yaml` symbol `name` and `alias` updated
+- [ ] `config.yaml` symbol `name` and `alias` updated (alias uses `::` — needs separate sed expression)
 - [ ] `config.yaml` downstream `expected_input` entries updated (if any)
 - [ ] `config.yaml` `skip_if_exists` entries updated (if any)
 - [ ] All `bin/*/OldName.*.yaml` files renamed to `NewName.*.yaml`
 - [ ] `func_name` (and `vtable_name`) fields inside output YAMLs updated
-- [ ] Reference YAMLs in `ida_preprocessor_scripts/references/` updated (if any)
+- [ ] Reference YAMLs in `ida_preprocessor_scripts/references/` renamed and/or updated (if any)
 - [ ] Test files in `tests/` bulk-replaced; vtable class in assertions corrected (if any)
 - [ ] Downstream preprocessor script `.py` and `config.yaml` entries updated (if any)
 - [ ] Final grep shows zero stale references
+- [ ] All changes committed to git
 
 ---
 
@@ -294,3 +335,42 @@ No downstream dependents, no reference YAMLs, no test files hit.
 5. `sed -i` on both reference YAML files (comments in IDA disassembly snippets)
 6. `sed -i` bulk replace across both test files; then manually fixed `func_vtable_relations`
    assertion: `("CLoopTypeBase_DeallocateLoopMode", "ILoopType")` → `(..., "CLoopTypeBase")`
+
+---
+
+### Batch (two renames at once, compound script name, downstream INHERIT_VFUNCS, reference YAML rename)
+
+**User says:** Rename `IGameSystemFactory_Allocate` → `IGameSystemFactory_CreateGameSystem`
+and `IGameSystemFactory_Deallocate` → `IGameSystemFactory_DestroyGameSystem`.
+
+**Affected files found (both symbols combined):**
+- `ida_preprocessor_scripts/find-IGameSystemFactory_Allocate-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName.py`
+- `ida_preprocessor_scripts/find-IGameSystem_GetName-AND-IGameSystemFactory_Deallocate.py`
+- `config.yaml` (2 skill entries, 2 symbol entries, 1 downstream `expected_input`)
+- `bin/*/client/IGameSystemFactory_Allocate.{platform}.yaml` (34 files)
+- `bin/*/client/IGameSystemFactory_Deallocate.{platform}.yaml` (34 files)
+- `ida_preprocessor_scripts/references/client/IGameSystem_AddByName.{windows,linux}.yaml` (content only)
+- `ida_preprocessor_scripts/references/client/IGameSystem_DestroyAllGameSystems.{windows,linux}.yaml` (content only)
+- `ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl.py`
+  (downstream: `INHERIT_VFUNCS` `base_vfunc_name` = `"../client/IGameSystemFactory_Deallocate"`)
+- `tests/test_ida_preprocessor_scripts.py`
+
+**Key observations:**
+
+- The Allocate script name is compound (`-AND-`): only `IGameSystemFactory_Allocate` changes in
+  the filename, the rest stays.
+- `config.yaml` aliases are `IGameSystemFactory::Allocate` / `IGameSystemFactory::Deallocate` —
+  a plain `s/IGameSystemFactory_Allocate/...` sed will not touch them; need separate `-e` clauses:
+  ```bash
+  sed -i \
+    -e 's/IGameSystemFactory_Allocate/IGameSystemFactory_CreateGameSystem/g' \
+    -e 's/IGameSystemFactory::Allocate/IGameSystemFactory::CreateGameSystem/g' \
+    -e 's/IGameSystemFactory_Deallocate/IGameSystemFactory_DestroyGameSystem/g' \
+    -e 's/IGameSystemFactory::Deallocate/IGameSystemFactory::DestroyGameSystem/g' \
+    config.yaml
+  ```
+- The downstream script's `INHERIT_VFUNCS` has `base_vfunc_name = "../client/IGameSystemFactory_Deallocate"` —
+  a plain `s/IGameSystemFactory_Deallocate/IGameSystemFactory_DestroyGameSystem/g` on that file catches it.
+- Reference YAMLs for these symbols are named after a different symbol (AddByName, DestroyAllGameSystems) —
+  content-only update, no file rename needed.
+- Both renames were batched in a single commit.

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 cs2_depot
 bin
 vcall_finder
+.codex/skills
+.agents/skills

--- a/.serena/memories/func_xrefs.md
+++ b/.serena/memories/func_xrefs.md
@@ -20,6 +20,7 @@
 - `ida_analyze_util.py` - `_filter_func_addrs_by_signature_via_mcp`
 - `ida_analyze_util.py` - `_filter_func_addrs_by_float_xrefs_via_mcp`
 - `ida_analyze_util.py` - `_normalize_float_xref_values`
+- `ida_analyze_util.py` - `_collect_single_call_or_jump_xref_func_starts_for_ea`
 - `tests/test_ida_analyze_util.py` - xref/signature/vtable/float filter coverage for the contract
 - `tests/test_ida_preprocessor_scripts.py` - script-level forwarding coverage for `func_xrefs`
 
@@ -28,7 +29,7 @@
 
 When a function is processed, `_try_preprocess_func_without_llm` first attempts `preprocess_func_sig_via_mcp`. If that fails and the function has a `func_xrefs` spec, it falls back to `preprocess_func_xrefs_via_mcp`. `_can_probe_future_func_fast_path` is checked earlier for LLM-assisted flows so that YAML-backed `xref_funcs` / symbolic `xref_gvs` dependencies are not probed before their current-version YAML files exist.
 
-`preprocess_func_xrefs_via_mcp` builds positive candidate sets from `xref_strings`, `xref_gvs`, `xref_signatures`, `xref_funcs`, and optional `vtable_class` entries. It intersects those sets, subtracts `exclude_funcs`, `exclude_strings`, and `exclude_gvs`, then applies `exclude_signatures` and readonly scalar float filters. The result must collapse to exactly one function start before YAML data is emitted.
+`preprocess_func_xrefs_via_mcp` builds positive candidate sets from `xref_strings`, `xref_gvs`, `xref_signatures`, `xref_funcs`, `inline_alias`, and optional `vtable_class` entries. It intersects those sets, subtracts `exclude_funcs`, `exclude_strings`, and `exclude_gvs`, then applies `exclude_signatures` and readonly scalar float filters. The result must collapse to exactly one function start before YAML data is emitted.
 
 ```mermaid
 flowchart TD
@@ -38,7 +39,7 @@ flowchart TD
     D --> E{"func_sig path succeeded?"}
     E -- Yes --> F["Emit function YAML"]
     E -- No --> G["preprocess_func_xrefs_via_mcp"]
-    G --> H["Collect positive candidate sets from strings, gvs, signatures, funcs, and optional vtable entries"]
+    G --> H["Collect positive candidate sets from strings, gvs, signatures, funcs, inline_alias, and optional vtable entries"]
     H --> I["Intersect candidates"]
     I --> J["Subtract exclude funcs, strings, and gvs"]
     J --> K["Apply exclude signatures and float filters"]
@@ -55,8 +56,9 @@ flowchart TD
 
 ## Notes
 - Only dict-style specs are accepted now; the older tuple schema is rejected.
-- Supported keys are `func_name`, `xref_strings`, `xref_gvs`, `xref_signatures`, `xref_funcs`, `xref_floats`, `exclude_funcs`, `exclude_strings`, `exclude_gvs`, `exclude_signatures`, and `exclude_floats`.
-- At least one positive source among `xref_strings`, `xref_gvs`, `xref_signatures`, and `xref_funcs` is required. `xref_floats` and `exclude_floats` are post-intersection filters, not positive candidate sources.
+- Supported keys are `func_name`, `xref_strings`, `xref_gvs`, `xref_signatures`, `xref_funcs`, `inline_alias`, `xref_floats`, `exclude_funcs`, `exclude_strings`, `exclude_gvs`, `exclude_signatures`, and `exclude_floats`.
+- At least one positive source among `xref_strings`, `xref_gvs`, `xref_signatures`, `xref_funcs`, and `inline_alias` is required. `xref_floats` and `exclude_floats` are post-intersection filters, not positive candidate sources.
+- `inline_alias` is a string naming a well-known function that must have a current-version YAML. It uses `_collect_single_call_or_jump_xref_func_starts_for_ea` to find functions containing exactly one call or jump to the alias — targeting thunk/wrapper patterns. If no single-call caller exists, the alias function address itself becomes the sole candidate (covering the case where the target is the alias function inlined directly). Unlike `xref_funcs` which collects all callers regardless of call count, `inline_alias` is stricter: only functions with a single call/jump to the alias qualify.
 - `xref_strings` uses substring matching by default; the `FULLMATCH:` prefix switches a string entry to exact matching.
 - `xref_signatures` first probes within already narrowed candidates when the candidate set is small enough; otherwise it falls back to a global `find_bytes` search.
 - Symbolic `xref_gvs` / `exclude_gvs` and all `xref_funcs` / `exclude_funcs` require current-version YAML artifacts in `new_binary_dir`. Explicit `0x...` gv addresses bypass that YAML lookup.

--- a/config.yaml
+++ b/config.yaml
@@ -600,6 +600,18 @@ modules:
         expected_input:
           - CGameResourceService_BuildResourceManifest.{platform}.yaml
 
+      - name: find-CGameResourceService_GetResourceManifestDebugName
+        expected_output:
+          - CGameResourceService_GetResourceManifestDebugName.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
+      - name: find-CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+        expected_output:
+          - CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
       - name: find-CNetworkGameServerBase_SendPeerList
         expected_output:
           - CNetworkGameServerBase_SendPeerList.{platform}.yaml
@@ -1332,6 +1344,16 @@ modules:
         category: vfunc
         alias:
           - CGameResourceService::LoadGameResourceManifestGroup
+
+      - name: CGameResourceService_GetResourceManifestDebugName
+        category: vfunc
+        alias:
+          - CGameResourceService::GetResourceManifestDebugName
+
+      - name: CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
+        category: vfunc
+        alias:
+          - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
 
       - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2845,6 +2845,14 @@ modules:
         expected_output:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
 
+      - name: find-IGameResourceService_SetEntityResourceManifestHandler-AND-g_pGameResourceService-AND-g_pGameEntitySystem
+        expected_output:
+          - IGameResourceService_SetEntityResourceManifestHandler.{platform}.yaml
+          - g_pGameResourceService.{platform}.yaml
+          - g_pGameEntitySystem.{platform}.yaml
+        expected_input:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
+
       - name: find-CSkeletonInstance_vtable
         expected_output:
           - CSkeletonInstance_vtable.{platform}.yaml
@@ -3754,6 +3762,17 @@ modules:
         category: gv
 
       - name: g_pGameResourceServiceServer
+        category: gv
+
+      - name: IGameResourceService_SetEntityResourceManifestHandler
+        category: vfunc
+        alias:
+          - IGameResourceService::SetEntityResourceManifestHandler
+
+      - name: g_pGameResourceService
+        category: gv
+
+      - name: g_pGameEntitySystem
         category: gv
 
       - name: g_pSource2EngineToClient
@@ -5854,6 +5873,14 @@ modules:
 
       - name: find-CSource2EntitySystem_StaticInit
         expected_output:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
+
+      - name: find-IGameResourceService_SetEntityResourceManifestHandler-AND-g_pGameResourceService-AND-g_pGameEntitySystem
+        expected_output:
+          - IGameResourceService_SetEntityResourceManifestHandler.{platform}.yaml
+          - g_pGameResourceService.{platform}.yaml
+          - g_pGameEntitySystem.{platform}.yaml
+        expected_input:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
 
       - name: find-INetworkMessages_SetNetworkSerializationContextData-AND-IFlattenedSerializers_CreateFieldChangedEventQueue
@@ -9602,6 +9629,17 @@ modules:
         category: gv
 
       - name: g_pGameResourceServiceServer
+        category: gv
+
+      - name: IGameResourceService_SetEntityResourceManifestHandler
+        category: vfunc
+        alias:
+          - IGameResourceService::SetEntityResourceManifestHandler
+
+      - name: g_pGameResourceService
+        category: gv
+
+      - name: g_pGameEntitySystem
         category: gv
 
       - name: g_pSource2EngineToClient

--- a/config.yaml
+++ b/config.yaml
@@ -2888,6 +2888,19 @@ modules:
         expected_input:
           - CGameSystemReallocatingFactory_CSource2EntitySystem_Init.{platform}.yaml
 
+      - name: find-CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+        expected_output:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.{platform}.yaml
+        expected_input:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
+          - IGameSystemFactory_CreateGameSystem.{platform}.yaml
+
+      - name: find-IGameSystemFactory_SetGlobalPtr
+        expected_output:
+          - IGameSystemFactory_SetGlobalPtr.{platform}.yaml
+        expected_input:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.{platform}.yaml
+
       - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl
         expected_output:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml
@@ -3537,6 +3550,11 @@ modules:
         alias:
           - IGameSystemFactory::Shutdown
 
+      - name: IGameSystemFactory_SetGlobalPtr
+        category: vfunc
+        alias:
+          - IGameSystemFactory::SetGlobalPtr
+
       - name: CPrediction_vtable
         category: vtable
 
@@ -3610,6 +3628,11 @@ modules:
         category: vfunc
         alias:
           - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+        category: vfunc
+        alias:
+          - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
 
       - name: CSkeletonInstance
         category: struct
@@ -6851,6 +6874,11 @@ modules:
         alias:
           - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
 
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+        category: vfunc
+        alias:
+          - CGameSystemReallocatingFactory<CSource2EntitySystem>::CreateGameSystem
+
       - name: IGameSystemFactory_Init
         category: vfunc
         alias:
@@ -6860,6 +6888,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::Shutdown
+
+      - name: IGameSystemFactory_SetGlobalPtr
+        category: vfunc
+        alias:
+          - IGameSystemFactory::SetGlobalPtr
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -10478,6 +10478,7 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - server # bin/{gamever}/server/CEntityInstance_*.{platform}.yaml
+      - client # bin/{gamever}/client/CEntityInstance_*.{platform}.yaml
 
   - name: IGameSystem_MSVC
     symbol: IGameSystem

--- a/config.yaml
+++ b/config.yaml
@@ -5578,6 +5578,12 @@ modules:
         expected_input:
           - CBaseEntity_vdtor.{platform}.yaml
 
+      - name: find-CEntityInstance_Spawn
+        expected_output:
+          - CEntityInstance_Spawn.{platform}.yaml
+        expected_input:
+          - CFlashbangProjectile_Spawn.{platform}.yaml
+
       - name: find-CEntFireOutputAutoCompletionFunctor_FireOutput
         expected_output:
           - CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml
@@ -9504,6 +9510,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::GetScriptDesc
+
+      - name: CEntityInstance_Spawn
+        category: vfunc
+        alias:
+          - CEntityInstance::Spawn
 
       - name: CEntityInstance_Precache
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2427,6 +2427,10 @@ modules:
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
 
+      - name: find-CLoopModeFactory_CLoopModeGame_vtable
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+
       - name: find-CLoopModeGame_StaticInit
         expected_output:
           - CLoopModeGame_StaticInit.{platform}.yaml
@@ -3138,6 +3142,9 @@ modules:
           - CLoopModeGame::StaticInit
 
       - name: CLoopModeGame_vtable
+        category: vtable
+
+      - name: CLoopModeFactory_CLoopModeGame_vtable
         category: vtable
 
       - name: CLoopModeGame_OnLoopActivate
@@ -6159,6 +6166,10 @@ modules:
       - name: find-CLoopModeGame_vtable
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
+
+      - name: find-CLoopModeFactory_CLoopModeGame_vtable
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
 
       - name: find-CLoopModeGame_StaticInit
         expected_output:
@@ -9287,6 +9298,9 @@ modules:
           - CLoopModeGame::StaticInit
 
       - name: CLoopModeGame_vtable
+        category: vtable
+
+      - name: CLoopModeFactory_CLoopModeGame_vtable
         category: vtable
 
       - name: CLoopModeGame_OnLoopActivate

--- a/config.yaml
+++ b/config.yaml
@@ -5584,6 +5584,12 @@ modules:
         expected_input:
           - CFlashbangProjectile_Spawn.{platform}.yaml
 
+      - name: find-CEntityInstance_Activate
+        expected_output:
+          - CEntityInstance_Activate.{platform}.yaml
+        expected_input:
+          - CPhysExplosion_Activate.{platform}.yaml
+
       - name: find-CEntFireOutputAutoCompletionFunctor_FireOutput
         expected_output:
           - CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml
@@ -9515,6 +9521,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::Spawn
+
+      - name: CEntityInstance_Activate
+        category: vfunc
+        alias:
+          - CEntityInstance::Activate
 
       - name: CEntityInstance_Precache
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2908,10 +2908,10 @@ modules:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
           - ../client/IGameSystemFactory_DestroyGameSystem.{platform}.yaml
 
-      - name: find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_dtor
+      - name: find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_vdtor
         expected_output:
           - IGameSystem_SetGameSystemGlobalPtrs.{platform}.yaml
-          - IGameSystem_dtor.{platform}.yaml
+          - IGameSystem_vdtor.{platform}.yaml
         expected_input:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml
 
@@ -6934,7 +6934,7 @@ modules:
         alias:
           - IGameSystem::SetGameSystemGlobalPtrs
 
-      - name: IGameSystem_dtor
+      - name: IGameSystem_vdtor
         category: vfunc
         alias:
           - IGameSystem::~IGameSystem

--- a/config.yaml
+++ b/config.yaml
@@ -4750,6 +4750,18 @@ modules:
         expected_input:
           - CSource2Server_Shutdown.{platform}.yaml
 
+      - name: find-IEngineServiceMgr_UnregisterLoopMode
+        expected_output:
+          - IEngineServiceMgr_UnregisterLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeRegistry_UnregisterLoopModes.{platform}.yaml
+
+      - name: find-IEngineServiceMgr_UnregisterEngineService
+        expected_output:
+          - IEngineServiceMgr_UnregisterEngineService.{platform}.yaml
+        expected_input:
+          - CEngineServiceRegistry_UnregisterEngineServices.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -7709,6 +7721,16 @@ modules:
         category: func
         alias:
           - CEngineServiceRegistry::UnregisterEngineServices
+
+      - name: IEngineServiceMgr_UnregisterLoopMode
+        category: vfunc
+        alias:
+          - IEngineServiceMgr::UnregisterLoopMode
+
+      - name: IEngineServiceMgr_UnregisterEngineService
+        category: vfunc
+        alias:
+          - IEngineServiceMgr::UnregisterEngineService
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -1117,6 +1117,12 @@ modules:
         expected_input:
           - CEngineServiceMgr_vtable.{platform}.yaml
 
+      - name: find-CEngineServiceMgr_RegisterLoopMode
+        expected_output:
+          - CEngineServiceMgr_RegisterLoopMode.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+
       - name: find-CEngineServiceMgr__MainLoop
         expected_output:
           - CEngineServiceMgr__MainLoop.{platform}.yaml
@@ -1907,6 +1913,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServiceMgr::RegisterEngineService
+
+      - name: CEngineServiceMgr_RegisterLoopMode
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::RegisterLoopMode
 
       - name: CEngineServiceMgr__MainLoop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -1017,9 +1017,9 @@ modules:
         expected_input:
           - CLoopTypeClientServer_LoopTypeInit.{platform}.yaml
 
-      - name: find-CLoopTypeClientServer_FrameUpdate
+      - name: find-CLoopTypeClientServer_Update
         expected_output:
-          - CLoopTypeClientServer_FrameUpdate.{platform}.yaml
+          - CLoopTypeClientServer_Update.{platform}.yaml
         expected_input:
           - CLoopTypeClientServer_vtable.{platform}.yaml
 
@@ -1047,9 +1047,9 @@ modules:
           - CLoopTypeClientServer_vtable.{platform}.yaml
           - CLoopTypeClientServer_WritePerfStats.{platform}.yaml
 
-      - name: find-CLoopTypeClientServer_EngineLoop
+      - name: find-CLoopTypeClientServer_OutputListeners
         expected_output:
-          - CLoopTypeClientServer_EngineLoop.{platform}.yaml
+          - CLoopTypeClientServer_OutputListeners.{platform}.yaml
         expected_input:
           - CLoopTypeClientServer_vtable.{platform}.yaml
 
@@ -1057,13 +1057,13 @@ modules:
         expected_output:
           - CLoopTypeBase_EngineLoop.{platform}.yaml
         expected_input:
-          - CLoopTypeClientServer_EngineLoop.{platform}.yaml
+          - CLoopTypeClientServer_OutputListeners.{platform}.yaml
 
       - name: find-CLoopTypeBase_FrameUpdate
         expected_output:
           - CLoopTypeBase_FrameUpdate.{platform}.yaml
         expected_input:
-          - CLoopTypeClientServer_FrameUpdate.{platform}.yaml
+          - CLoopTypeClientServer_Update.{platform}.yaml
 
       - name: find-CLoopTypeBase_ActivateLoop
         expected_output:
@@ -1828,10 +1828,10 @@ modules:
         alias:
           - CLoopTypeClientServer::LoopTypeInit
 
-      - name: CLoopTypeClientServer_FrameUpdate
+      - name: CLoopTypeClientServer_Update
         category: vfunc
         alias:
-          - CLoopTypeClientServer::FrameUpdate
+          - CLoopTypeClientServer::Update
 
       - name: CLoopTypeClientServer_ActivateLoop
         category: vfunc
@@ -1853,10 +1853,10 @@ modules:
         alias:
           - CLoopTypeClientServer::DeactivateLoop
 
-      - name: CLoopTypeClientServer_EngineLoop
+      - name: CLoopTypeClientServer_OutputListeners
         category: vfunc
         alias:
-          - CLoopTypeClientServer::EngineLoop
+          - CLoopTypeClientServer::OutputListeners
 
       - name: CLoopTypeSimple_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -2521,6 +2521,13 @@ modules:
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
           - ../engine/ILoopModeFactory_Shutdown.{platform}.yaml
 
+      - name: find-IEngineServiceMgr_GetEventDispatcher-AND-IGameSystem_ShutdownAllSystems
+        expected_output:
+          - IEngineServiceMgr_GetEventDispatcher.{platform}.yaml
+          - IGameSystem_ShutdownAllSystems.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
+
       - name: find-CEntityInstance_vtable
         expected_output:
           - CEntityInstance_vtable.{platform}.yaml
@@ -3368,6 +3375,11 @@ modules:
         alias:
           - IGameSystem::DestroyAllGameSystems
 
+      - name: IGameSystem_ShutdownAllSystems
+        category: func
+        alias:
+          - IGameSystem::ShutdownAllSystems
+
       - name: IGameSystem_LoopDestroyAllSystems
         category: func
         alias:
@@ -3506,6 +3518,11 @@ modules:
         category: vfunc
         alias:
           - IEngineServiceMgr::GetActiveLoopClientServerMode
+
+      - name: IEngineServiceMgr_GetEventDispatcher
+        category: vfunc
+        alias:
+          - IEngineServiceMgr::GetEventDispatcher
 
       - name: CAM_Command_CommandHandler
         category: func
@@ -6323,6 +6340,13 @@ modules:
         expected_input:
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
           - ../engine/ILoopModeFactory_Shutdown.{platform}.yaml
+
+      - name: find-IEngineServiceMgr_GetEventDispatcher-AND-IGameSystem_ShutdownAllSystems
+        expected_output:
+          - IEngineServiceMgr_GetEventDispatcher.{platform}.yaml
+          - IGameSystem_ShutdownAllSystems.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
 
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
@@ -9604,6 +9628,11 @@ modules:
         category: func
         alias:
           - IGameSystem::DestroyAllGameSystems
+
+      - name: IGameSystem_ShutdownAllSystems
+        category: func
+        alias:
+          - IGameSystem::ShutdownAllSystems
 
       - name: IGameSystem_LoopDestroyAllSystems
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -618,6 +618,12 @@ modules:
         expected_input:
           - CGameResourceService_vtable.{platform}.yaml
 
+      - name: find-CGameResourceService_DescribeContents
+        expected_output:
+          - CGameResourceService_DescribeContents.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
       - name: find-CNetworkGameServerBase_SendPeerList
         expected_output:
           - CNetworkGameServerBase_SendPeerList.{platform}.yaml
@@ -1365,6 +1371,11 @@ modules:
         category: vfunc
         alias:
           - CGameResourceService::LoadGameResourceManifest
+
+      - name: CGameResourceService_DescribeContents
+        category: vfunc
+        alias:
+          - CGameResourceService::DescribeContents
 
       - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2689,14 +2689,19 @@ modules:
         expected_input:
           - IGameSystem_PostInit.{platform}.yaml
 
-      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority
+      - name: find-IGameSystem_LoopInitAllSystems
         expected_output:
+          - IGameSystem_LoopInitAllSystems.{platform}.yaml
+
+      - name: find-IGameSystemFactory_ShouldAutoAdd-AND-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority
+        expected_output:
+          - IGameSystemFactory_ShouldAutoAdd.{platform}.yaml
           - IGameSystemFactory_CreateGameSystem.{platform}.yaml
           - IGameSystemFactory_IsReallocating.{platform}.yaml
           - IGameSystem_SetName.{platform}.yaml
           - IGameSystemFactory_GetPriority.{platform}.yaml
         expected_input:
-          - IGameSystem_AddByName.{platform}.yaml
+          - IGameSystem_LoopInitAllSystems.{platform}.yaml
 
       - name: find-IGameSystem_DestroyAllGameSystems-AND-IGameSystem_LoopDestroyAllSystems-AND-IGameSystem_LoopPreShutdownAllSystems
         expected_output:
@@ -3351,6 +3356,11 @@ modules:
         alias:
           - IGameSystem::InitAllSystems
 
+      - name: IGameSystem_LoopInitAllSystems
+        category: func
+        alias:
+          - IGameSystem::LoopInitAllSystems
+
       - name: IGameSystemFactory_PostInit
         category: vfunc
         alias:
@@ -3360,6 +3370,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::GetStaticGameSystem
+
+      - name: IGameSystemFactory_ShouldAutoAdd
+        category: vfunc
+        alias:
+          - IGameSystemFactory::ShouldAutoAdd
 
       - name: IGameSystemFactory_CreateGameSystem
         category: vfunc
@@ -5259,6 +5274,10 @@ modules:
           - IGameSystem_InitAllSystems_pFirst.{platform}.yaml
         expected_input:
           - IGameSystem_InitAllSystems.{platform}.yaml
+
+      - name: find-IGameSystem_LoopInitAllSystems
+        expected_output:
+          - IGameSystem_LoopInitAllSystems.{platform}.yaml
 
       - name: find-IGameSystem_LoopPostInitAllSystems
         expected_output:
@@ -8139,6 +8158,11 @@ modules:
         alias:
           - IGameSystem::InitAllSystems
 
+      - name: IGameSystem_LoopInitAllSystems
+        category: func
+        alias:
+          - IGameSystem::LoopInitAllSystems
+
       - name: IGameSystem_LoopPostInitAllSystems
         category: func
         alias:
@@ -10471,6 +10495,33 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - engine # bin/{gamever}/engine/CLoopTypeClientServer_*.{platform}.yaml
+
+  - name: IGameSystemFactory_MSVC
+    symbol: IGameSystemFactory
+    cpp: cpp_tests/igamesystemfactory.cpp
+    headers:
+    - hl2sdk_cs2/game/shared/igamesystemfactory.h # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - server # bin/{gamever}/server/IGameSystemFactory_*.{platform}.yaml
+      - client # bin/{gamever}/client/IGameSystemFactory_*.{platform}.yaml
 
   - name: SDL_Mouse_MSVC
     symbol: SDL_Mouse

--- a/config.yaml
+++ b/config.yaml
@@ -2562,11 +2562,12 @@ modules:
         expected_input:
           - CLoopModeGame_ReceivedServerInfo.{platform}.yaml
 
-      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName
+      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority
         expected_output:
           - IGameSystemFactory_CreateGameSystem.{platform}.yaml
           - IGameSystemFactory_IsReallocating.{platform}.yaml
           - IGameSystem_SetName.{platform}.yaml
+          - IGameSystemFactory_GetPriority.{platform}.yaml
         expected_input:
           - IGameSystem_AddByName.{platform}.yaml
 
@@ -3340,6 +3341,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::Init
+
+      - name: IGameSystemFactory_GetPriority
+        category: vfunc
+        alias:
+          - IGameSystemFactory::GetPriority
 
       - name: CPrediction_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -630,6 +630,26 @@ modules:
         expected_input:
           - CGameResourceService_vtable.{platform}.yaml
 
+      - name: find-CGameResourceService_RegisterEventMapInternal-windows
+        platform: windows
+        expected_output:
+          - CGameResourceService_RegisterEventMapInternal.{platform}.yaml
+
+      - name: find-CGameResourceService_RegisterEventMap-windows
+        platform: windows
+        expected_output:
+          - CGameResourceService_RegisterEventMap.{platform}.yaml
+        expected_input:
+          - CGameResourceService_RegisterEventMapInternal.{platform}.yaml
+          - CGameResourceService_vtable.{platform}.yaml
+
+      - name: find-CGameResourceService_RegisterEventMap-linux
+        platform: linux
+        expected_output:
+          - CGameResourceService_RegisterEventMap.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
       - name: find-CNetworkGameServerBase_SendPeerList
         expected_output:
           - CNetworkGameServerBase_SendPeerList.{platform}.yaml
@@ -1387,6 +1407,16 @@ modules:
         category: vfunc
         alias:
           - CGameResourceService::AppendToGameResourceManifest
+
+      - name: CGameResourceService_RegisterEventMapInternal
+        category: func
+        alias:
+          - CGameResourceService::RegisterEventMapInternal
+
+      - name: CGameResourceService_RegisterEventMap
+        category: vfunc
+        alias:
+          - CGameResourceService::RegisterEventMap
 
       - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -5572,6 +5572,12 @@ modules:
           - CBaseEntity_dtor.{platform}.yaml
           - CBaseEntity_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_vdtor
+        expected_output:
+          - CEntityInstance_vdtor.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vdtor.{platform}.yaml
+
       - name: find-CEntFireOutputAutoCompletionFunctor_FireOutput
         expected_output:
           - CEntFireOutputAutoCompletionFunctor_FireOutput.{platform}.yaml
@@ -7114,6 +7120,11 @@ modules:
         category: vfunc
         alias:
           - CBaseEntity::~CBaseEntity (virtual)
+
+      - name: CEntityInstance_vdtor
+        category: vfunc
+        alias:
+          - CEntityInstance::~CEntityInstance (virtual)
 
       - name: CEntitySaveRestoreBlockHandler_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -2514,6 +2514,13 @@ modules:
           - CLoopModeGame_StaticInit.{platform}.yaml
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
 
+      - name: find-CLoopModeFactory_CLoopModeGame_Shutdown
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+          - ../engine/ILoopModeFactory_Shutdown.{platform}.yaml
+
       - name: find-CEntityInstance_vtable
         expected_output:
           - CEntityInstance_vtable.{platform}.yaml
@@ -3230,6 +3237,11 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+
+      - name: CLoopModeFactory_CLoopModeGame_Shutdown
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::Shutdown
 
       - name: CLoopModeGame_OnLoopActivate
         category: vfunc
@@ -6304,6 +6316,13 @@ modules:
         expected_input:
           - CLoopModeGame_StaticInit.{platform}.yaml
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+
+      - name: find-CLoopModeFactory_CLoopModeGame_Shutdown
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+          - ../engine/ILoopModeFactory_Shutdown.{platform}.yaml
 
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
@@ -9477,6 +9496,11 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+
+      - name: CLoopModeFactory_CLoopModeGame_Shutdown
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::Shutdown
 
       - name: CLoopModeGame_OnLoopActivate
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4723,6 +4723,18 @@ modules:
         expected_input:
           - CSource2Server_Connect.{platform}.yaml
 
+      - name: find-CSource2Server_PreShutdown
+        expected_output:
+          - CSource2Server_PreShutdown.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+
+      - name: find-IAppSystem_PreShutdown
+        expected_output:
+          - IAppSystem_PreShutdown.{platform}.yaml
+        expected_input:
+          - CSource2Server_PreShutdown.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -7648,10 +7660,20 @@ modules:
         alias:
           - CSource2Server::Connect
 
+      - name: CSource2Server_PreShutdown
+        category: vfunc
+        alias:
+          - CSource2Server::PreShutdown
+
       - name: IAppSystem_Connect
         category: vfunc
         alias:
           - IAppSystem::Connect
+
+      - name: IAppSystem_PreShutdown
+        category: vfunc
+        alias:
+          - IAppSystem::PreShutdown
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2566,6 +2566,13 @@ modules:
         expected_output:
           - IGameSystem_PostInit.{platform}.yaml
 
+      - name: find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem
+        expected_output:
+          - IGameSystemFactory_PostInit.{platform}.yaml
+          - IGameSystemFactory_GetStaticGameSystem.{platform}.yaml
+        expected_input:
+          - IGameSystem_PostInit.{platform}.yaml
+
       - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority
         expected_output:
           - IGameSystemFactory_CreateGameSystem.{platform}.yaml
@@ -3204,6 +3211,16 @@ modules:
         category: func
         alias:
           - IGameSystem::PostInit
+
+      - name: IGameSystemFactory_PostInit
+        category: vfunc
+        alias:
+          - IGameSystemFactory::PostInit
+
+      - name: IGameSystemFactory_GetStaticGameSystem
+        category: vfunc
+        alias:
+          - IGameSystemFactory::GetStaticGameSystem
 
       - name: IGameSystemFactory_CreateGameSystem
         category: vfunc
@@ -5056,6 +5073,13 @@ modules:
 
       - name: find-IGameSystem_PostInit
         expected_output:
+          - IGameSystem_PostInit.{platform}.yaml
+
+      - name: find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem
+        expected_output:
+          - IGameSystemFactory_PostInit.{platform}.yaml
+          - IGameSystemFactory_GetStaticGameSystem.{platform}.yaml
+        expected_input:
           - IGameSystem_PostInit.{platform}.yaml
 
       - name: find-IGameSystem_LoopPostInitAllSystems_pEventDispatcher-AND-IGameSystem_LoopDestroyAllSystems_s_GameSystems
@@ -7851,6 +7875,16 @@ modules:
         category: func
         alias:
           - IGameSystem::PostInit
+
+      - name: IGameSystemFactory_PostInit
+        category: vfunc
+        alias:
+          - IGameSystemFactory::PostInit
+
+      - name: IGameSystemFactory_GetStaticGameSystem
+        category: vfunc
+        alias:
+          - IGameSystemFactory::GetStaticGameSystem
 
       - name: IGameSystem_InitAllSystems_pFirst
         category: gv

--- a/config.yaml
+++ b/config.yaml
@@ -4742,6 +4742,14 @@ modules:
           - CSource2Server_vtable.{platform}.yaml
           - ../engine/IAppSystem_Shutdown.{platform}.yaml
 
+      - name: find-CGameEventManager_Shutdown-AND-CLoopModeRegistry_UnregisterLoopModes-AND-CEngineServiceRegistry_UnregisterEngineServices
+        expected_output:
+          - CGameEventManager_Shutdown.{platform}.yaml
+          - CLoopModeRegistry_UnregisterLoopModes.{platform}.yaml
+          - CEngineServiceRegistry_UnregisterEngineServices.{platform}.yaml
+        expected_input:
+          - CSource2Server_Shutdown.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -7686,6 +7694,21 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::Shutdown
+
+      - name: CGameEventManager_Shutdown
+        category: func
+        alias:
+          - CGameEventManager::Shutdown
+
+      - name: CLoopModeRegistry_UnregisterLoopModes
+        category: func
+        alias:
+          - CLoopModeRegistry::UnregisterLoopModes
+
+      - name: CEngineServiceRegistry_UnregisterEngineServices
+        category: func
+        alias:
+          - CEngineServiceRegistry::UnregisterEngineServices
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -624,6 +624,12 @@ modules:
         expected_input:
           - CGameResourceService_vtable.{platform}.yaml
 
+      - name: find-CGameResourceService_AppendToGameResourceManifest
+        expected_output:
+          - CGameResourceService_AppendToGameResourceManifest.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
       - name: find-CNetworkGameServerBase_SendPeerList
         expected_output:
           - CNetworkGameServerBase_SendPeerList.{platform}.yaml
@@ -1376,6 +1382,11 @@ modules:
         category: vfunc
         alias:
           - CGameResourceService::DescribeContents
+
+      - name: CGameResourceService_AppendToGameResourceManifest
+        category: vfunc
+        alias:
+          - CGameResourceService::AppendToGameResourceManifest
 
       - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2435,6 +2435,13 @@ modules:
         expected_output:
           - CLoopModeGame_StaticInit.{platform}.yaml
 
+      - name: find-CLoopModeFactory_CLoopModeGame_Init
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_Init.{platform}.yaml
+        expected_input:
+          - CLoopModeGame_StaticInit.{platform}.yaml
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+
       - name: find-CEntityInstance_vtable
         expected_output:
           - CEntityInstance_vtable.{platform}.yaml
@@ -3146,6 +3153,11 @@ modules:
 
       - name: CLoopModeFactory_CLoopModeGame_vtable
         category: vtable
+
+      - name: CLoopModeFactory_CLoopModeGame_Init
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::Init
 
       - name: CLoopModeGame_OnLoopActivate
         category: vfunc
@@ -6174,6 +6186,13 @@ modules:
       - name: find-CLoopModeGame_StaticInit
         expected_output:
           - CLoopModeGame_StaticInit.{platform}.yaml
+
+      - name: find-CLoopModeFactory_CLoopModeGame_Init
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_Init.{platform}.yaml
+        expected_input:
+          - CLoopModeGame_StaticInit.{platform}.yaml
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
 
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
@@ -9302,6 +9321,11 @@ modules:
 
       - name: CLoopModeFactory_CLoopModeGame_vtable
         category: vtable
+
+      - name: CLoopModeFactory_CLoopModeGame_Init
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::Init
 
       - name: CLoopModeGame_OnLoopActivate
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2000,6 +2000,11 @@ modules:
         alias:
           - CEngineServiceMgr::GetActiveLoopClientServerMode
 
+      - name: CEngineServiceMgr_GetEventDispatcher
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::GetEventDispatcher
+
       - name: CEngineGameUI_vtable
         category: vtable
 
@@ -2527,6 +2532,12 @@ modules:
           - IGameSystem_ShutdownAllSystems.{platform}.yaml
         expected_input:
           - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
+
+      - name: find-IGameSystemFactory_Shutdown
+        expected_output:
+          - IGameSystemFactory_Shutdown.{platform}.yaml
+        expected_input:
+          - IGameSystem_ShutdownAllSystems.{platform}.yaml
 
       - name: find-CEntityInstance_vtable
         expected_output:
@@ -3505,6 +3516,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::GetPriority
+
+      - name: IGameSystemFactory_Shutdown
+        category: vfunc
+        alias:
+          - IGameSystemFactory::Shutdown
 
       - name: CPrediction_vtable
         category: vtable
@@ -6348,6 +6364,12 @@ modules:
         expected_input:
           - CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml
 
+      - name: find-IGameSystemFactory_Shutdown
+        expected_output:
+          - IGameSystemFactory_Shutdown.{platform}.yaml
+        expected_input:
+          - IGameSystem_ShutdownAllSystems.{platform}.yaml
+
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
           - CLoopModeGame_OnLoopActivate.{platform}.yaml
@@ -6814,6 +6836,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::Init
+
+      - name: IGameSystemFactory_Shutdown
+        category: vfunc
+        alias:
+          - IGameSystemFactory::Shutdown
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
         category: vfunc
@@ -10052,6 +10079,13 @@ modules:
         expected_input:
           - CEngineServiceMgr_vtable.{platform}.yaml
           - ../client/IEngineServiceMgr_GetActiveLoopClientServerMode.{platform}.yaml
+
+      - name: find-CEngineServiceMgr_GetEventDispatcher
+        expected_output:
+          - CEngineServiceMgr_GetEventDispatcher.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+          - ../client/IEngineServiceMgr_GetEventDispatcher.{platform}.yaml
 
       - name: find-CLoopTypeBase_GetClientServerMode
         expected_output:

--- a/config.yaml
+++ b/config.yaml
@@ -2566,6 +2566,10 @@ modules:
         expected_output:
           - IGameSystem_PostInit.{platform}.yaml
 
+      - name: find-IGameSystem_InitAllSystems
+        expected_output:
+          - IGameSystem_InitAllSystems.{platform}.yaml
+
       - name: find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem
         expected_output:
           - IGameSystemFactory_PostInit.{platform}.yaml
@@ -3211,6 +3215,11 @@ modules:
         category: func
         alias:
           - IGameSystem::PostInit
+
+      - name: IGameSystem_InitAllSystems
+        category: func
+        alias:
+          - IGameSystem::InitAllSystems
 
       - name: IGameSystemFactory_PostInit
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4735,6 +4735,13 @@ modules:
         expected_input:
           - CSource2Server_PreShutdown.{platform}.yaml
 
+      - name: find-CSource2Server_Shutdown
+        expected_output:
+          - CSource2Server_Shutdown.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+          - ../engine/IAppSystem_Shutdown.{platform}.yaml
+
       - name: find-CSource2Server_Init
         expected_output:
           - CSource2Server_Init.{platform}.yaml
@@ -7674,6 +7681,11 @@ modules:
         category: vfunc
         alias:
           - IAppSystem::PreShutdown
+
+      - name: CSource2Server_Shutdown
+        category: vfunc
+        alias:
+          - CSource2Server::Shutdown
 
       - name: CSource2Server_GameFrame
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2738,6 +2738,10 @@ modules:
         expected_output:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
 
+      - name: find-CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
+        expected_output:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
+
       - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl
         expected_output:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml
@@ -2821,6 +2825,18 @@ modules:
       - name: find-CEntitySystem_Init
         expected_output:
           - CEntitySystem_Init.{platform}.yaml
+
+      - name: find-CEntitySystem_PostCreateEntitySystem
+        expected_output:
+          - CEntitySystem_PostCreateEntitySystem.{platform}.yaml
+        expected_input:
+          - CEntitySystem_Init.{platform}.yaml
+          - CEntitySystem_ctor.{platform}.yaml
+          - CEntitySystem_CreateEntitySystem.{platform}.yaml
+
+      - name: find-CSource2EntitySystem_StaticInit
+        expected_output:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
 
       - name: find-CSkeletonInstance_vtable
         expected_output:
@@ -3349,6 +3365,19 @@ modules:
         category: func
         alias:
           - CEntitySystem::Init
+
+      - name: CEntitySystem_PostCreateEntitySystem
+        category: func
+        alias:
+          - CEntitySystem::PostCreateEntitySystem
+
+      - name: CSource2EntitySystem_StaticInit
+        category: func
+        alias:
+          - CSource2EntitySystem::StaticInit
+
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
+        category: vtable
 
       - name: CSkeletonInstance
         category: struct
@@ -5539,6 +5568,10 @@ modules:
         expected_output:
           - CSpawnGroupMgrGameSystem_vtable2.{platform}.yaml
 
+      - name: find-CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
+        expected_output:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
+
       - name: find-CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
         expected_output:
           - CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.{platform}.yaml
@@ -5791,6 +5824,18 @@ modules:
           - CEntitySystem_m_sEntSystemName.{platform}.yaml
         expected_input:
           - CEntitySystem_Init.{platform}.yaml
+
+      - name: find-CEntitySystem_PostCreateEntitySystem
+        expected_output:
+          - CEntitySystem_PostCreateEntitySystem.{platform}.yaml
+        expected_input:
+          - CEntitySystem_Init.{platform}.yaml
+          - CEntitySystem_ctor.{platform}.yaml
+          - CEntitySystem_CreateEntitySystem.{platform}.yaml
+
+      - name: find-CSource2EntitySystem_StaticInit
+        expected_output:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
 
       - name: find-INetworkMessages_SetNetworkSerializationContextData-AND-IFlattenedSerializers_CreateFieldChangedEventQueue
         expected_output:
@@ -6443,6 +6488,9 @@ modules:
         category: vtable
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_vtable
+        category: vtable
+
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
         category: vtable
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate
@@ -8871,6 +8919,16 @@ modules:
         category: func
         alias:
           - CEntitySystem::Init
+
+      - name: CEntitySystem_PostCreateEntitySystem
+        category: func
+        alias:
+          - CEntitySystem::PostCreateEntitySystem
+
+      - name: CSource2EntitySystem_StaticInit
+        category: func
+        alias:
+          - CSource2EntitySystem::StaticInit
 
       - name: CEntitySystem_m_sEntSystemName
         category: structmember

--- a/config.yaml
+++ b/config.yaml
@@ -1123,6 +1123,12 @@ modules:
         expected_input:
           - CEngineServiceMgr_vtable.{platform}.yaml
 
+      - name: find-CEngineServiceMgr_SwitchToLoop
+        expected_output:
+          - CEngineServiceMgr_SwitchToLoop.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+
       - name: find-CEngineServiceMgr__MainLoop
         expected_output:
           - CEngineServiceMgr__MainLoop.{platform}.yaml
@@ -1918,6 +1924,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServiceMgr::RegisterLoopMode
+
+      - name: CEngineServiceMgr_SwitchToLoop
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::SwitchToLoop
 
       - name: CEngineServiceMgr__MainLoop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2562,9 +2562,9 @@ modules:
         expected_input:
           - CLoopModeGame_ReceivedServerInfo.{platform}.yaml
 
-      - name: find-IGameSystemFactory_Allocate-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName
+      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName
         expected_output:
-          - IGameSystemFactory_Allocate.{platform}.yaml
+          - IGameSystemFactory_CreateGameSystem.{platform}.yaml
           - IGameSystemFactory_DoesGameSystemReallocate.{platform}.yaml
           - IGameSystem_SetName.{platform}.yaml
         expected_input:
@@ -2705,10 +2705,10 @@ modules:
         expected_output:
           - CSteamworksGameStats_OnReceivedSessionID.{platform}.yaml
 
-      - name: find-IGameSystem_GetName-AND-IGameSystemFactory_Deallocate
+      - name: find-IGameSystem_GetName-AND-IGameSystemFactory_DestroyGameSystem
         expected_output:
           - IGameSystem_GetName.{platform}.yaml
-          - IGameSystemFactory_Deallocate.{platform}.yaml
+          - IGameSystemFactory_DestroyGameSystem.{platform}.yaml
         expected_input:
           - IGameSystem_DestroyAllGameSystems.{platform}.yaml
 
@@ -2749,19 +2749,19 @@ modules:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
           - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
 
-      - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl
+      - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl
         expected_output:
-          - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml
+          - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml
         expected_input:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
-          - ../client/IGameSystemFactory_Deallocate.{platform}.yaml
+          - ../client/IGameSystemFactory_DestroyGameSystem.{platform}.yaml
 
       - name: find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_dtor
         expected_output:
           - IGameSystem_SetGameSystemGlobalPtrs.{platform}.yaml
           - IGameSystem_dtor.{platform}.yaml
         expected_input:
-          - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml
+          - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml
 
       - name: find-CPrediction_vtable
         expected_output:
@@ -3189,10 +3189,10 @@ modules:
         alias:
           - IGameSystem::Add
 
-      - name: IGameSystemFactory_Allocate
+      - name: IGameSystemFactory_CreateGameSystem
         category: vfunc
         alias:
-          - IGameSystemFactory::Allocate
+          - IGameSystemFactory::CreateGameSystem
 
       - name: IGameSystemFactory_DoesGameSystemReallocate
         category: vfunc
@@ -3325,10 +3325,10 @@ modules:
         alias:
           - IGameSystem::GetName
 
-      - name: IGameSystemFactory_Deallocate
+      - name: IGameSystemFactory_DestroyGameSystem
         category: vfunc
         alias:
-          - IGameSystemFactory::Deallocate
+          - IGameSystemFactory::DestroyGameSystem
 
       - name: CPrediction_vtable
         category: vtable
@@ -6544,7 +6544,7 @@ modules:
         alias:
           - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
 
-      - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate
+      - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
         category: vfunc
         alias:
           - CGameSystemReallocatingFactory<CSpawnGroupMgrGameSystem>::Deallocate

--- a/config.yaml
+++ b/config.yaml
@@ -2427,6 +2427,10 @@ modules:
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
 
+      - name: find-CLoopModeGame_StaticInit
+        expected_output:
+          - CLoopModeGame_StaticInit.{platform}.yaml
+
       - name: find-CEntityInstance_vtable
         expected_output:
           - CEntityInstance_vtable.{platform}.yaml
@@ -3127,6 +3131,11 @@ modules:
         category: func
         alias:
           - CLoopModeGame::OnFrameBoundary
+
+      - name: CLoopModeGame_StaticInit
+        category: func
+        alias:
+          - CLoopModeGame::StaticInit
 
       - name: CLoopModeGame_vtable
         category: vtable
@@ -6150,6 +6159,10 @@ modules:
       - name: find-CLoopModeGame_vtable
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
+
+      - name: find-CLoopModeGame_StaticInit
+        expected_output:
+          - CLoopModeGame_StaticInit.{platform}.yaml
 
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
@@ -9267,6 +9280,11 @@ modules:
 
       - name: PhysEnableEntityCollisions
         category: func
+
+      - name: CLoopModeGame_StaticInit
+        category: func
+        alias:
+          - CLoopModeGame::StaticInit
 
       - name: CLoopModeGame_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -2798,6 +2798,13 @@ modules:
         expected_output:
           - CEntitySystem_ctor.{platform}.yaml
 
+      - name: find-CGameEntitySystem_ctor
+        expected_output:
+          - CGameEntitySystem_ctor.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_vtable.{platform}.yaml
+          - CEntitySystem_ctor.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntitySystem
         expected_output:
           - CEntitySystem_CreateEntitySystem.{platform}.yaml
@@ -3326,6 +3333,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::CEntitySystem
+
+      - name: CGameEntitySystem_ctor
+        category: func
+        alias:
+          - CGameEntitySystem::CGameEntitySystem
 
       - name: CEntitySystem_CreateEntitySystem
         category: func
@@ -5748,6 +5760,13 @@ modules:
 
       - name: find-CEntitySystem_ctor
         expected_output:
+          - CEntitySystem_ctor.{platform}.yaml
+
+      - name: find-CGameEntitySystem_ctor
+        expected_output:
+          - CGameEntitySystem_ctor.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_vtable.{platform}.yaml
           - CEntitySystem_ctor.{platform}.yaml
 
       - name: find-CEntitySystem_CreateEntitySystem
@@ -8836,6 +8855,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::CEntitySystem
+
+      - name: CGameEntitySystem_ctor
+        category: func
+        alias:
+          - CGameEntitySystem::CGameEntitySystem
 
       - name: CEntitySystem_CreateEntitySystem
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2562,10 +2562,10 @@ modules:
         expected_input:
           - CLoopModeGame_ReceivedServerInfo.{platform}.yaml
 
-      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName
+      - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName
         expected_output:
           - IGameSystemFactory_CreateGameSystem.{platform}.yaml
-          - IGameSystemFactory_DoesGameSystemReallocate.{platform}.yaml
+          - IGameSystemFactory_IsReallocating.{platform}.yaml
           - IGameSystem_SetName.{platform}.yaml
         expected_input:
           - IGameSystem_AddByName.{platform}.yaml
@@ -2724,7 +2724,7 @@ modules:
         expected_output:
           - CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.{platform}.yaml
         expected_input:
-          - IGameSystemFactory_DoesGameSystemReallocate.{platform}.yaml
+          - IGameSystemFactory_IsReallocating.{platform}.yaml
           - CSpawnGroupMgrGameSystem_vtable2.{platform}.yaml
 
       - name: find-IGameSystem_DoesGameSystemReallocate
@@ -3194,10 +3194,10 @@ modules:
         alias:
           - IGameSystemFactory::CreateGameSystem
 
-      - name: IGameSystemFactory_DoesGameSystemReallocate
+      - name: IGameSystemFactory_IsReallocating
         category: vfunc
         alias:
-          - IGameSystemFactory::DoesGameSystemReallocate
+          - IGameSystemFactory::IsReallocating
 
       - name: IGameSystem_SetName
         category: vfunc
@@ -5614,7 +5614,7 @@ modules:
         expected_output:
           - CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.{platform}.yaml
         expected_input:
-          - ../client/IGameSystemFactory_DoesGameSystemReallocate.{platform}.yaml
+          - ../client/IGameSystemFactory_IsReallocating.{platform}.yaml
           - CSpawnGroupMgrGameSystem_vtable2.{platform}.yaml
 
       - name: find-CSpawnGroupMgrGameSystem_GetSpawnGroups

--- a/config.yaml
+++ b/config.yaml
@@ -2562,6 +2562,10 @@ modules:
         expected_input:
           - CLoopModeGame_ReceivedServerInfo.{platform}.yaml
 
+      - name: find-IGameSystem_PostInit
+        expected_output:
+          - IGameSystem_PostInit.{platform}.yaml
+
       - name: find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority
         expected_output:
           - IGameSystemFactory_CreateGameSystem.{platform}.yaml
@@ -3195,6 +3199,11 @@ modules:
         category: func
         alias:
           - IGameSystem::Add
+
+      - name: IGameSystem_PostInit
+        category: func
+        alias:
+          - IGameSystem::PostInit
 
       - name: IGameSystemFactory_CreateGameSystem
         category: vfunc
@@ -5044,6 +5053,10 @@ modules:
       - name: find-IGameSystem_LoopPostInitAllSystems
         expected_output:
           - IGameSystem_LoopPostInitAllSystems.{platform}.yaml
+
+      - name: find-IGameSystem_PostInit
+        expected_output:
+          - IGameSystem_PostInit.{platform}.yaml
 
       - name: find-IGameSystem_LoopPostInitAllSystems_pEventDispatcher-AND-IGameSystem_LoopDestroyAllSystems_s_GameSystems
         expected_output:
@@ -7833,6 +7846,11 @@ modules:
         category: func
         alias:
           - IGameSystem::LoopPostInitAllSystems
+
+      - name: IGameSystem_PostInit
+        category: func
+        alias:
+          - IGameSystem::PostInit
 
       - name: IGameSystem_InitAllSystems_pFirst
         category: gv

--- a/config.yaml
+++ b/config.yaml
@@ -1123,6 +1123,20 @@ modules:
         expected_input:
           - CEngineServiceMgr_vtable.{platform}.yaml
 
+      - name: find-CEngineServiceMgr_UnregisterLoopMode
+        expected_output:
+          - CEngineServiceMgr_UnregisterLoopMode.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+          - ../server/IEngineServiceMgr_UnregisterLoopMode.{platform}.yaml
+
+      - name: find-CEngineServiceMgr_UnregisterEngineService
+        expected_output:
+          - CEngineServiceMgr_UnregisterEngineService.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+          - ../server/IEngineServiceMgr_UnregisterEngineService.{platform}.yaml
+
       - name: find-CEngineServiceMgr_SwitchToLoop
         expected_output:
           - CEngineServiceMgr_SwitchToLoop.{platform}.yaml
@@ -1930,6 +1944,16 @@ modules:
         category: vfunc
         alias:
           - CEngineServiceMgr::RegisterLoopMode
+
+      - name: CEngineServiceMgr_UnregisterLoopMode
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::UnregisterLoopMode
+
+      - name: CEngineServiceMgr_UnregisterEngineService
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::UnregisterEngineService
 
       - name: CEngineServiceMgr_SwitchToLoop
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -4204,6 +4204,10 @@ modules:
         expected_output:
           - CBaseEntity_vtable.{platform}.yaml
 
+      - name: find-CNetworkTransmitComponent_vtable
+        expected_output:
+          - CNetworkTransmitComponent_vtable.{platform}.yaml
+
       - name: find-CGameSceneNode_vtable
         expected_output:
           - CGameSceneNode_vtable.{platform}.yaml
@@ -5541,6 +5545,32 @@ modules:
       - name: find-CEntFireOutputAutoCompletionFunctor_vtable
         expected_output:
           - CEntFireOutputAutoCompletionFunctor_vtable.{platform}.yaml
+
+      - name: find-CEntityIOOutput_vtable
+        expected_output:
+          - CEntityIOOutput_vtable.{platform}.yaml
+
+      - name: find-CBaseEntity_ctor
+        expected_output:
+          - CBaseEntity_ctor.{platform}.yaml
+        expected_input:
+          - CNetworkTransmitComponent_vtable.{platform}.yaml
+          - CBaseEntity_vtable.{platform}.yaml
+          - CEntityIOOutput_vtable.{platform}.yaml
+
+      - name: find-CBaseEntity_dtor
+        expected_output:
+          - CBaseEntity_dtor.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
+          - CBaseEntity_ctor.{platform}.yaml
+
+      - name: find-CBaseEntity_vdtor
+        expected_output:
+          - CBaseEntity_vdtor.{platform}.yaml
+        expected_input:
+          - CBaseEntity_dtor.{platform}.yaml
+          - CBaseEntity_vtable.{platform}.yaml
 
       - name: find-CEntFireOutputAutoCompletionFunctor_FireOutput
         expected_output:
@@ -7066,6 +7096,24 @@ modules:
 
       - name: CBaseEntity_vtable
         category: vtable
+
+      - name: CNetworkTransmitComponent_vtable
+        category: vtable
+
+      - name: CBaseEntity_ctor
+        category: func
+        alias:
+          - CBaseEntity::CBaseEntity
+
+      - name: CBaseEntity_dtor
+        category: func
+        alias:
+          - CBaseEntity::~CBaseEntity
+
+      - name: CBaseEntity_vdtor
+        category: vfunc
+        alias:
+          - CBaseEntity::~CBaseEntity (virtual)
 
       - name: CEntitySaveRestoreBlockHandler_vtable
         category: vtable
@@ -8787,6 +8835,9 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::ScriptEntityIO
+
+      - name: CEntityIOOutput_vtable
+        category: vtable
 
       - name: CEntityIOOutput_FireOutputInternal
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -1129,6 +1129,12 @@ modules:
         expected_input:
           - CEngineServiceMgr_vtable.{platform}.yaml
 
+      - name: find-CEngineServiceMgr_PrintStatus
+        expected_output:
+          - CEngineServiceMgr_PrintStatus.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_vtable.{platform}.yaml
+
       - name: find-CEngineServiceMgr__MainLoop
         expected_output:
           - CEngineServiceMgr__MainLoop.{platform}.yaml
@@ -1929,6 +1935,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServiceMgr::SwitchToLoop
+
+      - name: CEngineServiceMgr_PrintStatus
+        category: vfunc
+        alias:
+          - CEngineServiceMgr::PrintStatus
 
       - name: CEngineServiceMgr__MainLoop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -2742,6 +2742,13 @@ modules:
         expected_output:
           - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
 
+      - name: find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+        expected_output:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_Init.{platform}.yaml
+        expected_input:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
+
       - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl
         expected_output:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml
@@ -3378,6 +3385,11 @@ modules:
 
       - name: CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
         category: vtable
+
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+        category: vfunc
+        alias:
+          - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
 
       - name: CSkeletonInstance
         category: struct
@@ -5572,6 +5584,13 @@ modules:
         expected_output:
           - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
 
+      - name: find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+        expected_output:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_Init.{platform}.yaml
+        expected_input:
+          - CSource2EntitySystem_StaticInit.{platform}.yaml
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
+
       - name: find-CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
         expected_output:
           - CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.{platform}.yaml
@@ -6492,6 +6511,11 @@ modules:
 
       - name: CGameSystemReallocatingFactory_CSource2EntitySystem_vtable
         category: vtable
+
+      - name: CGameSystemReallocatingFactory_CSource2EntitySystem_Init
+        category: vfunc
+        alias:
+          - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -2749,6 +2749,12 @@ modules:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
           - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
 
+      - name: find-IGameSystemFactory_Init
+        expected_output:
+          - IGameSystemFactory_Init.{platform}.yaml
+        expected_input:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_Init.{platform}.yaml
+
       - name: find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl
         expected_output:
           - CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml
@@ -3329,6 +3335,11 @@ modules:
         category: vfunc
         alias:
           - IGameSystemFactory::DestroyGameSystem
+
+      - name: IGameSystemFactory_Init
+        category: vfunc
+        alias:
+          - IGameSystemFactory::Init
 
       - name: CPrediction_vtable
         category: vtable
@@ -5610,6 +5621,12 @@ modules:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
           - CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.{platform}.yaml
 
+      - name: find-IGameSystemFactory_Init
+        expected_output:
+          - IGameSystemFactory_Init.{platform}.yaml
+        expected_input:
+          - CGameSystemReallocatingFactory_CSource2EntitySystem_Init.{platform}.yaml
+
       - name: find-CSpawnGroupMgrGameSystem_DoesGameSystemReallocate
         expected_output:
           - CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.{platform}.yaml
@@ -6543,6 +6560,11 @@ modules:
         category: vfunc
         alias:
           - CGameSystemReallocatingFactory<CSource2EntitySystem>::Init
+
+      - name: IGameSystemFactory_Init
+        category: vfunc
+        alias:
+          - IGameSystemFactory::Init
 
       - name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -1932,6 +1932,21 @@ modules:
         alias:
           - CLoopTypeBase::GetClientServerMode
 
+      - name: CLoopTypeBase_GetImplType
+        category: vfunc
+        alias:
+          - CLoopTypeBase::GetImplType
+
+      - name: ILoopModeFactory_GetLoopModeType
+        category: vfunc
+        alias:
+          - ILoopModeFactory::GetLoopModeType
+
+      - name: ILoopModeFactory_Shutdown
+        category: vfunc
+        alias:
+          - ILoopModeFactory::Shutdown
+
       - name: CEngineServiceMgr_vtable
         category: vtable
 
@@ -9990,6 +10005,14 @@ modules:
           - CLoopTypeBase_GetClientServerMode.{platform}.yaml
         expected_input:
           - CEngineServiceMgr_GetActiveLoopClientServerMode.{platform}.yaml
+
+      - name: find-CLoopTypeBase_GetImplType-AND-ILoopModeFactory_GetLoopModeType-AND-ILoopModeFactory_Shutdown
+        expected_output:
+          - CLoopTypeBase_GetImplType.{platform}.yaml
+          - ILoopModeFactory_GetLoopModeType.{platform}.yaml
+          - ILoopModeFactory_Shutdown.{platform}.yaml
+        expected_input:
+          - CEngineServiceMgr_UnregisterLoopMode.{platform}.yaml
 
       - name: find-CNetSupportImpl_vtable
         expected_output:

--- a/config.yaml
+++ b/config.yaml
@@ -606,6 +606,12 @@ modules:
         expected_input:
           - CGameResourceService_vtable.{platform}.yaml
 
+      - name: find-CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+        expected_output:
+          - CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest.{platform}.yaml
+        expected_input:
+          - CGameResourceService_vtable.{platform}.yaml
+
       - name: find-CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded
         expected_output:
           - CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded.{platform}.yaml
@@ -1354,6 +1360,11 @@ modules:
         category: vfunc
         alias:
           - CGameResourceService::PrecacheEntitiesAndConfirmResourcesAreLoaded
+
+      - name: CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest
+        category: vfunc
+        alias:
+          - CGameResourceService::LoadGameResourceManifest
 
       - name: IEntityResourceManifestBuilder_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/cpp_tests/igamesystemfactory.cpp
+++ b/cpp_tests/igamesystemfactory.cpp
@@ -1,0 +1,19 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+#include <tier1/convar.h>
+#include <tier1/utlstring.h>
+#include <entity2/entityidentity.h>
+#include <entityhandle.h>
+#include <igamesystem.h>
+#include <igamesystemfactory.h>
+
+IGameSystemFactory * instanceptr();
+
+int main() {
+
+    instanceptr()->Shutdown();
+
+    return 0;
+}

--- a/cpp_tests_util.py
+++ b/cpp_tests_util.py
@@ -918,8 +918,8 @@ def compare_compiler_vtable_with_yaml(
         expected_member = ref_item.get("member_name", "")
         actual_member = compiled.get("member_name", "")
         if expected_member and actual_member and expected_member != actual_member:
-            # "dtor" in YAML matches any destructor "~ClassName" from compiler
-            if expected_member == "dtor" and actual_member.startswith("~"):
+            # "dtor"/"vdtor" in YAML matches any destructor "~ClassName" from compiler
+            if expected_member in {"dtor", "vdtor"} and actual_member.startswith("~"):
                 continue
             report["differences"].append(
                 {

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -1974,6 +1974,7 @@ def run_skill(skill_name, agent="claude", debug=False, expected_yaml_paths=None,
 
     # Verify SKILL.md exists before launching agent
     skill_md_path = os.path.join(".claude", "skills", skill_name, "SKILL.md")
+    print(f"    Falling back to: {skill_md_path}")
     if not os.path.exists(skill_md_path):
         print(f"    Error: Skill file not found: {skill_md_path}")
         return False

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -2376,10 +2376,7 @@ def process_binary(
                     )
                 else:
                     success_count += 1
-                    if old_binary_dir:
-                        print(f"  Pre-processed: {skill_name} (signature reuse)")
-                    else:
-                        print(f"  Pre-processed: {skill_name}")
+                    print(f"  Pre-processed: {skill_name} OK")
                 continue
             if preprocess_status == PREPROCESS_STATUS_ABSENT_OK:
                 skip_count += 1

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -6195,6 +6195,73 @@ async def _collect_xref_func_starts_for_ea(session, target_ea, debug=False):
     )
 
 
+async def _collect_single_call_or_jump_xref_func_starts_for_ea(
+    session, target_ea, debug=False
+):
+    """
+    Collect function-start addresses that contain exactly one call/jump xref
+    to the specified target address.
+
+    Returns:
+        Set[int]: Function start addresses, or None on py_eval failure.
+    """
+    try:
+        target_ea_int = _parse_int_value(target_ea)
+    except Exception:
+        return set()
+
+    py_code = (
+        "import idautils, ida_xref, idc, json\n"
+        f"target_ea = {target_ea_int}\n"
+        "type_names = ('fl_CF', 'fl_CN', 'fl_JF', 'fl_JN')\n"
+        "call_jump_types = {\n"
+        "    getattr(ida_xref, name)\n"
+        "    for name in type_names\n"
+        "    if hasattr(ida_xref, name)\n"
+        "}\n"
+        "code_addrs = set()\n"
+        "for xref in idautils.XrefsTo(target_ea, 0):\n"
+        "    mnem = idc.print_insn_mnem(xref.frm).lower()\n"
+        "    if xref.type in call_jump_types or mnem in {'call', 'jmp'}:\n"
+        "        code_addrs.add(xref.frm)\n"
+        "result = json.dumps([hex(ea) for ea in sorted(code_addrs)])\n"
+    )
+
+    try:
+        eval_result = await session.call_tool(
+            name="py_eval",
+            arguments={"code": py_code},
+        )
+        eval_data = parse_mcp_result(eval_result)
+    except Exception as e:
+        if debug:
+            print(f"    Preprocess: py_eval error for call/jump xref search: {e}")
+        return None
+
+    code_addrs = _parse_int_set_from_py_eval(eval_data, debug=debug)
+    if code_addrs is None:
+        return None
+
+    call_counts_by_func = {}
+    for code_addr in sorted(code_addrs):
+        func_start = await _normalize_func_start_for_code_addr(
+            session=session,
+            code_addr=code_addr,
+            debug=debug,
+        )
+        if func_start is None:
+            continue
+        call_counts_by_func[func_start] = (
+            call_counts_by_func.get(func_start, 0) + 1
+        )
+
+    return {
+        func_start
+        for func_start, call_count in call_counts_by_func.items()
+        if call_count == 1
+    }
+
+
 async def _collect_xref_func_starts_for_signature(
     session, xref_signature, debug=False
 ):
@@ -7208,19 +7275,28 @@ async def preprocess_func_xrefs_via_mcp(
     debug=False,
     xref_floats=None,
     exclude_floats=None,
+    inline_alias=None,
 ):
     """
     Resolve target function by intersecting candidate sets collected from
-    configured string/gv/signature/function xrefs, plus optional vtable
-    entries from a class name or vtable artifact stem, then applying
-    configured exclusions.
+    configured string/gv/signature/function xrefs, optional inline-alias
+    callers or fallback alias body, plus optional vtable entries from a class
+    name or vtable artifact stem, then applying configured exclusions.
     """
+    if inline_alias is not None and (
+        not isinstance(inline_alias, str) or not inline_alias
+    ):
+        if debug:
+            print(f"    Preprocess: invalid inline_alias for {func_name}")
+        return None
+
     has_explicit_positive_source = any(
         (
             xref_strings,
             xref_gvs,
             xref_signatures,
             xref_funcs,
+            inline_alias,
         )
     )
     xref_floats = xref_floats or []
@@ -7233,7 +7309,11 @@ async def preprocess_func_xrefs_via_mcp(
             )
         return None
 
-    dep_func_names = list(xref_funcs or []) + list(exclude_funcs or [])
+    dep_func_names = (
+        list(xref_funcs or [])
+        + list(exclude_funcs or [])
+        + ([inline_alias] if inline_alias else [])
+    )
     dep_gv_names = [
         gv_name
         for gv_name in list(xref_gvs or []) + list(exclude_gvs or [])
@@ -7371,6 +7451,44 @@ async def preprocess_func_xrefs_via_mcp(
                     f"    Preprocess: empty candidate set for signature xref: {short}"
                 )
             return None
+        candidate_sets.append(addr_set)
+
+    if inline_alias:
+        inline_alias_va = _load_symbol_addr_from_current_yaml(
+            new_binary_dir,
+            platform,
+            inline_alias,
+            "func_va",
+            debug=debug,
+            debug_label="inline_alias",
+        )
+        if inline_alias_va is None:
+            return None
+
+        addr_set = await _collect_single_call_or_jump_xref_func_starts_for_ea(
+            session=session,
+            target_ea=inline_alias_va,
+            debug=debug,
+        )
+        if addr_set is None:
+            if debug:
+                print(
+                    f"    Preprocess: failed to collect inline_alias callers: "
+                    f"{inline_alias}"
+                )
+            return None
+        if not addr_set:
+            addr_set = {inline_alias_va}
+            if debug:
+                print(
+                    f"    Preprocess: no single call/jump caller for "
+                    f"{inline_alias}; using alias function itself"
+                )
+        elif debug:
+            print(
+                f"    Preprocess: inline_alias {inline_alias} matched "
+                f"{len(addr_set)} caller function(s)"
+            )
         candidate_sets.append(addr_set)
 
     for dep_func_name in (xref_funcs or []):
@@ -7668,6 +7786,7 @@ async def _try_preprocess_func_without_llm(
             xref_signatures=xref_spec["xref_signatures"],
             xref_funcs=xref_spec["xref_funcs"],
             xref_floats=xref_spec["xref_floats"],
+            inline_alias=xref_spec["inline_alias"],
             exclude_funcs=xref_spec["exclude_funcs"],
             exclude_strings=xref_spec["exclude_strings"],
             exclude_gvs=xref_spec["exclude_gvs"],
@@ -7696,9 +7815,11 @@ def _can_probe_future_func_fast_path(
     if not isinstance(xref_spec, dict):
         return True
 
+    inline_alias = xref_spec.get("inline_alias")
     dependency_symbol_names = (
         list(xref_spec.get("xref_funcs") or [])
         + list(xref_spec.get("exclude_funcs") or [])
+        + ([inline_alias] if inline_alias else [])
         + [
             gv_name
             for gv_name in (xref_spec.get("xref_gvs") or [])
@@ -7793,9 +7914,9 @@ async def preprocess_common_skill(
     - ``func_xrefs``: locate functions via unified xref fallback through
       ``preprocess_func_xrefs_via_mcp``. Each element is a dict with
       ``func_name`` plus list fields for positive xref sources
-      (``xref_strings``, ``xref_gvs``, ``xref_signatures``, ``xref_funcs``)
-      and optional post-intersection scalar readonly float/double filters
-      (``xref_floats``)
+      (``xref_strings``, ``xref_gvs``, ``xref_signatures``, ``xref_funcs``,
+      ``inline_alias``) and optional post-intersection scalar readonly
+      float/double filters (``xref_floats``)
       and exclusions (``exclude_funcs``, ``exclude_strings``,
       ``exclude_gvs``, ``exclude_signatures``, ``exclude_floats``).
       ``xref_floats``/``exclude_floats`` do not count as positive xref
@@ -7832,8 +7953,8 @@ async def preprocess_common_skill(
         func_xrefs: List of dict specs for unified xref-based function lookup
             (may be empty/None). Supported keys are func_name,
             xref_strings/xref_gvs/xref_signatures/xref_funcs,
-            xref_floats, exclude_funcs/exclude_strings/exclude_gvs/
-            exclude_signatures/exclude_floats.
+            inline_alias, xref_floats, exclude_funcs/exclude_strings/
+            exclude_gvs/exclude_signatures/exclude_floats.
         func_vtable_relations: List of (func_name, vtable_class) tuples for
             enriching function YAML with vtable metadata; the vtable value may
             be a canonical class name or a vtable artifact stem
@@ -7882,6 +8003,7 @@ async def preprocess_common_skill(
         "xref_gvs",
         "xref_signatures",
         "xref_funcs",
+        "inline_alias",
         "xref_floats",
         "exclude_funcs",
         "exclude_strings",
@@ -7958,11 +8080,24 @@ async def preprocess_common_skill(
                     return False
             normalized_spec[field_name] = field_list
 
+        inline_alias = spec.get("inline_alias")
+        if inline_alias is not None and (
+            not isinstance(inline_alias, str) or not inline_alias
+        ):
+            if debug:
+                print(
+                    f"    Preprocess: invalid inline_alias for "
+                    f"{func_name}: {inline_alias}"
+                )
+            return False
+        normalized_spec["inline_alias"] = inline_alias
+
         if (
             not normalized_spec["xref_strings"]
             and not normalized_spec["xref_gvs"]
             and not normalized_spec["xref_signatures"]
             and not normalized_spec["xref_funcs"]
+            and not normalized_spec["inline_alias"]
         ):
             if debug:
                 print(f"    Preprocess: empty func_xrefs spec for {func_name}")

--- a/ida_preprocessor_scripts/find-CBaseEntity_ctor.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_ctor.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_ctor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseEntity_ctor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+def _linux_ztv_addr(vtable_va_str):
+    """Convert vtable_va (first function pointer) to _ZTV* symbol address (= va - 0x10).
+
+    On Linux, CBaseEntity_ctor references `_ZTV11CBaseEntity` via `lea rax, _ZTV...`,
+    not the `CBaseEntity_vtable` label (which IDA places at _ZTV* + 0x10).
+    """
+    return hex(int(vtable_va_str, 16) - 0x10)
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    cnetwork_vtable_yaml = os.path.join(
+        new_binary_dir, f"CNetworkTransmitComponent_vtable.{platform}.yaml"
+    )
+    cbaseentity_vtable_yaml = os.path.join(
+        new_binary_dir, f"CBaseEntity_vtable.{platform}.yaml"
+    )
+    centityiooutput_vtable_yaml = os.path.join(
+        new_binary_dir, f"CEntityIOOutput_vtable.{platform}.yaml"
+    )
+
+    cnetwork_va = _read_vtable_va(cnetwork_vtable_yaml)
+    cbaseentity_va = _read_vtable_va(cbaseentity_vtable_yaml)
+    centityiooutput_va = _read_vtable_va(centityiooutput_vtable_yaml)
+
+    if not cnetwork_va:
+        if debug:
+            print(
+                "    Preprocess: CNetworkTransmitComponent_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+    if not cbaseentity_va:
+        if debug:
+            print(
+                "    Preprocess: CBaseEntity_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+    if not centityiooutput_va:
+        if debug:
+            print(
+                "    Preprocess: CEntityIOOutput_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    if platform == "windows":
+        # Windows: ctor writes vtable_va directly to the object
+        xref_gvs = [cnetwork_va, cbaseentity_va, centityiooutput_va]
+    else:
+        # Linux: ctor does `lea rax, _ZTV*` which references _ZTV* = vtable_va - 0x10
+        xref_gvs = [
+            _linux_ztv_addr(cnetwork_va),
+            _linux_ztv_addr(cbaseentity_va),
+            _linux_ztv_addr(centityiooutput_va),
+        ]
+
+    # Build FUNC_XREFS dynamically with vtable VAs as xref_gvs (intersection)
+    func_xrefs = [
+        {
+            "func_name": "CBaseEntity_ctor",
+            "xref_strings": [],
+            "xref_gvs": xref_gvs,
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CBaseEntity_dtor.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_dtor.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_dtor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseEntity_dtor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_dtor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir, f"CBaseEntity_vtable.{platform}.yaml"
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CBaseEntity_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    # On Linux, the dtor references _ZTV* = vtable_va - 0x10 via `lea rax, _ZTV...`
+    xref_va = vtable_va if platform == "windows" else hex(int(vtable_va, 16) - 0x10)
+
+    # Build FUNC_XREFS dynamically with the vtable VA, excluding the already-found ctor
+    func_xrefs = [
+        {
+            "func_name": "CBaseEntity_dtor",
+            "xref_strings": [],
+            "xref_gvs": [xref_va],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": ["CBaseEntity_ctor"],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CBaseEntity_vdtor.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_vdtor.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_vdtor skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseEntity_vdtor",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBaseEntity_vdtor",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+        "inline_alias": "CBaseEntity_dtor",
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CBaseEntity_vdtor", "CBaseEntity"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_vdtor",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_GetEventDispatcher.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_GetEventDispatcher.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_GetEventDispatcher skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEngineServiceMgr_GetEventDispatcher",
+        "CEngineServiceMgr",
+        "../client/IEngineServiceMgr_GetEventDispatcher",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_GetEventDispatcher",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_PrintStatus.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_PrintStatus.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_PrintStatus skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServiceMgr_PrintStatus",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServiceMgr_PrintStatus",
+        "xref_strings": [
+            "----- Status -----",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServiceMgr_PrintStatus", "CEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_PrintStatus",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_RegisterLoopMode.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_RegisterLoopMode.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_RegisterLoopMode skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServiceMgr_RegisterLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServiceMgr_RegisterLoopMode",
+        "xref_strings": [
+            'Duplicate loop named "%s" registered!',
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServiceMgr_RegisterLoopMode", "CEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_RegisterLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_SwitchToLoop.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_SwitchToLoop.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_SwitchToLoop skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServiceMgr_SwitchToLoop",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServiceMgr_SwitchToLoop",
+        "xref_strings": [
+            'Attempted to switch to unknown loop "%s"!',
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServiceMgr_SwitchToLoop", "CEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_SwitchToLoop",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_UnregisterEngineService.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_UnregisterEngineService.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_UnregisterEngineService skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEngineServiceMgr_UnregisterEngineService",
+        "CEngineServiceMgr",
+        "../server/IEngineServiceMgr_UnregisterEngineService",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_UnregisterEngineService",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServiceMgr_UnregisterLoopMode.py
+++ b/ida_preprocessor_scripts/find-CEngineServiceMgr_UnregisterLoopMode.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServiceMgr_UnregisterLoopMode skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEngineServiceMgr_UnregisterLoopMode",
+        "CEngineServiceMgr",
+        "../server/IEngineServiceMgr_UnregisterLoopMode",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServiceMgr_UnregisterLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityIOOutput_vtable.py
+++ b/ida_preprocessor_scripts/find-CEntityIOOutput_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityIOOutput_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CEntityIOOutput"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityIOOutput",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CEntityIOOutput vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_Activate.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_Activate.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_Activate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_Activate", "CEntityInstance", "CPhysExplosion_Activate", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_Activate",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CPhysExplosion_Activate."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_Spawn.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_Spawn.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_Spawn skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_Spawn", "CEntityInstance", "CFlashbangProjectile_Spawn", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_Spawn",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CFlashbangProjectile_Spawn."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_vdtor.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_vdtor.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_vdtor skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_vdtor", "CEntityInstance", "CBaseEntity_vdtor", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_vdtor",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CBaseEntity_vdtor."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_PostCreateEntitySystem.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_PostCreateEntitySystem.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_PostCreateEntitySystem skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_PostCreateEntitySystem",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_PostCreateEntitySystem",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEntitySystem_Init"],
+        "exclude_funcs": ["CEntitySystem_ctor", "CEntitySystem_CreateEntitySystem"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_PostCreateEntitySystem",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_ctor.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_ctor.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_ctor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameEntitySystem_ctor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEntitySystem_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir, f"CGameEntitySystem_vtable.{platform}.yaml"
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CGameEntitySystem_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "CGameEntitySystem_ctor",
+            "xref_strings": [],
+            "xref_gvs": [str(vtable_va)],
+            "xref_signatures": [],
+            "xref_funcs": ["CEntitySystem_ctor"],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEventManager_Shutdown-AND-CLoopModeRegistry_UnregisterLoopModes-AND-CEngineServiceRegistry_UnregisterEngineServices.py
+++ b/ida_preprocessor_scripts/find-CGameEventManager_Shutdown-AND-CLoopModeRegistry_UnregisterLoopModes-AND-CEngineServiceRegistry_UnregisterEngineServices.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEventManager_Shutdown-AND-CLoopModeRegistry_UnregisterLoopModes-AND-CEngineServiceRegistry_UnregisterEngineServices skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameEventManager_Shutdown",
+    "CLoopModeRegistry_UnregisterLoopModes",
+    "CEngineServiceRegistry_UnregisterEngineServices",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameEventManager_Shutdown",
+        "prompt/call_llm_decompile.md",
+        "references/server/CSource2Server_Shutdown.{platform}.yaml",
+    ),
+    (
+        "CLoopModeRegistry_UnregisterLoopModes",
+        "prompt/call_llm_decompile.md",
+        "references/server/CSource2Server_Shutdown.{platform}.yaml",
+    ),
+    (
+        "CEngineServiceRegistry_UnregisterEngineServices",
+        "prompt/call_llm_decompile.md",
+        "references/server/CSource2Server_Shutdown.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEventManager_Shutdown",
+        [
+            "func_name",
+            "func_sig",
+            "func_sig_allow_across_function_boundary:true",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CLoopModeRegistry_UnregisterLoopModes",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CEngineServiceRegistry_UnregisterEngineServices",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_AppendToGameResourceManifest.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_AppendToGameResourceManifest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_AppendToGameResourceManifest skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_AppendToGameResourceManifest",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_AppendToGameResourceManifest",
+        "xref_strings": [
+            "FULLMATCH:%s appended",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_AppendToGameResourceManifest", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_AppendToGameResourceManifest",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_DescribeContents.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_DescribeContents.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_DescribeContents skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_DescribeContents",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_DescribeContents",
+        "xref_strings": [
+            "CGameResourceService::DescribeContents:  manifest handle == GAME_RESOURCE_MANIFEST_HANDLE_INVALID",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_DescribeContents", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_DescribeContents",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_GetResourceManifestDebugName.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_GetResourceManifestDebugName.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_GetResourceManifestDebugName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_GetResourceManifestDebugName",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_GetResourceManifestDebugName",
+        "xref_strings": [
+            "FULLMATCH:GAME_RESOURCE_MANIFEST_HANDLE_INVALID",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_GetResourceManifestDebugName", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_GetResourceManifestDebugName",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest",
+        "xref_strings": [
+            "CGameResourceService::BuildResourceManifest(start) [callback 0x%p]",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_LoadGameResourceManifest_IEntityResourceManifest",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded",
+        "xref_strings": [
+            "PrecacheEntitiesAndConfirmResourcesAreLoaded",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_PrecacheEntitiesAndConfirmResourcesAreLoaded",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMap-linux.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMap-linux.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_RegisterEventMap-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_RegisterEventMap",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_RegisterEventMap",
+        "xref_strings": [
+            "FULLMATCH:CGameResourceService",
+            "FULLMATCH:OnClientSimulate",
+            "FULLMATCH:OnServerEndSimulate",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_RegisterEventMap", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_RegisterEventMap",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMap-windows.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMap-windows.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_RegisterEventMap-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_RegisterEventMap",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_RegisterEventMap",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CGameResourceService_RegisterEventMapInternal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameResourceService_RegisterEventMap", "CGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_RegisterEventMap",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMapInternal-windows.py
+++ b/ida_preprocessor_scripts/find-CGameResourceService_RegisterEventMapInternal-windows.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameResourceService_RegisterEventMapInternal-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameResourceService_RegisterEventMapInternal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameResourceService_RegisterEventMapInternal",
+        "xref_strings": [
+            "FULLMATCH:CGameResourceService",
+            "FULLMATCH:OnClientSimulate",
+            "FULLMATCH:OnServerEndSimulate",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameResourceService_RegisterEventMapInternal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.py
+++ b/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem",
+        "CGameSystemReallocatingFactory_CSource2EntitySystem",
+        "IGameSystemFactory_CreateGameSystem",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index from IGameSystemFactory_CreateGameSystem."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init.py
+++ b/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init.py
@@ -13,11 +13,12 @@ FUNC_XREFS = [
         "xref_strings": [],
         "xref_gvs": [],
         "xref_signatures": [],
-        "xref_funcs": ["CSource2EntitySystem_StaticInit"],
+        "xref_funcs": [],
         "exclude_funcs": [],
         "exclude_strings": [],
         "exclude_gvs": [],
         "exclude_signatures": [],
+        "inline_alias": "CSource2EntitySystem_StaticInit",
     },
 ]
 

--- a/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init.py
+++ b/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSystemReallocatingFactory_CSource2EntitySystem_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameSystemReallocatingFactory_CSource2EntitySystem_Init",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameSystemReallocatingFactory_CSource2EntitySystem_Init",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CSource2EntitySystem_StaticInit"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameSystemReallocatingFactory_CSource2EntitySystem_Init", "CGameSystemReallocatingFactory_CSource2EntitySystem_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSystemReallocatingFactory_CSource2EntitySystem_Init",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.py
+++ b/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSource2EntitySystem_vtable.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameSystemReallocatingFactory_CSource2EntitySystem_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = [
+    "CGameSystemReallocatingFactory_CSource2EntitySystem",
+]
+
+MANGLED_CLASS_NAMES = {
+    "CGameSystemReallocatingFactory_CSource2EntitySystem": [
+        "??_7?$CGameSystemReallocatingFactory@VCSource2EntitySystem@@V1@@@6B@",
+        "_ZTV30CGameSystemReallocatingFactoryI20CSource2EntitySystemS0_E",
+    ],
+}
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameSystemReallocatingFactory_CSource2EntitySystem",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CGameSystemReallocatingFactory_CSource2EntitySystem vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        mangled_class_names=MANGLED_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl.py
+++ b/ida_preprocessor_scripts/find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl skill."""
+"""Preprocess script for find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
     (
-        "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate",
+        "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem",
         "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem",
-        "../client/IGameSystemFactory_Deallocate",
+        "../client/IGameSystemFactory_DestroyGameSystem",
         True,
     ),
 ]
@@ -17,7 +17,7 @@ INHERIT_VFUNCS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate",
+        "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_Init.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_Init.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_Init",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_Init",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+        "inline_alias": "CLoopModeGame_StaticInit",
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    (
+        "CLoopModeFactory_CLoopModeGame_Init",
+        "CLoopModeFactory_CLoopModeGame_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame_Init",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_Shutdown.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_Shutdown.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CLoopModeFactory_CLoopModeGame_Shutdown",
+        "CLoopModeFactory_CLoopModeGame_vtable",
+        "../engine/ILoopModeFactory_Shutdown",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_vtable.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_vtable.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = [
+    "CLoopModeFactory_CLoopModeGame",
+]
+
+MANGLED_CLASS_NAMES = {
+    "CLoopModeFactory_CLoopModeGame": [
+        "??_R4?$CLoopModeFactory@VCLoopModeGame@@@@6B@",
+        "_ZTV16CLoopModeFactoryI13CLoopModeGameE",
+    ],
+}
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CLoopModeFactory_CLoopModeGame vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        mangled_class_names=MANGLED_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeGame_StaticInit.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_StaticInit.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeGame_StaticInit skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeGame_StaticInit",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeGame_StaticInit",
+        "xref_strings": [
+            "FULLMATCH:CLoopModeGame::StaticInit-start",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = []
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeGame_StaticInit",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopTypeBase_EngineLoop.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeBase_EngineLoop.py
@@ -5,7 +5,7 @@ from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
-    ("CLoopTypeBase_EngineLoop", "CLoopTypeBase", "CLoopTypeClientServer_EngineLoop", False),
+    ("CLoopTypeBase_EngineLoop", "CLoopTypeBase", "CLoopTypeClientServer_OutputListeners", False),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -31,7 +31,7 @@ async def preprocess_skill(
     image_base,
     debug=False,
 ):
-    """Reuse old vfunc slot; fallback to inheriting vtable index from CLoopTypeClientServer_EngineLoop."""
+    """Reuse old vfunc slot; fallback to inheriting vtable index from CLoopTypeClientServer_OutputListeners."""
     _ = skill_name
 
     return await preprocess_common_skill(

--- a/ida_preprocessor_scripts/find-CLoopTypeBase_FrameUpdate.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeBase_FrameUpdate.py
@@ -5,7 +5,7 @@ from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
-    ("CLoopTypeBase_FrameUpdate", "CLoopTypeBase", "CLoopTypeClientServer_FrameUpdate", False),
+    ("CLoopTypeBase_FrameUpdate", "CLoopTypeBase", "CLoopTypeClientServer_Update", False),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -31,7 +31,7 @@ async def preprocess_skill(
     image_base,
     debug=False,
 ):
-    """Reuse old vfunc slot; fallback to inheriting vtable index from CLoopTypeClientServer_FrameUpdate."""
+    """Reuse old vfunc slot; fallback to inheriting vtable index from CLoopTypeClientServer_Update."""
     _ = skill_name
 
     return await preprocess_common_skill(

--- a/ida_preprocessor_scripts/find-CLoopTypeBase_GetImplType-AND-ILoopModeFactory_GetLoopModeType-AND-ILoopModeFactory_Shutdown.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeBase_GetImplType-AND-ILoopModeFactory_GetLoopModeType-AND-ILoopModeFactory_Shutdown.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopTypeBase_GetImplType-AND-ILoopModeFactory_GetLoopModeType-AND-ILoopModeFactory_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopTypeBase_GetImplType",
+    "ILoopModeFactory_GetLoopModeType",
+    "ILoopModeFactory_Shutdown",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CLoopTypeBase_GetImplType",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CEngineServiceMgr_UnregisterLoopMode.{platform}.yaml",
+    ),
+    (
+        "ILoopModeFactory_GetLoopModeType",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CEngineServiceMgr_UnregisterLoopMode.{platform}.yaml",
+    ),
+    (
+        "ILoopModeFactory_Shutdown",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CEngineServiceMgr_UnregisterLoopMode.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CLoopTypeBase_GetImplType", "CLoopTypeBase"),
+    ("ILoopModeFactory_GetLoopModeType", "ILoopModeFactory"),
+    ("ILoopModeFactory_Shutdown", "ILoopModeFactory"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopTypeBase_GetImplType",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "ILoopModeFactory_GetLoopModeType",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "ILoopModeFactory_Shutdown",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopTypeClientServer_OutputListeners.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeClientServer_OutputListeners.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CLoopTypeClientServer_FrameUpdate skill."""
+"""Preprocess script for find-CLoopTypeClientServer_OutputListeners skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CLoopTypeClientServer_FrameUpdate",
+    "CLoopTypeClientServer_OutputListeners",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CLoopTypeClientServer_FrameUpdate",
+        "func_name": "CLoopTypeClientServer_OutputListeners",
         "xref_strings": [
-            "%f FRAME start %d ticks",
+            "\nClientServerEngineLoop\n{\n",
         ],
         "xref_gvs": [],
         "xref_signatures": [],
@@ -24,12 +24,12 @@ FUNC_XREFS = [
 ]
 
 FUNC_VTABLE_RELATIONS = [
-    ("CLoopTypeClientServer_FrameUpdate", "CLoopTypeClientServer"),
+    ("CLoopTypeClientServer_OutputListeners", "CLoopTypeClientServer"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     (
-        "CLoopTypeClientServer_FrameUpdate",
+        "CLoopTypeClientServer_OutputListeners",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CLoopTypeClientServer_Update.py
+++ b/ida_preprocessor_scripts/find-CLoopTypeClientServer_Update.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CLoopTypeClientServer_EngineLoop skill."""
+"""Preprocess script for find-CLoopTypeClientServer_Update skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CLoopTypeClientServer_EngineLoop",
+    "CLoopTypeClientServer_Update",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CLoopTypeClientServer_EngineLoop",
+        "func_name": "CLoopTypeClientServer_Update",
         "xref_strings": [
-            "\nClientServerEngineLoop\n{\n",
+            "%f FRAME start %d ticks",
         ],
         "xref_gvs": [],
         "xref_signatures": [],
@@ -24,12 +24,12 @@ FUNC_XREFS = [
 ]
 
 FUNC_VTABLE_RELATIONS = [
-    ("CLoopTypeClientServer_EngineLoop", "CLoopTypeClientServer"),
+    ("CLoopTypeClientServer_Update", "CLoopTypeClientServer"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     (
-        "CLoopTypeClientServer_EngineLoop",
+        "CLoopTypeClientServer_Update",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CNetworkTransmitComponent_vtable.py
+++ b/ida_preprocessor_scripts/find-CNetworkTransmitComponent_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkTransmitComponent_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CNetworkTransmitComponent"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkTransmitComponent",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CNetworkTransmitComponent vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2EntitySystem_StaticInit skill."""
+
+import os
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2EntitySystem_StaticInit",
+]
+
+FUNC_XREFS_SERVER = [
+    {
+        "func_name": "CSource2EntitySystem_StaticInit",
+        "xref_strings": [
+            "FULLMATCH:server_entities",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_CLIENT = [
+    {
+        "func_name": "CSource2EntitySystem_StaticInit",
+        "xref_strings": [
+            "FULLMATCH:client_entities",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2EntitySystem_StaticInit",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    module_name = os.path.basename(os.path.normpath(new_binary_dir)) if new_binary_dir else "server"
+    func_xrefs = FUNC_XREFS_CLIENT if module_name == "client" else FUNC_XREFS_SERVER
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_PreShutdown.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_PreShutdown.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_PreShutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_PreShutdown",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_PreShutdown",
+        "xref_strings": [
+            "CSharedEdictChangeInfo high water mark %u",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2Server_PreShutdown", "CSource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_PreShutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_Shutdown.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_Shutdown.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CSource2Server_Shutdown", "CSource2Server", "../engine/IAppSystem_Shutdown", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Server_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.py
+++ b/ida_preprocessor_scripts/find-CSpawnGroupMgrGameSystem_DoesGameSystemReallocate.py
@@ -39,12 +39,12 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
 ]
 
-# Signature templates — last byte is IGameSystemFactory_DoesGameSystemReallocate vfunc_offset
+# Signature templates — last byte is IGameSystemFactory_IsReallocating vfunc_offset
 # Windows: mov rcx, cs:[rip+??]; mov rax, [rcx]; jmp [rax+OFFSET]
 _SIG_WINDOWS_TEMPLATE = "48 8B 0D ?? ?? ?? ?? 48 8B 01 48 FF 60 {:02X}"
 # Linux: mov rdi, cs:[rip+??]; mov rax, [rdi]; jmp [rax+OFFSET]
 _SIG_LINUX_TEMPLATE = "48 8B 3D ?? ?? ?? ?? 48 8B 07 FF 60 {:02X}"
-_FACTORY_STEM = "IGameSystemFactory_DoesGameSystemReallocate"
+_FACTORY_STEM = "IGameSystemFactory_IsReallocating"
 
 
 def _build_factory_yaml_paths(new_binary_dir, platform):
@@ -91,7 +91,7 @@ async def preprocess_skill(
             print("    Preprocess: PyYAML is required")
         return False
 
-    # Load vfunc_offset from IGameSystemFactory_DoesGameSystemReallocate YAML
+    # Load vfunc_offset from IGameSystemFactory_IsReallocating YAML
     vfunc_offset, factory_yaml_path = _read_factory_vfunc_offset(
         new_binary_dir,
         platform,
@@ -100,7 +100,7 @@ async def preprocess_skill(
         if debug:
             print(
                 "    Preprocess: failed to read vfunc_offset from "
-                "IGameSystemFactory_DoesGameSystemReallocate YAML"
+                "IGameSystemFactory_IsReallocating YAML"
             )
         return False
 

--- a/ida_preprocessor_scripts/find-IAppSystem_PreShutdown.py
+++ b/ida_preprocessor_scripts/find-IAppSystem_PreShutdown.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IAppSystem_PreShutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("IAppSystem_PreShutdown", "IAppSystem", "CSource2Server_PreShutdown", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # IMPORTANT: must be exactly these four fields to trigger slot-only mode
+    (
+        "IAppSystem_PreShutdown",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CSource2Server_PreShutdown."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IEngineServiceMgr_GetEventDispatcher-AND-IGameSystem_ShutdownAllSystems.py
+++ b/ida_preprocessor_scripts/find-IEngineServiceMgr_GetEventDispatcher-AND-IGameSystem_ShutdownAllSystems.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IEngineServiceMgr_GetEventDispatcher-AND-IGameSystem_ShutdownAllSystems skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IEngineServiceMgr_GetEventDispatcher",
+    "IGameSystem_ShutdownAllSystems",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IEngineServiceMgr_GetEventDispatcher",
+        "prompt/call_llm_decompile.md",
+        "references/client/CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml",
+    ),
+    (
+        "IGameSystem_ShutdownAllSystems",
+        "prompt/call_llm_decompile.md",
+        "references/client/CLoopModeFactory_CLoopModeGame_Shutdown.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IEngineServiceMgr_GetEventDispatcher", "IEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IEngineServiceMgr_GetEventDispatcher",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "IGameSystem_ShutdownAllSystems",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IEngineServiceMgr_UnregisterEngineService.py
+++ b/ida_preprocessor_scripts/find-IEngineServiceMgr_UnregisterEngineService.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IEngineServiceMgr_UnregisterEngineService skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IEngineServiceMgr_UnregisterEngineService",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IEngineServiceMgr_UnregisterEngineService",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEngineServiceRegistry_UnregisterEngineServices.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IEngineServiceMgr_UnregisterEngineService", "IEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IEngineServiceMgr_UnregisterEngineService",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IEngineServiceMgr_UnregisterLoopMode.py
+++ b/ida_preprocessor_scripts/find-IEngineServiceMgr_UnregisterLoopMode.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IEngineServiceMgr_UnregisterLoopMode skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IEngineServiceMgr_UnregisterLoopMode",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IEngineServiceMgr_UnregisterLoopMode",
+        "prompt/call_llm_decompile.md",
+        "references/server/CLoopModeRegistry_UnregisterLoopModes.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IEngineServiceMgr_UnregisterLoopMode", "IEngineServiceMgr"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IEngineServiceMgr_UnregisterLoopMode",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameResourceService_SetEntityResourceManifestHandler-AND-g_pGameResourceService-AND-g_pGameEntitySystem.py
+++ b/ida_preprocessor_scripts/find-IGameResourceService_SetEntityResourceManifestHandler-AND-g_pGameResourceService-AND-g_pGameEntitySystem.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameResourceService_SetEntityResourceManifestHandler-AND-g_pGameResourceService-AND-g_pGameEntitySystem skill."""
+
+import os
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameResourceService_SetEntityResourceManifestHandler",
+]
+
+TARGET_GLOBALVAR_NAMES = [
+    "g_pGameResourceService",
+    "g_pGameEntitySystem",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IGameResourceService_SetEntityResourceManifestHandler", "IGameResourceService"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameResourceService_SetEntityResourceManifestHandler",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+            "vfunc_sig",
+        ],
+    ),
+    (
+        "g_pGameResourceService",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+    (
+        "g_pGameEntitySystem",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig/gv_sig to locate targets and write YAML."""
+    module_name = os.path.basename(os.path.normpath(new_binary_dir)) if new_binary_dir else "server"
+
+    llm_decompile = [
+        (
+            "IGameResourceService_SetEntityResourceManifestHandler",
+            "prompt/call_llm_decompile.md",
+            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+        ),
+        (
+            "g_pGameResourceService",
+            "prompt/call_llm_decompile.md",
+            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+        ),
+        (
+            "g_pGameEntitySystem",
+            "prompt/call_llm_decompile.md",
+            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+        ),
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=llm_decompile,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystemFactory_Allocate-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName skill."""
+"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "IGameSystemFactory_Allocate",
+    "IGameSystemFactory_CreateGameSystem",
     "IGameSystemFactory_DoesGameSystemReallocate",
     "IGameSystem_SetName",
 ]
@@ -12,11 +12,11 @@ TARGET_FUNCTION_NAMES = [
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     # All three vfunc offsets found by decompiling IGameSystem_AddByName:
-    #   IGameSystemFactory_Allocate = first virtual call through IGameSystemFactory vtable (*v2), allocates a new game system
+    #   IGameSystemFactory_CreateGameSystem = first virtual call through IGameSystemFactory vtable (*v2), allocates a new game system
     #   IGameSystemFactory_DoesGameSystemReallocate  = second virtual call through IGameSystemFactory vtable (*v2), boolean check
     #   IGameSystem_SetName         = conditional virtual call through IGameSystem vtable (v7 = allocated instance)
     (
-        "IGameSystemFactory_Allocate",
+        "IGameSystemFactory_CreateGameSystem",
         "prompt/call_llm_decompile.md",
         "references/client/IGameSystem_AddByName.{platform}.yaml",
     ),
@@ -34,7 +34,7 @@ LLM_DECOMPILE = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("IGameSystemFactory_Allocate", "IGameSystemFactory"),
+    ("IGameSystemFactory_CreateGameSystem", "IGameSystemFactory"),
     ("IGameSystemFactory_DoesGameSystemReallocate", "IGameSystemFactory"),
     ("IGameSystem_SetName", "IGameSystem"),
 ]
@@ -42,7 +42,7 @@ FUNC_VTABLE_RELATIONS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "IGameSystemFactory_Allocate",
+        "IGameSystemFactory_CreateGameSystem",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName skill."""
+"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
@@ -7,14 +7,16 @@ TARGET_FUNCTION_NAMES = [
     "IGameSystemFactory_CreateGameSystem",
     "IGameSystemFactory_IsReallocating",
     "IGameSystem_SetName",
+    "IGameSystemFactory_GetPriority",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
-    # All three vfunc offsets found by decompiling IGameSystem_AddByName:
+    # All four vfunc offsets found by decompiling IGameSystem_AddByName:
     #   IGameSystemFactory_CreateGameSystem = first virtual call through IGameSystemFactory vtable (*v2), allocates a new game system
-    #   IGameSystemFactory_IsReallocating  = second virtual call through IGameSystemFactory vtable (*v2), boolean check
-    #   IGameSystem_SetName         = conditional virtual call through IGameSystem vtable (v7 = allocated instance)
+    #   IGameSystemFactory_IsReallocating   = second virtual call through IGameSystemFactory vtable (*v2), boolean check
+    #   IGameSystem_SetName                 = conditional virtual call through IGameSystem vtable (v7 = allocated instance)
+    #   IGameSystemFactory_GetPriority      = virtual call through IGameSystemFactory vtable at offset 0x30, returns priority int
     (
         "IGameSystemFactory_CreateGameSystem",
         "prompt/call_llm_decompile.md",
@@ -30,6 +32,11 @@ LLM_DECOMPILE = [
         "prompt/call_llm_decompile.md",
         "references/client/IGameSystem_AddByName.{platform}.yaml",
     ),
+    (
+        "IGameSystemFactory_GetPriority",
+        "prompt/call_llm_decompile.md",
+        "references/client/IGameSystem_AddByName.{platform}.yaml",
+    ),
 ]
 
 FUNC_VTABLE_RELATIONS = [
@@ -37,6 +44,7 @@ FUNC_VTABLE_RELATIONS = [
     ("IGameSystemFactory_CreateGameSystem", "IGameSystemFactory"),
     ("IGameSystemFactory_IsReallocating", "IGameSystemFactory"),
     ("IGameSystem_SetName", "IGameSystem"),
+    ("IGameSystemFactory_GetPriority", "IGameSystemFactory"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -68,6 +76,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_name",
             "vfunc_sig",
             "vfunc_sig_max_match:2",  # Signature at offset 0x1D8 matches multiple call sites
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "IGameSystemFactory_GetPriority",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_max_match:2",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_DoesGameSystemReallocate-AND-IGameSystem_SetName skill."""
+"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "IGameSystemFactory_CreateGameSystem",
-    "IGameSystemFactory_DoesGameSystemReallocate",
+    "IGameSystemFactory_IsReallocating",
     "IGameSystem_SetName",
 ]
 
@@ -13,7 +13,7 @@ LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     # All three vfunc offsets found by decompiling IGameSystem_AddByName:
     #   IGameSystemFactory_CreateGameSystem = first virtual call through IGameSystemFactory vtable (*v2), allocates a new game system
-    #   IGameSystemFactory_DoesGameSystemReallocate  = second virtual call through IGameSystemFactory vtable (*v2), boolean check
+    #   IGameSystemFactory_IsReallocating  = second virtual call through IGameSystemFactory vtable (*v2), boolean check
     #   IGameSystem_SetName         = conditional virtual call through IGameSystem vtable (v7 = allocated instance)
     (
         "IGameSystemFactory_CreateGameSystem",
@@ -21,7 +21,7 @@ LLM_DECOMPILE = [
         "references/client/IGameSystem_AddByName.{platform}.yaml",
     ),
     (
-        "IGameSystemFactory_DoesGameSystemReallocate",
+        "IGameSystemFactory_IsReallocating",
         "prompt/call_llm_decompile.md",
         "references/client/IGameSystem_AddByName.{platform}.yaml",
     ),
@@ -35,7 +35,7 @@ LLM_DECOMPILE = [
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
     ("IGameSystemFactory_CreateGameSystem", "IGameSystemFactory"),
-    ("IGameSystemFactory_DoesGameSystemReallocate", "IGameSystemFactory"),
+    ("IGameSystemFactory_IsReallocating", "IGameSystemFactory"),
     ("IGameSystem_SetName", "IGameSystem"),
 ]
 
@@ -52,7 +52,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "IGameSystemFactory_DoesGameSystemReallocate",
+        "IGameSystemFactory_IsReallocating",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_Init.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_Init.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystemFactory_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("IGameSystemFactory_Init", "IGameSystemFactory", "CGameSystemReallocatingFactory_CSource2EntitySystem_Init", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystemFactory_Init",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CGameSystemReallocatingFactory_CSource2EntitySystem_Init."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystemFactory_PostInit-AND-IGameSystemFactory_GetStaticGameSystem skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameSystemFactory_PostInit",
+    "IGameSystemFactory_GetStaticGameSystem",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IGameSystemFactory_PostInit",
+        "prompt/call_llm_decompile.md",
+        "references/server/IGameSystem_PostInit.{platform}.yaml",
+    ),
+    (
+        "IGameSystemFactory_GetStaticGameSystem",
+        "prompt/call_llm_decompile.md",
+        "references/server/IGameSystem_PostInit.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IGameSystemFactory_PostInit", "IGameSystemFactory"),
+    ("IGameSystemFactory_GetStaticGameSystem", "IGameSystemFactory"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystemFactory_PostInit",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "IGameSystemFactory_GetStaticGameSystem",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Locate target vfunc(s) via preprocessing and LLM decompile fallback."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_SetGlobalPtr.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_SetGlobalPtr.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystemFactory_SetGlobalPtr skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameSystemFactory_SetGlobalPtr",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    # Virtual call through IGameSystemFactory vtable found by decompiling
+    # CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+    (
+        "IGameSystemFactory_SetGlobalPtr",
+        "prompt/call_llm_decompile.md",
+        "references/client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IGameSystemFactory_SetGlobalPtr", "IGameSystemFactory"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystemFactory_SetGlobalPtr",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_sig_max_match:10",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig; fallback to LLM_DECOMPILE of CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_ShouldAutoAdd-AND-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_ShouldAutoAdd-AND-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority skill."""
+"""Preprocess script for find-IGameSystemFactory_ShouldAutoAdd-AND-IGameSystemFactory_CreateGameSystem-AND-IGameSystemFactory_IsReallocating-AND-IGameSystem_SetName-AND-IGameSystemFactory_GetPriority skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
+    "IGameSystemFactory_ShouldAutoAdd",
     "IGameSystemFactory_CreateGameSystem",
     "IGameSystemFactory_IsReallocating",
     "IGameSystem_SetName",
@@ -12,35 +13,42 @@ TARGET_FUNCTION_NAMES = [
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
-    # All four vfunc offsets found by decompiling IGameSystem_AddByName:
-    #   IGameSystemFactory_CreateGameSystem = first virtual call through IGameSystemFactory vtable (*v2), allocates a new game system
-    #   IGameSystemFactory_IsReallocating   = second virtual call through IGameSystemFactory vtable (*v2), boolean check
-    #   IGameSystem_SetName                 = conditional virtual call through IGameSystem vtable (v7 = allocated instance)
-    #   IGameSystemFactory_GetPriority      = virtual call through IGameSystemFactory vtable at offset 0x30, returns priority int
+    # All five vfunc offsets found by decompiling IGameSystem_LoopInitAllSystems:
+    #   IGameSystemFactory_ShouldAutoAdd    = virtual call through IGameSystemFactory vtable, boolean gate before adding
+    #   IGameSystemFactory_CreateGameSystem = virtual call through IGameSystemFactory vtable (*v), allocates a new game system
+    #   IGameSystemFactory_IsReallocating   = virtual call through IGameSystemFactory vtable (*v), boolean check
+    #   IGameSystem_SetName                 = conditional virtual call through IGameSystem vtable (allocated instance)
+    #   IGameSystemFactory_GetPriority      = virtual call through IGameSystemFactory vtable, returns priority int
+    (
+        "IGameSystemFactory_ShouldAutoAdd",
+        "prompt/call_llm_decompile.md",
+        "references/client/IGameSystem_LoopInitAllSystems.{platform}.yaml",
+    ),
     (
         "IGameSystemFactory_CreateGameSystem",
         "prompt/call_llm_decompile.md",
-        "references/client/IGameSystem_AddByName.{platform}.yaml",
+        "references/client/IGameSystem_LoopInitAllSystems.{platform}.yaml",
     ),
     (
         "IGameSystemFactory_IsReallocating",
         "prompt/call_llm_decompile.md",
-        "references/client/IGameSystem_AddByName.{platform}.yaml",
+        "references/client/IGameSystem_LoopInitAllSystems.{platform}.yaml",
     ),
     (
         "IGameSystem_SetName",
         "prompt/call_llm_decompile.md",
-        "references/client/IGameSystem_AddByName.{platform}.yaml",
+        "references/client/IGameSystem_LoopInitAllSystems.{platform}.yaml",
     ),
     (
         "IGameSystemFactory_GetPriority",
         "prompt/call_llm_decompile.md",
-        "references/client/IGameSystem_AddByName.{platform}.yaml",
+        "references/client/IGameSystem_LoopInitAllSystems.{platform}.yaml",
     ),
 ]
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
+    ("IGameSystemFactory_ShouldAutoAdd", "IGameSystemFactory"),
     ("IGameSystemFactory_CreateGameSystem", "IGameSystemFactory"),
     ("IGameSystemFactory_IsReallocating", "IGameSystemFactory"),
     ("IGameSystem_SetName", "IGameSystem"),
@@ -49,6 +57,16 @@ FUNC_VTABLE_RELATIONS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystemFactory_ShouldAutoAdd",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
     (
         "IGameSystemFactory_CreateGameSystem",
         [
@@ -64,7 +82,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         [
             "func_name",
             "vfunc_sig",
-            "vfunc_sig_max_match:2",  # Called from both IGameSystem_AddByName and IGameSystem_Add, so signature matches 2 call sites
+            "vfunc_sig_max_match:2",  # Called from both IGameSystem_LoopInitAllSystems and IGameSystem_Add, so signature matches 2 call sites
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",
@@ -99,7 +117,7 @@ async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever vfunc_sig to locate target function(s); fallback to LLM_DECOMPILE of IGameSystem_AddByName."""
+    """Reuse previous gamever vfunc_sig to locate target function(s); fallback to LLM_DECOMPILE of IGameSystem_LoopInitAllSystems."""
     _ = skill_name
     return await preprocess_common_skill(
         session=session,

--- a/ida_preprocessor_scripts/find-IGameSystemFactory_Shutdown.py
+++ b/ida_preprocessor_scripts/find-IGameSystemFactory_Shutdown.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystemFactory_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameSystemFactory_Shutdown",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "IGameSystemFactory_Shutdown",
+        "prompt/call_llm_decompile.md",
+        "references/client/IGameSystem_ShutdownAllSystems.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("IGameSystemFactory_Shutdown", "IGameSystemFactory"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystemFactory_Shutdown",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Locate target vfunc(s) via preprocessing and LLM decompile fallback."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystem_GetName-AND-IGameSystemFactory_DestroyGameSystem.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_GetName-AND-IGameSystemFactory_DestroyGameSystem.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystem_GetName-AND-IGameSystemFactory_Deallocate skill."""
+"""Preprocess script for find-IGameSystem_GetName-AND-IGameSystemFactory_DestroyGameSystem skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "IGameSystem_GetName",
-    "IGameSystemFactory_Deallocate",
+    "IGameSystemFactory_DestroyGameSystem",
 ]
 
 LLM_DECOMPILE = [
@@ -16,7 +16,7 @@ LLM_DECOMPILE = [
         "references/client/IGameSystem_DestroyAllGameSystems.{platform}.yaml",
     ),
     (
-        "IGameSystemFactory_Deallocate",
+        "IGameSystemFactory_DestroyGameSystem",
         "prompt/call_llm_decompile.md",
         "references/client/IGameSystem_DestroyAllGameSystems.{platform}.yaml",
     ),
@@ -25,7 +25,7 @@ LLM_DECOMPILE = [
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
     ("IGameSystem_GetName", "IGameSystem"),
-    ("IGameSystemFactory_Deallocate", "IGameSystemFactory"),
+    ("IGameSystemFactory_DestroyGameSystem", "IGameSystemFactory"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -41,7 +41,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "IGameSystemFactory_Deallocate",
+        "IGameSystemFactory_DestroyGameSystem",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/find-IGameSystem_LoopInitAllSystems.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_LoopInitAllSystems.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystem_LoopInitAllSystems skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameSystem_LoopInitAllSystems",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "IGameSystem_LoopInitAllSystems",
+        "xref_strings": [
+            "%s:  IGameSystem::LoopInitAllSystems(start)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystem_LoopInitAllSystems",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystem_PostInit.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_PostInit.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IGameSystem_PostInit skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameSystem_PostInit",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "IGameSystem_PostInit",
+        "xref_strings": [
+            "IGameSystem::PostInit( %-80s ) %8.3f msec",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "IGameSystem_PostInit",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_dtor.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_dtor.py
@@ -13,12 +13,12 @@ LLM_DECOMPILE = [
     (
         "IGameSystem_SetGameSystemGlobalPtrs",
         "prompt/call_llm_decompile.md",
-        "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml",
+        "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml",
     ),
     (
         "IGameSystem_dtor",
         "prompt/call_llm_decompile.md",
-        "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate.{platform}.yaml",
+        "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml",
     ),
 ]
 

--- a/ida_preprocessor_scripts/find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_vdtor.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_vdtor.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_dtor skill."""
+"""Preprocess script for find-IGameSystem_SetGameSystemGlobalPtrs-AND-IGameSystem_vdtor skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "IGameSystem_SetGameSystemGlobalPtrs",
-    "IGameSystem_dtor",
+    "IGameSystem_vdtor",
 ]
 
 LLM_DECOMPILE = [
@@ -16,7 +16,7 @@ LLM_DECOMPILE = [
         "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml",
     ),
     (
-        "IGameSystem_dtor",
+        "IGameSystem_vdtor",
         "prompt/call_llm_decompile.md",
         "references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.{platform}.yaml",
     ),
@@ -25,7 +25,7 @@ LLM_DECOMPILE = [
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
     ("IGameSystem_SetGameSystemGlobalPtrs", "IGameSystem"),
-    ("IGameSystem_dtor", "IGameSystem"),
+    ("IGameSystem_vdtor", "IGameSystem"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -44,7 +44,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "IGameSystem_dtor",
+        "IGameSystem_vdtor",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml
@@ -1,0 +1,49 @@
+func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+func_va: '0x1533920'
+disasm_code: |-
+  .text:0000000001533920                 push    rbp
+  .text:0000000001533921                 mov     esi, 18h
+  .text:0000000001533926                 mov     rbp, rsp
+  .text:0000000001533929                 push    rbx
+  .text:000000000153392A                 sub     rsp, 8
+  .text:000000000153392E                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001533935                 mov     rdi, [rax]
+  .text:0000000001533938                 mov     rax, [rdi]
+  .text:000000000153393B                 call    qword ptr [rax+10h]
+  .text:000000000153393E                 mov     rbx, rax
+  .text:0000000001533941                 test    rax, rax
+  .text:0000000001533944                 jz      short loc_1533954
+  .text:0000000001533946                 mov     dword ptr [rax+11h], 0
+  .text:000000000153394D                 mov     dword ptr [rax+14h], 0
+  .text:0000000001533954                 lea     rax, off_424D390
+  .text:000000000153395B                 mov     qword ptr [rbx+8], 0
+  .text:0000000001533963                 mov     [rbx], rax
+  .text:0000000001533966                 mov     rdi, cs:off_4404C58
+  .text:000000000153396D                 test    rdi, rdi
+  .text:0000000001533970                 jz      short loc_153397B
+  .text:0000000001533972                 mov     rax, [rdi]
+  .text:0000000001533975                 mov     rsi, rbx
+  .text:0000000001533978                 call    qword ptr [rax+38h]  ; 38h = IGameSystemFactory_SetGlobalPtr
+  .text:000000000153397B                 mov     rax, rbx
+  .text:000000000153397E                 mov     rbx, [rbp+var_8]
+  .text:0000000001533982                 leave
+  .text:0000000001533983                 retn
+procedure: |-
+  __int64 CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem()
+  {
+    __int64 v0; // rax
+    __int64 v1; // rbx
+
+    v0 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 16LL))(g_pMemAlloc, 24);
+    v1 = v0;
+    if ( v0 )
+    {
+      *(_DWORD *)(v0 + 17) = 0;
+      *(_DWORD *)(v0 + 20) = 0;
+    }
+    *(_QWORD *)(v0 + 8) = 0;
+    *(_QWORD *)v0 = off_424D390;
+    if ( off_4404C58 )
+      (*(void (__fastcall **)(__int64 *, __int64))(*off_4404C58 + 56))(off_4404C58, v0);// 56LL = 0x38 = IGameSystemFactory_SetGlobalPtr
+    return v1;
+  }

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml
@@ -1,0 +1,42 @@
+func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
+func_va: '0x1809248c0'
+disasm_code: |-
+  .text:00000001809248C0                 push    rbx
+  .text:00000001809248C2                 sub     rsp, 20h
+  .text:00000001809248C6                 mov     rax, cs:g_pMemAlloc
+  .text:00000001809248CD                 mov     edx, 18h
+  .text:00000001809248D2                 mov     rcx, [rax]
+  .text:00000001809248D5                 mov     rax, [rcx]
+  .text:00000001809248D8                 call    qword ptr [rax+8]
+  .text:00000001809248DB                 mov     rbx, rax
+  .text:00000001809248DE                 xor     eax, eax
+  .text:00000001809248E0                 test    rbx, rbx
+  .text:00000001809248E3                 jz      short loc_1809248E9
+  .text:00000001809248E5                 mov     [rbx+10h], rax
+  .text:00000001809248E9                 mov     [rbx+8], rax
+  .text:00000001809248ED                 lea     rax, ??_7CSource2EntitySystem@@6B@; const CSource2EntitySystem::`vftable'
+  .text:00000001809248F4                 mov     [rbx], rax
+  .text:00000001809248F7                 mov     rcx, cs:s_Source2EntitySystem
+  .text:00000001809248FE                 test    rcx, rcx
+  .text:0000000180924901                 jz      short loc_18092490D
+  .text:0000000180924903                 mov     r8, [rcx]
+  .text:0000000180924906                 mov     rdx, rbx
+  .text:0000000180924909                 call    qword ptr [r8+38h]  ; 38h = IGameSystemFactory_SetGlobalPtr
+  .text:000000018092490D                 mov     rax, rbx
+  .text:0000000180924910                 add     rsp, 20h
+  .text:0000000180924914                 pop     rbx
+  .text:0000000180924915                 retn
+procedure: |-
+  _QWORD *CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem()
+  {
+    _QWORD *v0; // rbx
+
+    v0 = (_QWORD *)(*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 24);
+    if ( v0 )
+      v0[2] = 0;
+    v0[1] = 0;
+    *v0 = &CSource2EntitySystem::`vftable';
+    if ( s_Source2EntitySystem )
+      (*(void (__fastcall **)(__int64, _QWORD *))(*(_QWORD *)s_Source2EntitySystem + 56LL))(s_Source2EntitySystem, v0);// 56LL = 0x38 = IGameSystemFactory_SetGlobalPtr
+    return v0;
+  }

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.linux.yaml
@@ -22,7 +22,7 @@ disasm_code: |-
   .text:0000000000EB1DCB                 call    qword ptr [rax+38h]
   .text:0000000000EB1DCE                 mov     rax, [rbx-8]
   .text:0000000000EB1DD2                 mov     rdi, r12
-  .text:0000000000EB1DD5                 call    qword ptr [rax+0E0h] ; 0xE0 = IGameSystem_dtor
+  .text:0000000000EB1DD5                 call    qword ptr [rax+0E0h] ; 0xE0 = IGameSystem_vdtor
   .text:0000000000EB1DDB                 mov     rax, cs:g_pMemAlloc_ptr
   .text:0000000000EB1DE2                 mov     rsi, r12
   .text:0000000000EB1DE5                 pop     rbx
@@ -64,6 +64,6 @@ procedure: |-
       ((void (__fastcall *)(__int64, _QWORD))v4)(v3, 0);
       v2 = *(_QWORD *)(a2 - 8);
     }
-    (*(void (__fastcall **)(__int64))(v2 + 224))(v3); // 224 = 0xE0 = IGameSystem_dtor
+    (*(void (__fastcall **)(__int64))(v2 + 224))(v3); // 224 = 0xE0 = IGameSystem_vdtor
     return (*(__int64 (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v3);
   }

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.linux.yaml
@@ -1,4 +1,4 @@
-func_name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate
+func_name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
 func_va: '0xeb1d90'
 disasm_code: |-
   .text:0000000000EB1D90                 test    rsi, rsi
@@ -40,7 +40,7 @@ disasm_code: |-
   .text:0000000000EB1E05                 mov     rax, qword ptr ds:dword_0
   .text:0000000000EB1E0D                 ud2
 procedure: |-
-  __int64 __fastcall CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate(__int64 a1, __int64 a2)
+  __int64 __fastcall CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem(__int64 a1, __int64 a2)
   {
     __int64 v2; // rax
     __int64 v3; // r12

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.windows.yaml
@@ -1,4 +1,4 @@
-func_name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate
+func_name: CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem
 func_va: '0x180389340'
 disasm_code: |-
   .text:0000000180389340                 mov     [rsp+arg_0], rbx
@@ -25,7 +25,7 @@ disasm_code: |-
   .text:0000000180389390                 pop     rdi
   .text:0000000180389391                 jmp     qword ptr [rax+18h]
 procedure: |-
-  __int64 __fastcall CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate(__int64 a1, __int64 a2)
+  __int64 __fastcall CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem(__int64 a1, __int64 a2)
   {
     __int64 v2; // rdi
 

--- a/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem.windows.yaml
@@ -15,7 +15,7 @@ disasm_code: |-
   .text:0000000180389367                 mov     rax, [rdi+8]
   .text:000000018038936B                 lea     rcx, [rdi+8]
   .text:000000018038936F                 xor     edx, edx
-  .text:0000000180389371                 call    qword ptr [rax+1E8h] ; 0x1E8 = IGameSystem_dtor
+  .text:0000000180389371                 call    qword ptr [rax+1E8h] ; 0x1E8 = IGameSystem_vdtor
   .text:0000000180389377                 mov     rax, cs:g_pMemAlloc
   .text:000000018038937E                 mov     rdx, rdi
   .text:0000000180389381                 mov     rcx, [rax]
@@ -33,6 +33,6 @@ procedure: |-
     if ( !a2 )
       v2 = 0;
     (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)(v2 + 8) + 464LL))(v2 + 8, 0); // 464LL = 0x1D0 = IGameSystem_SetGameSystemGlobalPtrs
-    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)(v2 + 8) + 488LL))(v2 + 8, 0); // 488LL = 0x1E8 = IGameSystem_dtor
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)(v2 + 8) + 488LL))(v2 + 8, 0); // 488LL = 0x1E8 = IGameSystem_vdtor
     return (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v2);
   }

--- a/ida_preprocessor_scripts/references/client/CLoopModeFactory_CLoopModeGame_Shutdown.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CLoopModeFactory_CLoopModeGame_Shutdown.linux.yaml
@@ -1,0 +1,151 @@
+func_name: CLoopModeFactory_CLoopModeGame_Shutdown
+func_va: '0x15d6c10'
+disasm_code: |-
+  .text:00000000015D6C10                 push    rbp
+  .text:00000000015D6C11                 mov     rbp, rsp
+  .text:00000000015D6C14                 push    rbx
+  .text:00000000015D6C15                 sub     rsp, 48h
+  .text:00000000015D6C19                 call    sub_1F49CC0
+  .text:00000000015D6C1E                 lea     rax, g_pEngineServiceMgr
+  .text:00000000015D6C25                 mov     rdi, [rax]
+  .text:00000000015D6C28                 mov     rax, [rdi]
+  .text:00000000015D6C2B                 call    qword ptr [rax+0E8h]  ; E8h = IEngineServiceMgr_GetEventDispatcher
+  .text:00000000015D6C31                 mov     rbx, rax
+  .text:00000000015D6C34                 call    nullsub_563
+  .text:00000000015D6C39                 lea     rax, off_41ECF30
+  .text:00000000015D6C40                 mov     rdi, [rax]
+  .text:00000000015D6C43                 call    sub_2A2DA30
+  .text:00000000015D6C48                 lea     rdx, IGameSystem_PostInit
+  .text:00000000015D6C4F                 lea     rcx, sub_BFADF0
+  .text:00000000015D6C56                 mov     [rbp+var_20], 0
+  .text:00000000015D6C5E                 mov     [rbp+var_28], rcx
+  .text:00000000015D6C62                 mov     [rbp+var_48], rax
+  .text:00000000015D6C66                 mov     [rbp+var_30], rdx
+  .text:00000000015D6C6A                 test    rax, rax
+  .text:00000000015D6C6D                 jz      loc_15D6D0B
+  .text:00000000015D6C73                 mov     rdi, rax
+  .text:00000000015D6C76                 call    sub_2A2DA40
+  .text:00000000015D6C7B                 test    al, al
+  .text:00000000015D6C7D                 jz      loc_15D6D0B
+  .text:00000000015D6C83                 call    _ThreadGetCurrentId
+  .text:00000000015D6C88                 ; unsigned __int64
+  .text:00000000015D6C88                 mov     rsi, rax; unsigned __int64
+  .text:00000000015D6C8B                 cmp     rax, [rbx+8]
+  .text:00000000015D6C8F                 jz      loc_15D6D18
+  .text:00000000015D6C95                 mov     eax, [rbx]
+  .text:00000000015D6C97                 test    eax, eax
+  .text:00000000015D6C99                 jz      loc_15D6D20
+  .text:00000000015D6C9F                 ; this
+  .text:00000000015D6C9F                 mov     rdi, rbx; this
+  .text:00000000015D6CA2                 call    __ZN12CAtomicMutex11AcquireLockEy; CAtomicMutex::AcquireLock(ulong long)
+  .text:00000000015D6CA7                 lea     rdx, [rbp+var_48]
+  .text:00000000015D6CAB                 lea     rsi, [rbx+18h]
+  .text:00000000015D6CAF                 lea     rdi, [rbx+20h]
+  .text:00000000015D6CB3                 call    sub_15D0D20
+  .text:00000000015D6CB8                 mov     rsi, rax
+  .text:00000000015D6CBB                 mov     [rbp+var_3C], rax
+  .text:00000000015D6CBF                 shr     rsi, 20h
+  .text:00000000015D6CC3                 mov     [rbp+var_34], edx
+  .text:00000000015D6CC6                 cmp     esi, [rbx+20h]
+  .text:00000000015D6CC9                 jnb     short loc_15D6CF6
+  .text:00000000015D6CCB                 mov     eax, esi
+  .text:00000000015D6CCD                 lea     rdx, [rax+rax*2]
+  .text:00000000015D6CD1                 shl     rdx, 4
+  .text:00000000015D6CD5                 test    dword ptr [rbx+24h], 7FFFFFFFh
+  .text:00000000015D6CDC                 jz      short loc_15D6D48
+  .text:00000000015D6CDE                 add     rdx, [rbx+28h]
+  .text:00000000015D6CE2                 cmp     esi, [rdx]
+  .text:00000000015D6CE4                 jz      short loc_15D6CF6
+  .text:00000000015D6CE6                 ; _QWORD
+  .text:00000000015D6CE6                 add     rdx, 18h; _QWORD
+  .text:00000000015D6CEA                 ; _QWORD
+  .text:00000000015D6CEA                 mov     rdi, rbx; _QWORD
+  .text:00000000015D6CED                 ; _QWORD
+  .text:00000000015D6CED                 lea     rsi, [rbp+var_30]; _QWORD
+  .text:00000000015D6CF1                 call    __ZN21CEventDispatcher_Base28UnregisterEventListener_BaseERK20CUtlAbstractDelegateR10CUtlVectorINS_19EventListenerInfo_tEi25CUtlVectorMemory_GrowableIS4_iLm0EEE; CEventDispatcher_Base::UnregisterEventListener_Base(CUtlAbstractDelegate const&,CUtlVector<CEventDispatcher_Base::EventListenerInfo_t,int,CUtlVectorMemory_Growable<CEventDispatcher_Base::EventListenerInfo_t,int,0ul>> &)
+  .text:00000000015D6CF6                 sub     word ptr [rbx+4], 1
+  .text:00000000015D6CFB                 jnz     short loc_15D6D0B
+  .text:00000000015D6CFD                 mov     qword ptr [rbx+8], 0
+  .text:00000000015D6D05                 lock sub dword ptr [rbx], 3
+  .text:00000000015D6D09                 jnz     short loc_15D6D50
+  .text:00000000015D6D0B                 mov     rbx, [rbp+var_8]
+  .text:00000000015D6D0F                 leave
+  .text:00000000015D6D10                 jmp     IGameSystem_ShutdownAllSystems
+  .text:00000000015D6D18                 add     word ptr [rbx+4], 1
+  .text:00000000015D6D1D                 jmp     short loc_15D6CA7
+  .text:00000000015D6D20                 mov     edx, 3
+  .text:00000000015D6D25                 lock cmpxchg [rbx], edx
+  .text:00000000015D6D29                 jnz     loc_15D6C9F
+  .text:00000000015D6D2F                 mov     eax, 1
+  .text:00000000015D6D34                 mov     [rbx+8], rsi
+  .text:00000000015D6D38                 mov     [rbx+4], ax
+  .text:00000000015D6D3C                 jmp     loc_15D6CA7
+  .text:00000000015D6D48                 cmp     [rdx], esi
+  .text:00000000015D6D4A                 jnz     short loc_15D6CE6
+  .text:00000000015D6D4C                 jmp     short loc_15D6CF6
+  .text:00000000015D6D50                 ; unsigned int *
+  .text:00000000015D6D50                 mov     rdi, rbx; unsigned int *
+  .text:00000000015D6D53                 call    __Z21ThreadAtomicNotifyOnePKj; ThreadAtomicNotifyOne(uint const*)
+  .text:00000000015D6D58                 jmp     short loc_15D6D0B
+procedure: |-
+  __int64 CLoopModeFactory_CLoopModeGame_Shutdown()
+  {
+    __int64 v0; // rbx
+    __int64 v1; // rax
+    unsigned __int64 CurrentId; // rsi
+    int v3; // edx
+    __int64 v4; // rdx
+    __int64 v7; // [rsp+8h] [rbp-48h] BYREF
+    __int64 v8; // [rsp+14h] [rbp-3Ch]
+    int v9; // [rsp+1Ch] [rbp-34h]
+    _QWORD v10[5]; // [rsp+20h] [rbp-30h] BYREF
+
+    sub_1F49CC0();
+    v0 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pEngineServiceMgr + 232LL))(g_pEngineServiceMgr); // 232LL = 0xE8 = IEngineServiceMgr_GetEventDispatcher
+    nullsub_563();
+    v1 = sub_2A2DA30(&unk_43DE5C0);
+    v10[2] = 0;
+    v10[1] = sub_BFADF0;
+    v7 = v1;
+    v10[0] = IGameSystem_PostInit;
+    if ( !v1 || !(unsigned __int8)sub_2A2DA40(v1) )
+      return IGameSystem_ShutdownAllSystems();
+    CurrentId = ThreadGetCurrentId();
+    if ( CurrentId == *(_QWORD *)(v0 + 8) )
+    {
+      ++*(_WORD *)(v0 + 4);
+    }
+    else if ( *(_DWORD *)v0 || _InterlockedCompareExchange((volatile signed __int32 *)v0, 3, 0) )
+    {
+      CAtomicMutex::AcquireLock((CAtomicMutex *)v0, CurrentId);
+    }
+    else
+    {
+      *(_QWORD *)(v0 + 8) = CurrentId;
+      *(_WORD *)(v0 + 4) = 1;
+    }
+    v8 = sub_15D0D20(v0 + 32, v0 + 24, &v7);
+    v9 = v3;
+    if ( HIDWORD(v8) < *(_DWORD *)(v0 + 32) )
+    {
+      v4 = 48LL * HIDWORD(v8);
+      if ( (*(_DWORD *)(v0 + 36) & 0x7FFFFFFF) == 0 )
+      {
+        if ( *(_DWORD *)v4 == HIDWORD(v8) )
+          goto LABEL_10;
+        goto LABEL_9;
+      }
+      v4 += *(_QWORD *)(v0 + 40);
+      if ( HIDWORD(v8) != *(_DWORD *)v4 )
+  LABEL_9:
+        CEventDispatcher_Base::UnregisterEventListener_Base(v0, v10, v4 + 24);
+    }
+  LABEL_10:
+    if ( (*(_WORD *)(v0 + 4))-- == 1 )
+    {
+      *(_QWORD *)(v0 + 8) = 0;
+      if ( _InterlockedSub((volatile signed __int32 *)v0, 3u) )
+        ThreadAtomicNotifyOne((const unsigned int *)v0);
+    }
+    return IGameSystem_ShutdownAllSystems();
+  }

--- a/ida_preprocessor_scripts/references/client/CLoopModeFactory_CLoopModeGame_Shutdown.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CLoopModeFactory_CLoopModeGame_Shutdown.windows.yaml
@@ -1,0 +1,41 @@
+func_name: CLoopModeFactory_CLoopModeGame_Shutdown
+func_va: '0x18099cd70'
+disasm_code: |-
+  .text:000000018099CD70                 push    rbx
+  .text:000000018099CD72                 sub     rsp, 30h
+  .text:000000018099CD76                 call    sub_181166E20
+  .text:000000018099CD7B                 mov     rcx, cs:g_pEngineServiceMgr
+  .text:000000018099CD82                 mov     rax, [rcx]
+  .text:000000018099CD85                 call    qword ptr [rax+0E8h]  ; E8h = IEngineServiceMgr_GetEventDispatcher
+  .text:000000018099CD8B                 mov     rbx, rax
+  .text:000000018099CD8E                 call    nullsub_325
+  .text:000000018099CD93                 mov     rdx, cs:off_1819F4B28
+  .text:000000018099CD9A                 lea     rcx, [rsp+38h+arg_8]
+  .text:000000018099CD9F                 call    unknown_libname_425; Microsoft VisualC v7/14 64bit runtime
+  .text:000000018099CDA4                 mov     r8, [rsp+38h+arg_8]
+  .text:000000018099CDA9                 lea     rax, sub_18016D940
+  .text:000000018099CDB0                 mov     [rsp+38h+var_10], rax
+  .text:000000018099CDB5                 lea     rdx, [rsp+38h+var_18]
+  .text:000000018099CDBA                 lea     rax, IGameSystem_PostInit
+  .text:000000018099CDC1                 mov     rcx, rbx
+  .text:000000018099CDC4                 mov     [rsp+38h+var_18], rax
+  .text:000000018099CDC9                 call    sub_18091C740
+  .text:000000018099CDCE                 add     rsp, 30h
+  .text:000000018099CDD2                 pop     rbx
+  .text:000000018099CDD3                 jmp     IGameSystem_ShutdownAllSystems
+procedure: |-
+  __int64 CLoopModeFactory_CLoopModeGame_Shutdown()
+  {
+    __int64 v0; // rbx
+    _QWORD v2[3]; // [rsp+20h] [rbp-18h] BYREF
+    __int64 v3; // [rsp+48h] [rbp+10h] BYREF
+
+    sub_181166E20();
+    v0 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineServiceMgr + 232LL))(g_pEngineServiceMgr); // 232LL = 0xE8 = IEngineServiceMgr_GetEventDispatcher
+    nullsub_325();
+    unknown_libname_425(&v3, &unk_18201C850);
+    v2[1] = sub_18016D940;
+    v2[0] = IGameSystem_PostInit;
+    sub_18091C740(v0, v2, v3);
+    return IGameSystem_ShutdownAllSystems();
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.linux.yaml
@@ -1,0 +1,359 @@
+func_name: CSource2EntitySystem_StaticInit
+func_va: '0x15c0a50'
+disasm_code: |-
+  .text:00000000015C0A50                 push    rbp
+  .text:00000000015C0A51                 mov     rbp, rsp
+  .text:00000000015C0A54                 push    r13
+  .text:00000000015C0A56                 push    r12
+  .text:00000000015C0A58                 push    rbx
+  .text:00000000015C0A59                 sub     rsp, 28h
+  .text:00000000015C0A5D                 lea     rdx, dword_480C440
+  .text:00000000015C0A64                 mov     eax, [rdx]
+  .text:00000000015C0A66                 lea     ecx, [rax+1]
+  .text:00000000015C0A69                 mov     [rdx], ecx
+  .text:00000000015C0A6B                 test    eax, eax
+  .text:00000000015C0A6D                 jg      short loc_15C0AA0
+  .text:00000000015C0A6F                 ; _QWORD
+  .text:00000000015C0A6F                 mov     edi, 2100h; _QWORD
+  .text:00000000015C0A74                 call    __Znwm; operator new(ulong)
+  .text:00000000015C0A79                 mov     rbx, rax
+  .text:00000000015C0A7C                 mov     rdi, rax
+  .text:00000000015C0A7F                 call    CGameEntitySystem_ctor
+  .text:00000000015C0A84                 xor     r8d, r8d
+  .text:00000000015C0A87                 mov     ecx, 1
+  .text:00000000015C0A8C                 mov     rdi, rbx
+  .text:00000000015C0A8F                 lea     rsi, aClientEntities; "client_entities"
+  .text:00000000015C0A96                 mov     edx, 1
+  .text:00000000015C0A9B                 call    CEntitySystem_PostCreateEntitySystem
+  .text:00000000015C0AA0                 lea     r13, g_pEntitySystem
+  .text:00000000015C0AA7                 mov     rbx, [r13+0]
+  .text:00000000015C0AAB                 movsxd  r12, dword ptr [rbx+0B90h]
+  .text:00000000015C0AB2                 mov     cs:g_pGameEntitySystem, rbx
+  .text:00000000015C0AB9                 mov     eax, r12d
+  .text:00000000015C0ABC                 cmp     r12d, [rbx+0BA0h]
+  .text:00000000015C0AC3                 jz      loc_15C0D78
+  .text:00000000015C0AC9                 add     eax, 1
+  .text:00000000015C0ACC                 ; _QWORD
+  .text:00000000015C0ACC                 mov     edi, 1338h; _QWORD
+  .text:00000000015C0AD1                 mov     [rbx+0B90h], eax
+  .text:00000000015C0AD7                 mov     rax, [rbx+0B98h]
+  .text:00000000015C0ADE                 lea     rcx, off_4404C60
+  .text:00000000015C0AE5                 mov     [rax+r12*8], rcx
+  .text:00000000015C0AE9                 call    __Znwm; operator new(ulong)
+  .text:00000000015C0AEE                 mov     rdi, rax
+  .text:00000000015C0AF1                 mov     rbx, rax
+  .text:00000000015C0AF4                 call    sub_1556BF0
+  .text:00000000015C0AF9                 mov     rax, cs:g_pGameEntitySystem
+  .text:00000000015C0B00                 lea     rdx, aMod; "MOD"
+  .text:00000000015C0B07                 lea     rsi, aSave; "save/"
+  .text:00000000015C0B0E                 mov     [rax+20E8h], rbx
+  .text:00000000015C0B15                 lea     rax, g_pFileSystem
+  .text:00000000015C0B1C                 mov     rdi, [rax]
+  .text:00000000015C0B1F                 mov     rax, [rdi]
+  .text:00000000015C0B22                 call    qword ptr [rax+180h]
+  .text:00000000015C0B28                 call    _CommandLine
+  .text:00000000015C0B2D                 xor     edx, edx
+  .text:00000000015C0B2F                 mov     esi, 6FEFF596h
+  .text:00000000015C0B34                 mov     rdi, rax
+  .text:00000000015C0B37                 mov     rax, [rax]
+  .text:00000000015C0B3A                 call    qword ptr [rax+30h]
+  .text:00000000015C0B3D                 test    eax, eax
+  .text:00000000015C0B3F                 jnz     short loc_15C0B49
+  .text:00000000015C0B41                 mov     rdi, rbx
+  .text:00000000015C0B44                 call    sub_15581F0
+  .text:00000000015C0B49                 mov     rdi, cs:qword_465C9F0
+  .text:00000000015C0B50                 mov     rax, [rdi]
+  .text:00000000015C0B53                 call    qword ptr [rax+70h]
+  .text:00000000015C0B56                 mov     [rbx+120h], rax
+  .text:00000000015C0B5D                 test    rax, rax
+  .text:00000000015C0B60                 jz      loc_15C0E00
+  .text:00000000015C0B66                 mov     rax, [rbx]
+  .text:00000000015C0B69                 lea     rdx, sub_1529C30
+  .text:00000000015C0B70                 mov     rdi, cs:qword_465A318
+  .text:00000000015C0B77                 mov     r12, [rax+88h]
+  .text:00000000015C0B7E                 mov     rax, [rdi]
+  .text:00000000015C0B81                 mov     rax, [rax+0C0h]
+  .text:00000000015C0B88                 cmp     rax, rdx
+  .text:00000000015C0B8B                 jnz     loc_15C0DF0
+  .text:00000000015C0B91                 lea     rax, g_pVApplication
+  .text:00000000015C0B98                 mov     rdi, [rax]
+  .text:00000000015C0B9B                 mov     rax, [rdi]
+  .text:00000000015C0B9E                 call    qword ptr [rax+0E0h]
+  .text:00000000015C0BA4                 ; char *
+  .text:00000000015C0BA4                 mov     rsi, rax; char *
+  .text:00000000015C0BA7                 lea     rax, sub_152C500
+  .text:00000000015C0BAE                 cmp     r12, rax
+  .text:00000000015C0BB1                 jnz     loc_15C0DE0
+  .text:00000000015C0BB7                 ; this
+  .text:00000000015C0BB7                 lea     rdi, [rbx+100h]; this
+  .text:00000000015C0BBE                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:00000000015C0BC3                 mov     rbx, cs:qword_465A2C8
+  .text:00000000015C0BCA                 test    rbx, rbx
+  .text:00000000015C0BCD                 jz      short loc_15C0BEF
+  .text:00000000015C0BCF                 nop
+  .text:00000000015C0BD0                 mov     ecx, [rbx+10h]
+  .text:00000000015C0BD3                 mov     rdx, [rbx]
+  .text:00000000015C0BD6                 mov     rsi, [rbx+8]
+  .text:00000000015C0BDA                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015C0BE1                 call    sub_15BD4D0
+  .text:00000000015C0BE6                 mov     rbx, [rbx+18h]
+  .text:00000000015C0BEA                 test    rbx, rbx
+  .text:00000000015C0BED                 jnz     short loc_15C0BD0
+  .text:00000000015C0BEF                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015C0BF6                 mov     esi, 1
+  .text:00000000015C0BFB                 call    sub_2AFF180
+  .text:00000000015C0C00                 mov     rax, cs:qword_465A318
+  .text:00000000015C0C07                 lea     rdx, sub_1531B60
+  .text:00000000015C0C0E                 lea     rdi, [rax+8]
+  .text:00000000015C0C12                 mov     rax, [rax+8]
+  .text:00000000015C0C16                 mov     rax, [rax+0A8h]
+  .text:00000000015C0C1D                 cmp     rax, rdx
+  .text:00000000015C0C20                 jnz     loc_15C0D98
+  .text:00000000015C0C26                 lea     rax, g_pVApplication
+  .text:00000000015C0C2D                 lea     rbx, [rbp+var_40]
+  .text:00000000015C0C31                 mov     rdi, [rax]
+  .text:00000000015C0C34                 mov     rax, [rdi]
+  .text:00000000015C0C37                 call    qword ptr [rax+0B8h]
+  .text:00000000015C0C3D                 test    al, al
+  .text:00000000015C0C3F                 jnz     loc_15C0D40
+  .text:00000000015C0C45                 lea     rax, g_pGameResourceService
+  .text:00000000015C0C4C                 mov     rdi, [rax]
+  .text:00000000015C0C4F                 test    rdi, rdi
+  .text:00000000015C0C52                 jz      short loc_15C0C64
+  .text:00000000015C0C54                 mov     rax, [rdi]
+  .text:00000000015C0C57                 mov     rsi, cs:g_pGameEntitySystem
+  .text:00000000015C0C5E                 call    qword ptr [rax+110h]  ; 110h = IGameResourceService_SetEntityResourceManifestHandler
+  .text:00000000015C0C64                 mov     rax, [r13+0]
+  .text:00000000015C0C68                 lea     r12, sub_152AE70
+  .text:00000000015C0C6F                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015C0C76                 mov     esi, [rax+278h]
+  .text:00000000015C0C7C                 call    sub_15C0990
+  .text:00000000015C0C81                 mov     rdi, [r13+0]
+  .text:00000000015C0C85                 mov     rdx, rbx
+  .text:00000000015C0C88                 mov     [rbp+var_38], r12
+  .text:00000000015C0C8C                 lea     rax, sub_156A6F0
+  .text:00000000015C0C93                 mov     esi, 28h ; '('
+  .text:00000000015C0C98                 mov     [rbp+var_30], 0
+  .text:00000000015C0CA0                 mov     [rbp+var_40], rax
+  .text:00000000015C0CA4                 call    sub_2B05A40
+  .text:00000000015C0CA9                 mov     rdi, [r13+0]
+  .text:00000000015C0CAD                 mov     rdx, rbx
+  .text:00000000015C0CB0                 mov     [rbp+var_38], r12
+  .text:00000000015C0CB4                 lea     rax, sub_156A940
+  .text:00000000015C0CBB                 mov     esi, 36h ; '6'
+  .text:00000000015C0CC0                 mov     [rbp+var_30], 0
+  .text:00000000015C0CC8                 mov     [rbp+var_40], rax
+  .text:00000000015C0CCC                 call    sub_2B05A40
+  .text:00000000015C0CD1                 mov     rdi, [r13+0]
+  .text:00000000015C0CD5                 mov     rdx, rbx
+  .text:00000000015C0CD8                 mov     [rbp+var_38], r12
+  .text:00000000015C0CDC                 lea     rax, sub_152D070
+  .text:00000000015C0CE3                 mov     esi, 43h ; 'C'
+  .text:00000000015C0CE8                 mov     [rbp+var_30], 0
+  .text:00000000015C0CF0                 mov     [rbp+var_40], rax
+  .text:00000000015C0CF4                 call    sub_2B05A40
+  .text:00000000015C0CF9                 lea     rax, g_pFlattenedSerializers
+  .text:00000000015C0D00                 lea     rcx, sub_152AE90
+  .text:00000000015C0D07                 mov     rsi, rbx
+  .text:00000000015C0D0A                 mov     rdi, [rax]
+  .text:00000000015C0D0D                 mov     rax, [rdi]
+  .text:00000000015C0D10                 mov     rax, [rax+108h]
+  .text:00000000015C0D17                 mov     [rbp+var_38], rcx
+  .text:00000000015C0D1B                 lea     rcx, sub_1529EC0
+  .text:00000000015C0D22                 mov     [rbp+var_30], 0
+  .text:00000000015C0D2A                 mov     [rbp+var_40], rcx
+  .text:00000000015C0D2E                 call    rax
+  .text:00000000015C0D30                 add     rsp, 28h
+  .text:00000000015C0D34                 mov     eax, 1
+  .text:00000000015C0D39                 pop     rbx
+  .text:00000000015C0D3A                 pop     r12
+  .text:00000000015C0D3C                 pop     r13
+  .text:00000000015C0D3E                 pop     rbp
+  .text:00000000015C0D3F                 retn
+  .text:00000000015C0D40                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015C0D47                 lea     rax, sub_152AE60
+  .text:00000000015C0D4E                 mov     rsi, rbx
+  .text:00000000015C0D51                 mov     [rbp+var_30], 0
+  .text:00000000015C0D59                 mov     [rbp+var_38], rax
+  .text:00000000015C0D5D                 lea     rax, sub_153EE00
+  .text:00000000015C0D64                 mov     [rbp+var_40], rax
+  .text:00000000015C0D68                 call    sub_2AF98D0
+  .text:00000000015C0D6D                 jmp     loc_15C0C45
+  .text:00000000015C0D78                 lea     rdi, [rbx+0B98h]
+  .text:00000000015C0D7F                 mov     esi, 1
+  .text:00000000015C0D84                 call    sub_1219940
+  .text:00000000015C0D89                 mov     eax, [rbx+0B90h]
+  .text:00000000015C0D8F                 jmp     loc_15C0AC9
+  .text:00000000015C0D98                 call    rax
+  .text:00000000015C0D9A                 test    al, al
+  .text:00000000015C0D9C                 jz      loc_15C0C26
+  .text:00000000015C0DA2                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015C0DA9                 lea     rax, sub_152AE60
+  .text:00000000015C0DB0                 mov     [rbp+var_30], 0
+  .text:00000000015C0DB8                 lea     rbx, [rbp+var_40]
+  .text:00000000015C0DBC                 mov     [rbp+var_38], rax
+  .text:00000000015C0DC0                 lea     rax, sub_153EE00
+  .text:00000000015C0DC7                 mov     rsi, rbx
+  .text:00000000015C0DCA                 mov     [rbp+var_40], rax
+  .text:00000000015C0DCE                 call    sub_2AF98D0
+  .text:00000000015C0DD3                 jmp     loc_15C0C45
+  .text:00000000015C0DE0                 mov     rdi, rbx
+  .text:00000000015C0DE3                 call    r12
+  .text:00000000015C0DE6                 jmp     loc_15C0BC3
+  .text:00000000015C0DF0                 call    rax
+  .text:00000000015C0DF2                 mov     rsi, rax
+  .text:00000000015C0DF5                 jmp     loc_15C0BA7
+  .text:00000000015C0E00                 ; _QWORD
+  .text:00000000015C0E00                 mov     edi, 350h; _QWORD
+  .text:00000000015C0E05                 call    __Znwm; operator new(ulong)
+  .text:00000000015C0E0A                 mov     rdi, rax
+  .text:00000000015C0E0D                 mov     r12, rax
+  .text:00000000015C0E10                 call    sub_15568E0
+  .text:00000000015C0E15                 mov     rdi, cs:qword_465C9F0
+  .text:00000000015C0E1C                 mov     [rbx+120h], r12
+  .text:00000000015C0E23                 mov     rsi, r12
+  .text:00000000015C0E26                 mov     byte ptr [rbx+128h], 1
+  .text:00000000015C0E2D                 mov     rax, [rdi]
+  .text:00000000015C0E30                 call    qword ptr [rax+68h]
+  .text:00000000015C0E33                 jmp     loc_15C0B66
+procedure: |-
+  __int64 CSource2EntitySystem_StaticInit()
+  {
+    int v0; // eax
+    __int64 v1; // rbx
+    __int64 v2; // rbx
+    __int64 v3; // r12
+    int v4; // eax
+    __int64 v5; // rbx
+    __int64 v6; // rax
+    __int64 v7; // rax
+    __int64 (__fastcall *v8)(); // r12
+    __int64 (*v9)(void); // rax
+    const char *v10; // rsi
+    __int64 i; // rbx
+    __int64 (__fastcall *v12)(); // rax
+    __int64 v13; // rdx
+    __int64 v14; // rcx
+    __int64 v15; // r8
+    __int64 v16; // r9
+    __int64 v17; // rcx
+    __int64 v18; // r8
+    __int64 v19; // r9
+    __int64 v20; // rcx
+    __int64 v21; // r8
+    __int64 v22; // r9
+    void (__fastcall *v23)(_QWORD *, __int64 (__fastcall **)()); // rax
+    __int64 v25; // r12
+    __int64 v26; // rdi
+    __int64 (__fastcall *v27)(); // [rsp+0h] [rbp-40h] BYREF
+    __int64 (__fastcall *v28)(); // [rsp+8h] [rbp-38h]
+    __int64 v29; // [rsp+10h] [rbp-30h]
+
+    v0 = dword_480C440++;
+    if ( v0 <= 0 )
+    {
+      v1 = operator new(8448);
+      CGameEntitySystem_ctor(v1);
+      CEntitySystem_PostCreateEntitySystem(v1, "client_entities", 1, 1, 0);
+    }
+    v2 = g_pEntitySystem;
+    v3 = *(int *)(g_pEntitySystem + 2960LL);
+    g_pGameEntitySystem = g_pEntitySystem;
+    v4 = v3;
+    if ( (_DWORD)v3 == *(_DWORD *)(g_pEntitySystem + 2976LL) )
+    {
+      sub_1219940(g_pEntitySystem + 2968LL, 1);
+      v4 = *(_DWORD *)(v2 + 2960);
+    }
+    *(_DWORD *)(v2 + 2960) = v4 + 1;
+    *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_4404C60;
+    v5 = operator new(4920);
+    sub_1556BF0(v5);
+    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;
+    (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*g_pFileSystem + 384LL))(g_pFileSystem, "save/", "MOD");
+    v6 = CommandLine();
+    if ( !(*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v6 + 48LL))(v6, 1877996950, 0) )
+      sub_15581F0(v5);
+    v7 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_465C9F0 + 112LL))(qword_465C9F0);
+    *(_QWORD *)(v5 + 288) = v7;
+    if ( !v7 )
+    {
+      v25 = operator new(848);
+      sub_15568E0(v25);
+      v26 = qword_465C9F0;
+      *(_QWORD *)(v5 + 288) = v25;
+      *(_BYTE *)(v5 + 296) = 1;
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v26 + 104LL))(v26, v25);
+    }
+    v8 = *(__int64 (__fastcall **)())(*(_QWORD *)v5 + 136LL);
+    v9 = *(__int64 (**)(void))(*(_QWORD *)qword_465A318 + 192LL);
+    if ( v9 == sub_1529C30 )
+      v10 = (const char *)(*(__int64 (__fastcall **)(_QWORD *))(*g_pVApplication + 224LL))(g_pVApplication);
+    else
+      v10 = (const char *)v9();
+    if ( v8 == sub_152C500 )
+      CUtlString::Set((CUtlString *)(v5 + 256), v10);
+    else
+      ((void (__fastcall *)(__int64, const char *))v8)(v5, v10);
+    for ( i = qword_465A2C8; i; i = *(_QWORD *)(i + 24) )
+      sub_15BD4D0(g_pGameEntitySystem, *(_QWORD *)(i + 8), *(_QWORD *)i, *(unsigned int *)(i + 16));
+    sub_2AFF180(g_pGameEntitySystem, 1);
+    v12 = *(__int64 (__fastcall **)())(*(_QWORD *)(qword_465A318 + 8) + 168LL);
+    if ( v12 == sub_1531B60 || !((unsigned __int8 (__fastcall *)(__int64))v12)(qword_465A318 + 8) )
+    {
+      if ( (*(unsigned __int8 (__fastcall **)(_QWORD *))(*g_pVApplication + 184LL))(g_pVApplication) )
+      {
+        v29 = 0;
+        v28 = sub_152AE60;
+        v27 = sub_153EE00;
+        ((void (__fastcall *)(__int64, __int64 (__fastcall **)(), __int64, __int64, __int64, __int64))sub_2AF98D0)(
+          g_pGameEntitySystem,
+          &v27,
+          v13,
+          v14,
+          v15,
+          v16);
+      }
+    }
+    else
+    {
+      v29 = 0;
+      v28 = sub_152AE60;
+      v27 = sub_153EE00;
+      ((void (__fastcall *)(__int64, __int64 (__fastcall **)()))sub_2AF98D0)(g_pGameEntitySystem, &v27);
+    }
+    if ( g_pGameResourceService )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService + 272LL))(  // 272LL = 0x110 = IGameResourceService_SetEntityResourceManifestHandler
+        g_pGameResourceService, g_pGameEntitySystem);
+    sub_15C0990(g_pGameEntitySystem, *(unsigned int *)(g_pEntitySystem + 632LL));
+    v28 = sub_152AE70;
+    v29 = 0;
+    v27 = sub_156A6F0;
+    ((void (__fastcall *)(_QWORD, __int64, __int64 (__fastcall **)()))sub_2B05A40)(g_pEntitySystem, 40, &v27);
+    v28 = sub_152AE70;
+    v29 = 0;
+    v27 = sub_156A940;
+    ((void (__fastcall *)(_QWORD, __int64, __int64 (__fastcall **)(), __int64, __int64, __int64))sub_2B05A40)(
+      g_pEntitySystem,
+      54,
+      &v27,
+      v17,
+      v18,
+      v19);
+    v28 = sub_152AE70;
+    v29 = 0;
+    v27 = sub_152D070;
+    ((void (__fastcall *)(_QWORD, __int64, __int64 (__fastcall **)(), __int64, __int64, __int64))sub_2B05A40)(
+      g_pEntitySystem,
+      67,
+      &v27,
+      v20,
+      v21,
+      v22);
+    v23 = *(void (__fastcall **)(_QWORD *, __int64 (__fastcall **)()))(*g_pFlattenedSerializers + 264LL);
+    v28 = sub_152AE90;
+    v29 = 0;
+    v27 = sub_1529EC0;
+    v23(g_pFlattenedSerializers, &v27);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
@@ -1,0 +1,495 @@
+func_name: CSource2EntitySystem_StaticInit
+func_va: '0x18098f440'
+disasm_code: |-
+  .text:000000018098F440                 mov     [rsp-18h+arg_8], rbx
+  .text:000000018098F445                 mov     [rsp-18h+arg_10], rsi
+  .text:000000018098F44A                 mov     [rsp-18h+arg_18], rdi
+  .text:000000018098F44F                 push    rbp
+  .text:000000018098F450                 push    r14
+  .text:000000018098F452                 push    r15
+  .text:000000018098F454                 mov     rbp, rsp
+  .text:000000018098F457                 sub     rsp, 50h
+  .text:000000018098F45B                 mov     eax, cs:dword_1824E44E8
+  .text:000000018098F461                 xor     r15d, r15d
+  .text:000000018098F464                 mov     ecx, eax
+  .text:000000018098F466                 inc     eax
+  .text:000000018098F468                 mov     cs:dword_1824E44E8, eax
+  .text:000000018098F46E                 test    ecx, ecx
+  .text:000000018098F470                 jg      short loc_18098F4AB
+  .text:000000018098F472                 mov     ecx, 20F0h
+  .text:000000018098F477                 call    operator_new
+  .text:000000018098F47C                 test    rax, rax
+  .text:000000018098F47F                 jz      short loc_18098F48B
+  .text:000000018098F481                 mov     rcx, rax
+  .text:000000018098F484                 call    CGameEntitySystem_ctor
+  .text:000000018098F489                 jmp     short loc_18098F48E
+  .text:000000018098F48B                 mov     rax, r15
+  .text:000000018098F48E                 mov     r9d, 1
+  .text:000000018098F494                 mov     byte ptr [rsp+50h+var_30], r15b
+  .text:000000018098F499                 mov     r8d, r9d
+  .text:000000018098F49C                 lea     rdx, aClientEntities; "client_entities"
+  .text:000000018098F4A3                 mov     rcx, rax
+  .text:000000018098F4A6                 call    CEntitySystem_PostCreateEntitySystem
+  .text:000000018098F4AB                 mov     rbx, cs:g_pEntitySystem
+  .text:000000018098F4B2                 mov     cs:g_pGameEntitySystem, rbx
+  .text:000000018098F4B9                 movsxd  r14, dword ptr [rbx+0B90h]
+  .text:000000018098F4C0                 cmp     r14d, [rbx+0BA0h]
+  .text:000000018098F4C7                 jnz     loc_18098F58F
+  .text:000000018098F4CD                 test    dword ptr [rbx+0BA4h], 40000000h
+  .text:000000018098F4D7                 jnz     loc_18098F58F
+  .text:000000018098F4DD                 mov     ecx, [rbx+0BA0h]
+  .text:000000018098F4E3                 cmp     ecx, 7FFFFFFEh
+  .text:000000018098F4E9                 jle     short loc_18098F4F6
+  .text:000000018098F4EB                 mov     edx, 1
+  .text:000000018098F4F0                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:000000018098F4F6                 mov     ecx, [rbx+0BA0h]
+  .text:000000018098F4FC                 mov     r9d, 8
+  .text:000000018098F502                 mov     edx, [rbx+0BA4h]
+  .text:000000018098F508                 and     edx, 3FFFFFFFh
+  .text:000000018098F50E                 lea     esi, [rcx+1]
+  .text:000000018098F511                 mov     r8d, esi
+  .text:000000018098F514                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:000000018098F51A                 mov     edi, eax
+  .text:000000018098F51C                 cmp     eax, esi
+  .text:000000018098F51E                 jge     short loc_18098F53E
+  .text:000000018098F520                 test    eax, eax
+  .text:000000018098F522                 jnz     short loc_18098F530
+  .text:000000018098F524                 cmp     esi, 0FFFFFFFFh
+  .text:000000018098F527                 jg      short loc_18098F530
+  .text:000000018098F529                 mov     edi, 0FFFFFFFFh
+  .text:000000018098F52E                 jmp     short loc_18098F53E
+  .text:000000018098F530                 lea     eax, [rdi+rsi]
+  .text:000000018098F533                 cdq
+  .text:000000018098F534                 sub     eax, edx
+  .text:000000018098F536                 sar     eax, 1
+  .text:000000018098F538                 mov     edi, eax
+  .text:000000018098F53A                 cmp     eax, esi
+  .text:000000018098F53C                 jl      short loc_18098F530
+  .text:000000018098F53E                 movsxd  r9, dword ptr [rbx+0BA0h]
+  .text:000000018098F545                 mov     rcx, [rbx+0B98h]
+  .text:000000018098F54C                 shl     r9, 3
+  .text:000000018098F550                 movsxd  r8, edi
+  .text:000000018098F553                 shl     r8, 3
+  .text:000000018098F557                 test    dword ptr [rbx+0BA4h], 0C0000000h
+  .text:000000018098F561                 setz    dl
+  .text:000000018098F564                 call    cs:UtlVectorMemory_Alloc
+  .text:000000018098F56A                 mov     [rbx+0B98h], rax
+  .text:000000018098F571                 mov     eax, [rbx+0BA4h]
+  .text:000000018098F577                 test    eax, 0C0000000h
+  .text:000000018098F57C                 jz      short loc_18098F589
+  .text:000000018098F57E                 and     eax, 3FFFFFFFh
+  .text:000000018098F583                 mov     [rbx+0BA4h], eax
+  .text:000000018098F589                 mov     [rbx+0BA0h], edi
+  .text:000000018098F58F                 inc     dword ptr [rbx+0B90h]
+  .text:000000018098F595                 lea     rdx, off_182042A38
+  .text:000000018098F59C                 mov     rax, [rbx+0B98h]
+  .text:000000018098F5A3                 mov     ecx, 1338h
+  .text:000000018098F5A8                 mov     [rax+r14*8], rdx
+  .text:000000018098F5AC                 call    operator_new
+  .text:000000018098F5B1                 mov     rbx, rax
+  .text:000000018098F5B4                 test    rax, rax
+  .text:000000018098F5B7                 jz      loc_18098F707
+  .text:000000018098F5BD                 lea     rax, ??_7CEntity2SaveRestore@@6B@; const CEntity2SaveRestore::`vftable'
+  .text:000000018098F5C4                 mov     [rbp+arg_0], r15
+  .text:000000018098F5C8                 mov     [rbx], rax
+  .text:000000018098F5CB                 lea     rdx, aU02u02u; "%u:%02u:%02u"
+  .text:000000018098F5D2                 mov     [rbx+10h], r15
+  .text:000000018098F5D6                 lea     rcx, [rbp+arg_0]
+  .text:000000018098F5DA                 mov     [rbx+18h], r15
+  .text:000000018098F5DE                 xor     r9d, r9d
+  .text:000000018098F5E1                 mov     [rbx+8], r15d
+  .text:000000018098F5E5                 xor     r8d, r8d
+  .text:000000018098F5E8                 mov     [rbx+20h], r15b
+  .text:000000018098F5EC                 mov     [rbx+28h], r15
+  .text:000000018098F5F0                 mov     [rbx+30h], r15
+  .text:000000018098F5F4                 mov     [rbx+38h], r15
+  .text:000000018098F5F8                 mov     [rbx+40h], r15
+  .text:000000018098F5FC                 mov     [rbx+48h], r15
+  .text:000000018098F600                 mov     [rbx+50h], r15
+  .text:000000018098F604                 mov     word ptr [rbx+58h], 100h
+  .text:000000018098F60A                 mov     [rbx+60h], r15
+  .text:000000018098F60E                 mov     [rbx+68h], r15d
+  .text:000000018098F612                 mov     [rbx+70h], r15
+  .text:000000018098F616                 mov     [rsp+50h+var_30], r15d
+  .text:000000018098F61B                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
+  .text:000000018098F621                 mov     rsi, [rbp+arg_0]
+  .text:000000018098F625                 cmp     [rbx+70h], r15
+  .text:000000018098F629                 jz      short loc_18098F635
+  .text:000000018098F62B                 lea     rcx, [rbx+70h]
+  .text:000000018098F62F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018098F635                 mov     [rbx+70h], rsi
+  .text:000000018098F639                 lea     rcx, [rbx+130h]
+  .text:000000018098F640                 mov     [rbx+90h], r15b
+  .text:000000018098F647                 mov     edx, 1
+  .text:000000018098F64C                 mov     [rbx+98h], r15
+  .text:000000018098F653                 mov     [rbx+0A0h], r15
+  .text:000000018098F65A                 mov     [rbx+0A8h], r15
+  .text:000000018098F661                 mov     [rbx+0B0h], r15
+  .text:000000018098F668                 mov     [rbx+0B8h], r15
+  .text:000000018098F66F                 mov     [rbx+0C0h], r15
+  .text:000000018098F676                 mov     word ptr [rbx+0C8h], 100h
+  .text:000000018098F67F                 mov     [rbx+0D0h], r15
+  .text:000000018098F686                 mov     [rbx+0D8h], r15d
+  .text:000000018098F68D                 mov     [rbx+0E8h], r15
+  .text:000000018098F694                 mov     [rbx+0F0h], r15
+  .text:000000018098F69B                 mov     [rbx+100h], r15
+  .text:000000018098F6A2                 mov     [rbx+78h], r15d
+  .text:000000018098F6A6                 mov     dword ptr [rbx+7Ch], 1000000h
+  .text:000000018098F6AD                 mov     [rbx+80h], r15w
+  .text:000000018098F6B5                 mov     [rbx+88h], r15w
+  .text:000000018098F6BD                 mov     [rbx+0E0h], r15
+  .text:000000018098F6C4                 mov     [rbx+0F8h], r15d
+  .text:000000018098F6CB                 mov     [rbp+arg_0], r15
+  .text:000000018098F6CF                 mov     [rbx+84h], r15d
+  .text:000000018098F6D6                 mov     [rbx+110h], r15
+  .text:000000018098F6DD                 mov     [rbx+118h], r15
+  .text:000000018098F6E4                 mov     [rbx+108h], r15d
+  .text:000000018098F6EB                 mov     [rbx+120h], r15
+  .text:000000018098F6F2                 mov     [rbx+128h], r15b
+  .text:000000018098F6F9                 call    sub_181829DC0
+  .text:000000018098F6FE                 mov     [rbx+1330h], r15
+  .text:000000018098F705                 jmp     short loc_18098F70A
+  .text:000000018098F707                 mov     rbx, r15
+  .text:000000018098F70A                 mov     rax, cs:g_pGameEntitySystem
+  .text:000000018098F711                 mov     rcx, rbx
+  .text:000000018098F714                 mov     [rax+20D8h], rbx
+  .text:000000018098F71B                 mov     rax, [rbx]
+  .text:000000018098F71E                 mov     rdx, [rax]
+  .text:000000018098F721                 lea     rax, sub_18095E160
+  .text:000000018098F728                 cmp     rdx, rax
+  .text:000000018098F72B                 jnz     short loc_18098F734
+  .text:000000018098F72D                 call    sub_18095E160
+  .text:000000018098F732                 jmp     short loc_18098F736
+  .text:000000018098F734                 call    rdx
+  .text:000000018098F736                 mov     rax, [rbx]
+  .text:000000018098F739                 mov     rcx, cs:qword_1823275E8
+  .text:000000018098F740                 mov     rdi, [rax+88h]
+  .text:000000018098F747                 mov     rax, [rcx]
+  .text:000000018098F74A                 call    qword ptr [rax+0C0h]
+  .text:000000018098F750                 lea     rcx, sub_180988040
+  .text:000000018098F757                 mov     rdx, rax
+  .text:000000018098F75A                 cmp     rdi, rcx
+  .text:000000018098F75D                 jnz     short loc_18098F76E
+  .text:000000018098F75F                 lea     rcx, [rbx+100h]
+  .text:000000018098F766                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018098F76C                 jmp     short loc_18098F773
+  .text:000000018098F76E                 mov     rcx, rbx
+  .text:000000018098F771                 call    rdi
+  .text:000000018098F773                 call    sub_1809771B0
+  .text:000000018098F778                 mov     rcx, cs:g_pGameEntitySystem
+  .text:000000018098F77F                 mov     dl, 1
+  .text:000000018098F781                 call    sub_1814B5020
+  .text:000000018098F786                 mov     rcx, cs:qword_1823275E8
+  .text:000000018098F78D                 add     rcx, 8
+  .text:000000018098F791                 mov     rax, [rcx]
+  .text:000000018098F794                 call    qword ptr [rax+0A8h]
+  .text:000000018098F79A                 test    al, al
+  .text:000000018098F79C                 jnz     short loc_18098F7B2
+  .text:000000018098F79E                 mov     rcx, cs:g_pVApplication
+  .text:000000018098F7A5                 mov     rax, [rcx]
+  .text:000000018098F7A8                 call    qword ptr [rax+0B0h]
+  .text:000000018098F7AE                 test    al, al
+  .text:000000018098F7B0                 jz      short loc_18098F7D8
+  .text:000000018098F7B2                 mov     rcx, cs:g_pGameEntitySystem
+  .text:000000018098F7B9                 lea     rax, sub_180964B60
+  .text:000000018098F7C0                 mov     [rbp+var_18], rax
+  .text:000000018098F7C4                 lea     rdx, [rbp+var_20]
+  .text:000000018098F7C8                 lea     rax, sub_180950550
+  .text:000000018098F7CF                 mov     [rbp+var_20], rax
+  .text:000000018098F7D3                 call    sub_1814BBE10
+  .text:000000018098F7D8                 mov     rcx, cs:g_pGameResourceService
+  .text:000000018098F7DF                 test    rcx, rcx
+  .text:000000018098F7E2                 jz      short loc_18098F7F4
+  .text:000000018098F7E4                 mov     rax, [rcx]
+  .text:000000018098F7E7                 mov     rdx, cs:g_pGameEntitySystem
+  .text:000000018098F7EE                 call    qword ptr [rax+110h]  ; 110h = IGameResourceService_SetEntityResourceManifestHandler
+  .text:000000018098F7F4                 mov     rax, cs:g_pEntitySystem
+  .text:000000018098F7FB                 lea     rcx, [rbp+var_20]
+  .text:000000018098F7FF                 mov     r14, cs:g_pGameEntitySystem
+  .text:000000018098F806                 mov     [rbp+var_18], 1388h
+  .text:000000018098F80E                 mov     [rbp+var_10], r15b
+  .text:000000018098F812                 mov     esi, [rax+278h]
+  .text:000000018098F818                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
+  .text:000000018098F81F                 mov     [rbp+var_20], rax
+  .text:000000018098F823                 call    cs:ToolsStallMonitorInternal_BeginScope
+  .text:000000018098F829                 mov     ecx, 48h ; 'H'
+  .text:000000018098F82E                 call    operator_new
+  .text:000000018098F833                 mov     rdi, rax
+  .text:000000018098F836                 test    rax, rax
+  .text:000000018098F839                 jz      short loc_18098F891
+  .text:000000018098F83B                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
+  .text:000000018098F842                 xor     edx, edx
+  .text:000000018098F844                 mov     [rdi], rax
+  .text:000000018098F847                 lea     rcx, [rdi+30h]
+  .text:000000018098F84B                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
+  .text:000000018098F852                 mov     r8d, 1
+  .text:000000018098F858                 mov     [rdi+8], rax
+  .text:000000018098F85C                 mov     [rdi+18h], r15
+  .text:000000018098F860                 mov     [rdi+20h], r15
+  .text:000000018098F864                 mov     [rdi+10h], r15d
+  .text:000000018098F868                 mov     [rdi+28h], r15b
+  .text:000000018098F86C                 mov     [rdi+30h], r15d
+  .text:000000018098F870                 mov     [rdi+38h], r15
+  .text:000000018098F874                 call    sub_18094D6C0
+  .text:000000018098F879                 mov     eax, 0FFFFh
+  .text:000000018098F87E                 mov     edx, esi
+  .text:000000018098F880                 mov     rcx, rdi
+  .text:000000018098F883                 mov     [rdi+40h], eax
+  .text:000000018098F886                 mov     [rdi+44h], ax
+  .text:000000018098F88A                 call    sub_18095E8D0
+  .text:000000018098F88F                 jmp     short loc_18098F894
+  .text:000000018098F891                 mov     rdi, r15
+  .text:000000018098F894                 lea     rcx, [rbp+var_20]
+  .text:000000018098F898                 mov     [r14+20E0h], rdi
+  .text:000000018098F89F                 call    cs:ToolsStallMonitorInternal_EndScope
+  .text:000000018098F8A5                 mov     rcx, cs:g_pEntitySystem
+  .text:000000018098F8AC                 lea     rax, sub_1809485C0
+  .text:000000018098F8B3                 lea     rbx, sub_180964BA0
+  .text:000000018098F8BA                 mov     [rbp+var_20], rax
+  .text:000000018098F8BE                 lea     r8, [rbp+var_20]
+  .text:000000018098F8C2                 mov     [rbp+var_18], rbx
+  .text:000000018098F8C6                 mov     dl, 28h ; '('
+  .text:000000018098F8C8                 call    sub_1814BBE30
+  .text:000000018098F8CD                 mov     rcx, cs:g_pEntitySystem
+  .text:000000018098F8D4                 lea     rax, sub_180948530
+  .text:000000018098F8DB                 lea     r8, [rbp+var_20]
+  .text:000000018098F8DF                 mov     [rbp+var_20], rax
+  .text:000000018098F8E3                 mov     dl, 36h ; '6'
+  .text:000000018098F8E5                 mov     [rbp+var_18], rbx
+  .text:000000018098F8E9                 call    sub_1814BBE30
+  .text:000000018098F8EE                 mov     rcx, cs:g_pEntitySystem
+  .text:000000018098F8F5                 lea     rax, sub_1809484E0
+  .text:000000018098F8FC                 lea     r8, [rbp+var_20]
+  .text:000000018098F900                 mov     [rbp+var_20], rax
+  .text:000000018098F904                 mov     dl, 43h ; 'C'
+  .text:000000018098F906                 mov     [rbp+var_18], rbx
+  .text:000000018098F90A                 call    sub_1814BBE30
+  .text:000000018098F90F                 mov     rcx, cs:g_pFlattenedSerializers
+  .text:000000018098F916                 lea     rdx, sub_180964B70
+  .text:000000018098F91D                 mov     rax, [rcx]
+  .text:000000018098F920                 mov     [rbp+var_18], rdx
+  .text:000000018098F924                 lea     rdx, unknown_libname_194; Microsoft VisualC v7/14 64bit runtime
+  .text:000000018098F92B                 mov     [rbp+var_20], rdx
+  .text:000000018098F92F                 lea     rdx, [rbp+var_20]
+  .text:000000018098F933                 call    qword ptr [rax+108h]
+  .text:000000018098F939                 lea     r11, [rsp+50h+var_s0]
+  .text:000000018098F93E                 mov     al, 1
+  .text:000000018098F940                 mov     rbx, [r11+28h]
+  .text:000000018098F944                 mov     rsi, [r11+30h]
+  .text:000000018098F948                 mov     rdi, [r11+38h]
+  .text:000000018098F94C                 mov     rsp, r11
+  .text:000000018098F94F                 pop     r15
+  .text:000000018098F951                 pop     r14
+  .text:000000018098F953                 pop     rbp
+  .text:000000018098F954                 retn
+procedure: |-
+  char sub_18098F440()
+  {
+    int v0; // ecx
+    __int64 v1; // rax
+    int v2; // eax
+    __int64 v3; // rbx
+    __int64 v4; // r14
+    __int64 v5; // rcx
+    __int64 v6; // rcx
+    int v7; // esi
+    int v8; // eax
+    __int64 v9; // rdx
+    int v10; // edi
+    int v11; // eax
+    __int64 v12; // rbx
+    __int64 v13; // rsi
+    void (__fastcall *v14)(__int64); // rdx
+    __int64 (__fastcall *v15)(); // rdi
+    const char *v16; // rdx
+    __int64 v17; // rdx
+    __int64 v18; // r14
+    unsigned int v19; // esi
+    __int64 v20; // rax
+    __int64 v21; // rdi
+    __int64 v22; // rdx
+    __int64 v23; // rdx
+    __int64 v24; // rdx
+    __int64 v25; // rax
+    const char *v27; // [rsp+30h] [rbp-20h] BYREF
+    __int64 v28; // [rsp+38h] [rbp-18h]
+    char v29; // [rsp+40h] [rbp-10h]
+    __int64 v30; // [rsp+70h] [rbp+20h] BYREF
+
+    v0 = dword_1824E44E8++;
+    if ( v0 <= 0 )
+    {
+      v1 = operator_new(8432);
+      if ( v1 )
+        v2 = CGameEntitySystem_ctor(v1);
+      else
+        v2 = 0;
+      CEntitySystem_PostCreateEntitySystem(v2, (unsigned int)"client_entities", 1, 1, 0);
+    }
+    v3 = g_pEntitySystem;
+    g_pGameEntitySystem = g_pEntitySystem;
+    v4 = *(int *)(g_pEntitySystem + 2960);
+    if ( (_DWORD)v4 == *(_DWORD *)(g_pEntitySystem + 2976) && (*(_DWORD *)(g_pEntitySystem + 2980) & 0x40000000) == 0 )
+    {
+      v5 = *(unsigned int *)(g_pEntitySystem + 2976);
+      if ( (_DWORD)v5 == 0x7FFFFFFF )
+        UtlVectorMemory_FailedAllocation(v5, 1);
+      v6 = *(unsigned int *)(v3 + 2976);
+      v7 = v6 + 1;
+      v8 = UtlVectorMemory_CalcNewAllocationCount(v6, *(_DWORD *)(v3 + 2980) & 0x3FFFFFFF, (unsigned int)(v6 + 1), 8);
+      v10 = v8;
+      if ( v8 < v7 )
+      {
+        if ( v8 || v7 > -1 )
+        {
+          do
+          {
+            v9 = (unsigned int)((v10 + v7) >> 31);
+            v10 = (v10 + v7) / 2;
+          }
+          while ( v10 < v7 );
+        }
+        else
+        {
+          v10 = -1;
+        }
+      }
+      LOBYTE(v9) = (*(_DWORD *)(v3 + 2980) & 0xC0000000) == 0;
+      *(_QWORD *)(v3 + 2968) = UtlVectorMemory_Alloc(*(_QWORD *)(v3 + 2968), v9, 8LL * v10, 8LL * *(int *)(v3 + 2976));
+      v11 = *(_DWORD *)(v3 + 2980);
+      if ( (v11 & 0xC0000000) != 0 )
+        *(_DWORD *)(v3 + 2980) = v11 & 0x3FFFFFFF;
+      *(_DWORD *)(v3 + 2976) = v10;
+    }
+    ++*(_DWORD *)(v3 + 2960);
+    *(_QWORD *)(*(_QWORD *)(v3 + 2968) + 8 * v4) = &off_182042A38;
+    v12 = operator_new(4920);
+    if ( v12 )
+    {
+      v30 = 0;
+      *(_QWORD *)v12 = &CEntity2SaveRestore::`vftable';
+      *(_QWORD *)(v12 + 16) = 0;
+      *(_QWORD *)(v12 + 24) = 0;
+      *(_DWORD *)(v12 + 8) = 0;
+      *(_BYTE *)(v12 + 32) = 0;
+      *(_QWORD *)(v12 + 40) = 0;
+      *(_QWORD *)(v12 + 48) = 0;
+      *(_QWORD *)(v12 + 56) = 0;
+      *(_QWORD *)(v12 + 64) = 0;
+      *(_QWORD *)(v12 + 72) = 0;
+      *(_QWORD *)(v12 + 80) = 0;
+      *(_WORD *)(v12 + 88) = 256;
+      *(_QWORD *)(v12 + 96) = 0;
+      *(_DWORD *)(v12 + 104) = 0;
+      *(_QWORD *)(v12 + 112) = 0;
+      CUtlString::Format((CUtlString *)&v30, "%u:%02u:%02u", 0, 0, 0);
+      v13 = v30;
+      if ( *(_QWORD *)(v12 + 112) )
+        CUtlString::FreeMemoryBlock((CUtlString *)(v12 + 112));
+      *(_QWORD *)(v12 + 112) = v13;
+      *(_BYTE *)(v12 + 144) = 0;
+      *(_QWORD *)(v12 + 152) = 0;
+      *(_QWORD *)(v12 + 160) = 0;
+      *(_QWORD *)(v12 + 168) = 0;
+      *(_QWORD *)(v12 + 176) = 0;
+      *(_QWORD *)(v12 + 184) = 0;
+      *(_QWORD *)(v12 + 192) = 0;
+      *(_WORD *)(v12 + 200) = 256;
+      *(_QWORD *)(v12 + 208) = 0;
+      *(_DWORD *)(v12 + 216) = 0;
+      *(_QWORD *)(v12 + 232) = 0;
+      *(_QWORD *)(v12 + 240) = 0;
+      *(_QWORD *)(v12 + 256) = 0;
+      *(_DWORD *)(v12 + 120) = 0;
+      *(_DWORD *)(v12 + 124) = 0x1000000;
+      *(_WORD *)(v12 + 128) = 0;
+      *(_WORD *)(v12 + 136) = 0;
+      *(_QWORD *)(v12 + 224) = 0;
+      *(_DWORD *)(v12 + 248) = 0;
+      v30 = 0;
+      *(_DWORD *)(v12 + 132) = 0;
+      *(_QWORD *)(v12 + 272) = 0;
+      *(_QWORD *)(v12 + 280) = 0;
+      *(_DWORD *)(v12 + 264) = 0;
+      *(_QWORD *)(v12 + 288) = 0;
+      *(_BYTE *)(v12 + 296) = 0;
+      sub_181829DC0(v12 + 304, 1);
+      *(_QWORD *)(v12 + 4912) = 0;
+    }
+    else
+    {
+      v12 = 0;
+    }
+    *(_QWORD *)(g_pGameEntitySystem + 8408) = v12;
+    v14 = **(void (__fastcall ***)(__int64))v12;
+    if ( (char *)v14 == (char *)sub_18095E160 )
+      sub_18095E160(v12);
+    else
+      v14(v12);
+    v15 = *(__int64 (__fastcall **)())(*(_QWORD *)v12 + 136LL);
+    v16 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_1823275E8 + 192LL))(qword_1823275E8);
+    if ( v15 == sub_180988040 )
+      CUtlString::Set((CUtlString *)(v12 + 256), v16);
+    else
+      ((void (__fastcall *)(__int64, const char *))v15)(v12, v16);
+    sub_1809771B0();
+    LOBYTE(v17) = 1;
+    sub_1814B5020(g_pGameEntitySystem, v17);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_1823275E8 + 8) + 168LL))(qword_1823275E8 + 8)
+      || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 176LL))(g_pVApplication) )
+    {
+      v28 = (__int64)sub_180964B60;
+      v27 = (const char *)sub_180950550;
+      sub_1814BBE10(g_pGameEntitySystem, &v27);
+    }
+    if ( g_pGameResourceService )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService + 272LL))(  // 272LL = 0x110 = IGameResourceService_SetEntityResourceManifestHandler
+        g_pGameResourceService,
+        g_pGameEntitySystem);
+    v18 = g_pGameEntitySystem;
+    v28 = 5000;
+    v29 = 0;
+    v19 = *(_DWORD *)(g_pEntitySystem + 632);
+    v27 = "CGameEntitySystem::InitEntity2NetworkClasses";
+    ToolsStallMonitorInternal_BeginScope(&v27);
+    v20 = operator_new(72);
+    v21 = v20;
+    if ( v20 )
+    {
+      *(_QWORD *)v20 = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v20 + 8) = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v20 + 24) = 0;
+      *(_QWORD *)(v20 + 32) = 0;
+      *(_DWORD *)(v20 + 16) = 0;
+      *(_BYTE *)(v20 + 40) = 0;
+      *(_DWORD *)(v20 + 48) = 0;
+      *(_QWORD *)(v20 + 56) = 0;
+      sub_18094D6C0(v20 + 48, 0, 1);
+      *(_DWORD *)(v21 + 64) = 0xFFFF;
+      *(_WORD *)(v21 + 68) = -1;
+      sub_18095E8D0(v21, v19);
+    }
+    else
+    {
+      v21 = 0;
+    }
+    *(_QWORD *)(v18 + 8416) = v21;
+    ToolsStallMonitorInternal_EndScope(&v27);
+    v27 = (const char *)sub_1809485C0;
+    v28 = (__int64)sub_180964BA0;
+    LOBYTE(v22) = 40;
+    sub_1814BBE30(g_pEntitySystem, v22, &v27);
+    v27 = (const char *)sub_180948530;
+    LOBYTE(v23) = 54;
+    v28 = (__int64)sub_180964BA0;
+    sub_1814BBE30(g_pEntitySystem, v23, &v27);
+    v27 = (const char *)sub_1809484E0;
+    LOBYTE(v24) = 67;
+    v28 = (__int64)sub_180964BA0;
+    sub_1814BBE30(g_pEntitySystem, v24, &v27);
+    v25 = *(_QWORD *)g_pFlattenedSerializers;
+    v28 = (__int64)sub_180964B70;
+    v27 = (const char *)unknown_libname_194;
+    (*(void (__fastcall **)(__int64, const char **))(v25 + 264))(g_pFlattenedSerializers, &v27);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
@@ -43,7 +43,7 @@ disasm_code: |-
   .text:0000000000E52784                 mov     cs:byte_43EC37B, 0
   .text:0000000000E5278B                 mov     r12, rax
   .text:0000000000E5278E                 mov     rax, [rdi]
-  .text:0000000000E52791                 call    qword ptr [rax+40h] ; 0x40 = IGameSystemFactory_DoesGameSystemReallocate
+  .text:0000000000E52791                 call    qword ptr [rax+40h] ; 0x40 = IGameSystemFactory_IsReallocating
   .text:0000000000E52794                 test    al, al
   .text:0000000000E52796                 jz      short loc_E527B8
   .text:0000000000E52798                 mov     rax, [r12]
@@ -148,7 +148,7 @@ procedure: |-
     v7 = *(_QWORD *)v1;
     byte_43EC37B = 0;
     v8 = (_QWORD *)v6;
-    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v7 + 64LL))(v7) ) // 64 = 0x40 = IGameSystemFactory_DoesGameSystemReallocate
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v7 + 64LL))(v7) ) // 64 = 0x40 = IGameSystemFactory_IsReallocating
     {
       v9 = *(__int64 (__fastcall **)())(*v8 + 472LL); // 472 = 0x1D8 = IGameSystem_SetName
       if ( v9 == sub_C2F370 )

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
@@ -38,7 +38,7 @@ disasm_code: |-
   .text:0000000000E52771                 mov     rdi, [rbx]
   .text:0000000000E52774                 mov     cs:byte_43EC37B, 1
   .text:0000000000E5277B                 mov     rax, [rdi]
-  .text:0000000000E5277E                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_Allocate
+  .text:0000000000E5277E                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_CreateGameSystem
   .text:0000000000E52781                 mov     rdi, [rbx]
   .text:0000000000E52784                 mov     cs:byte_43EC37B, 0
   .text:0000000000E5278B                 mov     r12, rax
@@ -144,7 +144,7 @@ procedure: |-
     }
     v5 = *(_QWORD *)v1;
     byte_43EC37B = 1;
-    v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 24LL))(v5); // 24 = 0x18 = IGameSystemFactory_Allocate
+    v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 24LL))(v5); // 24 = 0x18 = IGameSystemFactory_CreateGameSystem
     v7 = *(_QWORD *)v1;
     byte_43EC37B = 0;
     v8 = (_QWORD *)v6;

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.linux.yaml
@@ -1,104 +1,112 @@
 func_name: IGameSystem_AddByName
-func_va: '0xe526e0'
+func_va: '0xe5eee0'
 disasm_code: |-
-  .text:0000000000E526E0                 push    rbp
-  .text:0000000000E526E1                 lea     rsi, unk_43EC2F8
-  .text:0000000000E526E8                 mov     rbp, rsp
-  .text:0000000000E526EB                 push    r13
-  .text:0000000000E526ED                 push    r12
-  .text:0000000000E526EF                 mov     r12, rdi
-  .text:0000000000E526F2                 push    rbx
-  .text:0000000000E526F3                 lea     rdi, [rbp+var_22]
-  .text:0000000000E526F7                 mov     rdx, r12
-  .text:0000000000E526FA                 sub     rsp, 18h
-  .text:0000000000E526FE                 call    sub_BF8570
-  .text:0000000000E52703                 movzx   eax, [rbp+var_22]
-  .text:0000000000E52707                 cmp     ax, 0FFFFh
-  .text:0000000000E5270B                 jz      loc_E5284D
-  .text:0000000000E52711                 mov     rbx, rax
-  .text:0000000000E52714                 shl     rbx, 4
-  .text:0000000000E52718                 add     rbx, cs:qword_43EC2E8
-  .text:0000000000E5271F                 cmp     byte ptr [rbx+8], 0
-  .text:0000000000E52723                 jnz     loc_E5285E
-  .text:0000000000E52729                 mov     rdx, cs:qword_43EC320
-  .text:0000000000E52730                 mov     ecx, cs:dword_43EC330
-  .text:0000000000E52736                 mov     edx, [rdx+rax*4]
-  .text:0000000000E52739                 mov     eax, edx
-  .text:0000000000E5273B                 shr     eax, cl
-  .text:0000000000E5273D                 cmp     eax, cs:dword_43EC338
-  .text:0000000000E52743                 jnb     loc_E52838
-  .text:0000000000E52749                 xor     ecx, ecx
-  .text:0000000000E5274B                 cdqe
-  .text:0000000000E5274D                 test    cs:dword_43EC33C, 7FFFFFFFh
-  .text:0000000000E52757                 cmovnz  rcx, cs:qword_43EC340
-  .text:0000000000E5275F                 shl     rax, 4
-  .text:0000000000E52763                 and     edx, cs:dword_43EC334
-  .text:0000000000E52769                 add     rdx, [rcx+rax+8]
-  .text:0000000000E5276E                 mov     r13, rdx
-  .text:0000000000E52771                 mov     rdi, [rbx]
-  .text:0000000000E52774                 mov     cs:byte_43EC37B, 1
-  .text:0000000000E5277B                 mov     rax, [rdi]
-  .text:0000000000E5277E                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_CreateGameSystem
-  .text:0000000000E52781                 mov     rdi, [rbx]
-  .text:0000000000E52784                 mov     cs:byte_43EC37B, 0
-  .text:0000000000E5278B                 mov     r12, rax
-  .text:0000000000E5278E                 mov     rax, [rdi]
-  .text:0000000000E52791                 call    qword ptr [rax+40h] ; 0x40 = IGameSystemFactory_IsReallocating
-  .text:0000000000E52794                 test    al, al
-  .text:0000000000E52796                 jz      short loc_E527B8
-  .text:0000000000E52798                 mov     rax, [r12]
-  .text:0000000000E5279C                 lea     rdx, sub_C2F370
-  .text:0000000000E527A3                 mov     rax, [rax+1D8h] ; 0x1D8 = IGameSystem_SetName (vtable slot load)
-  .text:0000000000E527AA                 cmp     rax, rdx
-  .text:0000000000E527AD                 jnz     loc_E52840
-  .text:0000000000E527B3                 mov     [r12+8], r13
-  .text:0000000000E527B8                 mov     rdi, [rbx]
-  .text:0000000000E527BB                 mov     byte ptr [rbx+8], 1
-  .text:0000000000E527BF                 mov     rax, [rdi]
-  .text:0000000000E527C2                 call    qword ptr [rax+30h]
-  .text:0000000000E527C5                 mov     ebx, cs:dword_43EC3F0
-  .text:0000000000E527CB                 cmp     ebx, dword ptr cs:qword_43EC400
-  .text:0000000000E527D1                 mov     r13d, eax
-  .text:0000000000E527D4                 mov     edx, ebx
-  .text:0000000000E527D6                 jz      short loc_E52818
-  .text:0000000000E527D8                 mov     rax, cs:qword_43EC3F8
-  .text:0000000000E527DF                 add     edx, 1
-  .text:0000000000E527E2                 mov     cs:dword_43EC3F0, edx
-  .text:0000000000E527E8                 movsxd  rdx, ebx
-  .text:0000000000E527EB                 shl     rdx, 4
-  .text:0000000000E527EF                 mov     [rax+rdx], r12
-  .text:0000000000E527F3                 mov     rax, cs:qword_43EC3F8
-  .text:0000000000E527FA                 mov     [rax+rdx+8], r13d
-  .text:0000000000E527FF                 mov     rax, cs:qword_43EC3F8
-  .text:0000000000E52806                 mov     [rax+rdx+0Ch], ebx
-  .text:0000000000E5280A                 add     rsp, 18h
-  .text:0000000000E5280E                 pop     rbx
-  .text:0000000000E5280F                 pop     r12
-  .text:0000000000E52811                 pop     r13
-  .text:0000000000E52813                 pop     rbp
-  .text:0000000000E52814                 retn
-  .text:0000000000E52818                 lea     rdi, qword_43EC3F8
-  .text:0000000000E5281F                 mov     esi, 1
-  .text:0000000000E52824                 call    sub_E525C0
-  .text:0000000000E52829                 mov     edx, cs:dword_43EC3F0
-  .text:0000000000E5282F                 jmp     short loc_E527D8
-  .text:0000000000E52838                 xor     r13d, r13d
-  .text:0000000000E5283B                 jmp     loc_E52771
-  .text:0000000000E52840                 mov     rsi, r13
-  .text:0000000000E52843                 mov     rdi, r12
-  .text:0000000000E52846                 call    rax
-  .text:0000000000E52848                 jmp     loc_E527B8
-  .text:0000000000E5284D                 lea     rdi, aTriedToAddUnkn; "Tried to add unknown game system %s!\n"
-  .text:0000000000E52854                 mov     rsi, r12
-  .text:0000000000E52857                 xor     eax, eax
-  .text:0000000000E52859                 call    sub_BF8B30
-  .text:0000000000E5285E                 lea     rdi, aTriedToAddGame; "Tried to add game system %s twice!\n"
-  .text:0000000000E52865                 mov     rsi, r12
-  .text:0000000000E52868                 xor     eax, eax
-  .text:0000000000E5286A                 call    sub_BF8B30
-  .text:0000000000E5286F                 int     3; Trap to Debugger
+  .text:0000000000E5EEE0                 push    rbp
+  .text:0000000000E5EEE1                 ; _QWORD
+  .text:0000000000E5EEE1                 lea     rsi, qword_4497D38; _QWORD
+  .text:0000000000E5EEE8                 mov     rbp, rsp
+  .text:0000000000E5EEEB                 push    r13
+  .text:0000000000E5EEED                 push    r12
+  .text:0000000000E5EEEF                 mov     r12, rdi
+  .text:0000000000E5EEF2                 push    rbx
+  .text:0000000000E5EEF3                 ; _QWORD
+  .text:0000000000E5EEF3                 lea     rdi, [rbp+var_22]; _QWORD
+  .text:0000000000E5EEF7                 ; _QWORD
+  .text:0000000000E5EEF7                 mov     rdx, r12; _QWORD
+  .text:0000000000E5EEFA                 sub     rsp, 18h
+  .text:0000000000E5EEFE                 call    __ZNK15CUtlSymbolTable4FindEPKc; CUtlSymbolTable::Find(char const*)
+  .text:0000000000E5EF03                 movzx   eax, [rbp+var_22]
+  .text:0000000000E5EF07                 cmp     ax, 0FFFFh
+  .text:0000000000E5EF0B                 jz      loc_E5F04D
+  .text:0000000000E5EF11                 mov     rbx, rax
+  .text:0000000000E5EF14                 shl     rbx, 4
+  .text:0000000000E5EF18                 add     rbx, cs:qword_4497D28
+  .text:0000000000E5EF1F                 cmp     byte ptr [rbx+8], 0
+  .text:0000000000E5EF23                 jnz     loc_E5F05E
+  .text:0000000000E5EF29                 mov     rdx, cs:qword_4497D60
+  .text:0000000000E5EF30                 mov     ecx, cs:dword_4497D70
+  .text:0000000000E5EF36                 mov     edx, [rdx+rax*4]
+  .text:0000000000E5EF39                 mov     eax, edx
+  .text:0000000000E5EF3B                 shr     eax, cl
+  .text:0000000000E5EF3D                 cmp     eax, cs:dword_4497D78
+  .text:0000000000E5EF43                 jnb     loc_E5F038
+  .text:0000000000E5EF49                 xor     ecx, ecx
+  .text:0000000000E5EF4B                 cdqe
+  .text:0000000000E5EF4D                 test    cs:dword_4497D7C, 7FFFFFFFh
+  .text:0000000000E5EF57                 cmovnz  rcx, cs:qword_4497D80
+  .text:0000000000E5EF5F                 shl     rax, 4
+  .text:0000000000E5EF63                 and     edx, cs:dword_4497D74
+  .text:0000000000E5EF69                 add     rdx, [rcx+rax+8]
+  .text:0000000000E5EF6E                 mov     r13, rdx
+  .text:0000000000E5EF71                 mov     rdi, [rbx]
+  .text:0000000000E5EF74                 mov     cs:byte_4497DBB, 1
+  .text:0000000000E5EF7B                 mov     rax, [rdi]
+  .text:0000000000E5EF7E                 ; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000000E5EF7E                 call    qword ptr [rax+18h]; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000000E5EF81                 mov     rdi, [rbx]
+  .text:0000000000E5EF84                 mov     cs:byte_4497DBB, 0
+  .text:0000000000E5EF8B                 mov     r12, rax
+  .text:0000000000E5EF8E                 mov     rax, [rdi]
+  .text:0000000000E5EF91                 ; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000000E5EF91                 call    qword ptr [rax+40h]; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000000E5EF94                 test    al, al
+  .text:0000000000E5EF96                 jz      short loc_E5EFB8
+  .text:0000000000E5EF98                 mov     rax, [r12]
+  .text:0000000000E5EF9C                 lea     rdx, sub_C1AB10
+  .text:0000000000E5EFA3                 ; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000000E5EFA3                 mov     rax, [rax+1E0h]; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000000E5EFAA                 cmp     rax, rdx
+  .text:0000000000E5EFAD                 jnz     loc_E5F040
+  .text:0000000000E5EFB3                 mov     [r12+8], r13
+  .text:0000000000E5EFB8                 mov     rdi, [rbx]
+  .text:0000000000E5EFBB                 mov     byte ptr [rbx+8], 1
+  .text:0000000000E5EFBF                 mov     rax, [rdi]
+  .text:0000000000E5EFC2                 ; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000000E5EFC2                 call    qword ptr [rax+30h]; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000000E5EFC5                 mov     ebx, cs:dword_4497E30
+  .text:0000000000E5EFCB                 cmp     ebx, dword ptr cs:qword_4497E40
+  .text:0000000000E5EFD1                 mov     r13d, eax
+  .text:0000000000E5EFD4                 mov     edx, ebx
+  .text:0000000000E5EFD6                 jz      short loc_E5F018
+  .text:0000000000E5EFD8                 mov     rax, cs:qword_4497E38
+  .text:0000000000E5EFDF                 add     edx, 1
+  .text:0000000000E5EFE2                 mov     cs:dword_4497E30, edx
+  .text:0000000000E5EFE8                 movsxd  rdx, ebx
+  .text:0000000000E5EFEB                 shl     rdx, 4
+  .text:0000000000E5EFEF                 mov     [rax+rdx], r12
+  .text:0000000000E5EFF3                 mov     rax, cs:qword_4497E38
+  .text:0000000000E5EFFA                 mov     [rax+rdx+8], r13d
+  .text:0000000000E5EFFF                 mov     rax, cs:qword_4497E38
+  .text:0000000000E5F006                 mov     [rax+rdx+0Ch], ebx
+  .text:0000000000E5F00A                 add     rsp, 18h
+  .text:0000000000E5F00E                 pop     rbx
+  .text:0000000000E5F00F                 pop     r12
+  .text:0000000000E5F011                 pop     r13
+  .text:0000000000E5F013                 pop     rbp
+  .text:0000000000E5F014                 retn
+  .text:0000000000E5F018                 lea     rdi, qword_4497E38
+  .text:0000000000E5F01F                 mov     esi, 1
+  .text:0000000000E5F024                 call    sub_E5EDC0
+  .text:0000000000E5F029                 mov     edx, cs:dword_4497E30
+  .text:0000000000E5F02F                 jmp     short loc_E5EFD8
+  .text:0000000000E5F038                 xor     r13d, r13d
+  .text:0000000000E5F03B                 jmp     loc_E5EF71
+  .text:0000000000E5F040                 mov     rsi, r13
+  .text:0000000000E5F043                 mov     rdi, r12
+  .text:0000000000E5F046                 call    rax
+  .text:0000000000E5F048                 jmp     loc_E5EFB8
+  .text:0000000000E5F04D                 lea     rdi, aTriedToAddUnkn; "Tried to add unknown game system %s!\n"
+  .text:0000000000E5F054                 mov     rsi, r12
+  .text:0000000000E5F057                 xor     eax, eax
+  .text:0000000000E5F059                 call    _Plat_FatalError
+  .text:0000000000E5F05E                 lea     rdi, aTriedToAddGame; "Tried to add game system %s twice!\n"
+  .text:0000000000E5F065                 mov     rsi, r12
+  .text:0000000000E5F068                 xor     eax, eax
+  .text:0000000000E5F06A                 call    _Plat_FatalError
+  .text:0000000000E5F06F                 ; Trap to Debugger
+  .text:0000000000E5F06F                 int     3; Trap to Debugger
 procedure: |-
-  __int64 __fastcall IGameSystem_AddByName(const char *a1)
+  void *__fastcall IGameSystem_AddByName(const char *a1)
   {
     __int64 v1; // rbx
     unsigned int v2; // eax
@@ -115,63 +123,63 @@ procedure: |-
     int v13; // r13d
     int v14; // edx
     __int64 v15; // rdx
-    __int64 result; // rax
-    _WORD v17[17]; // [rsp+Eh] [rbp-22h] BYREF
+    void *result; // rax
+    unsigned __int16 v17[17]; // [rsp+Eh] [rbp-22h] BYREF
 
-    sub_BF8570(v17, &unk_43EC2F8, a1);
+    CUtlSymbolTable::Find(v17, &qword_4497D38, a1);
     if ( v17[0] == 0xFFFF )
     {
-      sub_BF8B30("Tried to add unknown game system %s!\n", a1);
+      Plat_FatalError("Tried to add unknown game system %s!\n", a1);
   LABEL_16:
-      sub_BF8B30("Tried to add game system %s twice!\n", a1);
+      Plat_FatalError("Tried to add game system %s twice!\n", a1);
       __debugbreak();
     }
-    v1 = qword_43EC2E8 + 16LL * v17[0];
+    v1 = qword_4497D28 + 16LL * v17[0];
     if ( *(_BYTE *)(v1 + 8) )
       goto LABEL_16;
-    v2 = *(_DWORD *)(qword_43EC320 + 4LL * v17[0]) >> dword_43EC330;
-    if ( v2 >= dword_43EC338 )
+    v2 = *(_DWORD *)(qword_4497D60 + 4LL * v17[0]) >> dword_4497D70;
+    if ( v2 >= dword_4497D78 )
     {
       v4 = 0;
     }
     else
     {
       v3 = 0;
-      if ( (dword_43EC33C & 0x7FFFFFFF) != 0 )
-        v3 = qword_43EC340;
+      if ( (dword_4497D7C & 0x7FFFFFFF) != 0 )
+        v3 = qword_4497D80;
       v4 = *(_QWORD *)(v3 + 16LL * (int)v2 + 8)
-         + ((unsigned int)dword_43EC334 & *(_DWORD *)(qword_43EC320 + 4LL * v17[0]));
+         + ((unsigned int)dword_4497D74 & *(_DWORD *)(qword_4497D60 + 4LL * v17[0]));
     }
     v5 = *(_QWORD *)v1;
-    byte_43EC37B = 1;
-    v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 24LL))(v5); // 24 = 0x18 = IGameSystemFactory_CreateGameSystem
+    byte_4497DBB = 1;
+    v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 24LL))(v5);// 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
     v7 = *(_QWORD *)v1;
-    byte_43EC37B = 0;
+    byte_4497DBB = 0;
     v8 = (_QWORD *)v6;
-    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v7 + 64LL))(v7) ) // 64 = 0x40 = IGameSystemFactory_IsReallocating
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v7 + 64LL))(v7) )// 64LL = 0x40 = IGameSystemFactory_IsReallocating
     {
-      v9 = *(__int64 (__fastcall **)())(*v8 + 472LL); // 472 = 0x1D8 = IGameSystem_SetName
-      if ( v9 == sub_C2F370 )
+      v9 = *(__int64 (__fastcall **)())(*v8 + 480LL);// 480LL = 0x1E0 = IGameSystem_SetName
+      if ( v9 == sub_C1AB10 )
         v8[1] = v4;
       else
         ((void (__fastcall *)(_QWORD *, __int64))v9)(v8, v4);
     }
     v10 = *(_QWORD *)v1;
     *(_BYTE *)(v1 + 8) = 1;
-    v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v10 + 48LL))(v10);
-    v12 = dword_43EC3F0;
+    v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v10 + 48LL))(v10);// 48LL = 0x30 = IGameSystemFactory_GetPriority
+    v12 = dword_4497E30;
     v13 = v11;
-    v14 = dword_43EC3F0;
-    if ( dword_43EC3F0 == (_DWORD)qword_43EC400 )
+    v14 = dword_4497E30;
+    if ( dword_4497E30 == (_DWORD)qword_4497E40 )
     {
-      sub_E525C0(&qword_43EC3F8, 1, (unsigned int)dword_43EC3F0);
-      v14 = dword_43EC3F0;
+      sub_E5EDC0(&qword_4497E38, 1, (unsigned int)dword_4497E30);
+      v14 = dword_4497E30;
     }
-    dword_43EC3F0 = v14 + 1;
+    dword_4497E30 = v14 + 1;
     v15 = 16LL * v12;
-    *(_QWORD *)(qword_43EC3F8 + v15) = v8;
-    *(_DWORD *)(qword_43EC3F8 + v15 + 8) = v13;
-    result = qword_43EC3F8;
-    *(_DWORD *)(qword_43EC3F8 + v15 + 12) = v12;
+    *(_QWORD *)((char *)qword_4497E38 + v15) = v8;
+    *(_DWORD *)((char *)qword_4497E38 + v15 + 8) = v13;
+    result = qword_4497E38;
+    *(_DWORD *)((char *)qword_4497E38 + v15 + 12) = v12;
     return result;
   }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
@@ -53,7 +53,7 @@ disasm_code: |-
   .text:000000018031F96C                 mov     cs:byte_1821CFE89, 1
   .text:000000018031F973                 mov     rcx, [rdi]
   .text:000000018031F976                 mov     rax, [rcx]
-  .text:000000018031F979                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_Allocate
+  .text:000000018031F979                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_CreateGameSystem
   .text:000000018031F97C                 mov     cs:byte_1821CFE89, 0
   .text:000000018031F983                 mov     rsi, rax
   .text:000000018031F986                 mov     rcx, [rdi]
@@ -126,7 +126,7 @@ procedure: |-
       v4 = 0;
     }
     byte_1821CFE89 = 1;
-    v6 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 24LL))(*v2);// 0x18 = 24LL = IGameSystemFactory_Allocate
+    v6 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 24LL))(*v2);// 0x18 = 24LL = IGameSystemFactory_CreateGameSystem
     byte_1821CFE89 = 0;
     v7 = v6;
     if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 64LL))(*v2) )// 0x40 = 64LL = IGameSystemFactory_DoesGameSystemReallocate

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
@@ -58,7 +58,7 @@ disasm_code: |-
   .text:000000018031F983                 mov     rsi, rax
   .text:000000018031F986                 mov     rcx, [rdi]
   .text:000000018031F989                 mov     r8, [rcx]
-  .text:000000018031F98C                 call    qword ptr [r8+40h] ; 0x40 = IGameSystemFactory_DoesGameSystemReallocate
+  .text:000000018031F98C                 call    qword ptr [r8+40h] ; 0x40 = IGameSystemFactory_IsReallocating
   .text:000000018031F990                 test    al, al
   .text:000000018031F992                 jz      short loc_18031F9A4
   .text:000000018031F994                 mov     r8, [rsi]
@@ -129,7 +129,7 @@ procedure: |-
     v6 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 24LL))(*v2);// 0x18 = 24LL = IGameSystemFactory_CreateGameSystem
     byte_1821CFE89 = 0;
     v7 = v6;
-    if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 64LL))(*v2) )// 0x40 = 64LL = IGameSystemFactory_DoesGameSystemReallocate
+    if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 64LL))(*v2) )// 0x40 = 64LL = IGameSystemFactory_IsReallocating
       (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v7 + 472LL))(v7, v4);// 0x1D8 = 472LL =IGameSystem_SetName
     v8 = *v2;
     *((_BYTE *)v2 + 8) = 1;

--- a/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_AddByName.windows.yaml
@@ -1,90 +1,96 @@
 func_name: IGameSystem_AddByName
-func_va: '0x18031f8a0'
+func_va: '0x1803309e0'
 disasm_code: |-
-  .text:000000018031F8A0                 push    rbx
-  .text:000000018031F8A2                 sub     rsp, 20h
-  .text:000000018031F8A6                 mov     rbx, rcx
-  .text:000000018031F8A9                 lea     rdx, [rsp+28h+arg_8]
-  .text:000000018031F8AE                 mov     r8, rcx
-  .text:000000018031F8B1                 lea     rcx, unk_181FD71D8
-  .text:000000018031F8B8                 call    cs:?Find@CUtlSymbolTable@@QEBA?AVCUtlSymbol@@PEBD@Z; CUtlSymbolTable::Find(char const *)
-  .text:000000018031F8BE                 movzx   eax, [rsp+28h+arg_8]
-  .text:000000018031F8C3                 mov     ecx, 0FFFFh
-  .text:000000018031F8C8                 cmp     ax, cx
-  .text:000000018031F8CB                 jnz     short loc_18031F8E8
-  .text:000000018031F8CD                 mov     eax, 0FFFFFFFFh
-  .text:000000018031F8D2                 cmp     ax, cx
-  .text:000000018031F8D5                 jnz     short loc_18031F8E8
-  .text:000000018031F8D7                 mov     rdx, rbx
-  .text:000000018031F8DA                 lea     rcx, aTriedToAddUnkn; "Tried to add unknown game system %s!\n"
-  .text:000000018031F8E1                 call    cs:Plat_FatalError
-  .text:000000018031F8E7                 int     3; Trap to Debugger
-  .text:000000018031F8E8                 mov     [rsp+28h+arg_10], rdi
-  .text:000000018031F8ED                 movzx   edx, ax
-  .text:000000018031F8F0                 mov     edi, edx
-  .text:000000018031F8F2                 shl     rdi, 4
-  .text:000000018031F8F6                 add     rdi, cs:qword_181FD71C8
-  .text:000000018031F8FD                 cmp     byte ptr [rdi+8], 0
-  .text:000000018031F901                 jz      short loc_18031F914
-  .text:000000018031F903                 mov     rdx, rbx
-  .text:000000018031F906                 lea     rcx, aTriedToAddGame; "Tried to add game system %s twice!\n"
-  .text:000000018031F90D                 call    cs:Plat_FatalError
-  .text:000000018031F913                 int     3; Trap to Debugger
-  .text:000000018031F914                 mov     rax, cs:qword_181FD7200
-  .text:000000018031F91B                 mov     ecx, cs:dword_181FD7210
-  .text:000000018031F921                 mov     [rsp+28h+arg_0], rsi
-  .text:000000018031F926                 mov     r8d, [rax+rdx*4]
-  .text:000000018031F92A                 mov     edx, r8d
-  .text:000000018031F92D                 shr     edx, cl
-  .text:000000018031F92F                 cmp     edx, cs:dword_181FD7218
-  .text:000000018031F935                 jb      short loc_18031F93B
-  .text:000000018031F937                 xor     ebx, ebx
-  .text:000000018031F939                 jmp     short loc_18031F96C
-  .text:000000018031F93B                 test    cs:dword_181FD721C, 7FFFFFFFh
-  .text:000000018031F945                 mov     ebx, 0
-  .text:000000018031F94A                 mov     eax, cs:dword_181FD7214
-  .text:000000018031F950                 mov     rcx, cs:qword_181FD7220
-  .text:000000018031F957                 cmovz   rcx, rbx
-  .text:000000018031F95B                 mov     rbx, r8
-  .text:000000018031F95E                 and     rbx, rax
-  .text:000000018031F961                 movsxd  rax, edx
-  .text:000000018031F964                 add     rax, rax
-  .text:000000018031F967                 add     rbx, [rcx+rax*8+8]
-  .text:000000018031F96C                 mov     cs:byte_1821CFE89, 1
-  .text:000000018031F973                 mov     rcx, [rdi]
-  .text:000000018031F976                 mov     rax, [rcx]
-  .text:000000018031F979                 call    qword ptr [rax+18h] ; 0x18 = IGameSystemFactory_CreateGameSystem
-  .text:000000018031F97C                 mov     cs:byte_1821CFE89, 0
-  .text:000000018031F983                 mov     rsi, rax
-  .text:000000018031F986                 mov     rcx, [rdi]
-  .text:000000018031F989                 mov     r8, [rcx]
-  .text:000000018031F98C                 call    qword ptr [r8+40h] ; 0x40 = IGameSystemFactory_IsReallocating
-  .text:000000018031F990                 test    al, al
-  .text:000000018031F992                 jz      short loc_18031F9A4
-  .text:000000018031F994                 mov     r8, [rsi]
-  .text:000000018031F997                 mov     rdx, rbx
-  .text:000000018031F99A                 mov     rcx, rsi
-  .text:000000018031F99D                 call    qword ptr [r8+1D8h] ; 0x1D8 = IGameSystem_SetName
-  .text:000000018031F9A4                 mov     rcx, [rdi]
-  .text:000000018031F9A7                 mov     byte ptr [rdi+8], 1
-  .text:000000018031F9AB                 mov     rax, [rcx]
-  .text:000000018031F9AE                 call    qword ptr [rax+30h]
-  .text:000000018031F9B1                 lea     rcx, dword_181FD95E8
-  .text:000000018031F9B8                 mov     ebx, eax
-  .text:000000018031F9BA                 call    sub_180322FE0
-  .text:000000018031F9BF                 mov     rcx, cs:qword_181FD95F0
-  .text:000000018031F9C6                 mov     rdi, [rsp+28h+arg_10]
-  .text:000000018031F9CB                 movsxd  rdx, eax
-  .text:000000018031F9CE                 add     rdx, rdx
-  .text:000000018031F9D1                 mov     [rcx+rdx*8], rsi
-  .text:000000018031F9D5                 mov     rcx, cs:qword_181FD95F0
-  .text:000000018031F9DC                 mov     rsi, [rsp+28h+arg_0]
-  .text:000000018031F9E1                 mov     [rcx+rdx*8+8], ebx
-  .text:000000018031F9E5                 mov     rcx, cs:qword_181FD95F0
-  .text:000000018031F9EC                 mov     [rcx+rdx*8+0Ch], eax
-  .text:000000018031F9F0                 add     rsp, 20h
-  .text:000000018031F9F4                 pop     rbx
-  .text:000000018031F9F5                 retn
+  .text:00000001803309E0                 push    rbx
+  .text:00000001803309E2                 sub     rsp, 20h
+  .text:00000001803309E6                 mov     rbx, rcx
+  .text:00000001803309E9                 lea     rdx, [rsp+28h+arg_8]
+  .text:00000001803309EE                 mov     r8, rcx
+  .text:00000001803309F1                 lea     rcx, unk_181FE04F8
+  .text:00000001803309F8                 call    cs:?Find@CUtlSymbolTable@@QEBA?AVCUtlSymbol@@PEBD@Z; CUtlSymbolTable::Find(char const *)
+  .text:00000001803309FE                 movzx   eax, [rsp+28h+arg_8]
+  .text:0000000180330A03                 mov     ecx, 0FFFFh
+  .text:0000000180330A08                 cmp     ax, cx
+  .text:0000000180330A0B                 jnz     short loc_180330A28
+  .text:0000000180330A0D                 mov     eax, 0FFFFFFFFh
+  .text:0000000180330A12                 cmp     ax, cx
+  .text:0000000180330A15                 jnz     short loc_180330A28
+  .text:0000000180330A17                 mov     rdx, rbx
+  .text:0000000180330A1A                 lea     rcx, aTriedToAddUnkn; "Tried to add unknown game system %s!\n"
+  .text:0000000180330A21                 call    cs:Plat_FatalError
+  .text:0000000180330A27                 ; Trap to Debugger
+  .text:0000000180330A27                 int     3; Trap to Debugger
+  .text:0000000180330A28                 mov     [rsp+28h+arg_10], rdi
+  .text:0000000180330A2D                 movzx   edx, ax
+  .text:0000000180330A30                 mov     edi, edx
+  .text:0000000180330A32                 shl     rdi, 4
+  .text:0000000180330A36                 add     rdi, cs:qword_181FE04E8
+  .text:0000000180330A3D                 cmp     byte ptr [rdi+8], 0
+  .text:0000000180330A41                 jz      short loc_180330A54
+  .text:0000000180330A43                 mov     rdx, rbx
+  .text:0000000180330A46                 lea     rcx, aTriedToAddGame; "Tried to add game system %s twice!\n"
+  .text:0000000180330A4D                 call    cs:Plat_FatalError
+  .text:0000000180330A53                 ; Trap to Debugger
+  .text:0000000180330A53                 int     3; Trap to Debugger
+  .text:0000000180330A54                 mov     rax, cs:qword_181FE0520
+  .text:0000000180330A5B                 mov     ecx, cs:dword_181FE0530
+  .text:0000000180330A61                 mov     [rsp+28h+arg_0], rsi
+  .text:0000000180330A66                 mov     r8d, [rax+rdx*4]
+  .text:0000000180330A6A                 mov     edx, r8d
+  .text:0000000180330A6D                 shr     edx, cl
+  .text:0000000180330A6F                 cmp     edx, cs:dword_181FE0538
+  .text:0000000180330A75                 jb      short loc_180330A7B
+  .text:0000000180330A77                 xor     ebx, ebx
+  .text:0000000180330A79                 jmp     short loc_180330AAC
+  .text:0000000180330A7B                 test    cs:dword_181FE053C, 7FFFFFFFh
+  .text:0000000180330A85                 mov     ebx, 0
+  .text:0000000180330A8A                 mov     eax, cs:dword_181FE0534
+  .text:0000000180330A90                 mov     rcx, cs:qword_181FE0540
+  .text:0000000180330A97                 cmovz   rcx, rbx
+  .text:0000000180330A9B                 mov     rbx, r8
+  .text:0000000180330A9E                 and     rbx, rax
+  .text:0000000180330AA1                 movsxd  rax, edx
+  .text:0000000180330AA4                 add     rax, rax
+  .text:0000000180330AA7                 add     rbx, [rcx+rax*8+8]
+  .text:0000000180330AAC                 mov     cs:byte_1821D6841, 1
+  .text:0000000180330AB3                 mov     rcx, [rdi]
+  .text:0000000180330AB6                 mov     rax, [rcx]
+  .text:0000000180330AB9                 ; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000180330AB9                 call    qword ptr [rax+18h]; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000180330ABC                 mov     cs:byte_1821D6841, 0
+  .text:0000000180330AC3                 mov     rsi, rax
+  .text:0000000180330AC6                 mov     rcx, [rdi]
+  .text:0000000180330AC9                 mov     r8, [rcx]
+  .text:0000000180330ACC                 ; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000180330ACC                 call    qword ptr [r8+40h]; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000180330AD0                 test    al, al
+  .text:0000000180330AD2                 jz      short loc_180330AE4
+  .text:0000000180330AD4                 mov     r8, [rsi]
+  .text:0000000180330AD7                 mov     rdx, rbx
+  .text:0000000180330ADA                 mov     rcx, rsi
+  .text:0000000180330ADD                 ; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000180330ADD                 call    qword ptr [r8+1E0h]; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000180330AE4                 mov     rcx, [rdi]
+  .text:0000000180330AE7                 mov     byte ptr [rdi+8], 1
+  .text:0000000180330AEB                 mov     rax, [rcx]
+  .text:0000000180330AEE                 ; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000180330AEE                 call    qword ptr [rax+30h]; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000180330AF1                 lea     rcx, dword_181FE09D8
+  .text:0000000180330AF8                 mov     ebx, eax
+  .text:0000000180330AFA                 call    sub_1803339C0
+  .text:0000000180330AFF                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180330B06                 mov     rdi, [rsp+28h+arg_10]
+  .text:0000000180330B0B                 movsxd  rdx, eax
+  .text:0000000180330B0E                 add     rdx, rdx
+  .text:0000000180330B11                 mov     [rcx+rdx*8], rsi
+  .text:0000000180330B15                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180330B1C                 mov     rsi, [rsp+28h+arg_0]
+  .text:0000000180330B21                 mov     [rcx+rdx*8+8], ebx
+  .text:0000000180330B25                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180330B2C                 mov     [rcx+rdx*8+0Ch], eax
+  .text:0000000180330B30                 add     rsp, 20h
+  .text:0000000180330B34                 pop     rbx
+  .text:0000000180330B35                 retn
 procedure: |-
   __int64 __fastcall IGameSystem_AddByName(const char *a1)
   {
@@ -100,44 +106,44 @@ procedure: |-
     __int64 v11; // rdx
     unsigned __int16 v12; // [rsp+38h] [rbp+10h] BYREF
 
-    CUtlSymbolTable::Find(&unk_181FD71D8, &v12, a1);
+    CUtlSymbolTable::Find(&unk_181FE04F8, &v12, a1);
     if ( v12 == 0xFFFF )
     {
       Plat_FatalError("Tried to add unknown game system %s!\n", a1);
       __debugbreak();
     }
-    v2 = (_QWORD *)(qword_181FD71C8 + 16LL * v12);
+    v2 = (_QWORD *)(qword_181FE04E8 + 16LL * v12);
     if ( *((_BYTE *)v2 + 8) )
     {
       Plat_FatalError("Tried to add game system %s twice!\n", a1);
       __debugbreak();
     }
-    v3 = *(_DWORD *)(qword_181FD7200 + 4LL * v12) >> dword_181FD7210;
-    if ( v3 < dword_181FD7218 )
+    v3 = *(_DWORD *)(qword_181FE0520 + 4LL * v12) >> dword_181FE0530;
+    if ( v3 < dword_181FE0538 )
     {
-      v5 = qword_181FD7220;
-      if ( (dword_181FD721C & 0x7FFFFFFF) == 0 )
+      v5 = qword_181FE0540;
+      if ( (dword_181FE053C & 0x7FFFFFFF) == 0 )
         v5 = 0;
       v4 = *(_QWORD *)(v5 + 16LL * (int)v3 + 8)
-         + ((unsigned int)dword_181FD7214 & *(_DWORD *)(qword_181FD7200 + 4LL * v12));
+         + ((unsigned int)dword_181FE0534 & *(_DWORD *)(qword_181FE0520 + 4LL * v12));
     }
     else
     {
       v4 = 0;
     }
-    byte_1821CFE89 = 1;
-    v6 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 24LL))(*v2);// 0x18 = 24LL = IGameSystemFactory_CreateGameSystem
-    byte_1821CFE89 = 0;
+    byte_1821D6841 = 1;
+    v6 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 24LL))(*v2);// 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+    byte_1821D6841 = 0;
     v7 = v6;
-    if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 64LL))(*v2) )// 0x40 = 64LL = IGameSystemFactory_IsReallocating
-      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v7 + 472LL))(v7, v4);// 0x1D8 = 472LL =IGameSystem_SetName
+    if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v2 + 64LL))(*v2) )// 64LL = 0x40 = IGameSystemFactory_IsReallocating
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v7 + 480LL))(v7, v4);// 480LL = 0x1E0 = IGameSystem_SetName
     v8 = *v2;
     *((_BYTE *)v2 + 8) = 1;
-    v9 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v8 + 48LL))(v8);
-    result = sub_180322FE0(&dword_181FD95E8);
+    v9 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v8 + 48LL))(v8);// 48LL = 0x30 = IGameSystemFactory_GetPriority
+    result = sub_1803339C0(&dword_181FE09D8);
     v11 = 2LL * (int)result;
-    *(_QWORD *)(qword_181FD95F0 + 8 * v11) = v7;
-    *(_DWORD *)(qword_181FD95F0 + 8 * v11 + 8) = v9;
-    *(_DWORD *)(qword_181FD95F0 + 8 * v11 + 12) = result;
+    *(_QWORD *)(qword_181FE09E0 + 8 * v11) = v7;
+    *(_DWORD *)(qword_181FE09E0 + 8 * v11 + 8) = v9;
+    *(_DWORD *)(qword_181FE09E0 + 8 * v11 + 12) = result;
     return result;
   }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_DestroyAllGameSystems.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_DestroyAllGameSystems.linux.yaml
@@ -39,7 +39,7 @@ disasm_code: |-
   .text:0000000000E353A7                 mov     rdi, [rax]
   .text:0000000000E353AA                 mov     r14, rax
   .text:0000000000E353AD                 mov     rdx, [rdi]
-  .text:0000000000E353B0                 call    qword ptr [rdx+20h] ; 0x20 = IGameSystemFactory_Deallocate
+  .text:0000000000E353B0                 call    qword ptr [rdx+20h] ; 0x20 = IGameSystemFactory_DestroyGameSystem
   .text:0000000000E353B3                 mov     cs:byte_43EC37A, 0
   .text:0000000000E353BA                 mov     byte ptr [r14+8], 0
   .text:0000000000E353BF                 cmp     rbx, r12
@@ -61,7 +61,7 @@ disasm_code: |-
   .text:0000000000E353FE                 mov     rdi, qword ptr ds:stru_FFFF0.r_offset[rax]
   .text:0000000000E35405                 mov     [rbp+var_50], rax
   .text:0000000000E35409                 mov     rdx, [rdi]
-  .text:0000000000E3540C                 call    qword ptr [rdx+20h] ; 0x20 = IGameSystemFactory_Deallocate
+  .text:0000000000E3540C                 call    qword ptr [rdx+20h] ; 0x20 = IGameSystemFactory_DestroyGameSystem
   .text:0000000000E3540F                 mov     rax, [rbp+var_50]
   .text:0000000000E35413                 mov     cs:byte_43EC37A, 0
   .text:0000000000E3541A                 mov     byte ptr [rax+0FFFF8h], 0
@@ -152,7 +152,7 @@ procedure: |-
           v1 -= 16;
           byte_43EC37A = 1;
           v4 = (_BYTE *)(qword_43EC2E8 + 16LL * v13[0]);
-          (*(void (__fastcall **)(_QWORD, _QWORD *))(**(_QWORD **)v4 + 32LL))(*(_QWORD *)v4, v5);// 32LL = 0x20 = IGameSystemFactory_Deallocate
+          (*(void (__fastcall **)(_QWORD, _QWORD *))(**(_QWORD **)v4 + 32LL))(*(_QWORD *)v4, v5);// 32LL = 0x20 = IGameSystemFactory_DestroyGameSystem
           byte_43EC37A = 0;
           v4[8] = 0;
           if ( v1 == v2 )

--- a/ida_preprocessor_scripts/references/client/IGameSystem_DestroyAllGameSystems.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_DestroyAllGameSystems.windows.yaml
@@ -35,7 +35,7 @@ disasm_code: |-
   .text:0000000180366D0C                 add     rbx, cs:qword_181FD71C8
   .text:0000000180366D13                 mov     rcx, [rbx]
   .text:0000000180366D16                 mov     rax, [rcx]
-  .text:0000000180366D19                 call    qword ptr [rax+20h] ; 0x20 = IGameSystemFactory_Deallocate
+  .text:0000000180366D19                 call    qword ptr [rax+20h] ; 0x20 = IGameSystemFactory_DestroyGameSystem
   .text:0000000180366D1C                 sub     rsi, 10h
   .text:0000000180366D20                 mov     cs:byte_1821CFE8A, 0
   .text:0000000180366D27                 sub     rdi, 1
@@ -75,7 +75,7 @@ procedure: |-
           v4 = -1;
         byte_1821CFE8A = 1;
         v5 = (_BYTE *)(qword_181FD71C8 + 16LL * v4);
-        (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)v5 + 32LL))(*(_QWORD *)v5, pGameSystem);// 32LL = 0x20 = IGameSystemFactory_Deallocate
+        (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)v5 + 32LL))(*(_QWORD *)v5, pGameSystem);// 32LL = 0x20 = IGameSystemFactory_DestroyGameSystem
         v1 -= 16;
         byte_1821CFE8A = 0;
         --v0;

--- a/ida_preprocessor_scripts/references/client/IGameSystem_LoopInitAllSystems.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_LoopInitAllSystems.linux.yaml
@@ -1,0 +1,1109 @@
+func_name: IGameSystem_LoopInitAllSystems
+func_va: '0xe8be80'
+disasm_code: |-
+  .text:0000000000E8BE80                 push    rbp
+  .text:0000000000E8BE81                 movq    xmm2, rdi
+  .text:0000000000E8BE86                 xor     eax, eax
+  .text:0000000000E8BE88                 mov     rbp, rsp
+  .text:0000000000E8BE8B                 push    r15
+  .text:0000000000E8BE8D                 pinsrq  xmm2, rsi, 1
+  .text:0000000000E8BE94                 xor     r15d, r15d
+  .text:0000000000E8BE97                 push    r14
+  .text:0000000000E8BE99                 push    r13
+  .text:0000000000E8BE9B                 push    r12
+  .text:0000000000E8BE9D                 push    rbx
+  .text:0000000000E8BE9E                 sub     rsp, 68h
+  .text:0000000000E8BEA2                 mov     [rbp-78h], rdi
+  .text:0000000000E8BEA6                 mov     [rbp-80h], rsi
+  .text:0000000000E8BEAA                 lea     rdi, aSIgamesystemLo_3; "%s:  IGameSystem::LoopInitAllSystems(st"...
+  .text:0000000000E8BEB1                 lea     rsi, aCl; "CL"
+  .text:0000000000E8BEB8                 movaps  xmmword ptr [rbp-70h], xmm2
+  .text:0000000000E8BEBC                 call    _COM_TimestampedLog
+  .text:0000000000E8BEC1                 mov     eax, cs:dword_4497D58
+  .text:0000000000E8BEC7                 movzx   r13d, ax
+  .text:0000000000E8BECB                 shl     r13, 2
+  .text:0000000000E8BECF                 test    ax, ax
+  .text:0000000000E8BED2                 jz      loc_E8BFFD
+  .text:0000000000E8BED8                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000000E8BEE0                 mov     rax, cs:qword_4497D28
+  .text:0000000000E8BEE7                 lea     r12, [rax+r15*4]
+  .text:0000000000E8BEEB                 cmp     byte ptr [r12+8], 0
+  .text:0000000000E8BEF1                 jnz     loc_E8BFF0
+  .text:0000000000E8BEF7                 mov     rdi, [r12]
+  .text:0000000000E8BEFB                 mov     rax, [rdi]
+  .text:0000000000E8BEFE                 call    qword ptr [rax+28h]; 40LL = 0x28 = IGameSystemFactory_ShouldAutoAdd
+  .text:0000000000E8BF01                 test    al, al
+  .text:0000000000E8BF03                 jz      loc_E8BFF0
+  .text:0000000000E8BF09                 mov     rax, cs:qword_4497D60
+  .text:0000000000E8BF10                 mov     ecx, cs:dword_4497D70
+  .text:0000000000E8BF16                 mov     edx, [rax+r15]
+  .text:0000000000E8BF1A                 mov     eax, edx
+  .text:0000000000E8BF1C                 shr     eax, cl
+  .text:0000000000E8BF1E                 cmp     eax, cs:dword_4497D78
+  .text:0000000000E8BF24                 jnb     loc_E8C6B0
+  .text:0000000000E8BF2A                 xor     ecx, ecx
+  .text:0000000000E8BF2C                 cdqe
+  .text:0000000000E8BF2E                 test    cs:dword_4497D7C, 7FFFFFFFh
+  .text:0000000000E8BF38                 cmovnz  rcx, cs:qword_4497D80
+  .text:0000000000E8BF40                 shl     rax, 4
+  .text:0000000000E8BF44                 and     edx, cs:dword_4497D74
+  .text:0000000000E8BF4A                 add     rdx, [rcx+rax+8]
+  .text:0000000000E8BF4F                 mov     rbx, rdx
+  .text:0000000000E8BF52                 mov     rdi, [r12]
+  .text:0000000000E8BF56                 mov     cs:byte_4497DBB, 1
+  .text:0000000000E8BF5D                 mov     rax, [rdi]
+  .text:0000000000E8BF60                 call    qword ptr [rax+18h]; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000000E8BF63                 mov     rdi, [r12]
+  .text:0000000000E8BF67                 mov     cs:byte_4497DBB, 0
+  .text:0000000000E8BF6E                 mov     r14, rax
+  .text:0000000000E8BF71                 mov     rax, [rdi]
+  .text:0000000000E8BF74                 call    qword ptr [rax+40h]; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000000E8BF77                 test    al, al
+  .text:0000000000E8BF79                 jz      short loc_E8BF99
+  .text:0000000000E8BF7B                 mov     rax, [r14]
+  .text:0000000000E8BF7E                 lea     rcx, sub_C1AB10
+  .text:0000000000E8BF85                 mov     rax, [rax+1E0h]; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000000E8BF8C                 cmp     rax, rcx
+  .text:0000000000E8BF8F                 jnz     loc_E8C808
+  .text:0000000000E8BF95                 mov     [r14+8], rbx
+  .text:0000000000E8BF99                 movsxd  rbx, cs:dword_4497E30
+  .text:0000000000E8BFA0                 mov     byte ptr [r12+8], 1
+  .text:0000000000E8BFA6                 cmp     ebx, dword ptr cs:qword_4497E40
+  .text:0000000000E8BFAC                 mov     eax, ebx
+  .text:0000000000E8BFAE                 jz      loc_E8C690
+  .text:0000000000E8BFB4                 add     eax, 1
+  .text:0000000000E8BFB7                 shl     rbx, 4
+  .text:0000000000E8BFBB                 mov     cs:dword_4497E30, eax
+  .text:0000000000E8BFC1                 mov     rax, cs:qword_4497E38
+  .text:0000000000E8BFC8                 mov     [rax+rbx], r14
+  .text:0000000000E8BFCC                 mov     rdi, [r12]
+  .text:0000000000E8BFD0                 mov     rax, [rdi]
+  .text:0000000000E8BFD3                 call    qword ptr [rax+30h]; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000000E8BFD6                 mov     rdx, cs:qword_4497E38
+  .text:0000000000E8BFDD                 mov     [rdx+rbx+8], eax
+  .text:0000000000E8BFE1                 mov     rax, cs:qword_4497E38
+  .text:0000000000E8BFE8                 mov     dword ptr [rax+rbx+0Ch], 7FFFFFFFh
+  .text:0000000000E8BFF0                 add     r15, 4
+  .text:0000000000E8BFF4                 cmp     r15, r13
+  .text:0000000000E8BFF7                 jnz     loc_E8BEE0
+  .text:0000000000E8BFFD                 movsxd  r15, cs:dword_4497E30
+  .text:0000000000E8C004                 mov     r14, cs:qword_4497E38
+  .text:0000000000E8C00B                 mov     rax, r15
+  .text:0000000000E8C00E                 shl     r15, 4
+  .text:0000000000E8C012                 lea     rbx, [r14+r15]
+  .text:0000000000E8C016                 mov     [rbp-58h], r15
+  .text:0000000000E8C01A                 cmp     r14, rbx
+  .text:0000000000E8C01D                 jz      loc_E8C136
+  .text:0000000000E8C023                 mov     rdx, r15
+  .text:0000000000E8C026                 mov     rsi, rbx
+  .text:0000000000E8C029                 mov     rdi, r14
+  .text:0000000000E8C02C                 mov     [rbp-60h], eax
+  .text:0000000000E8C02F                 lea     r12, [r14+10h]
+  .text:0000000000E8C033                 sar     rdx, 4
+  .text:0000000000E8C037                 bsr     rdx, rdx
+  .text:0000000000E8C03B                 movsxd  rdx, edx
+  .text:0000000000E8C03E                 add     rdx, rdx
+  .text:0000000000E8C041                 call    sub_E357A0
+  .text:0000000000E8C046                 cmp     r15, 100h
+  .text:0000000000E8C04D                 mov     eax, [rbp-60h]
+  .text:0000000000E8C050                 jg      loc_E8C6C0
+  .text:0000000000E8C056                 cmp     qword ptr [rbp-58h], 10h
+  .text:0000000000E8C05B                 jz      loc_E8C136
+  .text:0000000000E8C061                 mov     r13d, 10h
+  .text:0000000000E8C067                 mov     r15, r14
+  .text:0000000000E8C06A                 mov     [rbp-88h], eax
+  .text:0000000000E8C070                 jmp     short loc_E8C0C0
+  .text:0000000000E8C078                 setl    al
+  .text:0000000000E8C07B                 mov     r14, [r12]
+  .text:0000000000E8C07F                 test    al, al
+  .text:0000000000E8C081                 jz      short loc_E8C0E6
+  .text:0000000000E8C083                 mov     rdx, r12
+  .text:0000000000E8C086                 ; n
+  .text:0000000000E8C086                 sub     rdx, r15; n
+  .text:0000000000E8C089                 cmp     rdx, 10h
+  .text:0000000000E8C08D                 jle     loc_E8C851
+  .text:0000000000E8C093                 mov     rdi, r13
+  .text:0000000000E8C096                 ; src
+  .text:0000000000E8C096                 mov     rsi, r15; src
+  .text:0000000000E8C099                 movq    qword ptr [rbp-60h], xmm1
+  .text:0000000000E8C09E                 sub     rdi, rdx
+  .text:0000000000E8C0A1                 ; dest
+  .text:0000000000E8C0A1                 add     rdi, r12; dest
+  .text:0000000000E8C0A4                 call    _memmove
+  .text:0000000000E8C0A9                 movq    xmm1, qword ptr [rbp-60h]
+  .text:0000000000E8C0AE                 add     r12, 10h
+  .text:0000000000E8C0B2                 mov     [r15], r14
+  .text:0000000000E8C0B5                 movq    qword ptr [r15+8], xmm1
+  .text:0000000000E8C0BB                 cmp     rbx, r12
+  .text:0000000000E8C0BE                 jz      short loc_E8C130
+  .text:0000000000E8C0C0                 movq    xmm1, qword ptr [r12+8]
+  .text:0000000000E8C0C7                 pextrd  edi, xmm1, 1
+  .text:0000000000E8C0CD                 movd    ecx, xmm1
+  .text:0000000000E8C0D1                 cmp     [r15+8], ecx
+  .text:0000000000E8C0D5                 jnz     short loc_E8C078
+  .text:0000000000E8C0D7                 cmp     [r15+0Ch], edi
+  .text:0000000000E8C0DB                 mov     r14, [r12]
+  .text:0000000000E8C0DF                 setnle  al
+  .text:0000000000E8C0E2                 test    al, al
+  .text:0000000000E8C0E4                 jnz     short loc_E8C083
+  .text:0000000000E8C0E6                 mov     rax, r12
+  .text:0000000000E8C0E9                 jmp     short loc_E8C10C
+  .text:0000000000E8C100                 cmp     edx, ecx
+  .text:0000000000E8C102                 jge     short loc_E8C11F
+  .text:0000000000E8C104                 movdqu  xmm0, xmmword ptr [rax]
+  .text:0000000000E8C108                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000000E8C10C                 mov     edx, [rax-8]
+  .text:0000000000E8C10F                 mov     rsi, rax
+  .text:0000000000E8C112                 sub     rax, 10h
+  .text:0000000000E8C116                 cmp     edx, ecx
+  .text:0000000000E8C118                 jnz     short loc_E8C100
+  .text:0000000000E8C11A                 cmp     [rsi-4], edi
+  .text:0000000000E8C11D                 jg      short loc_E8C104
+  .text:0000000000E8C11F                 add     r12, 10h
+  .text:0000000000E8C123                 mov     [rsi], r14
+  .text:0000000000E8C126                 movq    qword ptr [rsi+8], xmm1
+  .text:0000000000E8C12B                 cmp     rbx, r12
+  .text:0000000000E8C12E                 jnz     short loc_E8C0C0
+  .text:0000000000E8C130                 mov     eax, [rbp-88h]
+  .text:0000000000E8C136                 lea     r12, xmmword_4497CF0
+  .text:0000000000E8C13D                 xor     r14d, r14d
+  .text:0000000000E8C140                 mov     cs:qword_4497DC0, r12
+  .text:0000000000E8C147                 lea     r13, off_4197F70
+  .text:0000000000E8C14E                 lea     r15, [rbp-40h]
+  .text:0000000000E8C152                 test    eax, eax
+  .text:0000000000E8C154                 jg      loc_E8C44E
+  .text:0000000000E8C15A                 jmp     loc_E8C5B0
+  .text:0000000000E8C160                 mov     rax, [rbx]
+  .text:0000000000E8C163                 movsxd  rdx, esi
+  .text:0000000000E8C166                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C16A                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C16F                 jz      short loc_E8C17D
+  .text:0000000000E8C171                 mov     rax, [r12]
+  .text:0000000000E8C175                 mov     rdx, rbx
+  .text:0000000000E8C178                 mov     rdi, r12
+  .text:0000000000E8C17B                 call    qword ptr [rax]
+  .text:0000000000E8C17D                 mov     esi, cs:dword_43BEBD0
+  .text:0000000000E8C183                 test    esi, esi
+  .text:0000000000E8C185                 js      loc_E8C520
+  .text:0000000000E8C18B                 mov     rax, [rbx]
+  .text:0000000000E8C18E                 movsxd  rdx, esi
+  .text:0000000000E8C191                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C195                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C19A                 jz      short loc_E8C1A8
+  .text:0000000000E8C19C                 mov     rax, [r12]
+  .text:0000000000E8C1A0                 mov     rdx, rbx
+  .text:0000000000E8C1A3                 mov     rdi, r12
+  .text:0000000000E8C1A6                 call    qword ptr [rax]
+  .text:0000000000E8C1A8                 mov     esi, cs:dword_43BEBCC
+  .text:0000000000E8C1AE                 test    esi, esi
+  .text:0000000000E8C1B0                 js      loc_E8C550
+  .text:0000000000E8C1B6                 mov     rax, [rbx]
+  .text:0000000000E8C1B9                 movsxd  rdx, esi
+  .text:0000000000E8C1BC                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C1C0                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C1C5                 jz      short loc_E8C1D3
+  .text:0000000000E8C1C7                 mov     rax, [r12]
+  .text:0000000000E8C1CB                 mov     rdx, rbx
+  .text:0000000000E8C1CE                 mov     rdi, r12
+  .text:0000000000E8C1D1                 call    qword ptr [rax]
+  .text:0000000000E8C1D3                 mov     rsi, r12
+  .text:0000000000E8C1D6                 mov     rdi, rbx
+  .text:0000000000E8C1D9                 call    sub_E8BC80
+  .text:0000000000E8C1DE                 mov     esi, cs:dword_43BEBC4
+  .text:0000000000E8C1E4                 test    esi, esi
+  .text:0000000000E8C1E6                 js      loc_E8C4F0
+  .text:0000000000E8C1EC                 mov     rax, [rbx]
+  .text:0000000000E8C1EF                 movsxd  rdx, esi
+  .text:0000000000E8C1F2                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C1F6                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C1FB                 jz      short loc_E8C209
+  .text:0000000000E8C1FD                 mov     rax, [r12]
+  .text:0000000000E8C201                 mov     rdx, rbx
+  .text:0000000000E8C204                 mov     rdi, r12
+  .text:0000000000E8C207                 call    qword ptr [rax]
+  .text:0000000000E8C209                 mov     esi, cs:dword_43BEBC0
+  .text:0000000000E8C20F                 test    esi, esi
+  .text:0000000000E8C211                 js      loc_E8C4C0
+  .text:0000000000E8C217                 mov     rax, [rbx]
+  .text:0000000000E8C21A                 movsxd  rdx, esi
+  .text:0000000000E8C21D                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C221                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C226                 jz      short loc_E8C234
+  .text:0000000000E8C228                 mov     rax, [r12]
+  .text:0000000000E8C22C                 mov     rdx, rbx
+  .text:0000000000E8C22F                 mov     rdi, r12
+  .text:0000000000E8C232                 call    qword ptr [rax]
+  .text:0000000000E8C234                 mov     rsi, r12
+  .text:0000000000E8C237                 mov     rdi, rbx
+  .text:0000000000E8C23A                 call    sub_E8BA80
+  .text:0000000000E8C23F                 mov     rsi, r12
+  .text:0000000000E8C242                 mov     rdi, rbx
+  .text:0000000000E8C245                 call    sub_E8B880
+  .text:0000000000E8C24A                 mov     rsi, r12
+  .text:0000000000E8C24D                 mov     rdi, rbx
+  .text:0000000000E8C250                 call    sub_E8B680
+  .text:0000000000E8C255                 mov     rsi, r12
+  .text:0000000000E8C258                 mov     rdi, rbx
+  .text:0000000000E8C25B                 call    sub_E8B480
+  .text:0000000000E8C260                 mov     rsi, r12
+  .text:0000000000E8C263                 mov     rdi, rbx
+  .text:0000000000E8C266                 call    sub_E8B280
+  .text:0000000000E8C26B                 mov     rsi, r12
+  .text:0000000000E8C26E                 mov     rdi, rbx
+  .text:0000000000E8C271                 call    sub_E8B080
+  .text:0000000000E8C276                 mov     rsi, r12
+  .text:0000000000E8C279                 mov     rdi, rbx
+  .text:0000000000E8C27C                 call    sub_E8AE80
+  .text:0000000000E8C281                 mov     rsi, r12
+  .text:0000000000E8C284                 mov     rdi, rbx
+  .text:0000000000E8C287                 call    sub_E8AC80
+  .text:0000000000E8C28C                 mov     rsi, r12
+  .text:0000000000E8C28F                 mov     rdi, rbx
+  .text:0000000000E8C292                 call    sub_E8AA80
+  .text:0000000000E8C297                 mov     rsi, r12
+  .text:0000000000E8C29A                 mov     rdi, rbx
+  .text:0000000000E8C29D                 call    sub_E8A880
+  .text:0000000000E8C2A2                 mov     rsi, r12
+  .text:0000000000E8C2A5                 mov     rdi, rbx
+  .text:0000000000E8C2A8                 call    sub_E8A680
+  .text:0000000000E8C2AD                 mov     rsi, r12
+  .text:0000000000E8C2B0                 mov     rdi, rbx
+  .text:0000000000E8C2B3                 call    sub_E8A480
+  .text:0000000000E8C2B8                 mov     rsi, r12
+  .text:0000000000E8C2BB                 mov     rdi, rbx
+  .text:0000000000E8C2BE                 call    sub_E8A280
+  .text:0000000000E8C2C3                 mov     rsi, r12
+  .text:0000000000E8C2C6                 mov     rdi, rbx
+  .text:0000000000E8C2C9                 call    sub_E8A080
+  .text:0000000000E8C2CE                 mov     rsi, r12
+  .text:0000000000E8C2D1                 mov     rdi, rbx
+  .text:0000000000E8C2D4                 call    sub_E89E80
+  .text:0000000000E8C2D9                 mov     rsi, r12
+  .text:0000000000E8C2DC                 mov     rdi, rbx
+  .text:0000000000E8C2DF                 call    sub_E89C80
+  .text:0000000000E8C2E4                 mov     rsi, r12
+  .text:0000000000E8C2E7                 mov     rdi, rbx
+  .text:0000000000E8C2EA                 call    sub_E89A80
+  .text:0000000000E8C2EF                 mov     rsi, r12
+  .text:0000000000E8C2F2                 mov     rdi, rbx
+  .text:0000000000E8C2F5                 call    sub_E89880
+  .text:0000000000E8C2FA                 mov     rsi, r12
+  .text:0000000000E8C2FD                 mov     rdi, rbx
+  .text:0000000000E8C300                 call    sub_E89680
+  .text:0000000000E8C305                 mov     rsi, r12
+  .text:0000000000E8C308                 mov     rdi, rbx
+  .text:0000000000E8C30B                 call    sub_E89480
+  .text:0000000000E8C310                 mov     rsi, r12
+  .text:0000000000E8C313                 mov     rdi, rbx
+  .text:0000000000E8C316                 call    sub_E89280
+  .text:0000000000E8C31B                 mov     rsi, r12
+  .text:0000000000E8C31E                 mov     rdi, rbx
+  .text:0000000000E8C321                 call    sub_E89080
+  .text:0000000000E8C326                 mov     rsi, r12
+  .text:0000000000E8C329                 mov     rdi, rbx
+  .text:0000000000E8C32C                 call    sub_E88E80
+  .text:0000000000E8C331                 mov     rsi, r12
+  .text:0000000000E8C334                 mov     rdi, rbx
+  .text:0000000000E8C337                 call    sub_E88C80
+  .text:0000000000E8C33C                 mov     rsi, r12
+  .text:0000000000E8C33F                 mov     rdi, rbx
+  .text:0000000000E8C342                 call    sub_E88A80
+  .text:0000000000E8C347                 mov     rsi, r12
+  .text:0000000000E8C34A                 mov     rdi, rbx
+  .text:0000000000E8C34D                 call    sub_E88880
+  .text:0000000000E8C352                 mov     rsi, r12
+  .text:0000000000E8C355                 mov     rdi, rbx
+  .text:0000000000E8C358                 call    sub_E88680
+  .text:0000000000E8C35D                 mov     rsi, r12
+  .text:0000000000E8C360                 mov     rdi, rbx
+  .text:0000000000E8C363                 call    sub_E88480
+  .text:0000000000E8C368                 mov     rsi, r12
+  .text:0000000000E8C36B                 mov     rdi, rbx
+  .text:0000000000E8C36E                 call    sub_E88280
+  .text:0000000000E8C373                 mov     rsi, r12
+  .text:0000000000E8C376                 mov     rdi, rbx
+  .text:0000000000E8C379                 call    sub_E88080
+  .text:0000000000E8C37E                 mov     rsi, r12
+  .text:0000000000E8C381                 mov     rdi, rbx
+  .text:0000000000E8C384                 call    sub_E87E80
+  .text:0000000000E8C389                 mov     rsi, r12
+  .text:0000000000E8C38C                 mov     rdi, rbx
+  .text:0000000000E8C38F                 call    sub_E87C80
+  .text:0000000000E8C394                 mov     rsi, r12
+  .text:0000000000E8C397                 mov     rdi, rbx
+  .text:0000000000E8C39A                 call    sub_E87A80
+  .text:0000000000E8C39F                 mov     rsi, r12
+  .text:0000000000E8C3A2                 mov     rdi, rbx
+  .text:0000000000E8C3A5                 add     r14, 10h
+  .text:0000000000E8C3A9                 call    sub_E87880
+  .text:0000000000E8C3AE                 mov     rsi, r12
+  .text:0000000000E8C3B1                 mov     rdi, rbx
+  .text:0000000000E8C3B4                 call    sub_E87680
+  .text:0000000000E8C3B9                 mov     rsi, r12
+  .text:0000000000E8C3BC                 mov     rdi, rbx
+  .text:0000000000E8C3BF                 call    sub_E87480
+  .text:0000000000E8C3C4                 mov     rsi, r12
+  .text:0000000000E8C3C7                 mov     rdi, rbx
+  .text:0000000000E8C3CA                 call    sub_E87280
+  .text:0000000000E8C3CF                 mov     rsi, r12
+  .text:0000000000E8C3D2                 mov     rdi, rbx
+  .text:0000000000E8C3D5                 call    sub_E87080
+  .text:0000000000E8C3DA                 mov     rsi, r12
+  .text:0000000000E8C3DD                 mov     rdi, rbx
+  .text:0000000000E8C3E0                 call    sub_E86E80
+  .text:0000000000E8C3E5                 mov     rsi, r12
+  .text:0000000000E8C3E8                 mov     rdi, rbx
+  .text:0000000000E8C3EB                 call    sub_E86C80
+  .text:0000000000E8C3F0                 mov     rsi, r12
+  .text:0000000000E8C3F3                 mov     rdi, rbx
+  .text:0000000000E8C3F6                 call    sub_E86A80
+  .text:0000000000E8C3FB                 mov     rsi, r12
+  .text:0000000000E8C3FE                 mov     rdi, rbx
+  .text:0000000000E8C401                 call    sub_E86880
+  .text:0000000000E8C406                 mov     rsi, r12
+  .text:0000000000E8C409                 mov     rdi, rbx
+  .text:0000000000E8C40C                 call    sub_E86680
+  .text:0000000000E8C411                 mov     rsi, r12
+  .text:0000000000E8C414                 mov     rdi, rbx
+  .text:0000000000E8C417                 call    sub_E86480
+  .text:0000000000E8C41C                 mov     rsi, r12
+  .text:0000000000E8C41F                 mov     rdi, rbx
+  .text:0000000000E8C422                 call    sub_E86280
+  .text:0000000000E8C427                 mov     rsi, r12
+  .text:0000000000E8C42A                 mov     rdi, rbx
+  .text:0000000000E8C42D                 call    sub_E86080
+  .text:0000000000E8C432                 mov     rsi, r12
+  .text:0000000000E8C435                 mov     rdi, rbx
+  .text:0000000000E8C438                 call    sub_E85E80
+  .text:0000000000E8C43D                 cmp     [rbp-58h], r14
+  .text:0000000000E8C441                 jz      loc_E8C5B0
+  .text:0000000000E8C447                 mov     r12, cs:qword_4497DC0
+  .text:0000000000E8C44E                 mov     rax, cs:qword_4497E38
+  .text:0000000000E8C455                 mov     esi, cs:dword_43BEBD8
+  .text:0000000000E8C45B                 mov     rbx, [rax+r14]
+  .text:0000000000E8C45F                 test    esi, esi
+  .text:0000000000E8C461                 js      loc_E8C580
+  .text:0000000000E8C467                 mov     rax, [rbx]
+  .text:0000000000E8C46A                 movsxd  rdx, esi
+  .text:0000000000E8C46D                 mov     rax, [rax+rdx*8]
+  .text:0000000000E8C471                 cmp     [r13+rdx*8+0], rax
+  .text:0000000000E8C476                 jz      short loc_E8C484
+  .text:0000000000E8C478                 mov     rax, [r12]
+  .text:0000000000E8C47C                 mov     rdx, rbx
+  .text:0000000000E8C47F                 mov     rdi, r12
+  .text:0000000000E8C482                 call    qword ptr [rax]
+  .text:0000000000E8C484                 mov     esi, cs:dword_43BEBD4
+  .text:0000000000E8C48A                 test    esi, esi
+  .text:0000000000E8C48C                 jns     loc_E8C160
+  .text:0000000000E8C492                 mov     esi, 21h ; '!'
+  .text:0000000000E8C497                 xor     edx, edx
+  .text:0000000000E8C499                 mov     rdi, r15
+  .text:0000000000E8C49C                 mov     [rbp-40h], r13
+  .text:0000000000E8C4A0                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C4A8                 call    sub_E51BC0
+  .text:0000000000E8C4AD                 mov     esi, eax
+  .text:0000000000E8C4AF                 mov     cs:dword_43BEBD4, eax
+  .text:0000000000E8C4B5                 jmp     loc_E8C160
+  .text:0000000000E8C4C0                 mov     esi, 61h ; 'a'
+  .text:0000000000E8C4C5                 xor     edx, edx
+  .text:0000000000E8C4C7                 mov     rdi, r15
+  .text:0000000000E8C4CA                 mov     [rbp-40h], r13
+  .text:0000000000E8C4CE                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C4D6                 call    sub_E52200
+  .text:0000000000E8C4DB                 mov     esi, eax
+  .text:0000000000E8C4DD                 mov     cs:dword_43BEBC0, eax
+  .text:0000000000E8C4E3                 jmp     loc_E8C217
+  .text:0000000000E8C4F0                 mov     esi, 41h ; 'A'
+  .text:0000000000E8C4F5                 xor     edx, edx
+  .text:0000000000E8C4F7                 mov     rdi, r15
+  .text:0000000000E8C4FA                 mov     [rbp-40h], r13
+  .text:0000000000E8C4FE                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C506                 call    sub_E52170
+  .text:0000000000E8C50B                 mov     esi, eax
+  .text:0000000000E8C50D                 mov     cs:dword_43BEBC4, eax
+  .text:0000000000E8C513                 jmp     loc_E8C1EC
+  .text:0000000000E8C520                 mov     esi, 29h ; ')'
+  .text:0000000000E8C525                 xor     edx, edx
+  .text:0000000000E8C527                 mov     rdi, r15
+  .text:0000000000E8C52A                 mov     [rbp-40h], r13
+  .text:0000000000E8C52E                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C536                 call    sub_E51E70
+  .text:0000000000E8C53B                 mov     esi, eax
+  .text:0000000000E8C53D                 mov     cs:dword_43BEBD0, eax
+  .text:0000000000E8C543                 jmp     loc_E8C18B
+  .text:0000000000E8C550                 mov     esi, 31h ; '1'
+  .text:0000000000E8C555                 xor     edx, edx
+  .text:0000000000E8C557                 mov     rdi, r15
+  .text:0000000000E8C55A                 mov     [rbp-40h], r13
+  .text:0000000000E8C55E                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C566                 call    sub_E52010
+  .text:0000000000E8C56B                 mov     esi, eax
+  .text:0000000000E8C56D                 mov     cs:dword_43BEBCC, eax
+  .text:0000000000E8C573                 jmp     loc_E8C1B6
+  .text:0000000000E8C580                 mov     esi, 19h
+  .text:0000000000E8C585                 xor     edx, edx
+  .text:0000000000E8C587                 mov     rdi, r15
+  .text:0000000000E8C58A                 mov     [rbp-40h], r13
+  .text:0000000000E8C58E                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C596                 call    sub_E51B30
+  .text:0000000000E8C59B                 mov     esi, eax
+  .text:0000000000E8C59D                 mov     cs:dword_43BEBD8, eax
+  .text:0000000000E8C5A3                 jmp     loc_E8C467
+  .text:0000000000E8C5B0                 cmp     cs:byte_4497DB8, 0
+  .text:0000000000E8C5B7                 jz      short loc_E8C5D8
+  .text:0000000000E8C5B9                 lea     rax, qword_472E440
+  .text:0000000000E8C5C0                 mov     rcx, cs:qword_4497DC0
+  .text:0000000000E8C5C7                 mov     rdx, [rbp-80h]
+  .text:0000000000E8C5CB                 mov     rsi, [rbp-78h]
+  .text:0000000000E8C5CF                 mov     rdi, [rax]
+  .text:0000000000E8C5D2                 mov     rax, [rdi]
+  .text:0000000000E8C5D5                 call    qword ptr [rax+58h]
+  .text:0000000000E8C5D8                 mov     eax, cs:dword_43BEBD8
+  .text:0000000000E8C5DE                 mov     cs:byte_4497DB9, 0
+  .text:0000000000E8C5E5                 movdqa  xmm3, xmmword ptr [rbp-70h]
+  .text:0000000000E8C5EA                 movaps  xmmword ptr [rbp-50h], xmm3
+  .text:0000000000E8C5EE                 test    eax, eax
+  .text:0000000000E8C5F0                 js      loc_E8C815
+  .text:0000000000E8C5F6                 cmp     cs:qword_4497DC0, 0
+  .text:0000000000E8C5FE                 jz      short loc_E8C64A
+  .text:0000000000E8C600                 cmp     dword ptr cs:qword_4497DF0, eax
+  .text:0000000000E8C606                 jle     short loc_E8C64A
+  .text:0000000000E8C608                 cdqe
+  .text:0000000000E8C60A                 lea     rdx, [rax+rax*2]
+  .text:0000000000E8C60E                 mov     rax, cs:qword_4497DF8
+  .text:0000000000E8C615                 lea     r14, [rax+rdx*8]
+  .text:0000000000E8C619                 movsxd  r12, dword ptr [r14]
+  .text:0000000000E8C61C                 test    r12d, r12d
+  .text:0000000000E8C61F                 jle     short loc_E8C64A
+  .text:0000000000E8C621                 lea     r13, [rbp-50h]
+  .text:0000000000E8C625                 shl     r12, 3
+  .text:0000000000E8C629                 xor     ebx, ebx
+  .text:0000000000E8C62B                 nop     dword ptr [rax+rax+00h]
+  .text:0000000000E8C630                 mov     rax, [r14+8]
+  .text:0000000000E8C634                 mov     rsi, r13
+  .text:0000000000E8C637                 mov     rdi, [rax+rbx]
+  .text:0000000000E8C63B                 add     rbx, 8
+  .text:0000000000E8C63F                 mov     rax, [rdi]
+  .text:0000000000E8C642                 call    qword ptr [rax+18h]
+  .text:0000000000E8C645                 cmp     rbx, r12
+  .text:0000000000E8C648                 jnz     short loc_E8C630
+  .text:0000000000E8C64A                 call    sub_E48C60
+  .text:0000000000E8C64F                 movzx   ebx, cs:byte_4497DB9
+  .text:0000000000E8C656                 xor     eax, eax
+  .text:0000000000E8C658                 mov     cs:byte_4497DB9, 0
+  .text:0000000000E8C65F                 lea     rsi, aCl; "CL"
+  .text:0000000000E8C666                 lea     rdi, aSIgamesystemLo_4; "%s:  IGameSystem::LoopInitAllSystems(fi"...
+  .text:0000000000E8C66D                 call    _COM_TimestampedLog
+  .text:0000000000E8C672                 add     rsp, 68h
+  .text:0000000000E8C676                 mov     eax, ebx
+  .text:0000000000E8C678                 pop     rbx
+  .text:0000000000E8C679                 xor     eax, 1
+  .text:0000000000E8C67C                 pop     r12
+  .text:0000000000E8C67E                 pop     r13
+  .text:0000000000E8C680                 pop     r14
+  .text:0000000000E8C682                 pop     r15
+  .text:0000000000E8C684                 pop     rbp
+  .text:0000000000E8C685                 retn
+  .text:0000000000E8C690                 lea     rdi, qword_4497E38
+  .text:0000000000E8C697                 mov     esi, 1
+  .text:0000000000E8C69C                 call    sub_E5EDC0
+  .text:0000000000E8C6A1                 mov     eax, cs:dword_4497E30
+  .text:0000000000E8C6A7                 jmp     loc_E8BFB4
+  .text:0000000000E8C6B0                 xor     ebx, ebx
+  .text:0000000000E8C6B2                 jmp     loc_E8BF52
+  .text:0000000000E8C6C0                 lea     r13, [r14+100h]
+  .text:0000000000E8C6C7                 mov     [rbp-88h], rbx
+  .text:0000000000E8C6CE                 mov     r15d, eax
+  .text:0000000000E8C6D1                 nop     dword ptr [rax+00000000h]
+  .text:0000000000E8C6D8                 movq    xmm1, qword ptr [r12+8]
+  .text:0000000000E8C6DF                 pextrd  edi, xmm1, 1
+  .text:0000000000E8C6E5                 movd    ecx, xmm1
+  .text:0000000000E8C6E9                 cmp     [r14+8], ecx
+  .text:0000000000E8C6ED                 jz      loc_E8C7C0
+  .text:0000000000E8C6F3                 jl      loc_E8C7CA
+  .text:0000000000E8C6F9                 mov     r8, [r12]
+  .text:0000000000E8C6FD                 mov     rax, r12
+  .text:0000000000E8C700                 jmp     short loc_E8C72C
+  .text:0000000000E8C720                 cmp     edx, ecx
+  .text:0000000000E8C722                 jge     short loc_E8C73F
+  .text:0000000000E8C724                 movdqu  xmm0, xmmword ptr [rax]
+  .text:0000000000E8C728                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000000E8C72C                 mov     edx, [rax-8]
+  .text:0000000000E8C72F                 mov     rsi, rax
+  .text:0000000000E8C732                 sub     rax, 10h
+  .text:0000000000E8C736                 cmp     edx, ecx
+  .text:0000000000E8C738                 jnz     short loc_E8C720
+  .text:0000000000E8C73A                 cmp     [rsi-4], edi
+  .text:0000000000E8C73D                 jg      short loc_E8C724
+  .text:0000000000E8C73F                 mov     [rsi], r8
+  .text:0000000000E8C742                 movq    qword ptr [rsi+8], xmm1
+  .text:0000000000E8C747                 add     r12, 10h
+  .text:0000000000E8C74B                 cmp     r13, r12
+  .text:0000000000E8C74E                 jnz     short loc_E8C6D8
+  .text:0000000000E8C750                 mov     rbx, [rbp-88h]
+  .text:0000000000E8C757                 mov     eax, r15d
+  .text:0000000000E8C75A                 nop     word ptr [rax+rax+00h]
+  .text:0000000000E8C760                 movq    xmm1, qword ptr [r13+8]
+  .text:0000000000E8C766                 mov     rdx, r13
+  .text:0000000000E8C769                 mov     r9, [r13+0]
+  .text:0000000000E8C76D                 pextrd  r8d, xmm1, 1
+  .text:0000000000E8C774                 movd    edi, xmm1
+  .text:0000000000E8C778                 jmp     short loc_E8C78C
+  .text:0000000000E8C780                 cmp     ecx, edi
+  .text:0000000000E8C782                 jge     short loc_E8C7A0
+  .text:0000000000E8C784                 movdqu  xmm0, xmmword ptr [rdx]
+  .text:0000000000E8C788                 movups  xmmword ptr [rdx+10h], xmm0
+  .text:0000000000E8C78C                 mov     ecx, [rdx-8]
+  .text:0000000000E8C78F                 mov     rsi, rdx
+  .text:0000000000E8C792                 sub     rdx, 10h
+  .text:0000000000E8C796                 cmp     ecx, edi
+  .text:0000000000E8C798                 jnz     short loc_E8C780
+  .text:0000000000E8C79A                 cmp     [rsi-4], r8d
+  .text:0000000000E8C79E                 jg      short loc_E8C784
+  .text:0000000000E8C7A0                 add     r13, 10h
+  .text:0000000000E8C7A4                 mov     [rsi], r9
+  .text:0000000000E8C7A7                 movq    qword ptr [rsi+8], xmm1
+  .text:0000000000E8C7AC                 cmp     rbx, r13
+  .text:0000000000E8C7AF                 jnz     short loc_E8C760
+  .text:0000000000E8C7B1                 jmp     loc_E8C136
+  .text:0000000000E8C7C0                 cmp     [r14+0Ch], edi
+  .text:0000000000E8C7C4                 jle     loc_E8C6F9
+  .text:0000000000E8C7CA                 mov     rdx, r12
+  .text:0000000000E8C7CD                 mov     rbx, [r12]
+  .text:0000000000E8C7D1                 ; n
+  .text:0000000000E8C7D1                 sub     rdx, r14; n
+  .text:0000000000E8C7D4                 cmp     rdx, 10h
+  .text:0000000000E8C7D8                 jle     short loc_E8C843
+  .text:0000000000E8C7DA                 mov     edi, 10h
+  .text:0000000000E8C7DF                 ; src
+  .text:0000000000E8C7DF                 mov     rsi, r14; src
+  .text:0000000000E8C7E2                 movq    qword ptr [rbp-60h], xmm1
+  .text:0000000000E8C7E7                 sub     rdi, rdx
+  .text:0000000000E8C7EA                 ; dest
+  .text:0000000000E8C7EA                 add     rdi, r12; dest
+  .text:0000000000E8C7ED                 call    _memmove
+  .text:0000000000E8C7F2                 movq    xmm1, qword ptr [rbp-60h]
+  .text:0000000000E8C7F7                 mov     [r14], rbx
+  .text:0000000000E8C7FA                 movq    qword ptr [r14+8], xmm1
+  .text:0000000000E8C800                 jmp     loc_E8C747
+  .text:0000000000E8C808                 mov     rsi, rbx
+  .text:0000000000E8C80B                 mov     rdi, r14
+  .text:0000000000E8C80E                 call    rax
+  .text:0000000000E8C810                 jmp     loc_E8BF99
+  .text:0000000000E8C815                 lea     rax, off_4197F70
+  .text:0000000000E8C81C                 mov     esi, 19h
+  .text:0000000000E8C821                 xor     edx, edx
+  .text:0000000000E8C823                 mov     qword ptr [rbp-38h], 0
+  .text:0000000000E8C82B                 lea     rdi, [rbp-40h]
+  .text:0000000000E8C82F                 mov     [rbp-40h], rax
+  .text:0000000000E8C833                 call    sub_E51B30
+  .text:0000000000E8C838                 mov     cs:dword_43BEBD8, eax
+  .text:0000000000E8C83E                 jmp     loc_E8C5F6
+  .text:0000000000E8C843                 jnz     short loc_E8C7F7
+  .text:0000000000E8C845                 movdqu  xmm0, xmmword ptr [r14]
+  .text:0000000000E8C84A                 movups  xmmword ptr [r12], xmm0
+  .text:0000000000E8C84F                 jmp     short loc_E8C7F7
+  .text:0000000000E8C851                 jnz     loc_E8C0AE
+  .text:0000000000E8C857                 movdqu  xmm0, xmmword ptr [r15]
+  .text:0000000000E8C85C                 movups  xmmword ptr [r12], xmm0
+  .text:0000000000E8C861                 jmp     loc_E8C0AE
+procedure: |-
+  __int64 __fastcall IGameSystem_LoopInitAllSystems(__m128i *a1, signed __int64 a2)
+  {
+    __m128i inserted; // xmm2
+    __int64 v3; // r15
+    __int64 (__fastcall ***v4)(); // rdi
+    __m128i *v5; // rsi
+    __int64 v6; // r13
+    _BYTE *v7; // r12
+    unsigned int v8; // eax
+    __int64 v9; // rcx
+    __m128i *v10; // rbx
+    __int64 v11; // rdi
+    __int64 v12; // rax
+    __int64 v13; // rdi
+    _QWORD *v14; // r14
+    __int64 v15; // rdx
+    __int64 (__fastcall *v16)(); // rax
+    __int64 v17; // rbx
+    int v18; // eax
+    __int64 v19; // rbx
+    __m128i *v20; // r14
+    int v21; // eax
+    __int64 v22; // r15
+    __m128i *v23; // rbx
+    char *v24; // r12
+    unsigned __int64 v25; // rdx
+    __m128i *v26; // r15
+    __int64 v27; // r14
+    __m128i v28; // xmm1
+    int v29; // ecx
+    const __m128i *j; // rax
+    int v31; // edx
+    __int128 *v32; // r12
+    __int64 v33; // r14
+    __int64 v34; // rsi
+    __int64 v35; // rsi
+    __int64 v36; // rsi
+    __int64 v37; // rsi
+    __int64 v38; // rsi
+    __int64 (__fastcall ***v39)(); // rbx
+    __int64 v40; // rsi
+    unsigned int v41; // eax
+    unsigned int v42; // eax
+    unsigned int v43; // eax
+    unsigned int v44; // eax
+    unsigned int v45; // eax
+    unsigned int v46; // eax
+    int v47; // eax
+    int *v48; // r14
+    __int64 v49; // r12
+    __int64 v50; // r12
+    __int64 v51; // rbx
+    int v52; // ebx
+    __m128i *v54; // r13
+    int v55; // r15d
+    __m128i v56; // xmm1
+    int epi32; // edi
+    int v58; // ecx
+    __int64 v59; // r8
+    const __m128i *i; // rax
+    int v61; // edx
+    __int64 *v62; // rsi
+    __m128i v63; // xmm1
+    const __m128i *v64; // rdx
+    __int64 v65; // r9
+    int v66; // r8d
+    int v67; // ecx
+    __int64 v68; // rbx
+    int v69; // [rsp-88h] [rbp-90h]
+    __m128i *v70; // [rsp-88h] [rbp-90h]
+    __m128i v73; // [rsp-70h] [rbp-78h] BYREF
+    __int64 v74; // [rsp-60h] [rbp-68h]
+    __int64 v75; // [rsp-58h] [rbp-60h]
+    __m128i v76; // [rsp-50h] [rbp-58h] BYREF
+    __int64 (__fastcall **v77)(); // [rsp-40h] [rbp-48h] BYREF
+    __int64 v78; // [rsp-38h] [rbp-40h]
+
+    inserted = _mm_insert_epi64((__m128i)(unsigned __int64)a1, a2, 1);
+    v3 = 0;
+    v4 = (__int64 (__fastcall ***)())"%s:  IGameSystem::LoopInitAllSystems(start)";
+    v5 = (__m128i *)"CL";
+    v73 = inserted;
+    COM_TimestampedLog("%s:  IGameSystem::LoopInitAllSystems(start)");
+    v6 = 4LL * (unsigned __int16)dword_4497D58;
+    if ( (_WORD)dword_4497D58 )
+    {
+      do
+      {
+        v7 = (_BYTE *)(qword_4497D28 + 4 * v3);
+        if ( !v7[8] )
+        {
+          v4 = *(__int64 (__fastcall ****)())v7;
+          if ( (*(unsigned __int8 (__fastcall **)(_QWORD, __m128i *))(**(_QWORD **)v7 + 40LL))(*(_QWORD *)v7, v5) )// 40LL = 0x28 = IGameSystemFactory_ShouldAutoAdd
+          {
+            v8 = *(_DWORD *)(qword_4497D60 + v3) >> dword_4497D70;
+            if ( v8 >= dword_4497D78 )
+            {
+              v10 = nullptr;
+            }
+            else
+            {
+              v9 = 0;
+              if ( (dword_4497D7C & 0x7FFFFFFF) != 0 )
+                v9 = qword_4497D80;
+              v10 = (__m128i *)(*(_QWORD *)(v9 + 16LL * (int)v8 + 8)
+                              + ((unsigned int)dword_4497D74 & *(_DWORD *)(qword_4497D60 + v3)));
+            }
+            v11 = *(_QWORD *)v7;
+            byte_4497DBB = 1;
+            v12 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v11 + 24LL))(v11);// 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+            v13 = *(_QWORD *)v7;
+            byte_4497DBB = 0;
+            v14 = (_QWORD *)v12;
+            if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v13 + 64LL))(v13) )// 64LL = 0x40 = IGameSystemFactory_IsReallocating
+            {
+              v16 = *(__int64 (__fastcall **)())(*v14 + 480LL);// 480LL = 0x1E0 = IGameSystem_SetName
+              if ( v16 == sub_C1AB10 )
+              {
+                v14[1] = v10;
+              }
+              else
+              {
+                v5 = v10;
+                ((void (__fastcall *)(_QWORD *, __m128i *))v16)(v14, v10);
+              }
+            }
+            v17 = dword_4497E30;
+            v7[8] = 1;
+            v18 = v17;
+            if ( (_DWORD)v17 == (_DWORD)qword_4497E40 )
+            {
+              v5 = (__m128i *)(&dword_0 + 1);
+              sub_E5EDC0(&qword_4497E38, 1, v15);
+              v18 = dword_4497E30;
+            }
+            v19 = 16 * v17;
+            dword_4497E30 = v18 + 1;
+            *(_QWORD *)((char *)qword_4497E38 + v19) = v14;
+            v4 = *(__int64 (__fastcall ****)())v7;
+            *(_DWORD *)((char *)qword_4497E38 + v19 + 8) = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)v7 + 48LL))(*(_QWORD *)v7);// 48LL = 0x30 = IGameSystemFactory_GetPriority
+            *(_DWORD *)((char *)qword_4497E38 + v19 + 12) = 0x7FFFFFFF;
+          }
+        }
+        v3 += 4;
+      }
+      while ( v3 != v6 );
+    }
+    v20 = (__m128i *)qword_4497E38;
+    v21 = dword_4497E30;
+    v22 = 16LL * dword_4497E30;
+    v23 = (__m128i *)((char *)qword_4497E38 + v22);
+    v75 = v22;
+    if ( qword_4497E38 != (char *)qword_4497E38 + v22 )
+    {
+      v5 = (__m128i *)((char *)qword_4497E38 + v22);
+      v4 = (__int64 (__fastcall ***)())qword_4497E38;
+      LODWORD(v74) = dword_4497E30;
+      v24 = (char *)qword_4497E38 + 16;
+      _BitScanReverse64(&v25, v22 >> 4);
+      sub_E357A0(qword_4497E38, v23, 2LL * (int)v25);
+      v21 = v74;
+      if ( v22 > 256 )
+      {
+        v54 = v20 + 16;
+        v70 = v23;
+        v55 = v74;
+        do
+        {
+          v56 = _mm_loadl_epi64((const __m128i *)(v24 + 8));
+          epi32 = _mm_extract_epi32(v56, 1);
+          v58 = _mm_cvtsi128_si32(v56);
+          if ( v20->m128i_i32[2] == v58 )
+          {
+            if ( v20->m128i_i32[3] <= epi32 )
+            {
+  LABEL_74:
+              v59 = *(_QWORD *)v24;
+              for ( i = (const __m128i *)v24; ; i[1] = _mm_loadu_si128(i) )
+              {
+                v61 = i[-1].m128i_i32[2];
+                v62 = (__int64 *)i--;
+                if ( v61 == v58 )
+                {
+                  if ( *((_DWORD *)v62 - 1) <= epi32 )
+                  {
+  LABEL_79:
+                    *v62 = v59;
+                    v62[1] = v56.m128i_i64[0];
+                    goto LABEL_80;
+                  }
+                }
+                else if ( v61 >= v58 )
+                {
+                  goto LABEL_79;
+                }
+              }
+            }
+          }
+          else if ( v20->m128i_i32[2] >= v58 )
+          {
+            goto LABEL_74;
+          }
+          v68 = *(_QWORD *)v24;
+          if ( v24 - (char *)v20 <= 16 )
+          {
+            if ( v24 - (char *)v20 == 16 )
+              *(__m128i *)v24 = _mm_loadu_si128(v20);
+          }
+          else
+          {
+            v74 = v56.m128i_i64[0];
+            memmove(&v20[1], v20, v24 - (char *)v20);
+          }
+          v20->m128i_i64[0] = v68;
+          v20->m128i_i64[1] = v56.m128i_i64[0];
+  LABEL_80:
+          v24 += 16;
+        }
+        while ( v54 != (__m128i *)v24 );
+        v21 = v55;
+  LABEL_82:
+        v63 = _mm_loadl_epi64((const __m128i *)&v54->m128i_u64[1]);
+        v64 = v54;
+        v65 = v54->m128i_i64[0];
+        v66 = _mm_extract_epi32(v63, 1);
+        v4 = (__int64 (__fastcall ***)())(unsigned int)_mm_cvtsi128_si32(v63);
+        while ( 1 )
+        {
+          v67 = v64[-1].m128i_i32[2];
+          v5 = (__m128i *)v64--;
+          if ( v67 == (_DWORD)v4 )
+          {
+            if ( v5[-1].m128i_i32[3] <= v66 )
+            {
+  LABEL_87:
+              ++v54;
+              v5->m128i_i64[0] = v65;
+              v5->m128i_i64[1] = v63.m128i_i64[0];
+              if ( v70 == v54 )
+                goto LABEL_32;
+              goto LABEL_82;
+            }
+          }
+          else if ( v67 >= (int)v4 )
+          {
+            goto LABEL_87;
+          }
+          v64[1] = _mm_loadu_si128(v64);
+        }
+      }
+      if ( v75 == 16 )
+        goto LABEL_32;
+      v26 = v20;
+      v69 = v74;
+  LABEL_23:
+      while ( 2 )
+      {
+        v28 = _mm_loadl_epi64((const __m128i *)(v24 + 8));
+        v4 = (__int64 (__fastcall ***)())(unsigned int)_mm_extract_epi32(v28, 1);
+        v29 = _mm_cvtsi128_si32(v28);
+        if ( v26->m128i_i32[2] == v29 )
+        {
+          v27 = *(_QWORD *)v24;
+          if ( v26->m128i_i32[3] <= (int)v4 )
+            goto LABEL_25;
+        }
+        else
+        {
+          v27 = *(_QWORD *)v24;
+          if ( v26->m128i_i32[2] >= v29 )
+          {
+  LABEL_25:
+            for ( j = (const __m128i *)v24; ; j[1] = _mm_loadu_si128(j) )
+            {
+              v31 = j[-1].m128i_i32[2];
+              v5 = (__m128i *)j--;
+              if ( v31 == v29 )
+              {
+                if ( v5[-1].m128i_i32[3] <= (int)v4 )
+                {
+  LABEL_30:
+                  v24 += 16;
+                  v5->m128i_i64[0] = v27;
+                  v5->m128i_i64[1] = v28.m128i_i64[0];
+                  if ( v23 == (__m128i *)v24 )
+                    goto LABEL_31;
+                  goto LABEL_23;
+                }
+              }
+              else if ( v31 >= v29 )
+              {
+                goto LABEL_30;
+              }
+            }
+          }
+        }
+        if ( v24 - (char *)v26 <= 16 )
+        {
+          if ( v24 - (char *)v26 == 16 )
+            *(__m128i *)v24 = _mm_loadu_si128(v26);
+        }
+        else
+        {
+          v5 = v26;
+          v74 = v28.m128i_i64[0];
+          v4 = (__int64 (__fastcall ***)())&v26[1];
+          memmove(&v26[1], v26, v24 - (char *)v26);
+          v28.m128i_i64[0] = v74;
+        }
+        v24 += 16;
+        v26->m128i_i64[0] = v27;
+        v26->m128i_i64[1] = v28.m128i_i64[0];
+        if ( v23 != (__m128i *)v24 )
+          continue;
+        break;
+      }
+  LABEL_31:
+      v21 = v69;
+    }
+  LABEL_32:
+    v32 = &xmmword_4497CF0;
+    v33 = 0;
+    qword_4497DC0 = (__int64)&xmmword_4497CF0;
+    if ( v21 > 0 )
+    {
+      while ( 1 )
+      {
+        v38 = (unsigned int)dword_43BEBD8;
+        v39 = *(__int64 (__fastcall ****)())((char *)qword_4497E38 + v33);
+        if ( dword_43BEBD8 < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v46 = sub_E51B30(&v77, 25, 0);
+          v38 = v46;
+          dword_43BEBD8 = v46;
+        }
+        if ( off_4197F70[(int)v38] != (*v39)[(int)v38] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v38, v39);
+        v40 = (unsigned int)dword_43BEBD4;
+        if ( dword_43BEBD4 < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v41 = sub_E51BC0(&v77, 33, 0);
+          v40 = v41;
+          dword_43BEBD4 = v41;
+        }
+        if ( off_4197F70[(int)v40] != (*v39)[(int)v40] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v40, v39);
+        v34 = (unsigned int)dword_43BEBD0;
+        if ( dword_43BEBD0 < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v44 = sub_E51E70(&v77, 41, 0);
+          v34 = v44;
+          dword_43BEBD0 = v44;
+        }
+        if ( off_4197F70[(int)v34] != (*v39)[(int)v34] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v34, v39);
+        v35 = (unsigned int)dword_43BEBCC;
+        if ( dword_43BEBCC < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v45 = sub_E52010(&v77, 49, 0);
+          v35 = v45;
+          dword_43BEBCC = v45;
+        }
+        if ( off_4197F70[(int)v35] != (*v39)[(int)v35] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v35, v39);
+        sub_E8BC80(v39, v32);
+        v36 = (unsigned int)dword_43BEBC4;
+        if ( dword_43BEBC4 < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v43 = sub_E52170(&v77, 65, 0);
+          v36 = v43;
+          dword_43BEBC4 = v43;
+        }
+        if ( off_4197F70[(int)v36] != (*v39)[(int)v36] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v36, v39);
+        v37 = (unsigned int)dword_43BEBC0;
+        if ( dword_43BEBC0 < 0 )
+        {
+          v77 = off_4197F70;
+          v78 = 0;
+          v42 = sub_E52200(&v77, 97, 0);
+          v37 = v42;
+          dword_43BEBC0 = v42;
+        }
+        if ( off_4197F70[(int)v37] != (*v39)[(int)v37] )
+          (**(void (__fastcall ***)(__int128 *, __int64, __int64 (__fastcall ***)()))v32)(v32, v37, v39);
+        sub_E8BA80(v39, v32);
+        sub_E8B880(v39, v32);
+        sub_E8B680(v39, v32);
+        sub_E8B480(v39, v32);
+        sub_E8B280(v39, v32);
+        sub_E8B080(v39, v32);
+        sub_E8AE80(v39, v32);
+        sub_E8AC80(v39, v32);
+        sub_E8AA80(v39, v32);
+        sub_E8A880(v39, v32);
+        sub_E8A680(v39, v32);
+        sub_E8A480(v39, v32);
+        sub_E8A280(v39, v32);
+        sub_E8A080(v39, v32);
+        sub_E89E80(v39, v32);
+        sub_E89C80(v39, v32);
+        sub_E89A80(v39, v32);
+        sub_E89880(v39, v32);
+        sub_E89680(v39, v32);
+        sub_E89480(v39, v32);
+        sub_E89280(v39, v32);
+        sub_E89080(v39, v32);
+        sub_E88E80(v39, v32);
+        sub_E88C80(v39, v32);
+        sub_E88A80(v39, v32);
+        sub_E88880(v39, v32);
+        sub_E88680(v39, v32);
+        sub_E88480(v39, v32);
+        sub_E88280(v39, v32);
+        sub_E88080(v39, v32);
+        sub_E87E80(v39, v32);
+        sub_E87C80(v39, v32);
+        sub_E87A80(v39, v32);
+        v33 += 16;
+        sub_E87880(v39, v32);
+        sub_E87680(v39, v32);
+        sub_E87480(v39, v32);
+        sub_E87280(v39, v32);
+        sub_E87080(v39, v32);
+        sub_E86E80(v39, v32);
+        sub_E86C80(v39, v32);
+        sub_E86A80(v39, v32);
+        sub_E86880(v39, v32);
+        sub_E86680(v39, v32);
+        sub_E86480(v39, v32);
+        sub_E86280(v39, v32);
+        sub_E86080(v39, v32);
+        v5 = (__m128i *)v32;
+        v4 = v39;
+        sub_E85E80(v39, v32);
+        if ( v75 == v33 )
+          break;
+        v32 = (__int128 *)qword_4497DC0;
+      }
+    }
+    if ( byte_4497DB8 )
+    {
+      v5 = a1;
+      v4 = (__int64 (__fastcall ***)())qword_472E440;
+      (*(void (__fastcall **)(_QWORD *, __m128i *, signed __int64, __int64))(*qword_472E440 + 88LL))(
+        qword_472E440,
+        a1,
+        a2,
+        qword_4497DC0);
+    }
+    v47 = dword_43BEBD8;
+    byte_4497DB9 = 0;
+    v76 = _mm_load_si128(&v73);
+    if ( dword_43BEBD8 < 0 )
+    {
+      v5 = (__m128i *)(&qword_18 + 1);
+      v78 = 0;
+      v4 = &v77;
+      v77 = off_4197F70;
+      v47 = sub_E51B30(&v77, 25, 0);
+      dword_43BEBD8 = v47;
+    }
+    if ( qword_4497DC0 )
+    {
+      if ( (int)qword_4497DF0 > v47 )
+      {
+        v48 = (int *)(qword_4497DF8 + 24LL * v47);
+        v49 = *v48;
+        if ( (int)v49 > 0 )
+        {
+          v50 = 8 * v49;
+          v51 = 0;
+          do
+          {
+            v5 = &v76;
+            v4 = *(__int64 (__fastcall ****)())(*((_QWORD *)v48 + 1) + v51);
+            v51 += 8;
+            ((void (__fastcall *)(__int64 (__fastcall ***)(), __m128i *))(*v4)[3])(v4, &v76);
+          }
+          while ( v51 != v50 );
+        }
+      }
+    }
+    sub_E48C60(v4, v5);
+    v52 = (unsigned __int8)byte_4497DB9;
+    byte_4497DB9 = 0;
+    COM_TimestampedLog("%s:  IGameSystem::LoopInitAllSystems(finish)");
+    return v52 ^ 1u;
+  }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_LoopInitAllSystems.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_LoopInitAllSystems.windows.yaml
@@ -1,0 +1,603 @@
+func_name: IGameSystem_LoopInitAllSystems
+func_va: '0x180357c10'
+disasm_code: |-
+  .text:0000000180357C10                 mov     rax, rsp
+  .text:0000000180357C13                 mov     [rax+10h], rdx
+  .text:0000000180357C17                 mov     [rax+8], rcx
+  .text:0000000180357C1B                 push    rbx
+  .text:0000000180357C1C                 sub     rsp, 70h
+  .text:0000000180357C20                 mov     [rax+18h], rbp
+  .text:0000000180357C24                 mov     rbp, rcx
+  .text:0000000180357C27                 mov     [rax-10h], rsi
+  .text:0000000180357C2B                 lea     rcx, aSIgamesystemLo_3; "%s:  IGameSystem::LoopInitAllSystems(st"...
+  .text:0000000180357C32                 mov     [rax-18h], rdi
+  .text:0000000180357C36                 mov     rsi, rdx
+  .text:0000000180357C39                 mov     [rax-30h], r14
+  .text:0000000180357C3D                 lea     rdx, aCl; "CL"
+  .text:0000000180357C44                 mov     [rax-38h], r15
+  .text:0000000180357C48                 call    cs:COM_TimestampedLog
+  .text:0000000180357C4E                 movzx   eax, word ptr cs:dword_181FE0518
+  .text:0000000180357C55                 xor     r15d, r15d
+  .text:0000000180357C58                 cmp     r15w, ax
+  .text:0000000180357C5C                 jnb     loc_180357E7C
+  .text:0000000180357C62                 mov     [rsp+78h+var_20], r12
+  .text:0000000180357C67                 mov     r14d, r15d
+  .text:0000000180357C6A                 mov     [rsp+78h+var_28], r13
+  .text:0000000180357C6F                 mov     r12d, r15d
+  .text:0000000180357C72                 mov     r13d, eax
+  .text:0000000180357C75                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180357C80                 mov     rsi, cs:qword_181FE04E8
+  .text:0000000180357C87                 add     rsi, r14
+  .text:0000000180357C8A                 cmp     byte ptr [rsi+8], 0
+  .text:0000000180357C8E                 jnz     loc_180357E50
+  .text:0000000180357C94                 mov     rcx, [rsi]
+  .text:0000000180357C97                 mov     rax, [rcx]
+  .text:0000000180357C9A                 call    qword ptr [rax+28h]; 40LL = 0x28 = IGameSystemFactory_ShouldAutoAdd
+  .text:0000000180357C9D                 test    al, al
+  .text:0000000180357C9F                 jz      loc_180357E50
+  .text:0000000180357CA5                 mov     rax, cs:qword_181FE0520
+  .text:0000000180357CAC                 mov     ecx, cs:dword_181FE0530
+  .text:0000000180357CB2                 mov     r8d, [r12+rax]
+  .text:0000000180357CB6                 mov     eax, r8d
+  .text:0000000180357CB9                 shr     eax, cl
+  .text:0000000180357CBB                 cmp     eax, cs:dword_181FE0538
+  .text:0000000180357CC1                 jb      short loc_180357CC8
+  .text:0000000180357CC3                 mov     rbx, r15
+  .text:0000000180357CC6                 jmp     short loc_180357CF1
+  .text:0000000180357CC8                 test    cs:dword_181FE053C, 7FFFFFFFh
+  .text:0000000180357CD2                 mov     rdx, cs:qword_181FE0540
+  .text:0000000180357CD9                 mov     ebx, cs:dword_181FE0534
+  .text:0000000180357CDF                 cmovz   rdx, r15
+  .text:0000000180357CE3                 movsxd  rcx, eax
+  .text:0000000180357CE6                 and     rbx, r8
+  .text:0000000180357CE9                 add     rcx, rcx
+  .text:0000000180357CEC                 add     rbx, [rdx+rcx*8+8]
+  .text:0000000180357CF1                 mov     cs:byte_1821D6841, 1
+  .text:0000000180357CF8                 mov     rcx, [rsi]
+  .text:0000000180357CFB                 mov     rax, [rcx]
+  .text:0000000180357CFE                 call    qword ptr [rax+18h]; 24LL = 0x18 = IGameSystemFactory_CreateGameSystem
+  .text:0000000180357D01                 mov     cs:byte_1821D6841, 0
+  .text:0000000180357D08                 mov     r15, rax
+  .text:0000000180357D0B                 mov     rcx, [rsi]
+  .text:0000000180357D0E                 mov     r8, [rcx]
+  .text:0000000180357D11                 call    qword ptr [r8+40h]; 64LL = 0x40 = IGameSystemFactory_IsReallocating
+  .text:0000000180357D15                 test    al, al
+  .text:0000000180357D17                 jz      short loc_180357D2C
+  .text:0000000180357D19                 mov     rcx, [r15]
+  .text:0000000180357D1C                 mov     rdx, rbx
+  .text:0000000180357D1F                 mov     r8, [rcx+1E0h]; 480LL = 0x1E0 = IGameSystem_SetName
+  .text:0000000180357D26                 mov     rcx, r15
+  .text:0000000180357D29                 call    r8
+  .text:0000000180357D2C                 mov     byte ptr [rsi+8], 1
+  .text:0000000180357D30                 movsxd  rax, cs:dword_181FE09D8
+  .text:0000000180357D37                 mov     ecx, cs:dword_181FE09E8
+  .text:0000000180357D3D                 mov     rbp, rax
+  .text:0000000180357D40                 cmp     eax, ecx
+  .text:0000000180357D42                 jnz     loc_180357E11
+  .text:0000000180357D48                 mov     edx, cs:dword_181FE09EC
+  .text:0000000180357D4E                 bt      edx, 1Eh
+  .text:0000000180357D52                 jb      loc_180357E11
+  .text:0000000180357D58                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180357D5E                 jle     short loc_180357D77
+  .text:0000000180357D60                 mov     edx, 1
+  .text:0000000180357D65                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180357D6B                 mov     edx, cs:dword_181FE09EC
+  .text:0000000180357D71                 mov     ecx, cs:dword_181FE09E8
+  .text:0000000180357D77                 lea     edi, [rcx+1]
+  .text:0000000180357D7A                 and     edx, 3FFFFFFFh
+  .text:0000000180357D80                 mov     r8d, edi
+  .text:0000000180357D83                 mov     r9d, 10h
+  .text:0000000180357D89                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180357D8F                 mov     ebx, eax
+  .text:0000000180357D91                 cmp     eax, edi
+  .text:0000000180357D93                 jge     short loc_180357DB3
+  .text:0000000180357D95                 test    eax, eax
+  .text:0000000180357D97                 jnz     short loc_180357DA5
+  .text:0000000180357D99                 cmp     edi, 0FFFFFFFFh
+  .text:0000000180357D9C                 jg      short loc_180357DA5
+  .text:0000000180357D9E                 mov     ebx, 0FFFFFFFFh
+  .text:0000000180357DA3                 jmp     short loc_180357DB3
+  .text:0000000180357DA5                 lea     eax, [rbx+rdi]
+  .text:0000000180357DA8                 cdq
+  .text:0000000180357DA9                 sub     eax, edx
+  .text:0000000180357DAB                 sar     eax, 1
+  .text:0000000180357DAD                 mov     ebx, eax
+  .text:0000000180357DAF                 cmp     eax, edi
+  .text:0000000180357DB1                 jl      short loc_180357DA5
+  .text:0000000180357DB3                 movsxd  r9, cs:dword_181FE09E8
+  .text:0000000180357DBA                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180357DC1                 shl     r9, 4
+  .text:0000000180357DC5                 test    cs:dword_181FE09EC, 0C0000000h
+  .text:0000000180357DCF                 movsxd  r8, ebx
+  .text:0000000180357DD2                 setz    dl
+  .text:0000000180357DD5                 shl     r8, 4
+  .text:0000000180357DD9                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180357DDF                 mov     ecx, cs:dword_181FE09EC
+  .text:0000000180357DE5                 mov     rdx, rax
+  .text:0000000180357DE8                 mov     cs:qword_181FE09E0, rax
+  .text:0000000180357DEF                 test    ecx, 0C0000000h
+  .text:0000000180357DF5                 jz      short loc_180357E03
+  .text:0000000180357DF7                 and     ecx, 3FFFFFFFh
+  .text:0000000180357DFD                 mov     cs:dword_181FE09EC, ecx
+  .text:0000000180357E03                 mov     eax, cs:dword_181FE09D8
+  .text:0000000180357E09                 mov     cs:dword_181FE09E8, ebx
+  .text:0000000180357E0F                 jmp     short loc_180357E18
+  .text:0000000180357E11                 mov     rdx, cs:qword_181FE09E0
+  .text:0000000180357E18                 inc     eax
+  .text:0000000180357E1A                 mov     rbx, rbp
+  .text:0000000180357E1D                 mov     cs:dword_181FE09D8, eax
+  .text:0000000180357E23                 add     rbx, rbx
+  .text:0000000180357E26                 mov     [rdx+rbx*8], r15
+  .text:0000000180357E2A                 mov     rcx, [rsi]
+  .text:0000000180357E2D                 mov     rax, [rcx]
+  .text:0000000180357E30                 call    qword ptr [rax+30h]; 48LL = 0x30 = IGameSystemFactory_GetPriority
+  .text:0000000180357E33                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180357E3A                 xor     r15d, r15d
+  .text:0000000180357E3D                 mov     [rcx+rbx*8+8], eax
+  .text:0000000180357E41                 mov     rax, cs:qword_181FE09E0
+  .text:0000000180357E48                 mov     dword ptr [rax+rbx*8+0Ch], 7FFFFFFFh
+  .text:0000000180357E50                 add     r14, 10h
+  .text:0000000180357E54                 add     r12, 4
+  .text:0000000180357E58                 sub     r13, 1
+  .text:0000000180357E5C                 jnz     loc_180357C80
+  .text:0000000180357E62                 mov     r13, [rsp+78h+var_28]
+  .text:0000000180357E67                 mov     r12, [rsp+78h+var_20]
+  .text:0000000180357E6C                 mov     rsi, [rsp+78h+arg_8]
+  .text:0000000180357E74                 mov     rbp, [rsp+78h+arg_0]
+  .text:0000000180357E7C                 movsxd  rbx, cs:dword_181FE09D8
+  .text:0000000180357E83                 mov     rcx, cs:qword_181FE09E0
+  .text:0000000180357E8A                 mov     rdx, rbx
+  .text:0000000180357E8D                 movzx   r9d, byte ptr [rsp+78h+arg_8]
+  .text:0000000180357E96                 mov     r8, rbx
+  .text:0000000180357E99                 shl     rdx, 4
+  .text:0000000180357E9D                 add     rdx, rcx
+  .text:0000000180357EA0                 call    sub_180328A70
+  .text:0000000180357EA5                 lea     r8, off_181FE0A08
+  .text:0000000180357EAC                 mov     rdi, rbx
+  .text:0000000180357EAF                 mov     cs:qword_1821D6838, r8
+  .text:0000000180357EB6                 test    ebx, ebx
+  .text:0000000180357EB8                 jle     short loc_180357EE4
+  .text:0000000180357EBA                 mov     rbx, r15
+  .text:0000000180357EBD                 nop     dword ptr [rax]
+  .text:0000000180357EC0                 mov     rax, cs:qword_181FE09E0
+  .text:0000000180357EC7                 mov     rdx, r8
+  .text:0000000180357ECA                 mov     rcx, [rbx+rax]
+  .text:0000000180357ECE                 call    sub_180362810
+  .text:0000000180357ED3                 mov     r8, cs:qword_1821D6838
+  .text:0000000180357EDA                 lea     rbx, [rbx+10h]
+  .text:0000000180357EDE                 sub     rdi, 1
+  .text:0000000180357EE2                 jnz     short loc_180357EC0
+  .text:0000000180357EE4                 cmp     cs:byte_1821D6844, 0
+  .text:0000000180357EEB                 jz      short loc_180357F0A
+  .text:0000000180357EED                 mov     rcx, cs:qword_1824E7B98
+  .text:0000000180357EF4                 mov     r9, r8
+  .text:0000000180357EF7                 mov     r8, rsi
+  .text:0000000180357EFA                 mov     rdx, rbp
+  .text:0000000180357EFD                 mov     rax, [rcx]
+  .text:0000000180357F00                 call    qword ptr [rax+58h]
+  .text:0000000180357F03                 mov     r8, cs:qword_1821D6838
+  .text:0000000180357F0A                 mov     eax, cs:dword_181FE0558
+  .text:0000000180357F10                 mov     cs:byte_1821D6843, 0
+  .text:0000000180357F17                 mov     cs:byte_1821D7F34, 1
+  .text:0000000180357F1E                 mov     [rsp+78h+var_48], rbp
+  .text:0000000180357F23                 mov     [rsp+78h+var_40], rsi
+  .text:0000000180357F28                 test    eax, eax
+  .text:0000000180357F2A                 jns     short loc_180357F7B
+  .text:0000000180357F2C                 mov     ecx, cs:TlsIndex
+  .text:0000000180357F32                 mov     rax, gs:58h
+  .text:0000000180357F3B                 mov     edx, 98h
+  .text:0000000180357F40                 mov     [rsp+78h+var_50], r15
+  .text:0000000180357F45                 mov     rax, [rax+rcx*8]
+  .text:0000000180357F49                 mov     eax, [rdx+rax]
+  .text:0000000180357F4C                 cmp     cs:dword_1821D6888, eax
+  .text:0000000180357F52                 jg      loc_18035818D
+  .text:0000000180357F58                 mov     rax, cs:qword_1821D6880
+  .text:0000000180357F5F                 lea     rcx, [rsp+78h+var_58]
+  .text:0000000180357F64                 mov     [rsp+78h+var_58], rax
+  .text:0000000180357F69                 call    GameSystem_OnGameInit
+  .text:0000000180357F6E                 mov     r8, cs:qword_1821D6838
+  .text:0000000180357F75                 mov     cs:dword_181FE0558, eax
+  .text:0000000180357F7B                 test    r8, r8
+  .text:0000000180357F7E                 jz      short loc_180357FD1
+  .text:0000000180357F80                 cmp     cs:dword_1821D6438, eax
+  .text:0000000180357F86                 jle     short loc_180357FD1
+  .text:0000000180357F88                 cdqe
+  .text:0000000180357F8A                 lea     rcx, [rax+rax*2]
+  .text:0000000180357F8E                 mov     rax, cs:qword_1821D6440
+  .text:0000000180357F95                 movsxd  rsi, dword ptr [rax+rcx*8]
+  .text:0000000180357F99                 lea     rdi, [rax+rcx*8]
+  .text:0000000180357F9D                 test    rsi, rsi
+  .text:0000000180357FA0                 jle     short loc_180357FD1
+  .text:0000000180357FA2                 mov     rbx, r15
+  .text:0000000180357FA5                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000180357FB0                 mov     rcx, [rdi+8]
+  .text:0000000180357FB4                 lea     rdx, [rsp+78h+var_48]
+  .text:0000000180357FB9                 mov     rcx, [rcx+rbx*8]
+  .text:0000000180357FBD                 call    GameSystem_OnGameInit
+  .text:0000000180357FC2                 inc     rbx
+  .text:0000000180357FC5                 cmp     rbx, rsi
+  .text:0000000180357FC8                 jl      short loc_180357FB0
+  .text:0000000180357FCA                 mov     r8, cs:qword_1821D6838
+  .text:0000000180357FD1                 movsxd  r14, cs:dword_1821D6468
+  .text:0000000180357FD8                 mov     r9, cs:qword_1821D6470
+  .text:0000000180357FDF                 mov     cs:byte_1821D7F34, 0
+  .text:0000000180357FE6                 test    r14, r14
+  .text:0000000180357FE9                 jle     loc_18035810B
+  .text:0000000180357FEF                 mov     edx, cs:dword_181FE09D8
+  .text:0000000180357FF5                 mov     rbp, r15
+  .text:0000000180357FF8                 mov     r15d, 0FFFFh
+  .text:0000000180357FFE                 xchg    ax, ax
+  .text:0000000180358000                 mov     rsi, [r9+rbp*8]
+  .text:0000000180358004                 lea     edi, [rdx-1]
+  .text:0000000180358007                 test    edi, edi
+  .text:0000000180358009                 js      loc_1803580FF
+  .text:000000018035800F                 movsxd  rcx, edi
+  .text:0000000180358012                 mov     rax, rcx
+  .text:0000000180358015                 shl     rax, 4
+  .text:0000000180358019                 add     rax, cs:qword_181FE09E0
+  .text:0000000180358020                 cmp     [rax], rsi
+  .text:0000000180358023                 jz      short loc_180358031
+  .text:0000000180358025                 dec     edi
+  .text:0000000180358027                 sub     rax, 10h
+  .text:000000018035802B                 sub     rcx, 1
+  .text:000000018035802F                 jns     short loc_180358020
+  .text:0000000180358031                 test    edi, edi
+  .text:0000000180358033                 js      loc_1803580FF
+  .text:0000000180358039                 mov     rax, [r8]
+  .text:000000018035803C                 mov     rdx, rsi
+  .text:000000018035803F                 mov     rcx, r8
+  .text:0000000180358042                 call    qword ptr [rax+8]
+  .text:0000000180358045                 mov     rax, [rsi]
+  .text:0000000180358048                 mov     rcx, rsi
+  .text:000000018035804B                 call    qword ptr [rax+1D0h]
+  .text:0000000180358051                 mov     r8, rax
+  .text:0000000180358054                 lea     rdx, [rsp+78h+arg_8]
+  .text:000000018035805C                 lea     rcx, unk_181FE04F8
+  .text:0000000180358063                 call    cs:?Find@CUtlSymbolTable@@QEBA?AVCUtlSymbol@@PEBD@Z; CUtlSymbolTable::Find(char const *)
+  .text:0000000180358069                 movzx   eax, word ptr [rsp+78h+arg_8]
+  .text:0000000180358071                 cmp     ax, r15w
+  .text:0000000180358075                 jnz     short loc_18035807C
+  .text:0000000180358077                 mov     eax, 0FFFFFFFFh
+  .text:000000018035807C                 movzx   ebx, ax
+  .text:000000018035807F                 mov     rdx, rsi
+  .text:0000000180358082                 mov     cs:byte_1821D6842, 1
+  .text:0000000180358089                 shl     rbx, 4
+  .text:000000018035808D                 add     rbx, cs:qword_181FE04E8
+  .text:0000000180358094                 mov     rcx, [rbx]
+  .text:0000000180358097                 mov     rax, [rcx]
+  .text:000000018035809A                 call    qword ptr [rax+20h]
+  .text:000000018035809D                 mov     cs:byte_1821D6842, 0
+  .text:00000001803580A4                 mov     byte ptr [rbx+8], 0
+  .text:00000001803580A8                 mov     edx, cs:dword_181FE09D8
+  .text:00000001803580AE                 mov     eax, edx
+  .text:00000001803580B0                 sub     eax, edi
+  .text:00000001803580B2                 dec     eax
+  .text:00000001803580B4                 test    eax, eax
+  .text:00000001803580B6                 jle     short loc_1803580E9
+  .text:00000001803580B8                 movsxd  r8, eax
+  .text:00000001803580BB                 lea     eax, [rdi+1]
+  .text:00000001803580BE                 movsxd  rdx, eax
+  .text:00000001803580C1                 shl     rdx, 4
+  .text:00000001803580C5                 add     rdx, cs:qword_181FE09E0
+  .text:00000001803580CC                 movsxd  rcx, edi
+  .text:00000001803580CF                 shl     rcx, 4
+  .text:00000001803580D3                 add     rcx, cs:qword_181FE09E0
+  .text:00000001803580DA                 shl     r8, 4
+  .text:00000001803580DE                 call    sub_1818C6740
+  .text:00000001803580E3                 mov     edx, cs:dword_181FE09D8
+  .text:00000001803580E9                 mov     r8, cs:qword_1821D6838
+  .text:00000001803580F0                 dec     edx
+  .text:00000001803580F2                 mov     r9, cs:qword_1821D6470
+  .text:00000001803580F9                 mov     cs:dword_181FE09D8, edx
+  .text:00000001803580FF                 inc     rbp
+  .text:0000000180358102                 cmp     rbp, r14
+  .text:0000000180358105                 jl      loc_180358000
+  .text:000000018035810B                 mov     r15, [rsp+78h+var_38]
+  .text:0000000180358110                 xor     ebx, ebx
+  .text:0000000180358112                 test    cs:dword_1821D647C, 0C0000000h
+  .text:000000018035811C                 mov     r14, [rsp+78h+var_30]
+  .text:0000000180358121                 mov     rdi, [rsp+78h+var_18]
+  .text:0000000180358126                 mov     rsi, [rsp+78h+var_10]
+  .text:000000018035812B                 mov     rbp, [rsp+78h+arg_10]
+  .text:0000000180358133                 mov     cs:dword_1821D6468, ebx
+  .text:0000000180358139                 jnz     short loc_180358160
+  .text:000000018035813B                 test    r9, r9
+  .text:000000018035813E                 jz      short loc_18035815A
+  .text:0000000180358140                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180358147                 mov     rdx, r9
+  .text:000000018035814A                 mov     rcx, [rax]
+  .text:000000018035814D                 mov     rax, [rcx]
+  .text:0000000180358150                 call    qword ptr [rax+18h]
+  .text:0000000180358153                 mov     cs:qword_1821D6470, rbx
+  .text:000000018035815A                 mov     cs:dword_1821D6478, ebx
+  .text:0000000180358160                 movzx   ebx, cs:byte_1821D6843
+  .text:0000000180358167                 lea     rdx, aCl; "CL"
+  .text:000000018035816E                 lea     rcx, aSIgamesystemLo_4; "%s:  IGameSystem::LoopInitAllSystems(fi"...
+  .text:0000000180358175                 mov     cs:byte_1821D6843, 0
+  .text:000000018035817C                 call    cs:COM_TimestampedLog
+  .text:0000000180358182                 test    bl, bl
+  .text:0000000180358184                 setz    al
+  .text:0000000180358187                 add     rsp, 70h
+  .text:000000018035818B                 pop     rbx
+  .text:000000018035818C                 retn
+  .text:000000018035818D                 lea     rcx, dword_1821D6888
+  .text:0000000180358194                 call    sub_18186CEF8
+  .text:0000000180358199                 cmp     cs:dword_1821D6888, 0FFFFFFFFh
+  .text:00000001803581A0                 jnz     loc_180357F58
+  .text:00000001803581A6                 mov     rax, cs:off_181FE0648
+  .text:00000001803581AD                 lea     rcx, dword_1821D6888
+  .text:00000001803581B4                 mov     cs:qword_1821D6880, rax
+  .text:00000001803581BB                 call    sub_18186CE8C
+  .text:00000001803581C0                 jmp     loc_180357F58
+procedure: |-
+  bool __fastcall IGameSystem_LoopInitAllSystems(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // rbp
+    __int64 v3; // rsi
+    __int64 v4; // r14
+    __int64 v5; // r12
+    __int64 v6; // r13
+    _QWORD *v7; // rsi
+    unsigned int v8; // eax
+    __int64 v9; // rbx
+    __int64 v10; // rdx
+    __int64 v11; // rax
+    __int64 v12; // r15
+    int v13; // eax
+    __int64 v14; // rcx
+    __int64 v15; // rbp
+    int v16; // edx
+    int v17; // edi
+    int v18; // eax
+    __int64 v19; // rdx
+    int v20; // ebx
+    __int64 v21; // rdx
+    __int64 v22; // rbx
+    __int64 (__fastcall ***v23)(); // r8
+    __int64 v24; // rdi
+    __int64 v25; // rbx
+    int v26; // eax
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v28; // rsi
+    __int64 v29; // rdi
+    __int64 i; // rbx
+    __int64 v31; // r14
+    __int64 v32; // r9
+    int v33; // edx
+    __int64 v34; // rbp
+    __int64 v35; // rsi
+    int v36; // edi
+    __int64 v37; // rcx
+    _QWORD *v38; // rax
+    __int64 v39; // rax
+    unsigned __int16 v40; // ax
+    _BYTE *v41; // rbx
+    int v42; // edx
+    char v43; // bl
+    _QWORD v45[4]; // [rsp+20h] [rbp-58h] BYREF
+    __int64 v47; // [rsp+88h] [rbp+10h] BYREF
+
+    v47 = a2;
+    v2 = a1;
+    v3 = a2;
+    COM_TimestampedLog("%s:  IGameSystem::LoopInitAllSystems(start)", "CL");
+    if ( (_WORD)dword_181FE0518 )
+    {
+      v4 = 0;
+      v5 = 0;
+      v6 = (unsigned __int16)dword_181FE0518;
+      do
+      {
+        v7 = (_QWORD *)(v4 + qword_181FE04E8);
+        if ( !*(_BYTE *)(v4 + qword_181FE04E8 + 8)
+          && (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v7 + 40LL))(*v7) )// IGameSystemFactory_ShouldAutoAdd
+        {
+          v8 = *(_DWORD *)(v5 + qword_181FE0520) >> dword_181FE0530;
+          if ( v8 < dword_181FE0538 )
+          {
+            v10 = qword_181FE0540;
+            if ( (dword_181FE053C & 0x7FFFFFFF) == 0 )
+              v10 = 0;
+            v9 = *(_QWORD *)(v10 + 16LL * (int)v8 + 8)
+               + (*(_DWORD *)(v5 + qword_181FE0520) & (unsigned int)dword_181FE0534);
+          }
+          else
+          {
+            v9 = 0;
+          }
+          byte_1821D6841 = 1;
+          v11 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v7 + 24LL))(*v7);// IGameSystemFactory_CreateGameSystem
+          byte_1821D6841 = 0;
+          v12 = v11;
+          if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v7 + 64LL))(*v7) )// IGameSystemFactory_IsReallocating
+            (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v12 + 480LL))(v12, v9);// IGameSystem_SetName
+          *((_BYTE *)v7 + 8) = 1;
+          v13 = dword_181FE09D8;
+          v14 = (unsigned int)dword_181FE09E8;
+          v15 = dword_181FE09D8;
+          if ( dword_181FE09D8 != dword_181FE09E8 || (v16 = dword_181FE09EC, (dword_181FE09EC & 0x40000000) != 0) )
+          {
+            v21 = qword_181FE09E0;
+          }
+          else
+          {
+            if ( dword_181FE09E8 == 0x7FFFFFFF )
+            {
+              UtlVectorMemory_FailedAllocation(0x7FFFFFFF, 1);
+              v16 = dword_181FE09EC;
+              v14 = (unsigned int)dword_181FE09E8;
+            }
+            v17 = v14 + 1;
+            v18 = UtlVectorMemory_CalcNewAllocationCount(v14, v16 & 0x3FFFFFFF, (unsigned int)(v14 + 1), 16);
+            v20 = v18;
+            if ( v18 < v17 )
+            {
+              if ( v18 || v17 > -1 )
+              {
+                do
+                {
+                  v19 = (unsigned int)((v20 + v17) >> 31);
+                  v20 = (v20 + v17) / 2;
+                }
+                while ( v20 < v17 );
+              }
+              else
+              {
+                v20 = -1;
+              }
+            }
+            LOBYTE(v19) = (dword_181FE09EC & 0xC0000000) == 0;
+            v21 = UtlVectorMemory_Alloc(qword_181FE09E0, v19, 16LL * v20, 16LL * dword_181FE09E8);
+            qword_181FE09E0 = v21;
+            if ( (dword_181FE09EC & 0xC0000000) != 0 )
+              dword_181FE09EC &= 0x3FFFFFFFu;
+            v13 = dword_181FE09D8;
+            dword_181FE09E8 = v20;
+          }
+          dword_181FE09D8 = v13 + 1;
+          *(_QWORD *)(v21 + 16 * v15) = v12;
+          *(_DWORD *)(qword_181FE09E0 + 16 * v15 + 8) = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v7 + 48LL))(*v7);// IGameSystemFactory_GetPriority
+          *(_DWORD *)(qword_181FE09E0 + 16 * v15 + 12) = 0x7FFFFFFF;
+        }
+        v4 += 16;
+        v5 += 4;
+        --v6;
+      }
+      while ( v6 );
+      v3 = v47;
+      v2 = a1;
+    }
+    v22 = dword_181FE09D8;
+    sub_180328A70(qword_181FE09E0, qword_181FE09E0 + 16LL * dword_181FE09D8, dword_181FE09D8, (unsigned __int8)v47);
+    v23 = &off_181FE0A08;
+    v24 = v22;
+    qword_1821D6838 = (__int64)&off_181FE0A08;
+    if ( (int)v22 > 0 )
+    {
+      v25 = 0;
+      do
+      {
+        sub_180362810(*(_QWORD *)(v25 + qword_181FE09E0), v23);
+        v23 = (__int64 (__fastcall ***)())qword_1821D6838;
+        v25 += 16;
+        --v24;
+      }
+      while ( v24 );
+    }
+    if ( byte_1821D6844 )
+    {
+      (*(void (__fastcall **)(__int64, __int64, __int64, __int64 (__fastcall ***)()))(*(_QWORD *)qword_1824E7B98 + 88LL))(
+        qword_1824E7B98,
+        v2,
+        v3,
+        v23);
+      v23 = (__int64 (__fastcall ***)())qword_1821D6838;
+    }
+    v26 = dword_181FE0558;
+    byte_1821D6843 = 0;
+    byte_1821D7F34 = 1;
+    v45[2] = v2;
+    v45[3] = v3;
+    if ( dword_181FE0558 < 0 )
+    {
+      ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+      v45[1] = 0;
+      if ( dword_1821D6888 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 152LL) )
+      {
+        sub_18186CEF8(&dword_1821D6888, 152);
+        if ( dword_1821D6888 == -1 )
+        {
+          qword_1821D6880 = (__int64)off_181FE0648[0];
+          sub_18186CE8C(&dword_1821D6888);
+        }
+      }
+      v45[0] = qword_1821D6880;
+      v26 = GameSystem_OnGameInit(v45);
+      v23 = (__int64 (__fastcall ***)())qword_1821D6838;
+      dword_181FE0558 = v26;
+    }
+    if ( v23 )
+    {
+      if ( dword_1821D6438 > v26 )
+      {
+        v28 = *(int *)(qword_1821D6440 + 24LL * v26);
+        v29 = qword_1821D6440 + 24LL * v26;
+        if ( v28 > 0 )
+        {
+          for ( i = 0; i < v28; ++i )
+            GameSystem_OnGameInit(*(_QWORD *)(*(_QWORD *)(v29 + 8) + 8 * i));
+          v23 = (__int64 (__fastcall ***)())qword_1821D6838;
+        }
+      }
+    }
+    v31 = dword_1821D6468;
+    v32 = qword_1821D6470;
+    byte_1821D7F34 = 0;
+    if ( dword_1821D6468 > 0 )
+    {
+      v33 = dword_181FE09D8;
+      v34 = 0;
+      do
+      {
+        v35 = *(_QWORD *)(v32 + 8 * v34);
+        v36 = v33 - 1;
+        if ( v33 - 1 >= 0 )
+        {
+          v37 = v36;
+          v38 = (_QWORD *)(qword_181FE09E0 + 16LL * v36);
+          do
+          {
+            if ( *v38 == v35 )
+              break;
+            --v36;
+            v38 -= 2;
+            --v37;
+          }
+          while ( v37 >= 0 );
+          if ( v36 >= 0 )
+          {
+            ((void (__fastcall *)(__int64 (__fastcall ***)(), _QWORD))(*v23)[1])(v23, *(_QWORD *)(v32 + 8 * v34));
+            v39 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v35 + 464LL))(v35);// IGameSystem_GetName
+            CUtlSymbolTable::Find(&unk_181FE04F8, &v47, v39);
+            v40 = v47;
+            if ( (_WORD)v47 == 0xFFFF )
+              v40 = -1;
+            byte_1821D6842 = 1;
+            v41 = (_BYTE *)(qword_181FE04E8 + 16LL * v40);
+            (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)v41 + 32LL))(*(_QWORD *)v41, v35);// IGameSystemFactory_DestroyGameSystem
+            byte_1821D6842 = 0;
+            v41[8] = 0;
+            v42 = dword_181FE09D8;
+            if ( dword_181FE09D8 - v36 - 1 > 0 )
+            {
+              sub_1818C6740(
+                qword_181FE09E0 + 16LL * v36,
+                qword_181FE09E0 + 16LL * (v36 + 1),
+                16LL * (dword_181FE09D8 - v36 - 1));
+              v42 = dword_181FE09D8;
+            }
+            v23 = (__int64 (__fastcall ***)())qword_1821D6838;
+            v33 = v42 - 1;
+            v32 = qword_1821D6470;
+            dword_181FE09D8 = v33;
+          }
+        }
+        ++v34;
+      }
+      while ( v34 < v31 );
+    }
+    dword_1821D6468 = 0;
+    if ( (dword_1821D647C & 0xC0000000) == 0 )
+    {
+      if ( v32 )
+      {
+        (*(void (__fastcall **)(_QWORD, __int64, __int64 (__fastcall ***)()))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v32, v23);
+        qword_1821D6470 = 0;
+      }
+      dword_1821D6478 = 0;
+    }
+    v43 = byte_1821D6843;
+    byte_1821D6843 = 0;
+    COM_TimestampedLog("%s:  IGameSystem::LoopInitAllSystems(finish)", "CL");
+    return v43 == 0;
+  }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_ShutdownAllSystems.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_ShutdownAllSystems.linux.yaml
@@ -1,0 +1,125 @@
+func_name: IGameSystem_ShutdownAllSystems
+func_va: '0xe48a00'
+disasm_code: |-
+  .text:0000000000E48A00                 movsxd  rax, dword ptr cs:qword_4497DD0
+  .text:0000000000E48A07                 push    rbp
+  .text:0000000000E48A08                 mov     rbp, rsp
+  .text:0000000000E48A0B                 push    r12
+  .text:0000000000E48A0D                 push    rbx
+  .text:0000000000E48A0E                 mov     edx, eax
+  .text:0000000000E48A10                 sub     edx, 1
+  .text:0000000000E48A13                 js      short loc_E48A73
+  .text:0000000000E48A15                 movsxd  rcx, edx
+  .text:0000000000E48A18                 mov     edx, edx
+  .text:0000000000E48A1A                 lea     rbx, [rcx+rcx*2]
+  .text:0000000000E48A1E                 sub     rax, rdx
+  .text:0000000000E48A21                 lea     rax, [rax+rax*2]
+  .text:0000000000E48A25                 shl     rbx, 3
+  .text:0000000000E48A29                 lea     r12, ds:0FFFFFFFFFFFFFFD0h[rax*8]
+  .text:0000000000E48A31                 nop     dword ptr [rax+00000000h]
+  .text:0000000000E48A38                 mov     rax, cs:qword_4497DD8
+  .text:0000000000E48A3F                 add     rax, rbx
+  .text:0000000000E48A42                 cmp     dword ptr [rax+14h], 3FFFFFFFh
+  .text:0000000000E48A49                 mov     dword ptr [rax], 0
+  .text:0000000000E48A4F                 ja      short loc_E48A6A
+  .text:0000000000E48A51                 mov     rsi, [rax+8]
+  .text:0000000000E48A55                 test    rsi, rsi
+  .text:0000000000E48A58                 jz      short loc_E48A6A
+  .text:0000000000E48A5A                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000E48A61                 mov     rdi, [rax]
+  .text:0000000000E48A64                 mov     rax, [rdi]
+  .text:0000000000E48A67                 call    qword ptr [rax+20h]
+  .text:0000000000E48A6A                 sub     rbx, 18h
+  .text:0000000000E48A6E                 cmp     r12, rbx
+  .text:0000000000E48A71                 jnz     short loc_E48A38
+  .text:0000000000E48A73                 cmp     dword ptr cs:qword_4497DE0+4, 3FFFFFFFh
+  .text:0000000000E48A7D                 mov     dword ptr cs:qword_4497DD0, 0
+  .text:0000000000E48A87                 ja      short loc_E48ABA
+  .text:0000000000E48A89                 mov     rsi, cs:qword_4497DD8
+  .text:0000000000E48A90                 test    rsi, rsi
+  .text:0000000000E48A93                 jz      short loc_E48AB0
+  .text:0000000000E48A95                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000E48A9C                 mov     rdi, [rax]
+  .text:0000000000E48A9F                 mov     rax, [rdi]
+  .text:0000000000E48AA2                 call    qword ptr [rax+20h]
+  .text:0000000000E48AA5                 mov     cs:qword_4497DD8, 0
+  .text:0000000000E48AB0                 mov     dword ptr cs:qword_4497DE0, 0
+  .text:0000000000E48ABA                 movsxd  rax, cs:dword_4497D58
+  .text:0000000000E48AC1                 mov     edx, eax
+  .text:0000000000E48AC3                 sub     edx, 1
+  .text:0000000000E48AC6                 js      short loc_E48B08
+  .text:0000000000E48AC8                 movsxd  rbx, edx
+  .text:0000000000E48ACB                 mov     edx, edx
+  .text:0000000000E48ACD                 sub     rax, rdx
+  .text:0000000000E48AD0                 add     rbx, rbx
+  .text:0000000000E48AD3                 lea     r12, [rax+rax-4]
+  .text:0000000000E48AD8                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000000E48AE0                 mov     rax, cs:qword_4497D08
+  .text:0000000000E48AE7                 movzx   eax, word ptr [rax+rbx]
+  .text:0000000000E48AEB                 sub     rbx, 2
+  .text:0000000000E48AEF                 shl     rax, 4
+  .text:0000000000E48AF3                 add     rax, cs:qword_4497D28
+  .text:0000000000E48AFA                 mov     rdi, [rax]
+  .text:0000000000E48AFD                 mov     rax, [rdi]
+  .text:0000000000E48B00                 call    qword ptr [rax+10h]  ; 10h = IGameSystemFactory_Shutdown
+  .text:0000000000E48B03                 cmp     r12, rbx
+  .text:0000000000E48B06                 jnz     short loc_E48AE0
+  .text:0000000000E48B08                 pop     rbx
+  .text:0000000000E48B09                 pop     r12
+  .text:0000000000E48B0B                 pop     rbp
+  .text:0000000000E48B0C                 retn
+procedure: |-
+  __int64 IGameSystem_ShutdownAllSystems()
+  {
+    __int64 v0; // rdx
+    __int64 v1; // rbx
+    unsigned __int64 v2; // r12
+    __int64 v3; // rax
+    bool v4; // cc
+    __int64 result; // rax
+    __int64 v6; // rbx
+    unsigned __int64 v7; // r12
+    __int64 v8; // rax
+
+    v0 = (unsigned int)(qword_4497DD0 - 1);
+    if ( (int)qword_4497DD0 - 1 >= 0 )
+    {
+      v0 = (unsigned int)v0;
+      v1 = 24LL * (int)v0;
+      v2 = 24 * ((int)qword_4497DD0 - (unsigned __int64)(unsigned int)v0) - 48;
+      do
+      {
+        v3 = v1 + qword_4497DD8;
+        v4 = *(_DWORD *)(v1 + qword_4497DD8 + 20) <= 0x3FFFFFFFu;
+        *(_DWORD *)(v1 + qword_4497DD8) = 0;
+        if ( v4 && *(_QWORD *)(v3 + 8) )
+          (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+        v1 -= 24;
+      }
+      while ( v2 != v1 );
+    }
+    LODWORD(qword_4497DD0) = 0;
+    if ( HIDWORD(qword_4497DE0) <= 0x3FFFFFFF )
+    {
+      if ( qword_4497DD8 )
+      {
+        (*(void (__fastcall **)(_QWORD *, __int64, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, qword_4497DD8, v0);
+        qword_4497DD8 = 0;
+      }
+      LODWORD(qword_4497DE0) = 0;
+    }
+    result = dword_4497D58;
+    if ( dword_4497D58 - 1 >= 0 )
+    {
+      v6 = 2LL * (dword_4497D58 - 1);
+      v7 = 2 * (dword_4497D58 - (unsigned __int64)(unsigned int)(dword_4497D58 - 1)) - 4;
+      do
+      {
+        v8 = *(unsigned __int16 *)(qword_4497D08 + v6);
+        v6 -= 2;
+        result = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)(qword_4497D28 + 16 * v8) + 16LL))(*(_QWORD *)(qword_4497D28 + 16 * v8));  // 16LL = 0x10 = IGameSystemFactory_Shutdown
+      }
+      while ( v7 != v6 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/client/IGameSystem_ShutdownAllSystems.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/IGameSystem_ShutdownAllSystems.windows.yaml
@@ -1,0 +1,45 @@
+func_name: IGameSystem_ShutdownAllSystems
+func_va: '0x18036b180'
+disasm_code: |-
+  .text:000000018036B180                 push    rbx
+  .text:000000018036B182                 sub     rsp, 20h
+  .text:000000018036B186                 lea     rcx, dword_1821D6450
+  .text:000000018036B18D                 call    sub_180361BA0
+  .text:000000018036B192                 mov     eax, cs:dword_181FE0518
+  .text:000000018036B198                 sub     eax, 1
+  .text:000000018036B19B                 movsxd  rbx, eax
+  .text:000000018036B19E                 js      short loc_18036B1C5
+  .text:000000018036B1A0                 mov     rax, cs:qword_1821D6488
+  .text:000000018036B1A7                 movzx   ecx, word ptr [rax+rbx*2]
+  .text:000000018036B1AB                 mov     rax, cs:qword_181FE04E8
+  .text:000000018036B1B2                 add     rcx, rcx
+  .text:000000018036B1B5                 mov     rcx, [rax+rcx*8]
+  .text:000000018036B1B9                 mov     rax, [rcx]
+  .text:000000018036B1BC                 call    qword ptr [rax+10h]  ; 10h = IGameSystemFactory_Shutdown
+  .text:000000018036B1BF                 sub     rbx, 1
+  .text:000000018036B1C3                 jns     short loc_18036B1A0
+  .text:000000018036B1C5                 add     rsp, 20h
+  .text:000000018036B1C9                 pop     rbx
+  .text:000000018036B1CA                 retn
+procedure: |-
+  __int64 IGameSystem_ShutdownAllSystems()
+  {
+    __int64 result; // rax
+    __int64 v1; // rbx
+    __int64 v2; // rcx
+
+    sub_180361BA0(&dword_1821D6450);
+    result = (unsigned int)(dword_181FE0518 - 1);
+    v1 = (int)result;
+    if ( dword_181FE0518 - 1 >= 0 )
+    {
+      do
+      {
+        v2 = *(_QWORD *)(qword_181FE04E8 + 16LL * *(unsigned __int16 *)(qword_1821D6488 + 2 * v1));
+        result = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v2 + 16LL))(v2);  // 16LL = 0x10 = IGameSystemFactory_Shutdown
+        --v1;
+      }
+      while ( v1 >= 0 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CEngineServiceMgr_UnregisterLoopMode.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CEngineServiceMgr_UnregisterLoopMode.linux.yaml
@@ -1,0 +1,142 @@
+func_name: CEngineServiceMgr_UnregisterLoopMode
+func_va: '0x517190'
+disasm_code: |-
+  .text:0000000000517190                 push    rbp
+  .text:0000000000517191                 mov     rbp, rsp
+  .text:0000000000517194                 push    r15
+  .text:0000000000517196                 push    r14
+  .text:0000000000517198                 push    r13
+  .text:000000000051719A                 mov     r13, rdx
+  .text:000000000051719D                 ; _QWORD
+  .text:000000000051719D                 mov     rdx, rsi; _QWORD
+  .text:00000000005171A0                 push    r12
+  .text:00000000005171A2                 push    rbx
+  .text:00000000005171A3                 mov     rbx, rdi
+  .text:00000000005171A6                 lea     rax, [rbx+48h]
+  .text:00000000005171AA                 sub     rsp, 18h
+  .text:00000000005171AE                 ; _QWORD
+  .text:00000000005171AE                 lea     rdi, [rbp+var_32]; _QWORD
+  .text:00000000005171B2                 ; _QWORD
+  .text:00000000005171B2                 mov     rsi, rax; _QWORD
+  .text:00000000005171B5                 call    __ZNK15CUtlSymbolTable4FindEPKc; CUtlSymbolTable::Find(char const*)
+  .text:00000000005171BA                 movzx   r12d, [rbp+var_32]
+  .text:00000000005171BF                 cmp     r12w, 0FFFFh
+  .text:00000000005171C4                 jz      short loc_517215
+  .text:00000000005171C6                 mov     rax, [rbx+38h]
+  .text:00000000005171CA                 lea     r14, ds:0[r12*8]
+  .text:00000000005171D2                 mov     r15, [rax+r12*8]
+  .text:00000000005171D6                 mov     rax, [r15]
+  .text:00000000005171D9                 mov     rdi, r15
+  .text:00000000005171DC                 call    qword ptr [rax+50h]  ; 50h = CLoopTypeBase_GetImplType
+  .text:00000000005171DF                 cmp     eax, 1
+  .text:00000000005171E2                 jz      short loc_517228
+  .text:00000000005171E4                 mov     rax, [rbx+38h]
+  .text:00000000005171E8                 mov     rdi, [rax+r12*8]
+  .text:00000000005171EC                 mov     rax, [rdi]
+  .text:00000000005171EF                 call    qword ptr [rax+20h]
+  .text:00000000005171F2                 mov     rax, [rbx+38h]
+  .text:00000000005171F6                 add     rax, r14
+  .text:00000000005171F9                 mov     rdi, [rax]
+  .text:00000000005171FC                 test    rdi, rdi
+  .text:00000000005171FF                 jz      short loc_51720E
+  .text:0000000000517201                 mov     rax, [rdi]
+  .text:0000000000517204                 call    qword ptr [rax+10h]
+  .text:0000000000517207                 mov     rax, [rbx+38h]
+  .text:000000000051720B                 add     rax, r14
+  .text:000000000051720E                 mov     qword ptr [rax], 0
+  .text:0000000000517215                 add     rsp, 18h
+  .text:0000000000517219                 pop     rbx
+  .text:000000000051721A                 pop     r12
+  .text:000000000051721C                 pop     r13
+  .text:000000000051721E                 pop     r14
+  .text:0000000000517220                 pop     r15
+  .text:0000000000517222                 pop     rbp
+  .text:0000000000517223                 retn
+  .text:0000000000517228                 mov     rax, [r13+0]
+  .text:000000000051722C                 mov     rdi, r13
+  .text:000000000051722F                 call    qword ptr [rax+20h]  ; 20h = ILoopModeFactory_GetLoopModeType
+  .text:0000000000517232                 cmp     eax, 2
+  .text:0000000000517235                 jz      short loc_5172A8
+  .text:0000000000517237                 cmp     eax, 3
+  .text:000000000051723A                 jz      short loc_517280
+  .text:000000000051723C                 cmp     eax, 1
+  .text:000000000051723F                 jnz     short loc_517215
+  .text:0000000000517241                 cmp     qword ptr [r15+90h], 0
+  .text:0000000000517249                 jz      short loc_517215
+  .text:000000000051724B                 mov     qword ptr [r15+90h], 0
+  .text:0000000000517256                 mov     qword ptr [r15+0A0h], 0
+  .text:0000000000517261                 mov     rax, [r13+0]
+  .text:0000000000517265                 mov     rdi, r13
+  .text:0000000000517268                 mov     rax, [rax+8]         ; 8h = ILoopModeFactory_Shutdown (tail-call via jmp rax)
+  .text:000000000051726C                 add     rsp, 18h
+  .text:0000000000517270                 pop     rbx
+  .text:0000000000517271                 pop     r12
+  .text:0000000000517273                 pop     r13
+  .text:0000000000517275                 pop     r14
+  .text:0000000000517277                 pop     r15
+  .text:0000000000517279                 pop     rbp
+  .text:000000000051727A                 jmp     rax
+  .text:0000000000517280                 cmp     qword ptr [r15+0C0h], 0
+  .text:0000000000517288                 jz      short loc_517215
+  .text:000000000051728A                 mov     qword ptr [r15+0C0h], 0
+  .text:0000000000517295                 mov     qword ptr [r15+0D0h], 0
+  .text:00000000005172A0                 jmp     short loc_517261
+  .text:00000000005172A8                 cmp     qword ptr [r15+0A8h], 0
+  .text:00000000005172B0                 jz      loc_517215
+  .text:00000000005172B6                 mov     qword ptr [r15+0A8h], 0
+  .text:00000000005172C1                 mov     qword ptr [r15+0B8h], 0
+  .text:00000000005172CC                 jmp     short loc_517261
+procedure: |-
+  _QWORD *__fastcall CEngineServiceMgr_UnregisterLoopMode(__int64 a1, __int64 a2, __int64 a3)
+  {
+    _QWORD *result; // rax
+    __int64 v6; // r12
+    __int64 v7; // r14
+    _QWORD *v8; // r15
+    __int64 v9; // rdi
+    unsigned __int16 v10[25]; // [rsp+Eh] [rbp-32h] BYREF
+
+    result = (_QWORD *)CUtlSymbolTable::Find(v10, a1 + 72, a2);
+    v6 = v10[0];
+    if ( v10[0] != 0xFFFF )
+    {
+      v7 = 8LL * v10[0];
+      v8 = *(_QWORD **)(*(_QWORD *)(a1 + 56) + v7);
+      if ( (*(unsigned int (__fastcall **)(_QWORD *))(*v8 + 80LL))(v8) == 1 ) // 80LL = 0x50 = CLoopTypeBase_GetImplType
+      {
+        result = (_QWORD *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a3 + 32LL))(a3); // 32LL = 0x20 = ILoopModeFactory_GetLoopModeType
+        if ( (_DWORD)result == 2 )
+        {
+          if ( !v8[21] )
+            return result;
+          v8[21] = 0;
+          v8[23] = 0;
+        }
+        else if ( (_DWORD)result == 3 )
+        {
+          if ( !v8[24] )
+            return result;
+          v8[24] = 0;
+          v8[26] = 0;
+        }
+        else
+        {
+          if ( (_DWORD)result != 1 || !v8[18] )
+            return result;
+          v8[18] = 0;
+          v8[20] = 0;
+        }
+        return (*(_QWORD *(__fastcall **)(__int64))(*(_QWORD *)a3 + 8LL))(a3); // 8LL = 0x8 = ILoopModeFactory_Shutdown
+      }
+      v9 = *(_QWORD *)(*(_QWORD *)(a1 + 56) + 8 * v6);
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)v9 + 32LL))(v9);
+      result = (_QWORD *)(v7 + *(_QWORD *)(a1 + 56));
+      if ( *result )
+      {
+        (*(void (__fastcall **)(_QWORD))(*(_QWORD *)*result + 16LL))(*result);
+        result = (_QWORD *)(v7 + *(_QWORD *)(a1 + 56));
+      }
+      *result = 0;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CEngineServiceMgr_UnregisterLoopMode.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CEngineServiceMgr_UnregisterLoopMode.windows.yaml
@@ -1,0 +1,144 @@
+func_name: CEngineServiceMgr_UnregisterLoopMode
+func_va: '0x180210cc0'
+disasm_code: |-
+  .text:0000000180210CC0                 mov     [rsp+arg_18], rsi
+  .text:0000000180210CC5                 push    rdi
+  .text:0000000180210CC6                 sub     rsp, 20h
+  .text:0000000180210CCA                 mov     rdi, r8
+  .text:0000000180210CCD                 mov     rsi, rcx
+  .text:0000000180210CD0                 mov     r8, rdx
+  .text:0000000180210CD3                 add     rcx, 48h ; 'H'
+  .text:0000000180210CD7                 lea     rdx, [rsp+28h+arg_0]
+  .text:0000000180210CDC                 call    cs:?Find@CUtlSymbolTable@@QEBA?AVCUtlSymbol@@PEBD@Z; CUtlSymbolTable::Find(char const *)
+  .text:0000000180210CE2                 movzx   eax, [rsp+28h+arg_0]
+  .text:0000000180210CE7                 mov     ecx, 0FFFFh
+  .text:0000000180210CEC                 cmp     ax, cx
+  .text:0000000180210CEF                 jnz     short loc_180210CFF
+  .text:0000000180210CF1                 mov     eax, 0FFFFFFFFh
+  .text:0000000180210CF6                 cmp     ax, cx
+  .text:0000000180210CF9                 jz      loc_180210DF7
+  .text:0000000180210CFF                 movzx   eax, ax
+  .text:0000000180210D02                 mov     [rsp+28h+arg_8], rbx
+  .text:0000000180210D07                 mov     [rsp+28h+arg_10], r14
+  .text:0000000180210D0C                 lea     r14, ds:0[rax*8]
+  .text:0000000180210D14                 mov     rax, [rsi+38h]
+  .text:0000000180210D18                 mov     rbx, [r14+rax]
+  .text:0000000180210D1C                 mov     rcx, rbx
+  .text:0000000180210D1F                 mov     rax, [rbx]
+  .text:0000000180210D22                 call    qword ptr [rax+48h]  ; 48h = CLoopTypeBase_GetImplType
+  .text:0000000180210D25                 cmp     eax, 1
+  .text:0000000180210D28                 jnz     loc_180210DBD
+  .text:0000000180210D2E                 mov     rax, [rdi]
+  .text:0000000180210D31                 mov     rcx, rdi
+  .text:0000000180210D34                 call    qword ptr [rax+20h]  ; 20h = ILoopModeFactory_GetLoopModeType
+  .text:0000000180210D37                 sub     eax, 1
+  .text:0000000180210D3A                 jz      short loc_180210D98
+  .text:0000000180210D3C                 sub     eax, 1
+  .text:0000000180210D3F                 jz      short loc_180210D73
+  .text:0000000180210D41                 cmp     eax, 1
+  .text:0000000180210D44                 jnz     loc_180210DED
+  .text:0000000180210D4A                 cmp     qword ptr [rbx+0C0h], 0
+  .text:0000000180210D52                 jz      loc_180210DED
+  .text:0000000180210D58                 xor     ecx, ecx
+  .text:0000000180210D5A                 mov     [rbx+0C0h], rcx
+  .text:0000000180210D61                 mov     [rbx+0D0h], rcx
+  .text:0000000180210D68                 mov     rcx, rdi
+  .text:0000000180210D6B                 mov     rax, [rdi]
+  .text:0000000180210D6E                 call    qword ptr [rax+8]    ; 8h = ILoopModeFactory_Shutdown
+  .text:0000000180210D71                 jmp     short loc_180210DED
+  .text:0000000180210D73                 cmp     qword ptr [rbx+0A8h], 0
+  .text:0000000180210D7B                 jz      short loc_180210DED
+  .text:0000000180210D7D                 xor     ecx, ecx
+  .text:0000000180210D7F                 mov     [rbx+0A8h], rcx
+  .text:0000000180210D86                 mov     [rbx+0B8h], rcx
+  .text:0000000180210D8D                 mov     rcx, rdi
+  .text:0000000180210D90                 mov     rax, [rdi]
+  .text:0000000180210D93                 call    qword ptr [rax+8]
+  .text:0000000180210D96                 jmp     short loc_180210DED
+  .text:0000000180210D98                 cmp     qword ptr [rbx+90h], 0
+  .text:0000000180210DA0                 jz      short loc_180210DED
+  .text:0000000180210DA2                 xor     ecx, ecx
+  .text:0000000180210DA4                 mov     [rbx+90h], rcx
+  .text:0000000180210DAB                 mov     [rbx+0A0h], rcx
+  .text:0000000180210DB2                 mov     rcx, rdi
+  .text:0000000180210DB5                 mov     rax, [rdi]
+  .text:0000000180210DB8                 call    qword ptr [rax+8]
+  .text:0000000180210DBB                 jmp     short loc_180210DED
+  .text:0000000180210DBD                 mov     rax, [rsi+38h]
+  .text:0000000180210DC1                 mov     rcx, [r14+rax]
+  .text:0000000180210DC5                 mov     rax, [rcx]
+  .text:0000000180210DC8                 call    qword ptr [rax+18h]
+  .text:0000000180210DCB                 mov     rax, [rsi+38h]
+  .text:0000000180210DCF                 mov     rcx, [r14+rax]
+  .text:0000000180210DD3                 test    rcx, rcx
+  .text:0000000180210DD6                 jz      short loc_180210DE3
+  .text:0000000180210DD8                 mov     rax, [rcx]
+  .text:0000000180210DDB                 mov     edx, 1
+  .text:0000000180210DE0                 call    qword ptr [rax+8]
+  .text:0000000180210DE3                 mov     rax, [rsi+38h]
+  .text:0000000180210DE7                 xor     ecx, ecx
+  .text:0000000180210DE9                 mov     [r14+rax], rcx
+  .text:0000000180210DED                 mov     rbx, [rsp+28h+arg_8]
+  .text:0000000180210DF2                 mov     r14, [rsp+28h+arg_10]
+  .text:0000000180210DF7                 mov     rsi, [rsp+28h+arg_18]
+  .text:0000000180210DFC                 add     rsp, 20h
+  .text:0000000180210E00                 pop     rdi
+  .text:0000000180210E01                 retn
+procedure: |-
+  __int64 __fastcall CEngineServiceMgr_UnregisterLoopMode(__int64 a1, __int64 a2, __int64 a3)
+  {
+    __int64 result; // rax
+    __int64 v6; // r14
+    _QWORD *v7; // rbx
+    __int64 v8; // rcx
+    unsigned __int16 v9; // [rsp+30h] [rbp+8h] BYREF
+
+    CUtlSymbolTable::Find(a1 + 72, &v9, a2);
+    if ( v9 == 0xFFFF )
+      return 0xFFFFFFFFLL;
+    v6 = 8LL * v9;
+    v7 = *(_QWORD **)(v6 + *(_QWORD *)(a1 + 56));
+    if ( (*(unsigned int (__fastcall **)(_QWORD *))(*v7 + 72LL))(v7) == 1 ) // 72LL = 0x48 = CLoopTypeBase_GetImplType
+    {
+      result = (*(unsigned int (__fastcall **)(__int64))(*(_QWORD *)a3 + 32LL))(a3) - 1; // 32LL = 0x20 = ILoopModeFactory_GetLoopModeType
+      if ( (_DWORD)result )
+      {
+        result = (unsigned int)(result - 1);
+        if ( (_DWORD)result )
+        {
+          if ( (_DWORD)result == 1 )
+          {
+            if ( v7[24] )
+            {
+              v7[24] = 0;
+              v7[26] = 0;
+              return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a3 + 8LL))(a3); // 8LL = 0x8 = ILoopModeFactory_Shutdown
+            }
+          }
+        }
+        else if ( v7[21] )
+        {
+          v7[21] = 0;
+          v7[23] = 0;
+          return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a3 + 8LL))(a3);// ILoopModeFactory_Shutdown
+        }
+      }
+      else if ( v7[18] )
+      {
+        v7[18] = 0;
+        v7[20] = 0;
+        return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a3 + 8LL))(a3);// ILoopModeFactory_Shutdown
+      }
+    }
+    else
+    {
+      (*(void (__fastcall **)(_QWORD))(**(_QWORD **)(v6 + *(_QWORD *)(a1 + 56)) + 24LL))(*(_QWORD *)(v6
+                                                                                                   + *(_QWORD *)(a1 + 56)));
+      v8 = *(_QWORD *)(v6 + *(_QWORD *)(a1 + 56));
+      if ( v8 )
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v8 + 8LL))(v8, 1);
+      result = *(_QWORD *)(a1 + 56);
+      *(_QWORD *)(v6 + result) = 0;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEngineServiceRegistry_UnregisterEngineServices.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEngineServiceRegistry_UnregisterEngineServices.linux.yaml
@@ -1,0 +1,45 @@
+func_name: CEngineServiceRegistry_UnregisterEngineServices
+func_va: '0x1d89570'
+disasm_code: |-
+  .text:0000000001D89570                 push    rbp
+  .text:0000000001D89571                 mov     rbp, rsp
+  .text:0000000001D89574                 push    r12
+  .text:0000000001D89576                 push    rbx
+  .text:0000000001D89577                 mov     rbx, cs:qword_2772320
+  .text:0000000001D8957E                 test    rbx, rbx
+  .text:0000000001D89581                 jz      short loc_1D895AA
+  .text:0000000001D89583                 lea     r12, g_pEngineServiceMgr
+  .text:0000000001D8958A                 nop     word ptr [rax+rax+00h]
+  .text:0000000001D89590                 mov     rdi, [r12]
+  .text:0000000001D89594                 mov     rdx, [rbx+8]
+  .text:0000000001D89598                 mov     rsi, [rbx+10h]
+  .text:0000000001D8959C                 mov     rax, [rdi]
+  .text:0000000001D8959F                 call    qword ptr [rax+60h]  ; 60h = IEngineServiceMgr_UnregisterEngineService
+  .text:0000000001D895A2                 mov     rbx, [rbx]
+  .text:0000000001D895A5                 test    rbx, rbx
+  .text:0000000001D895A8                 jnz     short loc_1D89590
+  .text:0000000001D895AA                 pop     rbx
+  .text:0000000001D895AB                 pop     r12
+  .text:0000000001D895AD                 pop     rbp
+  .text:0000000001D895AE                 retn
+procedure: |-
+  __int64 CEngineServiceRegistry_UnregisterEngineServices()
+  {
+    _QWORD *v0; // rbx
+    __int64 result; // rax
+
+    v0 = (_QWORD *)qword_2772320;
+    if ( qword_2772320 )
+    {
+      do
+      {
+        result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pEngineServiceMgr + 96LL))( // 96LL = 0x60 = IEngineServiceMgr_UnregisterEngineService
+                   g_pEngineServiceMgr,
+                   v0[2],
+                   v0[1]);
+        v0 = (_QWORD *)*v0;
+      }
+      while ( v0 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEngineServiceRegistry_UnregisterEngineServices.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEngineServiceRegistry_UnregisterEngineServices.windows.yaml
@@ -1,0 +1,43 @@
+func_name: CEngineServiceRegistry_UnregisterEngineServices
+func_va: '0x1811e3010'
+disasm_code: |-
+  .text:00000001811E3010                 push    rbx
+  .text:00000001811E3012                 sub     rsp, 20h
+  .text:00000001811E3016                 mov     rbx, cs:qword_1820B9378
+  .text:00000001811E301D                 test    rbx, rbx
+  .text:00000001811E3020                 jz      short loc_1811E304D
+  .text:00000001811E3022                 nop     dword ptr [rax+00h]
+  .text:00000001811E3026                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811E3030                 mov     rcx, cs:g_pEngineServiceMgr
+  .text:00000001811E3037                 mov     r8, [rbx+8]
+  .text:00000001811E303B                 mov     rdx, [rbx+10h]
+  .text:00000001811E303F                 mov     rax, [rcx]
+  .text:00000001811E3042                 call    qword ptr [rax+60h]  ; 60h = IEngineServiceMgr_UnregisterEngineService
+  .text:00000001811E3045                 mov     rbx, [rbx]
+  .text:00000001811E3048                 test    rbx, rbx
+  .text:00000001811E304B                 jnz     short loc_1811E3030
+  .text:00000001811E304D                 add     rsp, 20h
+  .text:00000001811E3051                 pop     rbx
+  .text:00000001811E3052                 retn
+procedure: |-
+  __int64 CEngineServiceRegistry_UnregisterEngineServices()
+  {
+    _QWORD *v0; // rbx
+    __int64 result; // rax
+
+    v0 = (_QWORD *)qword_1820B9378;
+    if ( qword_1820B9378 )
+    {
+      do
+      {
+        result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)g_pEngineServiceMgr
+                                                                    + 96LL))( // 96LL = 0x60 = IEngineServiceMgr_UnregisterEngineService
+                   g_pEngineServiceMgr,
+                   v0[2],
+                   v0[1]);
+        v0 = (_QWORD *)*v0;
+      }
+      while ( v0 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CLoopModeRegistry_UnregisterLoopModes.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CLoopModeRegistry_UnregisterLoopModes.linux.yaml
@@ -1,0 +1,47 @@
+func_name: CLoopModeRegistry_UnregisterLoopModes
+func_va: '0x1d89350'
+disasm_code: |-
+  .text:0000000001D89350                 push    rbp
+  .text:0000000001D89351                 mov     rbp, rsp
+  .text:0000000001D89354                 push    r12
+  .text:0000000001D89356                 push    rbx
+  .text:0000000001D89357                 mov     rbx, cs:qword_2772318
+  .text:0000000001D8935E                 test    rbx, rbx
+  .text:0000000001D89361                 jz      short loc_1D8938E
+  .text:0000000001D89363                 lea     r12, g_pEngineServiceMgr
+  .text:0000000001D8936A                 nop     word ptr [rax+rax+00h]
+  .text:0000000001D89370                 mov     rdi, [r12]
+  .text:0000000001D89374                 mov     rcx, [rbx+18h]
+  .text:0000000001D89378                 mov     rdx, [rbx+10h]
+  .text:0000000001D8937C                 mov     rsi, [rbx+8]
+  .text:0000000001D89380                 mov     rax, [rdi]
+  .text:0000000001D89383                 call    qword ptr [rax+70h]  ; 70h = IEngineServiceMgr_UnregisterLoopMode
+  .text:0000000001D89386                 mov     rbx, [rbx]
+  .text:0000000001D89389                 test    rbx, rbx
+  .text:0000000001D8938C                 jnz     short loc_1D89370
+  .text:0000000001D8938E                 pop     rbx
+  .text:0000000001D8938F                 pop     r12
+  .text:0000000001D89391                 pop     rbp
+  .text:0000000001D89392                 retn
+procedure: |-
+  __int64 CLoopModeRegistry_UnregisterLoopModes()
+  {
+    _QWORD *v0; // rbx
+    __int64 result; // rax
+
+    v0 = (_QWORD *)qword_2772318;
+    if ( qword_2772318 )
+    {
+      do
+      {
+        result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD, _QWORD))(*g_pEngineServiceMgr + 112LL))( // 112LL = 0x70 = IEngineServiceMgr_UnregisterLoopMode
+                   g_pEngineServiceMgr,
+                   v0[1],
+                   v0[2],
+                   v0[3]);
+        v0 = (_QWORD *)*v0;
+      }
+      while ( v0 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CLoopModeRegistry_UnregisterLoopModes.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CLoopModeRegistry_UnregisterLoopModes.windows.yaml
@@ -1,0 +1,45 @@
+func_name: CLoopModeRegistry_UnregisterLoopModes
+func_va: '0x1811e30e0'
+disasm_code: |-
+  .text:00000001811E30E0                 push    rbx
+  .text:00000001811E30E2                 sub     rsp, 20h
+  .text:00000001811E30E6                 mov     rbx, cs:qword_1820B9388
+  .text:00000001811E30ED                 test    rbx, rbx
+  .text:00000001811E30F0                 jz      short loc_1811E3121
+  .text:00000001811E30F2                 nop     dword ptr [rax+00h]
+  .text:00000001811E30F6                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811E3100                 mov     rcx, cs:g_pEngineServiceMgr
+  .text:00000001811E3107                 mov     r9, [rbx+18h]
+  .text:00000001811E310B                 mov     r8, [rbx+10h]
+  .text:00000001811E310F                 mov     rdx, [rbx+8]
+  .text:00000001811E3113                 mov     rax, [rcx]
+  .text:00000001811E3116                 call    qword ptr [rax+70h]  ; 70h = IEngineServiceMgr_UnregisterLoopMode
+  .text:00000001811E3119                 mov     rbx, [rbx]
+  .text:00000001811E311C                 test    rbx, rbx
+  .text:00000001811E311F                 jnz     short loc_1811E3100
+  .text:00000001811E3121                 add     rsp, 20h
+  .text:00000001811E3125                 pop     rbx
+  .text:00000001811E3126                 retn
+procedure: |-
+  __int64 CLoopModeRegistry_UnregisterLoopModes()
+  {
+    _QWORD *v0; // rbx
+    __int64 result; // rax
+
+    v0 = (_QWORD *)qword_1820B9388;
+    if ( qword_1820B9388 )
+    {
+      do
+      {
+        result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD, _QWORD))(*(_QWORD *)g_pEngineServiceMgr
+                                                                            + 112LL))( // 112LL = 0x70 = IEngineServiceMgr_UnregisterLoopMode
+                   g_pEngineServiceMgr,
+                   v0[1],
+                   v0[2],
+                   v0[3]);
+        v0 = (_QWORD *)*v0;
+      }
+      while ( v0 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
@@ -1,0 +1,365 @@
+func_name: CSource2EntitySystem_StaticInit
+func_va: '0x15bc690'
+disasm_code: |-
+  .text:00000000015BC690                 push    rbp
+  .text:00000000015BC691                 mov     rbp, rsp
+  .text:00000000015BC694                 push    r15
+  .text:00000000015BC696                 push    r14
+  .text:00000000015BC698                 push    r13
+  .text:00000000015BC69A                 push    r12
+  .text:00000000015BC69C                 push    rbx
+  .text:00000000015BC69D                 sub     rsp, 28h
+  .text:00000000015BC6A1                 lea     rdx, dword_27C4720
+  .text:00000000015BC6A8                 mov     eax, [rdx]
+  .text:00000000015BC6AA                 lea     ecx, [rax+1]
+  .text:00000000015BC6AD                 mov     [rdx], ecx
+  .text:00000000015BC6AF                 test    eax, eax
+  .text:00000000015BC6B1                 jg      short loc_15BC6DE
+  .text:00000000015BC6B3                 ; _QWORD
+  .text:00000000015BC6B3                 mov     edi, 2100h; _QWORD
+  .text:00000000015BC6B8                 call    __Znwm; operator new(ulong)
+  .text:00000000015BC6BD                 mov     rbx, rax
+  .text:00000000015BC6C0                 mov     rdi, rax
+  .text:00000000015BC6C3                 call    CGameEntitySystem_ctor
+  .text:00000000015BC6C8                 xor     r8d, r8d
+  .text:00000000015BC6CB                 xor     ecx, ecx
+  .text:00000000015BC6CD                 xor     edx, edx
+  .text:00000000015BC6CF                 lea     rsi, aServerEntities; "server_entities"
+  .text:00000000015BC6D6                 mov     rdi, rbx
+  .text:00000000015BC6D9                 call    CEntitySystem_PostCreateEntitySystem
+  .text:00000000015BC6DE                 lea     r13, g_pEntitySystem
+  .text:00000000015BC6E5                 mov     rbx, [r13+0]
+  .text:00000000015BC6E9                 movsxd  r12, dword ptr [rbx+0B90h]
+  .text:00000000015BC6F0                 mov     cs:g_pGameEntitySystem, rbx
+  .text:00000000015BC6F7                 mov     eax, r12d
+  .text:00000000015BC6FA                 cmp     r12d, [rbx+0BA0h]
+  .text:00000000015BC701                 jz      loc_15BCA30
+  .text:00000000015BC707                 add     eax, 1
+  .text:00000000015BC70A                 ; _QWORD
+  .text:00000000015BC70A                 mov     edi, 1340h; _QWORD
+  .text:00000000015BC70F                 mov     [rbx+0B90h], eax
+  .text:00000000015BC715                 mov     rax, [rbx+0B98h]
+  .text:00000000015BC71C                 lea     rcx, off_24C9FE0
+  .text:00000000015BC723                 mov     [rax+r12*8], rcx
+  .text:00000000015BC727                 call    __Znwm; operator new(ulong)
+  .text:00000000015BC72C                 mov     rdi, rax
+  .text:00000000015BC72F                 mov     rbx, rax
+  .text:00000000015BC732                 call    sub_1569780
+  .text:00000000015BC737                 mov     rax, cs:g_pGameEntitySystem
+  .text:00000000015BC73E                 lea     rdx, aMod_0; "MOD"
+  .text:00000000015BC745                 lea     rsi, aSave; "save/"
+  .text:00000000015BC74C                 mov     [rax+20E8h], rbx
+  .text:00000000015BC753                 lea     rax, qword_274C230
+  .text:00000000015BC75A                 mov     rdi, [rax]
+  .text:00000000015BC75D                 mov     rax, [rdi]
+  .text:00000000015BC760                 call    qword ptr [rax+180h]
+  .text:00000000015BC766                 lea     r14, qword_274C2B0
+  .text:00000000015BC76D                 mov     rdi, [r14]
+  .text:00000000015BC770                 test    rdi, rdi
+  .text:00000000015BC773                 jz      short loc_15BC787
+  .text:00000000015BC775                 mov     rax, [rdi]
+  .text:00000000015BC778                 call    qword ptr [rax+120h]
+  .text:00000000015BC77E                 cmp     eax, 2
+  .text:00000000015BC781                 jz      loc_15BCA20
+  .text:00000000015BC787                 movdqa  xmm0, cs:xmmword_86C670
+  .text:00000000015BC78F                 mov     byte ptr [rbp+var_40+4], 0
+  .text:00000000015BC793                 lea     r12, [rbp+var_50]
+  .text:00000000015BC797                 mov     dword ptr [rbp+var_40], 40000h
+  .text:00000000015BC79E                 movaps  [rbp+var_50], xmm0
+  .text:00000000015BC7A2                 call    _CreateNewThreadPool
+  .text:00000000015BC7A7                 lea     rdx, aSavejob; "SaveJob"
+  .text:00000000015BC7AE                 mov     rsi, r12
+  .text:00000000015BC7B1                 mov     rdi, rax
+  .text:00000000015BC7B4                 mov     [rbx+0E0h], rax
+  .text:00000000015BC7BB                 mov     rax, [rax]
+  .text:00000000015BC7BE                 call    qword ptr [rax+20h]
+  .text:00000000015BC7C1                 mov     rax, [rbx+0E0h]
+  .text:00000000015BC7C8                 mov     [rbx+0E8h], rax
+  .text:00000000015BC7CF                 call    _CommandLine
+  .text:00000000015BC7D4                 xor     edx, edx
+  .text:00000000015BC7D6                 mov     esi, 6FEFF596h
+  .text:00000000015BC7DB                 mov     rdi, rax
+  .text:00000000015BC7DE                 mov     rax, [rax]
+  .text:00000000015BC7E1                 call    qword ptr [rax+30h]
+  .text:00000000015BC7E4                 test    eax, eax
+  .text:00000000015BC7E6                 jnz     short loc_15BC7F0
+  .text:00000000015BC7E8                 mov     rdi, rbx
+  .text:00000000015BC7EB                 call    sub_1555CE0
+  .text:00000000015BC7F0                 mov     rdi, cs:qword_26E2FE0
+  .text:00000000015BC7F7                 mov     rax, [rdi]
+  .text:00000000015BC7FA                 call    qword ptr [rax+70h]
+  .text:00000000015BC7FD                 mov     [rbx+128h], rax
+  .text:00000000015BC804                 test    rax, rax
+  .text:00000000015BC807                 jz      loc_15BCA70
+  .text:00000000015BC80D                 mov     rax, [rbx]
+  .text:00000000015BC810                 lea     rdx, sub_152DD00
+  .text:00000000015BC817                 mov     rdi, cs:qword_26E0870
+  .text:00000000015BC81E                 mov     r15, [rax+88h]
+  .text:00000000015BC825                 mov     rax, [rdi]
+  .text:00000000015BC828                 mov     rax, [rax+0C0h]
+  .text:00000000015BC82F                 cmp     rax, rdx
+  .text:00000000015BC832                 jnz     loc_15BCA60
+  .text:00000000015BC838                 mov     rdi, [r14]
+  .text:00000000015BC83B                 mov     rax, [rdi]
+  .text:00000000015BC83E                 call    qword ptr [rax+0E0h]
+  .text:00000000015BC844                 ; char *
+  .text:00000000015BC844                 mov     rsi, rax; char *
+  .text:00000000015BC847                 lea     rax, sub_1530150
+  .text:00000000015BC84E                 cmp     r15, rax
+  .text:00000000015BC851                 jnz     loc_15BCA50
+  .text:00000000015BC857                 ; this
+  .text:00000000015BC857                 lea     rdi, [rbx+108h]; this
+  .text:00000000015BC85E                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:00000000015BC863                 mov     rbx, cs:qword_26E0828
+  .text:00000000015BC86A                 test    rbx, rbx
+  .text:00000000015BC86D                 jz      short loc_15BC88F
+  .text:00000000015BC86F                 nop
+  .text:00000000015BC870                 mov     ecx, [rbx+10h]
+  .text:00000000015BC873                 mov     rdx, [rbx]
+  .text:00000000015BC876                 mov     rsi, [rbx+8]
+  .text:00000000015BC87A                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC881                 call    sub_15B9110
+  .text:00000000015BC886                 mov     rbx, [rbx+18h]
+  .text:00000000015BC88A                 test    rbx, rbx
+  .text:00000000015BC88D                 jnz     short loc_15BC870
+  .text:00000000015BC88F                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC896                 mov     esi, 1
+  .text:00000000015BC89B                 call    sub_1E61B60
+  .text:00000000015BC8A0                 mov     rax, cs:qword_26E0870
+  .text:00000000015BC8A7                 lea     rdx, sub_1535520
+  .text:00000000015BC8AE                 lea     rdi, [rax+8]
+  .text:00000000015BC8B2                 mov     rax, [rax+8]
+  .text:00000000015BC8B6                 mov     rax, [rax+0A8h]
+  .text:00000000015BC8BD                 cmp     rax, rdx
+  .text:00000000015BC8C0                 jnz     loc_15BC9E0
+  .text:00000000015BC8C6                 mov     rdi, [r14]
+  .text:00000000015BC8C9                 mov     rax, [rdi]
+  .text:00000000015BC8CC                 call    qword ptr [rax+0B8h]
+  .text:00000000015BC8D2                 test    al, al
+  .text:00000000015BC8D4                 jnz     loc_15BC9EA
+  .text:00000000015BC8DA                 lea     rax, g_pGameResourceService
+  .text:00000000015BC8E1                 mov     rdi, [rax]
+  .text:00000000015BC8E4                 test    rdi, rdi
+  .text:00000000015BC8E7                 jz      short loc_15BC8F9
+  .text:00000000015BC8E9                 mov     rax, [rdi]
+  .text:00000000015BC8EC                 mov     rsi, cs:g_pGameEntitySystem
+  .text:00000000015BC8F3                 call    qword ptr [rax+110h]  ; 110h = IGameResourceService_SetEntityResourceManifestHandler
+  .text:00000000015BC8F9                 mov     rax, [r13+0]
+  .text:00000000015BC8FD                 lea     rbx, sub_152EFF0
+  .text:00000000015BC904                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC90B                 mov     esi, [rax+278h]
+  .text:00000000015BC911                 call    sub_15BC5D0
+  .text:00000000015BC916                 mov     rdi, [r13+0]
+  .text:00000000015BC91A                 mov     rdx, r12
+  .text:00000000015BC91D                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BC921                 lea     rax, sub_156AEA0
+  .text:00000000015BC928                 mov     esi, 28h ; '('
+  .text:00000000015BC92D                 mov     [rbp+var_40], 0
+  .text:00000000015BC935                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BC939                 call    sub_1E67E40
+  .text:00000000015BC93E                 mov     rdi, [r13+0]
+  .text:00000000015BC942                 mov     rdx, r12
+  .text:00000000015BC945                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BC949                 lea     rax, sub_156AF70
+  .text:00000000015BC950                 mov     esi, 36h ; '6'
+  .text:00000000015BC955                 mov     [rbp+var_40], 0
+  .text:00000000015BC95D                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BC961                 call    sub_1E67E40
+  .text:00000000015BC966                 mov     rdi, [r13+0]
+  .text:00000000015BC96A                 mov     rdx, r12
+  .text:00000000015BC96D                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BC971                 lea     rax, sub_1530BE0
+  .text:00000000015BC978                 mov     esi, 43h ; 'C'
+  .text:00000000015BC97D                 mov     [rbp+var_40], 0
+  .text:00000000015BC985                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BC989                 call    sub_1E67E40
+  .text:00000000015BC98E                 lea     rax, g_pFlattenedSerializers
+  .text:00000000015BC995                 lea     rcx, sub_152F010
+  .text:00000000015BC99C                 mov     rsi, r12
+  .text:00000000015BC99F                 mov     rdi, [rax]
+  .text:00000000015BC9A2                 mov     rax, [rdi]
+  .text:00000000015BC9A5                 mov     rax, [rax+108h]
+  .text:00000000015BC9AC                 mov     qword ptr [rbp+var_50+8], rcx
+  .text:00000000015BC9B0                 lea     rcx, sub_152DF60
+  .text:00000000015BC9B7                 mov     [rbp+var_40], 0
+  .text:00000000015BC9BF                 mov     qword ptr [rbp+var_50], rcx
+  .text:00000000015BC9C3                 call    rax
+  .text:00000000015BC9C5                 add     rsp, 28h
+  .text:00000000015BC9C9                 mov     eax, 1
+  .text:00000000015BC9CE                 pop     rbx
+  .text:00000000015BC9CF                 pop     r12
+  .text:00000000015BC9D1                 pop     r13
+  .text:00000000015BC9D3                 pop     r14
+  .text:00000000015BC9D5                 pop     r15
+  .text:00000000015BC9D7                 pop     rbp
+  .text:00000000015BC9D8                 retn
+  .text:00000000015BC9E0                 call    rax
+  .text:00000000015BC9E2                 test    al, al
+  .text:00000000015BC9E4                 jz      loc_15BC8C6
+  .text:00000000015BC9EA                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC9F1                 lea     rax, sub_152EFE0
+  .text:00000000015BC9F8                 mov     rsi, r12
+  .text:00000000015BC9FB                 mov     [rbp+var_40], 0
+  .text:00000000015BCA03                 mov     qword ptr [rbp+var_50+8], rax
+  .text:00000000015BCA07                 lea     rax, sub_15420E0
+  .text:00000000015BCA0E                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BCA12                 call    sub_1E5C790
+  .text:00000000015BCA17                 jmp     loc_15BC8DA
+  .text:00000000015BCA20                 lea     r12, [rbp+var_50]
+  .text:00000000015BCA24                 jmp     loc_15BC7C1
+  .text:00000000015BCA30                 lea     rdi, [rbx+0B98h]
+  .text:00000000015BCA37                 mov     esi, 1
+  .text:00000000015BCA3C                 call    sub_11A8EC0
+  .text:00000000015BCA41                 mov     eax, [rbx+0B90h]
+  .text:00000000015BCA47                 jmp     loc_15BC707
+  .text:00000000015BCA50                 mov     rdi, rbx
+  .text:00000000015BCA53                 call    r15
+  .text:00000000015BCA56                 jmp     loc_15BC863
+  .text:00000000015BCA60                 call    rax
+  .text:00000000015BCA62                 mov     rsi, rax
+  .text:00000000015BCA65                 jmp     loc_15BC847
+  .text:00000000015BCA70                 ; _QWORD
+  .text:00000000015BCA70                 mov     edi, 350h; _QWORD
+  .text:00000000015BCA75                 call    __Znwm; operator new(ulong)
+  .text:00000000015BCA7A                 mov     rdi, rax
+  .text:00000000015BCA7D                 mov     r15, rax
+  .text:00000000015BCA80                 call    sub_1553330
+  .text:00000000015BCA85                 mov     rdi, cs:qword_26E2FE0
+  .text:00000000015BCA8C                 mov     [rbx+128h], r15
+  .text:00000000015BCA93                 mov     rsi, r15
+  .text:00000000015BCA96                 mov     byte ptr [rbx+130h], 1
+  .text:00000000015BCA9D                 mov     rax, [rdi]
+  .text:00000000015BCAA0                 call    qword ptr [rax+68h]
+  .text:00000000015BCAA3                 jmp     loc_15BC80D
+procedure: |-
+  __int64 CSource2EntitySystem_StaticInit()
+  {
+    int v0; // eax
+    __int64 v1; // rbx
+    __int64 v2; // rbx
+    __int64 v3; // r12
+    int v4; // eax
+    __int64 v5; // rbx
+    __int64 v6; // rdx
+    _QWORD *v7; // rdi
+    __int64 NewThreadPool; // rax
+    __int64 v9; // rax
+    __int64 v10; // rax
+    __int64 (__fastcall *v11)(); // r15
+    __int64 (*v12)(void); // rax
+    const char *v13; // rsi
+    __int64 i; // rbx
+    __int64 (__fastcall *v15)(); // rax
+    __int64 v16; // rdx
+    __int64 v17; // rcx
+    __int64 v18; // r8
+    __int64 v19; // r9
+    void (__fastcall *v20)(_QWORD *, __m128i *); // rax
+    __int64 v22; // r15
+    __int64 v23; // rdi
+    __m128i si128; // [rsp+0h] [rbp-50h] BYREF
+    __int64 v25; // [rsp+10h] [rbp-40h]
+
+    v0 = dword_27C4720++;
+    if ( v0 <= 0 )
+    {
+      v1 = operator new(8448);
+      CGameEntitySystem_ctor(v1);
+      CEntitySystem_PostCreateEntitySystem(v1, "server_entities", 0, 0, 0);
+    }
+    v2 = g_pEntitySystem;
+    v3 = *(int *)(g_pEntitySystem + 2960LL);
+    g_pGameEntitySystem = g_pEntitySystem;
+    v4 = v3;
+    if ( (_DWORD)v3 == *(_DWORD *)(g_pEntitySystem + 2976LL) )
+    {
+      sub_11A8EC0(g_pEntitySystem + 2968LL, 1);
+      v4 = *(_DWORD *)(v2 + 2960);
+    }
+    *(_DWORD *)(v2 + 2960) = v4 + 1;
+    *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_24C9FE0;
+    v5 = operator new(4928);
+    sub_1569780(v5);
+    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;
+    (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*qword_274C230 + 384LL))(qword_274C230, "save/", "MOD");
+    v7 = qword_274C2B0;
+    if ( !qword_274C2B0 || (*(unsigned int (__fastcall **)(_QWORD *))(*qword_274C2B0 + 288LL))(qword_274C2B0) != 2 )
+    {
+      BYTE4(v25) = 0;
+      LODWORD(v25) = 0x40000;
+      si128 = _mm_load_si128((const __m128i *)&xmmword_86C670);
+      NewThreadPool = CreateNewThreadPool(v7, "save/", v6);
+      *(_QWORD *)(v5 + 224) = NewThreadPool;
+      (*(void (__fastcall **)(__int64, __m128i *, const char *))(*(_QWORD *)NewThreadPool + 32LL))(
+        NewThreadPool,
+        &si128,
+        "SaveJob");
+    }
+    *(_QWORD *)(v5 + 232) = *(_QWORD *)(v5 + 224);
+    v9 = CommandLine();
+    if ( !(*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v9 + 48LL))(v9, 1877996950, 0) )
+      sub_1555CE0(v5);
+    v10 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_26E2FE0 + 112LL))(qword_26E2FE0);
+    *(_QWORD *)(v5 + 296) = v10;
+    if ( !v10 )
+    {
+      v22 = operator new(848);
+      sub_1553330(v22);
+      v23 = qword_26E2FE0;
+      *(_QWORD *)(v5 + 296) = v22;
+      *(_BYTE *)(v5 + 304) = 1;
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v23 + 104LL))(v23, v22);
+    }
+    v11 = *(__int64 (__fastcall **)())(*(_QWORD *)v5 + 136LL);
+    v12 = *(__int64 (**)(void))(*(_QWORD *)qword_26E0870 + 192LL);
+    if ( v12 == sub_152DD00 )
+      v13 = (const char *)(*(__int64 (__fastcall **)(_QWORD *))(*qword_274C2B0 + 224LL))(qword_274C2B0);
+    else
+      v13 = (const char *)v12();
+    if ( v11 == sub_1530150 )
+      CUtlString::Set((CUtlString *)(v5 + 264), v13);
+    else
+      ((void (__fastcall *)(__int64, const char *))v11)(v5, v13);
+    for ( i = qword_26E0828; i; i = *(_QWORD *)(i + 24) )
+      sub_15B9110(g_pGameEntitySystem, *(_QWORD *)(i + 8), *(_QWORD *)i, *(unsigned int *)(i + 16));
+    sub_1E61B60(g_pGameEntitySystem, 1);
+    v15 = *(__int64 (__fastcall **)())(*(_QWORD *)(qword_26E0870 + 8) + 168LL);
+    if ( v15 != sub_1535520 && ((unsigned __int8 (__fastcall *)(__int64))v15)(qword_26E0870 + 8)
+      || (*(unsigned __int8 (__fastcall **)(_QWORD *))(*qword_274C2B0 + 184LL))(qword_274C2B0) )
+    {
+      v25 = 0;
+      si128.m128i_i64[1] = (__int64)sub_152EFE0;
+      si128.m128i_i64[0] = (__int64)sub_15420E0;
+      ((void (__fastcall *)(__int64, __m128i *, __int64, __int64, __int64, __int64))sub_1E5C790)(
+        g_pGameEntitySystem,
+        &si128,
+        v16,
+        v17,
+        v18,
+        v19);
+    }
+    if ( g_pGameResourceService )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService
+                                               + 272LL))(// 272LL = 0x110 = IGameResourceService_SetEntityResourceManifestHandler
+        g_pGameResourceService,
+        g_pGameEntitySystem);
+    sub_15BC5D0(g_pGameEntitySystem, *(unsigned int *)(g_pEntitySystem + 632LL));
+    si128.m128i_i64[1] = (__int64)sub_152EFF0;
+    v25 = 0;
+    si128.m128i_i64[0] = (__int64)sub_156AEA0;
+    sub_1E67E40(g_pEntitySystem, 40, si128.m128i_i64);
+    si128.m128i_i64[1] = (__int64)sub_152EFF0;
+    v25 = 0;
+    si128.m128i_i64[0] = (__int64)sub_156AF70;
+    sub_1E67E40(g_pEntitySystem, 54, si128.m128i_i64);
+    si128.m128i_i64[1] = (__int64)sub_152EFF0;
+    v25 = 0;
+    si128.m128i_i64[0] = (__int64)sub_1530BE0;
+    sub_1E67E40(g_pEntitySystem, 67, si128.m128i_i64);
+    v20 = *(void (__fastcall **)(_QWORD *, __m128i *))(*g_pFlattenedSerializers + 264LL);
+    si128.m128i_i64[1] = (__int64)sub_152F010;
+    v25 = 0;
+    si128.m128i_i64[0] = (__int64)sub_152DF60;
+    v20(g_pFlattenedSerializers, &si128);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
@@ -1,0 +1,365 @@
+func_name: CSource2EntitySystem_StaticInit
+func_va: '0x180b8d740'
+disasm_code: |-
+  .text:0000000180B8D740                 mov     [rsp-18h+arg_0], rbx
+  .text:0000000180B8D745                 mov     [rsp-18h+arg_8], rsi
+  .text:0000000180B8D74A                 mov     [rsp-18h+arg_10], rdi
+  .text:0000000180B8D74F                 push    rbp
+  .text:0000000180B8D750                 push    r14
+  .text:0000000180B8D752                 push    r15
+  .text:0000000180B8D754                 mov     rbp, rsp
+  .text:0000000180B8D757                 sub     rsp, 50h
+  .text:0000000180B8D75B                 mov     eax, cs:dword_1820B9400
+  .text:0000000180B8D761                 xor     r15d, r15d
+  .text:0000000180B8D764                 mov     ecx, eax
+  .text:0000000180B8D766                 inc     eax
+  .text:0000000180B8D768                 mov     cs:dword_1820B9400, eax
+  .text:0000000180B8D76E                 test    ecx, ecx
+  .text:0000000180B8D770                 jg      short loc_180B8D7A8
+  .text:0000000180B8D772                 mov     ecx, 20F0h
+  .text:0000000180B8D777                 call    operator_new
+  .text:0000000180B8D77C                 test    rax, rax
+  .text:0000000180B8D77F                 jz      short loc_180B8D78B
+  .text:0000000180B8D781                 mov     rcx, rax
+  .text:0000000180B8D784                 call    CGameEntitySystem_ctor
+  .text:0000000180B8D789                 jmp     short loc_180B8D78E
+  .text:0000000180B8D78B                 mov     rax, r15
+  .text:0000000180B8D78E                 xor     r9d, r9d
+  .text:0000000180B8D791                 mov     [rsp+50h+var_30], r15b
+  .text:0000000180B8D796                 xor     r8d, r8d
+  .text:0000000180B8D799                 lea     rdx, aServerEntities; "server_entities"
+  .text:0000000180B8D7A0                 mov     rcx, rax
+  .text:0000000180B8D7A3                 call    CEntitySystem_PostCreateEntitySystem
+  .text:0000000180B8D7A8                 mov     rbx, cs:g_pEntitySystem
+  .text:0000000180B8D7AF                 mov     cs:g_pGameEntitySystem, rbx
+  .text:0000000180B8D7B6                 movsxd  r14, dword ptr [rbx+0B90h]
+  .text:0000000180B8D7BD                 cmp     r14d, [rbx+0BA0h]
+  .text:0000000180B8D7C4                 jnz     loc_180B8D88F
+  .text:0000000180B8D7CA                 test    dword ptr [rbx+0BA4h], 40000000h
+  .text:0000000180B8D7D4                 jnz     loc_180B8D88F
+  .text:0000000180B8D7DA                 mov     ecx, [rbx+0BA0h]
+  .text:0000000180B8D7E0                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180B8D7E6                 jle     short loc_180B8D7F3
+  .text:0000000180B8D7E8                 mov     edx, 1
+  .text:0000000180B8D7ED                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180B8D7F3                 mov     ecx, [rbx+0BA0h]
+  .text:0000000180B8D7F9                 mov     r9d, 8
+  .text:0000000180B8D7FF                 mov     edx, [rbx+0BA4h]
+  .text:0000000180B8D805                 and     edx, 3FFFFFFFh
+  .text:0000000180B8D80B                 lea     esi, [rcx+1]
+  .text:0000000180B8D80E                 mov     r8d, esi
+  .text:0000000180B8D811                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180B8D817                 mov     edi, eax
+  .text:0000000180B8D819                 cmp     eax, esi
+  .text:0000000180B8D81B                 jge     short loc_180B8D83E
+  .text:0000000180B8D81D                 test    eax, eax
+  .text:0000000180B8D81F                 jnz     short loc_180B8D830
+  .text:0000000180B8D821                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180B8D824                 jg      short loc_180B8D830
+  .text:0000000180B8D826                 mov     edi, 0FFFFFFFFh
+  .text:0000000180B8D82B                 jmp     short loc_180B8D83E
+  .text:0000000180B8D830                 lea     eax, [rdi+rsi]
+  .text:0000000180B8D833                 cdq
+  .text:0000000180B8D834                 sub     eax, edx
+  .text:0000000180B8D836                 sar     eax, 1
+  .text:0000000180B8D838                 mov     edi, eax
+  .text:0000000180B8D83A                 cmp     eax, esi
+  .text:0000000180B8D83C                 jl      short loc_180B8D830
+  .text:0000000180B8D83E                 movsxd  r9, dword ptr [rbx+0BA0h]
+  .text:0000000180B8D845                 mov     rcx, [rbx+0B98h]
+  .text:0000000180B8D84C                 shl     r9, 3
+  .text:0000000180B8D850                 movsxd  r8, edi
+  .text:0000000180B8D853                 shl     r8, 3
+  .text:0000000180B8D857                 test    dword ptr [rbx+0BA4h], 0C0000000h
+  .text:0000000180B8D861                 setz    dl
+  .text:0000000180B8D864                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180B8D86A                 mov     [rbx+0B98h], rax
+  .text:0000000180B8D871                 mov     eax, [rbx+0BA4h]
+  .text:0000000180B8D877                 test    eax, 0C0000000h
+  .text:0000000180B8D87C                 jz      short loc_180B8D889
+  .text:0000000180B8D87E                 and     eax, 3FFFFFFFh
+  .text:0000000180B8D883                 mov     [rbx+0BA4h], eax
+  .text:0000000180B8D889                 mov     [rbx+0BA0h], edi
+  .text:0000000180B8D88F                 inc     dword ptr [rbx+0B90h]
+  .text:0000000180B8D895                 lea     rdx, off_181C16478
+  .text:0000000180B8D89C                 mov     rax, [rbx+0B98h]
+  .text:0000000180B8D8A3                 mov     ecx, 1340h
+  .text:0000000180B8D8A8                 mov     [rax+r14*8], rdx
+  .text:0000000180B8D8AC                 call    operator_new
+  .text:0000000180B8D8B1                 test    rax, rax
+  .text:0000000180B8D8B4                 jz      short loc_180B8D8C3
+  .text:0000000180B8D8B6                 mov     rcx, rax
+  .text:0000000180B8D8B9                 call    sub_180B38C50
+  .text:0000000180B8D8BE                 mov     rdi, rax
+  .text:0000000180B8D8C1                 jmp     short loc_180B8D8C6
+  .text:0000000180B8D8C3                 mov     rdi, r15
+  .text:0000000180B8D8C6                 mov     rax, cs:g_pGameEntitySystem
+  .text:0000000180B8D8CD                 mov     rcx, rdi
+  .text:0000000180B8D8D0                 mov     [rax+20D8h], rdi
+  .text:0000000180B8D8D7                 mov     rax, [rdi]
+  .text:0000000180B8D8DA                 call    qword ptr [rax]
+  .text:0000000180B8D8DC                 mov     rax, [rdi]
+  .text:0000000180B8D8DF                 mov     rcx, cs:qword_181F65210
+  .text:0000000180B8D8E6                 mov     rbx, [rax+88h]
+  .text:0000000180B8D8ED                 mov     rax, [rcx]
+  .text:0000000180B8D8F0                 call    qword ptr [rax+0C0h]
+  .text:0000000180B8D8F6                 mov     rdx, rax
+  .text:0000000180B8D8F9                 mov     rcx, rdi
+  .text:0000000180B8D8FC                 call    rbx
+  .text:0000000180B8D8FE                 call    sub_180B7AFE0
+  .text:0000000180B8D903                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180B8D90A                 mov     dl, 1
+  .text:0000000180B8D90C                 call    sub_1811F3F90
+  .text:0000000180B8D911                 mov     rcx, cs:qword_181F65210
+  .text:0000000180B8D918                 add     rcx, 8
+  .text:0000000180B8D91C                 mov     rax, [rcx]
+  .text:0000000180B8D91F                 call    qword ptr [rax+0A8h]
+  .text:0000000180B8D925                 test    al, al
+  .text:0000000180B8D927                 jnz     short loc_180B8D93D
+  .text:0000000180B8D929                 mov     rcx, cs:g_pVApplication
+  .text:0000000180B8D930                 mov     rax, [rcx]
+  .text:0000000180B8D933                 call    qword ptr [rax+0B0h]
+  .text:0000000180B8D939                 test    al, al
+  .text:0000000180B8D93B                 jz      short loc_180B8D963
+  .text:0000000180B8D93D                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180B8D944                 lea     rax, sub_180B68B10
+  .text:0000000180B8D94B                 mov     [rbp+var_18], rax
+  .text:0000000180B8D94F                 lea     rdx, [rbp+var_20]
+  .text:0000000180B8D953                 lea     rax, sub_180B56140
+  .text:0000000180B8D95A                 mov     [rbp+var_20], rax
+  .text:0000000180B8D95E                 call    sub_1811FA800
+  .text:0000000180B8D963                 mov     rcx, cs:g_pGameResourceService
+  .text:0000000180B8D96A                 test    rcx, rcx
+  .text:0000000180B8D96D                 jz      short loc_180B8D97F
+  .text:0000000180B8D96F                 mov     rax, [rcx]
+  .text:0000000180B8D972                 mov     rdx, cs:g_pGameEntitySystem
+  .text:0000000180B8D979                 call    qword ptr [rax+110h]  ; 110h = IGameResourceService_SetEntityResourceManifestHandler
+  .text:0000000180B8D97F                 mov     rax, cs:g_pEntitySystem
+  .text:0000000180B8D986                 lea     rcx, [rbp+var_20]
+  .text:0000000180B8D98A                 mov     r14, cs:g_pGameEntitySystem
+  .text:0000000180B8D991                 mov     [rbp+var_18], 1388h
+  .text:0000000180B8D999                 mov     [rbp+var_10], r15b
+  .text:0000000180B8D99D                 mov     esi, [rax+278h]
+  .text:0000000180B8D9A3                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
+  .text:0000000180B8D9AA                 mov     [rbp+var_20], rax
+  .text:0000000180B8D9AE                 call    cs:ToolsStallMonitorInternal_BeginScope
+  .text:0000000180B8D9B4                 mov     ecx, 48h ; 'H'
+  .text:0000000180B8D9B9                 call    operator_new
+  .text:0000000180B8D9BE                 mov     rdi, rax
+  .text:0000000180B8D9C1                 test    rax, rax
+  .text:0000000180B8D9C4                 jz      short loc_180B8DA1C
+  .text:0000000180B8D9C6                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
+  .text:0000000180B8D9CD                 xor     edx, edx
+  .text:0000000180B8D9CF                 mov     [rdi], rax
+  .text:0000000180B8D9D2                 lea     rcx, [rdi+30h]
+  .text:0000000180B8D9D6                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
+  .text:0000000180B8D9DD                 mov     r8d, 1
+  .text:0000000180B8D9E3                 mov     [rdi+8], rax
+  .text:0000000180B8D9E7                 mov     [rdi+18h], r15
+  .text:0000000180B8D9EB                 mov     [rdi+20h], r15
+  .text:0000000180B8D9EF                 mov     [rdi+10h], r15d
+  .text:0000000180B8D9F3                 mov     [rdi+28h], r15b
+  .text:0000000180B8D9F7                 mov     [rdi+30h], r15d
+  .text:0000000180B8D9FB                 mov     [rdi+38h], r15
+  .text:0000000180B8D9FF                 call    sub_180B52ED0
+  .text:0000000180B8DA04                 mov     eax, 0FFFFh
+  .text:0000000180B8DA09                 mov     edx, esi
+  .text:0000000180B8DA0B                 mov     rcx, rdi
+  .text:0000000180B8DA0E                 mov     [rdi+40h], eax
+  .text:0000000180B8DA11                 mov     [rdi+44h], ax
+  .text:0000000180B8DA15                 call    sub_180B62730
+  .text:0000000180B8DA1A                 jmp     short loc_180B8DA1F
+  .text:0000000180B8DA1C                 mov     rdi, r15
+  .text:0000000180B8DA1F                 lea     rcx, [rbp+var_20]
+  .text:0000000180B8DA23                 mov     [r14+20E0h], rdi
+  .text:0000000180B8DA2A                 call    cs:ToolsStallMonitorInternal_EndScope
+  .text:0000000180B8DA30                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DA37                 lea     rax, sub_180B4E030
+  .text:0000000180B8DA3E                 lea     rbx, sub_180B68B50
+  .text:0000000180B8DA45                 mov     [rbp+var_20], rax
+  .text:0000000180B8DA49                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DA4D                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DA51                 mov     dl, 28h ; '('
+  .text:0000000180B8DA53                 call    sub_1811FA820
+  .text:0000000180B8DA58                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DA5F                 lea     rax, sub_180B4DFA0
+  .text:0000000180B8DA66                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DA6A                 mov     [rbp+var_20], rax
+  .text:0000000180B8DA6E                 mov     dl, 36h ; '6'
+  .text:0000000180B8DA70                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DA74                 call    sub_1811FA820
+  .text:0000000180B8DA79                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DA80                 lea     rax, sub_180B4DF50
+  .text:0000000180B8DA87                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DA8B                 mov     [rbp+var_20], rax
+  .text:0000000180B8DA8F                 mov     dl, 43h ; 'C'
+  .text:0000000180B8DA91                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DA95                 call    sub_1811FA820
+  .text:0000000180B8DA9A                 mov     rcx, cs:g_pFlattenedSerializers
+  .text:0000000180B8DAA1                 lea     rdx, sub_180B68B20
+  .text:0000000180B8DAA8                 mov     rax, [rcx]
+  .text:0000000180B8DAAB                 mov     [rbp+var_18], rdx
+  .text:0000000180B8DAAF                 lea     rdx, unknown_libname_200; Microsoft VisualC v7/14 64bit runtime
+  .text:0000000180B8DAB6                 mov     [rbp+var_20], rdx
+  .text:0000000180B8DABA                 lea     rdx, [rbp+var_20]
+  .text:0000000180B8DABE                 call    qword ptr [rax+108h]
+  .text:0000000180B8DAC4                 mov     rbx, [rsp+50h+arg_0]
+  .text:0000000180B8DAC9                 mov     al, 1
+  .text:0000000180B8DACB                 mov     rsi, [rsp+50h+arg_8]
+  .text:0000000180B8DAD0                 mov     rdi, [rsp+50h+arg_10]
+  .text:0000000180B8DAD8                 add     rsp, 50h
+  .text:0000000180B8DADC                 pop     r15
+  .text:0000000180B8DADE                 pop     r14
+  .text:0000000180B8DAE0                 pop     rbp
+  .text:0000000180B8DAE1                 retn
+procedure: |-
+  char CSource2EntitySystem_StaticInit()
+  {
+    int v0; // ecx
+    __int64 v1; // rax
+    __int64 v2; // rax
+    __int64 v3; // rbx
+    __int64 v4; // r14
+    __int64 v5; // rcx
+    __int64 v6; // rcx
+    int v7; // esi
+    int v8; // eax
+    __int64 v9; // rdx
+    int v10; // edi
+    int v11; // eax
+    __int64 v12; // rax
+    __int64 v13; // rdi
+    void (__fastcall *v14)(__int64, __int64); // rbx
+    __int64 v15; // rax
+    __int64 v16; // r14
+    unsigned int v17; // esi
+    __int64 v18; // rax
+    __int64 v19; // rdi
+    __int64 v20; // rdx
+    __int64 v21; // rdx
+    __int64 v22; // rdx
+    __int64 v23; // rax
+    __int64 (__fastcall *v25)(unsigned int, __int64); // [rsp+30h] [rbp-20h] BYREF
+    __int64 v26; // [rsp+38h] [rbp-18h]
+    char v27; // [rsp+40h] [rbp-10h]
+
+    v0 = dword_1820B9400++;
+    if ( v0 <= 0 )
+    {
+      v1 = operator_new(8432);
+      if ( v1 )
+        v2 = CGameEntitySystem_ctor(v1);
+      else
+        v2 = 0;
+      CEntitySystem_PostCreateEntitySystem(v2, "server_entities", 0, 0, 0);
+    }
+    v3 = g_pEntitySystem;
+    g_pGameEntitySystem = g_pEntitySystem;
+    v4 = *(int *)(g_pEntitySystem + 2960);
+    if ( (_DWORD)v4 == *(_DWORD *)(g_pEntitySystem + 2976) && (*(_DWORD *)(g_pEntitySystem + 2980) & 0x40000000) == 0 )
+    {
+      v5 = *(unsigned int *)(g_pEntitySystem + 2976);
+      if ( (_DWORD)v5 == 0x7FFFFFFF )
+        UtlVectorMemory_FailedAllocation(v5, 1);
+      v6 = *(unsigned int *)(v3 + 2976);
+      v7 = v6 + 1;
+      v8 = UtlVectorMemory_CalcNewAllocationCount(v6, *(_DWORD *)(v3 + 2980) & 0x3FFFFFFF, (unsigned int)(v6 + 1), 8);
+      v10 = v8;
+      if ( v8 < v7 )
+      {
+        if ( v8 || v7 > -1 )
+        {
+          do
+          {
+            v9 = (unsigned int)((v10 + v7) >> 31);
+            v10 = (v10 + v7) / 2;
+          }
+          while ( v10 < v7 );
+        }
+        else
+        {
+          v10 = -1;
+        }
+      }
+      LOBYTE(v9) = (*(_DWORD *)(v3 + 2980) & 0xC0000000) == 0;
+      *(_QWORD *)(v3 + 2968) = UtlVectorMemory_Alloc(*(_QWORD *)(v3 + 2968), v9, 8LL * v10, 8LL * *(int *)(v3 + 2976));
+      v11 = *(_DWORD *)(v3 + 2980);
+      if ( (v11 & 0xC0000000) != 0 )
+        *(_DWORD *)(v3 + 2980) = v11 & 0x3FFFFFFF;
+      *(_DWORD *)(v3 + 2976) = v10;
+    }
+    ++*(_DWORD *)(v3 + 2960);
+    *(_QWORD *)(*(_QWORD *)(v3 + 2968) + 8 * v4) = &off_181C16478;
+    v12 = operator_new(4928);
+    if ( v12 )
+      v13 = sub_180B38C50(v12);
+    else
+      v13 = 0;
+    *(_QWORD *)(g_pGameEntitySystem + 8408) = v13;
+    (**(void (__fastcall ***)(__int64))v13)(v13);
+    v14 = *(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v13 + 136LL);
+    v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_181F65210 + 192LL))(qword_181F65210);
+    v14(v13, v15);
+    sub_180B7AFE0();
+    sub_1811F3F90(g_pGameEntitySystem, 1);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_181F65210 + 8) + 168LL))(qword_181F65210 + 8)
+      || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 176LL))(g_pVApplication) )
+    {
+      v26 = (__int64)sub_180B68B10;
+      v25 = sub_180B56140;
+      sub_1811FA800(g_pGameEntitySystem, (__int64 *)&v25);
+    }
+    if ( g_pGameResourceService )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService
+                                               + 272LL))(// 272LL = 0x110 = IGameResourceService_SetEntityResourceManifestHandler
+        g_pGameResourceService,
+        g_pGameEntitySystem);
+    v16 = g_pGameEntitySystem;
+    v26 = 5000;
+    v27 = 0;
+    v17 = *(_DWORD *)(g_pEntitySystem + 632);
+    v25 = (__int64 (__fastcall *)(unsigned int, __int64))"CGameEntitySystem::InitEntity2NetworkClasses";
+    ToolsStallMonitorInternal_BeginScope(&v25);
+    v18 = operator_new(72);
+    v19 = v18;
+    if ( v18 )
+    {
+      *(_QWORD *)v18 = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v18 + 8) = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v18 + 24) = 0;
+      *(_QWORD *)(v18 + 32) = 0;
+      *(_DWORD *)(v18 + 16) = 0;
+      *(_BYTE *)(v18 + 40) = 0;
+      *(_DWORD *)(v18 + 48) = 0;
+      *(_QWORD *)(v18 + 56) = 0;
+      sub_180B52ED0(v18 + 48, 0, 1);
+      *(_DWORD *)(v19 + 64) = 0xFFFF;
+      *(_WORD *)(v19 + 68) = -1;
+      sub_180B62730(v19, v17);
+    }
+    else
+    {
+      v19 = 0;
+    }
+    *(_QWORD *)(v16 + 8416) = v19;
+    ToolsStallMonitorInternal_EndScope(&v25);
+    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4E030;
+    v26 = (__int64)sub_180B68B50;
+    LOBYTE(v20) = 40;
+    sub_1811FA820(g_pEntitySystem, v20, &v25);
+    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4DFA0;
+    LOBYTE(v21) = 54;
+    v26 = (__int64)sub_180B68B50;
+    sub_1811FA820(g_pEntitySystem, v21, &v25);
+    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4DF50;
+    LOBYTE(v22) = 67;
+    v26 = (__int64)sub_180B68B50;
+    sub_1811FA820(g_pEntitySystem, v22, &v25);
+    v23 = *(_QWORD *)g_pFlattenedSerializers;
+    v26 = (__int64)sub_180B68B20;
+    v25 = (__int64 (__fastcall *)(unsigned int, __int64))unknown_libname_200;
+    (*(void (__fastcall **)(__int64, __int64 (__fastcall **)(unsigned int, __int64)))(v23 + 264))(
+      g_pFlattenedSerializers,
+      &v25);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2Server_Shutdown.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2Server_Shutdown.linux.yaml
@@ -1,0 +1,95 @@
+func_name: CSource2Server_Shutdown
+func_va: '0x177ab50'
+disasm_code: |-
+  .text:000000000177AB50                 push    rbp
+  .text:000000000177AB51                 mov     rbp, rsp
+  .text:000000000177AB54                 push    r13
+  .text:000000000177AB56                 push    r12
+  .text:000000000177AB58                 push    rbx
+  .text:000000000177AB59                 sub     rsp, 8
+  .text:000000000177AB5D                 lea     rax, gameeventmanager
+  .text:000000000177AB64                 mov     rdi, [rax]
+  .text:000000000177AB67                 call    CGameEventManager_Shutdown
+  .text:000000000177AB6C                 lea     rbx, off_24CA008
+  .text:000000000177AB73                 mov     r12, [rbx]
+  .text:000000000177AB76                 mov     rax, [r12]
+  .text:000000000177AB7A                 mov     r13, [rax+50h]
+  .text:000000000177AB7E                 call    sub_1557630
+  .text:000000000177AB83                 mov     rdi, r12
+  .text:000000000177AB86                 mov     rsi, rax
+  .text:000000000177AB89                 call    r13
+  .text:000000000177AB8C                 mov     r12, [rbx]
+  .text:000000000177AB8F                 mov     rax, [r12]
+  .text:000000000177AB93                 mov     r13, [rax+50h]
+  .text:000000000177AB97                 call    sub_1489B50
+  .text:000000000177AB9C                 mov     rdi, r12
+  .text:000000000177AB9F                 mov     rsi, rax
+  .text:000000000177ABA2                 call    r13
+  .text:000000000177ABA5                 mov     r12, [rbx]
+  .text:000000000177ABA8                 mov     rax, [r12]
+  .text:000000000177ABAC                 mov     r13, [rax+50h]
+  .text:000000000177ABB0                 call    sub_1802E00
+  .text:000000000177ABB5                 mov     rdi, r12
+  .text:000000000177ABB8                 mov     rsi, rax
+  .text:000000000177ABBB                 call    r13
+  .text:000000000177ABBE                 mov     rbx, [rbx]
+  .text:000000000177ABC1                 mov     rax, [rbx]
+  .text:000000000177ABC4                 mov     r12, [rax+50h]
+  .text:000000000177ABC8                 call    sub_1558D80
+  .text:000000000177ABCD                 mov     rdi, rbx
+  .text:000000000177ABD0                 mov     rsi, rax
+  .text:000000000177ABD3                 call    r12
+  .text:000000000177ABD6                 call    CLoopModeRegistry_UnregisterLoopModes
+  .text:000000000177ABDB                 call    CEngineServiceRegistry_UnregisterEngineServices
+  .text:000000000177ABE0                 call    ReleaseParticleEffects
+  .text:000000000177ABE5                 call    ReleaseCSBotManager
+  .text:000000000177ABEA                 call    sub_1E89B80
+  .text:000000000177ABEF                 add     rsp, 8
+  .text:000000000177ABF3                 pop     rbx
+  .text:000000000177ABF4                 ; _QWORD
+  .text:000000000177ABF4                 mov     rdi, rax; _QWORD
+  .text:000000000177ABF7                 pop     r12
+  .text:000000000177ABF9                 pop     r13
+  .text:000000000177ABFB                 pop     rbp
+  .text:000000000177ABFC                 jmp     sub_1E457A0
+procedure: |-
+  __int64 CSource2Server_Shutdown()
+  {
+    __int64 *v0; // r12
+    void (__fastcall *v1)(__int64 *, __int64); // r13
+    __int64 v2; // rax
+    __int64 *v3; // r12
+    void (__fastcall *v4)(__int64 *, __int64); // r13
+    __int64 v5; // rax
+    __int64 *v6; // r12
+    void (__fastcall *v7)(__int64 *, __int64); // r13
+    __int64 v8; // rax
+    __int64 *v9; // rbx
+    void (__fastcall *v10)(__int64 *, __int64); // r12
+    __int64 v11; // rax
+    __int64 v12; // rax
+
+    CGameEventManager_Shutdown(&s_GameEventManager);
+    v0 = off_24CA008;
+    v1 = *(void (__fastcall **)(__int64 *, __int64))(*off_24CA008 + 80);
+    v2 = sub_1557630();
+    v1(v0, v2);
+    v3 = off_24CA008;
+    v4 = *(void (__fastcall **)(__int64 *, __int64))(*off_24CA008 + 80);
+    v5 = sub_1489B50();
+    v4(v3, v5);
+    v6 = off_24CA008;
+    v7 = *(void (__fastcall **)(__int64 *, __int64))(*off_24CA008 + 80);
+    v8 = sub_1802E00();
+    v7(v6, v8);
+    v9 = off_24CA008;
+    v10 = *(void (__fastcall **)(__int64 *, __int64))(*off_24CA008 + 80);
+    v11 = sub_1558D80();
+    v10(v9, v11);
+    CLoopModeRegistry_UnregisterLoopModes();
+    CEngineServiceRegistry_UnregisterEngineServices();
+    ReleaseParticleEffects();
+    ReleaseCSBotManager();
+    v12 = sub_1E89B80();
+    return sub_1E457A0(v12);
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2Server_Shutdown.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2Server_Shutdown.windows.yaml
@@ -1,0 +1,77 @@
+func_name: CSource2Server_Shutdown
+func_va: '0x180ce82a0'
+disasm_code: |-
+  .text:0000000180CE82A0                 push    rbx
+  .text:0000000180CE82A2                 sub     rsp, 20h
+  .text:0000000180CE82A6                 mov     rcx, cs:gameeventmanager
+  .text:0000000180CE82AD                 call    CGameEventManager_Shutdown
+  .text:0000000180CE82B2                 mov     rax, cs:off_181C164A8
+  .text:0000000180CE82B9                 mov     rcx, [rax]
+  .text:0000000180CE82BC                 mov     rbx, [rcx+50h]
+  .text:0000000180CE82C0                 call    sub_180B5EA80
+  .text:0000000180CE82C5                 mov     rcx, cs:off_181C164A8
+  .text:0000000180CE82CC                 mov     rdx, rax
+  .text:0000000180CE82CF                 call    rbx
+  .text:0000000180CE82D1                 mov     rax, cs:off_181C164A8
+  .text:0000000180CE82D8                 mov     rcx, [rax]
+  .text:0000000180CE82DB                 mov     rbx, [rcx+50h]
+  .text:0000000180CE82DF                 call    sub_180ABCBE0
+  .text:0000000180CE82E4                 mov     rcx, cs:off_181C164A8
+  .text:0000000180CE82EB                 mov     rdx, rax
+  .text:0000000180CE82EE                 call    rbx
+  .text:0000000180CE82F0                 mov     rax, cs:off_181C164A8
+  .text:0000000180CE82F7                 mov     rcx, [rax]
+  .text:0000000180CE82FA                 mov     rbx, [rcx+50h]
+  .text:0000000180CE82FE                 call    sub_180D47490
+  .text:0000000180CE8303                 mov     rcx, cs:off_181C164A8
+  .text:0000000180CE830A                 mov     rdx, rax
+  .text:0000000180CE830D                 call    rbx
+  .text:0000000180CE830F                 mov     rax, cs:off_181C164A8
+  .text:0000000180CE8316                 mov     rcx, [rax]
+  .text:0000000180CE8319                 mov     rbx, [rcx+50h]
+  .text:0000000180CE831D                 call    sub_180B5E910
+  .text:0000000180CE8322                 mov     rcx, cs:off_181C164A8
+  .text:0000000180CE8329                 mov     rdx, rax
+  .text:0000000180CE832C                 call    rbx
+  .text:0000000180CE832E                 call    CLoopModeRegistry_UnregisterLoopModes
+  .text:0000000180CE8333                 call    CEngineServiceRegistry_UnregisterEngineServices
+  .text:0000000180CE8338                 call    ReleaseParticleEffects
+  .text:0000000180CE833D                 call    ReleaseCSBotManager
+  .text:0000000180CE8342                 call    sub_18120CFD0
+  .text:0000000180CE8347                 mov     rcx, rax
+  .text:0000000180CE834A                 add     rsp, 20h
+  .text:0000000180CE834E                 pop     rbx
+  .text:0000000180CE834F                 jmp     sub_1811E7E10
+procedure: |-
+  __int64 CSource2Server_Shutdown()
+  {
+    __int64 (__fastcall *v0)(); // rbx
+    __int64 (__fastcall ***v1)(); // rax
+    __int64 (__fastcall *v2)(); // rbx
+    __int64 v3; // rax
+    __int64 (__fastcall *v4)(); // rbx
+    __int64 v5; // rax
+    __int64 (__fastcall *v6)(); // rbx
+    __int64 v7; // rax
+    __int64 *v8; // rax
+
+    CGameEventManager_Shutdown((__int64)gameeventmanager);
+    v0 = (*off_181C164A8)[10];
+    v1 = sub_180B5EA80();
+    ((void (__fastcall *)(__int64 (__fastcall ***)(), __int64 (__fastcall ***)()))v0)(off_181C164A8, v1);
+    v2 = (*off_181C164A8)[10];
+    v3 = sub_180ABCBE0();
+    ((void (__fastcall *)(__int64 (__fastcall ***)(), __int64))v2)(off_181C164A8, v3);
+    v4 = (*off_181C164A8)[10];
+    v5 = sub_180D47490();
+    ((void (__fastcall *)(__int64 (__fastcall ***)(), __int64))v4)(off_181C164A8, v5);
+    v6 = (*off_181C164A8)[10];
+    v7 = sub_180B5E910();
+    ((void (__fastcall *)(__int64 (__fastcall ***)(), __int64))v6)(off_181C164A8, v7);
+    CLoopModeRegistry_UnregisterLoopModes();
+    CEngineServiceRegistry_UnregisterEngineServices();
+    ReleaseParticleEffects();
+    ReleaseCSBotManager();
+    v8 = sub_18120CFD0();
+    return sub_1811E7E10((__int64)v8);
+  }

--- a/ida_preprocessor_scripts/references/server/IGameSystem_PostInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/IGameSystem_PostInit.linux.yaml
@@ -1,0 +1,278 @@
+func_name: IGameSystem_PostInit
+func_va: '0xe23440'
+disasm_code: |-
+  .text:0000000000E23440                 push    rbp
+  .text:0000000000E23441                 mov     rbp, rsp
+  .text:0000000000E23444                 push    r15
+  .text:0000000000E23446                 push    r14
+  .text:0000000000E23448                 push    r13
+  .text:0000000000E2344A                 push    r12
+  .text:0000000000E2344C                 push    rbx
+  .text:0000000000E2344D                 sub     rsp, 38h
+  .text:0000000000E23451                 call    _Plat_NotifyOSAppIsNotHung
+  .text:0000000000E23456                 mov     r14d, cs:dword_25F8858
+  .text:0000000000E2345D                 test    r14d, r14d
+  .text:0000000000E23460                 jz      loc_E23590
+  .text:0000000000E23466                 lea     r15, off_22917A8
+  .text:0000000000E2346D                 xor     r12d, r12d
+  .text:0000000000E23470                 jmp     short loc_E234D1
+  .text:0000000000E23478                 mov     rdx, [r13+0]
+  .text:0000000000E2347C                 movsxd  r8, eax
+  .text:0000000000E2347F                 mov     rcx, [rdx+r8*8]
+  .text:0000000000E23483                 cmp     [r15+r8*8], rcx
+  .text:0000000000E23487                 jz      short loc_E234C4
+  .text:0000000000E23489                 mov     rcx, cs:qword_25F87D8
+  .text:0000000000E23490                 lea     ebx, [rax+1]
+  .text:0000000000E23493                 mov     eax, [rcx]
+  .text:0000000000E23495                 cmp     ebx, eax
+  .text:0000000000E23497                 jg      loc_E235A0
+  .text:0000000000E2349D                 mov     rax, [rcx+8]
+  .text:0000000000E234A1                 lea     rdx, [r8+r8*2]
+  .text:0000000000E234A5                 lea     rax, [rax+rdx*8]
+  .text:0000000000E234A9                 movsxd  rbx, dword ptr [rax]
+  .text:0000000000E234AC                 mov     edx, ebx
+  .text:0000000000E234AE                 cmp     ebx, [rax+10h]
+  .text:0000000000E234B1                 jz      loc_E23638
+  .text:0000000000E234B7                 add     edx, 1
+  .text:0000000000E234BA                 mov     [rax], edx
+  .text:0000000000E234BC                 mov     rax, [rax+8]
+  .text:0000000000E234C0                 mov     [rax+rbx*8], r13
+  .text:0000000000E234C4                 add     r12d, 1
+  .text:0000000000E234C8                 cmp     r14d, r12d
+  .text:0000000000E234CB                 jz      loc_E23590
+  .text:0000000000E234D1                 mov     rdx, cs:qword_25F87F8
+  .text:0000000000E234D8                 movsxd  rax, r12d
+  .text:0000000000E234DB                 movzx   eax, word ptr [rdx+rax*2]
+  .text:0000000000E234DF                 shl     rax, 4
+  .text:0000000000E234E3                 add     rax, cs:qword_25F8828
+  .text:0000000000E234EA                 mov     rbx, [rax]
+  .text:0000000000E234ED                 call    _Plat_RelativeTicks
+  .text:0000000000E234F2                 mov     r13, rax
+  .text:0000000000E234F5                 mov     rax, [rbx]
+  .text:0000000000E234F8                 mov     rdi, rbx
+  .text:0000000000E234FB                 call    qword ptr [rax+8]  ; 8h = IGameSystemFactory_PostInit
+  .text:0000000000E234FE                 call    _Plat_RelativeTicks
+  .text:0000000000E23503                 ; _QWORD
+  .text:0000000000E23503                 xor     edi, edi; _QWORD
+  .text:0000000000E23505                 sub     rax, r13
+  .text:0000000000E23508                 ; _QWORD
+  .text:0000000000E23508                 mov     rsi, rax; _QWORD
+  .text:0000000000E2350B                 call    _Plat_TickDiffMilliSecF
+  .text:0000000000E23510                 mov     rsi, [rbx+10h]
+  .text:0000000000E23514                 mov     eax, 1
+  .text:0000000000E23519                 lea     rdi, aIgamesystemPos; "IGameSystem::PostInit( %-80s ) %8.3f ms"...
+  .text:0000000000E23520                 call    _COM_TimestampedLog
+  .text:0000000000E23525                 call    _Plat_NotifyOSAppIsNotHung
+  .text:0000000000E2352A                 mov     rax, [rbx]
+  .text:0000000000E2352D                 mov     rdi, rbx
+  .text:0000000000E23530                 call    qword ptr [rax+40h]
+  .text:0000000000E23533                 test    al, al
+  .text:0000000000E23535                 jnz     short loc_E234C4
+  .text:0000000000E23537                 mov     rax, [rbx]
+  .text:0000000000E2353A                 mov     rdi, rbx
+  .text:0000000000E2353D                 call    qword ptr [rax+48h]  ; 48h = IGameSystemFactory_GetStaticGameSystem
+  .text:0000000000E23540                 mov     r13, rax
+  .text:0000000000E23543                 mov     eax, cs:dword_2477630
+  .text:0000000000E23549                 test    eax, eax
+  .text:0000000000E2354B                 jns     loc_E23478
+  .text:0000000000E23551                 mov     [rbp+var_38], 0
+  .text:0000000000E23559                 mov     [rbp+var_40], r15
+  .text:0000000000E2355D                 movzx   eax, cs:byte_25F82E0
+  .text:0000000000E23564                 test    al, al
+  .text:0000000000E23566                 jz      loc_E23658
+  .text:0000000000E2356C                 mov     rax, cs:qword_25F82E8
+  .text:0000000000E23573                 lea     rdi, [rbp+var_40]
+  .text:0000000000E23577                 mov     [rbp+var_40], rax
+  .text:0000000000E2357B                 call    qword ptr [rax+180h]
+  .text:0000000000E23581                 mov     cs:dword_2477630, eax
+  .text:0000000000E23587                 jmp     loc_E23478
+  .text:0000000000E23590                 add     rsp, 38h
+  .text:0000000000E23594                 pop     rbx
+  .text:0000000000E23595                 pop     r12
+  .text:0000000000E23597                 pop     r13
+  .text:0000000000E23599                 pop     r14
+  .text:0000000000E2359B                 pop     r15
+  .text:0000000000E2359D                 pop     rbp
+  .text:0000000000E2359E                 retn
+  .text:0000000000E235A0                 mov     edx, [rcx+10h]
+  .text:0000000000E235A3                 mov     r9d, ebx
+  .text:0000000000E235A6                 sub     r9d, eax
+  .text:0000000000E235A9                 cmp     ebx, edx
+  .text:0000000000E235AB                 jg      loc_E23690
+  .text:0000000000E235B1                 movsxd  rdx, eax
+  .text:0000000000E235B4                 movsxd  r9, r9d
+  .text:0000000000E235B7                 mov     [rcx], ebx
+  .text:0000000000E235B9                 lea     rax, [rdx+rdx*2]
+  .text:0000000000E235BD                 add     rdx, r9
+  .text:0000000000E235C0                 lea     rsi, [rdx+rdx*2]
+  .text:0000000000E235C4                 shl     rax, 3
+  .text:0000000000E235C8                 shl     rsi, 3
+  .text:0000000000E235CC                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000E235D7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000E235E2                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000E235ED                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000E235F8                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000000E23600                 mov     rdx, [rcx+8]
+  .text:0000000000E23604                 add     rdx, rax
+  .text:0000000000E23607                 add     rax, 18h
+  .text:0000000000E2360B                 mov     qword ptr [rdx], 0
+  .text:0000000000E23612                 mov     qword ptr [rdx+8], 0
+  .text:0000000000E2361A                 mov     qword ptr [rdx+10h], 0
+  .text:0000000000E23622                 cmp     rax, rsi
+  .text:0000000000E23625                 jnz     short loc_E23600
+  .text:0000000000E23627                 mov     rcx, cs:qword_25F87D8
+  .text:0000000000E2362E                 jmp     loc_E2349D
+  .text:0000000000E23638                 lea     rdi, [rax+8]
+  .text:0000000000E2363C                 mov     esi, 1
+  .text:0000000000E23641                 mov     [rbp+var_48], rax
+  .text:0000000000E23645                 call    sub_E07B80
+  .text:0000000000E2364A                 mov     rax, [rbp+var_48]
+  .text:0000000000E2364E                 mov     edx, [rax]
+  .text:0000000000E23650                 jmp     loc_E234B7
+  .text:0000000000E23658                 lea     rbx, byte_25F82E0
+  .text:0000000000E2365F                 ; _QWORD
+  .text:0000000000E2365F                 mov     rdi, rbx; _QWORD
+  .text:0000000000E23662                 call    ___cxa_guard_acquire
+  .text:0000000000E23667                 test    eax, eax
+  .text:0000000000E23669                 jz      loc_E2356C
+  .text:0000000000E2366F                 mov     rax, cs:off_2476F40
+  .text:0000000000E23676                 ; _QWORD
+  .text:0000000000E23676                 mov     rdi, rbx; _QWORD
+  .text:0000000000E23679                 mov     cs:qword_25F82E8, rax
+  .text:0000000000E23680                 call    ___cxa_guard_release
+  .text:0000000000E23685                 jmp     loc_E2356C
+  .text:0000000000E23690                 lea     rdi, [rcx+8]
+  .text:0000000000E23694                 mov     esi, ebx
+  .text:0000000000E23696                 mov     [rbp+var_58], r9d
+  .text:0000000000E2369A                 sub     esi, edx
+  .text:0000000000E2369C                 mov     [rbp+var_54], eax
+  .text:0000000000E2369F                 mov     [rbp+var_50], r8
+  .text:0000000000E236A3                 mov     [rbp+var_48], rcx
+  .text:0000000000E236A7                 call    sub_E231E0
+  .text:0000000000E236AC                 mov     r9d, [rbp+var_58]
+  .text:0000000000E236B0                 mov     eax, [rbp+var_54]
+  .text:0000000000E236B3                 mov     r8, [rbp+var_50]
+  .text:0000000000E236B7                 mov     rcx, [rbp+var_48]
+  .text:0000000000E236BB                 jmp     loc_E235B1
+procedure: |-
+  __int64 IGameSystem_PostInit()
+  {
+    __int64 result; // rax
+    int v1; // r14d
+    int v2; // r12d
+    __int64 v3; // r8
+    __int64 v4; // rcx
+    int v5; // ebx
+    int v6; // eax
+    int *v7; // rax
+    __int64 v8; // rbx
+    int v9; // edx
+    _QWORD *v10; // rbx
+    __int64 v11; // r13
+    __int64 v12; // rax
+    __int64 v13; // rsi
+    _QWORD *v14; // r13
+    int v15; // edx
+    int v16; // r9d
+    __int64 v17; // rdx
+    __int64 v18; // rax
+    __int64 v19; // rsi
+    _QWORD *v20; // rdx
+    int v21; // [rsp+8h] [rbp-58h]
+    int v22; // [rsp+Ch] [rbp-54h]
+    __int64 v23; // [rsp+10h] [rbp-50h]
+    int *v24; // [rsp+18h] [rbp-48h]
+    __int64 v25; // [rsp+18h] [rbp-48h]
+    _QWORD v26[8]; // [rsp+20h] [rbp-40h] BYREF
+
+    result = Plat_NotifyOSAppIsNotHung();
+    v1 = dword_25F8858;
+    if ( dword_25F8858 )
+    {
+      v2 = 0;
+      do
+      {
+        v10 = *(_QWORD **)(qword_25F8828 + 16LL * *(unsigned __int16 *)(qword_25F87F8 + 2LL * v2));
+        v11 = Plat_RelativeTicks();
+        (*(void (__fastcall **)(_QWORD *))(*v10 + 8LL))(v10);// 8LL = 0x8 = IGameSystemFactory_PostInit
+        v12 = Plat_RelativeTicks();
+        Plat_TickDiffMilliSecF(0, v12 - v11);
+        v13 = v10[2];
+        COM_TimestampedLog("IGameSystem::PostInit( %-80s ) %8.3f msec");
+        Plat_NotifyOSAppIsNotHung();
+        result = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*v10 + 64LL))(v10, v13);
+        if ( !(_BYTE)result )
+        {
+          v14 = (_QWORD *)(*(__int64 (__fastcall **)(_QWORD *))(*v10 + 72LL))(v10);// 72LL = 0x48 = IGameSystemFactory_GetStaticGameSystem
+          result = (unsigned int)dword_2477630;
+          if ( dword_2477630 < 0 )
+          {
+            v26[1] = 0;
+            v26[0] = off_22917A8;
+            if ( !(_BYTE)byte_25F82E0 && (unsigned int)__cxa_guard_acquire(&byte_25F82E0) )
+            {
+              qword_25F82E8 = (__int64)off_2476F40[0];
+              __cxa_guard_release(&byte_25F82E0);
+            }
+            v26[0] = qword_25F82E8;
+            result = (*(__int64 (__fastcall **)(_QWORD *))(qword_25F82E8 + 384))(v26);
+            dword_2477630 = result;
+          }
+          v3 = (int)result;
+          if ( off_22917A8[(int)result] != *(__int64 (__fastcall **)())(*v14 + 8LL * (int)result) )
+          {
+            v4 = qword_25F87D8;
+            v5 = result + 1;
+            v6 = *(_DWORD *)qword_25F87D8;
+            if ( v5 > *(_DWORD *)qword_25F87D8 )
+            {
+              v15 = *(_DWORD *)(qword_25F87D8 + 16);
+              v16 = v5 - v6;
+              if ( v5 > v15 )
+              {
+                v21 = v5 - v6;
+                v22 = *(_DWORD *)qword_25F87D8;
+                v23 = v3;
+                v25 = qword_25F87D8;
+                sub_E231E0(qword_25F87D8 + 8, (unsigned int)(v5 - v15));
+                v16 = v21;
+                v6 = v22;
+                v3 = v23;
+                v4 = v25;
+              }
+              *(_DWORD *)v4 = v5;
+              v17 = v16 + (__int64)v6;
+              v18 = 24LL * v6;
+              v19 = 24 * v17;
+              do
+              {
+                v20 = (_QWORD *)(v18 + *(_QWORD *)(v4 + 8));
+                v18 += 24;
+                *v20 = 0;
+                v20[1] = 0;
+                v20[2] = 0;
+              }
+              while ( v18 != v19 );
+              v4 = qword_25F87D8;
+            }
+            v7 = (int *)(*(_QWORD *)(v4 + 8) + 24 * v3);
+            v8 = *v7;
+            v9 = v8;
+            if ( (_DWORD)v8 == v7[4] )
+            {
+              v24 = (int *)(*(_QWORD *)(v4 + 8) + 24 * v3);
+              sub_E07B80(v7 + 2, 1, (unsigned int)v8);
+              v7 = v24;
+              v9 = *v24;
+            }
+            *v7 = v9 + 1;
+            result = *((_QWORD *)v7 + 1);
+            *(_QWORD *)(result + 8 * v8) = v14;
+          }
+        }
+        ++v2;
+      }
+      while ( v1 != v2 );
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/IGameSystem_PostInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/IGameSystem_PostInit.windows.yaml
@@ -1,0 +1,181 @@
+func_name: IGameSystem_PostInit
+func_va: '0x180530360'
+disasm_code: |-
+  .text:0000000180530360                 push    rbp
+  .text:0000000180530362                 push    rdi
+  .text:0000000180530363                 push    r13
+  .text:0000000180530365                 sub     rsp, 40h
+  .text:0000000180530369                 call    cs:Plat_NotifyOSAppIsNotHung
+  .text:000000018053036F                 mov     ebp, cs:dword_181BA2D48
+  .text:0000000180530375                 xor     r13d, r13d
+  .text:0000000180530378                 mov     edi, r13d
+  .text:000000018053037B                 test    ebp, ebp
+  .text:000000018053037D                 jz      loc_1805304DA
+  .text:0000000180530383                 mov     [rsp+58h+arg_8], rbx
+  .text:0000000180530388                 mov     [rsp+58h+arg_10], rsi
+  .text:000000018053038D                 mov     [rsp+58h+arg_18], r12
+  .text:0000000180530392                 lea     r12, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180530399                 mov     [rsp+58h+var_20], r14
+  .text:000000018053039E                 mov     r14d, cs:TlsIndex
+  .text:00000001805303A5                 mov     [rsp+58h+var_28], r15
+  .text:00000001805303AA                 mov     r15, gs:58h
+  .text:00000001805303B3                 nop     dword ptr [rax+00h]
+  .text:00000001805303B7                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001805303C0                 mov     rax, cs:qword_181E1C6C0
+  .text:00000001805303C7                 movsxd  rcx, edi
+  .text:00000001805303CA                 movzx   edx, word ptr [rax+rcx*2]
+  .text:00000001805303CE                 mov     rax, cs:qword_181BA2D18
+  .text:00000001805303D5                 add     rdx, rdx
+  .text:00000001805303D8                 mov     rsi, [rax+rdx*8]
+  .text:00000001805303DC                 call    cs:Plat_RelativeTicks
+  .text:00000001805303E2                 mov     rdx, [rsi]
+  .text:00000001805303E5                 mov     rcx, rsi
+  .text:00000001805303E8                 mov     rbx, rax
+  .text:00000001805303EB                 call    qword ptr [rdx+8]  ; 8h = IGameSystemFactory_PostInit
+  .text:00000001805303EE                 call    cs:Plat_RelativeTicks
+  .text:00000001805303F4                 sub     rax, rbx
+  .text:00000001805303F7                 lea     rcx, [rsp+58h+arg_0]
+  .text:00000001805303FC                 mov     [rsp+58h+arg_0], rax
+  .text:0000000180530401                 call    sub_1805213B0
+  .text:0000000180530406                 mov     rdx, [rsi+10h]
+  .text:000000018053040A                 lea     rcx, aIgamesystemPos; "IGameSystem::PostInit( %-80s ) %8.3f ms"...
+  .text:0000000180530411                 movaps  xmm2, xmm0
+  .text:0000000180530414                 movq    r8, xmm0
+  .text:0000000180530419                 call    cs:COM_TimestampedLog
+  .text:000000018053041F                 call    cs:Plat_NotifyOSAppIsNotHung
+  .text:0000000180530425                 mov     rax, [rsi]
+  .text:0000000180530428                 mov     rcx, rsi
+  .text:000000018053042B                 call    qword ptr [rax+40h]
+  .text:000000018053042E                 test    al, al
+  .text:0000000180530430                 jnz     loc_1805304B7
+  .text:0000000180530436                 mov     rax, [rsi]
+  .text:0000000180530439                 mov     rcx, rsi
+  .text:000000018053043C                 call    qword ptr [rax+48h]  ; 48h = IGameSystemFactory_GetStaticGameSystem
+  .text:000000018053043F                 mov     edx, cs:dword_181BA2E50
+  .text:0000000180530445                 mov     rbx, rax
+  .text:0000000180530448                 test    edx, edx
+  .text:000000018053044A                 jns     short loc_180530494
+  .text:000000018053044C                 mov     rcx, [r15+r14*8]
+  .text:0000000180530450                 mov     eax, 218h
+  .text:0000000180530455                 mov     [rsp+58h+var_30], r13
+  .text:000000018053045A                 mov     [rsp+58h+var_38], r12
+  .text:000000018053045F                 mov     ecx, [rax+rcx]
+  .text:0000000180530462                 cmp     cs:dword_181E1CBB8, ecx
+  .text:0000000180530468                 jg      short loc_1805304E3
+  .text:000000018053046A                 mov     rax, cs:qword_181E1CBB0
+  .text:0000000180530471                 lea     rcx, [rsp+58h+var_38]
+  .text:0000000180530476                 mov     [rsp+58h+var_38], rax
+  .text:000000018053047B                 call    sub_18050D1E0
+  .text:0000000180530480                 mov     edx, eax
+  .text:0000000180530482                 mov     cs:dword_181BA2E50, eax
+  .text:0000000180530488                 lea     rax, IGameSystem_vtable
+  .text:000000018053048F                 mov     [rsp+58h+var_38], rax
+  .text:0000000180530494                 mov     rax, [rbx]
+  .text:0000000180530497                 movsxd  rcx, edx
+  .text:000000018053049A                 mov     rax, [rax+rcx*8]
+  .text:000000018053049E                 cmp     [r12+rcx*8], rax
+  .text:00000001805304A2                 jz      short loc_1805304B7
+  .text:00000001805304A4                 mov     rax, cs:off_181BA33E8
+  .text:00000001805304AB                 lea     rcx, off_181BA33E8
+  .text:00000001805304B2                 mov     r8, rbx
+  .text:00000001805304B5                 call    qword ptr [rax]
+  .text:00000001805304B7                 inc     edi
+  .text:00000001805304B9                 cmp     edi, ebp
+  .text:00000001805304BB                 jb      loc_1805303C0
+  .text:00000001805304C1                 mov     r15, [rsp+58h+var_28]
+  .text:00000001805304C6                 mov     r14, [rsp+58h+var_20]
+  .text:00000001805304CB                 mov     r12, [rsp+58h+arg_18]
+  .text:00000001805304D0                 mov     rsi, [rsp+58h+arg_10]
+  .text:00000001805304D5                 mov     rbx, [rsp+58h+arg_8]
+  .text:00000001805304DA                 add     rsp, 40h
+  .text:00000001805304DE                 pop     r13
+  .text:00000001805304E0                 pop     rdi
+  .text:00000001805304E1                 pop     rbp
+  .text:00000001805304E2                 retn
+  .text:00000001805304E3                 lea     rcx, dword_181E1CBB8
+  .text:00000001805304EA                 call    sub_1814FE9A4
+  .text:00000001805304EF                 cmp     cs:dword_181E1CBB8, 0FFFFFFFFh
+  .text:00000001805304F6                 jnz     loc_18053046A
+  .text:00000001805304FC                 mov     rax, cs:off_181BA3020
+  .text:0000000180530503                 lea     rcx, dword_181E1CBB8
+  .text:000000018053050A                 mov     cs:qword_181E1CBB0, rax
+  .text:0000000180530511                 call    sub_1814FE938
+  .text:0000000180530516                 jmp     loc_18053046A
+procedure: |-
+  void *__fastcall IGameSystem_PostInit(__int64 a1, __int64 a2)
+  {
+    void *result; // rax
+    unsigned int v3; // ebp
+    signed int v4; // edi
+    __int64 v5; // r14
+    _QWORD *ThreadLocalStoragePointer; // r15
+    _QWORD *v7; // rsi
+    __int64 v8; // rbx
+    __int64 v9; // rdx
+    __int64 v10; // rcx
+    double v11; // xmm0_8
+    __int64 v12; // rdx
+    __int64 v13; // rcx
+    __int64 v14; // rax
+    __int64 v15; // rdx
+    _QWORD *v16; // rbx
+    __int64 v17; // rcx
+    unsigned int v18; // eax
+    _QWORD v19[2]; // [rsp+20h] [rbp-38h] BYREF
+    __int64 v20; // [rsp+60h] [rbp+8h] BYREF
+
+    result = (void *)Plat_NotifyOSAppIsNotHung(a1, a2);
+    v3 = dword_181BA2D48;
+    v4 = 0;
+    if ( dword_181BA2D48 )
+    {
+      v5 = (unsigned int)TlsIndex;
+      ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+      do
+      {
+        v7 = *(_QWORD **)(qword_181BA2D18 + 16LL * *(unsigned __int16 *)(qword_181E1C6C0 + 2LL * v4));
+        v8 = Plat_RelativeTicks(v4, 2LL * *(unsigned __int16 *)(qword_181E1C6C0 + 2LL * v4));
+        (*(void (__fastcall **)(_QWORD *))(*v7 + 8LL))(v7);// 8LL = 0x8 = IGameSystemFactory_PostInit
+        v20 = Plat_RelativeTicks(v10, v9) - v8;
+        v11 = sub_1805213B0(&v20);
+        COM_TimestampedLog("IGameSystem::PostInit( %-80s ) %8.3f msec", v7[2], v11);
+        Plat_NotifyOSAppIsNotHung(v13, v12);
+        result = (void *)(*(__int64 (__fastcall **)(_QWORD *))(*v7 + 64LL))(v7);// IGameSystemFactory_IsReallocating
+        if ( !(_BYTE)result )
+        {
+          v14 = (*(__int64 (__fastcall **)(_QWORD *))(*v7 + 72LL))(v7);// 72LL = 0x48 = IGameSystemFactory_GetStaticGameSystem
+          v15 = (unsigned int)dword_181BA2E50;
+          v16 = (_QWORD *)v14;
+          if ( dword_181BA2E50 < 0 )
+          {
+            v17 = ThreadLocalStoragePointer[v5];
+            v19[1] = 0;
+            v19[0] = &CDontUseThisGameSystem::`vftable';
+            if ( dword_181E1CBB8 > *(_DWORD *)(v17 + 536) )
+            {
+              sub_1814FE9A4(&dword_181E1CBB8);
+              if ( dword_181E1CBB8 == -1 )
+              {
+                qword_181E1CBB0 = (__int64)off_181BA3020[0];
+                sub_1814FE938(&dword_181E1CBB8);
+              }
+            }
+            v19[0] = qword_181E1CBB0;
+            v18 = sub_18050D1E0((__int64)v19);
+            v15 = v18;
+            dword_181BA2E50 = v18;
+            v19[0] = IGameSystem_vtable;
+          }
+          result = *(void **)(*v16 + 8LL * (int)v15);
+          if ( *(&CDontUseThisGameSystem::`vftable' + (int)v15) != result )
+            result = (void *)((__int64 (__fastcall *)(__int64 (__fastcall ***)(), __int64, _QWORD *))*off_181BA33E8)(
+                               &off_181BA33E8,
+                               v15,
+                               v16);
+        }
+        ++v4;
+      }
+      while ( v4 < v3 );
+    }
+    return result;
+  }

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -3656,6 +3656,148 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
         )
         mock_load_symbol.assert_called_once()
 
+    async def test_preprocess_func_xrefs_uses_inline_alias_single_caller(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "_load_symbol_addr_from_current_yaml",
+            return_value=0x180200000,
+        ) as mock_load_symbol, patch.object(
+            ida_analyze_util,
+            "_collect_single_call_or_jump_xref_func_starts_for_ea",
+            AsyncMock(return_value={0x180300000}),
+        ) as mock_collect_callers, patch.object(
+            ida_analyze_util,
+            "preprocess_gen_func_sig_via_mcp",
+            AsyncMock(
+                return_value={
+                    "func_va": "0x180300000",
+                    "func_rva": "0x300000",
+                    "func_size": "0x20",
+                    "func_sig": "55 48 89 E5",
+                }
+            ),
+        ) as mock_gen_sig:
+            result = await ida_analyze_util.preprocess_func_xrefs_via_mcp(
+                session="session",
+                func_name="CLoopModeFactory_CLoopModeGame_Init",
+                xref_strings=[],
+                xref_gvs=[],
+                xref_signatures=[],
+                xref_funcs=[],
+                exclude_funcs=[],
+                exclude_strings=[],
+                exclude_gvs=[],
+                exclude_signatures=[],
+                inline_alias="CLoopModeGame_StaticInit",
+                new_binary_dir="bin_dir",
+                platform="linux",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertEqual("CLoopModeFactory_CLoopModeGame_Init", result["func_name"])
+        self.assertEqual("0x180300000", result["func_va"])
+        mock_load_symbol.assert_called_once_with(
+            "bin_dir",
+            "linux",
+            "CLoopModeGame_StaticInit",
+            "func_va",
+            debug=True,
+            debug_label="inline_alias",
+        )
+        mock_collect_callers.assert_awaited_once_with(
+            session="session",
+            target_ea=0x180200000,
+            debug=True,
+        )
+        self.assertEqual(0x180300000, mock_gen_sig.await_args.kwargs["func_va"])
+
+    async def test_preprocess_func_xrefs_uses_inline_alias_self_without_callers(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "_load_symbol_addr_from_current_yaml",
+            return_value=0x180200000,
+        ), patch.object(
+            ida_analyze_util,
+            "_collect_single_call_or_jump_xref_func_starts_for_ea",
+            AsyncMock(return_value=set()),
+        ) as mock_collect_callers, patch.object(
+            ida_analyze_util,
+            "preprocess_gen_func_sig_via_mcp",
+            AsyncMock(
+                return_value={
+                    "func_va": "0x180200000",
+                    "func_rva": "0x200000",
+                    "func_size": "0x80",
+                    "func_sig": "48 89 5C 24 08",
+                }
+            ),
+        ) as mock_gen_sig:
+            result = await ida_analyze_util.preprocess_func_xrefs_via_mcp(
+                session="session",
+                func_name="CLoopModeFactory_CLoopModeGame_Init",
+                xref_strings=[],
+                xref_gvs=[],
+                xref_signatures=[],
+                xref_funcs=[],
+                exclude_funcs=[],
+                exclude_strings=[],
+                exclude_gvs=[],
+                exclude_signatures=[],
+                inline_alias="CLoopModeGame_StaticInit",
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertEqual("CLoopModeFactory_CLoopModeGame_Init", result["func_name"])
+        self.assertEqual("0x180200000", result["func_va"])
+        mock_collect_callers.assert_awaited_once()
+        self.assertEqual(0x180200000, mock_gen_sig.await_args.kwargs["func_va"])
+
+    async def test_single_call_or_jump_xref_helper_requires_one_xref_per_function(
+        self,
+    ) -> None:
+        session = AsyncMock()
+        session.call_tool = AsyncMock(
+            return_value=_py_eval_payload(
+                ["0x180101000", "0x180101020", "0x180202000"]
+            )
+        )
+
+        with patch.object(
+            ida_analyze_util,
+            "_normalize_func_start_for_code_addr",
+            AsyncMock(
+                side_effect=[
+                    0x180100000,
+                    0x180100000,
+                    0x180200000,
+                ]
+            ),
+        ) as mock_normalize:
+            helper = getattr(
+                ida_analyze_util,
+                "_collect_single_call_or_jump_xref_func_starts_for_ea",
+            )
+            result = await helper(
+                session=session,
+                target_ea=0x180300000,
+                debug=True,
+            )
+
+        self.assertEqual({0x180200000}, result)
+        self.assertEqual(3, mock_normalize.await_count)
+        self.assertIn(
+            "fl_CF",
+            session.call_tool.await_args.kwargs["arguments"]["code"],
+        )
+
     async def test_preprocess_func_xrefs_fails_when_signature_set_is_empty(
         self,
     ) -> None:
@@ -3735,6 +3877,7 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
                         "xref_gvs": ["g_NetworkingState"],
                         "xref_signatures": ["C7 44 24 40 64 FF FF FF"],
                         "xref_funcs": ["LoggingChannel_Shutdown"],
+                        "inline_alias": "LoggingChannel_StaticInit",
                         "xref_floats": ["64.0", "0.5"],
                         "exclude_funcs": ["LoggingChannel_Rebuild"],
                         "exclude_strings": ["FULLMATCH:Networking"],
@@ -3771,6 +3914,10 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             ["LoggingChannel_Shutdown"],
             mock_func_xrefs.call_args.kwargs["xref_funcs"],
+        )
+        self.assertEqual(
+            "LoggingChannel_StaticInit",
+            mock_func_xrefs.call_args.kwargs["inline_alias"],
         )
         self.assertEqual(
             ["64.0", "0.5"],
@@ -3900,6 +4047,72 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertFalse(result)
+
+    async def test_preprocess_common_skill_allows_inline_alias_positive_source(
+        self,
+    ) -> None:
+        with patch.object(
+            ida_analyze_util,
+            "preprocess_func_sig_via_mcp",
+            AsyncMock(return_value=None),
+        ), patch.object(
+            ida_analyze_util,
+            "preprocess_func_xrefs_via_mcp",
+            AsyncMock(
+                return_value={
+                    "func_name": "CLoopModeFactory_CLoopModeGame_Init",
+                    "func_va": "0x180200000",
+                    "func_rva": "0x200000",
+                    "func_size": "0x80",
+                }
+            ),
+        ) as mock_func_xrefs, patch.object(
+            ida_analyze_util,
+            "write_func_yaml",
+        ) as mock_write_func_yaml, patch.object(
+            ida_analyze_util,
+            "_rename_func_in_ida",
+            AsyncMock(return_value=None),
+        ):
+            result = await ida_analyze_util.preprocess_common_skill(
+                session="session",
+                expected_outputs=[
+                    "/tmp/CLoopModeFactory_CLoopModeGame_Init.windows.yaml"
+                ],
+                old_yaml_map={},
+                new_binary_dir="/tmp",
+                platform="windows",
+                image_base=0x180000000,
+                func_names=["CLoopModeFactory_CLoopModeGame_Init"],
+                func_xrefs=[
+                    {
+                        "func_name": "CLoopModeFactory_CLoopModeGame_Init",
+                        "xref_strings": [],
+                        "xref_gvs": [],
+                        "xref_signatures": [],
+                        "xref_funcs": [],
+                        "exclude_funcs": [],
+                        "exclude_strings": [],
+                        "exclude_gvs": [],
+                        "exclude_signatures": [],
+                        "inline_alias": "CLoopModeGame_StaticInit",
+                    }
+                ],
+                generate_yaml_desired_fields=[
+                    (
+                        "CLoopModeFactory_CLoopModeGame_Init",
+                        ["func_name", "func_va", "func_rva", "func_size"],
+                    )
+                ],
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        self.assertEqual(
+            "CLoopModeGame_StaticInit",
+            mock_func_xrefs.call_args.kwargs["inline_alias"],
+        )
+        mock_write_func_yaml.assert_called_once()
 
     async def test_preprocess_common_skill_rejects_invalid_float_xref_values(
         self,
@@ -4064,6 +4277,54 @@ class TestFuncXrefsSignatureSupport(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertTrue(result)
+
+    def test_can_probe_future_func_fast_path_requires_inline_alias_yaml(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result_before_yaml = ida_analyze_util._can_probe_future_func_fast_path(
+                func_name="CLoopModeFactory_CLoopModeGame_Init",
+                func_xrefs_map={
+                    "CLoopModeFactory_CLoopModeGame_Init": {
+                        "xref_strings": [],
+                        "xref_gvs": [],
+                        "xref_signatures": [],
+                        "xref_funcs": [],
+                        "exclude_funcs": [],
+                        "exclude_strings": [],
+                        "exclude_gvs": [],
+                        "exclude_signatures": [],
+                        "inline_alias": "CLoopModeGame_StaticInit",
+                    }
+                },
+                new_binary_dir=temp_dir,
+                platform="windows",
+                debug=True,
+            )
+            alias_yaml_path = Path(temp_dir) / "CLoopModeGame_StaticInit.windows.yaml"
+            alias_yaml_path.write_text("func_va: '0x180200000'\n", encoding="utf-8")
+            result_after_yaml = ida_analyze_util._can_probe_future_func_fast_path(
+                func_name="CLoopModeFactory_CLoopModeGame_Init",
+                func_xrefs_map={
+                    "CLoopModeFactory_CLoopModeGame_Init": {
+                        "xref_strings": [],
+                        "xref_gvs": [],
+                        "xref_signatures": [],
+                        "xref_funcs": [],
+                        "exclude_funcs": [],
+                        "exclude_strings": [],
+                        "exclude_gvs": [],
+                        "exclude_signatures": [],
+                        "inline_alias": "CLoopModeGame_StaticInit",
+                    }
+                },
+                new_binary_dir=temp_dir,
+                platform="windows",
+                debug=True,
+            )
+
+        self.assertFalse(result_before_yaml)
+        self.assertTrue(result_after_yaml)
 
 
 class TestFunctionDetailExportPyEvalBuilder(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -63,6 +63,10 @@ CNETWORK_SERVER_SERVICE_INIT_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CNetworkServerService_Init.py"
 )
+CLOOPMODE_FACTORY_GAME_INIT_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/"
+    "find-CLoopModeFactory_CLoopModeGame_Init.py"
+)
 PROCESS_MOVEMENT_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
     "find-CCSPlayer_MovementServices_ProcessMovement.py"
@@ -2549,6 +2553,80 @@ class TestFindCNetworkServerServiceInit(unittest.IsolatedAsyncioTestCase):
             platform="windows",
             image_base=0x180000000,
             func_names=["CNetworkServerService_Init"],
+            func_xrefs=expected_func_xrefs,
+            func_vtable_relations=expected_func_vtable_relations,
+            generate_yaml_desired_fields=expected_generate_yaml_desired_fields,
+            debug=True,
+        )
+
+
+class TestFindCLoopModeFactoryCLoopModeGameInit(unittest.IsolatedAsyncioTestCase):
+    async def test_script_forwards_inline_alias_func_xrefs(self) -> None:
+        module = _load_module(
+            CLOOPMODE_FACTORY_GAME_INIT_SCRIPT_PATH,
+            "find_CLoopModeFactory_CLoopModeGame_Init",
+        )
+        mock_preprocess_common_skill = AsyncMock(return_value=True)
+        expected_func_xrefs = [
+            {
+                "func_name": "CLoopModeFactory_CLoopModeGame_Init",
+                "xref_strings": [],
+                "xref_gvs": [],
+                "xref_signatures": [],
+                "xref_funcs": [],
+                "exclude_funcs": [],
+                "exclude_strings": [],
+                "exclude_gvs": [],
+                "exclude_signatures": [],
+                "inline_alias": "CLoopModeGame_StaticInit",
+            }
+        ]
+        expected_func_vtable_relations = [
+            (
+                "CLoopModeFactory_CLoopModeGame_Init",
+                "CLoopModeFactory_CLoopModeGame_vtable",
+            )
+        ]
+        expected_generate_yaml_desired_fields = [
+            (
+                "CLoopModeFactory_CLoopModeGame_Init",
+                [
+                    "func_name",
+                    "func_va",
+                    "func_rva",
+                    "func_size",
+                    "vtable_name",
+                    "vfunc_offset",
+                    "vfunc_index",
+                ],
+            )
+        ]
+
+        with patch.object(
+            module,
+            "preprocess_common_skill",
+            mock_preprocess_common_skill,
+        ):
+            result = await module.preprocess_skill(
+                session="session",
+                skill_name="skill",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={"k": "v"},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+        self.assertTrue(result)
+        mock_preprocess_common_skill.assert_awaited_once_with(
+            session="session",
+            expected_outputs=["out.yaml"],
+            old_yaml_map={"k": "v"},
+            new_binary_dir="bin_dir",
+            platform="windows",
+            image_base=0x180000000,
+            func_names=["CLoopModeFactory_CLoopModeGame_Init"],
             func_xrefs=expected_func_xrefs,
             func_vtable_relations=expected_func_vtable_relations,
             generate_yaml_desired_fields=expected_generate_yaml_desired_fields,

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -1592,14 +1592,14 @@ class TestFindCSpawnGroupMgrGameSystemDoesGameSystemReallocate(
                     / "bin"
                     / "14141"
                     / "server"
-                    / "IGameSystemFactory_DoesGameSystemReallocate.linux.yaml"
+                    / "IGameSystemFactory_IsReallocating.linux.yaml"
                 ),
                 str(
                     Path(temp_dir)
                     / "bin"
                     / "14141"
                     / "client"
-                    / "IGameSystemFactory_DoesGameSystemReallocate.linux.yaml"
+                    / "IGameSystemFactory_IsReallocating.linux.yaml"
                 ),
             ],
             paths,
@@ -1665,7 +1665,7 @@ class TestFindCSpawnGroupMgrGameSystemDoesGameSystemReallocate(
             server_dir.mkdir(parents=True, exist_ok=True)
             client_dir.mkdir(parents=True, exist_ok=True)
             (
-                client_dir / "IGameSystemFactory_DoesGameSystemReallocate.linux.yaml"
+                client_dir / "IGameSystemFactory_IsReallocating.linux.yaml"
             ).write_text("vfunc_offset: 0x20\n", encoding="utf-8")
 
             with patch.object(

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -42,7 +42,7 @@ REALLOCATING_FACTORY_SCRIPT_PATH = Path(
 )
 REALLOCATING_FACTORY_DEALLOCATE_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
-    "find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate-impl.py"
+    "find-CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem-impl.py"
 )
 CSPAWNGROUP_VTABLE2_SCRIPT_PATH = Path(
     "ida_preprocessor_scripts/"
@@ -1416,20 +1416,20 @@ class TestFindCGameSystemReallocatingFactoryCSpawnGroupMgrGameSystemDeallocateIm
     async def test_preprocess_skill_forwards_expected_inherit_vfuncs(self) -> None:
         module = _load_module(
             REALLOCATING_FACTORY_DEALLOCATE_SCRIPT_PATH,
-            "find_CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate_impl",
+            "find_CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem_impl",
         )
         mock_preprocess_common_skill = AsyncMock(return_value=True)
         expected_inherit_vfuncs = [
             (
-                "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate",
+                "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem",
                 "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem",
-                "../client/IGameSystemFactory_Deallocate",
+                "../client/IGameSystemFactory_DestroyGameSystem",
                 True,
             )
         ]
         expected_generate_yaml_desired_fields = [
             (
-                "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_Deallocate",
+                "CGameSystemReallocatingFactory_CSpawnGroupMgrGameSystem_DestroyGameSystem",
                 [
                     "func_name",
                     "func_va",


### PR DESCRIPTION
## Summary

- Added 40+ new preprocessor scripts covering `IGameSystem`, `IGameSystemFactory`, `CEngineServiceMgr`, `CLoopModeFactory`, `CLoopModeGame`, `CSource2Server`, `CSource2EntitySystem`, `CGameResourceService`, `CBaseEntity`, and related symbols
- Added shutdown/unregister/switch lifecycle finders: `SwitchToLoop`, `RegisterLoopMode`, `UnregisterLoopMode`, `UnregisterEngineService`, `PrintStatus`, `PreShutdown`, `Shutdown`
- Added vtable finders for `CNetworkTransmitComponent`, `CEntityIOOutput`, `CLoopModeFactory_CLoopModeGame`, `CGameSystemReallocatingFactory_CSource2EntitySystem`
- Added global variable finders: `g_pGameResourceService`, `g_pGameEntitySystem`
- Renamed `CLoopTypeClientServer_FrameUpdate` → `CLoopTypeClientServer_Update` and `CLoopTypeClientServer_EngineLoop` → `CLoopTypeClientServer_OutputListeners`
- Renamed `IGameSystemFactory_DoesGameSystemReallocate` → `IGameSystemFactory_IsReallocating`, `Allocate/Deallocate` → `CreateGameSystem/DestroyGameSystem`
- Added `igamesystemfactory.cpp` C++ test, expanded `test_ida_preprocessor_scripts.py` and `test_ida_analyze_util.py`
- Fixed vdtor destructor matching in cpp-tests; refactored IGameSystem destructor symbol names

## Test plan
- [x] Run `uv run ida_analyze_bin.py -debug` to validate new preprocessor scripts pass
- [x] Confirm renamed symbols resolve correctly in IDA
- [x] Verify vtable finders locate correct addresses for new entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)