### PR TITLE
Add find-CBaseEntity_FullEdictChanged and related struct-member skills

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5145,6 +5145,26 @@ modules:
           - CBaseEntity_vtable.{platform}.yaml
           - CNetworkTransmitComponent_StateChanged.{platform}.yaml
 
+      - name: find-CBaseEntity_m_NetworkTransmitComponent
+        expected_output:
+          - CBaseEntity_m_NetworkTransmitComponent.{platform}.yaml
+        expected_input:
+          - CBaseEntity_SetStateChanged.{platform}.yaml
+
+      - name: find-CNetworkTransmitComponent_m_nStateFlags
+        expected_output:
+          - CNetworkTransmitComponent_m_nStateFlags.{platform}.yaml
+        expected_input:
+          - CNetworkTransmitComponent_StateChanged.{platform}.yaml
+
+      - name: find-CBaseEntity_FullEdictChanged
+        expected_output:
+          - CBaseEntity_FullEdictChanged.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
+          - CBaseEntity_m_NetworkTransmitComponent.{platform}.yaml
+          - CNetworkTransmitComponent_m_nStateFlags.{platform}.yaml
+
       - name: find-CBaseCombatCharacter_OnKilled
         expected_output:
           - CBaseCombatCharacter_OnKilled.{platform}.yaml
@@ -6294,6 +6314,12 @@ modules:
           - CEntityInstance_NetworkStateChanged.{platform}.yaml
         expected_input:
           - CBaseEntity_NetworkStateChanged.{platform}.yaml
+
+      - name: find-CEntityInstance_FullEdictChanged
+        expected_output:
+          - CEntityInstance_FullEdictChanged.{platform}.yaml
+        expected_input:
+          - CBaseEntity_FullEdictChanged.{platform}.yaml
 
       - name: find-CEntityInstance_NetworkStateChangedLog
         expected_output:
@@ -8168,10 +8194,29 @@ modules:
         alias:
           - CBaseEntity::NetworkStateChanged
 
+      - name: CBaseEntity_FullEdictChanged
+        category: vfunc
+        alias:
+          - CBaseEntity::FullEdictChanged
+
+      - name: CBaseEntity_m_NetworkTransmitComponent
+        category: structmember
+        struct: CBaseEntity
+        member: m_NetworkTransmitComponent
+        alias:
+          - CBaseEntity::m_NetworkTransmitComponent
+
       - name: CNetworkTransmitComponent_StateChanged
         category: func
         alias:
           - CNetworkTransmitComponent::StateChanged
+
+      - name: CNetworkTransmitComponent_m_nStateFlags
+        category: structmember
+        struct: CNetworkTransmitComponent
+        member: m_nStateFlags
+        alias:
+          - CNetworkTransmitComponent::m_nStateFlags
 
       - name: Host_Say
         category: func
@@ -9546,6 +9591,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::NetworkStateChanged
+
+      - name: CEntityInstance_FullEdictChanged
+        category: vfunc
+        alias:
+          - CEntityInstance::FullEdictChanged
 
       - name: CEntityInstance_NetworkUpdateState
         category: vfunc

--- a/ida_preprocessor_scripts/find-CBaseEntity_FullEdictChanged.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_FullEdictChanged.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_FullEdictChanged skill."""
+
+import os
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseEntity_FullEdictChanged",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CBaseEntity_FullEdictChanged", "CBaseEntity"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_FullEdictChanged",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+# Signature templates -- the 4-byte placeholder is the combined offset
+# (CBaseEntity::m_NetworkTransmitComponent + CNetworkTransmitComponent::m_nStateFlags),
+# loaded via `mov eax, [reg+disp32]; shr eax, 1`.
+# Windows: 8B 81 ?? ?? ?? ?? D1 E8  (mov eax, [rcx+disp32]; shr eax, 1)
+# Linux:   8B 87 ?? ?? ?? ?? D1 E8  (mov eax, [rdi+disp32]; shr eax, 1)
+_SIG_WINDOWS_TEMPLATE = "8B 81 {b0:02X} {b1:02X} {b2:02X} {b3:02X} D1 E8"
+_SIG_LINUX_TEMPLATE = "8B 87 {b0:02X} {b1:02X} {b2:02X} {b3:02X} D1 E8"
+
+_NETWORK_TRANSMIT_COMPONENT_STEM = "CBaseEntity_m_NetworkTransmitComponent"
+_STATE_FLAGS_STEM = "CNetworkTransmitComponent_m_nStateFlags"
+
+
+def _read_offset(yaml_path):
+    """Read `offset` from a struct-member YAML file, returning integer or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            val = data.get("offset")
+            if val is not None:
+                return int(str(val).strip(), 0)
+    except Exception:
+        pass
+    return None
+
+
+def _read_struct_offset(new_binary_dir, stem, platform):
+    """Read a struct-member offset YAML in the current module directory."""
+    yaml_path = os.path.join(new_binary_dir, f"{stem}.{platform}.yaml")
+    return _read_offset(yaml_path), yaml_path
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Locate CBaseEntity_FullEdictChanged via dynamic xref signature built from struct offsets."""
+    if yaml is None:
+        if debug:
+            print("    Preprocess: PyYAML is required")
+        return False
+
+    transmit_offset, transmit_yaml = _read_struct_offset(
+        new_binary_dir, _NETWORK_TRANSMIT_COMPONENT_STEM, platform,
+    )
+    if transmit_offset is None:
+        if debug:
+            print(
+                f"    Preprocess: failed to read offset from {os.path.basename(transmit_yaml)}"
+            )
+        return False
+
+    state_flags_offset, state_flags_yaml = _read_struct_offset(
+        new_binary_dir, _STATE_FLAGS_STEM, platform,
+    )
+    if state_flags_offset is None:
+        if debug:
+            print(
+                f"    Preprocess: failed to read offset from {os.path.basename(state_flags_yaml)}"
+            )
+        return False
+
+    combined_offset = transmit_offset + state_flags_offset
+    if combined_offset < 0 or combined_offset > 0xFFFFFFFF:
+        if debug:
+            print(
+                f"    Preprocess: combined offset 0x{combined_offset:X} out of 32-bit range"
+            )
+        return False
+
+    # Little-endian 4-byte encoding of the disp32 in `mov eax, [reg+disp32]`.
+    b0 = combined_offset & 0xFF
+    b1 = (combined_offset >> 8) & 0xFF
+    b2 = (combined_offset >> 16) & 0xFF
+    b3 = (combined_offset >> 24) & 0xFF
+
+    if platform == "windows":
+        sig = _SIG_WINDOWS_TEMPLATE.format(b0=b0, b1=b1, b2=b2, b3=b3)
+    elif platform == "linux":
+        sig = _SIG_LINUX_TEMPLATE.format(b0=b0, b1=b1, b2=b2, b3=b3)
+    else:
+        return False
+
+    if debug:
+        print(
+            "    Preprocess: combined offset "
+            f"0x{transmit_offset:X} + 0x{state_flags_offset:X} = 0x{combined_offset:X}, "
+            f"xref signature: {sig}"
+        )
+
+    func_xrefs = [
+        {
+            "func_name": "CBaseEntity_FullEdictChanged",
+            "xref_strings": [],
+            "xref_gvs": [],
+            "xref_signatures": [sig],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CBaseEntity_m_NetworkTransmitComponent.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_m_NetworkTransmitComponent.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_m_NetworkTransmitComponent skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CBaseEntity_m_NetworkTransmitComponent",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CBaseEntity_m_NetworkTransmitComponent",
+        "prompt/call_llm_decompile.md",
+        "references/server/CBaseEntity_SetStateChanged.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # `size` is omitted because the member is an embedded sub-object only ever
+    # accessed via pointer arithmetic (add/lea), so size cannot be inferred from
+    # the instruction operand width.
+    (
+        "CBaseEntity_m_NetworkTransmitComponent",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_FullEdictChanged.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_FullEdictChanged.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_FullEdictChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEntityInstance_FullEdictChanged", "CEntityInstance", "CBaseEntity_FullEdictChanged", False),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slot-only mode: empty/short vfunc, only vtable slot position is needed.
+    (
+        "CEntityInstance_FullEdictChanged",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old vfunc slot; fallback to inheriting slot index from CBaseEntity_FullEdictChanged."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkTransmitComponent_m_nStateFlags.py
+++ b/ida_preprocessor_scripts/find-CNetworkTransmitComponent_m_nStateFlags.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkTransmitComponent_m_nStateFlags skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CNetworkTransmitComponent_m_nStateFlags",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CNetworkTransmitComponent_m_nStateFlags",
+        "prompt/call_llm_decompile.md",
+        "references/server/CNetworkTransmitComponent_StateChanged.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkTransmitComponent_m_nStateFlags",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_SetStateChanged.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_SetStateChanged.linux.yaml
@@ -1,0 +1,70 @@
+func_name: CBaseEntity_SetStateChanged
+func_va: '0x9b95b0'
+disasm_code: |-
+  .text:00000000009B95B0                 push    rbp
+  .text:00000000009B95B1                 mov     rbp, rsp
+  .text:00000000009B95B4                 push    rbx
+  .text:00000000009B95B5                 mov     rbx, rdi
+  .text:00000000009B95B8                 add     rdi, 38h ; '8' ; 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+  .text:00000000009B95BC                 sub     rsp, 8
+  .text:00000000009B95C0                 mov     eax, [rsi]
+  .text:00000000009B95C2                 test    eax, eax
+  .text:00000000009B95C4                 jnz     short loc_9B9640
+  .text:00000000009B95C6                 cmp     byte ptr [rbx+318h], 0
+  .text:00000000009B95CD                 jnz     short loc_9B95E8
+  .text:00000000009B95CF                 mov     rax, [rbx+48h]
+  .text:00000000009B95D3                 test    rax, rax
+  .text:00000000009B95D6                 jz      short loc_9B9610
+  .text:00000000009B95D8                 cmp     byte ptr [rax+18h], 0
+  .text:00000000009B95DC                 jz      short loc_9B9610
+  .text:00000000009B95DE                 mov     byte ptr [rbx+315h], 1
+  .text:00000000009B95E5                 nop     dword ptr [rax]
+  .text:00000000009B95E8                 lea     rax, off_2503B68
+  .text:00000000009B95EF                 mov     rax, [rax]
+  .text:00000000009B95F2                 movss   xmm0, dword ptr [rax+30h]
+  .text:00000000009B95F7                 comiss  xmm0, dword ptr [rbx+538h]
+  .text:00000000009B95FE                 ja      short loc_9B9620
+  .text:00000000009B9600                 mov     rbx, [rbp+var_8]
+  .text:00000000009B9604                 leave
+  .text:00000000009B9605                 retn
+  .text:00000000009B9610                 call    sub_9B94F0
+  .text:00000000009B9615                 jmp     short loc_9B95E8
+  .text:00000000009B9620                 movss   dword ptr [rbx+538h], xmm0
+  .text:00000000009B9628                 mov     qword ptr [rbx+530h], 0
+  .text:00000000009B9633                 mov     rbx, [rbp+var_8]
+  .text:00000000009B9637                 leave
+  .text:00000000009B9638                 retn
+  .text:00000000009B9640                 mov     rdx, rsi
+  .text:00000000009B9643                 mov     rsi, rbx
+  .text:00000000009B9646                 call    CNetworkTransmitComponent_StateChanged
+  .text:00000000009B964B                 jmp     short loc_9B95E8
+procedure: |-
+  void *__fastcall CBaseEntity_SetStateChanged(__int64 a1, _DWORD *a2, __int64 a3, __int64 a4, int a5, int a6)
+  {
+    __int64 v7; // rdi
+    __int64 v8; // rax
+    void *result; // rax
+    float v10; // xmm0_4
+
+    v7 = a1 + 56;                                 // 56 = 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+    if ( *a2 )
+    {
+      CNetworkTransmitComponent_StateChanged(v7, a1, (__int64)a2, a4, a5, a6);
+    }
+    else if ( !*(_BYTE *)(a1 + 792) )
+    {
+      v8 = *(_QWORD *)(a1 + 72);
+      if ( v8 && *(_BYTE *)(v8 + 24) )
+        *(_BYTE *)(a1 + 789) = 1;
+      else
+        sub_9B94F0(v7);
+    }
+    result = off_2503B68;
+    v10 = *((float *)off_2503B68 + 12);
+    if ( v10 > *(float *)(a1 + 1336) )
+    {
+      *(float *)(a1 + 1336) = v10;
+      *(_QWORD *)(a1 + 1328) = 0;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CBaseEntity_SetStateChanged.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBaseEntity_SetStateChanged.windows.yaml
@@ -1,0 +1,140 @@
+func_name: CBaseEntity_SetStateChanged
+func_va: '0x180189ba0'
+disasm_code: |-
+  .text:0000000180189BA0                 mov     rax, rsp
+  .text:0000000180189BA3                 push    rsi
+  .text:0000000180189BA4                 sub     rsp, 140h
+  .text:0000000180189BAB                 cmp     dword ptr [rdx], 0
+  .text:0000000180189BAE                 mov     rsi, rcx
+  .text:0000000180189BB1                 mov     [rax+10h], rbp
+  .text:0000000180189BB5                 mov     rbp, rdx
+  .text:0000000180189BB8                 mov     [rax+18h], rdi
+  .text:0000000180189BBC                 jz      short loc_180189BD2
+  .text:0000000180189BBE                 mov     r8, rdx
+  .text:0000000180189BC1                 mov     rdx, rcx
+  .text:0000000180189BC4                 add     rcx, 38h ; '8' ; 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+  .text:0000000180189BC8                 call    CNetworkTransmitComponent_StateChanged
+  .text:0000000180189BCD                 jmp     loc_180189CA3
+  .text:0000000180189BD2                 cmp     byte ptr [rcx+1C0h], 0
+  .text:0000000180189BD9                 jnz     loc_180189CA3
+  .text:0000000180189BDF                 mov     rax, [rcx+48h]
+  .text:0000000180189BE3                 test    rax, rax
+  .text:0000000180189BE6                 jz      short loc_180189BFA
+  .text:0000000180189BE8                 cmp     byte ptr [rax+18h], 0
+  .text:0000000180189BEC                 jz      short loc_180189BFA
+  .text:0000000180189BEE                 mov     byte ptr [rcx+1BDh], 1
+  .text:0000000180189BF5                 jmp     loc_180189CA3
+  .text:0000000180189BFA                 mov     rax, [rdx+28h]
+  .text:0000000180189BFE                 mov     [rsp+148h+arg_0], rbx
+  .text:0000000180189C06                 test    rax, rax
+  .text:0000000180189C09                 mov     ebx, [rdx+30h]
+  .text:0000000180189C0C                 mov     [rsp+148h+arg_18], r14
+  .text:0000000180189C14                 lea     r14, Src
+  .text:0000000180189C1B                 mov     rcx, r14
+  .text:0000000180189C1E                 cmovnz  rcx, rax
+  .text:0000000180189C22                 call    cs:V_UnqualifiedFileName
+  .text:0000000180189C28                 mov     rcx, [rbp+20h]
+  .text:0000000180189C2C                 lea     rdx, aCnetworktransm; "CNetworkTransmitComponent::StateChanged"...
+  .text:0000000180189C33                 test    rcx, rcx
+  .text:0000000180189C36                 mov     [rsp+148h+var_128], ebx
+  .text:0000000180189C3A                 mov     r8, r14
+  .text:0000000180189C3D                 mov     r9, rax
+  .text:0000000180189C40                 cmovnz  r8, rcx
+  .text:0000000180189C44                 lea     rcx, [rsp+148h+var_118]
+  .text:0000000180189C49                 call    sub_18017E2C0
+  .text:0000000180189C4E                 mov     rbx, [rsp+148h+arg_0]
+  .text:0000000180189C56                 mov     ecx, [rax+4]
+  .text:0000000180189C59                 bt      ecx, 1Eh
+  .text:0000000180189C5D                 jnb     short loc_180189C65
+  .text:0000000180189C5F                 lea     r14, [rax+8]
+  .text:0000000180189C63                 jmp     short loc_180189C71
+  .text:0000000180189C65                 test    ecx, 3FFFFFFFh
+  .text:0000000180189C6B                 jbe     short loc_180189C71
+  .text:0000000180189C6D                 mov     r14, [rax+8]
+  .text:0000000180189C71                 mov     rdx, r14
+  .text:0000000180189C74                 lea     rcx, [rsi+38h]  ; 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+  .text:0000000180189C78                 call    sub_1801C7EF0
+  .text:0000000180189C7D                 xor     edx, edx
+  .text:0000000180189C7F                 lea     rcx, [rsp+148h+var_118]
+  .text:0000000180189C84                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180189C8A                 lock or dword ptr [rsi+1B8h], 3
+  .text:0000000180189C92                 mov     r14, [rsp+148h+arg_18]
+  .text:0000000180189C9A                 xor     eax, eax
+  .text:0000000180189C9C                 mov     [rsi+1D6h], ax
+  .text:0000000180189CA3                 mov     rax, cs:off_181C4FC68
+  .text:0000000180189CAA                 mov     rdi, [rsp+148h+arg_10]
+  .text:0000000180189CB2                 mov     rbp, [rsp+148h+arg_8]
+  .text:0000000180189CBA                 movss   xmm0, dword ptr [rax+30h]
+  .text:0000000180189CBF                 comiss  xmm0, dword ptr [rsi+280h]
+  .text:0000000180189CC6                 jbe     short loc_180189CD9
+  .text:0000000180189CC8                 xor     eax, eax
+  .text:0000000180189CCA                 movss   dword ptr [rsi+280h], xmm0
+  .text:0000000180189CD2                 mov     [rsi+278h], rax
+  .text:0000000180189CD9                 add     rsp, 140h
+  .text:0000000180189CE0                 pop     rsi
+  .text:0000000180189CE1                 retn
+procedure: |-
+  void *__fastcall CBaseEntity_SetStateChanged(__int64 a1, __int64 a2)
+  {
+    __int64 v4; // rax
+    int v5; // ebx
+    char *v6; // r14
+    char *v7; // rcx
+    __int64 v8; // rax
+    char *v9; // r8
+    __int64 v10; // rax
+    int v11; // ecx
+    void *result; // rax
+    float v13; // xmm0_4
+    int v14; // [rsp+20h] [rbp-128h]
+    _BYTE v15[280]; // [rsp+30h] [rbp-118h] BYREF
+
+    if ( *(_DWORD *)a2 )
+    {
+      CNetworkTransmitComponent_StateChanged(a1 + 56, a1, a2);  // 56 = 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+    }
+    else if ( !*(_BYTE *)(a1 + 448) )
+    {
+      v4 = *(_QWORD *)(a1 + 72);
+      if ( v4 && *(_BYTE *)(v4 + 24) )
+      {
+        *(_BYTE *)(a1 + 445) = 1;
+      }
+      else
+      {
+        v5 = *(_DWORD *)(a2 + 48);
+        v6 = Src;
+        v7 = Src;
+        if ( *(_QWORD *)(a2 + 40) )
+          v7 = *(char **)(a2 + 40);
+        v8 = V_UnqualifiedFileName(v7);
+        v14 = v5;
+        v9 = Src;
+        if ( *(_QWORD *)(a2 + 32) )
+          v9 = *(char **)(a2 + 32);
+        v10 = sub_18017E2C0(v15, "CNetworkTransmitComponent::StateChanged(%s) @%s:%d", v9, v8, v14);
+        v11 = *(_DWORD *)(v10 + 4);
+        if ( (v11 & 0x40000000) != 0 )
+        {
+          v6 = (char *)(v10 + 8);
+        }
+        else if ( (v11 & 0x3FFFFFFF) != 0 )
+        {
+          v6 = *(char **)(v10 + 8);
+        }
+        sub_1801C7EF0(a1 + 56, v6);  // 56 = 0x38 = CBaseEntity::m_NetworkTransmitComponent (structmember, struct=CBaseEntity, member=m_NetworkTransmitComponent)
+        CBufferString::Purge((CBufferString *)v15, 0);
+        _InterlockedOr((volatile signed __int32 *)(a1 + 440), 3u);
+        *(_WORD *)(a1 + 470) = 0;
+      }
+    }
+    result = off_181C4FC68;
+    v13 = *((float *)off_181C4FC68 + 12);
+    if ( v13 > *(float *)(a1 + 640) )
+    {
+      *(float *)(a1 + 640) = v13;
+      *(_QWORD *)(a1 + 632) = 0;
+      return nullptr;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CNetworkTransmitComponent_StateChanged.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CNetworkTransmitComponent_StateChanged.linux.yaml
@@ -1,0 +1,745 @@
+func_name: CNetworkTransmitComponent_StateChanged
+func_va: '0xa0b210'
+disasm_code: |-
+  .text:0000000000A0B210                 cmp     byte ptr [rdi+2E0h], 0
+  .text:0000000000A0B217                 jnz     locret_A0B410
+  .text:0000000000A0B21D                 push    rbp
+  .text:0000000000A0B21E                 mov     rbp, rsp
+  .text:0000000000A0B221                 push    r15
+  .text:0000000000A0B223                 push    r14
+  .text:0000000000A0B225                 mov     r14, rdx
+  .text:0000000000A0B228                 push    r13
+  .text:0000000000A0B22A                 push    r12
+  .text:0000000000A0B22C                 mov     r12, rsi
+  .text:0000000000A0B22F                 push    rbx
+  .text:0000000000A0B230                 sub     rsp, 168h
+  .text:0000000000A0B237                 mov     rdx, [rsi+10h]
+  .text:0000000000A0B23B                 mov     eax, [rdx+30h]
+  .text:0000000000A0B23E                 test    ah, 3
+  .text:0000000000A0B241                 jnz     loc_A0B400
+  .text:0000000000A0B247                 mov     rbx, rdi
+  .text:0000000000A0B24A                 test    ah, 8
+  .text:0000000000A0B24D                 jnz     loc_A0B750
+  .text:0000000000A0B253                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000000A0B257                 jz      loc_A0B400
+  .text:0000000000A0B25D                 movzx   eax, word ptr [rdx+10h]
+  .text:0000000000A0B261                 and     ax, 7FFFh
+  .text:0000000000A0B265                 cmp     ax, 3FFFh
+  .text:0000000000A0B269                 ja      loc_A0B400
+  .text:0000000000A0B26F                 mov     rax, [rbx+10h]
+  .text:0000000000A0B273                 test    rax, rax
+  .text:0000000000A0B276                 jz      short loc_A0B282
+  .text:0000000000A0B278                 cmp     byte ptr [rax+18h], 0
+  .text:0000000000A0B27C                 jnz     loc_A0B790
+  .text:0000000000A0B282                 cmp     cs:byte_2444C15, 0
+  .text:0000000000A0B289                 jz      loc_A0B3F8
+  .text:0000000000A0B28F                 movzx   r15d, cs:byte_2444C14
+  .text:0000000000A0B297                 test    r15b, r15b
+  .text:0000000000A0B29A                 jz      loc_A0B3F8
+  .text:0000000000A0B2A0                 mov     edi, cs:dword_2574414
+  .text:0000000000A0B2A6                 test    edi, edi
+  .text:0000000000A0B2A8                 jg      loc_A0B418
+  .text:0000000000A0B2AE                 mov     eax, cs:dword_2444C10
+  .text:0000000000A0B2B4                 cmp     eax, 0FFFFFFFEh
+  .text:0000000000A0B2B7                 jz      loc_A0B900
+  .text:0000000000A0B2BD                 cmp     eax, 0FFFFFFFDh
+  .text:0000000000A0B2C0                 jz      loc_A0B418
+  .text:0000000000A0B2C6                 mov     rdi, r12
+  .text:0000000000A0B2C9                 call    sub_1E51490
+  .text:0000000000A0B2CE                 cmp     dword ptr [r14+38h], 0FFFFFFFEh
+  .text:0000000000A0B2D3                 mov     edx, cs:dword_2444C10
+  .text:0000000000A0B2D9                 jz      loc_A0B9F8
+  .text:0000000000A0B2DF                 cmp     eax, edx
+  .text:0000000000A0B2E1                 setz    r15b
+  .text:0000000000A0B2E5                 mov     rcx, [rbx+8]
+  .text:0000000000A0B2E9                 test    rcx, rcx
+  .text:0000000000A0B2EC                 jz      loc_A0B918
+  .text:0000000000A0B2F2                 lea     rax, [rbx+2F4h]
+  .text:0000000000A0B2F9                 mov     rdi, r12
+  .text:0000000000A0B2FC                 mov     [rbp-168h], rcx
+  .text:0000000000A0B303                 mov     [rbp-188h], rax
+  .text:0000000000A0B30A                 mov     eax, [r14+34h]
+  .text:0000000000A0B30E                 mov     [rbp-148h], ax
+  .text:0000000000A0B315                 mov     eax, [r14+38h]
+  .text:0000000000A0B319                 mov     [rbp-14Ch], eax
+  .text:0000000000A0B31F                 call    sub_1E51490
+  .text:0000000000A0B324                 mov     r13, [r14+10h]
+  .text:0000000000A0B328                 mov     [rbp-17Ch], eax
+  .text:0000000000A0B32E                 lea     rax, qword_2700F88
+  .text:0000000000A0B335                 mov     rax, [rax]
+  .text:0000000000A0B338                 prefetcht0 byte ptr [rax]
+  .text:0000000000A0B33B                 movsxd  rax, dword ptr [r14+8]
+  .text:0000000000A0B33F                 mov     qword ptr [rbp-158h], 0
+  .text:0000000000A0B34A                 lea     r11, [r13+rax*4+0]
+  .text:0000000000A0B34F                 cmp     r11, r13
+  .text:0000000000A0B352                 jz      loc_A0B400
+  .text:0000000000A0B358                 mov     rcx, [rbp-168h]
+  .text:0000000000A0B35F                 mov     r14, r13
+  .text:0000000000A0B362                 mov     [rbp-168h], r11
+  .text:0000000000A0B369                 mov     [rbp-178h], r12
+  .text:0000000000A0B370                 mov     [rbp-170h], rcx
+  .text:0000000000A0B377                 jmp     short loc_A0B396
+  .text:0000000000A0B380                 test    r15b, r15b
+  .text:0000000000A0B383                 jnz     loc_A0B760
+  .text:0000000000A0B389                 add     r14, 4
+  .text:0000000000A0B38D                 cmp     [rbp-168h], r14
+  .text:0000000000A0B394                 jz      short loc_A0B400
+  .text:0000000000A0B396                 mov     eax, [r14]
+  .text:0000000000A0B399                 mov     [rbp-150h], eax
+  .text:0000000000A0B39F                 mov     eax, [rbx+2D8h]  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B3A5                 test    al, 2
+  .text:0000000000A0B3A7                 jnz     short loc_A0B380
+  .text:0000000000A0B3A9                 mov     rsi, [rbp-170h]
+  .text:0000000000A0B3B0                 lea     r12, [rbp-150h]
+  .text:0000000000A0B3B7                 mov     rdi, rbx
+  .text:0000000000A0B3BA                 mov     rdx, r12
+  .text:0000000000A0B3BD                 call    sub_9F8240
+  .text:0000000000A0B3C2                 test    al, al
+  .text:0000000000A0B3C4                 jz      loc_A0B578
+  .text:0000000000A0B3CA                 test    r15b, r15b
+  .text:0000000000A0B3CD                 jz      short loc_A0B389
+  .text:0000000000A0B3CF                 lea     r8, aIgnored; " ignored"
+  .text:0000000000A0B3D6                 mov     rdx, [rbp-170h]
+  .text:0000000000A0B3DD                 mov     rcx, r12
+  .text:0000000000A0B3E0                 mov     rdi, rbx
+  .text:0000000000A0B3E3                 mov     rsi, [rbp-178h]
+  .text:0000000000A0B3EA                 call    sub_A0ACC0
+  .text:0000000000A0B3EF                 jmp     short loc_A0B389
+  .text:0000000000A0B3F8                 lock or dword ptr [rbx+2D8h], 2  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B400                 lea     rsp, [rbp-28h]
+  .text:0000000000A0B404                 pop     rbx
+  .text:0000000000A0B405                 pop     r12
+  .text:0000000000A0B407                 pop     r13
+  .text:0000000000A0B409                 pop     r14
+  .text:0000000000A0B40B                 pop     r15
+  .text:0000000000A0B40D                 pop     rbp
+  .text:0000000000A0B40E                 retn
+  .text:0000000000A0B410                 retn
+  .text:0000000000A0B418                 cmp     dword ptr [r14+38h], 0FFFFFFFEh
+  .text:0000000000A0B41D                 jnz     loc_A0B2E5
+  .text:0000000000A0B423                 mov     rcx, [r14+10h]
+  .text:0000000000A0B427                 lea     r13, [rbp-150h]
+  .text:0000000000A0B42E                 mov     qword ptr [rbp-150h], 0
+  .text:0000000000A0B439                 movsxd  rax, dword ptr [r14+8]
+  .text:0000000000A0B43D                 lea     rax, [rcx+rax*4]
+  .text:0000000000A0B441                 cmp     rcx, rax
+  .text:0000000000A0B444                 jz      loc_A0B4C7
+  .text:0000000000A0B44A                 mov     [rbp-168h], rbx
+  .text:0000000000A0B451                 lea     r13, [rbp-150h]
+  .text:0000000000A0B458                 mov     rbx, rcx
+  .text:0000000000A0B45B                 mov     r15, rax
+  .text:0000000000A0B45E                 lea     r12, [rbp-140h]
+  .text:0000000000A0B465                 nop     dword ptr [rax]
+  .text:0000000000A0B468                 mov     edx, [rbx]
+  .text:0000000000A0B46A                 lea     rsi, aU_1; "%u,"
+  .text:0000000000A0B471                 mov     rdi, r12
+  .text:0000000000A0B474                 xor     eax, eax
+  .text:0000000000A0B476                 call    sub_9A70A0
+  .text:0000000000A0B47B                 lea     rsi, [rbp-138h]
+  .text:0000000000A0B482                 test    byte ptr [rbp-139h], 40h
+  .text:0000000000A0B489                 jnz     short loc_A0B4A5
+  .text:0000000000A0B48B                 lea     rsi, haystack
+  .text:0000000000A0B492                 test    dword ptr [rbp-13Ch], 3FFFFFFFh
+  .text:0000000000A0B49C                 jz      short loc_A0B4A5
+  .text:0000000000A0B49E                 ; _QWORD
+  .text:0000000000A0B49E                 mov     rsi, [rbp-138h]; _QWORD
+  .text:0000000000A0B4A5                 ; _QWORD
+  .text:0000000000A0B4A5                 mov     rdi, r13; _QWORD
+  .text:0000000000A0B4A8                 add     rbx, 4
+  .text:0000000000A0B4AC                 call    __ZN10CUtlStringpLEPKc; CUtlString::operator+=(char const*)
+  .text:0000000000A0B4B1                 ; int
+  .text:0000000000A0B4B1                 xor     esi, esi; int
+  .text:0000000000A0B4B3                 ; this
+  .text:0000000000A0B4B3                 mov     rdi, r12; this
+  .text:0000000000A0B4B6                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:0000000000A0B4BB                 cmp     r15, rbx
+  .text:0000000000A0B4BE                 jnz     short loc_A0B468
+  .text:0000000000A0B4C0                 mov     rbx, [rbp-168h]
+  .text:0000000000A0B4C7                 lea     rsi, asc_87F8CC; ","
+  .text:0000000000A0B4CE                 ; this
+  .text:0000000000A0B4CE                 mov     rdi, r13; this
+  .text:0000000000A0B4D1                 call    __ZN10CUtlString9TrimRightEPKc; CUtlString::TrimRight(char const*)
+  .text:0000000000A0B4D6                 lea     r12, dword_2701020
+  .text:0000000000A0B4DD                 ; _QWORD
+  .text:0000000000A0B4DD                 mov     esi, 2; _QWORD
+  .text:0000000000A0B4E2                 ; _QWORD
+  .text:0000000000A0B4E2                 mov     edi, [r12]; _QWORD
+  .text:0000000000A0B4E6                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000000A0B4EB                 test    al, al
+  .text:0000000000A0B4ED                 jz      short loc_A0B559
+  .text:0000000000A0B4EF                 lea     rax, haystack
+  .text:0000000000A0B4F6                 mov     rdx, [rbx+2E8h]
+  .text:0000000000A0B4FD                 ; _QWORD
+  .text:0000000000A0B4FD                 mov     esi, 2; _QWORD
+  .text:0000000000A0B502                 mov     rcx, [rbp-150h]
+  .text:0000000000A0B509                 mov     r9d, [r14+8]
+  .text:0000000000A0B50D                 mov     rdi, [rdx+10h]
+  .text:0000000000A0B511                 test    rcx, rcx
+  .text:0000000000A0B514                 cmovz   rcx, rax
+  .text:0000000000A0B518                 mov     rdx, [rdi+20h]
+  .text:0000000000A0B51C                 test    rdx, rdx
+  .text:0000000000A0B51F                 cmovnz  rax, rdx
+  .text:0000000000A0B523                 mov     r8, rax
+  .text:0000000000A0B526                 call    sub_9E9470
+  .text:0000000000A0B52B                 ; _QWORD
+  .text:0000000000A0B52B                 mov     edi, [r12]; _QWORD
+  .text:0000000000A0B52F                 mov     edx, eax
+  .text:0000000000A0B531                 and     edx, 7FFFh
+  .text:0000000000A0B537                 cmp     eax, 0FFFFFFFFh
+  .text:0000000000A0B53A                 mov     eax, 7FFFh
+  .text:0000000000A0B53F                 cmovnz  eax, edx
+  .text:0000000000A0B542                 sub     rsp, 8
+  .text:0000000000A0B546                 push    rcx
+  .text:0000000000A0B547                 lea     rdx, aDSDOffsetSSAre; "%d %s [%d] offset(s) %s are culled\n"
+  .text:0000000000A0B54E                 mov     ecx, eax
+  .text:0000000000A0B550                 xor     eax, eax
+  .text:0000000000A0B552                 call    _LoggingSystem_Log
+  .text:0000000000A0B557                 pop     rcx
+  .text:0000000000A0B558                 pop     rsi
+  .text:0000000000A0B559                 cmp     qword ptr [rbp-150h], 0
+  .text:0000000000A0B561                 jz      loc_A0B400
+  .text:0000000000A0B567                 ; this
+  .text:0000000000A0B567                 mov     rdi, r13; this
+  .text:0000000000A0B56A                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:0000000000A0B56F                 jmp     loc_A0B400
+  .text:0000000000A0B578                 lock or dword ptr [rbx+2D8h], 1  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B580                 lea     rax, qword_2700F88
+  .text:0000000000A0B587                 mov     esi, 0FFFFFFFFh
+  .text:0000000000A0B58C                 lea     rdi, qword_25744F0
+  .text:0000000000A0B593                 mov     rax, [rax]
+  .text:0000000000A0B596                 movzx   r13d, word ptr ds:stru_23E380.r_offset[rax]
+  .text:0000000000A0B59E                 call    sub_1B10F70
+  .text:0000000000A0B5A3                 test    rax, rax
+  .text:0000000000A0B5A6                 jz      loc_A0B830
+  .text:0000000000A0B5AC                 movzx   eax, byte ptr [rax]
+  .text:0000000000A0B5AF                 test    al, al
+  .text:0000000000A0B5B1                 jz      loc_A0B677
+  .text:0000000000A0B5B7                 mov     eax, cs:dword_25744A0
+  .text:0000000000A0B5BD                 cmp     r13d, eax
+  .text:0000000000A0B5C0                 jz      short loc_A0B5D2
+  .text:0000000000A0B5C2                 cmp     eax, 0FFFFFFFFh
+  .text:0000000000A0B5C5                 jnz     loc_A0B7E0
+  .text:0000000000A0B5CB                 mov     cs:dword_25744A0, r13d
+  .text:0000000000A0B5D2                 mov     ecx, [rbp-150h]
+  .text:0000000000A0B5D8                 lea     r13, [rbp-140h]
+  .text:0000000000A0B5DF                 xor     eax, eax
+  .text:0000000000A0B5E1                 mov     edx, [rbp-17Ch]
+  .text:0000000000A0B5E7                 lea     rsi, aDDDD_0; "%d %d %d %d\n"
+  .text:0000000000A0B5EE                 mov     rdi, r13
+  .text:0000000000A0B5F1                 mov     r9d, [rbp-14Ch]
+  .text:0000000000A0B5F8                 movsx   r8d, word ptr [rbp-148h]
+  .text:0000000000A0B600                 call    sub_9A70A0
+  .text:0000000000A0B605                 lea     rcx, [rbp-138h]
+  .text:0000000000A0B60C                 test    byte ptr [rbp-139h], 40h
+  .text:0000000000A0B613                 jnz     short loc_A0B62C
+  .text:0000000000A0B615                 lea     rcx, haystack
+  .text:0000000000A0B61C                 test    dword ptr [rbp-13Ch], 3FFFFFFFh
+  .text:0000000000A0B626                 jnz     loc_A0B7D0
+  .text:0000000000A0B62C                 cmp     cs:byte_25744A4, 0
+  .text:0000000000A0B633                 jnz     loc_A0B7BA
+  .text:0000000000A0B639                 mov     rsi, cs:qword_2574498
+  .text:0000000000A0B640                 mov     cs:byte_25744A4, 1
+  .text:0000000000A0B647                 test    rsi, rsi
+  .text:0000000000A0B64A                 jz      loc_A0B7A0
+  .text:0000000000A0B650                 lea     rax, qword_274C230
+  .text:0000000000A0B657                 lea     rdx, aS_27; "%s"
+  .text:0000000000A0B65E                 mov     rdi, [rax]
+  .text:0000000000A0B661                 xor     eax, eax
+  .text:0000000000A0B663                 mov     r8, [rdi]
+  .text:0000000000A0B666                 call    qword ptr [r8+1C0h]
+  .text:0000000000A0B66D                 ; int
+  .text:0000000000A0B66D                 xor     esi, esi; int
+  .text:0000000000A0B66F                 ; this
+  .text:0000000000A0B66F                 mov     rdi, r13; this
+  .text:0000000000A0B672                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:0000000000A0B677                 cmp     qword ptr [rbp-158h], 0
+  .text:0000000000A0B67F                 jz      loc_A0B878
+  .text:0000000000A0B685                 mov     edx, [rbx+2E4h]
+  .text:0000000000A0B68B                 test    edx, edx
+  .text:0000000000A0B68D                 js      loc_A0B840
+  .text:0000000000A0B693                 mov     rax, [rbp-158h]
+  .text:0000000000A0B69A                 mov     rsi, r12
+  .text:0000000000A0B69D                 lea     rdi, [rax+8]
+  .text:0000000000A0B6A1                 call    sub_9FB960
+  .text:0000000000A0B6A6                 test    al, al
+  .text:0000000000A0B6A8                 jnz     short loc_A0B6E0
+  .text:0000000000A0B6AA                 xor     eax, eax
+  .text:0000000000A0B6AC                 cmp     cs:byte_2574410, 0
+  .text:0000000000A0B6B3                 mov     [rbx+2F6h], ax
+  .text:0000000000A0B6BA                 jz      short loc_A0B6D8
+  .text:0000000000A0B6BC                 mov     eax, [rbx+2D8h]  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B6C2                 test    al, 2
+  .text:0000000000A0B6C4                 jnz     short loc_A0B6D8
+  .text:0000000000A0B6C6                 lea     rsi, aCnetworktransm_2; "CNetworkTransmitComponent::StateChanged"...
+  .text:0000000000A0B6CD                 mov     rdi, rbx
+  .text:0000000000A0B6D0                 call    sub_9EBF40
+  .text:0000000000A0B6D5                 nop     dword ptr [rax]
+  .text:0000000000A0B6D8                 lock or dword ptr [rbx+2D8h], 2  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B6E0                 lea     r8, haystack
+  .text:0000000000A0B6E7                 test    r15b, r15b
+  .text:0000000000A0B6EA                 jnz     loc_A0B3D6
+  .text:0000000000A0B6F0                 cmp     cs:byte_2574412, 0
+  .text:0000000000A0B6F7                 jz      loc_A0B389
+  .text:0000000000A0B6FD                 mov     rax, [rbp-178h]
+  .text:0000000000A0B704                 lea     rsi, [rbp-140h]
+  .text:0000000000A0B70B                 xor     r8d, r8d
+  .text:0000000000A0B70E                 mov     rdi, rbx
+  .text:0000000000A0B711                 mov     rax, [rax+10h]
+  .text:0000000000A0B715                 mov     rdx, [rax+8]
+  .text:0000000000A0B719                 mov     rcx, [rdx+0D8h]
+  .text:0000000000A0B720                 mov     rdx, [rdx+0E0h]
+  .text:0000000000A0B727                 mov     [rbp-140h], rcx
+  .text:0000000000A0B72E                 mov     rcx, r12
+  .text:0000000000A0B731                 mov     [rbp-138h], rdx
+  .text:0000000000A0B738                 mov     rax, [rax+8]
+  .text:0000000000A0B73C                 mov     rax, [rax+50h]
+  .text:0000000000A0B740                 mov     rdx, [rax+8]
+  .text:0000000000A0B744                 call    sub_A09940
+  .text:0000000000A0B749                 jmp     loc_A0B389
+  .text:0000000000A0B750                 test    al, 40h
+  .text:0000000000A0B752                 jnz     loc_A0B26F
+  .text:0000000000A0B758                 jmp     loc_A0B400
+  .text:0000000000A0B760                 mov     rsi, [rbp-170h]
+  .text:0000000000A0B767                 lea     r12, [rbp-150h]
+  .text:0000000000A0B76E                 mov     rdi, rbx
+  .text:0000000000A0B771                 mov     rdx, r12
+  .text:0000000000A0B774                 call    sub_9F8240
+  .text:0000000000A0B779                 lea     r8, aIgnoredFlFullE; " ignored FL_FULL_EDICT_CHANGED"
+  .text:0000000000A0B780                 test    al, al
+  .text:0000000000A0B782                 jz      loc_A0B389
+  .text:0000000000A0B788                 jmp     loc_A0B3D6
+  .text:0000000000A0B790                 mov     byte ptr [rbx+2DDh], 1
+  .text:0000000000A0B797                 jmp     loc_A0B400
+  .text:0000000000A0B7A0                 lea     rdi, qword_2574480
+  .text:0000000000A0B7A7                 mov     [rbp-190h], rcx
+  .text:0000000000A0B7AE                 call    sub_9EA7C0
+  .text:0000000000A0B7B3                 mov     rcx, [rbp-190h]
+  .text:0000000000A0B7BA                 mov     rsi, cs:qword_2574498
+  .text:0000000000A0B7C1                 test    rsi, rsi
+  .text:0000000000A0B7C4                 jnz     loc_A0B650
+  .text:0000000000A0B7CA                 jmp     loc_A0B66D
+  .text:0000000000A0B7D0                 mov     rcx, [rbp-138h]
+  .text:0000000000A0B7D7                 jmp     loc_A0B62C
+  .text:0000000000A0B7E0                 cmp     cs:byte_25744A4, 0
+  .text:0000000000A0B7E7                 jnz     loc_A0B8E1
+  .text:0000000000A0B7ED                 mov     rsi, cs:qword_2574498
+  .text:0000000000A0B7F4                 mov     cs:byte_25744A4, 1
+  .text:0000000000A0B7FB                 test    rsi, rsi
+  .text:0000000000A0B7FE                 jz      loc_A0B8D5
+  .text:0000000000A0B804                 lea     rax, qword_274C230
+  .text:0000000000A0B80B                 lea     rcx, aTick; "tick\n"
+  .text:0000000000A0B812                 lea     rdx, aS_27; "%s"
+  .text:0000000000A0B819                 mov     rdi, [rax]
+  .text:0000000000A0B81C                 xor     eax, eax
+  .text:0000000000A0B81E                 mov     r8, [rdi]
+  .text:0000000000A0B821                 call    qword ptr [r8+1C0h]
+  .text:0000000000A0B828                 jmp     loc_A0B5CB
+  .text:0000000000A0B830                 mov     rax, cs:qword_25744F8
+  .text:0000000000A0B837                 mov     rax, [rax+8]
+  .text:0000000000A0B83B                 jmp     loc_A0B5AC
+  .text:0000000000A0B840                 lea     rdi, qword_2574420
+  .text:0000000000A0B847                 mov     esi, 0FFFFFFFFh
+  .text:0000000000A0B84C                 call    sub_1B10F70
+  .text:0000000000A0B851                 test    rax, rax
+  .text:0000000000A0B854                 jz      short loc_A0B860
+  .text:0000000000A0B856                 mov     edx, [rax]
+  .text:0000000000A0B858                 jmp     loc_A0B693
+  .text:0000000000A0B860                 mov     rax, cs:qword_2574428
+  .text:0000000000A0B867                 mov     rax, [rax+8]
+  .text:0000000000A0B86B                 mov     edx, [rax]
+  .text:0000000000A0B86D                 jmp     loc_A0B693
+  .text:0000000000A0B878                 mov     rdx, [rbp-170h]
+  .text:0000000000A0B87F                 lea     rcx, [rbp-158h]
+  .text:0000000000A0B886                 mov     rdi, rbx
+  .text:0000000000A0B889                 mov     rsi, [rbp-188h]
+  .text:0000000000A0B890                 call    sub_9F8620
+  .text:0000000000A0B895                 test    al, al
+  .text:0000000000A0B897                 jnz     loc_A0B685
+  .text:0000000000A0B89D                 xor     edx, edx
+  .text:0000000000A0B89F                 cmp     cs:byte_2574410, 0
+  .text:0000000000A0B8A6                 mov     [rbx+2F6h], dx
+  .text:0000000000A0B8AD                 jz      loc_A0B6D8
+  .text:0000000000A0B8B3                 mov     eax, [rbx+2D8h]  ; 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:0000000000A0B8B9                 test    al, 2
+  .text:0000000000A0B8BB                 jnz     loc_A0B6D8
+  .text:0000000000A0B8C1                 lea     rsi, aCnetworktransm_3; "CNetworkTransmitComponent::StateChanged"...
+  .text:0000000000A0B8C8                 mov     rdi, rbx
+  .text:0000000000A0B8CB                 call    sub_9EBF40
+  .text:0000000000A0B8D0                 jmp     loc_A0B6D8
+  .text:0000000000A0B8D5                 lea     rdi, qword_2574480
+  .text:0000000000A0B8DC                 call    sub_9EA7C0
+  .text:0000000000A0B8E1                 mov     rsi, cs:qword_2574498
+  .text:0000000000A0B8E8                 test    rsi, rsi
+  .text:0000000000A0B8EB                 jnz     loc_A0B804
+  .text:0000000000A0B8F1                 jmp     loc_A0B5CB
+  .text:0000000000A0B900                 xor     r15d, r15d
+  .text:0000000000A0B903                 cmp     dword ptr [r14+38h], 0FFFFFFFEh
+  .text:0000000000A0B908                 jnz     loc_A0B2E5
+  .text:0000000000A0B90E                 jmp     loc_A0B400
+  .text:0000000000A0B918                 ; _QWORD
+  .text:0000000000A0B918                 mov     edi, 180h; _QWORD
+  .text:0000000000A0B91D                 call    __Znwm; operator new(ulong)
+  .text:0000000000A0B922                 lea     r13, [rax+38h]
+  .text:0000000000A0B926                 mov     rcx, rax
+  .text:0000000000A0B929                 mov     rax, 400000000h
+  .text:0000000000A0B933                 mov     [rcx], rax
+  .text:0000000000A0B936                 mov     rax, 8000000000000004h
+  .text:0000000000A0B940                 mov     qword ptr [rcx+18h], 0
+  .text:0000000000A0B948                 mov     qword ptr [rcx+28h], 0
+  .text:0000000000A0B950                 mov     [rcx+30h], rax
+  .text:0000000000A0B954                 test    cl, 7
+  .text:0000000000A0B957                 jnz     loc_A0BA05
+  .text:0000000000A0B95D                 pcmpeqd xmm0, xmm0
+  .text:0000000000A0B961                 mov     [rcx+28h], r13
+  .text:0000000000A0B965                 mov     dword ptr [rcx+20h], 0
+  .text:0000000000A0B96C                 mov     qword ptr [rcx+0E0h], 0
+  .text:0000000000A0B977                 movups  xmmword ptr [rcx+60h], xmm0
+  .text:0000000000A0B97B                 movups  xmmword ptr [rcx+70h], xmm0
+  .text:0000000000A0B97F                 movups  xmmword ptr [rcx+80h], xmm0
+  .text:0000000000A0B986                 movups  xmmword ptr [rcx+90h], xmm0
+  .text:0000000000A0B98D                 movups  xmmword ptr [rcx+0A0h], xmm0
+  .text:0000000000A0B994                 movups  xmmword ptr [rcx+0B0h], xmm0
+  .text:0000000000A0B99B                 movups  xmmword ptr [rcx+0C0h], xmm0
+  .text:0000000000A0B9A2                 movups  xmmword ptr [rcx+0D0h], xmm0
+  .text:0000000000A0B9A9                 mov     qword ptr [rcx+170h], 0
+  .text:0000000000A0B9B4                 movups  xmmword ptr [rcx+0F0h], xmm0
+  .text:0000000000A0B9BB                 movups  xmmword ptr [rcx+100h], xmm0
+  .text:0000000000A0B9C2                 movups  xmmword ptr [rcx+110h], xmm0
+  .text:0000000000A0B9C9                 movups  xmmword ptr [rcx+120h], xmm0
+  .text:0000000000A0B9D0                 movups  xmmword ptr [rcx+130h], xmm0
+  .text:0000000000A0B9D7                 movups  xmmword ptr [rcx+140h], xmm0
+  .text:0000000000A0B9DE                 movups  xmmword ptr [rcx+150h], xmm0
+  .text:0000000000A0B9E5                 movups  xmmword ptr [rcx+160h], xmm0
+  .text:0000000000A0B9EC                 mov     [rbx+8], rcx
+  .text:0000000000A0B9F0                 jmp     loc_A0B2F2
+  .text:0000000000A0B9F8                 cmp     eax, edx
+  .text:0000000000A0B9FA                 jnz     loc_A0B400
+  .text:0000000000A0BA00                 jmp     loc_A0B423
+  .text:0000000000A0BA05                 mov     [rbp-168h], rcx
+  .text:0000000000A0BA0C                 call    sub_1B25B60
+  .text:0000000000A0BA11                 mov     rcx, [rbp-168h]
+  .text:0000000000A0BA18                 jmp     loc_A0B95D
+procedure: |-
+  void __fastcall CNetworkTransmitComponent_StateChanged(__int64 a1, __int64 a2, __int64 a3, __int64 a4, int a5, int a6)
+  {
+    __int64 v7; // rdx
+    int v8; // eax
+    __int64 v9; // rbx
+    __int64 v10; // rax
+    char v11; // r15
+    int v12; // eax
+    __int64 v13; // rcx
+    int v14; // eax
+    _DWORD *v15; // r13
+    __int64 v16; // rax
+    __int64 v17; // rcx
+    _DWORD *v18; // r14
+    const char *v19; // r8
+    _DWORD *v20; // rcx
+    _DWORD *v21; // rbx
+    _DWORD *v22; // r15
+    const bool *v23; // rsi
+    const bool *v24; // rax
+    const bool *v25; // rcx
+    __int64 v26; // rdi
+    __int64 v27; // rdx
+    int v28; // r13d
+    _BYTE *v29; // rax
+    const char *v30; // rcx
+    __int64 v31; // rsi
+    bool v32; // zf
+    __int64 v33; // rax
+    __int64 v34; // rdx
+    __int64 v35; // rcx
+    __int64 v36; // rdx
+    char v37; // al
+    __int64 v38; // rsi
+    __int64 v39; // rax
+    __int64 v40; // r13
+    const char *v41; // [rsp-198h] [rbp-198h]
+    int v42; // [rsp-184h] [rbp-184h]
+    __int64 v44; // [rsp-178h] [rbp-178h]
+    __int64 v45; // [rsp-170h] [rbp-170h]
+    _DWORD *v46; // [rsp-170h] [rbp-170h]
+    __int64 v47; // [rsp-170h] [rbp-170h]
+    __int64 v48; // [rsp-160h] [rbp-160h] BYREF
+    const bool *v49; // [rsp-158h] [rbp-158h] BYREF
+    __int16 v50; // [rsp-150h] [rbp-150h]
+    __int64 v51; // [rsp-148h] [rbp-148h] BYREF
+    _QWORD v52[39]; // [rsp-140h] [rbp-140h] BYREF
+    __int64 v53; // [rsp-8h] [rbp-8h] BYREF
+
+    if ( *(_BYTE *)(a1 + 736) )
+      return;
+    v7 = *(_QWORD *)(a2 + 16);
+    v8 = *(_DWORD *)(v7 + 48);
+    if ( (v8 & 0x300) != 0 )
+      return;
+    v9 = a1;
+    if ( (v8 & 0x800) != 0 )
+    {
+      if ( (v8 & 0x40) == 0 )
+        return;
+    }
+    else if ( *(_DWORD *)(v7 + 16) == -1 || (*(_WORD *)(v7 + 16) & 0x7FFFu) > 0x3FFF )
+    {
+      return;
+    }
+    v10 = *(_QWORD *)(a1 + 16);
+    if ( v10 && *(_BYTE *)(v10 + 24) )
+    {
+      *(_BYTE *)(a1 + 733) = 1;
+      return;
+    }
+    if ( !byte_2444C15 || (v11 = byte_2444C14) == 0 )
+    {
+      _InterlockedOr((volatile signed __int32 *)(a1 + 728), 2u);  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+      return;
+    }
+    if ( dword_2574414 <= 0 )
+    {
+      if ( dword_2444C10 == -2 )
+      {
+        v11 = 0;
+        if ( *(_DWORD *)(a3 + 56) == -2 )
+          return;
+        goto LABEL_15;
+      }
+      if ( dword_2444C10 != -3 )
+      {
+        v12 = sub_1E51490(a2, a2, v7);
+        v7 = (unsigned int)dword_2444C10;
+        if ( *(_DWORD *)(a3 + 56) != -2 )
+        {
+          v11 = v12 == dword_2444C10;
+          goto LABEL_15;
+        }
+        if ( v12 != dword_2444C10 )
+          return;
+  LABEL_29:
+        v20 = *(_DWORD **)(a3 + 16);
+        v49 = nullptr;
+        if ( v20 != &v20[*(int *)(a3 + 8)] )
+        {
+          v21 = v20;
+          v22 = &v20[*(int *)(a3 + 8)];
+          do
+          {
+            sub_9A70A0((unsigned int)&v53 - 320, (unsigned int)"%u,", *v21, (_DWORD)v20, a5, a6);
+            v23 = (const bool *)v52;
+            if ( (v51 & 0x4000000000000000LL) == 0 )
+            {
+              v23 = &haystack;
+              if ( (v51 & 0x3FFFFFFF00000000LL) != 0 )
+                v23 = (const bool *)v52[0];
+            }
+            ++v21;
+            CUtlString::operator+=(&v49, v23);
+            CBufferString::Purge((CBufferString *)&v51, 0);
+          }
+          while ( v22 != v21 );
+          v9 = a1;
+        }
+        CUtlString::TrimRight((CUtlString *)&v49, ",");
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_2701020, 2) )
+        {
+          v24 = &haystack;
+          v25 = v49;
+          v26 = *(_QWORD *)(*(_QWORD *)(v9 + 744) + 16LL);
+          if ( !v49 )
+            v25 = &haystack;
+          v27 = *(_QWORD *)(v26 + 32);
+          if ( v27 )
+            v24 = *(const bool **)(v26 + 32);
+          sub_9E9470(v26, 2, v27, v25, v24, *(unsigned int *)(a3 + 8));
+          LoggingSystem_Log((unsigned int)dword_2701020, 2, "%d %s [%d] offset(s) %s are culled\n");
+        }
+        if ( v49 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v49);
+        return;
+      }
+    }
+    if ( *(_DWORD *)(a3 + 56) == -2 )
+      goto LABEL_29;
+  LABEL_15:
+    v13 = *(_QWORD *)(a1 + 8);
+    if ( !v13 )
+    {
+      v39 = operator new(384);
+      v40 = v39 + 56;
+      v13 = v39;
+      *(_QWORD *)v39 = 0x400000000LL;
+      *(_QWORD *)(v39 + 24) = 0;
+      *(_QWORD *)(v39 + 40) = 0;
+      *(_QWORD *)(v39 + 48) = 0x8000000000000004LL;
+      if ( (v39 & 7) != 0 )
+      {
+        v47 = v39;
+        sub_1B25B60(384, a2);
+        v13 = v47;
+      }
+      *(_QWORD *)(v13 + 40) = v40;
+      *(_DWORD *)(v13 + 32) = 0;
+      *(_QWORD *)(v13 + 224) = 0;
+      *(_OWORD *)(v13 + 96) = -1;
+      *(_OWORD *)(v13 + 112) = -1;
+      *(_OWORD *)(v13 + 128) = -1;
+      *(_OWORD *)(v13 + 144) = -1;
+      *(_OWORD *)(v13 + 160) = -1;
+      *(_OWORD *)(v13 + 176) = -1;
+      *(_OWORD *)(v13 + 192) = -1;
+      *(_OWORD *)(v13 + 208) = -1;
+      *(_QWORD *)(v13 + 368) = 0;
+      *(_OWORD *)(v13 + 240) = -1;
+      *(_OWORD *)(v13 + 256) = -1;
+      *(_OWORD *)(v13 + 272) = -1;
+      *(_OWORD *)(v13 + 288) = -1;
+      *(_OWORD *)(v13 + 304) = -1;
+      *(_OWORD *)(v13 + 320) = -1;
+      *(_OWORD *)(v13 + 336) = -1;
+      *(_OWORD *)(v13 + 352) = -1;
+      *(_QWORD *)(a1 + 8) = v13;
+    }
+    v45 = v13;
+    v50 = *(_DWORD *)(a3 + 52);
+    HIDWORD(v49) = *(_DWORD *)(a3 + 56);
+    v14 = sub_1E51490(a2, a2, v7);
+    v15 = *(_DWORD **)(a3 + 16);
+    v42 = v14;
+    _mm_prefetch((const char *)qword_2700F88, 1);
+    v16 = *(int *)(a3 + 8);
+    v48 = 0;
+    if ( &v15[v16] != v15 )
+    {
+      v17 = v45;
+      v18 = v15;
+      v46 = &v15[v16];
+      v44 = v17;
+      while ( 1 )
+      {
+        LODWORD(v49) = *v18;
+        if ( (*(_DWORD *)(a1 + 728) & 2) != 0 )  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+        {
+          if ( !v11 )
+            goto LABEL_19;
+          v37 = sub_9F8240(a1, v44, &v49);
+          v19 = " ignored FL_FULL_EDICT_CHANGED";
+          if ( !v37 )
+            goto LABEL_19;
+          goto LABEL_24;
+        }
+        if ( !(unsigned __int8)sub_9F8240(a1, v44, &v49) )
+          break;
+        if ( v11 )
+        {
+          v19 = " ignored";
+  LABEL_24:
+          sub_A0ACC0(a1, a2, v44, &v49, v19);
+        }
+  LABEL_19:
+        if ( v46 == ++v18 )
+          return;
+      }
+      _InterlockedOr((volatile signed __int32 *)(a1 + 728), 1u);  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+      v28 = *(unsigned __int16 *)((char *)&stru_23E380.r_offset + qword_2700F88);
+      v29 = (_BYTE *)sub_1B10F70(&qword_25744F0, 0xFFFFFFFFLL);
+      if ( !v29 )
+        v29 = *(_BYTE **)(qword_25744F8 + 8);
+      if ( !*v29 )
+      {
+  LABEL_57:
+        if ( v48 || (unsigned __int8)sub_9F8620(a1, a1 + 756, v44, &v48) )
+        {
+          if ( *(int *)(a1 + 740) < 0 )
+            sub_1B10F70(&qword_2574420, 0xFFFFFFFFLL);
+          if ( (unsigned __int8)sub_9FB960(v48 + 8, &v49) )
+          {
+  LABEL_65:
+            v19 = (const char *)&haystack;
+            if ( !v11 )
+            {
+              if ( byte_2574412 )
+              {
+                v33 = *(_QWORD *)(a2 + 16);
+                v34 = *(_QWORD *)(v33 + 8);
+                v35 = *(_QWORD *)(v34 + 216);
+                v36 = *(_QWORD *)(v34 + 224);
+                v51 = v35;
+                v52[0] = v36;
+                sub_A09940(a1, &v51, *(_QWORD *)(*(_QWORD *)(*(_QWORD *)(v33 + 8) + 80LL) + 8LL), &v49, 0);
+              }
+              goto LABEL_19;
+            }
+            goto LABEL_24;
+          }
+          v32 = byte_2574410 == 0;
+          *(_WORD *)(a1 + 758) = 0;
+          if ( !v32 && (*(_DWORD *)(a1 + 728) & 2) == 0 )  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+            sub_9EBF40(a1, "CNetworkTransmitComponent::StateChanged( overflowed offsets )");
+        }
+        else
+        {
+          v32 = byte_2574410 == 0;
+          *(_WORD *)(a1 + 758) = 0;
+          if ( !v32 && (*(_DWORD *)(a1 + 728) & 2) == 0 )  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+            sub_9EBF40(a1, "CNetworkTransmitComponent::StateChanged( overflowed shared changeinfos )");
+        }
+        _InterlockedOr((volatile signed __int32 *)(a1 + 728), 2u);  // 728 = 0x2D8 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+        goto LABEL_65;
+      }
+      if ( v28 == dword_25744A0 )
+      {
+  LABEL_50:
+        sub_9A70A0((unsigned int)&v51, (unsigned int)"%d %d %d %d\n", v42, (_DWORD)v49, v50, HIDWORD(v49));
+        v30 = (const char *)v52;
+        if ( (v51 & 0x4000000000000000LL) == 0 )
+        {
+          v30 = (const char *)&haystack;
+          if ( (v51 & 0x3FFFFFFF00000000LL) != 0 )
+            v30 = (const char *)v52[0];
+        }
+        if ( !byte_25744A4 )
+        {
+          v31 = qword_2574498;
+          byte_25744A4 = 1;
+          if ( qword_2574498 )
+          {
+  LABEL_55:
+            (*(void (**)(_QWORD *, __int64, const char *, ...))(*qword_274C230 + 448LL))(qword_274C230, v31, "%s", v30);
+  LABEL_56:
+            CBufferString::Purge((CBufferString *)&v51, 0);
+            goto LABEL_57;
+          }
+          v41 = v30;
+          sub_9EA7C0(&qword_2574480);
+          v30 = v41;
+        }
+        v31 = qword_2574498;
+        if ( !qword_2574498 )
+          goto LABEL_56;
+        goto LABEL_55;
+      }
+      if ( dword_25744A0 == -1 )
+      {
+  LABEL_49:
+        dword_25744A0 = v28;
+        goto LABEL_50;
+      }
+      if ( !byte_25744A4 )
+      {
+        v38 = qword_2574498;
+        byte_25744A4 = 1;
+        if ( qword_2574498 )
+        {
+  LABEL_78:
+          (*(void (**)(_QWORD *, __int64, const char *, ...))(*qword_274C230 + 448LL))(qword_274C230, v38, "%s", "tick\n");
+          goto LABEL_49;
+        }
+        sub_9EA7C0(&qword_2574480);
+      }
+      v38 = qword_2574498;
+      if ( !qword_2574498 )
+        goto LABEL_49;
+      goto LABEL_78;
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CNetworkTransmitComponent_StateChanged.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CNetworkTransmitComponent_StateChanged.windows.yaml
@@ -1,0 +1,770 @@
+func_name: CNetworkTransmitComponent_StateChanged
+func_va: '0x1801cd220'
+disasm_code: |-
+  .text:00000001801CD220                 push    rbp
+  .text:00000001801CD222                 push    rsi
+  .text:00000001801CD223                 push    rdi
+  .text:00000001801CD224                 push    r13
+  .text:00000001801CD226                 lea     rbp, [rsp-98h]
+  .text:00000001801CD22E                 sub     rsp, 198h
+  .text:00000001801CD235                 cmp     byte ptr [rcx+188h], 0
+  .text:00000001801CD23C                 mov     rsi, r8
+  .text:00000001801CD23F                 mov     r13, rdx
+  .text:00000001801CD242                 mov     rdi, rcx
+  .text:00000001801CD245                 jnz     loc_1801CD926
+  .text:00000001801CD24B                 mov     rcx, [rdx+10h]
+  .text:00000001801CD24F                 mov     eax, [rcx+30h]
+  .text:00000001801CD252                 test    eax, 300h
+  .text:00000001801CD257                 jnz     loc_1801CD926
+  .text:00000001801CD25D                 bt      eax, 0Bh
+  .text:00000001801CD261                 jnb     short loc_1801CD26A
+  .text:00000001801CD263                 shr     eax, 6
+  .text:00000001801CD266                 and     al, 1
+  .text:00000001801CD268                 jmp     short loc_1801CD290
+  .text:00000001801CD26A                 test    rcx, rcx
+  .text:00000001801CD26D                 jz      short loc_1801CD27E
+  .text:00000001801CD26F                 cmp     dword ptr [rcx+10h], 0FFFFFFFFh
+  .text:00000001801CD273                 mov     eax, 7FFFh
+  .text:00000001801CD278                 cmovnz  eax, [rcx+10h]
+  .text:00000001801CD27C                 jmp     short loc_1801CD283
+  .text:00000001801CD27E                 mov     eax, 0FFFFFFFFh
+  .text:00000001801CD283                 and     eax, 7FFFh
+  .text:00000001801CD288                 cmp     eax, 4000h
+  .text:00000001801CD28D                 setb    al
+  .text:00000001801CD290                 test    al, al
+  .text:00000001801CD292                 jz      loc_1801CD926
+  .text:00000001801CD298                 mov     rax, [rdi+10h]
+  .text:00000001801CD29C                 test    rax, rax
+  .text:00000001801CD29F                 jz      short loc_1801CD2BB
+  .text:00000001801CD2A1                 cmp     byte ptr [rax+18h], 0
+  .text:00000001801CD2A5                 jz      short loc_1801CD2BB
+  .text:00000001801CD2A7                 mov     byte ptr [rdi+185h], 1
+  .text:00000001801CD2AE                 add     rsp, 198h
+  .text:00000001801CD2B5                 pop     r13
+  .text:00000001801CD2B7                 pop     rdi
+  .text:00000001801CD2B8                 pop     rsi
+  .text:00000001801CD2B9                 pop     rbp
+  .text:00000001801CD2BA                 retn
+  .text:00000001801CD2BB                 cmp     cs:byte_181B71F24, 0
+  .text:00000001801CD2C2                 jz      loc_1801CD933
+  .text:00000001801CD2C8                 cmp     cs:byte_181B71F25, 0
+  .text:00000001801CD2CF                 jz      loc_1801CD933
+  .text:00000001801CD2D5                 mov     [rsp+1B0h+arg_8], rbx
+  .text:00000001801CD2DD                 mov     rcx, rdi
+  .text:00000001801CD2E0                 mov     [rsp+1B0h+var_28], r14
+  .text:00000001801CD2E8                 mov     [rsp+1B0h+var_30], r15
+  .text:00000001801CD2F0                 call    sub_1801CCA00
+  .text:00000001801CD2F5                 cmp     dword ptr [rsi+38h], 0FFFFFFFEh
+  .text:00000001801CD2F9                 movzx   ebx, al
+  .text:00000001801CD2FC                 mov     byte ptr [rbp+0B0h+arg_0], al
+  .text:00000001801CD302                 jnz     loc_1801CD47C
+  .text:00000001801CD308                 test    al, al
+  .text:00000001801CD30A                 jz      loc_1801CD90E
+  .text:00000001801CD310                 mov     rbx, [rsi+10h]
+  .text:00000001801CD314                 lea     r15, Src
+  .text:00000001801CD31B                 movsxd  rax, dword ptr [rsi+8]
+  .text:00000001801CD31F                 mov     [rbp+0B0h+arg_0], 0
+  .text:00000001801CD32A                 lea     r14, [rbx+rax*4]
+  .text:00000001801CD32E                 cmp     rbx, r14
+  .text:00000001801CD331                 jz      short loc_1801CD397
+  .text:00000001801CD333                 nop     dword ptr [rax+00h]
+  .text:00000001801CD337                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001801CD340                 mov     r8d, [rbx]
+  .text:00000001801CD343                 lea     rdx, aU_0; "%u,"
+  .text:00000001801CD34A                 lea     rcx, [rsp+1B0h+var_140]
+  .text:00000001801CD34F                 call    sub_18017E2C0
+  .text:00000001801CD354                 mov     ecx, [rax+4]
+  .text:00000001801CD357                 bt      ecx, 1Eh
+  .text:00000001801CD35B                 jnb     short loc_1801CD363
+  .text:00000001801CD35D                 lea     rdx, [rax+8]
+  .text:00000001801CD361                 jmp     short loc_1801CD374
+  .text:00000001801CD363                 test    ecx, 3FFFFFFFh
+  .text:00000001801CD369                 jbe     short loc_1801CD371
+  .text:00000001801CD36B                 mov     rdx, [rax+8]
+  .text:00000001801CD36F                 jmp     short loc_1801CD374
+  .text:00000001801CD371                 mov     rdx, r15
+  .text:00000001801CD374                 lea     rcx, [rbp+0B0h+arg_0]
+  .text:00000001801CD37B                 call    cs:??YCUtlString@@QEAAAEAV0@PEBD@Z; CUtlString::operator+=(char const *)
+  .text:00000001801CD381                 xor     edx, edx
+  .text:00000001801CD383                 lea     rcx, [rsp+1B0h+var_140]
+  .text:00000001801CD388                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001801CD38E                 add     rbx, 4
+  .text:00000001801CD392                 cmp     rbx, r14
+  .text:00000001801CD395                 jnz     short loc_1801CD340
+  .text:00000001801CD397                 lea     rdx, asc_1815A88A8; ","
+  .text:00000001801CD39E                 lea     rcx, [rbp+0B0h+arg_0]
+  .text:00000001801CD3A5                 call    cs:?TrimRight@CUtlString@@QEAAXPEBD@Z; CUtlString::TrimRight(char const *)
+  .text:00000001801CD3AB                 mov     ecx, cs:dword_181F7F918
+  .text:00000001801CD3B1                 mov     edx, 2
+  .text:00000001801CD3B6                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001801CD3BC                 test    al, al
+  .text:00000001801CD3BE                 jz      loc_1801CD45C
+  .text:00000001801CD3C4                 mov     rax, [rbp+0B0h+arg_0]
+  .text:00000001801CD3CB                 mov     r8, r15
+  .text:00000001801CD3CE                 mov     r10d, [rsi+8]
+  .text:00000001801CD3D2                 test    rax, rax
+  .text:00000001801CD3D5                 cmovnz  r8, rax
+  .text:00000001801CD3D9                 mov     rax, [rdi+190h]
+  .text:00000001801CD3E0                 mov     rcx, [rax+10h]
+  .text:00000001801CD3E4                 mov     rax, [rcx+20h]
+  .text:00000001801CD3E8                 test    rax, rax
+  .text:00000001801CD3EB                 cmovnz  r15, rax
+  .text:00000001801CD3EF                 test    rcx, rcx
+  .text:00000001801CD3F2                 jz      short loc_1801CD42F
+  .text:00000001801CD3F4                 mov     edx, [rcx+10h]
+  .text:00000001801CD3F7                 mov     r9d, edx
+  .text:00000001801CD3FA                 mov     eax, [rcx+30h]
+  .text:00000001801CD3FD                 mov     ecx, 7FFFh
+  .text:00000001801CD402                 shr     r9d, 0Fh
+  .text:00000001801CD406                 and     eax, 1
+  .text:00000001801CD409                 sub     r9d, eax
+  .text:00000001801CD40C                 mov     eax, edx
+  .text:00000001801CD40E                 and     eax, 7FFFh
+  .text:00000001801CD413                 shl     r9d, 0Fh
+  .text:00000001801CD417                 cmp     edx, 0FFFFFFFFh
+  .text:00000001801CD41A                 cmovnz  ecx, eax
+  .text:00000001801CD41D                 or      r9d, ecx
+  .text:00000001801CD420                 cmp     r9d, 0FFFFFFFFh
+  .text:00000001801CD424                 jz      short loc_1801CD42F
+  .text:00000001801CD426                 and     r9d, 7FFFh
+  .text:00000001801CD42D                 jmp     short loc_1801CD435
+  .text:00000001801CD42F                 mov     r9d, 7FFFh
+  .text:00000001801CD435                 mov     ecx, cs:dword_181F7F918
+  .text:00000001801CD43B                 mov     edx, 2
+  .text:00000001801CD440                 mov     [rsp+1B0h+var_180], r8
+  .text:00000001801CD445                 lea     r8, aDSDOffsetSSAre; "%d %s [%d] offset(s) %s are culled\n"
+  .text:00000001801CD44C                 mov     dword ptr [rsp+1B0h+var_188], r10d
+  .text:00000001801CD451                 mov     [rsp+1B0h+var_190], r15
+  .text:00000001801CD456                 call    cs:LoggingSystem_Log
+  .text:00000001801CD45C                 cmp     [rbp+0B0h+arg_0], 0
+  .text:00000001801CD464                 jz      loc_1801CD90E
+  .text:00000001801CD46A                 lea     rcx, [rbp+0B0h+arg_0]
+  .text:00000001801CD471                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:00000001801CD477                 jmp     loc_1801CD90E
+  .text:00000001801CD47C                 mov     rcx, rdi
+  .text:00000001801CD47F                 mov     [rsp+1B0h+var_20], r12
+  .text:00000001801CD487                 call    sub_180184630
+  .text:00000001801CD48C                 movzx   ecx, word ptr [rsi+34h]
+  .text:00000001801CD490                 lea     rdx, [rbp+0B0h+arg_18]
+  .text:00000001801CD497                 mov     [rsp+1B0h+var_168], cx
+  .text:00000001801CD49C                 mov     r14, rax
+  .text:00000001801CD49F                 mov     ecx, [rsi+38h]
+  .text:00000001801CD4A2                 mov     [rsp+1B0h+var_16C], ecx
+  .text:00000001801CD4A6                 mov     rcx, r13
+  .text:00000001801CD4A9                 call    sub_181213DB0
+  .text:00000001801CD4AE                 mov     rcx, cs:qword_181F805B0
+  .text:00000001801CD4B5                 mov     eax, [rax]
+  .text:00000001801CD4B7                 mov     [rbp+0B0h+arg_18], eax
+  .text:00000001801CD4BD                 prefetcht0 byte ptr [rcx]
+  .text:00000001801CD4C0                 mov     r12, [rsi+10h]
+  .text:00000001801CD4C4                 movsxd  rax, dword ptr [rsi+8]
+  .text:00000001801CD4C8                 mov     [rsp+1B0h+var_160], 0
+  .text:00000001801CD4D1                 lea     rax, [r12+rax*4]
+  .text:00000001801CD4D5                 mov     [rsp+1B0h+var_158], rax
+  .text:00000001801CD4DA                 cmp     r12, rax
+  .text:00000001801CD4DD                 jz      loc_1801CD906
+  .text:00000001801CD4E3                 lea     r15, Src
+  .text:00000001801CD4EA                 xor     esi, esi
+  .text:00000001801CD4EC                 nop     dword ptr [rax+00h]
+  .text:00000001801CD4F0                 mov     eax, [r12]
+  .text:00000001801CD4F4                 mov     [rsp+1B0h+var_170], eax
+  .text:00000001801CD4F8                 mov     eax, [rdi+180h]  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD4FE                 test    al, 2
+  .text:00000001801CD500                 jz      short loc_1801CD546
+  .text:00000001801CD502                 test    bl, bl
+  .text:00000001801CD504                 jz      loc_1801CD8F7
+  .text:00000001801CD50A                 lea     r8, [rsp+1B0h+var_170]
+  .text:00000001801CD50F                 mov     rdx, r14
+  .text:00000001801CD512                 mov     rcx, rdi
+  .text:00000001801CD515                 call    sub_1801CB830
+  .text:00000001801CD51A                 test    al, al
+  .text:00000001801CD51C                 jz      loc_1801CD8F7
+  .text:00000001801CD522                 lea     rax, aIgnoredFlFullE; " ignored FL_FULL_EDICT_CHANGED"
+  .text:00000001801CD529                 mov     [rsp+1B0h+var_190], rax
+  .text:00000001801CD52E                 lea     r9, [rsp+1B0h+var_170]
+  .text:00000001801CD533                 mov     r8, r14
+  .text:00000001801CD536                 mov     rdx, r13
+  .text:00000001801CD539                 mov     rcx, rdi
+  .text:00000001801CD53C                 call    sub_1801D0000
+  .text:00000001801CD541                 jmp     loc_1801CD8F7
+  .text:00000001801CD546                 lea     r8, [rsp+1B0h+var_170]
+  .text:00000001801CD54B                 mov     rdx, r14
+  .text:00000001801CD54E                 mov     rcx, rdi
+  .text:00000001801CD551                 call    sub_1801CB830
+  .text:00000001801CD556                 test    al, al
+  .text:00000001801CD558                 jz      short loc_1801CD56B
+  .text:00000001801CD55A                 test    bl, bl
+  .text:00000001801CD55C                 jz      loc_1801CD8F7
+  .text:00000001801CD562                 lea     rax, aIgnored; " ignored"
+  .text:00000001801CD569                 jmp     short loc_1801CD529
+  .text:00000001801CD56B                 lock or dword ptr [rdi+180h], 1  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD573                 mov     rax, cs:qword_181F805B0
+  .text:00000001801CD57A                 lea     rcx, unk_181D9E9E0
+  .text:00000001801CD581                 mov     edx, 0FFFFFFFFh
+  .text:00000001801CD586                 movzx   ebx, word ptr [rax+23E380h]
+  .text:00000001801CD58D                 call    sub_1814E69B0
+  .text:00000001801CD592                 test    rax, rax
+  .text:00000001801CD595                 jnz     short loc_1801CD5A2
+  .text:00000001801CD597                 mov     rax, cs:qword_181D9E9E8
+  .text:00000001801CD59E                 mov     rax, [rax+8]
+  .text:00000001801CD5A2                 cmp     [rax], sil
+  .text:00000001801CD5A5                 jz      loc_1801CD6A3
+  .text:00000001801CD5AB                 mov     eax, cs:dword_181B756A8
+  .text:00000001801CD5B1                 cmp     ebx, eax
+  .text:00000001801CD5B3                 jz      short loc_1801CD606
+  .text:00000001801CD5B5                 cmp     eax, 0FFFFFFFFh
+  .text:00000001801CD5B8                 jz      short loc_1801CD600
+  .text:00000001801CD5BA                 cmp     cs:byte_181B756AC, sil
+  .text:00000001801CD5C1                 jnz     short loc_1801CD5D6
+  .text:00000001801CD5C3                 lea     rcx, off_181B75688
+  .text:00000001801CD5CA                 mov     cs:byte_181B756AC, 1
+  .text:00000001801CD5D1                 call    sub_1801C4410
+  .text:00000001801CD5D6                 mov     rdx, cs:qword_181B756A0
+  .text:00000001801CD5DD                 test    rdx, rdx
+  .text:00000001801CD5E0                 jz      short loc_1801CD600
+  .text:00000001801CD5E2                 mov     rcx, cs:g_pFileSystem
+  .text:00000001801CD5E9                 lea     r9, aTick_0; "tick\n"
+  .text:00000001801CD5F0                 lea     r8, aS_1; "%s"
+  .text:00000001801CD5F7                 mov     rax, [rcx]
+  .text:00000001801CD5FA                 call    qword ptr [rax+1C8h]
+  .text:00000001801CD600                 mov     cs:dword_181B756A8, ebx
+  .text:00000001801CD606                 movsx   ecx, [rsp+1B0h+var_168]
+  .text:00000001801CD60B                 lea     rdx, aDDDD_0; "%d %d %d %d\n"
+  .text:00000001801CD612                 mov     eax, [rsp+1B0h+var_16C]
+  .text:00000001801CD616                 mov     r9d, [rsp+1B0h+var_170]
+  .text:00000001801CD61B                 mov     r8d, [rbp+0B0h+arg_18]
+  .text:00000001801CD622                 mov     dword ptr [rsp+1B0h+var_188], eax
+  .text:00000001801CD626                 mov     dword ptr [rsp+1B0h+var_190], ecx
+  .text:00000001801CD62A                 lea     rcx, [rsp+1B0h+var_140]
+  .text:00000001801CD62F                 call    sub_18017E2C0
+  .text:00000001801CD634                 mov     ecx, [rax+4]
+  .text:00000001801CD637                 bt      ecx, 1Eh
+  .text:00000001801CD63B                 jnb     short loc_1801CD643
+  .text:00000001801CD63D                 lea     rbx, [rax+8]
+  .text:00000001801CD641                 jmp     short loc_1801CD654
+  .text:00000001801CD643                 test    ecx, 3FFFFFFFh
+  .text:00000001801CD649                 jbe     short loc_1801CD651
+  .text:00000001801CD64B                 mov     rbx, [rax+8]
+  .text:00000001801CD64F                 jmp     short loc_1801CD654
+  .text:00000001801CD651                 mov     rbx, r15
+  .text:00000001801CD654                 cmp     cs:byte_181B756AC, sil
+  .text:00000001801CD65B                 jnz     short loc_1801CD670
+  .text:00000001801CD65D                 lea     rcx, off_181B75688
+  .text:00000001801CD664                 mov     cs:byte_181B756AC, 1
+  .text:00000001801CD66B                 call    sub_1801C4410
+  .text:00000001801CD670                 mov     rdx, cs:qword_181B756A0
+  .text:00000001801CD677                 test    rdx, rdx
+  .text:00000001801CD67A                 jz      short loc_1801CD696
+  .text:00000001801CD67C                 mov     rcx, cs:g_pFileSystem
+  .text:00000001801CD683                 lea     r8, aS_1; "%s"
+  .text:00000001801CD68A                 mov     r9, rbx
+  .text:00000001801CD68D                 mov     rax, [rcx]
+  .text:00000001801CD690                 call    qword ptr [rax+1C8h]
+  .text:00000001801CD696                 xor     edx, edx
+  .text:00000001801CD698                 lea     rcx, [rsp+1B0h+var_140]
+  .text:00000001801CD69D                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001801CD6A3                 mov     rbx, [rsp+1B0h+var_160]
+  .text:00000001801CD6A8                 test    rbx, rbx
+  .text:00000001801CD6AB                 jnz     loc_1801CD781
+  .text:00000001801CD6B1                 lea     r9, [rsp+1B0h+var_160]
+  .text:00000001801CD6B6                 mov     r8, r14
+  .text:00000001801CD6B9                 lea     rdx, [rdi+19Ch]
+  .text:00000001801CD6C0                 mov     rcx, rdi
+  .text:00000001801CD6C3                 call    sub_1801BB7C0
+  .text:00000001801CD6C8                 test    al, al
+  .text:00000001801CD6CA                 jnz     loc_1801CD77C
+  .text:00000001801CD6D0                 mov     [rdi+19Eh], si
+  .text:00000001801CD6D7                 cmp     cs:byte_181DA061A, sil
+  .text:00000001801CD6DE                 jz      loc_1801CD88E
+  .text:00000001801CD6E4                 mov     eax, [rdi+180h]  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD6EA                 test    al, 2
+  .text:00000001801CD6EC                 jnz     loc_1801CD88E
+  .text:00000001801CD6F2                 mov     ecx, cs:dword_181F7F918
+  .text:00000001801CD6F8                 mov     edx, 2
+  .text:00000001801CD6FD                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001801CD703                 test    al, al
+  .text:00000001801CD705                 jz      loc_1801CD88E
+  .text:00000001801CD70B                 mov     rax, [rdi+190h]
+  .text:00000001801CD712                 mov     r9, r15
+  .text:00000001801CD715                 mov     rcx, [rax+10h]
+  .text:00000001801CD719                 mov     rax, [rcx+20h]
+  .text:00000001801CD71D                 test    rax, rax
+  .text:00000001801CD720                 cmovnz  r9, rax
+  .text:00000001801CD724                 test    rcx, rcx
+  .text:00000001801CD727                 jz      short loc_1801CD766
+  .text:00000001801CD729                 mov     r8d, [rcx+10h]
+  .text:00000001801CD72D                 mov     edx, 7FFFh
+  .text:00000001801CD732                 mov     ecx, [rcx+30h]
+  .text:00000001801CD735                 mov     eax, r8d
+  .text:00000001801CD738                 and     ecx, 1
+  .text:00000001801CD73B                 shr     eax, 0Fh
+  .text:00000001801CD73E                 sub     eax, ecx
+  .text:00000001801CD740                 mov     [rsp+1B0h+var_188], r9
+  .text:00000001801CD745                 shl     eax, 0Fh
+  .text:00000001801CD748                 lea     r9, aCnetworktransm_2; "CNetworkTransmitComponent::StateChanged"...
+  .text:00000001801CD74F                 mov     ecx, r8d
+  .text:00000001801CD752                 and     ecx, 7FFFh
+  .text:00000001801CD758                 cmp     r8d, 0FFFFFFFFh
+  .text:00000001801CD75C                 cmovnz  edx, ecx
+  .text:00000001801CD75F                 or      eax, edx
+  .text:00000001801CD761                 jmp     loc_1801CD85F
+  .text:00000001801CD766                 mov     [rsp+1B0h+var_188], r9
+  .text:00000001801CD76B                 mov     eax, 0FFFFFFFFh
+  .text:00000001801CD770                 lea     r9, aCnetworktransm_2; "CNetworkTransmitComponent::StateChanged"...
+  .text:00000001801CD777                 jmp     loc_1801CD85F
+  .text:00000001801CD77C                 mov     rbx, [rsp+1B0h+var_160]
+  .text:00000001801CD781                 mov     r8d, [rdi+18Ch]
+  .text:00000001801CD788                 test    r8d, r8d
+  .text:00000001801CD78B                 jns     short loc_1801CD7B1
+  .text:00000001801CD78D                 mov     edx, 0FFFFFFFFh
+  .text:00000001801CD792                 lea     rcx, unk_181D9EA68
+  .text:00000001801CD799                 call    sub_1814E69B0
+  .text:00000001801CD79E                 test    rax, rax
+  .text:00000001801CD7A1                 jnz     short loc_1801CD7AE
+  .text:00000001801CD7A3                 mov     rax, cs:qword_181D9EA70
+  .text:00000001801CD7AA                 mov     rax, [rax+8]
+  .text:00000001801CD7AE                 mov     r8d, [rax]
+  .text:00000001801CD7B1                 lea     rcx, [rbx+8]
+  .text:00000001801CD7B5                 lea     rdx, [rsp+1B0h+var_170]
+  .text:00000001801CD7BA                 call    sub_1801B3E50
+  .text:00000001801CD7BF                 test    al, al
+  .text:00000001801CD7C1                 jnz     loc_1801CD896
+  .text:00000001801CD7C7                 mov     [rdi+19Eh], si
+  .text:00000001801CD7CE                 cmp     cs:byte_181DA061A, sil
+  .text:00000001801CD7D5                 jz      loc_1801CD88E
+  .text:00000001801CD7DB                 mov     eax, [rdi+180h]  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD7E1                 test    al, 2
+  .text:00000001801CD7E3                 jnz     loc_1801CD88E
+  .text:00000001801CD7E9                 mov     ecx, cs:dword_181F7F918
+  .text:00000001801CD7EF                 mov     edx, 2
+  .text:00000001801CD7F4                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001801CD7FA                 test    al, al
+  .text:00000001801CD7FC                 jz      loc_1801CD88E
+  .text:00000001801CD802                 mov     rax, [rdi+190h]
+  .text:00000001801CD809                 mov     r9, r15
+  .text:00000001801CD80C                 mov     rcx, [rax+10h]
+  .text:00000001801CD810                 mov     rax, [rcx+20h]
+  .text:00000001801CD814                 test    rax, rax
+  .text:00000001801CD817                 cmovnz  r9, rax
+  .text:00000001801CD81B                 test    rcx, rcx
+  .text:00000001801CD81E                 jz      short loc_1801CD84E
+  .text:00000001801CD820                 mov     r8d, [rcx+10h]
+  .text:00000001801CD824                 mov     edx, 7FFFh
+  .text:00000001801CD829                 mov     ecx, [rcx+30h]
+  .text:00000001801CD82C                 mov     eax, r8d
+  .text:00000001801CD82F                 and     ecx, 1
+  .text:00000001801CD832                 shr     eax, 0Fh
+  .text:00000001801CD835                 sub     eax, ecx
+  .text:00000001801CD837                 mov     ecx, r8d
+  .text:00000001801CD83A                 and     ecx, 7FFFh
+  .text:00000001801CD840                 shl     eax, 0Fh
+  .text:00000001801CD843                 cmp     r8d, 0FFFFFFFFh
+  .text:00000001801CD847                 cmovnz  edx, ecx
+  .text:00000001801CD84A                 or      eax, edx
+  .text:00000001801CD84C                 jmp     short loc_1801CD853
+  .text:00000001801CD84E                 mov     eax, 0FFFFFFFFh
+  .text:00000001801CD853                 mov     [rsp+1B0h+var_188], r9
+  .text:00000001801CD858                 lea     r9, aCnetworktransm_3; "CNetworkTransmitComponent::StateChanged"...
+  .text:00000001801CD85F                 mov     ecx, eax
+  .text:00000001801CD861                 lea     r8, aSDSBeingMarked; "%s:  %d %s being marked full change\n"
+  .text:00000001801CD868                 and     ecx, 7FFFh
+  .text:00000001801CD86E                 mov     edx, 7FFFh
+  .text:00000001801CD873                 cmp     eax, 0FFFFFFFFh
+  .text:00000001801CD876                 cmovnz  edx, ecx
+  .text:00000001801CD879                 mov     ecx, cs:dword_181F7F918
+  .text:00000001801CD87F                 mov     dword ptr [rsp+1B0h+var_190], edx
+  .text:00000001801CD883                 mov     edx, 2
+  .text:00000001801CD888                 call    cs:LoggingSystem_Log
+  .text:00000001801CD88E                 lock or dword ptr [rdi+180h], 2  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD896                 movzx   ebx, byte ptr [rbp+0B0h+arg_0]
+  .text:00000001801CD89D                 test    bl, bl
+  .text:00000001801CD89F                 jz      short loc_1801CD8AB
+  .text:00000001801CD8A1                 mov     [rsp+1B0h+var_190], r15
+  .text:00000001801CD8A6                 jmp     loc_1801CD52E
+  .text:00000001801CD8AB                 cmp     cs:byte_181DA0618, sil
+  .text:00000001801CD8B2                 jz      short loc_1801CD8F7
+  .text:00000001801CD8B4                 mov     rdx, [r13+10h]
+  .text:00000001801CD8B8                 lea     r9, [rsp+1B0h+var_170]
+  .text:00000001801CD8BD                 mov     [rsp+1B0h+var_190], rsi
+  .text:00000001801CD8C2                 mov     rcx, [rdx+8]
+  .text:00000001801CD8C6                 mov     rax, [rcx+0D8h]
+  .text:00000001801CD8CD                 mov     [rsp+1B0h+var_150], rax
+  .text:00000001801CD8D2                 mov     rax, [rcx+0E0h]
+  .text:00000001801CD8D9                 mov     rcx, rdi
+  .text:00000001801CD8DC                 mov     [rsp+1B0h+var_148], rax
+  .text:00000001801CD8E1                 mov     rax, [rdx+8]
+  .text:00000001801CD8E5                 lea     rdx, [rsp+1B0h+var_150]
+  .text:00000001801CD8EA                 mov     r8, [rax+50h]
+  .text:00000001801CD8EE                 mov     r8, [r8+8]
+  .text:00000001801CD8F2                 call    sub_1801CF560
+  .text:00000001801CD8F7                 add     r12, 4
+  .text:00000001801CD8FB                 cmp     r12, [rsp+1B0h+var_158]
+  .text:00000001801CD900                 jnz     loc_1801CD4F0
+  .text:00000001801CD906                 mov     r12, [rsp+1B0h+var_20]
+  .text:00000001801CD90E                 mov     r14, [rsp+1B0h+var_28]
+  .text:00000001801CD916                 mov     r15, [rsp+1B0h+var_30]
+  .text:00000001801CD91E                 mov     rbx, [rsp+1B0h+arg_8]
+  .text:00000001801CD926                 add     rsp, 198h
+  .text:00000001801CD92D                 pop     r13
+  .text:00000001801CD92F                 pop     rdi
+  .text:00000001801CD930                 pop     rsi
+  .text:00000001801CD931                 pop     rbp
+  .text:00000001801CD932                 retn
+  .text:00000001801CD933                 lock or dword ptr [rdi+180h], 2  ; 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+  .text:00000001801CD93B                 add     rsp, 198h
+  .text:00000001801CD942                 pop     r13
+  .text:00000001801CD944                 pop     rdi
+  .text:00000001801CD945                 pop     rsi
+  .text:00000001801CD946                 pop     rbp
+  .text:00000001801CD947                 retn
+procedure: |-
+  void __fastcall CNetworkTransmitComponent_StateChanged(__int64 a1, __int64 a2, __int64 a3)
+  {
+    __int64 v6; // rcx
+    int v7; // eax
+    bool v8; // al
+    int v9; // eax
+    __int64 v10; // rax
+    char v11; // al
+    bool v12; // zf
+    char v13; // bl
+    _DWORD *v14; // rbx
+    const char *v15; // r15
+    __int64 v16; // rax
+    _DWORD *i; // r14
+    __int64 v18; // rax
+    int v19; // ecx
+    char *v20; // rdx
+    const char *v21; // r8
+    __int64 v22; // rcx
+    unsigned int v23; // edx
+    int v24; // eax
+    int v25; // ecx
+    int v26; // r9d
+    __int64 v27; // rax
+    __int64 v28; // r14
+    int *v29; // r12
+    __int64 v30; // rax
+    const char *v31; // rax
+    int v32; // ebx
+    _BYTE *v33; // rax
+    __int64 v34; // rax
+    int v35; // ecx
+    char *v36; // rbx
+    __int64 v37; // rbx
+    char *v38; // r9
+    __int64 v39; // rcx
+    unsigned int v40; // r8d
+    int v41; // edx
+    const char *v42; // r9
+    int v43; // eax
+    char *v44; // r9
+    __int64 v45; // rcx
+    unsigned int v46; // r8d
+    int v47; // edx
+    int v48; // edx
+    __int64 v49; // rdx
+    __int64 v50; // rcx
+    __int64 v51; // [rsp+20h] [rbp-E0h]
+    char *v52; // [rsp+28h] [rbp-D8h]
+    int v53; // [rsp+40h] [rbp-C0h] BYREF
+    int v54; // [rsp+44h] [rbp-BCh]
+    __int16 v55; // [rsp+48h] [rbp-B8h]
+    __int64 v56; // [rsp+50h] [rbp-B0h] BYREF
+    int *v57; // [rsp+58h] [rbp-A8h]
+    _QWORD v58[2]; // [rsp+60h] [rbp-A0h] BYREF
+    _BYTE v59[272]; // [rsp+70h] [rbp-90h] BYREF
+    const char *v60; // [rsp+1C0h] [rbp+C0h] BYREF
+    int v61; // [rsp+1D8h] [rbp+D8h] BYREF
+
+    if ( !*(_BYTE *)(a1 + 392) )
+    {
+      v6 = *(_QWORD *)(a2 + 16);
+      v7 = *(_DWORD *)(v6 + 48);
+      if ( (v7 & 0x300) == 0 )
+      {
+        if ( (v7 & 0x800) != 0 )
+        {
+          v8 = (*(_DWORD *)(v6 + 48) & 0x40) != 0;
+        }
+        else
+        {
+          if ( v6 )
+          {
+            LOWORD(v9) = 0x7FFF;
+            if ( *(_DWORD *)(v6 + 16) != -1 )
+              v9 = *(_DWORD *)(v6 + 16);
+          }
+          else
+          {
+            LOWORD(v9) = -1;
+          }
+          v8 = (v9 & 0x7FFFu) < 0x4000;
+        }
+        if ( v8 )
+        {
+          v10 = *(_QWORD *)(a1 + 16);
+          if ( v10 && *(_BYTE *)(v10 + 24) )
+          {
+            *(_BYTE *)(a1 + 389) = 1;
+            return;
+          }
+          if ( !byte_181B71F24 || !byte_181B71F25 )
+          {
+            _InterlockedOr((volatile signed __int32 *)(a1 + 384), 2u);  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+            return;
+          }
+          v11 = sub_1801CCA00(a1);
+          v12 = *(_DWORD *)(a3 + 56) == -2;
+          v13 = v11;
+          LOBYTE(v60) = v11;
+          if ( v12 )
+          {
+            if ( v11 )
+            {
+              v14 = *(_DWORD **)(a3 + 16);
+              v15 = Src;
+              v16 = *(int *)(a3 + 8);
+              v60 = nullptr;
+              for ( i = &v14[v16]; v14 != i; ++v14 )
+              {
+                v18 = sub_18017E2C0(v59, "%u,", *v14);
+                v19 = *(_DWORD *)(v18 + 4);
+                if ( (v19 & 0x40000000) != 0 )
+                {
+                  v20 = (char *)(v18 + 8);
+                }
+                else if ( (v19 & 0x3FFFFFFF) != 0 )
+                {
+                  v20 = *(char **)(v18 + 8);
+                }
+                else
+                {
+                  v20 = Src;
+                }
+                CUtlString::operator+=(&v60, v20);
+                CBufferString::Purge((CBufferString *)v59, 0);
+              }
+              CUtlString::TrimRight((CUtlString *)&v60, ",");
+              if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F7F918, 2) )
+              {
+                v21 = Src;
+                if ( v60 )
+                  v21 = v60;
+                v22 = *(_QWORD *)(*(_QWORD *)(a1 + 400) + 16LL);
+                if ( *(_QWORD *)(v22 + 32) )
+                  v15 = *(const char **)(v22 + 32);
+                if ( !v22 )
+                  goto LABEL_36;
+                v23 = *(_DWORD *)(v22 + 16);
+                v24 = *(_DWORD *)(v22 + 48);
+                v25 = 0x7FFF;
+                if ( v23 != -1 )
+                  v25 = v23 & 0x7FFF;
+                if ( (v25 | (((v23 >> 15) - (v24 & 1)) << 15)) == 0xFFFFFFFF )
+  LABEL_36:
+                  v26 = 0x7FFF;
+                else
+                  v26 = v25 & 0x7FFF;
+                LoggingSystem_Log(
+                  (unsigned int)dword_181F7F918,
+                  2,
+                  "%d %s [%d] offset(s) %s are culled\n",
+                  v26,
+                  v15,
+                  *(_DWORD *)(a3 + 8),
+                  v21);
+              }
+              if ( v60 )
+                CUtlString::FreeMemoryBlock((CUtlString *)&v60);
+            }
+            return;
+          }
+          v27 = sub_180184630(a1);
+          v55 = *(_WORD *)(a3 + 52);
+          v28 = v27;
+          v54 = *(_DWORD *)(a3 + 56);
+          v61 = *(_DWORD *)sub_181213DB0(a2, &v61);
+          _mm_prefetch((const char *)qword_181F805B0, 1);
+          v29 = *(int **)(a3 + 16);
+          v30 = *(int *)(a3 + 8);
+          v56 = 0;
+          v57 = &v29[v30];
+          if ( v29 == v57 )
+            return;
+          while ( 1 )
+          {
+            v53 = *v29;
+            if ( (*(_DWORD *)(a1 + 384) & 2) != 0 )  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+              break;
+            if ( !(unsigned __int8)sub_1801CB830(a1, v28, &v53) )
+            {
+              _InterlockedOr((volatile signed __int32 *)(a1 + 384), 1u);  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+              v32 = *(unsigned __int16 *)(qword_181F805B0 + 2352000);
+              v33 = (_BYTE *)sub_1814E69B0(&unk_181D9E9E0, 0xFFFFFFFFLL);
+              if ( !v33 )
+                v33 = *(_BYTE **)(qword_181D9E9E8 + 8);
+              if ( *v33 )
+              {
+                if ( v32 != dword_181B756A8 )
+                {
+                  if ( dword_181B756A8 != -1 )
+                  {
+                    if ( !byte_181B756AC )
+                    {
+                      byte_181B756AC = 1;
+                      sub_1801C4410(&off_181B75688);
+                    }
+                    if ( qword_181B756A0 )
+                      (*(void (**)(__int64, __int64, const char *, ...))(*(_QWORD *)g_pFileSystem + 456LL))(
+                        g_pFileSystem,
+                        qword_181B756A0,
+                        "%s",
+                        "tick\n");
+                  }
+                  dword_181B756A8 = v32;
+                }
+                v34 = sub_18017E2C0(v59, "%d %d %d %d\n", v61, v53, v55, v54);
+                v35 = *(_DWORD *)(v34 + 4);
+                if ( (v35 & 0x40000000) != 0 )
+                {
+                  v36 = (char *)(v34 + 8);
+                }
+                else if ( (v35 & 0x3FFFFFFF) != 0 )
+                {
+                  v36 = *(char **)(v34 + 8);
+                }
+                else
+                {
+                  v36 = Src;
+                }
+                if ( !byte_181B756AC )
+                {
+                  byte_181B756AC = 1;
+                  sub_1801C4410(&off_181B75688);
+                }
+                if ( qword_181B756A0 )
+                  (*(void (**)(__int64, __int64, const char *, ...))(*(_QWORD *)g_pFileSystem + 456LL))(
+                    g_pFileSystem,
+                    qword_181B756A0,
+                    "%s",
+                    v36);
+                CBufferString::Purge((CBufferString *)v59, 0);
+              }
+              v37 = v56;
+              if ( !v56 )
+              {
+                if ( !(unsigned __int8)sub_1801BB7C0(a1, a1 + 412, v28, &v56) )
+                {
+                  *(_WORD *)(a1 + 414) = 0;
+                  if ( byte_181DA061A
+                    && (*(_DWORD *)(a1 + 384) & 2) == 0  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+                    && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F7F918, 2) )
+                  {
+                    v38 = Src;
+                    v39 = *(_QWORD *)(*(_QWORD *)(a1 + 400) + 16LL);
+                    if ( *(_QWORD *)(v39 + 32) )
+                      v38 = *(char **)(v39 + 32);
+                    if ( v39 )
+                    {
+                      v40 = *(_DWORD *)(v39 + 16);
+                      v41 = 0x7FFF;
+                      v52 = v38;
+                      v42 = "CNetworkTransmitComponent::StateChanged( overflowed shared changeinfos )";
+                      if ( v40 != -1 )
+                        v41 = v40 & 0x7FFF;
+                      v43 = v41 | (((v40 >> 15) - (*(_DWORD *)(v39 + 48) & 1)) << 15);
+                    }
+                    else
+                    {
+                      v52 = v38;
+                      v43 = -1;
+                      v42 = "CNetworkTransmitComponent::StateChanged( overflowed shared changeinfos )";
+                    }
+                    goto LABEL_96;
+                  }
+                  goto LABEL_99;
+                }
+                v37 = v56;
+              }
+              if ( *(int *)(a1 + 396) < 0 )
+                sub_1814E69B0(&unk_181D9EA68, 0xFFFFFFFFLL);
+              if ( !(unsigned __int8)sub_1801B3E50(v37 + 8, &v53) )
+              {
+                *(_WORD *)(a1 + 414) = 0;
+                if ( byte_181DA061A
+                  && (*(_DWORD *)(a1 + 384) & 2) == 0  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+                  && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F7F918, 2) )
+                {
+                  v44 = Src;
+                  v45 = *(_QWORD *)(*(_QWORD *)(a1 + 400) + 16LL);
+                  if ( *(_QWORD *)(v45 + 32) )
+                    v44 = *(char **)(v45 + 32);
+                  if ( v45 )
+                  {
+                    v46 = *(_DWORD *)(v45 + 16);
+                    v47 = 0x7FFF;
+                    if ( v46 != -1 )
+                      v47 = v46 & 0x7FFF;
+                    v43 = v47 | (((v46 >> 15) - (*(_DWORD *)(v45 + 48) & 1)) << 15);
+                  }
+                  else
+                  {
+                    v43 = -1;
+                  }
+                  v52 = v44;
+                  v42 = "CNetworkTransmitComponent::StateChanged( overflowed offsets )";
+  LABEL_96:
+                  v48 = 0x7FFF;
+                  if ( v43 != -1 )
+                    v48 = v43 & 0x7FFF;
+                  LODWORD(v51) = v48;
+                  LoggingSystem_Log(
+                    (unsigned int)dword_181F7F918,
+                    2,
+                    "%s:  %d %s being marked full change\n",
+                    v42,
+                    v51,
+                    v52);
+                }
+  LABEL_99:
+                _InterlockedOr((volatile signed __int32 *)(a1 + 384), 2u);  // 384 = 0x180 = CNetworkTransmitComponent::m_nStateFlags (structmember, struct=CNetworkTransmitComponent, member=m_nStateFlags)
+              }
+              v13 = (char)v60;
+              if ( (_BYTE)v60 )
+              {
+                sub_1801D0000(a1, a2, v28, (unsigned int)&v53, (__int64)Src);
+              }
+              else if ( byte_181DA0618 )
+              {
+                v49 = *(_QWORD *)(a2 + 16);
+                v50 = *(_QWORD *)(v49 + 8);
+                v58[0] = *(_QWORD *)(v50 + 216);
+                v58[1] = *(_QWORD *)(v50 + 224);
+                sub_1801CF560(
+                  a1,
+                  (unsigned int)v58,
+                  *(_QWORD *)(*(_QWORD *)(*(_QWORD *)(v49 + 8) + 80LL) + 8LL),
+                  (unsigned int)&v53,
+                  0);
+              }
+              goto LABEL_104;
+            }
+            if ( v13 )
+            {
+              v31 = " ignored";
+  LABEL_45:
+              sub_1801D0000(a1, a2, v28, (unsigned int)&v53, (__int64)v31);
+            }
+  LABEL_104:
+            if ( ++v29 == v57 )
+              return;
+          }
+          if ( !v13 || !(unsigned __int8)sub_1801CB830(a1, v28, &v53) )
+            goto LABEL_104;
+          v31 = " ignored FL_FULL_EDICT_CHANGED";
+          goto LABEL_45;
+        }
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- Add four new preprocessor scripts covering `CBaseEntity::m_NetworkTransmitComponent`, `CNetworkTransmitComponent::m_nStateFlags`, `CBaseEntity::FullEdictChanged`, and the inherited `CEntityInstance::FullEdictChanged` slot.
- `find-CBaseEntity_FullEdictChanged` builds its `xref_signatures` at runtime by summing the two struct-member offsets above and patching the 4-byte disp32 into platform templates (`8B 81 ?? ?? ?? ?? D1 E8` / `8B 87 ?? ?? ?? ?? D1 E8`).
- `find-CEntityInstance_FullEdictChanged` is Pattern F slot-only — inherits the vtable slot from `CBaseEntity_FullEdictChanged`, no `func_sig` / `vfunc_sig` needed.

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` — Successful: 3, Failed: 0
- [x] Output YAMLs present for all 4 symbols × 2 platforms
- [x] `CBaseEntity_FullEdictChanged` resolves to vfunc_index 33 (Windows, vfunc_offset 0x108) and 34 (Linux, vfunc_offset 0x110)
- [x] `CEntityInstance_FullEdictChanged` slot-only YAML matches the same indices

🤖 Generated with [Claude Code](https://claude.com/claude-code)