### PR TITLE
Add entity system + save/restore preprocessor scripts and offset_sig_max_match support

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6794,6 +6794,59 @@ modules:
           - CEntitySaveRestoreBlockHandler_SaveInternal.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CreateEntityTransitionList
+        expected_output:
+          - CreateEntityTransitionList.{platform}.yaml
+
+      - name: find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_WriteSaveHeaders.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
+
+      - name: find-CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_ReadRestoreHeaders.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
+          - CEntitySaveRestoreBlockHandler_WriteSaveHeaders.{platform}.yaml
+
+      - name: find-CEntity2SaveRestore_vtable
+        expected_output:
+          - CEntity2SaveRestore_vtable.{platform}.yaml
+
+      - name: find-CEntity2SaveRestore_StreamEntitiesFromFile
+        expected_output:
+          - CEntity2SaveRestore_StreamEntitiesFromFile.{platform}.yaml
+        expected_input:
+          - CEntity2SaveRestore_vtable.{platform}.yaml
+
+      - name: find-CSaveRestoreBlockSet_vtable
+        expected_output:
+          - CSaveRestoreBlockSet_vtable.{platform}.yaml
+
+      - name: find-CEntity2SaveRestore_StreamEntitiesFromFile-decompiles
+        expected_output:
+          - CSaveRestoreBlockSet_PreRestore.{platform}.yaml
+          - CSaveRestoreBlockSet_PostRestore.{platform}.yaml
+        expected_input:
+          - CEntity2SaveRestore_StreamEntitiesFromFile.{platform}.yaml
+          - CSaveRestoreBlockSet_vtable.{platform}.yaml
+
+      - name: find-CEntitySaveRestoreBlockHandler_PreRestore
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_PreRestore.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
+          - CSaveRestoreBlockSet_PreRestore.{platform}.yaml
+
+      - name: find-CEntitySaveRestoreBlockHandler_PostRestore
+        expected_output:
+          - CEntitySaveRestoreBlockHandler_PostRestore.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
+          - CSaveRestoreBlockSet_PostRestore.{platform}.yaml
+
       - name: find-PolymorphicHelper_t__SetPolymorphicPointer
         expected_output:
           - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
@@ -7255,6 +7308,52 @@ modules:
         category: func
         alias:
           - CEntitySaveRestoreBlockHandler::RestoreEntity
+
+      - name: CreateEntityTransitionList
+        category: func
+        alias:
+          - CreateEntityTransitionList
+
+      - name: CEntitySaveRestoreBlockHandler_WriteSaveHeaders
+        category: vfunc
+        alias:
+          - CEntitySaveRestoreBlockHandler::WriteSaveHeaders
+
+      - name: CEntitySaveRestoreBlockHandler_ReadRestoreHeaders
+        category: vfunc
+        alias:
+          - CEntitySaveRestoreBlockHandler::ReadRestoreHeaders
+
+      - name: CEntity2SaveRestore_vtable
+        category: vtable
+
+      - name: CEntity2SaveRestore_StreamEntitiesFromFile
+        category: vfunc
+        alias:
+          - CEntity2SaveRestore::StreamEntitiesFromFile
+
+      - name: CSaveRestoreBlockSet_vtable
+        category: vtable
+
+      - name: CSaveRestoreBlockSet_PreRestore
+        category: vfunc
+        alias:
+          - CSaveRestoreBlockSet::PreRestore
+
+      - name: CSaveRestoreBlockSet_PostRestore
+        category: vfunc
+        alias:
+          - CSaveRestoreBlockSet::PostRestore
+
+      - name: CEntitySaveRestoreBlockHandler_PreRestore
+        category: vfunc
+        alias:
+          - CEntitySaveRestoreBlockHandler::PreRestore
+
+      - name: CEntitySaveRestoreBlockHandler_PostRestore
+        category: vfunc
+        alias:
+          - CEntitySaveRestoreBlockHandler::PostRestore
 
       - name: CEntitySystem_SetInPVS
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -10747,6 +10747,38 @@ cpp_tests:
       - server # bin/{gamever}/server/IGameSystemFactory_*.{platform}.yaml
       - client # bin/{gamever}/client/IGameSystemFactory_*.{platform}.yaml
 
+  - name: CEntitySystem_MSVC
+    symbol: CEntitySystem
+    alias_symbols:
+      - CGameEntitySystem
+    cpp: cpp_tests/centitysystem.cpp
+    headers:
+    - hl2sdk_cs2/public/entity2/entitysystem.h # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/mathlib
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+      - Xclang
+      - fdump-record-layouts
+    reference_modules:
+      - server # bin/{gamever}/server/{CEntitySystem,CGameEntitySystem}_*.{platform}.yaml
+      - client # bin/{gamever}/client/{CEntitySystem,CGameEntitySystem}_*.{platform}.yaml
+
   - name: SDL_Mouse_MSVC
     symbol: SDL_Mouse
     cpp: cpp_tests/SDL_Mouse.cpp

--- a/config.yaml
+++ b/config.yaml
@@ -4674,6 +4674,19 @@ modules:
         expected_input:
           - ScriptBinding_Entity_SetEntityName.{platform}.yaml
 
+      - name: find-CEntitySystem_RemoveEntityFromNameMap-AND-CEntitySystem_AddEntityToNameMap
+        expected_output:
+          - CEntitySystem_RemoveEntityFromNameMap.{platform}.yaml
+          - CEntitySystem_AddEntityToNameMap.{platform}.yaml
+        expected_input:
+          - CEntityIdentity_SetEntityName.{platform}.yaml
+
+      - name: find-CEntitySystem_m_entityNames
+        expected_output:
+          - CEntitySystem_m_entityNames.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityToNameMap.{platform}.yaml
+
       - name: find-ScriptBinding_Entity_SetEntityName
         expected_output:
           - ScriptBinding_Entity_SetEntityName.{platform}.yaml
@@ -7725,6 +7738,16 @@ modules:
         alias:
           - CEntityIdentity::SetEntityName
 
+      - name: CEntitySystem_RemoveEntityFromNameMap
+        category: func
+        alias:
+          - CEntitySystem::RemoveEntityFromNameMap
+
+      - name: CEntitySystem_AddEntityToNameMap
+        category: func
+        alias:
+          - CEntitySystem::AddEntityToNameMap
+
       - name: ScriptBinding_Entity_SetEntityName
         category: func
         alias:
@@ -8177,6 +8200,13 @@ modules:
         member: m_EntityList
         alias:
           - CEntitySystem::m_EntityList
+
+      - name: CEntitySystem_m_entityNames
+        category: structmember
+        struct: CEntitySystem
+        member: m_entityNames
+        alias:
+          - CEntitySystem::m_entityNames
 
       - name: CEntityIdentity_FreeAttributes
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -6840,6 +6840,26 @@ modules:
           - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
           - CSaveRestoreBlockSet_PreRestore.{platform}.yaml
 
+      - name: find-CEntitySystem_ForceSetInPVSCallsIntoQueue
+        expected_output:
+          - CEntitySystem_ForceSetInPVSCallsIntoQueue.{platform}.yaml
+        expected_input:
+          - CEntitySaveRestoreBlockHandler_PreRestore.{platform}.yaml
+
+      - name: find-CEntitySystem_m_nSuppressDormancyChangeCount-AND-CEntitySystem_m_nExecuteQueuedCreationDepth-AND-CEntitySystem_ExecuteQueuedSetInPVS
+        expected_output:
+          - CEntitySystem_m_nSuppressDormancyChangeCount.{platform}.yaml
+          - CEntitySystem_m_nExecuteQueuedCreationDepth.{platform}.yaml
+          - CEntitySystem_ExecuteQueuedSetInPVS.{platform}.yaml
+        expected_input:
+          - CEntitySystem_ForceSetInPVSCallsIntoQueue.{platform}.yaml
+
+      - name: find-CEntitySystem_m_queuedDormancyChanges
+        expected_output:
+          - CEntitySystem_m_queuedDormancyChanges.{platform}.yaml
+        expected_input:
+          - CEntitySystem_ExecuteQueuedSetInPVS.{platform}.yaml
+
       - name: find-CEntitySaveRestoreBlockHandler_PostRestore
         expected_output:
           - CEntitySaveRestoreBlockHandler_PostRestore.{platform}.yaml
@@ -7354,6 +7374,37 @@ modules:
         category: vfunc
         alias:
           - CEntitySaveRestoreBlockHandler::PostRestore
+
+      - name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+        category: func
+        alias:
+          - CEntitySystem::ForceSetInPVSCallsIntoQueue
+
+      - name: CEntitySystem_ExecuteQueuedSetInPVS
+        category: func
+        alias:
+          - CEntitySystem::ExecuteQueuedSetInPVS
+
+      - name: CEntitySystem_m_nSuppressDormancyChangeCount
+        category: structmember
+        struct: CEntitySystem
+        member: m_nSuppressDormancyChangeCount
+        alias:
+          - CEntitySystem::m_nSuppressDormancyChangeCount
+
+      - name: CEntitySystem_m_nExecuteQueuedCreationDepth
+        category: structmember
+        struct: CEntitySystem
+        member: m_nExecuteQueuedCreationDepth
+        alias:
+          - CEntitySystem::m_nExecuteQueuedCreationDepth
+
+      - name: CEntitySystem_m_queuedDormancyChanges
+        category: structmember
+        struct: CEntitySystem
+        member: m_queuedDormancyChanges
+        alias:
+          - CEntitySystem::m_queuedDormancyChanges
 
       - name: CEntitySystem_SetInPVS
         category: func

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -1026,11 +1026,20 @@ def _get_preprocessor_scripts_dir():
     return Path(__file__).resolve().parent / "ida_preprocessor_scripts"
 
 
-def _resolve_llm_decompile_template_value(value, platform):
+def _derive_module_name(new_binary_dir):
+    if not new_binary_dir:
+        return ""
+    return os.path.basename(os.path.normpath(str(new_binary_dir)))
+
+
+def _resolve_llm_decompile_template_value(value, platform, module_name=None):
     resolved = str(value or "")
     platform_text = str(platform or "").strip()
     if platform_text:
         resolved = resolved.replace("{platform}", platform_text)
+    module_text = str(module_name or "").strip()
+    if module_text:
+        resolved = resolved.replace("{module_name}", module_text)
     return resolved
 
 
@@ -2398,8 +2407,10 @@ def _prepare_llm_decompile_request(
     llm_decompile_specs_map,
     llm_config,
     platform=None,
+    new_binary_dir=None,
     debug=False,
 ):
+    module_name = _derive_module_name(new_binary_dir)
     llm_spec = (llm_decompile_specs_map or {}).get(func_name)
     if llm_spec is None:
         return None
@@ -2522,6 +2533,7 @@ def _prepare_llm_decompile_request(
         _resolve_llm_decompile_template_value(
             prompt_value,
             platform,
+            module_name=module_name,
         )
     )
     if not prompt_path.is_absolute():
@@ -2562,6 +2574,7 @@ def _prepare_llm_decompile_request(
             _resolve_llm_decompile_template_value(
                 reference_value,
                 platform,
+                module_name=module_name,
             )
         )
         if not reference_yaml_path.is_absolute():
@@ -2684,6 +2697,7 @@ async def call_llm_decompile(
     target_blocks=None,
     prompt_template=None,
     platform=None,
+    new_binary_dir=None,
     temperature=None,
     effort=None,
     api_key=None,
@@ -2695,6 +2709,7 @@ async def call_llm_decompile(
     retry_max_delay=None,
     debug=False,
 ):
+    module_name = _derive_module_name(new_binary_dir)
     if not callable(call_llm_text):
         if debug:
             print("    Preprocess: call_llm_text unavailable for llm_decompile")
@@ -2734,6 +2749,7 @@ async def call_llm_decompile(
             prompt = _resolve_llm_decompile_template_value(
                 prompt_template,
                 platform,
+                module_name=module_name,
             ).format(
                 symbol_name_list=symbol_name_text,
                 disasm_for_reference=str(disasm_for_reference or ""),
@@ -2743,6 +2759,7 @@ async def call_llm_decompile(
                 reference_blocks=str(reference_blocks or ""),
                 target_blocks=str(target_blocks or ""),
                 platform=str(platform or "").strip(),
+                module_name=module_name,
             )
         except Exception as exc:
             if debug:
@@ -8463,6 +8480,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             candidate_request = llm_request_cache.get(candidate_func_name)
@@ -8490,6 +8508,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             candidate_request = llm_request_cache.get(candidate_gv_name)
@@ -8527,6 +8546,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             candidate_request = llm_request_cache.get(candidate_struct_name)
@@ -8571,6 +8591,7 @@ async def preprocess_common_skill(
                 target_blocks=target_blocks,
                 prompt_template=llm_request["prompt_template"],
                 platform=platform,
+                new_binary_dir=new_binary_dir,
                 temperature=llm_request.get("temperature"),
                 effort=llm_request.get("effort"),
                 api_key=llm_request.get("api_key"),
@@ -8627,6 +8648,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             llm_request = llm_request_cache.get(func_name)
@@ -8907,6 +8929,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             llm_request = llm_request_cache.get(gv_name)
@@ -9045,6 +9068,7 @@ async def preprocess_common_skill(
                     llm_decompile_specs_map,
                     llm_config,
                     platform=platform,
+                    new_binary_dir=new_binary_dir,
                     debug=debug,
                 )
             llm_request = llm_request_cache.get(struct_member_name)

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -543,6 +543,43 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
                 generation_options["vfunc_sig_max_match"] = max_match
                 continue
 
+            if field_name == "offset_sig_max_match":
+                if debug:
+                    print(
+                        f"    Preprocess: bare offset_sig_max_match field is "
+                        f"not allowed for {symbol_name}"
+                    )
+                return None
+
+            if field_name.startswith("offset_sig_max_match:"):
+                if "offset_sig_max_match" in generation_options:
+                    if debug:
+                        print(
+                            f"    Preprocess: duplicated offset_sig_max_match "
+                            f"directive for {symbol_name}"
+                        )
+                    return None
+                max_match_text = field_name.split(":", 1)[1]
+                try:
+                    max_match = int(max_match_text)
+                except ValueError:
+                    if debug:
+                        print(
+                            f"    Preprocess: invalid offset_sig_max_match "
+                            f"value for {symbol_name}: {max_match_text}"
+                        )
+                    return None
+                if max_match <= 0:
+                    if debug:
+                        print(
+                            f"    Preprocess: invalid offset_sig_max_match "
+                            f"value for {symbol_name}: {max_match_text}"
+                        )
+                    return None
+                desired_output_fields.append("offset_sig_max_match")
+                generation_options["offset_sig_max_match"] = max_match
+                continue
+
             handled_true_directive = False
             for directive_name in true_directive_fields:
                 directive_parse_result = _handle_true_directive(
@@ -563,6 +600,13 @@ def _normalize_generate_yaml_desired_fields(generate_yaml_desired_fields, debug=
             if debug:
                 print(
                     f"    Preprocess: vfunc_sig_max_match requires vfunc_sig "
+                    f"for {symbol_name}"
+                )
+            return None
+        if "offset_sig_max_match" in generation_options and "offset_sig" not in desired_output_fields:
+            if debug:
+                print(
+                    f"    Preprocess: offset_sig_max_match requires offset_sig "
                     f"for {symbol_name}"
                 )
             return None
@@ -763,6 +807,7 @@ STRUCT_MEMBER_YAML_ORDER = [
     "size",
     "offset_sig",
     "offset_sig_disp",
+    "offset_sig_max_match",
     "offset_sig_allow_across_function_boundary",
 ]
 TARGET_KIND_TO_FIELD_ORDER = {
@@ -5245,6 +5290,29 @@ async def preprocess_struct_offset_sig_via_mcp(
             print(f"    Preprocess: offset_sig_disp must be >= 0 in {os.path.basename(old_path)}")
         return None
 
+    offset_sig_max_match = 1
+    try:
+        raw_max_match = old_data.get("offset_sig_max_match")
+        if raw_max_match is not None:
+            offset_sig_max_match = _parse_int_field(
+                raw_max_match, "offset_sig_max_match"
+            )
+    except Exception:
+        if debug:
+            print(
+                "    Preprocess: invalid offset_sig_max_match in "
+                f"{os.path.basename(old_path)}"
+            )
+        return None
+
+    if offset_sig_max_match <= 0:
+        if debug:
+            print(
+                "    Preprocess: offset_sig_max_match must be > 0 in "
+                f"{os.path.basename(old_path)}"
+            )
+        return None
+
     old_offset = None
     try:
         if old_data.get("offset") is not None:
@@ -5257,7 +5325,10 @@ async def preprocess_struct_offset_sig_via_mcp(
     try:
         fb_result = await session.call_tool(
             name="find_bytes",
-            arguments={"patterns": [offset_sig], "limit": 2}
+            arguments={
+                "patterns": [offset_sig],
+                "limit": offset_sig_max_match + 1,
+            },
         )
         fb_data = parse_mcp_result(fb_result)
     except Exception as e:
@@ -5272,24 +5343,45 @@ async def preprocess_struct_offset_sig_via_mcp(
     matches = entry.get("matches", [])
     match_count = entry.get("n", len(matches))
 
-    if match_count != 1:
+    if match_count < 1 or not matches:
         if debug:
-            print(f"    Preprocess: {os.path.basename(old_path)} offset sig matched {match_count} (need 1)")
+            print(
+                f"    Preprocess: {os.path.basename(old_path)} offset sig "
+                f"matched {match_count} (need >= 1)"
+            )
+        return None
+    if match_count > offset_sig_max_match:
+        if debug:
+            print(
+                f"    Preprocess: {os.path.basename(old_path)} offset sig "
+                f"matched {match_count} (max {offset_sig_max_match})"
+            )
         return None
 
-    match_addr = matches[0]
+    try:
+        match_addr_ints = [_parse_int_field(m, "match_addr") for m in matches]
+    except Exception:
+        if debug:
+            print(
+                f"    Preprocess: invalid match addr in {os.path.basename(old_path)}"
+            )
+        return None
     expected_offset_expr = "None" if old_offset is None else str(old_offset)
+    sig_addrs_literal = "[" + ", ".join(str(a) for a in match_addr_ints) + "]"
 
     py_code = (
         "import idaapi, ida_bytes, idautils, ida_ua, json\n"
-        f"sig_addr = {match_addr}\n"
-        f"inst_addr = sig_addr + {offset_sig_disp}\n"
+        f"sig_addrs = {sig_addrs_literal}\n"
+        f"offset_sig_disp = {offset_sig_disp}\n"
         f"expected_offset = {expected_offset_expr}\n"
-        "insn = idautils.DecodeInstruction(inst_addr)\n"
-        "raw = ida_bytes.get_bytes(inst_addr, insn.size) if insn and insn.size > 0 else None\n"
-        "if not insn or insn.size <= 0 or not raw:\n"
-        "    result = json.dumps(None)\n"
-        "else:\n"
+        "best_result = None\n"
+        "any_result = None\n"
+        "for sig_addr in sig_addrs:\n"
+        "    inst_addr = sig_addr + offset_sig_disp\n"
+        "    insn = idautils.DecodeInstruction(inst_addr)\n"
+        "    raw = ida_bytes.get_bytes(inst_addr, insn.size) if insn and insn.size > 0 else None\n"
+        "    if not insn or insn.size <= 0 or not raw:\n"
+        "        continue\n"
         "    candidates = []\n"
         "    for op in insn.ops:\n"
         "        ot = int(op.type)\n"
@@ -5334,20 +5426,25 @@ async def preprocess_struct_offset_sig_via_mcp(
         "        seen.add(key)\n"
         "        uniq.append(c)\n"
         "    if not uniq:\n"
-        "        result = json.dumps(None)\n"
-        "    else:\n"
-        "        preferred = [c for c in uniq if c['expected']]\n"
-        "        pool = preferred if preferred else uniq\n"
-        "        pool.sort(key=lambda c: (c['size'], -c['off']), reverse=True)\n"
-        "        best = pool[0]\n"
-        "        final_offset = best['signed'] if best['signed'] < 0 else best['unsigned']\n"
-        "        result = json.dumps({\n"
-        "            'offset': final_offset,\n"
-        "            'sig_va': hex(sig_addr),\n"
-        "            'inst_va': hex(inst_addr),\n"
-        "            'offset_size': best['size'],\n"
-        "            'matched_expected': bool(preferred),\n"
-        "        })\n"
+        "        continue\n"
+        "    preferred = [c for c in uniq if c['expected']]\n"
+        "    pool = preferred if preferred else uniq\n"
+        "    pool.sort(key=lambda c: (c['size'], -c['off']), reverse=True)\n"
+        "    best = pool[0]\n"
+        "    final_offset = best['signed'] if best['signed'] < 0 else best['unsigned']\n"
+        "    candidate_result = {\n"
+        "        'offset': final_offset,\n"
+        "        'sig_va': hex(sig_addr),\n"
+        "        'inst_va': hex(inst_addr),\n"
+        "        'offset_size': best['size'],\n"
+        "        'matched_expected': bool(preferred),\n"
+        "    }\n"
+        "    if any_result is None:\n"
+        "        any_result = candidate_result\n"
+        "    if candidate_result['matched_expected']:\n"
+        "        best_result = candidate_result\n"
+        "        break\n"
+        "result = json.dumps(best_result if best_result is not None else any_result)\n"
     )
 
     try:
@@ -5374,16 +5471,22 @@ async def preprocess_struct_offset_sig_via_mcp(
             except (json.JSONDecodeError, TypeError):
                 pass
 
+    matches_preview = _debug_format_addr_preview(match_addr_ints)
     if not isinstance(offset_info, dict) or "offset" not in offset_info:
         if debug:
-            print(f"    Preprocess: could not resolve struct offset at {match_addr}")
+            print(
+                f"    Preprocess: could not resolve struct offset at "
+                f"{matches_preview}"
+            )
         return None
 
     try:
         offset_int = _parse_int_field(offset_info["offset"], "offset")
     except Exception:
         if debug:
-            print(f"    Preprocess: invalid parsed offset at {match_addr}")
+            print(
+                f"    Preprocess: invalid parsed offset at {matches_preview}"
+            )
         return None
 
     new_data = {
@@ -5393,6 +5496,8 @@ async def preprocess_struct_offset_sig_via_mcp(
         "offset_sig": offset_sig,
         "offset_sig_disp": offset_sig_disp,
     }
+    if offset_sig_max_match > 1:
+        new_data["offset_sig_max_match"] = offset_sig_max_match
 
     raw_size = old_data.get("size")
     if raw_size is not None:
@@ -5405,9 +5510,10 @@ async def preprocess_struct_offset_sig_via_mcp(
                 print(f"    Preprocess: invalid size in {os.path.basename(old_path)}")
 
     if debug:
+        resolved_sig_va = offset_info.get("sig_va", matches_preview)
         print(
             "    Preprocess: reused offset_sig at "
-            f"{match_addr} for {os.path.basename(new_path)}"
+            f"{resolved_sig_va} for {os.path.basename(new_path)}"
         )
 
     return new_data
@@ -6712,6 +6818,7 @@ async def _preprocess_direct_struct_offset_sig_via_mcp(
     size=None,
     old_path=None,
     allow_across_function_boundary=False,
+    offset_sig_max_match=1,
     debug=False,
 ):
     metadata = _load_struct_member_metadata_from_yaml(old_path)
@@ -6753,6 +6860,7 @@ async def _preprocess_direct_struct_offset_sig_via_mcp(
         image_base=image_base,
         size=resolved_size,
         allow_across_function_boundary=allow_across_function_boundary,
+        max_match_count=offset_sig_max_match,
         debug=debug,
     )
     if not isinstance(payload, dict):
@@ -6777,6 +6885,7 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
     max_instructions=64,
     extra_wildcard_offsets=None,
     allow_across_function_boundary=False,
+    max_match_count=1,
     debug=False,
 ):
     _ = image_base
@@ -6787,7 +6896,16 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
         min_sig_bytes = max(1, int(min_sig_bytes))
         max_sig_bytes = max(1, int(max_sig_bytes))
         max_instructions = max(1, int(max_instructions))
+        max_match_count = int(max_match_count)
     except Exception:
+        return None
+
+    if max_match_count <= 0:
+        if debug:
+            print(
+                "    Preprocess: invalid max_match_count for struct offset sig "
+                f"of {struct_name}.{member_name}"
+            )
         return None
 
     resolved_size = None
@@ -7002,7 +7120,10 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
             try:
                 fb_result = await session.call_tool(
                     name="find_bytes",
-                    arguments={"patterns": [candidate_sig], "limit": 2},
+                    arguments={
+                        "patterns": [candidate_sig],
+                        "limit": max_match_count + 1,
+                    },
                 )
                 fb_data = parse_mcp_result(fb_result)
             except Exception:
@@ -7029,7 +7150,7 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
                         f"hits={match_preview}"
                     )
                 continue
-            if match_count != 1:
+            if match_count > max_match_count:
                 if debug:
                     print(
                         "    Preprocess: struct offset candidate rejected with "
@@ -7039,8 +7160,10 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
                     )
                 continue
 
+            match_addrs = set()
             try:
-                match_addr = _parse_int_value(matches[0])
+                for match in matches:
+                    match_addrs.add(_parse_int_value(match))
             except Exception:
                 if debug:
                     print(
@@ -7050,11 +7173,11 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
                         f"hits={match_preview}"
                     )
                 continue
-            if match_addr != offset_inst_va_int:
+            if offset_inst_va_int not in match_addrs:
                 if debug:
                     print(
                         "    Preprocess: struct offset candidate rejected "
-                        "because unique hit does not match target address for "
+                        "because hits do not include target address for "
                         f"{struct_name}.{member_name}: sig={candidate_sig}; "
                         f"hits={match_preview}; expected={hex(offset_inst_va_int)}"
                     )
@@ -7067,6 +7190,8 @@ async def preprocess_gen_struct_offset_sig_via_mcp(
                 "offset_sig": candidate_sig,
                 "offset_sig_disp": 0,
             }
+            if max_match_count > 1:
+                payload["offset_sig_max_match"] = max_match_count
             if resolved_size is not None:
                 payload["size"] = resolved_size
             return payload
@@ -9141,6 +9266,10 @@ async def preprocess_common_skill(
                     allow_across_function_boundary=_struct_gen_opts.get(
                         "offset_sig_allow_across_function_boundary",
                         False,
+                    ),
+                    offset_sig_max_match=_struct_gen_opts.get(
+                        "offset_sig_max_match",
+                        1,
                     ),
                     debug=debug,
                     size=entry.get("size"),

--- a/ida_preprocessor_scripts/find-CEntity2SaveRestore_StreamEntitiesFromFile-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntity2SaveRestore_StreamEntitiesFromFile-decompiles.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntity2SaveRestore_StreamEntitiesFromFile-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSaveRestoreBlockSet_PreRestore",
+    "CSaveRestoreBlockSet_PostRestore",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CSaveRestoreBlockSet_PreRestore",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntity2SaveRestore_StreamEntitiesFromFile.{platform}.yaml",
+    ),
+    (
+        "CSaveRestoreBlockSet_PostRestore",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntity2SaveRestore_StreamEntitiesFromFile.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSaveRestoreBlockSet_PreRestore", "CSaveRestoreBlockSet"),
+    ("CSaveRestoreBlockSet_PostRestore", "CSaveRestoreBlockSet"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSaveRestoreBlockSet_PreRestore",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "CSaveRestoreBlockSet_PostRestore",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntity2SaveRestore_StreamEntitiesFromFile.py
+++ b/ida_preprocessor_scripts/find-CEntity2SaveRestore_StreamEntitiesFromFile.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntity2SaveRestore_StreamEntitiesFromFile skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntity2SaveRestore_StreamEntitiesFromFile",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntity2SaveRestore_StreamEntitiesFromFile",
+        "xref_strings": [
+            "%s:  StreamEntitiesFromFile:  '%s' [%d entities]",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntity2SaveRestore_StreamEntitiesFromFile", "CEntity2SaveRestore"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntity2SaveRestore_StreamEntitiesFromFile",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntity2SaveRestore_vtable.py
+++ b/ida_preprocessor_scripts/find-CEntity2SaveRestore_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntity2SaveRestore_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CEntity2SaveRestore"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntity2SaveRestore",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CEntity2SaveRestore vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_PostRestore.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_PostRestore.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_PostRestore skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEntitySaveRestoreBlockHandler_PostRestore",
+        "CEntitySaveRestoreBlockHandler",
+        "CSaveRestoreBlockSet_PostRestore",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySaveRestoreBlockHandler_PostRestore",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_PreRestore.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_PreRestore.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_PreRestore skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEntitySaveRestoreBlockHandler_PreRestore",
+        "CEntitySaveRestoreBlockHandler",
+        "CSaveRestoreBlockSet_PreRestore",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySaveRestoreBlockHandler_PreRestore",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_ReadRestoreHeaders.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_ReadRestoreHeaders.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_ReadRestoreHeaders skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySaveRestoreBlockHandler_ReadRestoreHeaders",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySaveRestoreBlockHandler_ReadRestoreHeaders",
+        "xref_strings": [
+            "FULLMATCH:EntityTables",
+            "FULLMATCH:ETABLE",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [
+            "CEntitySaveRestoreBlockHandler_WriteSaveHeaders",
+        ],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySaveRestoreBlockHandler_ReadRestoreHeaders", "CEntitySaveRestoreBlockHandler"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySaveRestoreBlockHandler_ReadRestoreHeaders",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders.py
+++ b/ida_preprocessor_scripts/find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySaveRestoreBlockHandler_WriteSaveHeaders",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySaveRestoreBlockHandler_WriteSaveHeaders",
+        "xref_strings": [
+            "FULLMATCH:EntityTables",
+            "SaveHeaders KV3 Write",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySaveRestoreBlockHandler_WriteSaveHeaders", "CEntitySaveRestoreBlockHandler"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySaveRestoreBlockHandler_WriteSaveHeaders",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_ForceSetInPVSCallsIntoQueue.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_ForceSetInPVSCallsIntoQueue.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_ForceSetInPVSCallsIntoQueue skill."""
+
+from ida_preprocessor_scripts._direct_branch_target_common import (
+    preprocess_direct_branch_target_skill,
+)
+
+
+SOURCE_FUNCTION_NAME = "CEntitySaveRestoreBlockHandler_PreRestore"
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_ForceSetInPVSCallsIntoQueue",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_ForceSetInPVSCallsIntoQueue",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_direct_branch_target_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        source_yaml_stem=SOURCE_FUNCTION_NAME,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntityFromNameMap-AND-CEntitySystem_AddEntityToNameMap.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RemoveEntityFromNameMap-AND-CEntitySystem_AddEntityToNameMap.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RemoveEntityFromNameMap-AND-CEntitySystem_AddEntityToNameMap skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RemoveEntityFromNameMap",
+    "CEntitySystem_AddEntityToNameMap",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_RemoveEntityFromNameMap",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityIdentity_SetEntityName.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_AddEntityToNameMap",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityIdentity_SetEntityName.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_RemoveEntityFromNameMap",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CEntitySystem_AddEntityToNameMap",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_entityNames.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_entityNames.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_entityNames skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_entityNames",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_entityNames",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityToNameMap.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_entityNames",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_nSuppressDormancyChangeCount-AND-CEntitySystem_m_nExecuteQueuedCreationDepth-AND-CEntitySystem_ExecuteQueuedSetInPVS.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_nSuppressDormancyChangeCount-AND-CEntitySystem_m_nExecuteQueuedCreationDepth-AND-CEntitySystem_ExecuteQueuedSetInPVS.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_nSuppressDormancyChangeCount-AND-CEntitySystem_m_nExecuteQueuedCreationDepth-AND-CEntitySystem_ExecuteQueuedSetInPVS skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_ExecuteQueuedSetInPVS",
+]
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_nSuppressDormancyChangeCount",
+    "CEntitySystem_m_nExecuteQueuedCreationDepth",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_nSuppressDormancyChangeCount",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_nExecuteQueuedCreationDepth",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_ExecuteQueuedSetInPVS",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_nSuppressDormancyChangeCount",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_nExecuteQueuedCreationDepth",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_max_match:8",
+        ],
+    ),
+    (
+        "CEntitySystem_ExecuteQueuedSetInPVS",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever sigs to locate struct members and function, write YAMLs."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_queuedDormancyChanges.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_queuedDormancyChanges.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_queuedDormancyChanges skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_queuedDormancyChanges",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_queuedDormancyChanges",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_ExecuteQueuedSetInPVS.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_queuedDormancyChanges",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSaveRestoreBlockSet_vtable.py
+++ b/ida_preprocessor_scripts/find-CSaveRestoreBlockSet_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSaveRestoreBlockSet_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CSaveRestoreBlockSet"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSaveRestoreBlockSet",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CSaveRestoreBlockSet vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Preprocess script for find-CSource2EntitySystem_StaticInit-decompiles skill."""
 
-import os
-
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
@@ -101,38 +99,36 @@ async def preprocess_skill(
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
     """Reuse previous gamever vfunc_sig/gv_sig/offset_sig to locate targets and write YAML."""
-    module_name = os.path.basename(os.path.normpath(new_binary_dir)) if new_binary_dir else "server"
-
     llm_decompile = [
         (
             "IGameResourceService_SetEntityResourceManifestHandler",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
         (
             "g_pGameResourceService",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
         (
             "g_pGameEntitySystem",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
         (
             "CEntitySystem_m_entityIONotifiers",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
         (
             "CEntitySystem_EnableAutoDeletionExecution",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
         (
             "CEntitySystem_InstallPostSpawnCallback",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/CSource2EntitySystem_StaticInit.{{platform}}.yaml",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
     ]
 

--- a/ida_preprocessor_scripts/find-CreateEntityTransitionList.py
+++ b/ida_preprocessor_scripts/find-CreateEntityTransitionList.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CreateEntityTransitionList skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CreateEntityTransitionList",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CreateEntityTransitionList",
+        "xref_strings": [
+            "%s:  suppress %d %s (in solid)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CreateEntityTransitionList",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-g_pInterfaceGlobals.py
+++ b/ida_preprocessor_scripts/find-g_pInterfaceGlobals.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 """Preprocess script for find-g_pInterfaceGlobals skill."""
 
-import os
-
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_GLOBALVAR_NAMES = [
@@ -31,13 +29,11 @@ async def preprocess_skill(
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
     """Reuse previous gamever gv_sig; fallback to LLM_DECOMPILE of ConnectInterfaces."""
-    module_name = os.path.basename(os.path.normpath(new_binary_dir)) if new_binary_dir else "server"
-
     llm_decompile = [
         (
             "g_pInterfaceGlobals",
             "prompt/call_llm_decompile.md",
-            f"references/{module_name}/ConnectInterfaces.{{platform}}.yaml",
+            "references/{module_name}/ConnectInterfaces.{platform}.yaml",
         ),
     ]
 

--- a/ida_preprocessor_scripts/references/server/CEntity2SaveRestore_StreamEntitiesFromFile.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntity2SaveRestore_StreamEntitiesFromFile.linux.yaml
@@ -1,0 +1,877 @@
+func_name: CEntity2SaveRestore_StreamEntitiesFromFile
+func_va: '0x15b4f50'
+disasm_code: |-
+  .text:00000000015B4F50                 push    rbp
+  .text:00000000015B4F51                 mov     rbp, rsp
+  .text:00000000015B4F54                 push    r15
+  .text:00000000015B4F56                 push    r14
+  .text:00000000015B4F58                 lea     r14, [rbp+var_190]
+  .text:00000000015B4F5F                 push    r13
+  .text:00000000015B4F61                 mov     r13, rcx
+  .text:00000000015B4F64                 push    r12
+  .text:00000000015B4F66                 push    rbx
+  .text:00000000015B4F67                 mov     rbx, rsi
+  .text:00000000015B4F6A                 mov     rsi, rdi
+  .text:00000000015B4F6D                 sub     rsp, 248h
+  .text:00000000015B4F74                 mov     [rbp+var_238], rdi
+  .text:00000000015B4F7B                 mov     rdi, r14
+  .text:00000000015B4F7E                 mov     [rbp+var_240], rdx
+  .text:00000000015B4F85                 mov     [rbp+var_24C], r8d
+  .text:00000000015B4F8C                 call    CEntity2SaveRestore__GetSaveGameSpawnGroupName
+  .text:00000000015B4F91                 mov     rdx, [rbp+var_190]
+  .text:00000000015B4F98                 lea     rax, haystack
+  .text:00000000015B4F9F                 lea     rdi, [rbp+var_140]
+  .text:00000000015B4FA6                 lea     rcx, a1; "1"
+  .text:00000000015B4FAD                 mov     [rbp+var_248], rdi
+  .text:00000000015B4FB4                 lea     rsi, aSaveSHlS; "save/%s.hl%s"
+  .text:00000000015B4FBB                 test    rdx, rdx
+  .text:00000000015B4FBE                 cmovz   rdx, rax
+  .text:00000000015B4FC2                 xor     eax, eax
+  .text:00000000015B4FC4                 call    V_sprintf
+  .text:00000000015B4FC9                 cmp     [rbp+var_190], 0
+  .text:00000000015B4FD1                 jz      short loc_15B4FDB
+  .text:00000000015B4FD3                 ; this
+  .text:00000000015B4FD3                 mov     rdi, r14; this
+  .text:00000000015B4FD6                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:00000000015B4FDB                 lea     r15, [rbp+var_1E0]
+  .text:00000000015B4FE2                 ; _QWORD
+  .text:00000000015B4FE2                 xor     edx, edx; _QWORD
+  .text:00000000015B4FE4                 ; _QWORD
+  .text:00000000015B4FE4                 xor     ecx, ecx; _QWORD
+  .text:00000000015B4FE6                 ; _QWORD
+  .text:00000000015B4FE6                 xor     esi, esi; _QWORD
+  .text:00000000015B4FE8                 ; _QWORD
+  .text:00000000015B4FE8                 mov     rdi, r15; _QWORD
+  .text:00000000015B4FEB                 call    __ZN10CUtlBufferC1EiiNS_13BufferFlags_tE; CUtlBuffer::CUtlBuffer(int,int,CUtlBuffer::BufferFlags_t)
+  .text:00000000015B4FF0                 mov     rax, [r13+0]
+  .text:00000000015B4FF4                 lea     rdx, sub_152DE00
+  .text:00000000015B4FFB                 mov     rax, [rax+18h]
+  .text:00000000015B4FFF                 cmp     rax, rdx
+  .text:00000000015B5002                 jnz     loc_15B55F0
+  .text:00000000015B5008                 lea     r12, [r13+1228h]
+  .text:00000000015B500F                 mov     rax, [r12]
+  .text:00000000015B5013                 lea     rsi, [rbp+var_138]
+  .text:00000000015B501A                 mov     rax, [rax+10h]
+  .text:00000000015B501E                 test    [rbp+var_139], 40h
+  .text:00000000015B5025                 jnz     short loc_15B503A
+  .text:00000000015B5027                 lea     rsi, haystack
+  .text:00000000015B502E                 test    dword ptr [rbp-13Ch], 3FFFFFFFh
+  .text:00000000015B5038                 jnz     short loc_15B5090
+  .text:00000000015B503A                 mov     rdx, r15
+  .text:00000000015B503D                 mov     rdi, r12
+  .text:00000000015B5040                 call    rax
+  .text:00000000015B5042                 mov     r15d, eax
+  .text:00000000015B5045                 test    al, al
+  .text:00000000015B5047                 jnz     short loc_15B50A6
+  .text:00000000015B5049                 mov     dword ptr [rbp+var_1E0], 0
+  .text:00000000015B5053                 mov     eax, dword ptr [rbp+var_1E0+4]
+  .text:00000000015B5059                 test    eax, 7FFFFFFFh
+  .text:00000000015B505E                 jz      short loc_15B5068
+  .text:00000000015B5060                 test    eax, eax
+  .text:00000000015B5062                 jns     loc_15B5500
+  .text:00000000015B5068                 ; this
+  .text:00000000015B5068                 mov     rdi, [rbp+var_248]; this
+  .text:00000000015B506F                 ; int
+  .text:00000000015B506F                 xor     esi, esi; int
+  .text:00000000015B5071                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:00000000015B5076                 add     rsp, 248h
+  .text:00000000015B507D                 mov     eax, r15d
+  .text:00000000015B5080                 pop     rbx
+  .text:00000000015B5081                 pop     r12
+  .text:00000000015B5083                 pop     r13
+  .text:00000000015B5085                 pop     r14
+  .text:00000000015B5087                 pop     r15
+  .text:00000000015B5089                 pop     rbp
+  .text:00000000015B508A                 retn
+  .text:00000000015B5090                 mov     rdx, r15
+  .text:00000000015B5093                 mov     rsi, [rbp+var_138]
+  .text:00000000015B509A                 mov     rdi, r12
+  .text:00000000015B509D                 call    rax
+  .text:00000000015B509F                 mov     r15d, eax
+  .text:00000000015B50A2                 test    al, al
+  .text:00000000015B50A4                 jz      short loc_15B5049
+  .text:00000000015B50A6                 mov     rsi, [rbp+var_240]
+  .text:00000000015B50AD                 xor     edx, edx
+  .text:00000000015B50AF                 mov     rdi, [rbp+var_238]
+  .text:00000000015B50B6                 call    sub_1554AC0
+  .text:00000000015B50BB                 mov     ecx, [rbp+var_1CC]
+  .text:00000000015B50C1                 xor     edx, edx
+  .text:00000000015B50C3                 test    dword ptr [rbp+var_1E0+4], 7FFFFFFFh
+  .text:00000000015B50CD                 jz      short loc_15B50D6
+  .text:00000000015B50CF                 mov     rdx, [rbp+var_1D8]
+  .text:00000000015B50D6                 mov     rsi, [rbp+var_240]
+  .text:00000000015B50DD                 mov     rdi, [rbp+var_238]
+  .text:00000000015B50E4                 call    sub_1554BB0
+  .text:00000000015B50E9                 mov     [rbp+var_260], rax
+  .text:00000000015B50F0                 test    rax, rax
+  .text:00000000015B50F3                 jz      loc_15B55C0
+  .text:00000000015B50F9                 lea     rax, [rax+18h]
+  .text:00000000015B50FD                 mov     rsi, r13
+  .text:00000000015B5100                 mov     rdi, rax
+  .text:00000000015B5103                 mov     [rbp+var_268], rax
+  .text:00000000015B510A                 call    sub_FA9000
+  .text:00000000015B510F                 lea     rax, off_2503B68
+  .text:00000000015B5116                 mov     rsi, [rbp+var_260]
+  .text:00000000015B511D                 mov     rax, [rax]
+  .text:00000000015B5120                 mov     rdi, rsi
+  .text:00000000015B5123                 movss   xmm0, dword ptr [rax+30h]
+  .text:00000000015B5128                 movss   dword ptr [rsi+338h], xmm0
+  .text:00000000015B5130                 mov     eax, [rax+44h]
+  .text:00000000015B5133                 mov     [rsi+33Ch], eax
+  .text:00000000015B5139                 call    sub_1591EC0
+  .text:00000000015B513E                 mov     rdi, r14
+  .text:00000000015B5141                 mov     rsi, rax
+  .text:00000000015B5144                 mov     r13, rax
+  .text:00000000015B5147                 call    sub_1552090
+  .text:00000000015B514C                 mov     rax, [rbx]
+  .text:00000000015B514F                 lea     rcx, _ZN20CSaveRestoreBlockSet10PreRestoreEv; CSaveRestoreBlockSet::PreRestore(void)
+  .text:00000000015B5156                 mov     rdx, [rax+28h]
+  .text:00000000015B515A                 cmp     rdx, rcx
+  .text:00000000015B515D                 jnz     loc_15B5860
+  .text:00000000015B5163                 mov     esi, [rbx+10h]
+  .text:00000000015B5166                 test    esi, esi
+  .text:00000000015B5168                 jle     short loc_15B518B
+  .text:00000000015B516A                 xor     r14d, r14d
+  .text:00000000015B516D                 nop     dword ptr [rax]
+  .text:00000000015B5170                 mov     rax, [rbx+18h]
+  .text:00000000015B5174                 mov     rdi, [rax+r14*8]
+  .text:00000000015B5178                 add     r14, 1
+  .text:00000000015B517C                 mov     rax, [rdi]
+  .text:00000000015B517F                 call    qword ptr [rax+28h]  ; 28h = CSaveRestoreBlockSet_PreRestore
+  .text:00000000015B5182                 cmp     [rbx+10h], r14d
+  .text:00000000015B5186                 jg      short loc_15B5170
+  .text:00000000015B5188                 mov     rax, [rbx]
+  .text:00000000015B518B                 mov     rsi, r13
+  .text:00000000015B518E                 mov     rdi, rbx
+  .text:00000000015B5191                 call    qword ptr [rax+30h]
+  .text:00000000015B5194                 lea     r14, dword_2666BA0
+  .text:00000000015B519B                 ; _QWORD
+  .text:00000000015B519B                 mov     esi, 1; _QWORD
+  .text:00000000015B51A0                 ; _QWORD
+  .text:00000000015B51A0                 mov     edi, [r14]; _QWORD
+  .text:00000000015B51A3                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000015B51A8                 test    al, al
+  .text:00000000015B51AA                 jnz     loc_15B5758
+  .text:00000000015B51B0                 mov     r14, [rbp+var_260]
+  .text:00000000015B51B7                 mov     rdx, r13
+  .text:00000000015B51BA                 mov     rdi, [rbp+var_238]
+  .text:00000000015B51C1                 mov     rsi, r14
+  .text:00000000015B51C4                 call    sub_156D940
+  .text:00000000015B51C9                 mov     rcx, [rbp+var_240]
+  .text:00000000015B51D0                 mov     rdx, r14
+  .text:00000000015B51D3                 mov     rsi, r12
+  .text:00000000015B51D6                 mov     rdi, [rbp+var_238]
+  .text:00000000015B51DD                 call    sub_156C7D0
+  .text:00000000015B51E2                 lea     rax, off_2503B68
+  .text:00000000015B51E9                 lea     rcx, _ZN20CSaveRestoreBlockSet7RestoreEP8IRestorejb; CSaveRestoreBlockSet::Restore(IRestore *,uint,bool)
+  .text:00000000015B51F0                 mov     rax, [rax]
+  .text:00000000015B51F3                 movss   xmm0, dword ptr [rax+30h]
+  .text:00000000015B51F8                 movss   dword ptr [r14+338h], xmm0
+  .text:00000000015B5201                 mov     eax, [rax+44h]
+  .text:00000000015B5204                 mov     [r14+33Ch], eax
+  .text:00000000015B520B                 mov     rdx, [rbx]
+  .text:00000000015B520E                 mov     rax, [rdx+38h]
+  .text:00000000015B5212                 cmp     rax, rcx
+  .text:00000000015B5215                 jnz     loc_15B5840
+  .text:00000000015B521B                 mov     ecx, [rbx+10h]
+  .text:00000000015B521E                 test    ecx, ecx
+  .text:00000000015B5220                 jle     loc_15B5812
+  .text:00000000015B5226                 lea     rax, [rbp+var_200]
+  .text:00000000015B522D                 xor     r14d, r14d
+  .text:00000000015B5230                 mov     [rbp+var_24D], r15b
+  .text:00000000015B5237                 mov     [rbp+var_258], rax
+  .text:00000000015B523E                 xchg    ax, ax
+  .text:00000000015B5240                 mov     rax, [rbx+18h]
+  .text:00000000015B5244                 mov     r12, [rax+r14*8]
+  .text:00000000015B5248                 mov     rax, [r12]
+  .text:00000000015B524C                 mov     rdi, r12
+  .text:00000000015B524F                 call    qword ptr [rax]
+  .text:00000000015B5251                 lea     rsi, aEntities; "Entities"
+  .text:00000000015B5258                 ; _QWORD
+  .text:00000000015B5258                 mov     rdi, rax; _QWORD
+  .text:00000000015B525B                 call    _V_stricmp_fast
+  .text:00000000015B5260                 mov     rdi, r12
+  .text:00000000015B5263                 mov     r15d, eax
+  .text:00000000015B5266                 mov     rax, [r12]
+  .text:00000000015B526A                 call    qword ptr [rax]
+  .text:00000000015B526C                 mov     rdi, [rbp+var_258]
+  .text:00000000015B5273                 xor     ecx, ecx
+  .text:00000000015B5275                 test    r15d, r15d
+  .text:00000000015B5278                 setnz   cl
+  .text:00000000015B527B                 mov     r9, rax
+  .text:00000000015B527E                 mov     rsi, r13
+  .text:00000000015B5281                 lea     r8, a1616s; "%-16.16s | "
+  .text:00000000015B5288                 xor     eax, eax
+  .text:00000000015B528A                 xor     edx, edx
+  .text:00000000015B528C                 call    sub_1570830
+  .text:00000000015B5291                 mov     rax, [rbx]
+  .text:00000000015B5294                 lea     rsi, CSaveRestoreBlockSet__CallBlockHandlerRestore
+  .text:00000000015B529B                 mov     rax, [rax+58h]
+  .text:00000000015B529F                 cmp     rax, rsi
+  .text:00000000015B52A2                 jnz     loc_15B5698
+  .text:00000000015B52A8                 mov     rax, [r13+0]
+  .text:00000000015B52AC                 mov     rdi, r12
+  .text:00000000015B52AF                 mov     r15, [rax+40h]
+  .text:00000000015B52B3                 mov     rax, [r12]
+  .text:00000000015B52B7                 call    qword ptr [rax]
+  .text:00000000015B52B9                 mov     rdx, rax
+  .text:00000000015B52BC                 xor     eax, eax
+  .text:00000000015B52BE                 test    rdx, rdx
+  .text:00000000015B52C1                 jz      short loc_15B52CC
+  .text:00000000015B52C3                 cmp     byte ptr [rdx], 0
+  .text:00000000015B52C6                 jnz     loc_15B56B8
+  .text:00000000015B52CC                 lea     rsi, sub_1538F00
+  .text:00000000015B52D3                 mov     [rbp+var_220], eax
+  .text:00000000015B52D9                 mov     [rbp+var_21C], 0FFFFFFFFh
+  .text:00000000015B52E3                 mov     [rbp+var_218], rdx
+  .text:00000000015B52EA                 cmp     r15, rsi
+  .text:00000000015B52ED                 jnz     loc_15B56E0
+  .text:00000000015B52F3                 mov     rdi, [r13+138h]
+  .text:00000000015B52FA                 movzx   ecx, word ptr [rdi]
+  .text:00000000015B52FD                 shr     cx, 2
+  .text:00000000015B5301                 and     ecx, 0Fh
+  .text:00000000015B5304                 cmp     cl, 8
+  .text:00000000015B5307                 jz      loc_15B5624
+  .text:00000000015B530D                 mov     [rbp+var_208], rdx
+  .text:00000000015B5314                 xor     ecx, ecx
+  .text:00000000015B5316                 lea     rdx, [rbp+var_224]
+  .text:00000000015B531D                 mov     [rbp+var_210], eax
+  .text:00000000015B5323                 lea     rsi, [rbp+var_210]
+  .text:00000000015B532A                 mov     [rbp+var_224], 0FFFFFFFFh
+  .text:00000000015B5334                 mov     [rbp+var_20C], 0FFFFFFFFh
+  .text:00000000015B533E                 call    sub_1B1E6B0
+  .text:00000000015B5343                 test    rax, rax
+  .text:00000000015B5346                 jnz     loc_15B5618
+  .text:00000000015B534C                 mov     rdi, [rbp+var_200]
+  .text:00000000015B5353                 test    rdi, rdi
+  .text:00000000015B5356                 jz      short loc_15B53D0
+  .text:00000000015B5358                 mov     rax, [rdi]
+  .text:00000000015B535B                 lea     rsi, sub_1535D00
+  .text:00000000015B5362                 mov     rax, [rax+210h]
+  .text:00000000015B5369                 cmp     rax, rsi
+  .text:00000000015B536C                 jnz     loc_15B56D8
+  .text:00000000015B5372                 mov     eax, [rdi-1Ch]
+  .text:00000000015B5375                 sub     eax, 1
+  .text:00000000015B5378                 mov     [rdi-1Ch], eax
+  .text:00000000015B537B                 test    eax, eax
+  .text:00000000015B537D                 jnz     short loc_15B53C5
+  .text:00000000015B537F                 mov     rdi, [rbp+var_200]
+  .text:00000000015B5386                 lea     rcx, haystack
+  .text:00000000015B538D                 mov     rdx, [rbp+var_1F8]
+  .text:00000000015B5394                 movzx   esi, [rbp+var_1F0]
+  .text:00000000015B539B                 mov     rax, [rdi]
+  .text:00000000015B539E                 test    rdx, rdx
+  .text:00000000015B53A1                 cmovz   rdx, rcx
+  .text:00000000015B53A5                 mov     rax, [rax+1D0h]
+  .text:00000000015B53AC                 lea     rcx, sub_156CF20
+  .text:00000000015B53B3                 cmp     rax, rcx
+  .text:00000000015B53B6                 jnz     loc_15B5700
+  .text:00000000015B53BC                 sub     rdi, 48h ; 'H'
+  .text:00000000015B53C0                 call    sub_156CE30
+  .text:00000000015B53C5                 mov     [rbp+var_200], 0
+  .text:00000000015B53D0                 cmp     [rbp+var_1F8], 0
+  .text:00000000015B53D8                 jz      loc_15B5600
+  .text:00000000015B53DE                 ; this
+  .text:00000000015B53DE                 lea     rdi, [rbp+var_1F8]; this
+  .text:00000000015B53E5                 add     r14, 1
+  .text:00000000015B53E9                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:00000000015B53EE                 cmp     [rbx+10h], r14d
+  .text:00000000015B53F2                 jg      loc_15B5240
+  .text:00000000015B53F8                 movzx   r15d, [rbp+var_24D]
+  .text:00000000015B5400                 mov     rax, [rbx]
+  .text:00000000015B5403                 lea     rdx, _ZN20CSaveRestoreBlockSet11PostRestoreEv; CSaveRestoreBlockSet::PostRestore(void)
+  .text:00000000015B540A                 mov     rax, [rax+40h]
+  .text:00000000015B540E                 cmp     rax, rdx
+  .text:00000000015B5411                 jnz     loc_15B5830
+  .text:00000000015B5417                 mov     eax, [rbx+10h]
+  .text:00000000015B541A                 xor     r12d, r12d
+  .text:00000000015B541D                 test    eax, eax
+  .text:00000000015B541F                 jle     short loc_15B5440
+  .text:00000000015B5421                 nop     dword ptr [rax+00000000h]
+  .text:00000000015B5428                 mov     rax, [rbx+18h]
+  .text:00000000015B542C                 mov     rdi, [rax+r12*8]
+  .text:00000000015B5430                 add     r12, 1
+  .text:00000000015B5434                 mov     rax, [rdi]
+  .text:00000000015B5437                 call    qword ptr [rax+40h]  ; 40h = CSaveRestoreBlockSet_PostRestore
+  .text:00000000015B543A                 cmp     [rbx+10h], r12d
+  .text:00000000015B543E                 jg      short loc_15B5428
+  .text:00000000015B5440                 mov     r12, [rbp+var_268]
+  .text:00000000015B5447                 xor     ebx, ebx
+  .text:00000000015B5449                 mov     r13, [rbp+arg_8]
+  .text:00000000015B544D                 jmp     short loc_15B5453
+  .text:00000000015B5450                 add     ebx, 1
+  .text:00000000015B5453                 mov     rdi, r12
+  .text:00000000015B5456                 call    CGameSaveRestoreInfo__NumEntities
+  .text:00000000015B545B                 cmp     ebx, eax
+  .text:00000000015B545D                 jge     loc_15B5520
+  .text:00000000015B5463                 mov     esi, ebx
+  .text:00000000015B5465                 mov     rdi, r12
+  .text:00000000015B5468                 call    sub_FA89B0
+  .text:00000000015B546D                 mov     edx, [rax+0Ch]
+  .text:00000000015B5470                 cmp     edx, 7FFEh
+  .text:00000000015B5476                 ja      short loc_15B5450
+  .text:00000000015B5478                 lea     rax, g_pEntitySystem
+  .text:00000000015B547F                 mov     rcx, [rax]
+  .text:00000000015B5482                 mov     eax, edx
+  .text:00000000015B5484                 sar     eax, 9
+  .text:00000000015B5487                 cdqe
+  .text:00000000015B5489                 mov     rax, [rcx+rax*8+10h]
+  .text:00000000015B548E                 test    rax, rax
+  .text:00000000015B5491                 jz      short loc_15B5450
+  .text:00000000015B5493                 mov     ecx, edx
+  .text:00000000015B5495                 and     ecx, 1FFh
+  .text:00000000015B549B                 imul    rcx, 70h ; 'p'
+  .text:00000000015B549F                 add     rax, rcx
+  .text:00000000015B54A2                 movzx   ecx, word ptr [rax+10h]
+  .text:00000000015B54A6                 and     ecx, 7FFFh
+  .text:00000000015B54AC                 cmp     ecx, edx
+  .text:00000000015B54AE                 jnz     short loc_15B5450
+  .text:00000000015B54B0                 mov     r14d, [rax+10h]
+  .text:00000000015B54B4                 mov     edx, [rax+30h]
+  .text:00000000015B54B7                 shr     r14d, 0Fh
+  .text:00000000015B54BB                 and     edx, 1
+  .text:00000000015B54BE                 sub     r14d, edx
+  .text:00000000015B54C1                 cmp     dword ptr [rax+10h], 0FFFFFFFFh
+  .text:00000000015B54C5                 jz      loc_15B5808
+  .text:00000000015B54CB                 movsxd  rax, dword ptr [r13+0]
+  .text:00000000015B54CF                 shl     r14d, 0Fh
+  .text:00000000015B54D3                 or      r14d, ecx
+  .text:00000000015B54D6                 mov     edx, eax
+  .text:00000000015B54D8                 cmp     eax, [r13+10h]
+  .text:00000000015B54DC                 jz      loc_15B5730
+  .text:00000000015B54E2                 add     edx, 1
+  .text:00000000015B54E5                 mov     [r13+0], edx
+  .text:00000000015B54E9                 mov     rdx, [r13+8]
+  .text:00000000015B54ED                 mov     [rdx+rax*4], r14d
+  .text:00000000015B54F1                 jmp     loc_15B5450
+  .text:00000000015B5500                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000015B5507                 mov     rsi, [rbp+var_1D8]
+  .text:00000000015B550E                 mov     rdi, [rax]
+  .text:00000000015B5511                 mov     rax, [rdi]
+  .text:00000000015B5514                 call    qword ptr [rax+20h]
+  .text:00000000015B5517                 jmp     loc_15B5068
+  .text:00000000015B5520                 mov     rbx, [rbp+var_238]
+  .text:00000000015B5527                 mov     rsi, [rbp+var_240]
+  .text:00000000015B552E                 mov     rdi, [rbx+128h]
+  .text:00000000015B5535                 call    sub_15B4AC0
+  .text:00000000015B553A                 mov     rsi, [rbp+var_268]
+  .text:00000000015B5541                 mov     rdi, rax
+  .text:00000000015B5544                 call    sub_FAFBC0
+  .text:00000000015B5549                 mov     rdi, [rbp+var_260]
+  .text:00000000015B5550                 call    sub_1552BA0
+  .text:00000000015B5555                 cmp     qword ptr [rbx+0D0h], 0
+  .text:00000000015B555D                 jz      loc_15B57B8
+  .text:00000000015B5563                 mov     rbx, [rbp+var_238]
+  .text:00000000015B556A                 mov     eax, [rbx+0D8h]
+  .text:00000000015B5570                 mov     [rbp+var_24C], eax
+  .text:00000000015B5576                 sub     eax, 1
+  .text:00000000015B5579                 mov     [rbx+0D8h], eax
+  .text:00000000015B557F                 jnz     short loc_15B55C0
+  .text:00000000015B5581                 mov     rbx, [rbx+0D0h]
+  .text:00000000015B5588                 test    rbx, rbx
+  .text:00000000015B558B                 jz      short loc_15B55A2
+  .text:00000000015B558D                 ; this
+  .text:00000000015B558D                 mov     rdi, rbx; this
+  .text:00000000015B5590                 call    __ZN12CMemoryStackD1Ev; CMemoryStack::~CMemoryStack()
+  .text:00000000015B5595                 ; _QWORD
+  .text:00000000015B5595                 mov     esi, 50h ; 'P'; _QWORD
+  .text:00000000015B559A                 ; _QWORD
+  .text:00000000015B559A                 mov     rdi, rbx; _QWORD
+  .text:00000000015B559D                 call    __ZdlPvm; operator delete(void *,ulong)
+  .text:00000000015B55A2                 mov     rax, [rbp+var_238]
+  .text:00000000015B55A9                 mov     qword ptr [rax+0D0h], 0
+  .text:00000000015B55B4                 mov     dword ptr [rax+0D8h], 0
+  .text:00000000015B55BE                 xchg    ax, ax
+  .text:00000000015B55C0                 mov     rax, [rbp+var_238]
+  .text:00000000015B55C7                 cmp     byte ptr [rax+7Ch], 0
+  .text:00000000015B55CB                 jz      loc_15B5049
+  .text:00000000015B55D1                 mov     rcx, [rbp+arg_0]
+  .text:00000000015B55D5                 xor     edx, edx
+  .text:00000000015B55D7                 mov     rdi, rax
+  .text:00000000015B55DA                 mov     rsi, [rbp+var_240]
+  .text:00000000015B55E1                 call    sub_153F970
+  .text:00000000015B55E6                 jmp     loc_15B5049
+  .text:00000000015B55F0                 mov     rdi, r13
+  .text:00000000015B55F3                 call    rax
+  .text:00000000015B55F5                 mov     r12, rax
+  .text:00000000015B55F8                 jmp     loc_15B500F
+  .text:00000000015B5600                 add     r14, 1
+  .text:00000000015B5604                 cmp     [rbx+10h], r14d
+  .text:00000000015B5608                 jg      loc_15B5240
+  .text:00000000015B560E                 jmp     loc_15B53F8
+  .text:00000000015B5618                 lea     rdi, [r13+10h]
+  .text:00000000015B561C                 mov     rsi, rax
+  .text:00000000015B561F                 call    sub_1B24310
+  .text:00000000015B5624                 mov     rax, [r13+0]
+  .text:00000000015B5628                 lea     rsi, sub_D45F10
+  .text:00000000015B562F                 mov     rax, [rax+248h]
+  .text:00000000015B5636                 cmp     rax, rsi
+  .text:00000000015B5639                 jnz     loc_15B5720
+  .text:00000000015B563F                 mov     rax, [r13+138h]
+  .text:00000000015B5646                 movzx   eax, word ptr [rax]
+  .text:00000000015B5649                 shr     ax, 2
+  .text:00000000015B564D                 and     eax, 0Fh
+  .text:00000000015B5650                 cmp     al, 1
+  .text:00000000015B5652                 jz      short loc_15B566C
+  .text:00000000015B5654                 mov     rax, [r12]
+  .text:00000000015B5658                 mov     ecx, 1
+  .text:00000000015B565D                 mov     rsi, r13
+  .text:00000000015B5660                 mov     rdi, r12
+  .text:00000000015B5663                 mov     edx, [rbp+var_24C]
+  .text:00000000015B5669                 call    qword ptr [rax+38h]
+  .text:00000000015B566C                 mov     rax, [r13+0]
+  .text:00000000015B5670                 lea     rcx, sub_1535D40
+  .text:00000000015B5677                 mov     rax, [rax+48h]
+  .text:00000000015B567B                 cmp     rax, rcx
+  .text:00000000015B567E                 jnz     loc_15B5710
+  .text:00000000015B5684                 lea     rdi, [r13+10h]
+  .text:00000000015B5688                 call    sub_1B244F0
+  .text:00000000015B568D                 jmp     loc_15B534C
+  .text:00000000015B5698                 mov     ecx, [rbp+var_24C]
+  .text:00000000015B569E                 mov     rdx, r13
+  .text:00000000015B56A1                 mov     rsi, r12
+  .text:00000000015B56A4                 mov     rdi, rbx
+  .text:00000000015B56A7                 mov     r8d, 1
+  .text:00000000015B56AD                 call    rax
+  .text:00000000015B56AF                 jmp     loc_15B534C
+  .text:00000000015B56B8                 mov     rdi, rdx
+  .text:00000000015B56BB                 mov     [rbp+var_270], rdx
+  .text:00000000015B56C2                 call    sub_153DDC0
+  .text:00000000015B56C7                 mov     rdx, [rbp+var_270]
+  .text:00000000015B56CE                 jmp     loc_15B52CC
+  .text:00000000015B56D8                 call    rax
+  .text:00000000015B56DA                 jmp     loc_15B537B
+  .text:00000000015B56E0                 lea     rsi, [rbp+var_220]
+  .text:00000000015B56E7                 mov     rdi, r13
+  .text:00000000015B56EA                 call    r15
+  .text:00000000015B56ED                 test    al, al
+  .text:00000000015B56EF                 jz      loc_15B534C
+  .text:00000000015B56F5                 jmp     loc_15B5624
+  .text:00000000015B5700                 call    rax
+  .text:00000000015B5702                 jmp     loc_15B53C5
+  .text:00000000015B5710                 mov     rdi, r13
+  .text:00000000015B5713                 call    rax
+  .text:00000000015B5715                 jmp     loc_15B534C
+  .text:00000000015B5720                 mov     rdi, r13
+  .text:00000000015B5723                 call    rax
+  .text:00000000015B5725                 jmp     loc_15B5646
+  .text:00000000015B5730                 lea     rdi, [r13+8]
+  .text:00000000015B5734                 mov     esi, 1
+  .text:00000000015B5739                 mov     [rbp+var_24C], eax
+  .text:00000000015B573F                 call    sub_AE1280
+  .text:00000000015B5744                 mov     edx, [r13+0]
+  .text:00000000015B5748                 movsxd  rax, [rbp+var_24C]
+  .text:00000000015B574F                 jmp     loc_15B54E2
+  .text:00000000015B5758                 mov     rdi, [rbp+var_268]
+  .text:00000000015B575F                 call    CGameSaveRestoreInfo__NumEntities
+  .text:00000000015B5764                 lea     r8, [rbp+var_138]
+  .text:00000000015B576B                 mov     r9d, eax
+  .text:00000000015B576E                 test    [rbp+var_139], 40h
+  .text:00000000015B5775                 jnz     short loc_15B5791
+  .text:00000000015B5777                 lea     r8, haystack
+  .text:00000000015B577E                 test    dword ptr [rbp-13Ch], 3FFFFFFFh
+  .text:00000000015B5788                 jz      short loc_15B5791
+  .text:00000000015B578A                 mov     r8, [rbp+var_138]
+  .text:00000000015B5791                 ; _QWORD
+  .text:00000000015B5791                 mov     edi, [r14]; _QWORD
+  .text:00000000015B5794                 lea     rcx, aSv_0; "SV"
+  .text:00000000015B579B                 ; _QWORD
+  .text:00000000015B579B                 mov     esi, 1; _QWORD
+  .text:00000000015B57A0                 xor     eax, eax
+  .text:00000000015B57A2                 lea     rdx, aSStreamentitie_1; "%s:  StreamEntitiesFromFile:  '%s' [%d "...
+  .text:00000000015B57A9                 call    _LoggingSystem_Log
+  .text:00000000015B57AE                 jmp     loc_15B51B0
+  .text:00000000015B57B8                 ; _QWORD
+  .text:00000000015B57B8                 mov     edi, 50h ; 'P'; _QWORD
+  .text:00000000015B57BD                 call    __Znwm; operator new(ulong)
+  .text:00000000015B57C2                 ; this
+  .text:00000000015B57C2                 mov     rdi, rax; this
+  .text:00000000015B57C5                 mov     rbx, rax
+  .text:00000000015B57C8                 call    __ZN12CMemoryStackC1Ev; CMemoryStack::CMemoryStack(void)
+  .text:00000000015B57CD                 mov     rax, [rbp+var_238]
+  .text:00000000015B57D4                 ; unsigned int
+  .text:00000000015B57D4                 mov     r9d, 10h; unsigned int
+  .text:00000000015B57DA                 ; unsigned int
+  .text:00000000015B57DA                 mov     r8d, 230000h; unsigned int
+  .text:00000000015B57E0                 ; unsigned int
+  .text:00000000015B57E0                 mov     ecx, 40h ; '@'; unsigned int
+  .text:00000000015B57E5                 ; unsigned int
+  .text:00000000015B57E5                 mov     edx, 2000000h; unsigned int
+  .text:00000000015B57EA                 ; this
+  .text:00000000015B57EA                 mov     rdi, rbx; this
+  .text:00000000015B57ED                 lea     rsi, aCsavememory; "CSaveMemory"
+  .text:00000000015B57F4                 mov     [rax+0D0h], rbx
+  .text:00000000015B57FB                 call    __ZN12CMemoryStack4InitEPKcjjjj; CMemoryStack::Init(char const*,uint,uint,uint,uint)
+  .text:00000000015B5800                 jmp     loc_15B5563
+  .text:00000000015B5808                 mov     ecx, 7FFFh
+  .text:00000000015B580D                 jmp     loc_15B54CB
+  .text:00000000015B5812                 mov     rax, [rdx+40h]
+  .text:00000000015B5816                 lea     rdx, _ZN20CSaveRestoreBlockSet11PostRestoreEv; CSaveRestoreBlockSet::PostRestore(void)
+  .text:00000000015B581D                 cmp     rax, rdx
+  .text:00000000015B5820                 jz      loc_15B5440
+  .text:00000000015B5826                 nop     word ptr [rax+rax+00000000h]
+  .text:00000000015B5830                 mov     rdi, rbx
+  .text:00000000015B5833                 call    rax
+  .text:00000000015B5835                 jmp     loc_15B5440
+  .text:00000000015B5840                 mov     edx, [rbp+var_24C]
+  .text:00000000015B5846                 mov     ecx, 1
+  .text:00000000015B584B                 mov     rsi, r13
+  .text:00000000015B584E                 mov     rdi, rbx
+  .text:00000000015B5851                 call    rax
+  .text:00000000015B5853                 jmp     loc_15B5400
+  .text:00000000015B5860                 mov     rdi, rbx
+  .text:00000000015B5863                 call    rdx
+  .text:00000000015B5865                 jmp     loc_15B5188
+procedure: |-
+  __int64 __fastcall CEntity2SaveRestore_StreamEntitiesFromFile(
+          __int64 a1,
+          CSaveRestoreBlockSet *a2,
+          __int64 a3,
+          __int64 a4,
+          unsigned int a5,
+          __int64 a6,
+          __int64 a7,
+          int *a8)
+  {
+    int v10; // r8d
+    int v11; // r9d
+    const bool *v12; // rdx
+    __int64 (__fastcall *v13)(); // rax
+    __int64 v14; // r12
+    const bool *v15; // rsi
+    __int64 (__fastcall *v16)(__int64, __int64, int *); // rax
+    unsigned int v17; // r15d
+    __int64 v19; // r8
+    __int64 v20; // r9
+    __int64 v21; // rdx
+    __int64 v22; // rax
+    _DWORD *v23; // rax
+    _QWORD *v24; // r13
+    __int64 v25; // rax
+    __int64 (__fastcall *v26)(); // rdx
+    __int64 v27; // r14
+    __int64 v28; // rdi
+    _DWORD *v29; // rax
+    __int64 (__fastcall *v30)(); // rax
+    __int64 v31; // r14
+    __int64 v32; // r12
+    __int64 v33; // rax
+    int v34; // r15d
+    int v35; // eax
+    __int64 (__fastcall *v36)(); // rax
+    __int64 (__fastcall *v37)(); // r15
+    char *v38; // rdx
+    int v39; // eax
+    _WORD *v40; // rdi
+    __int64 v41; // rax
+    __int64 (*v42)(void); // rax
+    int v43; // eax
+    const bool *v44; // rdx
+    __int64 (__fastcall *v45)(); // rax
+    __int64 (__fastcall *v46)(CSaveRestoreBlockSet *__hidden); // rax
+    __int64 i; // r12
+    __int64 v48; // rdi
+    int j; // ebx
+    int v50; // edx
+    __int64 v51; // rax
+    __int64 v52; // rax
+    int v53; // ecx
+    int v54; // r14d
+    __int64 v55; // rax
+    int v56; // r14d
+    int v57; // edx
+    __int64 v58; // rax
+    __int64 v59; // rdx
+    __int64 v60; // rcx
+    CMemoryStack *v61; // rbx
+    __int64 (__fastcall *v62)(); // rax
+    _WORD *v63; // rax
+    __int64 (__fastcall *v64)(); // rax
+    CMemoryStack *v65; // rbx
+    char *v66; // [rsp+0h] [rbp-270h]
+    __int64 v67; // [rsp+8h] [rbp-268h]
+    __int64 v68; // [rsp+10h] [rbp-260h]
+    unsigned __int8 v69; // [rsp+23h] [rbp-24Dh]
+    int v71; // [rsp+24h] [rbp-24Ch]
+    int v72; // [rsp+24h] [rbp-24Ch]
+    int v75; // [rsp+4Ch] [rbp-224h] BYREF
+    _DWORD v76[2]; // [rsp+50h] [rbp-220h] BYREF
+    char *v77; // [rsp+58h] [rbp-218h]
+    _DWORD v78[2]; // [rsp+60h] [rbp-210h] BYREF
+    char *v79; // [rsp+68h] [rbp-208h]
+    __int64 v80; // [rsp+70h] [rbp-200h] BYREF
+    const bool *v81; // [rsp+78h] [rbp-1F8h] BYREF
+    unsigned __int8 v82; // [rsp+80h] [rbp-1F0h]
+    int v83; // [rsp+90h] [rbp-1E0h] BYREF
+    int v84; // [rsp+94h] [rbp-1DCh]
+    __int64 v85; // [rsp+98h] [rbp-1D8h]
+    unsigned int v86; // [rsp+A4h] [rbp-1CCh]
+    _QWORD v87[10]; // [rsp+E0h] [rbp-190h] BYREF
+    _BYTE v88[4]; // [rsp+130h] [rbp-140h] BYREF
+    int v89; // [rsp+134h] [rbp-13Ch]
+    __int64 v90; // [rsp+138h] [rbp-138h] BYREF
+
+    CEntity2SaveRestore::GetSaveGameSpawnGroupName(v87, a1, a3);
+    LODWORD(v12) = v87[0];
+    if ( !v87[0] )
+      v12 = &haystack;
+    V_sprintf((unsigned int)v88, (unsigned int)"save/%s.hl%s", (_DWORD)v12, (unsigned int)"1", v10, v11);
+    if ( v87[0] )
+      CUtlString::FreeMemoryBlock((CUtlString *)v87);
+    CUtlBuffer::CUtlBuffer(&v83, 0, 0, 0);
+    v13 = *(__int64 (__fastcall **)())(*(_QWORD *)a4 + 24LL);
+    if ( v13 == sub_152DE00 )
+      v14 = a4 + 4648;
+    else
+      v14 = ((__int64 (__fastcall *)(__int64))v13)(a4);
+    v15 = (const bool *)&v90;
+    v16 = *(__int64 (__fastcall **)(__int64, __int64, int *))(*(_QWORD *)v14 + 16LL);
+    if ( (v89 & 0x40000000) == 0 && (v15 = &haystack, (v89 & 0x3FFFFFFF) != 0) )
+    {
+      v17 = v16(v14, v90, &v83);
+      if ( !(_BYTE)v17 )
+        goto LABEL_10;
+    }
+    else
+    {
+      v17 = v16(v14, (__int64)v15, &v83);
+      if ( !(_BYTE)v17 )
+        goto LABEL_10;
+    }
+    sub_1554AC0(a1, a3, 0);
+    v21 = 0;
+    if ( (v84 & 0x7FFFFFFF) != 0 )
+      v21 = v85;
+    v22 = sub_1554BB0(a1, a3, v21, v86, v19, v20);
+    v68 = v22;
+    if ( v22 )
+    {
+      v67 = v22 + 24;
+      sub_FA9000(v22 + 24, a4);
+      v23 = off_2503B68;
+      *(_DWORD *)(v68 + 824) = *((_DWORD *)off_2503B68 + 12);
+      *(_DWORD *)(v68 + 828) = v23[17];
+      v24 = (_QWORD *)sub_1591EC0(v68);
+      sub_1552090(v87, v24);
+      v25 = *(_QWORD *)a2;
+      v26 = *(__int64 (__fastcall **)())(*(_QWORD *)a2 + 40LL);// 40LL = 0x28 = CSaveRestoreBlockSet_PreRestore
+      if ( v26 == CSaveRestoreBlockSet::PreRestore )
+      {
+        if ( *((int *)a2 + 4) <= 0 )
+          goto LABEL_23;
+        v27 = 0;
+        do
+        {
+          v28 = *(_QWORD *)(*((_QWORD *)a2 + 3) + 8 * v27++);
+          (*(void (__fastcall **)(__int64))(*(_QWORD *)v28 + 40LL))(v28);
+        }
+        while ( *((_DWORD *)a2 + 4) > (int)v27 );
+      }
+      else
+      {
+        ((void (__fastcall *)(CSaveRestoreBlockSet *))v26)(a2);
+      }
+      v25 = *(_QWORD *)a2;
+  LABEL_23:
+      (*(void (__fastcall **)(CSaveRestoreBlockSet *, _QWORD *))(v25 + 48))(a2, v24);// 48 = 0x30 = CSaveRestoreBlockSet_ReadRestoreHeaders
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_2666BA0, 1) )
+      {
+        CGameSaveRestoreInfo::NumEntities(v67);
+        LoggingSystem_Log((unsigned int)dword_2666BA0, 1, "%s:  StreamEntitiesFromFile:  '%s' [%d entities]\n");
+      }
+      sub_156D940(a1, v68, v24);
+      sub_156C7D0(a1, v14, v68, a3);
+      v29 = off_2503B68;
+      *(_DWORD *)(v68 + 824) = *((_DWORD *)off_2503B68 + 12);
+      *(_DWORD *)(v68 + 828) = v29[17];
+      v30 = *(__int64 (__fastcall **)())(*(_QWORD *)a2 + 56LL);// 56LL = 0x38 = CSaveRestoreBlockSet_Restore
+      if ( v30 == CSaveRestoreBlockSet::Restore )
+      {
+        if ( *((int *)a2 + 4) > 0 )
+        {
+          v31 = 0;
+          v69 = v17;
+          while ( 1 )
+          {
+            v32 = *(_QWORD *)(*((_QWORD *)a2 + 3) + 8 * v31);
+            v33 = (**(__int64 (__fastcall ***)(__int64))v32)(v32);
+            v34 = V_stricmp_fast(v33, "Entities");
+            v35 = (**(__int64 (__fastcall ***)(__int64))v32)(v32);
+            sub_1570830((unsigned int)&v80, (_DWORD)v24, 0, v34 != 0, (unsigned int)"%-16.16s | ", v35, (char)v66);
+            v36 = *(__int64 (__fastcall **)())(*(_QWORD *)a2 + 88LL);// CSaveRestoreBlockSet::CallBlockHandlerRestore
+            if ( v36 == CSaveRestoreBlockSet::CallBlockHandlerRestore )
+            {
+              v37 = *(__int64 (__fastcall **)())(*v24 + 64LL);
+              v38 = (char *)(**(__int64 (__fastcall ***)(__int64))v32)(v32);
+              v39 = 0;
+              if ( v38 && *v38 )
+              {
+                v66 = v38;
+                v39 = sub_153DDC0(v38);
+                v38 = v66;
+              }
+              v76[0] = v39;
+              v76[1] = -1;
+              v77 = v38;
+              if ( v37 == sub_1538F00 )
+              {
+                v40 = (_WORD *)v24[39];
+                if ( ((*v40 >> 2) & 0xF) == 8 )
+                  goto LABEL_73;
+                v79 = v38;
+                v78[0] = v39;
+                v75 = -1;
+                v78[1] = -1;
+                v41 = sub_1B1E6B0(v40, v78, &v75, 0);
+                if ( v41 )
+                {
+                  sub_1B24310(v24 + 2, v41);
+  LABEL_73:
+                  v62 = *(__int64 (__fastcall **)())(*v24 + 584LL);
+                  if ( v62 == sub_D45F10 )
+                    v63 = (_WORD *)v24[39];
+                  else
+                    v63 = (_WORD *)((__int64 (__fastcall *)(_QWORD *))v62)(v24);
+                  if ( ((*v63 >> 2) & 0xF) != 1 )
+                    (*(void (__fastcall **)(__int64, _QWORD *, _QWORD, __int64))(*(_QWORD *)v32 + 56LL))(v32, v24, a5, 1);
+                  v64 = *(__int64 (__fastcall **)())(*v24 + 72LL);
+                  if ( v64 == sub_1535D40 )
+                    sub_1B244F0(v24 + 2);
+                  else
+                    ((void (__fastcall *)(_QWORD *))v64)(v24);
+                }
+              }
+              else if ( ((unsigned __int8 (__fastcall *)(_QWORD *, _DWORD *))v37)(v24, v76) )
+              {
+                goto LABEL_73;
+              }
+            }
+            else
+            {
+              ((void (__fastcall *)(CSaveRestoreBlockSet *, __int64, _QWORD *, _QWORD, __int64))v36)(a2, v32, v24, a5, 1);
+            }
+            if ( v80 )
+            {
+              v42 = *(__int64 (**)(void))(*(_QWORD *)v80 + 528LL);
+              if ( v42 == sub_1535D00 )
+              {
+                v43 = *(_DWORD *)(v80 - 28) - 1;
+                *(_DWORD *)(v80 - 28) = v43;
+              }
+              else
+              {
+                v43 = v42();
+              }
+              if ( !v43 )
+              {
+                v44 = v81;
+                if ( !v81 )
+                  v44 = &haystack;
+                v45 = *(__int64 (__fastcall **)())(*(_QWORD *)v80 + 464LL);
+                if ( v45 == sub_156CF20 )
+                  sub_156CE30(v80 - 72, v82, v44);
+                else
+                  ((void (__fastcall *)(__int64, _QWORD, const bool *))v45)(v80, v82, v44);
+              }
+              v80 = 0;
+            }
+            if ( v81 )
+            {
+              ++v31;
+              CUtlString::FreeMemoryBlock((CUtlString *)&v81);
+              if ( *((_DWORD *)a2 + 4) <= (int)v31 )
+                goto LABEL_46;
+            }
+            else if ( *((_DWORD *)a2 + 4) <= (int)++v31 )
+            {
+  LABEL_46:
+              v17 = v69;
+              goto LABEL_47;
+            }
+          }
+        }
+        v46 = *(__int64 (__fastcall **)(CSaveRestoreBlockSet *__hidden))(*(_QWORD *)a2 + 64LL);// 64LL = 0x40 = CSaveRestoreBlockSet_PostRestore
+        if ( v46 == CSaveRestoreBlockSet::PostRestore )
+          goto LABEL_50;
+      }
+      else
+      {
+        ((void (__fastcall *)(CSaveRestoreBlockSet *, _QWORD *, _QWORD, __int64))v30)(a2, v24, a5, 1);
+  LABEL_47:
+        v46 = *(__int64 (__fastcall **)(CSaveRestoreBlockSet *__hidden))(*(_QWORD *)a2 + 64LL);// 64LL = 0x40 = CSaveRestoreBlockSet_PostRestore
+        if ( v46 == CSaveRestoreBlockSet::PostRestore )
+        {
+          for ( i = 0; *((_DWORD *)a2 + 4) > (int)i; ++i )
+          {
+            v48 = *(_QWORD *)(*((_QWORD *)a2 + 3) + 8 * i);
+            (*(void (__fastcall **)(__int64))(*(_QWORD *)v48 + 64LL))(v48);
+          }
+          goto LABEL_50;
+        }
+      }
+      v46(a2);
+  LABEL_50:
+      for ( j = 0; j < (int)CGameSaveRestoreInfo::NumEntities(v67); ++j )
+      {
+        v50 = *(_DWORD *)(sub_FA89B0(v67) + 12);
+        if ( (unsigned int)v50 <= 0x7FFE )
+        {
+          v51 = *(_QWORD *)(g_pEntitySystem + 8LL * (v50 >> 9) + 16);
+          if ( v51 )
+          {
+            v52 = 112LL * (v50 & 0x1FF) + v51;
+            v53 = *(_WORD *)(v52 + 16) & 0x7FFF;
+            if ( v53 == v50 )
+            {
+              v54 = (*(_DWORD *)(v52 + 16) >> 15) - (*(_DWORD *)(v52 + 48) & 1);
+              if ( *(_DWORD *)(v52 + 16) == -1 )
+                v53 = 0x7FFF;
+              v55 = *a8;
+              v56 = v53 | (v54 << 15);
+              v57 = v55;
+              if ( (_DWORD)v55 == a8[4] )
+              {
+                v72 = *a8;
+                sub_AE1280(a8 + 2, 1);
+                v57 = *a8;
+                v55 = v72;
+              }
+              *a8 = v57 + 1;
+              *(_DWORD *)(*((_QWORD *)a8 + 1) + 4 * v55) = v56;
+            }
+          }
+        }
+      }
+      v58 = sub_15B4AC0(*(_QWORD *)(a1 + 296), a3);
+      sub_FAFBC0(v58, v67);
+      sub_1552BA0(v68, v67, v59, v60);
+      if ( !*(_QWORD *)(a1 + 208) )
+      {
+        v65 = (CMemoryStack *)operator new(80);
+        CMemoryStack::CMemoryStack(v65);
+        *(_QWORD *)(a1 + 208) = v65;
+        CMemoryStack::Init(v65, "CSaveMemory", 0x2000000u, 0x40u, 0x230000u, 0x10u);
+      }
+      v71 = *(_DWORD *)(a1 + 216);
+      *(_DWORD *)(a1 + 216) = v71 - 1;
+      if ( v71 == 1 )
+      {
+        v61 = *(CMemoryStack **)(a1 + 208);
+        if ( v61 )
+        {
+          CMemoryStack::~CMemoryStack(v61);
+          operator delete(v61, 80);
+        }
+        *(_QWORD *)(a1 + 208) = 0;
+        *(_DWORD *)(a1 + 216) = 0;
+      }
+    }
+    if ( *(_BYTE *)(a1 + 124) )
+      sub_153F970(a1, a3, 0, a7);
+  LABEL_10:
+    v83 = 0;
+    if ( (v84 & 0x7FFFFFFF) != 0 && v84 >= 0 )
+      (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v85);
+    CBufferString::Purge((CBufferString *)v88, 0);
+    return v17;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntity2SaveRestore_StreamEntitiesFromFile.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntity2SaveRestore_StreamEntitiesFromFile.windows.yaml
@@ -1,0 +1,646 @@
+func_name: CEntity2SaveRestore_StreamEntitiesFromFile
+func_va: '0x180b8dc30'
+disasm_code: |-
+  .text:0000000180B8DC30                 mov     [rsp-8+arg_0], rbx
+  .text:0000000180B8DC35                 mov     [rsp-8+arg_10], r8
+  .text:0000000180B8DC3A                 push    rbp
+  .text:0000000180B8DC3B                 push    rsi
+  .text:0000000180B8DC3C                 push    rdi
+  .text:0000000180B8DC3D                 push    r12
+  .text:0000000180B8DC3F                 push    r13
+  .text:0000000180B8DC41                 push    r14
+  .text:0000000180B8DC43                 push    r15
+  .text:0000000180B8DC45                 lea     rbp, [rsp-0E0h]
+  .text:0000000180B8DC4D                 sub     rsp, 1E0h
+  .text:0000000180B8DC54                 mov     r14, rdx
+  .text:0000000180B8DC57                 mov     r15, rcx
+  .text:0000000180B8DC5A                 xor     eax, eax
+  .text:0000000180B8DC5C                 lea     rcx, [rbp+110h+arg_18]
+  .text:0000000180B8DC63                 mov     rdx, r8
+  .text:0000000180B8DC66                 mov     [rbp+110h+arg_18], rax
+  .text:0000000180B8DC6D                 mov     rdi, r9
+  .text:0000000180B8DC70                 mov     r13, r8
+  .text:0000000180B8DC73                 xor     r12b, r12b
+  .text:0000000180B8DC76                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180B8DC7C                 lea     rdx, [rsp+210h+var_1D8]
+  .text:0000000180B8DC81                 lea     rcx, [rbp+110h+arg_18]
+  .text:0000000180B8DC88                 call    cs:?GetBaseFilename@CUtlString@@QEBA?AV1@XZ; CUtlString::GetBaseFilename(void)
+  .text:0000000180B8DC8E                 cmp     [rbp+110h+arg_18], 0
+  .text:0000000180B8DC96                 jz      short loc_180B8DCA5
+  .text:0000000180B8DC98                 lea     rcx, [rbp+110h+arg_18]
+  .text:0000000180B8DC9F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180B8DCA5                 mov     rax, [rsp+210h+var_1D8]
+  .text:0000000180B8DCAA                 lea     rbx, Src
+  .text:0000000180B8DCB1                 test    rax, rax
+  .text:0000000180B8DCB4                 mov     [rsp+210h+var_1E0], rax
+  .text:0000000180B8DCB9                 mov     r8, rbx
+  .text:0000000180B8DCBC                 lea     r9, a1; "1"
+  .text:0000000180B8DCC3                 cmovnz  r8, rax
+  .text:0000000180B8DCC7                 lea     rdx, aSaveSHlS; "save/%s.hl%s"
+  .text:0000000180B8DCCE                 lea     rcx, [rbp+110h+var_190]
+  .text:0000000180B8DCD2                 call    sub_18017E2C0
+  .text:0000000180B8DCD7                 cmp     [rsp+210h+var_1E0], 0
+  .text:0000000180B8DCDD                 jz      short loc_180B8DCEA
+  .text:0000000180B8DCDF                 lea     rcx, [rsp+210h+var_1E0]
+  .text:0000000180B8DCE4                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180B8DCEA                 xor     r9d, r9d
+  .text:0000000180B8DCED                 lea     rcx, [rsp+210h+var_1D0]
+  .text:0000000180B8DCF2                 xor     r8d, r8d
+  .text:0000000180B8DCF5                 xor     edx, edx
+  .text:0000000180B8DCF7                 call    cs:??0CUtlBuffer@@QEAA@HHW4BufferFlags_t@0@@Z; CUtlBuffer::CUtlBuffer(int,int,CUtlBuffer::BufferFlags_t)
+  .text:0000000180B8DCFD                 mov     rax, [rdi]
+  .text:0000000180B8DD00                 mov     rcx, rdi
+  .text:0000000180B8DD03                 call    qword ptr [rax+18h]
+  .text:0000000180B8DD06                 mov     rsi, rax
+  .text:0000000180B8DD09                 mov     rax, [rax]
+  .text:0000000180B8DD0C                 mov     r9, [rax+8]
+  .text:0000000180B8DD10                 mov     rax, [rbp+110h+var_18C]
+  .text:0000000180B8DD14                 bt      eax, 1Eh
+  .text:0000000180B8DD18                 jnb     short loc_180B8DD20
+  .text:0000000180B8DD1A                 lea     rdx, [rbp+110h+var_18C+4]
+  .text:0000000180B8DD1E                 jmp     short loc_180B8DD2D
+  .text:0000000180B8DD20                 test    eax, 3FFFFFFFh
+  .text:0000000180B8DD25                 mov     rdx, rbx
+  .text:0000000180B8DD28                 cmova   rdx, [rbp+110h+var_18C+4]
+  .text:0000000180B8DD2D                 lea     r8, [rsp+210h+var_1D0]
+  .text:0000000180B8DD32                 mov     rcx, rsi
+  .text:0000000180B8DD35                 call    r9
+  .text:0000000180B8DD38                 test    al, al
+  .text:0000000180B8DD3A                 jz      loc_180B8E1DB
+  .text:0000000180B8DD40                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DD46                 mov     r12b, 1
+  .text:0000000180B8DD49                 mov     edx, 1
+  .text:0000000180B8DD4E                 mov     byte ptr [rbp+110h+arg_18], r12b
+  .text:0000000180B8DD55                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B8DD5B                 test    al, al
+  .text:0000000180B8DD5D                 jz      short loc_180B8DD88
+  .text:0000000180B8DD5F                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DD65                 lea     r9, aSv; "SV"
+  .text:0000000180B8DD6C                 mov     [rsp+210h+var_1E8], rbx
+  .text:0000000180B8DD71                 lea     r8, aSBeginrestoree; "%s:  BeginRestoreEntities( %s%s )\n"
+  .text:0000000180B8DD78                 mov     edx, 1
+  .text:0000000180B8DD7D                 mov     [rsp+210h+var_1F0], r13
+  .text:0000000180B8DD82                 call    cs:LoggingSystem_Log
+  .text:0000000180B8DD88                 cmp     byte ptr [r15+7Ch], 0
+  .text:0000000180B8DD8D                 jz      short loc_180B8DDCA
+  .text:0000000180B8DD8F                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DD95                 mov     edx, 3
+  .text:0000000180B8DD9A                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B8DDA0                 test    al, al
+  .text:0000000180B8DDA2                 jz      short loc_180B8DDBC
+  .text:0000000180B8DDA4                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DDAA                 lea     r8, aBeginrestoreen; "BeginRestoreEntities without previous E"...
+  .text:0000000180B8DDB1                 mov     edx, 3
+  .text:0000000180B8DDB6                 call    cs:LoggingSystem_Log
+  .text:0000000180B8DDBC                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DDC3                 xor     edx, edx
+  .text:0000000180B8DDC5                 call    sub_1811F55E0
+  .text:0000000180B8DDCA                 xor     eax, eax
+  .text:0000000180B8DDCC                 test    dword ptr [r15+1Ch], 0C0000000h
+  .text:0000000180B8DDD4                 mov     [r15+8], eax
+  .text:0000000180B8DDD8                 jnz     short loc_180B8DDFD
+  .text:0000000180B8DDDA                 mov     rdx, [r15+10h]
+  .text:0000000180B8DDDE                 test    rdx, rdx
+  .text:0000000180B8DDE1                 jz      short loc_180B8DDF9
+  .text:0000000180B8DDE3                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180B8DDEA                 mov     rcx, [rax]
+  .text:0000000180B8DDED                 mov     rax, [rcx]
+  .text:0000000180B8DDF0                 call    qword ptr [rax+18h]
+  .text:0000000180B8DDF3                 xor     eax, eax
+  .text:0000000180B8DDF5                 mov     [r15+10h], rax
+  .text:0000000180B8DDF9                 mov     [r15+18h], eax
+  .text:0000000180B8DDFD                 test    [rsp+210h+var_1CC], 7FFFFFFFh
+  .text:0000000180B8DE05                 mov     rdx, r13
+  .text:0000000180B8DE08                 mov     r8, [rsp+210h+var_1C8]
+  .text:0000000180B8DE0D                 mov     rcx, r15
+  .text:0000000180B8DE10                 mov     r9d, [rsp+210h+var_1BC]
+  .text:0000000180B8DE15                 cmovz   r8, rax
+  .text:0000000180B8DE19                 mov     word ptr [r15+7Ch], 1
+  .text:0000000180B8DE20                 call    sub_180B6CAF0
+  .text:0000000180B8DE25                 mov     [rsp+210h+var_1D8], rax
+  .text:0000000180B8DE2A                 mov     r13, rax
+  .text:0000000180B8DE2D                 test    rax, rax
+  .text:0000000180B8DE30                 jz      loc_180B8E1C2
+  .text:0000000180B8DE36                 lea     r12, [rax+18h]
+  .text:0000000180B8DE3A                 mov     rdx, rdi
+  .text:0000000180B8DE3D                 mov     rcx, r12
+  .text:0000000180B8DE40                 mov     [rsp+210h+var_1E0], r12
+  .text:0000000180B8DE45                 call    sub_1806A6070
+  .text:0000000180B8DE4A                 mov     rax, cs:off_181C4FC68
+  .text:0000000180B8DE51                 mov     ecx, [rax+30h]
+  .text:0000000180B8DE54                 mov     [r13+338h], ecx
+  .text:0000000180B8DE5B                 mov     rax, cs:off_181C4FC68
+  .text:0000000180B8DE62                 mov     ecx, [rax+44h]
+  .text:0000000180B8DE65                 mov     [r13+33Ch], ecx
+  .text:0000000180B8DE6C                 mov     rcx, r13
+  .text:0000000180B8DE6F                 call    sub_180B5FB40
+  .text:0000000180B8DE74                 mov     rdx, rax
+  .text:0000000180B8DE77                 lea     rcx, [rbp+110h+var_80]
+  .text:0000000180B8DE7E                 mov     rdi, rax
+  .text:0000000180B8DE81                 call    sub_180B395A0
+  .text:0000000180B8DE86                 mov     rax, [r14]
+  .text:0000000180B8DE89                 mov     rcx, r14
+  .text:0000000180B8DE8C                 call    qword ptr [rax+28h]  ; 28h = CSaveRestoreBlockSet_PreRestore
+  .text:0000000180B8DE8F                 mov     rax, [r14]
+  .text:0000000180B8DE92                 mov     rdx, rdi
+  .text:0000000180B8DE95                 mov     rcx, r14
+  .text:0000000180B8DE98                 call    qword ptr [rax+30h]  ; 30h = CSaveRestoreBlockSet_ReadRestoreHeaders
+  .text:0000000180B8DE9B                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DEA1                 mov     edx, 1
+  .text:0000000180B8DEA6                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180B8DEAC                 test    al, al
+  .text:0000000180B8DEAE                 jz      short loc_180B8DEFC
+  .text:0000000180B8DEB0                 mov     rcx, r12
+  .text:0000000180B8DEB3                 call    CGameSaveRestoreInfo__NumEntities
+  .text:0000000180B8DEB8                 mov     ecx, eax
+  .text:0000000180B8DEBA                 mov     rax, [rbp+110h+var_18C]
+  .text:0000000180B8DEBE                 bt      eax, 1Eh
+  .text:0000000180B8DEC2                 jnb     short loc_180B8DECA
+  .text:0000000180B8DEC4                 lea     rbx, [rbp+110h+var_18C+4]
+  .text:0000000180B8DEC8                 jmp     short loc_180B8DED4
+  .text:0000000180B8DECA                 test    eax, 3FFFFFFFh
+  .text:0000000180B8DECF                 cmova   rbx, [rbp+110h+var_18C+4]
+  .text:0000000180B8DED4                 mov     dword ptr [rsp+210h+var_1E8], ecx
+  .text:0000000180B8DED8                 lea     r9, aSv; "SV"
+  .text:0000000180B8DEDF                 mov     ecx, cs:dword_181EEEF18
+  .text:0000000180B8DEE5                 lea     r8, aSStreamentitie; "%s:  StreamEntitiesFromFile:  '%s' [%d "...
+  .text:0000000180B8DEEC                 mov     edx, 1
+  .text:0000000180B8DEF1                 mov     [rsp+210h+var_1F0], rbx
+  .text:0000000180B8DEF6                 call    cs:LoggingSystem_Log
+  .text:0000000180B8DEFC                 mov     r8, rdi
+  .text:0000000180B8DEFF                 mov     rdx, r13
+  .text:0000000180B8DF02                 mov     rcx, r15
+  .text:0000000180B8DF05                 call    sub_180B71070
+  .text:0000000180B8DF0A                 mov     r9, [rbp+110h+arg_10]
+  .text:0000000180B8DF11                 mov     r8, r13
+  .text:0000000180B8DF14                 mov     rdx, rsi
+  .text:0000000180B8DF17                 mov     rcx, r15
+  .text:0000000180B8DF1A                 call    sub_180B575E0
+  .text:0000000180B8DF1F                 mov     rax, cs:off_181C4FC68
+  .text:0000000180B8DF26                 mov     r9b, 1
+  .text:0000000180B8DF29                 mov     r8d, [rbp+110h+arg_20]
+  .text:0000000180B8DF30                 mov     rdx, rdi
+  .text:0000000180B8DF33                 mov     ecx, [rax+30h]
+  .text:0000000180B8DF36                 mov     [r13+338h], ecx
+  .text:0000000180B8DF3D                 mov     rax, cs:off_181C4FC68
+  .text:0000000180B8DF44                 mov     ecx, [rax+44h]
+  .text:0000000180B8DF47                 mov     [r13+33Ch], ecx
+  .text:0000000180B8DF4E                 mov     rcx, r14
+  .text:0000000180B8DF51                 mov     rax, [r14]
+  .text:0000000180B8DF54                 call    qword ptr [rax+38h]  ; 38h = CSaveRestoreBlockSet_Restore
+  .text:0000000180B8DF57                 mov     rax, [r14]
+  .text:0000000180B8DF5A                 mov     rcx, r14
+  .text:0000000180B8DF5D                 call    qword ptr [rax+40h]  ; 40h = CSaveRestoreBlockSet_PostRestore
+  .text:0000000180B8DF60                 mov     rdi, [rsp+210h+var_1E0]
+  .text:0000000180B8DF65                 xor     esi, esi
+  .text:0000000180B8DF67                 mov     rcx, rdi
+  .text:0000000180B8DF6A                 mov     r12d, esi
+  .text:0000000180B8DF6D                 call    CGameSaveRestoreInfo__NumEntities
+  .text:0000000180B8DF72                 test    eax, eax
+  .text:0000000180B8DF74                 jle     loc_180B8E0FF
+  .text:0000000180B8DF7A                 mov     r14, [rbp+110h+arg_38]
+  .text:0000000180B8DF81                 mov     edx, r12d
+  .text:0000000180B8DF84                 mov     rcx, rdi
+  .text:0000000180B8DF87                 call    sub_1806986A0
+  .text:0000000180B8DF8C                 mov     r9, cs:g_pEntitySystem
+  .text:0000000180B8DF93                 mov     eax, [rax+0Ch]
+  .text:0000000180B8DF96                 cmp     eax, 7FFEh
+  .text:0000000180B8DF9B                 ja      loc_180B8E0E4
+  .text:0000000180B8DFA1                 mov     edx, eax
+  .text:0000000180B8DFA3                 sar     edx, 9
+  .text:0000000180B8DFA6                 cmp     edx, 3Fh ; '?'
+  .text:0000000180B8DFA9                 ja      loc_180B8E0E4
+  .text:0000000180B8DFAF                 movsxd  rcx, edx
+  .text:0000000180B8DFB2                 mov     r8, [r9+rcx*8+10h]
+  .text:0000000180B8DFB7                 test    r8, r8
+  .text:0000000180B8DFBA                 jz      loc_180B8E0E4
+  .text:0000000180B8DFC0                 mov     ecx, eax
+  .text:0000000180B8DFC2                 and     ecx, 1FFh
+  .text:0000000180B8DFC8                 imul    rcx, 70h ; 'p'
+  .text:0000000180B8DFCC                 add     rcx, r8
+  .text:0000000180B8DFCF                 jz      loc_180B8E0E4
+  .text:0000000180B8DFD5                 mov     ecx, [rcx+10h]
+  .text:0000000180B8DFD8                 and     ecx, 7FFFh
+  .text:0000000180B8DFDE                 cmp     ecx, eax
+  .text:0000000180B8DFE0                 jnz     loc_180B8E0E4
+  .text:0000000180B8DFE6                 movsxd  r13, dword ptr [r14]
+  .text:0000000180B8DFE9                 and     eax, 1FFh
+  .text:0000000180B8DFEE                 imul    rax, 70h ; 'p'
+  .text:0000000180B8DFF2                 movsxd  rcx, edx
+  .text:0000000180B8DFF5                 add     rax, [r9+rcx*8+10h]
+  .text:0000000180B8DFFA                 mov     ecx, 7FFFh
+  .text:0000000180B8DFFF                 mov     edx, [rax+10h]
+  .text:0000000180B8E002                 mov     ebx, edx
+  .text:0000000180B8E004                 mov     eax, [rax+30h]
+  .text:0000000180B8E007                 and     eax, 1
+  .text:0000000180B8E00A                 shr     ebx, 0Fh
+  .text:0000000180B8E00D                 sub     ebx, eax
+  .text:0000000180B8E00F                 mov     eax, edx
+  .text:0000000180B8E011                 and     eax, 7FFFh
+  .text:0000000180B8E016                 shl     ebx, 0Fh
+  .text:0000000180B8E019                 cmp     edx, 0FFFFFFFFh
+  .text:0000000180B8E01C                 cmovnz  ecx, eax
+  .text:0000000180B8E01F                 or      ebx, ecx
+  .text:0000000180B8E021                 cmp     r13d, [r14+10h]
+  .text:0000000180B8E025                 jnz     loc_180B8E0D9
+  .text:0000000180B8E02B                 test    dword ptr [r14+14h], 40000000h
+  .text:0000000180B8E033                 jnz     loc_180B8E0D9
+  .text:0000000180B8E039                 mov     ecx, [r14+10h]
+  .text:0000000180B8E03D                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180B8E043                 jle     short loc_180B8E050
+  .text:0000000180B8E045                 mov     edx, 1
+  .text:0000000180B8E04A                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180B8E050                 mov     ecx, [r14+10h]
+  .text:0000000180B8E054                 mov     r9d, 4
+  .text:0000000180B8E05A                 mov     edx, [r14+14h]
+  .text:0000000180B8E05E                 and     edx, 3FFFFFFFh
+  .text:0000000180B8E064                 lea     esi, [rcx+1]
+  .text:0000000180B8E067                 mov     r8d, esi
+  .text:0000000180B8E06A                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180B8E070                 mov     edi, eax
+  .text:0000000180B8E072                 cmp     eax, esi
+  .text:0000000180B8E074                 jge     short loc_180B8E094
+  .text:0000000180B8E076                 test    eax, eax
+  .text:0000000180B8E078                 jnz     short loc_180B8E086
+  .text:0000000180B8E07A                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180B8E07D                 jg      short loc_180B8E086
+  .text:0000000180B8E07F                 mov     edi, 0FFFFFFFFh
+  .text:0000000180B8E084                 jmp     short loc_180B8E094
+  .text:0000000180B8E086                 lea     eax, [rdi+rsi]
+  .text:0000000180B8E089                 cdq
+  .text:0000000180B8E08A                 sub     eax, edx
+  .text:0000000180B8E08C                 sar     eax, 1
+  .text:0000000180B8E08E                 mov     edi, eax
+  .text:0000000180B8E090                 cmp     eax, esi
+  .text:0000000180B8E092                 jl      short loc_180B8E086
+  .text:0000000180B8E094                 movsxd  r9, dword ptr [r14+10h]
+  .text:0000000180B8E098                 mov     rcx, [r14+8]
+  .text:0000000180B8E09C                 shl     r9, 2
+  .text:0000000180B8E0A0                 movsxd  r8, edi
+  .text:0000000180B8E0A3                 shl     r8, 2
+  .text:0000000180B8E0A7                 test    dword ptr [r14+14h], 0C0000000h
+  .text:0000000180B8E0AF                 setz    dl
+  .text:0000000180B8E0B2                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180B8E0B8                 mov     [r14+8], rax
+  .text:0000000180B8E0BC                 mov     eax, [r14+14h]
+  .text:0000000180B8E0C0                 test    eax, 0C0000000h
+  .text:0000000180B8E0C5                 jz      short loc_180B8E0D0
+  .text:0000000180B8E0C7                 and     eax, 3FFFFFFFh
+  .text:0000000180B8E0CC                 mov     [r14+14h], eax
+  .text:0000000180B8E0D0                 mov     [r14+10h], edi
+  .text:0000000180B8E0D4                 mov     rdi, [rsp+210h+var_1E0]
+  .text:0000000180B8E0D9                 inc     dword ptr [r14]
+  .text:0000000180B8E0DC                 mov     rax, [r14+8]
+  .text:0000000180B8E0E0                 mov     [rax+r13*4], ebx
+  .text:0000000180B8E0E4                 mov     rcx, rdi
+  .text:0000000180B8E0E7                 inc     r12d
+  .text:0000000180B8E0EA                 call    CGameSaveRestoreInfo__NumEntities
+  .text:0000000180B8E0EF                 cmp     r12d, eax
+  .text:0000000180B8E0F2                 jl      loc_180B8DF81
+  .text:0000000180B8E0F8                 mov     r13, [rsp+210h+var_1D8]
+  .text:0000000180B8E0FD                 xor     esi, esi
+  .text:0000000180B8E0FF                 mov     rdx, [rbp+110h+arg_10]
+  .text:0000000180B8E106                 mov     rcx, [r15+128h]
+  .text:0000000180B8E10D                 call    sub_180B5BC30
+  .text:0000000180B8E112                 lea     rdx, [r13+18h]
+  .text:0000000180B8E116                 mov     rcx, rax
+  .text:0000000180B8E119                 call    sub_1806A4F70
+  .text:0000000180B8E11E                 mov     rcx, r13
+  .text:0000000180B8E121                 call    sub_180B3D6B0
+  .text:0000000180B8E126                 cmp     qword ptr [r15+0D0h], 0
+  .text:0000000180B8E12E                 jnz     short loc_180B8E180
+  .text:0000000180B8E130                 mov     ecx, 50h ; 'P'
+  .text:0000000180B8E135                 call    operator_new
+  .text:0000000180B8E13A                 test    rax, rax
+  .text:0000000180B8E13D                 jz      short loc_180B8E14A
+  .text:0000000180B8E13F                 mov     rcx, rax
+  .text:0000000180B8E142                 call    cs:??0CMemoryStack@@QEAA@XZ; CMemoryStack::CMemoryStack(void)
+  .text:0000000180B8E148                 jmp     short loc_180B8E14D
+  .text:0000000180B8E14A                 mov     rax, rsi
+  .text:0000000180B8E14D                 mov     dword ptr [rsp+210h+var_1E8], 10h
+  .text:0000000180B8E155                 lea     rdx, aCsavememory; "CSaveMemory"
+  .text:0000000180B8E15C                 mov     r9d, 40h ; '@'
+  .text:0000000180B8E162                 mov     dword ptr [rsp+210h+var_1F0], 230000h
+  .text:0000000180B8E16A                 mov     r8d, 2000000h
+  .text:0000000180B8E170                 mov     [r15+0D0h], rax
+  .text:0000000180B8E177                 mov     rcx, rax
+  .text:0000000180B8E17A                 call    cs:?Init@CMemoryStack@@QEAA_NPEBDIIII@Z; CMemoryStack::Init(char const *,uint,uint,uint,uint)
+  .text:0000000180B8E180                 sub     dword ptr [r15+0D8h], 1
+  .text:0000000180B8E188                 jnz     short loc_180B8E1BA
+  .text:0000000180B8E18A                 mov     rbx, [r15+0D0h]
+  .text:0000000180B8E191                 test    rbx, rbx
+  .text:0000000180B8E194                 jz      short loc_180B8E1AC
+  .text:0000000180B8E196                 mov     rcx, rbx
+  .text:0000000180B8E199                 call    cs:??1CMemoryStack@@QEAA@XZ; CMemoryStack::~CMemoryStack(void)
+  .text:0000000180B8E19F                 mov     edx, 50h ; 'P'
+  .text:0000000180B8E1A4                 mov     rcx, rbx
+  .text:0000000180B8E1A7                 call    sub_180E7C980
+  .text:0000000180B8E1AC                 mov     [r15+0D0h], rsi
+  .text:0000000180B8E1B3                 mov     [r15+0D8h], esi
+  .text:0000000180B8E1BA                 movzx   r12d, byte ptr [rbp+110h+arg_18]
+  .text:0000000180B8E1C2                 mov     r9, [rbp+110h+arg_30]
+  .text:0000000180B8E1C9                 xor     r8d, r8d
+  .text:0000000180B8E1CC                 mov     rdx, [rbp+110h+arg_10]
+  .text:0000000180B8E1D3                 mov     rcx, r15
+  .text:0000000180B8E1D6                 call    sub_180B52000
+  .text:0000000180B8E1DB                 mov     eax, [rsp+210h+var_1CC]
+  .text:0000000180B8E1DF                 xor     ebx, ebx
+  .text:0000000180B8E1E1                 mov     [rsp+210h+var_1D0], ebx
+  .text:0000000180B8E1E5                 test    eax, 7FFFFFFFh
+  .text:0000000180B8E1EA                 jbe     short loc_180B8E20E
+  .text:0000000180B8E1EC                 shr     eax, 1Fh
+  .text:0000000180B8E1EF                 test    al, al
+  .text:0000000180B8E1F1                 jnz     short loc_180B8E209
+  .text:0000000180B8E1F3                 mov     rcx, cs:g_pMemAlloc
+  .text:0000000180B8E1FA                 mov     rdx, [rsp+210h+var_1C8]
+  .text:0000000180B8E1FF                 mov     rcx, [rcx]
+  .text:0000000180B8E202                 mov     r8, [rcx]
+  .text:0000000180B8E205                 call    qword ptr [r8+18h]
+  .text:0000000180B8E209                 mov     [rsp+210h+var_1C8], rbx
+  .text:0000000180B8E20E                 xor     edx, edx
+  .text:0000000180B8E210                 mov     [rsp+210h+var_1CC], ebx
+  .text:0000000180B8E214                 lea     rcx, [rbp+110h+var_190]
+  .text:0000000180B8E218                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180B8E21E                 mov     rbx, [rsp+210h+arg_0]
+  .text:0000000180B8E226                 movzx   eax, r12b
+  .text:0000000180B8E22A                 add     rsp, 1E0h
+  .text:0000000180B8E231                 pop     r15
+  .text:0000000180B8E233                 pop     r14
+  .text:0000000180B8E235                 pop     r13
+  .text:0000000180B8E237                 pop     r12
+  .text:0000000180B8E239                 pop     rdi
+  .text:0000000180B8E23A                 pop     rsi
+  .text:0000000180B8E23B                 pop     rbp
+  .text:0000000180B8E23C                 retn
+procedure: |-
+  __int64 __fastcall CEntity2SaveRestore_StreamEntitiesFromFile(
+          __int64 a1,
+          __int64 a2,
+          const char *a3,
+          __int64 a4,
+          unsigned int a5,
+          int a6,
+          __int64 a7,
+          int *a8)
+  {
+    unsigned __int8 v12; // r12
+    const char *v13; // rbx
+    const char *v14; // r8
+    __int64 v15; // rsi
+    char *v16; // rdx
+    bool v17; // zf
+    __int64 v18; // r8
+    __int64 v19; // r9
+    __int64 v20; // rax
+    __int64 v21; // r13
+    __int64 v22; // r12
+    __int64 v23; // rdi
+    int v24; // ecx
+    __int64 v25; // r9
+    __int64 v26; // r8
+    __int64 v27; // rdi
+    int v28; // r12d
+    int *v29; // r14
+    int v30; // eax
+    int v31; // edx
+    __int64 v32; // r8
+    __int64 v33; // rcx
+    __int64 v34; // r13
+    __int64 v35; // rax
+    int v36; // ecx
+    unsigned int v37; // edx
+    int v38; // ebx
+    __int64 v39; // rcx
+    __int64 v40; // rcx
+    int v41; // esi
+    int v42; // eax
+    __int64 v43; // rdx
+    int v44; // edi
+    int v45; // eax
+    __int64 v46; // rax
+    CMemoryStack *v47; // rax
+    CMemoryStack *v48; // rax
+    __int64 v49; // rbx
+    __int64 v51; // [rsp+30h] [rbp-D0h] BYREF
+    __int64 v52; // [rsp+38h] [rbp-C8h] BYREF
+    int v53; // [rsp+40h] [rbp-C0h] BYREF
+    int v54; // [rsp+44h] [rbp-BCh]
+    __int64 v55; // [rsp+48h] [rbp-B8h]
+    unsigned int v56; // [rsp+54h] [rbp-ACh]
+    _BYTE v57[4]; // [rsp+80h] [rbp-80h] BYREF
+    int v58; // [rsp+84h] [rbp-7Ch]
+    _QWORD v59[33]; // [rsp+88h] [rbp-78h] BYREF
+    _BYTE v60[128]; // [rsp+190h] [rbp+90h] BYREF
+    __int64 v62; // [rsp+238h] [rbp+138h] BYREF
+
+    v62 = 0;
+    v12 = 0;
+    CUtlString::Set((CUtlString *)&v62, a3);
+    CUtlString::GetBaseFilename(&v62, &v52);
+    if ( v62 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v62);
+    v13 = Src;
+    v51 = v52;
+    v14 = Src;
+    if ( v52 )
+      v14 = (const char *)v52;
+    sub_18017E2C0(v57, "save/%s.hl%s", v14, "1");
+    if ( v51 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v51);
+    CUtlBuffer::CUtlBuffer(&v53, 0, 0, 0);
+    v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a4 + 24LL))(a4);
+    if ( (v58 & 0x40000000) != 0 )
+    {
+      v16 = (char *)v59;
+    }
+    else
+    {
+      v16 = Src;
+      if ( (v58 & 0x3FFFFFFF) != 0 )
+        v16 = (char *)v59[0];
+    }
+    if ( (*(unsigned __int8 (__fastcall **)(__int64, char *, int *))(*(_QWORD *)v15 + 8LL))(v15, v16, &v53) )
+    {
+      v12 = 1;
+      LOBYTE(v62) = 1;
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181EEEF18, 1) )
+        LoggingSystem_Log((unsigned int)dword_181EEEF18, 1, "%s:  BeginRestoreEntities( %s%s )\n", "SV", a3, Src);
+      if ( *(_BYTE *)(a1 + 124) )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181EEEF18, 3) )
+          LoggingSystem_Log(
+            (unsigned int)dword_181EEEF18,
+            3,
+            "BeginRestoreEntities without previous EndRestoreEntities.\n");
+        sub_1811F55E0(g_pEntitySystem, 0);
+      }
+      v17 = (*(_DWORD *)(a1 + 28) & 0xC0000000) == 0;
+      *(_DWORD *)(a1 + 8) = 0;
+      if ( v17 )
+      {
+        if ( *(_QWORD *)(a1 + 16) )
+        {
+          (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+          *(_QWORD *)(a1 + 16) = 0;
+        }
+        *(_DWORD *)(a1 + 24) = 0;
+      }
+      v18 = v55;
+      v19 = v56;
+      if ( (v54 & 0x7FFFFFFF) == 0 )
+        v18 = 0;
+      *(_WORD *)(a1 + 124) = 1;
+      v20 = sub_180B6CAF0(a1, a3, v18, v19);
+      v52 = v20;
+      v21 = v20;
+      if ( v20 )
+      {
+        v22 = v20 + 24;
+        v51 = v20 + 24;
+        sub_1806A6070(v20 + 24, a4);
+        *(_DWORD *)(v21 + 824) = *((_DWORD *)off_181C4FC68 + 12);
+        *(_DWORD *)(v21 + 828) = *((_DWORD *)off_181C4FC68 + 17);
+        v23 = sub_180B5FB40(v21);
+        sub_180B395A0(v60, v23);
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)a2 + 40LL))(a2);// 40LL = 0x28 = CSaveRestoreBlockSet_PreRestore
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a2 + 48LL))(a2, v23);// 48LL = 0x30 = CSaveRestoreBlockSet_ReadRestoreHeaders
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181EEEF18, 1) )
+        {
+          v24 = CGameSaveRestoreInfo::NumEntities(v22);
+          if ( (v58 & 0x40000000) != 0 )
+          {
+            v13 = (const char *)v59;
+          }
+          else if ( (v58 & 0x3FFFFFFF) != 0 )
+          {
+            v13 = (const char *)v59[0];
+          }
+          LoggingSystem_Log(
+            (unsigned int)dword_181EEEF18,
+            1,
+            "%s:  StreamEntitiesFromFile:  '%s' [%d entities]\n",
+            "SV",
+            v13,
+            v24);
+        }
+        sub_180B71070(a1, v21, v23);
+        sub_180B575E0(a1, v15, v21, a3);
+        LOBYTE(v25) = 1;
+        v26 = a5;
+        *(_DWORD *)(v21 + 824) = *((_DWORD *)off_181C4FC68 + 12);
+        *(_DWORD *)(v21 + 828) = *((_DWORD *)off_181C4FC68 + 17);
+        (*(void (__fastcall **)(__int64, __int64, __int64, __int64))(*(_QWORD *)a2 + 56LL))(a2, v23, v26, v25);// 56LL = 0x38 = CSaveRestoreBlockSet_Restore
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)a2 + 64LL))(a2);// 64LL = 0x40 = CSaveRestoreBlockSet_PostRestore
+        v27 = v51;
+        v28 = 0;
+        if ( (int)CGameSaveRestoreInfo::NumEntities(v51) > 0 )
+        {
+          v29 = a8;
+          do
+          {
+            v30 = *(_DWORD *)(sub_1806986A0(v27, v28) + 12);
+            if ( (unsigned int)v30 <= 0x7FFE )
+            {
+              v31 = v30 >> 9;
+              if ( (unsigned int)(v30 >> 9) <= 0x3F )
+              {
+                v32 = *(_QWORD *)(g_pEntitySystem + 8LL * v31 + 16);
+                if ( v32 )
+                {
+                  v33 = v32 + 112LL * (v30 & 0x1FF);
+                  if ( v33 )
+                  {
+                    if ( (*(_DWORD *)(v33 + 16) & 0x7FFF) == v30 )
+                    {
+                      v34 = *v29;
+                      v35 = *(_QWORD *)(g_pEntitySystem + 8LL * v31 + 16) + 112LL * (v30 & 0x1FF);
+                      v36 = 0x7FFF;
+                      v37 = *(_DWORD *)(v35 + 16);
+                      if ( v37 != -1 )
+                        v36 = v37 & 0x7FFF;
+                      v38 = v36 | (((v37 >> 15) - (*(_DWORD *)(v35 + 48) & 1)) << 15);
+                      if ( (_DWORD)v34 == v29[4] && (v29[5] & 0x40000000) == 0 )
+                      {
+                        v39 = (unsigned int)v29[4];
+                        if ( (_DWORD)v39 == 0x7FFFFFFF )
+                          UtlVectorMemory_FailedAllocation(v39, 1);
+                        v40 = (unsigned int)v29[4];
+                        v41 = v40 + 1;
+                        v42 = UtlVectorMemory_CalcNewAllocationCount(v40, v29[5] & 0x3FFFFFFF, (unsigned int)(v40 + 1), 4);
+                        v44 = v42;
+                        if ( v42 < v41 )
+                        {
+                          if ( v42 || v41 > -1 )
+                          {
+                            do
+                            {
+                              v43 = (unsigned int)((v44 + v41) >> 31);
+                              v44 = (v44 + v41) / 2;
+                            }
+                            while ( v44 < v41 );
+                          }
+                          else
+                          {
+                            v44 = -1;
+                          }
+                        }
+                        LOBYTE(v43) = (v29[5] & 0xC0000000) == 0;
+                        *((_QWORD *)v29 + 1) = UtlVectorMemory_Alloc(*((_QWORD *)v29 + 1), v43, 4LL * v44, 4LL * v29[4]);
+                        v45 = v29[5];
+                        if ( (v45 & 0xC0000000) != 0 )
+                          v29[5] = v45 & 0x3FFFFFFF;
+                        v29[4] = v44;
+                        v27 = v51;
+                      }
+                      ++*v29;
+                      *(_DWORD *)(*((_QWORD *)v29 + 1) + 4 * v34) = v38;
+                    }
+                  }
+                }
+              }
+            }
+            ++v28;
+          }
+          while ( v28 < (int)CGameSaveRestoreInfo::NumEntities(v27) );
+          v21 = v52;
+        }
+        v46 = sub_180B5BC30(*(_QWORD *)(a1 + 296), a3);
+        sub_1806A4F70(v46, v21 + 24);
+        sub_180B3D6B0(v21);
+        if ( !*(_QWORD *)(a1 + 208) )
+        {
+          v47 = (CMemoryStack *)operator_new(80);
+          if ( v47 )
+            v48 = CMemoryStack::CMemoryStack(v47);
+          else
+            v48 = nullptr;
+          *(_QWORD *)(a1 + 208) = v48;
+          CMemoryStack::Init(v48, "CSaveMemory", 0x2000000u, 0x40u, 0x230000u, 0x10u);
+        }
+        v17 = (*(_DWORD *)(a1 + 216))-- == 1;
+        if ( v17 )
+        {
+          v49 = *(_QWORD *)(a1 + 208);
+          if ( v49 )
+          {
+            CMemoryStack::~CMemoryStack(*(CMemoryStack **)(a1 + 208));
+            sub_180E7C980(v49);
+          }
+          *(_QWORD *)(a1 + 208) = 0;
+          *(_DWORD *)(a1 + 216) = 0;
+        }
+        v12 = v62;
+      }
+      sub_180B52000(a1, a3, 0, a7);
+    }
+    v53 = 0;
+    if ( (v54 & 0x7FFFFFFF) != 0 )
+    {
+      if ( v54 >= 0 )
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v55);
+      v55 = 0;
+    }
+    v54 = 0;
+    CBufferString::Purge((CBufferString *)v57, 0);
+    return v12;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityIdentity_SetEntityName.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityIdentity_SetEntityName.linux.yaml
@@ -1,0 +1,409 @@
+func_name: CEntityIdentity_SetEntityName
+func_va: '0x1e4dbd0'
+disasm_code: |-
+  .text:0000000001E4DBD0                 push    rbp
+  .text:0000000001E4DBD1                 mov     rdx, rsi
+  .text:0000000001E4DBD4                 mov     rbp, rsp
+  .text:0000000001E4DBD7                 push    r13
+  .text:0000000001E4DBD9                 push    r12
+  .text:0000000001E4DBDB                 push    rbx
+  .text:0000000001E4DBDC                 mov     rbx, rdi
+  .text:0000000001E4DBDF                 lea     rdi, [rbp+var_68]
+  .text:0000000001E4DBE3                 sub     rsp, 58h
+  .text:0000000001E4DBE7                 lea     r13, g_pEntitySystem
+  .text:0000000001E4DBEE                 mov     rsi, [r13+0]
+  .text:0000000001E4DBF2                 call    sub_1E72500
+  .text:0000000001E4DBF7                 mov     r12, [rbp+var_68]
+  .text:0000000001E4DBFB                 cmp     r12, [rbx+18h]
+  .text:0000000001E4DBFF                 jz      loc_1E4DD43
+  .text:0000000001E4DC05                 test    byte ptr [rbx+31h], 48h
+  .text:0000000001E4DC09                 jz      loc_1E4DD50
+  .text:0000000001E4DC0F                 mov     [rbx+18h], r12
+  .text:0000000001E4DC13                 cmp     cs:byte_27C44B8, 0
+  .text:0000000001E4DC1A                 jz      loc_1E4DD43
+  .text:0000000001E4DC20                 mov     rdi, cs:qword_27C44B0
+  .text:0000000001E4DC27                 test    r12, r12
+  .text:0000000001E4DC2A                 jnz     loc_1E4DD78
+  .text:0000000001E4DC30                 mov     eax, [rbx+14h]
+  .text:0000000001E4DC33                 test    rdi, rdi
+  .text:0000000001E4DC36                 jz      loc_1E4DEB0
+  .text:0000000001E4DC3C                 cmp     eax, 0FFFFFFFFh
+  .text:0000000001E4DC3F                 jz      loc_1E4DD43
+  .text:0000000001E4DC45                 xor     edx, edx
+  .text:0000000001E4DC47                 ; _QWORD
+  .text:0000000001E4DC47                 mov     ecx, 4; _QWORD
+  .text:0000000001E4DC4C                 ; _QWORD
+  .text:0000000001E4DC4C                 xor     esi, esi; _QWORD
+  .text:0000000001E4DC4E                 pxor    xmm0, xmm0
+  .text:0000000001E4DC52                 mov     [rbp+var_24], dx
+  .text:0000000001E4DC56                 ; _QWORD
+  .text:0000000001E4DC56                 xor     edi, edi; _QWORD
+  .text:0000000001E4DC58                 ; _QWORD
+  .text:0000000001E4DC58                 mov     edx, 1; _QWORD
+  .text:0000000001E4DC5D                 mov     [rbp+var_60], 1
+  .text:0000000001E4DC65                 mov     [rbp+var_58], 0
+  .text:0000000001E4DC6D                 mov     [rbp+var_50], 0
+  .text:0000000001E4DC75                 mov     [rbp+var_48], 0
+  .text:0000000001E4DC7D                 movaps  [rbp+var_40], xmm0
+  .text:0000000001E4DC81                 mov     [rbp+var_30], 0FFFFFFFFFFFFFFFFh
+  .text:0000000001E4DC89                 mov     [rbp+var_28], 0FFFFFFFFh
+  .text:0000000001E4DC90                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E4DC95                 mov     r12d, eax
+  .text:0000000001E4DC98                 test    eax, eax
+  .text:0000000001E4DC9A                 jle     loc_1E4DEAA
+  .text:0000000001E4DCA0                 movsxd  rcx, dword ptr [rbp+var_48]
+  .text:0000000001E4DCA4                 movsxd  rdx, r12d
+  .text:0000000001E4DCA7                 xor     esi, esi
+  .text:0000000001E4DCA9                 ; _QWORD
+  .text:0000000001E4DCA9                 shl     rdx, 2; _QWORD
+  .text:0000000001E4DCAD                 ; _QWORD
+  .text:0000000001E4DCAD                 mov     rdi, [rbp+var_50]; _QWORD
+  .text:0000000001E4DCB1                 ; _QWORD
+  .text:0000000001E4DCB1                 shl     rcx, 2; _QWORD
+  .text:0000000001E4DCB5                 cmp     dword ptr [rbp+var_48+4], 3FFFFFFFh
+  .text:0000000001E4DCBC                 ; _QWORD
+  .text:0000000001E4DCBC                 setbe   sil; _QWORD
+  .text:0000000001E4DCC0                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E4DCC5                 mov     edx, dword ptr [rbp+var_48+4]
+  .text:0000000001E4DCC8                 mov     [rbp+var_50], rax
+  .text:0000000001E4DCCC                 cmp     edx, 3FFFFFFFh
+  .text:0000000001E4DCD2                 jbe     short loc_1E4DCDD
+  .text:0000000001E4DCD4                 and     edx, 3FFFFFFFh
+  .text:0000000001E4DCDA                 mov     dword ptr [rbp+var_48+4], edx
+  .text:0000000001E4DCDD                 add     dword ptr [rbp+var_58], 1
+  .text:0000000001E4DCE1                 mov     dword ptr [rbp+var_48], r12d
+  .text:0000000001E4DCE5                 mov     dword ptr [rax], 14h
+  .text:0000000001E4DCEB                 mov     rdi, [rbx]
+  .text:0000000001E4DCEE                 test    rdi, rdi
+  .text:0000000001E4DCF1                 jz      short loc_1E4DD13
+  .text:0000000001E4DCF3                 mov     eax, [rbx+40h]
+  .text:0000000001E4DCF6                 lea     rdx, nullsub_1653
+  .text:0000000001E4DCFD                 mov     [rbp+var_28], eax
+  .text:0000000001E4DD00                 mov     rax, [rdi]
+  .text:0000000001E4DD03                 mov     rax, [rax+0E8h]
+  .text:0000000001E4DD0A                 cmp     rax, rdx
+  .text:0000000001E4DD0D                 jnz     loc_1E4DF58
+  .text:0000000001E4DD13                 cmp     dword ptr [rbp+var_48+4], 3FFFFFFFh
+  .text:0000000001E4DD1A                 mov     dword ptr [rbp+var_58], 0
+  .text:0000000001E4DD21                 ja      short loc_1E4DD3C
+  .text:0000000001E4DD23                 mov     rsi, [rbp+var_50]
+  .text:0000000001E4DD27                 test    rsi, rsi
+  .text:0000000001E4DD2A                 jz      short loc_1E4DD3C
+  .text:0000000001E4DD2C                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E4DD33                 mov     rdi, [rax]
+  .text:0000000001E4DD36                 mov     rax, [rdi]
+  .text:0000000001E4DD39                 call    qword ptr [rax+20h]
+  .text:0000000001E4DD3C                 mov     dword ptr [rbx+14h], 0FFFFFFFFh
+  .text:0000000001E4DD43                 add     rsp, 58h
+  .text:0000000001E4DD47                 pop     rbx
+  .text:0000000001E4DD48                 pop     r12
+  .text:0000000001E4DD4A                 pop     r13
+  .text:0000000001E4DD4C                 pop     rbp
+  .text:0000000001E4DD4D                 retn
+  .text:0000000001E4DD50                 mov     rdi, [r13+0]
+  .text:0000000001E4DD54                 mov     rsi, rbx
+  .text:0000000001E4DD57                 call    CEntitySystem_RemoveEntityFromNameMap
+  .text:0000000001E4DD5C                 ; a1
+  .text:0000000001E4DD5C                 mov     rdi, [r13+0]; a1
+  .text:0000000001E4DD60                 mov     [rbx+18h], r12
+  .text:0000000001E4DD64                 ; a2
+  .text:0000000001E4DD64                 mov     rsi, rbx; a2
+  .text:0000000001E4DD67                 call    CEntitySystem_AddEntityToNameMap
+  .text:0000000001E4DD6C                 jmp     loc_1E4DC13
+  .text:0000000001E4DD78                 test    rdi, rdi
+  .text:0000000001E4DD7B                 jz      loc_1E4DF20
+  .text:0000000001E4DD81                 mov     rdx, [rbx+18h]
+  .text:0000000001E4DD85                 lea     rax, haystack
+  .text:0000000001E4DD8C                 mov     esi, 1
+  .text:0000000001E4DD91                 test    rdx, rdx
+  .text:0000000001E4DD94                 cmovz   rdx, rax
+  .text:0000000001E4DD98                 mov     rax, [rdi]
+  .text:0000000001E4DD9B                 xor     ecx, ecx
+  .text:0000000001E4DD9D                 call    qword ptr [rax+40h]
+  .text:0000000001E4DDA0                 mov     r12d, eax
+  .text:0000000001E4DDA3                 cmp     [rbx+14h], eax
+  .text:0000000001E4DDA6                 jz      short loc_1E4DD43
+  .text:0000000001E4DDA8                 xor     eax, eax
+  .text:0000000001E4DDAA                 ; _QWORD
+  .text:0000000001E4DDAA                 xor     esi, esi; _QWORD
+  .text:0000000001E4DDAC                 pxor    xmm0, xmm0
+  .text:0000000001E4DDB0                 movaps  [rbp+var_40], xmm0
+  .text:0000000001E4DDB4                 ; _QWORD
+  .text:0000000001E4DDB4                 mov     ecx, 4; _QWORD
+  .text:0000000001E4DDB9                 ; _QWORD
+  .text:0000000001E4DDB9                 mov     edx, 1; _QWORD
+  .text:0000000001E4DDBE                 ; _QWORD
+  .text:0000000001E4DDBE                 xor     edi, edi; _QWORD
+  .text:0000000001E4DDC0                 mov     [rbp+var_24], ax
+  .text:0000000001E4DDC4                 mov     [rbp+var_60], 1
+  .text:0000000001E4DDCC                 mov     [rbp+var_58], 0
+  .text:0000000001E4DDD4                 mov     [rbp+var_50], 0
+  .text:0000000001E4DDDC                 mov     [rbp+var_48], 0
+  .text:0000000001E4DDE4                 mov     [rbp+var_30], 0FFFFFFFFFFFFFFFFh
+  .text:0000000001E4DDEC                 mov     [rbp+var_28], 0FFFFFFFFh
+  .text:0000000001E4DDF3                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E4DDF8                 mov     r13d, eax
+  .text:0000000001E4DDFB                 test    eax, eax
+  .text:0000000001E4DDFD                 jle     loc_1E4DEA8
+  .text:0000000001E4DE03                 movsxd  rcx, dword ptr [rbp+var_48]
+  .text:0000000001E4DE07                 movsxd  rdx, eax
+  .text:0000000001E4DE0A                 xor     esi, esi
+  .text:0000000001E4DE0C                 ; _QWORD
+  .text:0000000001E4DE0C                 shl     rdx, 2; _QWORD
+  .text:0000000001E4DE10                 ; _QWORD
+  .text:0000000001E4DE10                 mov     rdi, [rbp+var_50]; _QWORD
+  .text:0000000001E4DE14                 ; _QWORD
+  .text:0000000001E4DE14                 shl     rcx, 2; _QWORD
+  .text:0000000001E4DE18                 cmp     dword ptr [rbp+var_48+4], 3FFFFFFFh
+  .text:0000000001E4DE1F                 ; _QWORD
+  .text:0000000001E4DE1F                 setbe   sil; _QWORD
+  .text:0000000001E4DE23                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E4DE28                 mov     edx, dword ptr [rbp+var_48+4]
+  .text:0000000001E4DE2B                 mov     [rbp+var_50], rax
+  .text:0000000001E4DE2F                 cmp     edx, 3FFFFFFFh
+  .text:0000000001E4DE35                 jbe     short loc_1E4DE40
+  .text:0000000001E4DE37                 and     edx, 3FFFFFFFh
+  .text:0000000001E4DE3D                 mov     dword ptr [rbp+var_48+4], edx
+  .text:0000000001E4DE40                 add     dword ptr [rbp+var_58], 1
+  .text:0000000001E4DE44                 mov     dword ptr [rbp+var_48], r13d
+  .text:0000000001E4DE48                 mov     dword ptr [rax], 14h
+  .text:0000000001E4DE4E                 mov     rdi, [rbx]
+  .text:0000000001E4DE51                 test    rdi, rdi
+  .text:0000000001E4DE54                 jz      short loc_1E4DE76
+  .text:0000000001E4DE56                 mov     eax, [rbx+40h]
+  .text:0000000001E4DE59                 lea     rdx, nullsub_1653
+  .text:0000000001E4DE60                 mov     [rbp+var_28], eax
+  .text:0000000001E4DE63                 mov     rax, [rdi]
+  .text:0000000001E4DE66                 mov     rax, [rax+0E8h]
+  .text:0000000001E4DE6D                 cmp     rax, rdx
+  .text:0000000001E4DE70                 jnz     loc_1E4DF63
+  .text:0000000001E4DE76                 cmp     dword ptr [rbp+var_48+4], 3FFFFFFFh
+  .text:0000000001E4DE7D                 mov     dword ptr [rbp+var_58], 0
+  .text:0000000001E4DE84                 ja      short loc_1E4DE9F
+  .text:0000000001E4DE86                 mov     rsi, [rbp+var_50]
+  .text:0000000001E4DE8A                 test    rsi, rsi
+  .text:0000000001E4DE8D                 jz      short loc_1E4DE9F
+  .text:0000000001E4DE8F                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E4DE96                 mov     rdi, [rax]
+  .text:0000000001E4DE99                 mov     rax, [rdi]
+  .text:0000000001E4DE9C                 call    qword ptr [rax+20h]
+  .text:0000000001E4DE9F                 mov     [rbx+14h], r12d
+  .text:0000000001E4DEA3                 jmp     loc_1E4DD43
+  .text:0000000001E4DEA8                 jmp     short loc_1E4DEA8
+  .text:0000000001E4DEAA                 jmp     short loc_1E4DEAA
+  .text:0000000001E4DEB0                 cmp     eax, 0FFFFFFFFh
+  .text:0000000001E4DEB3                 jz      loc_1E4DD43
+  .text:0000000001E4DEB9                 xor     ecx, ecx
+  .text:0000000001E4DEBB                 ; _QWORD
+  .text:0000000001E4DEBB                 mov     edx, 1; _QWORD
+  .text:0000000001E4DEC0                 ; _QWORD
+  .text:0000000001E4DEC0                 xor     esi, esi; _QWORD
+  .text:0000000001E4DEC2                 pxor    xmm0, xmm0
+  .text:0000000001E4DEC6                 mov     [rbp+var_24], cx
+  .text:0000000001E4DECA                 ; _QWORD
+  .text:0000000001E4DECA                 xor     edi, edi; _QWORD
+  .text:0000000001E4DECC                 ; _QWORD
+  .text:0000000001E4DECC                 mov     ecx, 4; _QWORD
+  .text:0000000001E4DED1                 mov     [rbp+var_60], 1
+  .text:0000000001E4DED9                 mov     [rbp+var_58], 0
+  .text:0000000001E4DEE1                 mov     [rbp+var_50], 0
+  .text:0000000001E4DEE9                 mov     [rbp+var_48], 0
+  .text:0000000001E4DEF1                 movaps  [rbp+var_40], xmm0
+  .text:0000000001E4DEF5                 mov     [rbp+var_30], 0FFFFFFFFFFFFFFFFh
+  .text:0000000001E4DEFD                 mov     [rbp+var_28], 0FFFFFFFFh
+  .text:0000000001E4DF04                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E4DF09                 mov     r12d, eax
+  .text:0000000001E4DF0C                 test    eax, eax
+  .text:0000000001E4DF0E                 jg      loc_1E4DCA0
+  .text:0000000001E4DF14                 jmp     short loc_1E4DF14
+  .text:0000000001E4DF20                 lea     rbx, dword_27C47DC
+  .text:0000000001E4DF27                 ; _QWORD
+  .text:0000000001E4DF27                 mov     esi, 3; _QWORD
+  .text:0000000001E4DF2C                 ; _QWORD
+  .text:0000000001E4DF2C                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E4DF2E                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E4DF33                 test    al, al
+  .text:0000000001E4DF35                 jz      loc_1E4DD43
+  .text:0000000001E4DF3B                 ; _QWORD
+  .text:0000000001E4DF3B                 mov     edi, [rbx]; _QWORD
+  .text:0000000001E4DF3D                 lea     rdx, aCentityidentit; "CEntityIdentity::SetEntityName called, "...
+  .text:0000000001E4DF44                 ; _QWORD
+  .text:0000000001E4DF44                 mov     esi, 3; _QWORD
+  .text:0000000001E4DF49                 xor     eax, eax
+  .text:0000000001E4DF4B                 call    _LoggingSystem_Log
+  .text:0000000001E4DF50                 jmp     loc_1E4DD43
+  .text:0000000001E4DF58                 lea     rsi, [rbp+var_60]
+  .text:0000000001E4DF5C                 call    rax
+  .text:0000000001E4DF5E                 jmp     loc_1E4DD13
+  .text:0000000001E4DF63                 lea     rsi, [rbp+var_60]
+  .text:0000000001E4DF67                 call    rax
+  .text:0000000001E4DF69                 jmp     loc_1E4DE76
+procedure: |-
+  void __fastcall CEntityIdentity_SetEntityName(__int64 *a1, _BYTE *a2)
+  {
+    __int64 v3; // r12
+    int v4; // eax
+    int v5; // r12d
+    _DWORD *v6; // rax
+    __int64 v7; // rdi
+    __int64 (__fastcall *v8)(); // rax
+    __int64 v9; // rdi
+    const bool *v10; // rdx
+    int v11; // r12d
+    int v12; // eax
+    int v13; // r13d
+    _DWORD *v14; // rax
+    __int64 v15; // rdi
+    __int64 (__fastcall *v16)(); // rax
+    __int64 v17; // [rsp+8h] [rbp-68h] BYREF
+    __int64 v18; // [rsp+10h] [rbp-60h] BYREF
+    __int64 v19; // [rsp+18h] [rbp-58h]
+    _DWORD *v20; // [rsp+20h] [rbp-50h]
+    __int64 v21; // [rsp+28h] [rbp-48h]
+    __int128 v22; // [rsp+30h] [rbp-40h]
+    __int64 v23; // [rsp+40h] [rbp-30h]
+    int v24; // [rsp+48h] [rbp-28h]
+    __int16 v25; // [rsp+4Ch] [rbp-24h]
+
+    sub_1E72500(&v17, g_pEntitySystem, a2);
+    v3 = v17;
+    if ( v17 != a1[3] )
+    {
+      if ( (*((_BYTE *)a1 + 49) & 0x48) != 0 )
+      {
+        a1[3] = v17;
+      }
+      else
+      {
+        CEntitySystem_RemoveEntityFromNameMap(g_pEntitySystem, (__int64)a1);
+        v9 = g_pEntitySystem;
+        a1[3] = v3;
+        CEntitySystem_AddEntityToNameMap(v9, (__int64)a1);
+      }
+      if ( byte_27C44B8 )
+      {
+        if ( v3 )
+        {
+          if ( qword_27C44B0 )
+          {
+            v10 = (const bool *)a1[3];
+            if ( !v10 )
+              v10 = &haystack;
+            v11 = (*(__int64 (__fastcall **)(__int64, __int64, const bool *, _QWORD))(*(_QWORD *)qword_27C44B0 + 64LL))(
+                    qword_27C44B0,
+                    1,
+                    v10,
+                    0);
+            if ( *((_DWORD *)a1 + 5) != v11 )
+            {
+              v22 = 0;
+              v25 = 0;
+              v18 = 1;
+              v19 = 0;
+              v20 = nullptr;
+              v21 = 0;
+              v23 = -1;
+              v24 = -1;
+              v12 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4);
+              v13 = v12;
+              if ( v12 <= 0 )
+              {
+                while ( 1 )
+                  ;
+              }
+              v14 = (_DWORD *)UtlVectorMemory_Alloc(v20, HIDWORD(v21) <= 0x3FFFFFFF, 4LL * v12, 4LL * (int)v21);
+              v20 = v14;
+              if ( HIDWORD(v21) > 0x3FFFFFFF )
+                HIDWORD(v21) &= 0x3FFFFFFFu;
+              LODWORD(v19) = v19 + 1;
+              LODWORD(v21) = v13;
+              *v14 = 20;
+              v15 = *a1;
+              if ( *a1 )
+              {
+                v24 = *((_DWORD *)a1 + 16);
+                v16 = *(__int64 (__fastcall **)())(*(_QWORD *)v15 + 232LL);
+                if ( v16 != nullsub_1653 )
+                  ((void (__fastcall *)(__int64, __int64 *))v16)(v15, &v18);
+              }
+              LODWORD(v19) = 0;
+              if ( HIDWORD(v21) <= 0x3FFFFFFF && v20 )
+                (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+              *((_DWORD *)a1 + 5) = v11;
+            }
+          }
+          else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_27C47DC, 3) )
+          {
+            LoggingSystem_Log(
+              (unsigned int)dword_27C47DC,
+              3,
+              "CEntityIdentity::SetEntityName called, but there is no entity name string table pointer!\n");
+          }
+        }
+        else
+        {
+          v4 = *((_DWORD *)a1 + 5);
+          if ( qword_27C44B0 )
+          {
+            if ( v4 == -1 )
+              return;
+            v25 = 0;
+            v18 = 1;
+            v19 = 0;
+            v20 = nullptr;
+            v21 = 0;
+            v22 = 0;
+            v23 = -1;
+            v24 = -1;
+            v5 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4);
+            if ( v5 <= 0 )
+            {
+              while ( 1 )
+                ;
+            }
+          }
+          else
+          {
+            if ( v4 == -1 )
+              return;
+            v25 = 0;
+            v18 = 1;
+            v19 = 0;
+            v20 = nullptr;
+            v21 = 0;
+            v22 = 0;
+            v23 = -1;
+            v24 = -1;
+            v5 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4);
+            if ( v5 <= 0 )
+            {
+              while ( 1 )
+                ;
+            }
+          }
+          v6 = (_DWORD *)UtlVectorMemory_Alloc(v20, HIDWORD(v21) <= 0x3FFFFFFF, 4LL * v5, 4LL * (int)v21);
+          v20 = v6;
+          if ( HIDWORD(v21) > 0x3FFFFFFF )
+            HIDWORD(v21) &= 0x3FFFFFFFu;
+          LODWORD(v19) = v19 + 1;
+          LODWORD(v21) = v5;
+          *v6 = 20;
+          v7 = *a1;
+          if ( *a1 )
+          {
+            v24 = *((_DWORD *)a1 + 16);
+            v8 = *(__int64 (__fastcall **)())(*(_QWORD *)v7 + 232LL);
+            if ( v8 != nullsub_1653 )
+              ((void (__fastcall *)(__int64, __int64 *))v8)(v7, &v18);
+          }
+          LODWORD(v19) = 0;
+          if ( HIDWORD(v21) <= 0x3FFFFFFF )
+          {
+            if ( v20 )
+              (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+          }
+          *((_DWORD *)a1 + 5) = -1;
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityIdentity_SetEntityName.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityIdentity_SetEntityName.windows.yaml
@@ -1,0 +1,134 @@
+func_name: CEntityIdentity_SetEntityName
+func_va: '0x181218100'
+disasm_code: |-
+  .text:0000000181218100                 mov     [rsp+arg_8], rbx
+  .text:0000000181218105                 push    rdi
+  .text:0000000181218106                 sub     rsp, 20h
+  .text:000000018121810A                 mov     rbx, rcx
+  .text:000000018121810D                 mov     r8, rdx
+  .text:0000000181218110                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000181218117                 lea     rdx, [rsp+28h+arg_0]
+  .text:000000018121811C                 call    sub_1811EED20
+  .text:0000000181218121                 mov     rdi, [rsp+28h+arg_0]
+  .text:0000000181218126                 cmp     [rbx+18h], rdi
+  .text:000000018121812A                 jz      loc_181218222
+  .text:0000000181218130                 test    dword ptr [rbx+30h], 4800h
+  .text:0000000181218137                 jnz     short loc_18121815D
+  .text:0000000181218139                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000181218140                 mov     rdx, rbx
+  .text:0000000181218143                 call    CEntitySystem_RemoveEntityFromNameMap
+  .text:0000000181218148                 mov     [rbx+18h], rdi
+  .text:000000018121814C                 mov     rdx, rbx
+  .text:000000018121814F                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000181218156                 call    CEntitySystem_AddEntityToNameMap
+  .text:000000018121815B                 jmp     short loc_181218161
+  .text:000000018121815D                 mov     [rbx+18h], rdi
+  .text:0000000181218161                 movzx   edx, cs:byte_1820B97B8
+  .text:0000000181218168                 test    dl, dl
+  .text:000000018121816A                 jz      loc_181218222
+  .text:0000000181218170                 test    rdi, rdi
+  .text:0000000181218173                 jnz     short loc_1812181A5
+  .text:0000000181218175                 cmp     dword ptr [rbx+14h], 0FFFFFFFFh
+  .text:0000000181218179                 jz      loc_181218222
+  .text:000000018121817F                 mov     edx, 0FFFFFFFFh
+  .text:0000000181218184                 lea     rcx, [rbx+14h]
+  .text:0000000181218188                 mov     r8d, 0FFFFFFFFh
+  .text:000000018121818E                 call    sub_180B6E400
+  .text:0000000181218193                 mov     dword ptr [rbx+14h], 0FFFFFFFFh
+  .text:000000018121819A                 mov     rbx, [rsp+28h+arg_8]
+  .text:000000018121819F                 add     rsp, 20h
+  .text:00000001812181A3                 pop     rdi
+  .text:00000001812181A4                 retn
+  .text:00000001812181A5                 mov     rcx, cs:qword_1820B97B0
+  .text:00000001812181AC                 test    rcx, rcx
+  .text:00000001812181AF                 jnz     short loc_1812181E9
+  .text:00000001812181B1                 mov     ecx, cs:dword_1820B9828
+  .text:00000001812181B7                 mov     edx, 3
+  .text:00000001812181BC                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001812181C2                 test    al, al
+  .text:00000001812181C4                 jz      short loc_181218222
+  .text:00000001812181C6                 mov     ecx, cs:dword_1820B9828
+  .text:00000001812181CC                 lea     r8, aCentityidentit; "CEntityIdentity::SetEntityName called, "...
+  .text:00000001812181D3                 mov     edx, 3
+  .text:00000001812181D8                 call    cs:LoggingSystem_Log
+  .text:00000001812181DE                 mov     rbx, [rsp+28h+arg_8]
+  .text:00000001812181E3                 add     rsp, 20h
+  .text:00000001812181E7                 pop     rdi
+  .text:00000001812181E8                 retn
+  .text:00000001812181E9                 mov     rax, [rbx+18h]
+  .text:00000001812181ED                 lea     r8, Src
+  .text:00000001812181F4                 test    rax, rax
+  .text:00000001812181F7                 cmovnz  r8, rax
+  .text:00000001812181FB                 mov     rax, [rcx]
+  .text:00000001812181FE                 xor     r9d, r9d
+  .text:0000000181218201                 call    qword ptr [rax+38h]
+  .text:0000000181218204                 mov     edi, eax
+  .text:0000000181218206                 cmp     [rbx+14h], eax
+  .text:0000000181218209                 jz      short loc_181218222
+  .text:000000018121820B                 mov     edx, 0FFFFFFFFh
+  .text:0000000181218210                 lea     rcx, [rbx+14h]
+  .text:0000000181218214                 mov     r8d, 0FFFFFFFFh
+  .text:000000018121821A                 call    sub_180B6E400
+  .text:000000018121821F                 mov     [rbx+14h], edi
+  .text:0000000181218222                 mov     rbx, [rsp+28h+arg_8]
+  .text:0000000181218227                 add     rsp, 20h
+  .text:000000018121822B                 pop     rdi
+  .text:000000018121822C                 retn
+procedure: |-
+  void __fastcall CEntityIdentity_SetEntityName(__int64 a1, __int64 a2)
+  {
+    __int64 v3; // rdi
+    char *v4; // r8
+    int v5; // edi
+    __int64 v6; // [rsp+30h] [rbp+8h] BYREF
+
+    sub_1811EED20(g_pEntitySystem, &v6, (_BYTE *)a2);
+    v3 = v6;
+    if ( *(_QWORD *)(a1 + 24) != v6 )
+    {
+      if ( (*(_DWORD *)(a1 + 48) & 0x4800) != 0 )
+      {
+        *(_QWORD *)(a1 + 24) = v6;
+      }
+      else
+      {
+        CEntitySystem_RemoveEntityFromNameMap(g_pEntitySystem, a1);
+        *(_QWORD *)(a1 + 24) = v3;
+        CEntitySystem_AddEntityToNameMap(g_pEntitySystem, a1);
+      }
+      if ( byte_1820B97B8 )
+      {
+        if ( v3 )
+        {
+          if ( qword_1820B97B0 )
+          {
+            v4 = Src;
+            if ( *(_QWORD *)(a1 + 24) )
+              v4 = *(char **)(a1 + 24);
+            v5 = (*(__int64 (__fastcall **)(__int64, _QWORD, char *, _QWORD))(*(_QWORD *)qword_1820B97B0 + 56LL))(
+                   qword_1820B97B0,
+                   (unsigned __int8)byte_1820B97B8,
+                   v4,
+                   0);
+            if ( *(_DWORD *)(a1 + 20) != v5 )
+            {
+              sub_180B6E400(a1 + 20, -1, -1);
+              *(_DWORD *)(a1 + 20) = v5;
+            }
+          }
+          else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B9828, 3) )
+          {
+            LoggingSystem_Log(
+              (unsigned int)dword_1820B9828,
+              3,
+              "CEntityIdentity::SetEntityName called, but there is no entity name string table pointer!\n");
+          }
+        }
+        else if ( *(_DWORD *)(a1 + 20) != -1 )
+        {
+          sub_180B6E400(a1 + 20, -1, -1);
+          *(_DWORD *)(a1 + 20) = -1;
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityToNameMap.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityToNameMap.linux.yaml
@@ -1,0 +1,825 @@
+func_name: CEntitySystem_AddEntityToNameMap
+func_va: '0x1e6be50'
+disasm_code: |-
+  .text:0000000001E6BDD4                 movq    xmm0, cs:off_241E310; "../public/tier0/utlrbtree.h"
+  .text:0000000001E6BDDC                 lea     rax, aInsert; "Insert"
+  .text:0000000001E6BDE3                 mov     [rbp+var_38], 8B0h
+  .text:0000000001E6BDEA                 ; _QWORD
+  .text:0000000001E6BDEA                 lea     rdi, [rbp+var_50]; _QWORD
+  .text:0000000001E6BDEE                 pinsrq  xmm0, rax, 1
+  .text:0000000001E6BDF5                 lea     rax, aLink; "!link"
+  .text:0000000001E6BDFC                 movaps  xmmword ptr [rbp+var_50], xmm0
+  .text:0000000001E6BE00                 mov     [rbp+var_40], rax
+  .text:0000000001E6BE04                 movzx   eax, [rbp+var_34]
+  .text:0000000001E6BE08                 lea     rsi, aFoundExistingV; "Found existing value when inserting int"...
+  .text:0000000001E6BE0F                 and     eax, 0FFFFFF80h
+  .text:0000000001E6BE12                 or      eax, 14h
+  .text:0000000001E6BE15                 mov     [rbp+var_34], al
+  .text:0000000001E6BE18                 xor     eax, eax
+  .text:0000000001E6BE1A                 call    __Z22Assert_ConditionFailedRK34_AssertCompileTimeConstantStruct_tPKcz; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const&,char const*,...)
+  .text:0000000001E6BE1F                 test    al, al
+  .text:0000000001E6BE21                 jz      short loc_1E6BE24
+  .text:0000000001E6BE23                 ; Trap to Debugger
+  .text:0000000001E6BE23                 int     3; Trap to Debugger
+  .text:0000000001E6BE24                 test    word ptr [r12+0AFAh], 7FFFh
+  .text:0000000001E6BE2F                 jz      short loc_1E6BE49
+  .text:0000000001E6BE31                 mov     rax, [r12+0B00h]
+  .text:0000000001E6BE39                 add     rax, rbx
+  .text:0000000001E6BE3C                 mov     [rax+8], r14
+  .text:0000000001E6BE40                 mov     [rax+10h], r15
+  .text:0000000001E6BE44                 jmp     loc_1E6BF42
+  .text:0000000001E6BE49                 xor     eax, eax
+  .text:0000000001E6BE4B                 jmp     short loc_1E6BE39
+  .text:0000000001E6BE50                 push    rbp
+  .text:0000000001E6BE51                 mov     rbp, rsp
+  .text:0000000001E6BE54                 push    r15
+  .text:0000000001E6BE56                 push    r14
+  .text:0000000001E6BE58                 push    r13
+  .text:0000000001E6BE5A                 push    r12
+  .text:0000000001E6BE5C                 push    rbx
+  .text:0000000001E6BE5D                 sub     rsp, 58h
+  .text:0000000001E6BE61                 mov     r14, [rsi+18h]
+  .text:0000000001E6BE65                 mov     [rbp+var_58], r14
+  .text:0000000001E6BE69                 test    r14, r14
+  .text:0000000001E6BE6C                 jz      loc_1E6BF42
+  .text:0000000001E6BE72                 lea     r13, [rdi+0AF8h]
+  .text:0000000001E6BE79                 mov     r12, rdi
+  .text:0000000001E6BE7C                 mov     rbx, rsi
+  .text:0000000001E6BE7F                 lea     rdx, [rbp+var_58]
+  .text:0000000001E6BE83                 lea     rsi, [rdi+0AF0h]  ; 0AF0h = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+  .text:0000000001E6BE8A                 mov     rdi, r13
+  .text:0000000001E6BE8D                 call    sub_1E59BD0
+  .text:0000000001E6BE92                 mov     rdx, rax
+  .text:0000000001E6BE95                 mov     [rbp+var_5E], ax
+  .text:0000000001E6BE99                 shr     rax, 20h
+  .text:0000000001E6BE9D                 shr     rdx, 10h
+  .text:0000000001E6BEA1                 mov     [rbp+var_5A], ax
+  .text:0000000001E6BEA5                 mov     [rbp+var_5C], dx
+  .text:0000000001E6BEA9                 cmp     dx, 0FFFFh
+  .text:0000000001E6BEAD                 jz      loc_1E6BF60
+  .text:0000000001E6BEB3                 xor     eax, eax
+  .text:0000000001E6BEB5                 test    word ptr [r12+0AFAh], 7FFFh
+  .text:0000000001E6BEC0                 jz      short loc_1E6BECA
+  .text:0000000001E6BEC2                 mov     rax, [r12+0B00h]
+  .text:0000000001E6BECA                 movzx   edx, dx
+  .text:0000000001E6BECD                 lea     rdx, [rdx+rdx*2]
+  .text:0000000001E6BED1                 mov     r12, [rax+rdx*8+10h]
+  .text:0000000001E6BED6                 mov     eax, [rbx+10h]
+  .text:0000000001E6BED9                 mov     edx, [rbx+30h]
+  .text:0000000001E6BEDC                 shr     eax, 0Fh
+  .text:0000000001E6BEDF                 and     edx, 1
+  .text:0000000001E6BEE2                 sub     eax, edx
+  .text:0000000001E6BEE4                 cmp     dword ptr [rbx+10h], 0FFFFFFFFh
+  .text:0000000001E6BEE8                 jz      short loc_1E6BF58
+  .text:0000000001E6BEEA                 movzx   edx, word ptr [rbx+10h]
+  .text:0000000001E6BEEE                 and     dx, 7FFFh
+  .text:0000000001E6BEF3                 mov     esi, [r12]
+  .text:0000000001E6BEF7                 mov     r8d, eax
+  .text:0000000001E6BEFA                 movzx   edi, dx
+  .text:0000000001E6BEFD                 shl     eax, 0Fh
+  .text:0000000001E6BF00                 and     edx, 7FFFh
+  .text:0000000001E6BF06                 and     r8d, 1FFFFh
+  .text:0000000001E6BF0D                 or      edx, eax
+  .text:0000000001E6BF0F                 movsxd  rbx, esi
+  .text:0000000001E6BF12                 test    esi, esi
+  .text:0000000001E6BF14                 jle     loc_1E6C140
+  .text:0000000001E6BF1A                 mov     rcx, [r12+8]
+  .text:0000000001E6BF1F                 movsxd  rbx, esi
+  .text:0000000001E6BF22                 xor     eax, eax
+  .text:0000000001E6BF24                 jmp     short loc_1E6BF3D
+  .text:0000000001E6BF30                 add     rax, 1
+  .text:0000000001E6BF34                 cmp     rax, rbx
+  .text:0000000001E6BF37                 jz      loc_1E6C140
+  .text:0000000001E6BF3D                 cmp     [rcx+rax*4], edx
+  .text:0000000001E6BF40                 jnz     short loc_1E6BF30
+  .text:0000000001E6BF42                 add     rsp, 58h
+  .text:0000000001E6BF46                 pop     rbx
+  .text:0000000001E6BF47                 pop     r12
+  .text:0000000001E6BF49                 pop     r13
+  .text:0000000001E6BF4B                 pop     r14
+  .text:0000000001E6BF4D                 pop     r15
+  .text:0000000001E6BF4F                 pop     rbp
+  .text:0000000001E6BF50                 retn
+  .text:0000000001E6BF58                 mov     edx, 7FFFh
+  .text:0000000001E6BF5D                 jmp     short loc_1E6BEF3
+  .text:0000000001E6BF60                 ; _QWORD
+  .text:0000000001E6BF60                 mov     edi, 20h ; ' '; _QWORD
+  .text:0000000001E6BF65                 call    __Znwm; operator new(ulong)
+  .text:0000000001E6BF6A                 mov     edx, [rbx+30h]
+  .text:0000000001E6BF6D                 mov     r15, rax
+  .text:0000000001E6BF70                 mov     qword ptr [rax], 0
+  .text:0000000001E6BF77                 mov     qword ptr [rax+8], 0
+  .text:0000000001E6BF7F                 mov     qword ptr [rax+10h], 0
+  .text:0000000001E6BF87                 mov     dword ptr [rax+18h], 1
+  .text:0000000001E6BF8E                 mov     eax, [rbx+10h]
+  .text:0000000001E6BF91                 and     edx, 1
+  .text:0000000001E6BF94                 shr     eax, 0Fh
+  .text:0000000001E6BF97                 sub     eax, edx
+  .text:0000000001E6BF99                 cmp     dword ptr [rbx+10h], 0FFFFFFFFh
+  .text:0000000001E6BF9D                 jz      loc_1E6C1CD
+  .text:0000000001E6BFA3                 movzx   edx, word ptr [rbx+10h]
+  .text:0000000001E6BFA7                 and     dx, 7FFFh
+  .text:0000000001E6BFAC                 movzx   edx, dx
+  .text:0000000001E6BFAF                 shl     eax, 0Fh
+  .text:0000000001E6BFB2                 mov     esi, 1
+  .text:0000000001E6BFB7                 lea     rdi, [r15+8]
+  .text:0000000001E6BFBB                 or      eax, edx
+  .text:0000000001E6BFBD                 mov     ebx, eax
+  .text:0000000001E6BFBF                 call    sub_AE1280
+  .text:0000000001E6BFC4                 mov     rax, [r15+8]
+  .text:0000000001E6BFC8                 add     dword ptr [r15], 1
+  .text:0000000001E6BFCC                 mov     [rax], ebx
+  .text:0000000001E6BFCE                 movzx   esi, word ptr [r12+0AFAh]
+  .text:0000000001E6BFD7                 movzx   eax, word ptr [r12+0B08h]
+  .text:0000000001E6BFE0                 mov     edx, esi
+  .text:0000000001E6BFE2                 and     dx, 7FFFh
+  .text:0000000001E6BFE7                 cmp     ax, 0FFFFh
+  .text:0000000001E6BFEB                 jz      loc_1E6C070
+  .text:0000000001E6BFF1                 test    dx, dx
+  .text:0000000001E6BFF4                 jz      short loc_1E6C049
+  .text:0000000001E6BFF6                 mov     rdi, [r12+0B00h]
+  .text:0000000001E6BFFE                 movzx   ecx, ax
+  .text:0000000001E6C001                 lea     rbx, [rcx+rcx*2]
+  .text:0000000001E6C005                 shl     rbx, 3
+  .text:0000000001E6C009                 lea     rcx, [rdi+rbx]
+  .text:0000000001E6C00D                 cmp     r14, [rcx+8]
+  .text:0000000001E6C011                 jb      loc_1E6C170
+  .text:0000000001E6C017                 jz      loc_1E6BDD4
+  .text:0000000001E6C01D                 movzx   ecx, word ptr [rcx+2]
+  .text:0000000001E6C021                 xor     r8d, r8d
+  .text:0000000001E6C024                 cmp     cx, 0FFFFh
+  .text:0000000001E6C028                 jz      loc_1E6C1D7
+  .text:0000000001E6C02E                 mov     eax, ecx
+  .text:0000000001E6C030                 jmp     short loc_1E6BFFE
+  .text:0000000001E6C032                 movzx   ecx, word ptr ds:dword_0+2[rcx*8]
+  .text:0000000001E6C03A                 xor     r8d, r8d
+  .text:0000000001E6C03D                 cmp     cx, 0FFFFh
+  .text:0000000001E6C041                 jz      loc_1E6C36B
+  .text:0000000001E6C047                 mov     eax, ecx
+  .text:0000000001E6C049                 movzx   ecx, ax
+  .text:0000000001E6C04C                 lea     rcx, [rcx+rcx*2]
+  .text:0000000001E6C050                 lea     rbx, ds:0[rcx*8]
+  .text:0000000001E6C058                 cmp     r14, qword ptr ds:byte_8[rcx*8]
+  .text:0000000001E6C060                 jb      loc_1E6C19D
+  .text:0000000001E6C066                 jz      loc_1E6BDD4
+  .text:0000000001E6C06C                 jmp     short loc_1E6C032
+  .text:0000000001E6C070                 movzx   ecx, word ptr [r12+0B0Ch]
+  .text:0000000001E6C079                 cmp     cx, 0FFFFh
+  .text:0000000001E6C07D                 jz      loc_1E6C34F
+  .text:0000000001E6C083                 mov     r8d, 1
+  .text:0000000001E6C089                 test    dx, dx
+  .text:0000000001E6C08C                 jz      loc_1E6C17E
+  .text:0000000001E6C092                 movzx   edx, cx
+  .text:0000000001E6C095                 lea     rbx, [rdx+rdx*2]
+  .text:0000000001E6C099                 mov     rdx, [r12+0B00h]
+  .text:0000000001E6C0A1                 shl     rbx, 3
+  .text:0000000001E6C0A5                 movzx   esi, word ptr [rdx+rbx+2]
+  .text:0000000001E6C0AA                 mov     [r12+0B0Ch], si
+  .text:0000000001E6C0B3                 add     rdx, rbx
+  .text:0000000001E6C0B6                 mov     [rdx+8], r14
+  .text:0000000001E6C0BA                 mov     [rdx+10h], r15
+  .text:0000000001E6C0BE                 xor     edx, edx
+  .text:0000000001E6C0C0                 test    word ptr [r12+0AFAh], 7FFFh
+  .text:0000000001E6C0CB                 jz      short loc_1E6C0D5
+  .text:0000000001E6C0CD                 mov     rdx, [r12+0B00h]
+  .text:0000000001E6C0D5                 lea     rsi, [rdx+rbx]
+  .text:0000000001E6C0D9                 mov     dword ptr [rdx+rbx], 0FFFFFFFFh
+  .text:0000000001E6C0E0                 mov     byte ptr [rsi+6], 0
+  .text:0000000001E6C0E4                 mov     [rsi+4], ax
+  .text:0000000001E6C0E8                 movzx   esi, cx
+  .text:0000000001E6C0EB                 cmp     ax, 0FFFFh
+  .text:0000000001E6C0EF                 jz      loc_1E6C3B4
+  .text:0000000001E6C0F5                 movzx   edx, word ptr [r12+0AFAh]
+  .text:0000000001E6C0FE                 xor     edi, edi
+  .text:0000000001E6C100                 and     dx, 7FFFh
+  .text:0000000001E6C105                 test    r8b, r8b
+  .text:0000000001E6C108                 jz      loc_1E6C396
+  .text:0000000001E6C10E                 test    dx, dx
+  .text:0000000001E6C111                 jz      short loc_1E6C11B
+  .text:0000000001E6C113                 mov     rdi, [r12+0B00h]
+  .text:0000000001E6C11B                 movzx   eax, ax
+  .text:0000000001E6C11E                 lea     rax, [rax+rax*2]
+  .text:0000000001E6C122                 mov     [rdi+rax*8], cx
+  .text:0000000001E6C126                 mov     rdi, r13
+  .text:0000000001E6C129                 call    sub_1E6BA20
+  .text:0000000001E6C12E                 add     word ptr [r12+0B0Ah], 1
+  .text:0000000001E6C138                 jmp     loc_1E6BF42
+  .text:0000000001E6C140                 shl     r8d, 0Fh
+  .text:0000000001E6C144                 or      r8d, edi
+  .text:0000000001E6C147                 cmp     [r12+10h], esi
+  .text:0000000001E6C14C                 jz      short loc_1E6C1B0
+  .text:0000000001E6C14E                 mov     rax, [r12+8]
+  .text:0000000001E6C153                 add     esi, 1
+  .text:0000000001E6C156                 mov     [r12], esi
+  .text:0000000001E6C15A                 mov     [rax+rbx*4], r8d
+  .text:0000000001E6C15E                 add     rsp, 58h
+  .text:0000000001E6C162                 pop     rbx
+  .text:0000000001E6C163                 pop     r12
+  .text:0000000001E6C165                 pop     r13
+  .text:0000000001E6C167                 pop     r14
+  .text:0000000001E6C169                 pop     r15
+  .text:0000000001E6C16B                 pop     rbp
+  .text:0000000001E6C16C                 retn
+  .text:0000000001E6C170                 movzx   ecx, word ptr [rcx]
+  .text:0000000001E6C173                 mov     r8d, 1
+  .text:0000000001E6C179                 jmp     loc_1E6C024
+  .text:0000000001E6C17E                 movzx   edx, cx
+  .text:0000000001E6C181                 lea     rbx, [rdx+rdx*2]
+  .text:0000000001E6C185                 shl     rbx, 3
+  .text:0000000001E6C189                 movzx   edx, word ptr [rbx+2]
+  .text:0000000001E6C18D                 mov     [r12+0B0Ch], dx
+  .text:0000000001E6C196                 xor     edx, edx
+  .text:0000000001E6C198                 jmp     loc_1E6C0B3
+  .text:0000000001E6C19D                 movzx   ecx, word ptr ds:dword_0[rcx*8]
+  .text:0000000001E6C1A5                 mov     r8d, 1
+  .text:0000000001E6C1AB                 jmp     loc_1E6C03D
+  .text:0000000001E6C1B0                 lea     rdi, [r12+8]
+  .text:0000000001E6C1B5                 mov     esi, 1
+  .text:0000000001E6C1BA                 mov     dword ptr [rbp+dest], r8d
+  .text:0000000001E6C1BE                 call    sub_AE1280
+  .text:0000000001E6C1C3                 mov     esi, [r12]
+  .text:0000000001E6C1C7                 mov     r8d, dword ptr [rbp+dest]
+  .text:0000000001E6C1CB                 jmp     short loc_1E6C14E
+  .text:0000000001E6C1CD                 mov     edx, 7FFFh
+  .text:0000000001E6C1D2                 jmp     loc_1E6BFAC
+  .text:0000000001E6C1D7                 movzx   ecx, word ptr [r12+0B0Ch]
+  .text:0000000001E6C1E0                 cmp     cx, 0FFFFh
+  .text:0000000001E6C1E4                 jnz     loc_1E6C092
+  .text:0000000001E6C1EA                 movzx   ebx, word ptr [r12+0AF8h]
+  .text:0000000001E6C1F3                 mov     ecx, eax
+  .text:0000000001E6C1F5                 lea     edi, [rbx+1]
+  .text:0000000001E6C1F8                 cmp     dx, di
+  .text:0000000001E6C1FB                 jnb     loc_1E6C493
+  .text:0000000001E6C201                 test    di, di
+  .text:0000000001E6C204                 js      loc_1E6C4A4
+  .text:0000000001E6C20A                 cmp     dx, di
+  .text:0000000001E6C20D                 jnb     short loc_1E6C21F
+  .text:0000000001E6C20F                 cmp     dx, 3FFEh
+  .text:0000000001E6C214                 jbe     loc_1E6C322
+  .text:0000000001E6C21A                 mov     edx, 7FFFh
+  .text:0000000001E6C21F                 movzx   eax, dx
+  .text:0000000001E6C222                 mov     dword ptr [rbp+var_80], edx
+  .text:0000000001E6C225                 lea     r11, [rax+rax*2]
+  .text:0000000001E6C229                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E6C230                 mov     [rbp+var_79], r8b
+  .text:0000000001E6C234                 shl     r11, 3
+  .text:0000000001E6C238                 mov     dword ptr [rbp+var_78], ecx
+  .text:0000000001E6C23B                 mov     rdi, [rax]
+  .text:0000000001E6C23E                 mov     rax, [rdi]
+  .text:0000000001E6C241                 test    si, si
+  .text:0000000001E6C244                 js      loc_1E6C3E4
+  .text:0000000001E6C24A                 mov     rdx, r11
+  .text:0000000001E6C24D                 mov     [rbp+var_70], r11
+  .text:0000000001E6C251                 mov     rsi, [r12+0B00h]
+  .text:0000000001E6C259                 call    qword ptr [rax+18h]
+  .text:0000000001E6C25C                 mov     r9, rax
+  .text:0000000001E6C25F                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E6C266                 mov     rsi, r9
+  .text:0000000001E6C269                 mov     [rbp+dest], r9
+  .text:0000000001E6C26D                 mov     rdi, [rax]
+  .text:0000000001E6C270                 mov     rax, [rdi]
+  .text:0000000001E6C273                 call    qword ptr [rax+90h]
+  .text:0000000001E6C279                 mov     r11, [rbp+var_70]
+  .text:0000000001E6C27D                 movzx   r8d, [rbp+var_79]
+  .text:0000000001E6C282                 mov     ecx, dword ptr [rbp+var_78]
+  .text:0000000001E6C285                 mov     r9, [rbp+dest]
+  .text:0000000001E6C289                 cmp     r11, rax
+  .text:0000000001E6C28C                 cmovnb  rax, r11
+  .text:0000000001E6C290                 mov     r10, rax
+  .text:0000000001E6C293                 mov     rax, 0AAAAAAAAAAAAAAABh
+  .text:0000000001E6C29D                 mov     [r12+0B00h], r9
+  .text:0000000001E6C2A5                 mul     r10
+  .text:0000000001E6C2A8                 mov     rax, rdx
+  .text:0000000001E6C2AB                 mov     edx, 7FFFh
+  .text:0000000001E6C2B0                 shr     rax, 4
+  .text:0000000001E6C2B4                 cmp     rax, rdx
+  .text:0000000001E6C2B7                 cmova   rax, rdx
+  .text:0000000001E6C2BB                 mov     [r12+0AFAh], ax
+  .text:0000000001E6C2C4                 mov     eax, ecx
+  .text:0000000001E6C2C6                 mov     ecx, ebx
+  .text:0000000001E6C2C8                 movzx   edx, cx
+  .text:0000000001E6C2CB                 lea     rsi, [rdx+rdx*2+3]
+  .text:0000000001E6C2D0                 shl     rsi, 3
+  .text:0000000001E6C2D4                 lea     rbx, [rsi-18h]
+  .text:0000000001E6C2D8                 lea     rdx, [r9+rbx]
+  .text:0000000001E6C2DC                 add     r9, rsi
+  .text:0000000001E6C2DF                 cmp     rdx, r9
+  .text:0000000001E6C2E2                 jnb     short loc_1E6C2E9
+  .text:0000000001E6C2E4                 and     edx, 7
+  .text:0000000001E6C2E7                 jnz     short loc_1E6C333
+  .text:0000000001E6C2E9                 add     word ptr [r12+0AF8h], 1
+  .text:0000000001E6C2F3                 xor     edx, edx
+  .text:0000000001E6C2F5                 test    word ptr [r12+0AFAh], 7FFFh
+  .text:0000000001E6C300                 jz      loc_1E6C0B3
+  .text:0000000001E6C306                 mov     rdx, [r12+0B00h]
+  .text:0000000001E6C30E                 jmp     loc_1E6C0B3
+  .text:0000000001E6C313                 mov     edx, 2
+  .text:0000000001E6C318                 cmp     di, 2
+  .text:0000000001E6C31C                 jbe     loc_1E6C21F
+  .text:0000000001E6C322                 movzx   eax, dx
+  .text:0000000001E6C325                 add     eax, eax
+  .text:0000000001E6C327                 cmp     eax, 1
+  .text:0000000001E6C32A                 jle     short loc_1E6C313
+  .text:0000000001E6C32C                 add     edx, edx
+  .text:0000000001E6C32E                 jmp     loc_1E6C20A
+  .text:0000000001E6C333                 mov     byte ptr [rbp+var_78], r8b
+  .text:0000000001E6C337                 mov     dword ptr [rbp+var_70], ecx
+  .text:0000000001E6C33A                 mov     dword ptr [rbp+dest], eax
+  .text:0000000001E6C33D                 call    sub_1B25B60
+  .text:0000000001E6C342                 movzx   r8d, byte ptr [rbp+var_78]
+  .text:0000000001E6C347                 mov     ecx, dword ptr [rbp+var_70]
+  .text:0000000001E6C34A                 mov     eax, dword ptr [rbp+dest]
+  .text:0000000001E6C34D                 jmp     short loc_1E6C2E9
+  .text:0000000001E6C34F                 movzx   ebx, word ptr [r12+0AF8h]
+  .text:0000000001E6C358                 lea     edi, [rbx+1]
+  .text:0000000001E6C35B                 cmp     dx, di
+  .text:0000000001E6C35E                 jnb     short loc_1E6C3CB
+  .text:0000000001E6C360                 mov     r8d, 1
+  .text:0000000001E6C366                 jmp     loc_1E6C201
+  .text:0000000001E6C36B                 movzx   ecx, word ptr [r12+0B0Ch]
+  .text:0000000001E6C374                 cmp     cx, 0FFFFh
+  .text:0000000001E6C378                 jnz     loc_1E6C17E
+  .text:0000000001E6C37E                 movzx   ebx, word ptr [r12+0AF8h]
+  .text:0000000001E6C387                 mov     edi, ebx
+  .text:0000000001E6C389                 add     di, 1
+  .text:0000000001E6C38D                 jz      short loc_1E6C3DC
+  .text:0000000001E6C38F                 mov     ecx, eax
+  .text:0000000001E6C391                 jmp     loc_1E6C201
+  .text:0000000001E6C396                 test    dx, dx
+  .text:0000000001E6C399                 jz      short loc_1E6C3A3
+  .text:0000000001E6C39B                 mov     rdi, [r12+0B00h]
+  .text:0000000001E6C3A3                 movzx   eax, ax
+  .text:0000000001E6C3A6                 lea     rax, [rax+rax*2]
+  .text:0000000001E6C3AA                 mov     [rdi+rax*8+2], cx
+  .text:0000000001E6C3AF                 jmp     loc_1E6C126
+  .text:0000000001E6C3B4                 test    r8b, r8b
+  .text:0000000001E6C3B7                 jz      loc_1E6C126
+  .text:0000000001E6C3BD                 mov     [r12+0B08h], cx
+  .text:0000000001E6C3C6                 jmp     loc_1E6C126
+  .text:0000000001E6C3CB                 test    dx, dx
+  .text:0000000001E6C3CE                 jnz     loc_1E6C48D
+  .text:0000000001E6C3D4                 mov     ecx, ebx
+  .text:0000000001E6C3D6                 mov     r8d, 1
+  .text:0000000001E6C3DC                 xor     r9d, r9d
+  .text:0000000001E6C3DF                 jmp     loc_1E6C2C8
+  .text:0000000001E6C3E4                 mov     rsi, r11
+  .text:0000000001E6C3E7                 mov     [rbp+var_70], r11
+  .text:0000000001E6C3EB                 call    qword ptr [rax+10h]
+  .text:0000000001E6C3EE                 mov     r9, rax
+  .text:0000000001E6C3F1                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E6C3F8                 mov     rsi, r9
+  .text:0000000001E6C3FB                 mov     [rbp+dest], r9
+  .text:0000000001E6C3FF                 mov     rdi, [rax]
+  .text:0000000001E6C402                 mov     rax, [rdi]
+  .text:0000000001E6C405                 call    qword ptr [rax+90h]
+  .text:0000000001E6C40B                 mov     r11, [rbp+var_70]
+  .text:0000000001E6C40F                 mov     r9, [rbp+dest]
+  .text:0000000001E6C413                 mov     ecx, dword ptr [rbp+var_78]
+  .text:0000000001E6C416                 movzx   r8d, [rbp+var_79]
+  .text:0000000001E6C41B                 cmp     r11, rax
+  .text:0000000001E6C41E                 mov     edx, dword ptr [rbp+var_80]
+  .text:0000000001E6C421                 cmovnb  rax, r11
+  .text:0000000001E6C425                 xor     esi, esi
+  .text:0000000001E6C427                 test    word ptr [r12+0AFAh], 7FFFh
+  .text:0000000001E6C432                 mov     r10, rax
+  .text:0000000001E6C435                 jz      short loc_1E6C43F
+  .text:0000000001E6C437                 ; src
+  .text:0000000001E6C437                 mov     rsi, [r12+0B00h]; src
+  .text:0000000001E6C43F                 movzx   eax, word ptr [r12+0AF8h]
+  .text:0000000001E6C448                 cmp     dx, ax
+  .text:0000000001E6C44B                 cmovbe  eax, edx
+  .text:0000000001E6C44E                 movzx   eax, ax
+  .text:0000000001E6C451                 lea     rdx, [rax+rax*2]
+  .text:0000000001E6C455                 ; n
+  .text:0000000001E6C455                 shl     rdx, 3; n
+  .text:0000000001E6C459                 lea     rax, [rsi+rdx]
+  .text:0000000001E6C45D                 cmp     rsi, rax
+  .text:0000000001E6C460                 jnb     loc_1E6C293
+  .text:0000000001E6C466                 ; dest
+  .text:0000000001E6C466                 mov     rdi, r9; dest
+  .text:0000000001E6C469                 mov     [rbp+var_78], r10
+  .text:0000000001E6C46D                 mov     byte ptr [rbp+var_70], r8b
+  .text:0000000001E6C471                 mov     dword ptr [rbp+dest], ecx
+  .text:0000000001E6C474                 call    _memcpy
+  .text:0000000001E6C479                 mov     ecx, dword ptr [rbp+dest]
+  .text:0000000001E6C47C                 movzx   r8d, byte ptr [rbp+var_70]
+  .text:0000000001E6C481                 mov     r9, rax
+  .text:0000000001E6C484                 mov     r10, [rbp+var_78]
+  .text:0000000001E6C488                 jmp     loc_1E6C293
+  .text:0000000001E6C48D                 mov     r8d, 1
+  .text:0000000001E6C493                 mov     eax, ecx
+  .text:0000000001E6C495                 mov     r9, [r12+0B00h]
+  .text:0000000001E6C49D                 mov     ecx, ebx
+  .text:0000000001E6C49F                 jmp     loc_1E6C2C8
+  .text:0000000001E6C4A4                 movzx   edi, di
+  .text:0000000001E6C4A7                 call    sub_1E599F0
+procedure: |-
+  void __fastcall CEntitySystem_AddEntityToNameMap(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // rax
+    __int64 v3; // rax
+    unsigned __int64 v4; // r14
+    __int64 v5; // r13
+    unsigned __int64 v7; // rax
+    unsigned __int64 v8; // rdx
+    __int64 v9; // rax
+    int *v10; // r12
+    int v11; // eax
+    unsigned __int16 v12; // dx
+    int v13; // esi
+    int v14; // edi
+    int v15; // r8d
+    int v16; // edx
+    __int64 v17; // rbx
+    __int64 v18; // rax
+    __int64 v19; // rax
+    int v20; // edx
+    __int64 v21; // r15
+    int v22; // eax
+    unsigned __int16 v23; // dx
+    int v24; // ebx
+    int *v25; // rax
+    __int16 v26; // si
+    unsigned __int16 v27; // ax
+    unsigned __int16 v28; // dx
+    __int64 v29; // rdi
+    __int64 v30; // rbx
+    unsigned __int16 *v31; // rcx
+    unsigned __int16 v32; // cx
+    char v33; // r8
+    unsigned __int16 v34; // cx
+    unsigned __int16 v35; // cx
+    __int64 v36; // rdx
+    __int64 v37; // rbx
+    __int64 v38; // rdx
+    __int64 v39; // rdx
+    __int64 v40; // rsi
+    __int64 v41; // rdi
+    __int16 v42; // dx
+    int v43; // r8d
+    __int64 v44; // rax
+    int v45; // ebx
+    unsigned __int64 v46; // rdi
+    __int64 v47; // rax
+    unsigned __int64 v48; // rax
+    unsigned __int16 v49; // cx
+    _QWORD *v50; // r9
+    unsigned __int64 v51; // r10
+    unsigned __int64 v52; // rax
+    __int64 v53; // rsi
+    unsigned __int64 v54; // rdx
+    unsigned __int64 v55; // rax
+    char *v56; // rsi
+    unsigned __int16 v57; // ax
+    size_t v58; // rdx
+    _QWORD *v59; // rax
+    unsigned __int16 v60; // [rsp+0h] [rbp-80h]
+    char v61; // [rsp+7h] [rbp-79h]
+    unsigned __int16 v62; // [rsp+8h] [rbp-78h]
+    char v63; // [rsp+8h] [rbp-78h]
+    unsigned __int64 v64; // [rsp+8h] [rbp-78h]
+    unsigned __int64 v65; // [rsp+10h] [rbp-70h]
+    unsigned __int16 v66; // [rsp+10h] [rbp-70h]
+    unsigned __int64 v67; // [rsp+10h] [rbp-70h]
+    int desta; // [rsp+18h] [rbp-68h]
+    _QWORD *destb; // [rsp+18h] [rbp-68h]
+    unsigned __int16 destc; // [rsp+18h] [rbp-68h]
+    _QWORD *dest; // [rsp+18h] [rbp-68h]
+    unsigned __int16 destd; // [rsp+18h] [rbp-68h]
+    unsigned __int64 v73; // [rsp+28h] [rbp-58h] BYREF
+    __m128i inserted; // [rsp+30h] [rbp-50h] BYREF
+    const char *v75; // [rsp+40h] [rbp-40h]
+    int v76; // [rsp+48h] [rbp-38h]
+    char v77; // [rsp+4Ch] [rbp-34h]
+
+    v4 = *(_QWORD *)(a2 + 24);
+    v73 = v4;
+    if ( !v4 )
+      return;
+    v5 = a1 + 2808;
+    v7 = sub_1E59BD0(a1 + 2808, a1 + 2800, &v73); // 2800 = 0xAF0 = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+    v8 = v7 >> 16;
+    if ( WORD1(v7) == 0xFFFF )
+    {
+      v19 = operator new(32);
+      v20 = *(_DWORD *)(a2 + 48);
+      v21 = v19;
+      *(_QWORD *)v19 = 0;
+      *(_QWORD *)(v19 + 8) = 0;
+      *(_QWORD *)(v19 + 16) = 0;
+      *(_DWORD *)(v19 + 24) = 1;
+      v22 = (*(_DWORD *)(a2 + 16) >> 15) - (v20 & 1);
+      if ( *(_DWORD *)(a2 + 16) == -1 )
+        v23 = 0x7FFF;
+      else
+        v23 = *(_WORD *)(a2 + 16) & 0x7FFF;
+      v24 = v23 | (v22 << 15);
+      sub_AE1280(v21 + 8, 1);
+      v25 = *(int **)(v21 + 8);
+      ++*(_DWORD *)v21;
+      *v25 = v24;
+      v26 = *(_WORD *)(a1 + 2810);
+      v27 = *(_WORD *)(a1 + 2824);
+      v28 = v26 & 0x7FFF;
+      if ( v27 == 0xFFFF )
+      {
+        v35 = *(_WORD *)(a1 + 2828);
+        if ( v35 != 0xFFFF )
+        {
+          v33 = 1;
+          if ( !v28 )
+          {
+  LABEL_43:
+            v37 = 24LL * v35;
+            *(_WORD *)(a1 + 2828) = *(_WORD *)((char *)dword_0 + v37 + 2);
+            v36 = 0;
+            goto LABEL_31;
+          }
+  LABEL_30:
+          v36 = *(_QWORD *)(a1 + 2816);
+          v37 = 24LL * v35;
+          *(_WORD *)(a1 + 2828) = *(_WORD *)(v36 + v37 + 2);
+  LABEL_31:
+          v38 = v37 + v36;
+          *(_QWORD *)(v38 + 8) = v4;
+          *(_QWORD *)(v38 + 16) = v21;
+          v39 = 0;
+          if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+            v39 = *(_QWORD *)(a1 + 2816);
+          v40 = v39 + v37;
+          *(_DWORD *)(v39 + v37) = -1;
+          *(_BYTE *)(v40 + 6) = 0;
+          *(_WORD *)(v40 + 4) = v27;
+          if ( v27 == 0xFFFF )
+          {
+            if ( v33 )
+              *(_WORD *)(a1 + 2824) = v35;
+          }
+          else
+          {
+            v41 = 0;
+            v42 = *(_WORD *)(a1 + 2810) & 0x7FFF;
+            if ( v33 )
+            {
+              if ( v42 )
+                v41 = *(_QWORD *)(a1 + 2816);
+              *(_WORD *)(v41 + 24LL * v27) = v35;
+            }
+            else
+            {
+              if ( v42 )
+                v41 = *(_QWORD *)(a1 + 2816);
+              *(_WORD *)(v41 + 24LL * v27 + 2) = v35;
+            }
+          }
+          sub_1E6BA20(v5, v35);
+          ++*(_WORD *)(a1 + 2826);
+          return;
+        }
+        v45 = *(unsigned __int16 *)(a1 + 2808);
+        v46 = (unsigned int)(v45 + 1);
+        if ( v28 < (unsigned __int16)(v45 + 1) )
+        {
+          v33 = 1;
+          goto LABEL_48;
+        }
+        if ( v28 )
+        {
+          v33 = 1;
+  LABEL_89:
+          v27 = v35;
+          v50 = *(_QWORD **)(a1 + 2816);
+          v35 = v45;
+  LABEL_59:
+          v53 = 3LL * v35 + 3;
+          v37 = v53 * 8 - 24;
+          v54 = (unsigned __int64)&v50[v53 - 3];
+          if ( v54 < (unsigned __int64)&v50[v53] && (v54 & 7) != 0 )
+          {
+            v63 = v33;
+            v66 = v35;
+            destc = v27;
+            sub_1B25B60(v46, v53 * 8);
+            v33 = v63;
+            v35 = v66;
+            v27 = destc;
+          }
+          ++*(_WORD *)(a1 + 2808);
+          v36 = 0;
+          if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+            v36 = *(_QWORD *)(a1 + 2816);
+          goto LABEL_31;
+        }
+        v35 = v45;
+        v33 = 1;
+      }
+      else
+      {
+        if ( v28 )
+        {
+          v29 = *(_QWORD *)(a1 + 2816);
+          while ( 1 )
+          {
+            v30 = 24LL * v27;
+            v31 = (unsigned __int16 *)(v29 + v30);
+            if ( v4 < *(_QWORD *)(v29 + v30 + 8) )
+            {
+              v32 = *v31;
+              v33 = 1;
+            }
+            else
+            {
+              if ( v4 == *(_QWORD *)(v29 + v30 + 8) )
+                goto LABEL_91;
+              v32 = v31[1];
+              v33 = 0;
+            }
+            if ( v32 == 0xFFFF )
+              break;
+            v27 = v32;
+          }
+          v35 = *(_WORD *)(a1 + 2828);
+          if ( v35 == 0xFFFF )
+          {
+            v45 = *(unsigned __int16 *)(a1 + 2808);
+            v35 = v27;
+            v46 = (unsigned int)(v45 + 1);
+            if ( v28 < (unsigned __int16)(v45 + 1) )
+            {
+  LABEL_48:
+              if ( (v46 & 0x8000u) != 0LL )
+                sub_1E599F0((unsigned __int16)v46);
+              while ( v28 < (unsigned __int16)v46 )
+              {
+                if ( v28 > 0x3FFEu )
+                {
+                  v28 = 0x7FFF;
+                  break;
+                }
+                while ( 2 * v28 <= 1 )
+                {
+                  v28 = 2;
+                  if ( (unsigned __int16)v46 <= 2u )
+                    goto LABEL_52;
+                }
+                v28 *= 2;
+              }
+  LABEL_52:
+              v60 = v28;
+              v61 = v33;
+              v62 = v35;
+              v47 = *g_pMemAlloc;
+              if ( v26 < 0 )
+              {
+                v67 = 24LL * v28;
+                dest = (_QWORD *)(*(__int64 (__fastcall **)(_QWORD *, unsigned __int64))(v47 + 16))(g_pMemAlloc, v67);
+                v46 = (unsigned __int64)g_pMemAlloc;
+                v55 = (*(__int64 (__fastcall **)(_QWORD *, _QWORD *))(*g_pMemAlloc + 144LL))(g_pMemAlloc, dest);
+                v50 = dest;
+                v49 = v62;
+                v33 = v61;
+                if ( v67 >= v55 )
+                  v55 = v67;
+                v56 = nullptr;
+                v51 = v55;
+                if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+                  v56 = *(char **)(a1 + 2816);
+                v57 = *(_WORD *)(a1 + 2808);
+                if ( v60 <= v57 )
+                  v57 = v60;
+                v58 = 24LL * v57;
+                if ( v56 < &v56[v58] )
+                {
+                  v46 = (unsigned __int64)dest;
+                  v64 = v51;
+                  destd = v49;
+                  v59 = memcpy((void *)v46, v56, v58);
+                  v49 = destd;
+                  v33 = v61;
+                  v50 = v59;
+                  v51 = v64;
+                }
+              }
+              else
+              {
+                v65 = 24LL * v28;
+                destb = (_QWORD *)(*(__int64 (__fastcall **)(_QWORD *, _QWORD, unsigned __int64))(v47 + 24))(
+                                    g_pMemAlloc,
+                                    *(_QWORD *)(a1 + 2816),
+                                    v65);
+                v46 = (unsigned __int64)g_pMemAlloc;
+                v48 = (*(__int64 (__fastcall **)(_QWORD *, _QWORD *))(*g_pMemAlloc + 144LL))(g_pMemAlloc, destb);
+                v33 = v61;
+                v49 = v62;
+                v50 = destb;
+                if ( v65 >= v48 )
+                  v48 = v65;
+                v51 = v48;
+              }
+              *(_QWORD *)(a1 + 2816) = v50;
+              v52 = v51 / 0x18;
+              if ( v51 / 0x18 > 0x7FFF )
+                LOWORD(v52) = 0x7FFF;
+              *(_WORD *)(a1 + 2810) = v52;
+              v27 = v49;
+              v35 = v45;
+              goto LABEL_59;
+            }
+            goto LABEL_89;
+          }
+          goto LABEL_30;
+        }
+        while ( 1 )
+        {
+          v30 = 24LL * v27;
+          if ( v4 < *(_QWORD *)&byte_8[v30] )
+          {
+            v34 = *(_WORD *)(24LL * v27);
+            v33 = 1;
+          }
+          else
+          {
+            if ( v4 == *(_QWORD *)&byte_8[24 * v27] )
+            {
+  LABEL_91:
+              v76 = 2224;
+              inserted = _mm_insert_epi64(_mm_loadl_epi64((const __m128i *)&off_241E310), (signed __int64)"Insert", 1);
+              v75 = "!link";
+              v77 = v77 & 0x80 | 0x14;
+              if ( (unsigned __int8)Assert_ConditionFailed(
+                                      &inserted,
+                                      "Found existing value when inserting into tree - replacing existing value with new va"
+                                      "lue. If this is intended behavior, use InsertOrReplace. If leaving existing values a"
+                                      "lone is intended, use InsertIfNotFound. If duplicate entries are intended, use InsertWithDupes.") )
+                __debugbreak();
+              if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+                v2 = *(_QWORD *)(a1 + 2816);
+              else
+                v2 = 0;
+              v3 = v30 + v2;
+              *(_QWORD *)(v3 + 8) = v4;
+              *(_QWORD *)(v3 + 16) = v21;
+              return;
+            }
+            v34 = HIWORD(dword_0[6 * v27]);
+            v33 = 0;
+          }
+          if ( v34 == 0xFFFF )
+            break;
+          v27 = v34;
+        }
+        v35 = *(_WORD *)(a1 + 2828);
+        if ( v35 != 0xFFFF )
+          goto LABEL_43;
+        LOWORD(v45) = *(_WORD *)(a1 + 2808);
+        v46 = (unsigned __int16)v45;
+        LOWORD(v46) = v45 + 1;
+        if ( (_WORD)v45 != 0xFFFF )
+        {
+          v35 = v27;
+          goto LABEL_48;
+        }
+      }
+      v50 = nullptr;
+      goto LABEL_59;
+    }
+    v9 = 0;
+    if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+      v9 = *(_QWORD *)(a1 + 2816);
+    v10 = *(int **)(v9 + 24LL * (unsigned __int16)v8 + 16);
+    v11 = (*(_DWORD *)(a2 + 16) >> 15) - (*(_DWORD *)(a2 + 48) & 1);
+    if ( *(_DWORD *)(a2 + 16) == -1 )
+      v12 = 0x7FFF;
+    else
+      v12 = *(_WORD *)(a2 + 16) & 0x7FFF;
+    v13 = *v10;
+    v14 = v12;
+    v15 = v11 & 0x1FFFF;
+    v16 = (v11 << 15) | v12 & 0x7FFF;
+    v17 = *v10;
+    if ( *v10 <= 0 )
+    {
+  LABEL_39:
+      v43 = v14 | (v15 << 15);
+      if ( v10[4] == v13 )
+      {
+        desta = v43;
+        sub_AE1280(v10 + 2, 1);
+        v13 = *v10;
+        v43 = desta;
+      }
+      v44 = *((_QWORD *)v10 + 1);
+      *v10 = v13 + 1;
+      *(_DWORD *)(v44 + 4 * v17) = v43;
+    }
+    else
+    {
+      v17 = v13;
+      v18 = 0;
+      while ( *(_DWORD *)(*((_QWORD *)v10 + 1) + 4 * v18) != v16 )
+      {
+        if ( ++v18 == v13 )
+          goto LABEL_39;
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityToNameMap.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityToNameMap.windows.yaml
@@ -1,0 +1,280 @@
+func_name: CEntitySystem_AddEntityToNameMap
+func_va: '0x1811ed720'
+disasm_code: |-
+  .text:00000001811ED720                 push    rbp
+  .text:00000001811ED722                 push    rbx
+  .text:00000001811ED723                 push    rsi
+  .text:00000001811ED724                 mov     rbp, rsp
+  .text:00000001811ED727                 sub     rsp, 70h
+  .text:00000001811ED72B                 mov     rax, [rdx+18h]
+  .text:00000001811ED72F                 mov     rsi, rdx
+  .text:00000001811ED732                 mov     [rbp+arg_18], rax
+  .text:00000001811ED736                 mov     rbx, rcx
+  .text:00000001811ED739                 test    rax, rax
+  .text:00000001811ED73C                 jz      loc_1811ED94F
+  .text:00000001811ED742                 mov     [rsp+70h+arg_0], rdi
+  .text:00000001811ED74A                 lea     rax, [rbp+arg_18]
+  .text:00000001811ED74E                 lea     rdi, [rcx+0AF0h]  ; 0AF0h = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+  .text:00000001811ED755                 mov     [rsp+70h+var_8], r14
+  .text:00000001811ED75A                 lea     rcx, [rdi+8]
+  .text:00000001811ED75E                 mov     [rsp+70h+var_10], r15
+  .text:00000001811ED763                 lea     r8, [rbp+var_50]
+  .text:00000001811ED767                 mov     [rbp+var_50], rdi
+  .text:00000001811ED76B                 lea     rdx, [rbp+arg_10]
+  .text:00000001811ED76F                 mov     [rbp+var_48], rax
+  .text:00000001811ED773                 mov     [rbp+var_40], rdi
+  .text:00000001811ED777                 call    sub_1811EA730
+  .text:00000001811ED77C                 mov     r15d, 0FFFFh
+  .text:00000001811ED782                 movzx   ecx, word ptr [rax+2]
+  .text:00000001811ED786                 cmp     cx, r15w
+  .text:00000001811ED78A                 jz      loc_1811ED842
+  .text:00000001811ED790                 xor     r8d, r8d
+  .text:00000001811ED793                 mov     r10d, 7FFFh
+  .text:00000001811ED799                 mov     r11d, r10d
+  .text:00000001811ED79C                 mov     edx, r8d
+  .text:00000001811ED79F                 and     r11w, [rbx+0AFAh]
+  .text:00000001811ED7A7                 jz      short loc_1811ED7B0
+  .text:00000001811ED7A9                 mov     rdx, [rbx+0B00h]
+  .text:00000001811ED7B0                 mov     eax, [rsi+30h]
+  .text:00000001811ED7B3                 lea     rcx, [rcx+rcx*2]
+  .text:00000001811ED7B7                 and     eax, 1
+  .text:00000001811ED7BA                 lea     r14, ds:0[rcx*8]
+  .text:00000001811ED7C2                 mov     ecx, [rsi+10h]
+  .text:00000001811ED7C5                 mov     r9d, ecx
+  .text:00000001811ED7C8                 mov     rdi, [r14+rdx+10h]
+  .text:00000001811ED7CD                 mov     edx, r8d
+  .text:00000001811ED7D0                 shr     r9d, 0Fh
+  .text:00000001811ED7D4                 sub     r9d, eax
+  .text:00000001811ED7D7                 mov     eax, ecx
+  .text:00000001811ED7D9                 and     eax, r10d
+  .text:00000001811ED7DC                 shl     r9d, 0Fh
+  .text:00000001811ED7E0                 cmp     ecx, 0FFFFFFFFh
+  .text:00000001811ED7E3                 cmovnz  r10d, eax
+  .text:00000001811ED7E7                 movsxd  rax, dword ptr [rdi]
+  .text:00000001811ED7EA                 or      r9d, r10d
+  .text:00000001811ED7ED                 test    eax, eax
+  .text:00000001811ED7EF                 jle     short loc_1811ED81E
+  .text:00000001811ED7F1                 mov     r10, rax
+  .text:00000001811ED7F4                 mov     rcx, r8
+  .text:00000001811ED7F7                 mov     rax, [rdi+8]
+  .text:00000001811ED7FB                 nop     dword ptr [rax+rax+00h]
+  .text:00000001811ED800                 cmp     [rax], r9d
+  .text:00000001811ED803                 jz      short loc_1811ED815
+  .text:00000001811ED805                 inc     edx
+  .text:00000001811ED807                 inc     rcx
+  .text:00000001811ED80A                 add     rax, 4
+  .text:00000001811ED80E                 cmp     rcx, r10
+  .text:00000001811ED811                 jl      short loc_1811ED800
+  .text:00000001811ED813                 jmp     short loc_1811ED81E
+  .text:00000001811ED815                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811ED818                 jnz     loc_1811ED93D
+  .text:00000001811ED81E                 test    r11w, r11w
+  .text:00000001811ED822                 jz      short loc_1811ED82B
+  .text:00000001811ED824                 mov     r8, [rbx+0B00h]
+  .text:00000001811ED82B                 mov     rcx, [r14+r8+10h]
+  .text:00000001811ED830                 lea     rdx, [rbp+arg_8]
+  .text:00000001811ED834                 mov     [rbp+arg_8], r9d
+  .text:00000001811ED838                 call    sub_1811EE020
+  .text:00000001811ED83D                 jmp     loc_1811ED93D
+  .text:00000001811ED842                 mov     ecx, 20h ; ' '
+  .text:00000001811ED847                 call    operator_new
+  .text:00000001811ED84C                 xor     r8d, r8d
+  .text:00000001811ED84F                 mov     rbx, rax
+  .text:00000001811ED852                 test    rax, rax
+  .text:00000001811ED855                 jz      short loc_1811ED868
+  .text:00000001811ED857                 mov     [rax+8], r8
+  .text:00000001811ED85B                 mov     [rax+10h], r8
+  .text:00000001811ED85F                 mov     [rax], r8d
+  .text:00000001811ED862                 mov     [rax+18h], r8d
+  .text:00000001811ED866                 jmp     short loc_1811ED86B
+  .text:00000001811ED868                 mov     rbx, r8
+  .text:00000001811ED86B                 inc     dword ptr [rbx+18h]
+  .text:00000001811ED86E                 mov     r10d, 7FFFh
+  .text:00000001811ED874                 mov     ecx, [rsi+10h]
+  .text:00000001811ED877                 mov     edx, ecx
+  .text:00000001811ED879                 mov     eax, [rsi+30h]
+  .text:00000001811ED87C                 shr     edx, 0Fh
+  .text:00000001811ED87F                 and     eax, 1
+  .text:00000001811ED882                 sub     edx, eax
+  .text:00000001811ED884                 mov     eax, ecx
+  .text:00000001811ED886                 shl     edx, 0Fh
+  .text:00000001811ED889                 and     eax, r10d
+  .text:00000001811ED88C                 cmp     ecx, 0FFFFFFFFh
+  .text:00000001811ED88F                 mov     rcx, rbx
+  .text:00000001811ED892                 cmovnz  r10d, eax
+  .text:00000001811ED896                 or      edx, r10d
+  .text:00000001811ED899                 mov     [rbp+arg_8], edx
+  .text:00000001811ED89C                 lea     rdx, [rbp+arg_8]
+  .text:00000001811ED8A0                 call    sub_1811EE020
+  .text:00000001811ED8A5                 mov     rax, [rbp+arg_18]
+  .text:00000001811ED8A9                 lea     r8, [rbp+var_38]
+  .text:00000001811ED8AD                 mov     [rbp+var_50], rax
+  .text:00000001811ED8B1                 lea     rdx, [rbp+arg_8]
+  .text:00000001811ED8B5                 lea     rax, [rbp+var_50]
+  .text:00000001811ED8B9                 mov     [rbp+var_48], rbx
+  .text:00000001811ED8BD                 lea     rcx, [rdi+8]
+  .text:00000001811ED8C1                 mov     [rbp+var_28], rax
+  .text:00000001811ED8C5                 mov     [rbp+var_38], rdi
+  .text:00000001811ED8C9                 mov     byte ptr [rbp+var_30], 1
+  .text:00000001811ED8CD                 call    sub_1811EAC90
+  .text:00000001811ED8D2                 cmp     word ptr [rbp+arg_8+2], r15w
+  .text:00000001811ED8D7                 jz      short loc_1811ED91E
+  .text:00000001811ED8D9                 lea     rax, aCBuildworkerCs_1; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811ED8E0                 mov     [rbp+var_20], 8B0h
+  .text:00000001811ED8E7                 mov     [rbp+var_38], rax
+  .text:00000001811ED8EB                 lea     rdx, aFoundExistingV_0; "Found existing value when inserting int"...
+  .text:00000001811ED8F2                 lea     rax, aCutlrbtreeStru_86; "CUtlRBTree<struct CUtlOrderedMapBase<cl"...
+  .text:00000001811ED8F9                 mov     [rbp+var_1C], 14h
+  .text:00000001811ED900                 mov     [rbp+var_30], rax
+  .text:00000001811ED904                 lea     rcx, [rbp+var_38]
+  .text:00000001811ED908                 lea     rax, aLink; "!link"
+  .text:00000001811ED90F                 mov     [rbp+var_28], rax
+  .text:00000001811ED913                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@PEBDZZ; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &,char const *,...)
+  .text:00000001811ED919                 test    al, al
+  .text:00000001811ED91B                 jz      short loc_1811ED91E
+  .text:00000001811ED91D                 ; Trap to Debugger
+  .text:00000001811ED91D                 int     3; Trap to Debugger
+  .text:00000001811ED91E                 mov     eax, [rbp+arg_8]
+  .text:00000001811ED921                 lea     r8, [rbp+var_50]
+  .text:00000001811ED925                 mov     [rbp+arg_10], eax
+  .text:00000001811ED928                 lea     rdx, [rbp+arg_10]
+  .text:00000001811ED92C                 movzx   eax, [rbp+arg_C]
+  .text:00000001811ED930                 lea     rcx, [rdi+8]
+  .text:00000001811ED934                 mov     [rbp+arg_14], ax
+  .text:00000001811ED938                 call    sub_1811E9AC0
+  .text:00000001811ED93D                 mov     r14, [rsp+70h+var_8]
+  .text:00000001811ED942                 mov     rdi, [rsp+70h+arg_0]
+  .text:00000001811ED94A                 mov     r15, [rsp+70h+var_10]
+  .text:00000001811ED94F                 add     rsp, 70h
+  .text:00000001811ED953                 pop     rsi
+  .text:00000001811ED954                 pop     rbx
+  .text:00000001811ED955                 pop     rbp
+  .text:00000001811ED956                 retn
+procedure: |-
+  _DWORD *__fastcall CEntitySystem_AddEntityToNameMap(__int64 a1, __int64 a2)
+  {
+    _DWORD *result; // rax
+    const char *v5; // rdi
+    __int64 v6; // rcx
+    __int64 v7; // r8
+    int v8; // r10d
+    __int64 v9; // rdx
+    __int64 v10; // r14
+    int *v11; // rdi
+    int v12; // edx
+    __int64 v13; // rcx
+    __int64 v14; // rcx
+    __int64 v15; // rax
+    __int64 v16; // rbx
+    int v17; // r10d
+    _DWORD *v18; // [rsp+20h] [rbp-50h] BYREF
+    _QWORD *v19; // [rsp+28h] [rbp-48h]
+    __int64 v20; // [rsp+30h] [rbp-40h]
+    const char *v21; // [rsp+38h] [rbp-38h] BYREF
+    const char *v22; // [rsp+40h] [rbp-30h]
+    const char *v23; // [rsp+48h] [rbp-28h]
+    int v24; // [rsp+50h] [rbp-20h]
+    int v25; // [rsp+54h] [rbp-1Ch]
+    int v26; // [rsp+98h] [rbp+28h] BYREF
+    __int16 v27; // [rsp+9Ch] [rbp+2Ch]
+    int v28; // [rsp+A0h] [rbp+30h] BYREF
+    __int16 v29; // [rsp+A4h] [rbp+34h]
+    _DWORD *v30; // [rsp+A8h] [rbp+38h] BYREF
+
+    result = *(_DWORD **)(a2 + 24);
+    v30 = result;
+    if ( result )
+    {
+      v5 = (const char *)(a1 + 2800);             // 2800 = 0xAF0 = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+      v18 = (_DWORD *)(a1 + 2800);                // 2800 = 0xAF0 = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+      v19 = &v30;
+      v20 = a1 + 2800;                            // 2800 = 0xAF0 = CEntitySystem::m_entityNames (structmember, struct=CEntitySystem, member=m_entityNames)
+      v6 = *(unsigned __int16 *)(sub_1811EA730(a1 + 2808, &v28, &v18) + 2);
+      if ( (_WORD)v6 == 0xFFFF )
+      {
+        v15 = operator_new(32);
+        v16 = v15;
+        if ( v15 )
+        {
+          *(_QWORD *)(v15 + 8) = 0;
+          *(_QWORD *)(v15 + 16) = 0;
+          *(_DWORD *)v15 = 0;
+          *(_DWORD *)(v15 + 24) = 0;
+        }
+        else
+        {
+          v16 = 0;
+        }
+        ++*(_DWORD *)(v16 + 24);
+        v17 = 0x7FFF;
+        if ( *(_DWORD *)(a2 + 16) != -1 )
+          v17 = *(_DWORD *)(a2 + 16) & 0x7FFF;
+        v26 = v17 | (((*(_DWORD *)(a2 + 16) >> 15) - (*(_DWORD *)(a2 + 48) & 1)) << 15);
+        sub_1811EE020(v16, &v26, 0);
+        v18 = v30;
+        v19 = (_QWORD *)v16;
+        v23 = (const char *)&v18;
+        v21 = v5;
+        LOBYTE(v22) = 1;
+        sub_1811EAC90(v5 + 8, &v26, &v21);
+        if ( HIWORD(v26) != 0xFFFF )
+        {
+          v24 = 2224;
+          v21 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\public\\tier0\\utlrbtree.h";
+          v25 = 20;
+          v22 = "CUtlRBTree<struct CUtlOrderedMapBase<class CUtlSymbolLarge,class CEntityNameList *,class CDefLess<class CU"
+                "tlSymbolLarge>,unsigned short>::Node_t,class CUtlOrderedMapBase<class CUtlSymbolLarge,class CEntityNameLis"
+                "t *,class CDefLess<class CUtlSymbolLarge>,unsigned short>::CKeyLess,unsigned short,class CUtlLeanVector<st"
+                "ruct UtlRBTreeNode_t<struct CUtlOrderedMapBase<class CUtlSymbolLarge,class CEntityNameList *,class CDefLes"
+                "s<class CUtlSymbolLarge>,unsigned short>::Node_t,unsigned short>,unsigned short,class CMemAllocAllocator> >::Insert";
+          v23 = "!link";
+          if ( Assert_ConditionFailed(
+                 (const struct _AssertCompileTimeConstantStruct_t *)&v21,
+                 "Found existing value when inserting into tree - replacing existing value with new value. If this is inten"
+                 "ded behavior, use InsertOrReplace. If leaving existing values alone is intended, use InsertIfNotFound. If"
+                 " duplicate entries are intended, use InsertWithDupes.") )
+          {
+            __debugbreak();
+          }
+        }
+        v28 = v26;
+        v29 = v27;
+        return (_DWORD *)sub_1811E9AC0(v5 + 8, &v28, &v18);
+      }
+      else
+      {
+        v7 = 0;
+        v8 = 0x7FFF;
+        v9 = 0;
+        if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+          v9 = *(_QWORD *)(a1 + 2816);
+        v10 = 24 * v6;
+        v11 = *(int **)(24 * v6 + v9 + 16);
+        v12 = 0;
+        if ( *(_DWORD *)(a2 + 16) != -1 )
+          v8 = *(_DWORD *)(a2 + 16) & 0x7FFF;
+        if ( *v11 <= 0 )
+          goto LABEL_13;
+        v13 = 0;
+        result = *((_DWORD **)v11 + 1);
+        while ( *result != (v8 | (((*(_DWORD *)(a2 + 16) >> 15) - (*(_DWORD *)(a2 + 48) & 1)) << 15)) )
+        {
+          ++v12;
+          ++v13;
+          ++result;
+          if ( v13 >= *v11 )
+            goto LABEL_13;
+        }
+        if ( v12 == -1 )
+        {
+  LABEL_13:
+          if ( (*(_WORD *)(a1 + 2810) & 0x7FFF) != 0 )
+            v7 = *(_QWORD *)(a1 + 2816);
+          v14 = *(_QWORD *)(v10 + v7 + 16);
+          v26 = v8 | (((*(_DWORD *)(a2 + 16) >> 15) - (*(_DWORD *)(a2 + 48) & 1)) << 15);
+          return (_DWORD *)sub_1811EE020(v14, &v26, v7);
+        }
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_ExecuteQueuedSetInPVS.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_ExecuteQueuedSetInPVS.linux.yaml
@@ -1,0 +1,364 @@
+func_name: CEntitySystem_ExecuteQueuedSetInPVS
+func_va: '0x1e610e0'
+disasm_code: |-
+  .text:0000000001E610E0                 push    rbp
+  .text:0000000001E610E1                 mov     rbp, rsp
+  .text:0000000001E610E4                 push    r15
+  .text:0000000001E610E6                 push    r14
+  .text:0000000001E610E8                 push    r13
+  .text:0000000001E610EA                 mov     r13, rdi
+  .text:0000000001E610ED                 push    r12
+  .text:0000000001E610EF                 push    rbx
+  .text:0000000001E610F0                 sub     rsp, 28h
+  .text:0000000001E610F4                 mov     r14d, [rdi+0C58h]  ; 0C58h = CEntitySystem::m_queuedDormancyChanges (structmember, struct=CEntitySystem, member=m_queuedDormancyChanges)
+  .text:0000000001E610FB                 test    r14d, r14d
+  .text:0000000001E610FE                 jle     loc_1E61368
+  .text:0000000001E61104                 movsxd  rdx, r14d
+  .text:0000000001E61107                 ; _QWORD
+  .text:0000000001E61107                 xor     ecx, ecx; _QWORD
+  .text:0000000001E61109                 ; _QWORD
+  .text:0000000001E61109                 mov     esi, 1; _QWORD
+  .text:0000000001E6110E                 ; _QWORD
+  .text:0000000001E6110E                 shl     rdx, 4; _QWORD
+  .text:0000000001E61112                 ; _QWORD
+  .text:0000000001E61112                 xor     edi, edi; _QWORD
+  .text:0000000001E61114                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E61119                 mov     r8d, [r13+0C58h]
+  .text:0000000001E61120                 mov     r15, rax
+  .text:0000000001E61123                 test    r8d, r8d
+  .text:0000000001E61126                 jle     loc_1E61389
+  .text:0000000001E6112C                 xor     ebx, ebx
+  .text:0000000001E6112E                 xor     esi, esi
+  .text:0000000001E61130                 mov     rax, [r13+0C60h]
+  .text:0000000001E61137                 lea     r12, [rax+rbx*8]
+  .text:0000000001E6113B                 ; _QWORD
+  .text:0000000001E6113B                 mov     edx, [r12]; _QWORD
+  .text:0000000001E6113F                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001E61142                 jz      loc_1E61206
+  .text:0000000001E61148                 mov     rcx, cs:qword_256F420
+  .text:0000000001E6114F                 test    rcx, rcx
+  .text:0000000001E61152                 jz      loc_1E61206
+  .text:0000000001E61158                 cmp     edx, 0FFFFFFFEh
+  .text:0000000001E6115B                 jz      loc_1E61206
+  .text:0000000001E61161                 movzx   edi, word ptr [r12]
+  .text:0000000001E61166                 mov     rax, rdi
+  .text:0000000001E61169                 shr     rax, 9
+  .text:0000000001E6116D                 and     eax, 3Fh
+  .text:0000000001E61170                 mov     rax, [rcx+rax*8]
+  .text:0000000001E61174                 test    rax, rax
+  .text:0000000001E61177                 jz      loc_1E61206
+  .text:0000000001E6117D                 mov     r9, rdi
+  .text:0000000001E61180                 and     r9d, 1FFh
+  .text:0000000001E61187                 imul    r9, 70h ; 'p'
+  .text:0000000001E6118B                 add     rax, r9
+  .text:0000000001E6118E                 cmp     edx, [rax+10h]
+  .text:0000000001E61191                 jnz     short loc_1E61206
+  .text:0000000001E61193                 mov     eax, [rax+30h]
+  .text:0000000001E61196                 test    ah, 2
+  .text:0000000001E61199                 jnz     short loc_1E61206
+  .text:0000000001E6119B                 shr     al, 7
+  .text:0000000001E6119E                 xor     eax, 1
+  .text:0000000001E611A1                 cmp     [r12+4], al
+  .text:0000000001E611A6                 jz      short loc_1E61206
+  .text:0000000001E611A8                 movsxd  r9, esi
+  .text:0000000001E611AB                 lea     r10d, [rsi+1]
+  .text:0000000001E611AF                 shl     r9, 4
+  .text:0000000001E611B3                 lea     rax, [r15+r9]
+  .text:0000000001E611B7                 cmp     r14d, esi
+  .text:0000000001E611BA                 jz      loc_1E61268
+  .text:0000000001E611C0                 mov     rsi, rdi
+  .text:0000000001E611C3                 shr     rsi, 9
+  .text:0000000001E611C7                 and     esi, 3Fh
+  .text:0000000001E611CA                 mov     rcx, [rcx+rsi*8]
+  .text:0000000001E611CE                 test    rcx, rcx
+  .text:0000000001E611D1                 jz      loc_1E6131A
+  .text:0000000001E611D7                 and     edi, 1FFh
+  .text:0000000001E611DD                 imul    rdi, 70h ; 'p'
+  .text:0000000001E611E1                 add     rcx, rdi
+  .text:0000000001E611E4                 cmp     [rcx+10h], edx
+  .text:0000000001E611E7                 jnz     loc_1E6131A
+  .text:0000000001E611ED                 mov     rcx, [rcx]
+  .text:0000000001E611F0                 mov     [rax], rcx
+  .text:0000000001E611F3                 movzx   edx, byte ptr [r12+4]
+  .text:0000000001E611F9                 mov     esi, r10d
+  .text:0000000001E611FC                 mov     [rax+8], dl
+  .text:0000000001E611FF                 mov     r8d, [r13+0C58h]
+  .text:0000000001E61206                 add     rbx, 1
+  .text:0000000001E6120A                 cmp     r8d, ebx
+  .text:0000000001E6120D                 jg      loc_1E61130
+  .text:0000000001E61213                 mov     dword ptr [r13+0C58h], 0
+  .text:0000000001E6121E                 mov     rdx, r15
+  .text:0000000001E61221                 mov     rdi, r13
+  .text:0000000001E61224                 call    CEntitySystem_SetInPVS
+  .text:0000000001E61229                 test    r15, r15
+  .text:0000000001E6122C                 jz      short loc_1E61252
+  .text:0000000001E6122E                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E61235                 mov     rsi, r15
+  .text:0000000001E61238                 mov     rdi, [rax]
+  .text:0000000001E6123B                 mov     rax, [rdi]
+  .text:0000000001E6123E                 mov     rax, [rax+20h]
+  .text:0000000001E61242                 add     rsp, 28h
+  .text:0000000001E61246                 pop     rbx
+  .text:0000000001E61247                 pop     r12
+  .text:0000000001E61249                 pop     r13
+  .text:0000000001E6124B                 pop     r14
+  .text:0000000001E6124D                 pop     r15
+  .text:0000000001E6124F                 pop     rbp
+  .text:0000000001E61250                 jmp     rax
+  .text:0000000001E61252                 add     rsp, 28h
+  .text:0000000001E61256                 pop     rbx
+  .text:0000000001E61257                 pop     r12
+  .text:0000000001E61259                 pop     r13
+  .text:0000000001E6125B                 pop     r14
+  .text:0000000001E6125D                 pop     r15
+  .text:0000000001E6125F                 pop     rbp
+  .text:0000000001E61260                 retn
+  .text:0000000001E61268                 cmp     r14d, 7FFFFFFFh
+  .text:0000000001E6126F                 jz      loc_1E61328
+  .text:0000000001E61275                 ; _QWORD
+  .text:0000000001E61275                 mov     edx, r10d; _QWORD
+  .text:0000000001E61278                 ; _QWORD
+  .text:0000000001E61278                 xor     esi, esi; _QWORD
+  .text:0000000001E6127A                 ; _QWORD
+  .text:0000000001E6127A                 mov     ecx, 10h; _QWORD
+  .text:0000000001E6127F                 mov     [rbp+var_40], r9
+  .text:0000000001E61283                 ; _QWORD
+  .text:0000000001E61283                 mov     edi, r14d; _QWORD
+  .text:0000000001E61286                 mov     [rbp+var_38], r10d
+  .text:0000000001E6128A                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E6128F                 mov     r10d, [rbp+var_38]
+  .text:0000000001E61293                 mov     r9, [rbp+var_40]
+  .text:0000000001E61297                 mov     r8d, eax
+  .text:0000000001E6129A                 cmp     eax, r10d
+  .text:0000000001E6129D                 jge     short loc_1E612B6
+  .text:0000000001E6129F                 nop
+  .text:0000000001E612A0                 lea     eax, [r8+r10]
+  .text:0000000001E612A4                 mov     r8d, eax
+  .text:0000000001E612A7                 shr     r8d, 1Fh
+  .text:0000000001E612AB                 add     r8d, eax
+  .text:0000000001E612AE                 sar     r8d, 1
+  .text:0000000001E612B1                 cmp     r8d, r10d
+  .text:0000000001E612B4                 jl      short loc_1E612A0
+  .text:0000000001E612B6                 movsxd  rdx, r8d
+  .text:0000000001E612B9                 movsxd  rcx, r14d
+  .text:0000000001E612BC                 ; _QWORD
+  .text:0000000001E612BC                 mov     rdi, r15; _QWORD
+  .text:0000000001E612BF                 mov     [rbp+var_44], r10d
+  .text:0000000001E612C3                 ; _QWORD
+  .text:0000000001E612C3                 shl     rcx, 4; _QWORD
+  .text:0000000001E612C7                 ; _QWORD
+  .text:0000000001E612C7                 shl     rdx, 4; _QWORD
+  .text:0000000001E612CB                 ; _QWORD
+  .text:0000000001E612CB                 mov     esi, 1; _QWORD
+  .text:0000000001E612D0                 mov     [rbp+var_40], r9
+  .text:0000000001E612D4                 mov     [rbp+var_38], r8d
+  .text:0000000001E612D8                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E612DD                 mov     edx, [r12]
+  .text:0000000001E612E1                 xor     ecx, ecx
+  .text:0000000001E612E3                 mov     r9, [rbp+var_40]
+  .text:0000000001E612E7                 mov     r15, rax
+  .text:0000000001E612EA                 mov     r8d, [rbp+var_38]
+  .text:0000000001E612EE                 mov     r10d, [rbp+var_44]
+  .text:0000000001E612F2                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001E612F5                 lea     rax, [rax+r9]
+  .text:0000000001E612F9                 mov     r14d, r8d
+  .text:0000000001E612FC                 jz      loc_1E611F0
+  .text:0000000001E61302                 mov     rcx, cs:qword_256F420
+  .text:0000000001E61309                 test    rcx, rcx
+  .text:0000000001E6130C                 jz      short loc_1E61317
+  .text:0000000001E6130E                 cmp     edx, 0FFFFFFFEh
+  .text:0000000001E61311                 jnz     loc_1E613A4
+  .text:0000000001E61317                 mov     r14d, r8d
+  .text:0000000001E6131A                 xor     ecx, ecx
+  .text:0000000001E6131C                 jmp     loc_1E611F0
+  .text:0000000001E61328                 ; _QWORD
+  .text:0000000001E61328                 mov     esi, 1; _QWORD
+  .text:0000000001E6132D                 ; _QWORD
+  .text:0000000001E6132D                 mov     edi, 7FFFFFFFh; _QWORD
+  .text:0000000001E61332                 mov     dword ptr [rbp+var_40], r10d
+  .text:0000000001E61336                 mov     qword ptr [rbp+var_38], r9
+  .text:0000000001E6133A                 call    _UtlVectorMemory_FailedAllocation
+  .text:0000000001E6133F                 ; _QWORD
+  .text:0000000001E6133F                 mov     ecx, 10h; _QWORD
+  .text:0000000001E61344                 ; _QWORD
+  .text:0000000001E61344                 mov     edx, 80000000h; _QWORD
+  .text:0000000001E61349                 ; _QWORD
+  .text:0000000001E61349                 xor     esi, esi; _QWORD
+  .text:0000000001E6134B                 ; _QWORD
+  .text:0000000001E6134B                 mov     edi, 7FFFFFFFh; _QWORD
+  .text:0000000001E61350                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E61355                 mov     r9, qword ptr [rbp+var_38]
+  .text:0000000001E61359                 mov     r10d, dword ptr [rbp+var_40]
+  .text:0000000001E6135D                 mov     r8d, eax
+  .text:0000000001E61360                 jmp     loc_1E612B6
+  .text:0000000001E61368                 mov     dword ptr [rdi+0C58h], 0
+  .text:0000000001E61372                 add     rsp, 28h
+  .text:0000000001E61376                 xor     edx, edx
+  .text:0000000001E61378                 xor     esi, esi
+  .text:0000000001E6137A                 pop     rbx
+  .text:0000000001E6137B                 pop     r12
+  .text:0000000001E6137D                 pop     r13
+  .text:0000000001E6137F                 pop     r14
+  .text:0000000001E61381                 pop     r15
+  .text:0000000001E61383                 pop     rbp
+  .text:0000000001E61384                 jmp     CEntitySystem_SetInPVS
+  .text:0000000001E61389                 xor     eax, eax
+  .text:0000000001E6138B                 mov     rdx, r15
+  .text:0000000001E6138E                 xor     esi, esi
+  .text:0000000001E61390                 mov     [r13+0C58h], eax
+  .text:0000000001E61397                 mov     rdi, r13
+  .text:0000000001E6139A                 call    CEntitySystem_SetInPVS
+  .text:0000000001E6139F                 jmp     loc_1E61229
+  .text:0000000001E613A4                 movzx   edi, word ptr [r12]
+  .text:0000000001E613A9                 jmp     loc_1E611C0
+procedure: |-
+  void __fastcall CEntitySystem_ExecuteQueuedSetInPVS(__int64 a1)
+  {
+    int v2; // r14d
+    _BYTE *v3; // rax
+    int v4; // r8d
+    _BYTE *v5; // r15
+    __int64 v6; // rbx
+    int v7; // esi
+    unsigned int *v8; // r12
+    __int64 v9; // rdx
+    __int64 v10; // rcx
+    unsigned __int64 v11; // rdi
+    __int64 v12; // rax
+    __int64 v13; // rax
+    int v14; // eax
+    unsigned int v15; // r10d
+    _BYTE *v16; // rax
+    __int64 v17; // rcx
+    __int64 *v18; // rcx
+    __int64 v19; // rcx
+    int v20; // eax
+    int v21; // r10d
+    __int64 v22; // r9
+    int v23; // r8d
+    __int64 v24; // rax
+    int v25; // eax
+    unsigned int v26; // [rsp+Ch] [rbp-44h]
+    __int64 v27; // [rsp+10h] [rbp-40h]
+    int v28; // [rsp+18h] [rbp-38h]
+    int v29; // [rsp+18h] [rbp-38h]
+
+    v2 = *(_DWORD *)(a1 + 3160);                  // 3160 = 0xC58 = CEntitySystem::m_queuedDormancyChanges (structmember, struct=CEntitySystem, member=m_queuedDormancyChanges)
+    if ( v2 <= 0 )
+    {
+      *(_DWORD *)(a1 + 3160) = 0;
+      CEntitySystem_SetInPVS((int *)a1, 0, nullptr);
+      return;
+    }
+    v3 = (_BYTE *)UtlVectorMemory_Alloc(0, 1, 16LL * v2, 0);
+    v4 = *(_DWORD *)(a1 + 3160);
+    v5 = v3;
+    if ( v4 <= 0 )
+    {
+      *(_DWORD *)(a1 + 3160) = 0;
+      CEntitySystem_SetInPVS((int *)a1, 0, v3);
+      goto LABEL_18;
+    }
+    v6 = 0;
+    v7 = 0;
+    do
+    {
+      v8 = (unsigned int *)(*(_QWORD *)(a1 + 3168) + 8 * v6);
+      v9 = *v8;
+      if ( (_DWORD)v9 != -1 )
+      {
+        v10 = qword_256F420;
+        if ( qword_256F420 )
+        {
+          if ( (_DWORD)v9 != -2 )
+          {
+            v11 = *(unsigned __int16 *)v8;
+            v12 = *(_QWORD *)(qword_256F420 + 8 * ((v11 >> 9) & 0x3F));
+            if ( v12 )
+            {
+              v13 = 112 * (v11 & 0x1FF) + v12;
+              if ( (_DWORD)v9 == *(_DWORD *)(v13 + 16) )
+              {
+                v14 = *(_DWORD *)(v13 + 48);
+                if ( (v14 & 0x200) == 0 && *((_BYTE *)v8 + 4) != !((unsigned __int8)v14 >> 7) )
+                {
+                  v15 = v7 + 1;
+                  v16 = &v5[16 * v7];
+                  if ( v2 == v7 )
+                  {
+                    if ( v2 == 0x7FFFFFFF )
+                    {
+                      UtlVectorMemory_FailedAllocation(0x7FFFFFFF, 1, v9);
+                      v25 = UtlVectorMemory_CalcNewAllocationCount(0x7FFFFFFF, 0, 0x80000000LL, 16);
+                      v22 = 16LL * v7;
+                      v21 = v7 + 1;
+                      v23 = v25;
+                    }
+                    else
+                    {
+                      v28 = v7 + 1;
+                      v20 = UtlVectorMemory_CalcNewAllocationCount((unsigned int)v2, 0, v15, 16);
+                      v21 = v7 + 1;
+                      v22 = 16LL * v7;
+                      v23 = v20;
+                      if ( v20 < v7 + 1 )
+                      {
+                        do
+                          v23 = (v23 + v28) / 2;
+                        while ( v23 < v28 );
+                      }
+                    }
+                    v26 = v21;
+                    v27 = v22;
+                    v29 = v23;
+                    v24 = UtlVectorMemory_Alloc(v5, 1, 16LL * v23, 16LL * v2);
+                    LODWORD(v9) = *v8;
+                    v19 = 0;
+                    v5 = (_BYTE *)v24;
+                    v15 = v26;
+                    v16 = (_BYTE *)(v24 + v27);
+                    v2 = v29;
+                    if ( *v8 == -1 )
+                      goto LABEL_15;
+                    v10 = qword_256F420;
+                    if ( !qword_256F420 || (_DWORD)v9 == -2 )
+                    {
+                      v2 = v29;
+                      goto LABEL_28;
+                    }
+                    v11 = *(unsigned __int16 *)v8;
+                  }
+                  v17 = *(_QWORD *)(v10 + 8 * ((v11 >> 9) & 0x3F));
+                  if ( v17 )
+                  {
+                    v18 = (__int64 *)(112 * (v11 & 0x1FF) + v17);
+                    if ( *((_DWORD *)v18 + 4) == (_DWORD)v9 )
+                    {
+                      v19 = *v18;
+  LABEL_15:
+                      *(_QWORD *)v16 = v19;
+                      v7 = v15;
+                      v16[8] = *((_BYTE *)v8 + 4);
+                      v4 = *(_DWORD *)(a1 + 3160);
+                      goto LABEL_16;
+                    }
+                  }
+  LABEL_28:
+                  v19 = 0;
+                  goto LABEL_15;
+                }
+              }
+            }
+          }
+        }
+      }
+  LABEL_16:
+      ++v6;
+    }
+    while ( v4 > (int)v6 );
+    *(_DWORD *)(a1 + 3160) = 0;
+    CEntitySystem_SetInPVS((int *)a1, v7, v5);
+  LABEL_18:
+    if ( v5 )
+      (*(void (__fastcall **)(_QWORD *, _BYTE *))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v5);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_ExecuteQueuedSetInPVS.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_ExecuteQueuedSetInPVS.windows.yaml
@@ -1,0 +1,400 @@
+func_name: CEntitySystem_ExecuteQueuedSetInPVS
+func_va: '0x1811f5ae0'
+disasm_code: |-
+  .text:00000001811F5AE0                 push    r13
+  .text:00000001811F5AE2                 sub     rsp, 70h
+  .text:00000001811F5AE6                 cmp     dword ptr [rcx+0BB8h], 0
+  .text:00000001811F5AED                 mov     r13, rcx
+  .text:00000001811F5AF0                 jg      loc_1811F5E44
+  .text:00000001811F5AF6                 mov     [rsp+78h+var_28], rdi
+  .text:00000001811F5AFB                 movsxd  rdi, dword ptr [rcx+0C58h]  ; 0C58h = CEntitySystem::m_queuedDormancyChanges (structmember, struct=CEntitySystem, member=m_queuedDormancyChanges)
+  .text:00000001811F5B02                 test    edi, edi
+  .text:00000001811F5B04                 jz      loc_1811F5E3F
+  .text:00000001811F5B0A                 mov     [rsp+78h+var_10], rbx
+  .text:00000001811F5B0F                 mov     [rsp+78h+var_18], rbp
+  .text:00000001811F5B14                 mov     [rsp+78h+var_20], rsi
+  .text:00000001811F5B19                 mov     [rsp+78h+var_38], r14
+  .text:00000001811F5B1E                 xor     r14d, r14d
+  .text:00000001811F5B21                 mov     [rsp+78h+arg_18], r14
+  .text:00000001811F5B29                 mov     ebp, r14d
+  .text:00000001811F5B2C                 mov     [rsp+78h+arg_0], r14d
+  .text:00000001811F5B34                 mov     ebx, r14d
+  .text:00000001811F5B37                 mov     [rsp+78h+arg_8], r14d
+  .text:00000001811F5B3F                 mov     esi, r14d
+  .text:00000001811F5B42                 mov     r11d, r14d
+  .text:00000001811F5B45                 test    edi, edi
+  .text:00000001811F5B47                 jle     short loc_1811F5B6D
+  .text:00000001811F5B49                 mov     r8, rdi
+  .text:00000001811F5B4C                 xor     r9d, r9d
+  .text:00000001811F5B4F                 shl     r8, 4
+  .text:00000001811F5B53                 mov     dl, 1
+  .text:00000001811F5B55                 xor     ecx, ecx
+  .text:00000001811F5B57                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001811F5B5D                 mov     [rsp+78h+arg_18], rax
+  .text:00000001811F5B65                 mov     ebx, edi
+  .text:00000001811F5B67                 mov     rbp, rax
+  .text:00000001811F5B6A                 mov     r11d, r14d
+  .text:00000001811F5B6D                 mov     edi, r14d
+  .text:00000001811F5B70                 mov     [rsp+78h+arg_10], r14d
+  .text:00000001811F5B78                 cmp     [r13+0C58h], esi
+  .text:00000001811F5B7F                 jle     loc_1811F5DF6
+  .text:00000001811F5B85                 mov     r8, cs:qword_181D9D980
+  .text:00000001811F5B8C                 mov     [rsp+78h+var_30], r12
+  .text:00000001811F5B91                 mov     [rsp+78h+var_40], r15
+  .text:00000001811F5B96                 mov     [rsp+78h+var_58], r14
+  .text:00000001811F5B9B                 nop     dword ptr [rax+rax+00h]
+  .text:00000001811F5BA0                 mov     r12, [r13+0C60h]
+  .text:00000001811F5BA7                 add     r12, rsi
+  .text:00000001811F5BAA                 mov     ecx, [r12]
+  .text:00000001811F5BAE                 cmp     ecx, 0FFFFFFFFh
+  .text:00000001811F5BB1                 jz      loc_1811F5DC6
+  .text:00000001811F5BB7                 test    r8, r8
+  .text:00000001811F5BBA                 jz      loc_1811F5DC6
+  .text:00000001811F5BC0                 cmp     ecx, 0FFFFFFFEh
+  .text:00000001811F5BC3                 jz      loc_1811F5DC6
+  .text:00000001811F5BC9                 mov     r9d, ecx
+  .text:00000001811F5BCC                 and     r9d, 7FFFh
+  .text:00000001811F5BD3                 mov     eax, r9d
+  .text:00000001811F5BD6                 shr     rax, 9
+  .text:00000001811F5BDA                 mov     edx, r9d
+  .text:00000001811F5BDD                 mov     r10, [r8+rax*8]
+  .text:00000001811F5BE1                 test    r10, r10
+  .text:00000001811F5BE4                 jz      loc_1811F5DC6
+  .text:00000001811F5BEA                 and     edx, 1FFh
+  .text:00000001811F5BF0                 imul    rax, rdx, 70h ; 'p'
+  .text:00000001811F5BF4                 add     rax, r10
+  .text:00000001811F5BF7                 jz      loc_1811F5DC6
+  .text:00000001811F5BFD                 cmp     [rax+10h], ecx
+  .text:00000001811F5C00                 jnz     loc_1811F5DC6
+  .text:00000001811F5C06                 mov     ecx, r9d
+  .text:00000001811F5C09                 mov     eax, r9d
+  .text:00000001811F5C0C                 shr     rax, 9
+  .text:00000001811F5C10                 and     ecx, 1FFh
+  .text:00000001811F5C16                 imul    rdx, rcx, 70h ; 'p'
+  .text:00000001811F5C1A                 mov     r10d, r9d
+  .text:00000001811F5C1D                 add     rdx, [r8+rax*8]
+  .text:00000001811F5C21                 mov     eax, [rdx+30h]
+  .text:00000001811F5C24                 shr     eax, 9
+  .text:00000001811F5C27                 test    al, 1
+  .text:00000001811F5C29                 jnz     loc_1811F5DC6
+  .text:00000001811F5C2F                 mov     ecx, r10d
+  .text:00000001811F5C32                 mov     eax, r10d
+  .text:00000001811F5C35                 shr     rax, 9
+  .text:00000001811F5C39                 and     ecx, 1FFh
+  .text:00000001811F5C3F                 imul    rdx, rcx, 70h ; 'p'
+  .text:00000001811F5C43                 add     rdx, [r8+rax*8]
+  .text:00000001811F5C47                 mov     eax, [rdx+30h]
+  .text:00000001811F5C4A                 shr     eax, 7
+  .text:00000001811F5C4D                 not     al
+  .text:00000001811F5C4F                 and     al, 1
+  .text:00000001811F5C51                 cmp     [r12+4], al
+  .text:00000001811F5C56                 jz      loc_1811F5DC6
+  .text:00000001811F5C5C                 movsxd  r15, r11d
+  .text:00000001811F5C5F                 cmp     r11d, ebx
+  .text:00000001811F5C62                 jnz     loc_1811F5D4C
+  .text:00000001811F5C68                 mov     eax, [rsp+78h+arg_0]
+  .text:00000001811F5C6F                 mov     esi, eax
+  .text:00000001811F5C71                 and     esi, 0C0000000h
+  .text:00000001811F5C77                 test    esi, 7FFFFFFFh
+  .text:00000001811F5C7D                 jnz     loc_1811F5D47
+  .text:00000001811F5C83                 movsxd  rbp, ebx
+  .text:00000001811F5C86                 cmp     rbp, 7FFFFFFEh
+  .text:00000001811F5C8D                 jle     short loc_1811F5CA3
+  .text:00000001811F5C8F                 mov     edx, 1
+  .text:00000001811F5C94                 mov     ecx, ebx
+  .text:00000001811F5C96                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:00000001811F5C9C                 mov     eax, [rsp+78h+arg_0]
+  .text:00000001811F5CA3                 mov     r14d, eax
+  .text:00000001811F5CA6                 lea     edi, [rbx+1]
+  .text:00000001811F5CA9                 and     r14d, 3FFFFFFFh
+  .text:00000001811F5CB0                 mov     r9d, 10h
+  .text:00000001811F5CB6                 mov     edx, r14d
+  .text:00000001811F5CB9                 mov     r8d, edi
+  .text:00000001811F5CBC                 mov     ecx, ebx
+  .text:00000001811F5CBE                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001811F5CC4                 mov     ebx, eax
+  .text:00000001811F5CC6                 cmp     eax, edi
+  .text:00000001811F5CC8                 jge     short loc_1811F5CEE
+  .text:00000001811F5CCA                 test    eax, eax
+  .text:00000001811F5CCC                 jnz     short loc_1811F5CE0
+  .text:00000001811F5CCE                 cmp     edi, 0FFFFFFFFh
+  .text:00000001811F5CD1                 jg      short loc_1811F5CE0
+  .text:00000001811F5CD3                 mov     ebx, 0FFFFFFFFh
+  .text:00000001811F5CD8                 jmp     short loc_1811F5CEE
+  .text:00000001811F5CE0                 lea     eax, [rbx+rdi]
+  .text:00000001811F5CE3                 cdq
+  .text:00000001811F5CE4                 sub     eax, edx
+  .text:00000001811F5CE6                 sar     eax, 1
+  .text:00000001811F5CE8                 mov     ebx, eax
+  .text:00000001811F5CEA                 cmp     eax, edi
+  .text:00000001811F5CEC                 jl      short loc_1811F5CE0
+  .text:00000001811F5CEE                 mov     rcx, [rsp+78h+arg_18]
+  .text:00000001811F5CF6                 shl     rbp, 4
+  .text:00000001811F5CFA                 movsxd  r8, ebx
+  .text:00000001811F5CFD                 mov     r9, rbp
+  .text:00000001811F5D00                 shl     r8, 4
+  .text:00000001811F5D04                 test    esi, esi
+  .text:00000001811F5D06                 setz    dl
+  .text:00000001811F5D09                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001811F5D0F                 mov     r8, cs:qword_181D9D980
+  .text:00000001811F5D16                 test    esi, esi
+  .text:00000001811F5D18                 mov     r11d, [rsp+78h+arg_8]
+  .text:00000001811F5D20                 mov     rbp, rax
+  .text:00000001811F5D23                 mov     edi, [rsp+78h+arg_10]
+  .text:00000001811F5D2A                 mov     [rsp+78h+arg_18], rax
+  .text:00000001811F5D32                 mov     eax, [rsp+78h+arg_0]
+  .text:00000001811F5D39                 cmovnz  eax, r14d
+  .text:00000001811F5D3D                 xor     r14d, r14d
+  .text:00000001811F5D40                 mov     [rsp+78h+arg_0], eax
+  .text:00000001811F5D47                 mov     rsi, [rsp+78h+var_58]
+  .text:00000001811F5D4C                 mov     edx, [r12]
+  .text:00000001811F5D50                 inc     r11d
+  .text:00000001811F5D53                 mov     rcx, r15
+  .text:00000001811F5D56                 mov     [rsp+78h+arg_8], r11d
+  .text:00000001811F5D5E                 add     rcx, rcx
+  .text:00000001811F5D61                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811F5D64                 jz      short loc_1811F5DAD
+  .text:00000001811F5D66                 test    r8, r8
+  .text:00000001811F5D69                 jz      short loc_1811F5DAD
+  .text:00000001811F5D6B                 cmp     edx, 0FFFFFFFEh
+  .text:00000001811F5D6E                 jz      short loc_1811F5DA0
+  .text:00000001811F5D70                 mov     eax, edx
+  .text:00000001811F5D72                 and     eax, 7FFFh
+  .text:00000001811F5D77                 mov     r9d, eax
+  .text:00000001811F5D7A                 shr     rax, 9
+  .text:00000001811F5D7E                 mov     r10, [r8+rax*8]
+  .text:00000001811F5D82                 test    r10, r10
+  .text:00000001811F5D85                 jz      short loc_1811F5DA0
+  .text:00000001811F5D87                 and     r9d, 1FFh
+  .text:00000001811F5D8E                 imul    rax, r9, 70h ; 'p'
+  .text:00000001811F5D92                 add     rax, r10
+  .text:00000001811F5D95                 jz      short loc_1811F5DA0
+  .text:00000001811F5D97                 cmp     [rax+10h], edx
+  .text:00000001811F5D9A                 cmovnz  rax, r14
+  .text:00000001811F5D9E                 jmp     short loc_1811F5DA3
+  .text:00000001811F5DA0                 mov     rax, r14
+  .text:00000001811F5DA3                 test    rax, rax
+  .text:00000001811F5DA6                 jz      short loc_1811F5DAD
+  .text:00000001811F5DA8                 mov     rdx, [rax]
+  .text:00000001811F5DAB                 jmp     short loc_1811F5DB0
+  .text:00000001811F5DAD                 mov     rdx, r14
+  .text:00000001811F5DB0                 mov     [rbp+rcx*8+0], rdx
+  .text:00000001811F5DB5                 movzx   eax, byte ptr [r12+4]
+  .text:00000001811F5DBB                 mov     [rbp+rcx*8+8], al
+  .text:00000001811F5DBF                 mov     r8, cs:qword_181D9D980
+  .text:00000001811F5DC6                 inc     edi
+  .text:00000001811F5DC8                 add     rsi, 8
+  .text:00000001811F5DCC                 mov     [rsp+78h+arg_10], edi
+  .text:00000001811F5DD3                 mov     [rsp+78h+var_58], rsi
+  .text:00000001811F5DD8                 cmp     edi, [r13+0C58h]
+  .text:00000001811F5DDF                 jl      loc_1811F5BA0
+  .text:00000001811F5DE5                 mov     r15, [rsp+78h+var_40]
+  .text:00000001811F5DEA                 mov     r12, [rsp+78h+var_30]
+  .text:00000001811F5DEF                 mov     esi, [rsp+78h+arg_0]
+  .text:00000001811F5DF6                 mov     r8, rbp
+  .text:00000001811F5DF9                 mov     [r13+0C58h], r14d
+  .text:00000001811F5E00                 mov     edx, r11d
+  .text:00000001811F5E03                 mov     rcx, r13
+  .text:00000001811F5E06                 call    CEntitySystem_SetInPVS
+  .text:00000001811F5E0B                 mov     r14, [rsp+78h+var_38]
+  .text:00000001811F5E10                 test    esi, 0C0000000h
+  .text:00000001811F5E16                 mov     rsi, [rsp+78h+var_20]
+  .text:00000001811F5E1B                 mov     rbx, [rsp+78h+var_10]
+  .text:00000001811F5E20                 jnz     short loc_1811F5E3A
+  .text:00000001811F5E22                 test    rbp, rbp
+  .text:00000001811F5E25                 jz      short loc_1811F5E3A
+  .text:00000001811F5E27                 mov     rax, cs:g_pMemAlloc
+  .text:00000001811F5E2E                 mov     rdx, rbp
+  .text:00000001811F5E31                 mov     rcx, [rax]
+  .text:00000001811F5E34                 mov     rax, [rcx]
+  .text:00000001811F5E37                 call    qword ptr [rax+18h]
+  .text:00000001811F5E3A                 mov     rbp, [rsp+78h+var_18]
+  .text:00000001811F5E3F                 mov     rdi, [rsp+78h+var_28]
+  .text:00000001811F5E44                 add     rsp, 70h
+  .text:00000001811F5E48                 pop     r13
+  .text:00000001811F5E4A                 retn
+procedure: |-
+  void __fastcall CEntitySystem_ExecuteQueuedSetInPVS(__int64 a1, __int64 a2)
+  {
+    __int64 v3; // rdi
+    _BYTE *v4; // rbp
+    int v5; // ebx
+    __int64 v6; // rsi
+    int v7; // r11d
+    int v8; // edi
+    __int64 v9; // r8
+    int *v10; // r12
+    int v11; // ecx
+    __int64 v12; // r10
+    __int64 v13; // rax
+    __int64 v14; // r15
+    int v15; // eax
+    unsigned int v16; // esi
+    __int64 v17; // rbp
+    int v18; // edi
+    int v19; // r14d
+    int v20; // eax
+    __int64 v21; // rdx
+    __int64 v22; // rax
+    int v23; // eax
+    int v24; // edx
+    __int64 v25; // r10
+    __int64 *v26; // rax
+    __int64 v27; // rdx
+    __int64 v28; // [rsp+20h] [rbp-58h]
+    int v29; // [rsp+80h] [rbp+8h]
+    int v30; // [rsp+88h] [rbp+10h]
+    int v31; // [rsp+90h] [rbp+18h]
+    __int64 v32; // [rsp+98h] [rbp+20h]
+
+    if ( *(int *)(a1 + 3000) <= 0 )
+    {
+      v3 = *(int *)(a1 + 3160);                   // 3160 = 0xC58 = CEntitySystem::m_queuedDormancyChanges (structmember, struct=CEntitySystem, member=m_queuedDormancyChanges)
+      if ( (_DWORD)v3 )
+      {
+        v32 = 0;
+        v4 = nullptr;
+        v29 = 0;
+        v5 = 0;
+        v30 = 0;
+        v6 = 0;
+        v7 = 0;
+        if ( (int)v3 > 0 )
+        {
+          LOBYTE(a2) = 1;
+          v32 = UtlVectorMemory_Alloc(0, a2, 16 * v3, 0);
+          v5 = v3;
+          v4 = (_BYTE *)v32;
+          v7 = 0;
+        }
+        v8 = 0;
+        v31 = 0;
+        if ( *(int *)(a1 + 3160) > 0 )
+        {
+          v9 = qword_181D9D980;
+          v28 = 0;
+          do
+          {
+            v10 = (int *)(v6 + *(_QWORD *)(a1 + 3168));
+            v11 = *v10;
+            if ( *v10 != -1 )
+            {
+              if ( v9 )
+              {
+                if ( v11 != -2 )
+                {
+                  v12 = *(_QWORD *)(v9 + 8 * ((unsigned __int64)(v11 & 0x7FFF) >> 9));
+                  if ( v12 )
+                  {
+                    v13 = v12 + 112LL * (v11 & 0x1FF);
+                    if ( v13 )
+                    {
+                      if ( *(_DWORD *)(v13 + 16) == v11
+                        && (*(_DWORD *)(*(_QWORD *)(v9 + 8 * ((unsigned __int64)(v11 & 0x7FFF) >> 9))
+                                      + 112LL * (v11 & 0x1FF)
+                                      + 48)
+                          & 0x200) == 0
+                        && *((_BYTE *)v10 + 4) != ((*(_DWORD *)(*(_QWORD *)(v9
+                                                                          + 8 * ((unsigned __int64)(v11 & 0x7FFF) >> 9))
+                                                              + 112LL * (v11 & 0x1FF)
+                                                              + 48)
+                                                  & 0x80) == 0) )
+                      {
+                        v14 = v7;
+                        if ( v7 == v5 )
+                        {
+                          v15 = v29;
+                          v16 = v29 & 0xC0000000;
+                          if ( (v29 & 0x40000000) == 0 )
+                          {
+                            v17 = v5;
+                            if ( v5 > 2147483646LL )
+                            {
+                              UtlVectorMemory_FailedAllocation((unsigned int)v5, 1);
+                              v15 = v29;
+                            }
+                            v18 = v5 + 1;
+                            v19 = v15 & 0x3FFFFFFF;
+                            v20 = UtlVectorMemory_CalcNewAllocationCount(
+                                    (unsigned int)v5,
+                                    v15 & 0x3FFFFFFF,
+                                    (unsigned int)(v5 + 1),
+                                    16);
+                            v5 = v20;
+                            if ( v20 < v18 )
+                            {
+                              if ( v20 || v18 > -1 )
+                              {
+                                do
+                                {
+                                  v21 = (unsigned int)((v5 + v18) >> 31);
+                                  v5 = (v5 + v18) / 2;
+                                }
+                                while ( v5 < v18 );
+                              }
+                              else
+                              {
+                                v5 = -1;
+                              }
+                            }
+                            LOBYTE(v21) = v16 == 0;
+                            v22 = UtlVectorMemory_Alloc(v32, v21, 16LL * v5, 16 * v17);
+                            v9 = qword_181D9D980;
+                            v7 = v30;
+                            v4 = (_BYTE *)v22;
+                            v8 = v31;
+                            v32 = v22;
+                            v23 = v29;
+                            if ( v16 )
+                              v23 = v19;
+                            v29 = v23;
+                          }
+                          v6 = v28;
+                        }
+                        v24 = *v10;
+                        v30 = ++v7;
+                        if ( *v10 == -1 || !v9 )
+                          goto LABEL_39;
+                        if ( v24 != -2
+                          && (v25 = *(_QWORD *)(v9 + 8 * ((unsigned __int64)(v24 & 0x7FFF) >> 9))) != 0
+                          && (v26 = (__int64 *)(v25 + 112LL * (v24 & 0x1FF))) != nullptr )
+                        {
+                          if ( *((_DWORD *)v26 + 4) != v24 )
+                            v26 = nullptr;
+                        }
+                        else
+                        {
+                          v26 = nullptr;
+                        }
+                        if ( v26 )
+                          v27 = *v26;
+                        else
+  LABEL_39:
+                          v27 = 0;
+                        *(_QWORD *)&v4[16 * v14] = v27;
+                        v4[16 * v14 + 8] = *((_BYTE *)v10 + 4);
+                        v9 = qword_181D9D980;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            ++v8;
+            v6 += 8;
+            v31 = v8;
+            v28 = v6;
+          }
+          while ( v8 < *(_DWORD *)(a1 + 3160) );
+          LODWORD(v6) = v29;
+        }
+        *(_DWORD *)(a1 + 3160) = 0;
+        CEntitySystem_SetInPVS(a1, v7, v4);
+        if ( (v6 & 0xC0000000) == 0 )
+        {
+          if ( v4 )
+            (*(void (__fastcall **)(_QWORD, _BYTE *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v4);
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.linux.yaml
@@ -1,0 +1,45 @@
+func_name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+func_va: '0x1e61b10'
+disasm_code: |-
+  .text:0000000001E61B10                 mov     eax, [rdi+0BB8h]  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:0000000001E61B16                 test    sil, sil
+  .text:0000000001E61B19                 jz      short loc_1E61B28
+  .text:0000000001E61B1B                 add     eax, 1
+  .text:0000000001E61B1E                 mov     [rdi+0BB8h], eax  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:0000000001E61B24                 retn
+  .text:0000000001E61B28                 sub     eax, 1
+  .text:0000000001E61B2B                 mov     [rdi+0BB8h], eax  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:0000000001E61B31                 jnz     short locret_1E61B50
+  .text:0000000001E61B33                 mov     edx, [rdi+0BC0h]  ; 0BC0h = CEntitySystem::m_nExecuteQueuedCreationDepth (structmember, struct=CEntitySystem, member=m_nExecuteQueuedCreationDepth)
+  .text:0000000001E61B39                 test    edx, edx
+  .text:0000000001E61B3B                 jnz     short locret_1E61B50
+  .text:0000000001E61B3D                 mov     eax, [rdi+0C58h]
+  .text:0000000001E61B43                 test    eax, eax
+  .text:0000000001E61B45                 jz      short locret_1E61B50
+  .text:0000000001E61B47                 jmp     CEntitySystem_ExecuteQueuedSetInPVS
+  .text:0000000001E61B50                 retn
+procedure: |-
+  __int64 __fastcall CEntitySystem_ForceSetInPVSCallsIntoQueue(__int64 a1, char a2)
+  {
+    int v2; // eax
+    __int64 result; // rax
+
+    v2 = *(_DWORD *)(a1 + 3000);                  // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+    if ( a2 )
+    {
+      result = (unsigned int)(v2 + 1);
+      *(_DWORD *)(a1 + 3000) = result;            // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+    }
+    else
+    {
+      result = (unsigned int)(v2 - 1);
+      *(_DWORD *)(a1 + 3000) = result;            // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+      if ( !(_DWORD)result && !*(_DWORD *)(a1 + 3008) )// 3008 = 0xBC0 = CEntitySystem::m_nExecuteQueuedCreationDepth (structmember, struct=CEntitySystem, member=m_nExecuteQueuedCreationDepth)
+      {
+        result = *(unsigned int *)(a1 + 3160);
+        if ( (_DWORD)result )
+          return CEntitySystem_ExecuteQueuedSetInPVS(a1);
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_ForceSetInPVSCallsIntoQueue.windows.yaml
@@ -1,0 +1,36 @@
+func_name: CEntitySystem_ForceSetInPVSCallsIntoQueue
+func_va: '0x1811f7200'
+disasm_code: |-
+  .text:00000001811F7200                 mov     eax, [rcx+0BB8h]  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:00000001811F7206                 test    dl, dl
+  .text:00000001811F7208                 jz      short loc_1811F7213
+  .text:00000001811F720A                 inc     eax
+  .text:00000001811F720C                 mov     [rcx+0BB8h], eax  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:00000001811F7212                 retn
+  .text:00000001811F7213                 sub     eax, 1
+  .text:00000001811F7216                 mov     [rcx+0BB8h], eax  ; 0BB8h = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+  .text:00000001811F721C                 jnz     short locret_1811F722B
+  .text:00000001811F721E                 cmp     dword ptr [rcx+0BC0h], 0  ; 0BC0h = CEntitySystem::m_nExecuteQueuedCreationDepth (structmember, struct=CEntitySystem, member=m_nExecuteQueuedCreationDepth)
+  .text:00000001811F7225                 jz      CEntitySystem_ExecuteQueuedSetInPVS
+  .text:00000001811F722B                 retn
+procedure: |-
+  __int64 __fastcall CEntitySystem_ForceSetInPVSCallsIntoQueue(__int64 a1, char a2)
+  {
+    int v2; // eax
+    __int64 result; // rax
+
+    v2 = *(_DWORD *)(a1 + 3000);                  // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+    if ( a2 )
+    {
+      result = (unsigned int)(v2 + 1);
+      *(_DWORD *)(a1 + 3000) = result;            // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+    }
+    else
+    {
+      result = (unsigned int)(v2 - 1);
+      *(_DWORD *)(a1 + 3000) = result;            // 3000 = 0xBB8 = CEntitySystem::m_nSuppressDormancyChangeCount (structmember, struct=CEntitySystem, member=m_nSuppressDormancyChangeCount)
+      if ( !(_DWORD)result && !*(_DWORD *)(a1 + 3008) )// 3008 = 0xBC0 = CEntitySystem::m_nExecuteQueuedCreationDepth (structmember, struct=CEntitySystem, member=m_nExecuteQueuedCreationDepth)
+        return CEntitySystem_ExecuteQueuedSetInPVS(a1);
+    }
+    return result;
+  }

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -5526,7 +5526,10 @@ found_struct_offset: []
                     )
                 if name == "py_eval":
                     code = arguments["code"]
-                    self.assertIn("inst_addr = sig_addr + 0", code)
+                    self.assertIn("offset_sig_disp = 0", code)
+                    self.assertIn(
+                        "inst_addr = sig_addr + offset_sig_disp", code
+                    )
                     return _py_eval_payload(
                         {
                             "offset": 0x58,
@@ -7933,6 +7936,7 @@ found_struct_offset: []
             size="8",
             old_path=str(old_struct_yaml_path),
             allow_across_function_boundary=False,
+            offset_sig_max_match=1,
             debug=True,
         )
         mock_write_func_yaml.assert_called_once()
@@ -8139,6 +8143,7 @@ found_struct_offset: []
             size="8",
             old_path=str(old_struct_yaml_path),
             allow_across_function_boundary=True,
+            offset_sig_max_match=1,
             debug=True,
         )
         mock_write_struct_offset_yaml.assert_called_once()

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -1305,6 +1305,7 @@ class TestGenerateYamlDesiredFieldsContract(unittest.IsolatedAsyncioTestCase):
                     "generation_options": {
                         "vfunc_sig_max_match": 10,
                     },
+                    "optional_fields": set(),
                 }
             },
             result,
@@ -1520,6 +1521,7 @@ class TestGenerateYamlDesiredFieldsContract(unittest.IsolatedAsyncioTestCase):
                         "gv_sig_allow_across_function_boundary": True,
                         "offset_sig_allow_across_function_boundary": True,
                     },
+                    "optional_fields": set(),
                 }
             },
             result,


### PR DESCRIPTION
## Summary
- Add preprocessor scripts and YAML outputs for server save/restore (`CEntity2SaveRestore_StreamEntitiesFromFile`, `CEntitySaveRestoreBlockHandler_*`, `CSaveRestoreBlockSet_vtable`, `CreateEntityTransitionList`).
- Add preprocessor scripts for `CEntitySystem_ForceSetInPVSCallsIntoQueue` / `CEntitySystem_ExecuteQueuedSetInPVS` (with `m_iCurrentSetInPVSDepth` / `m_queuedDormancyChanges`) and for `CEntitySystem_RemoveEntityFromNameMap` / `AddEntityToNameMap` / `m_entityNames`.
- Extend `ida_analyze_util` with `offset_sig_max_match` support and include `optional_fields` in normalized expected results; restore `CEntitySystem_MSVC` in `config.yaml`.
- `llm_decompile`: support `{module_name}` placeholder in deferred template substitution.

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` passes locally
- [ ] New YAMLs match expectations on both Linux and Windows builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 提示词

```
Create "find-CEntitySystem_RemoveEntityFromNameMap-AND-CEntitySystem_AddEntityToNameMap" by LLM_DECOMPILE with CEntityIdentity_SetEntityName, where both CEntitySystem_RemoveEntityFromNameMap and CEntitySystem_AddEntityToNameMap are regular functions in server.

Create "find-CEntitySystem_m_entityNames" by LLM_DECOMPILE with CEntitySystem_AddEntityToNameMap where CEntitySystem_m_entityNames is a struct member of CEntitySystem.

Create "find-CreateEntityTransitionList" by xref_strings "%s:  suppress %d %s (in solid)" where CreateEntityTransitionList is a regular function in server.

Create "find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders" by xref_strings "FULLMATCH:EntityTables" "SaveHeaders KV3 Write", where CEntitySaveRestoreBlockHandler_WriteSaveHeaders is a vfunc of CEntitySaveRestoreBlockHandler_vtable in server.

Create "find-CEntitySaveRestoreBlockHandler_WriteSaveHeaders" by xref_strings "FULLMATCH:EntityTables" "SaveHeaders KV3 Write", where CEntitySaveRestoreBlockHandler_WriteSaveHeaders is a vfunc of CEntitySaveRestoreBlockHandler_vtable in server .

Create "find-CEntitySaveRestoreBlockHandler_ReadRestoreHeaders" by xref_strings "FULLMATCH:EntityTables" "FULLMATCH:ETABLE", exclude_funcs "CEntitySaveRestoreBlockHandler_WriteSaveHeaders", where CEntitySaveRestoreBlockHandler_ReadRestoreHeaders is a vfunc of CEntitySaveRestoreBlockHandler_vtable in server.

Create "find-CEntity2SaveRestore_StreamEntitiesFromFile" by xref_strings "%s:  StreamEntitiesFromFile:  '%s' [%d entities]" where CEntity2SaveRestore_StreamEntitiesFromFile is a vfunc of CEntity2SaveRestore_vtable in server.

Create "find-CEntity2SaveRestore_StreamEntitiesFromFile-decompiles" by LLM_DECOMPILE with CEntity2SaveRestore_StreamEntitiesFromFile, find "CSaveRestoreBlockSet_PreRestore", "CSaveRestoreBlockSet_PostRestore" , where CSaveRestoreBlockSet_PreRestore and CSaveRestoreBlockSet_PostRestore are vfunc of CSaveRestoreBlockSet_vtable in server.

Create "find-CEntitySaveRestoreBlockHandler_PreRestore" by INHERIT_VFUNCS with CSaveRestoreBlockSet_PreRestore where CEntitySaveRestoreBlockHandler_PreRestore is a vfunc of CEntitySaveRestoreBlockHandler_vtable.

Create "find-CEntitySaveRestoreBlockHandler_PostRestore" by INHERIT_VFUNCS with CSaveRestoreBlockSet_PostRestore where CEntitySaveRestoreBlockHandler_PostRestore is a vfunc of CEntitySaveRestoreBlockHandler_vtable.

Create "find-CEntitySystem_ForceSetInPVSCallsIntoQueue" by checking ida_preprocessor_scripts\find-CEntitySystem_QueueDestroyEntity.py as reference. SOURCE_FUNCTION_NAME = CEntitySaveRestoreBlockHandler_PreRestore. CEntitySystem_ForceSetInPVSCallsIntoQueue is a regular function in server.

Create "find-CEntitySystem_m_nSuppressDormancyChangeCount-AND-CEntitySystem_m_nExecuteQueuedCreationDepth-AND-CEntitySystem_ExecuteQueuedSetInPVS" by LLM_DECOMPILE with CEntitySystem_ForceSetInPVSCallsIntoQueue, where CEntitySystem_m_nSuppressDormancyChangeCount and CEntitySystem_m_nExecuteQueuedCreationDepth are structmembers of CEntitySystem. CEntitySystem_ExecuteQueuedSetInPVS is a regular function in server.

Create "find-CEntitySystem_m_queuedDormancyChanges" by LLM_DECOMPILE with CEntitySystem_ExecuteQueuedSetInPVS where CEntitySystem_m_queuedDormancyChanges is a structmember of CEntitySystem in server.
```