### PR TITLE
feat: add CEntitySystem_m_ComponentUnserializerInfoAllocator to find-CEntitySystem_Init-decompiles

### DIFF
--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -11,6 +11,7 @@ TARGET_FUNCTION_NAMES = [
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_sEntSystemName",
     "CEntitySystem_m_eNetworkSerializationMode",
+    "CEntitySystem_m_ComponentUnserializerInfoAllocator",
 ]
 
 LLM_DECOMPILE = [
@@ -32,6 +33,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_eNetworkSerializationMode",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -78,6 +84,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_eNetworkSerializationMode",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
         [
             "struct_name",
             "member_name",


### PR DESCRIPTION
## Summary
- Add `CEntitySystem_m_ComponentUnserializerInfoAllocator` struct member of `CEntitySystem` to `find-CEntitySystem_Init-decompiles` preprocessor script
- Added to `TARGET_STRUCT_MEMBER_NAMES`, `LLM_DECOMPILE`, and `GENERATE_YAML_DESIRED_FIELDS`