### PR TITLE
feat: add CEntitySpawner_CPlayerSprayDecal_Spawn and CEntitySystem_m_EntityKeyValuesAllocator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6333,6 +6333,12 @@ modules:
         expected_input:
           - CEntitySystem_InstallCreationWrapperCallbacks.{platform}.yaml
 
+      - name: find-CEntitySystem_m_EntityKeyValuesAllocator
+        expected_output:
+          - CEntitySystem_m_EntityKeyValuesAllocator.{platform}.yaml
+        expected_input:
+          - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
+
       - name: find-INetworkMessages_RegisterSchemaTypeOverride
         expected_output:
           - INetworkMessages_RegisterSchemaTypeOverride.{platform}.yaml
@@ -8448,6 +8454,13 @@ modules:
         member: m_EntityPostSpawnCallback
         alias:
           - CEntitySystem::m_EntityPostSpawnCallback
+
+      - name: CEntitySystem_m_EntityKeyValuesAllocator
+        category: structmember
+        struct: CEntitySystem
+        member: m_EntityKeyValuesAllocator
+        alias:
+          - CEntitySystem::m_EntityKeyValuesAllocator
 
       - name: CEntityIdentity_FreeAttributes
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5673,6 +5673,10 @@ modules:
         expected_input:
           - CFlashbangProjectile_Spawn.{platform}.yaml
 
+      - name: find-CEntitySpawner_CPlayerSprayDecal_Spawn
+        expected_output:
+          - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
+
       - name: find-CEntityInstance_Activate
         expected_output:
           - CEntityInstance_Activate.{platform}.yaml
@@ -9914,6 +9918,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::Spawn
+
+      - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+        category: func
+        alias:
+          - CEntitySpawner<CPlayerSprayDecal>::Spawn
 
       - name: CEntityInstance_Activate
         category: vfunc

--- a/ida_preprocessor_scripts/find-CEntitySpawner_CPlayerSprayDecal_Spawn.py
+++ b/ida_preprocessor_scripts/find-CEntitySpawner_CPlayerSprayDecal_Spawn.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySpawner_CPlayerSprayDecal_Spawn skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySpawner_CPlayerSprayDecal_Spawn",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySpawner_CPlayerSprayDecal_Spawn",
+        "xref_strings": [
+            "CEntitySpawner<class CPlayerSprayDecal>::Spawn",
+        ],
+        "xref_gvs": [], "xref_signatures": [], "xref_funcs": [],
+        "exclude_funcs": [], "exclude_strings": [], "exclude_gvs": [], "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySpawner_CPlayerSprayDecal_Spawn",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_EntityKeyValuesAllocator.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_EntityKeyValuesAllocator.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_EntityKeyValuesAllocator skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_EntityKeyValuesAllocator",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_EntityKeyValuesAllocator",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_EntityKeyValuesAllocator",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
@@ -1,0 +1,958 @@
+func_name: CEntitySpawner_CPlayerSprayDecal_Spawn
+func_va: '0x1802a0b50'
+disasm_code: |-
+  .text:00000001802A0B50                 mov     rax, rsp
+  .text:00000001802A0B53                 push    rbp
+  .text:00000001802A0B54                 lea     rbp, [rax-0C8h]
+  .text:00000001802A0B5B                 sub     rsp, 1C0h
+  .text:00000001802A0B62                 mov     [rax+10h], rbx
+  .text:00000001802A0B66                 mov     [rax+18h], rsi
+  .text:00000001802A0B6A                 mov     rsi, rcx
+  .text:00000001802A0B6D                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A0B74                 mov     [rax+20h], rdi
+  .text:00000001802A0B78                 xor     edi, edi
+  .text:00000001802A0B7A                 mov     [rax-10h], r12
+  .text:00000001802A0B7E                 mov     [rax-18h], r13
+  .text:00000001802A0B82                 mov     r13, rdx
+  .text:00000001802A0B85                 mov     [rax-20h], r14
+  .text:00000001802A0B89                 lea     rbx, [rcx+0CC8h]  ; 0CC8h = CEntitySystem::m_EntityKeyValuesAllocator (structmember, struct=CEntitySystem, member=m_EntityKeyValuesAllocator)
+  .text:00000001802A0B90                 lea     rax, ??_7?$CEntitySpawner@VCPlayerSprayDecal@@@@6B@; const CEntitySpawner<CPlayerSprayDecal>::`vftable'
+  .text:00000001802A0B97                 mov     [rbp+0C0h+var_D8], rdi
+  .text:00000001802A0B9B                 mov     [rbp+0C0h+var_100], rax
+  .text:00000001802A0B9F                 mov     r14d, 0FFFFFFFFh
+  .text:00000001802A0BA5                 mov     [rbp+0C0h+var_8F], dil
+  .text:00000001802A0BA9                 mov     [rbp+0C0h+var_88], rdi
+  .text:00000001802A0BAD                 mov     [rbp+0C0h+var_70], rdi
+  .text:00000001802A0BB1                 mov     [rbp+0C0h+var_68], 0FFFFFFFFFFFFFFFFh
+  .text:00000001802A0BB9                 mov     [rbp+0C0h+var_60], dil
+  .text:00000001802A0BBD                 call    sub_1811F0000
+  .text:00000001802A0BC2                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A0BC9                 mov     [rbp+0C0h+var_CC], eax
+  .text:00000001802A0BCC                 call    sub_1811F0300
+  .text:00000001802A0BD1                 mov     rcx, cs:qword_182117A80
+  .text:00000001802A0BD8                 movaps  xmm0, xmmword ptr [rax]
+  .text:00000001802A0BDB                 movaps  [rbp+0C0h+var_C0], xmm0
+  .text:00000001802A0BDF                 movaps  xmm1, xmmword ptr [rax+10h]
+  .text:00000001802A0BE3                 movaps  [rbp+0C0h+var_B0], xmm1
+  .text:00000001802A0BE7                 movaps  xmm0, xmmword ptr [rax+20h]
+  .text:00000001802A0BEB                 mov     rax, cs:qword_181DE6248
+  .text:00000001802A0BF2                 mov     [rbp+0C0h+var_E0], rax
+  .text:00000001802A0BF6                 movaps  [rbp+0C0h+var_A0], xmm0
+  .text:00000001802A0BFA                 mov     [rbp+0C0h+var_F0], rdi
+  .text:00000001802A0BFE                 mov     [rbp+0C0h+var_E8], rbx
+  .text:00000001802A0C02                 test    rcx, rcx
+  .text:00000001802A0C05                 jz      short loc_1802A0C18
+  .text:00000001802A0C07                 mov     rax, [rcx]
+  .text:00000001802A0C0A                 call    qword ptr [rax+0C8h]
+  .text:00000001802A0C10                 mov     [rbp+0C0h+var_90], 1
+  .text:00000001802A0C14                 test    al, al
+  .text:00000001802A0C16                 jnz     short loc_1802A0C1C
+  .text:00000001802A0C18                 mov     [rbp+0C0h+var_90], dil
+  .text:00000001802A0C1C                 mov     rax, [rbp+0C0h+var_100]
+  .text:00000001802A0C20                 lea     rcx, [rbp+0C0h+var_100]
+  .text:00000001802A0C24                 mov     [rbp+0C0h+var_D0], edi
+  .text:00000001802A0C27                 mov     rdx, [rax]
+  .text:00000001802A0C2A                 lea     rax, sub_1802B65D0
+  .text:00000001802A0C31                 cmp     rdx, rax
+  .text:00000001802A0C34                 jnz     short loc_1802A0C3D
+  .text:00000001802A0C36                 call    sub_1802B6690
+  .text:00000001802A0C3B                 jmp     short loc_1802A0C3F
+  .text:00000001802A0C3D                 call    rdx
+  .text:00000001802A0C3F                 lea     rdx, [rsi+8]
+  .text:00000001802A0C43                 lea     rcx, [rbp+0C0h+var_120]
+  .text:00000001802A0C47                 call    sub_1801B26C0
+  .text:00000001802A0C4C                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A0C50                 lea     rax, aOrigin; "origin"
+  .text:00000001802A0C57                 lea     r8, [rbp+0C0h+var_120]
+  .text:00000001802A0C5B                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A0C60                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A0C65                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFE4200216h
+  .text:00000001802A0C6E                 mov     r12d, 0FFFFFFFFh
+  .text:00000001802A0C74                 call    sub_1802B5B20
+  .text:00000001802A0C79                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A0C7D                 lea     rax, aAngles; "angles"
+  .text:00000001802A0C84                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A0C89                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A0C8E                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFBA98DACFh
+  .text:00000001802A0C97                 call    sub_1811FFFC0
+  .text:00000001802A0C9C                 test    rax, rax
+  .text:00000001802A0C9F                 jz      short loc_1802A0CB8
+  .text:00000001802A0CA1                 mov     r9b, 22h ; '"'
+  .text:00000001802A0CA4                 lea     r8, qword_18159B9F0
+  .text:00000001802A0CAB                 mov     edx, 3
+  .text:00000001802A0CB0                 mov     rcx, rax
+  .text:00000001802A0CB3                 call    sub_1814DC620
+  .text:00000001802A0CB8                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A0CBC                 lea     rax, aOwner; "owner"
+  .text:00000001802A0CC3                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A0CC8                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A0CCD                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFBE26849Fh
+  .text:00000001802A0CD6                 call    sub_1811FFFC0
+  .text:00000001802A0CDB                 mov     rbx, rax
+  .text:00000001802A0CDE                 test    rax, rax
+  .text:00000001802A0CE1                 jz      short loc_1802A0D05
+  .text:00000001802A0CE3                 mov     [rsp+1C0h+var_190], dil
+  .text:00000001802A0CE8                 xor     r9d, r9d
+  .text:00000001802A0CEB                 mov     [rsp+1C0h+var_198], edi
+  .text:00000001802A0CEF                 mov     r8b, 26h ; '&'
+  .text:00000001802A0CF2                 mov     dl, 4
+  .text:00000001802A0CF4                 mov     qword ptr [rsp+1C0h+var_1A0], rdi
+  .text:00000001802A0CF9                 mov     rcx, rax
+  .text:00000001802A0CFC                 call    sub_1814D79A0
+  .text:00000001802A0D01                 mov     [rbx+8], r12
+  .text:00000001802A0D05                 cmp     [rbp+0C0h+var_F0], rdi
+  .text:00000001802A0D09                 jz      loc_1802A13CF
+  .text:00000001802A0D0F                 lea     rax, aCBuildworkerCs_3; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001802A0D16                 mov     [rsp+1C0h+var_178], 4BBh
+  .text:00000001802A0D1F                 mov     qword ptr [rsp+1C0h+var_188+8], rax
+  .text:00000001802A0D24                 lea     r8, [rbp+0C0h+var_50]
+  .text:00000001802A0D28                 movups  xmm0, [rsp+1C0h+var_188+8]
+  .text:00000001802A0D2D                 lea     rax, aSpawn; "Spawn"
+  .text:00000001802A0D34                 mov     [rsp+1C0h+var_20], r15
+  .text:00000001802A0D3C                 mov     [rsp+1C0h+var_170], rax
+  .text:00000001802A0D41                 lea     rdx, off_181B756B8; "Server Simulation"
+  .text:00000001802A0D48                 movsd   xmm1, [rsp+1C0h+var_170]
+  .text:00000001802A0D4E                 lea     rcx, aCentityspawner_0; "CEntitySpawner<class CPlayerSprayDecal>"...
+  .text:00000001802A0D55                 movsd   [rbp+0C0h+var_40], xmm1
+  .text:00000001802A0D5D                 movaps  [rbp+0C0h+var_50], xmm0
+  .text:00000001802A0D61                 call    cs:?EnterScopeInternalBudgetFlags@?$VProfScopeHelper@$0A@$0A@@@SAP6AXXZPEBDAEAUVProfBudgetGroupCallSite@@AEBVCUtlSourceLocation@@@Z; VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(char const *,VProfBudgetGroupCallSite &,CUtlSourceLocation const &)
+  .text:00000001802A0D67                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A0D6B                 lea     r15, aClassname; "classname"
+  .text:00000001802A0D72                 lea     r8, [rbp+0C0h+arg_0]
+  .text:00000001802A0D79                 mov     [rsp+1C0h+var_178], r15
+  .text:00000001802A0D7E                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A0D83                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFC61B1C62h
+  .text:00000001802A0D8C                 mov     rdi, rax
+  .text:00000001802A0D8F                 call    sub_1811FFEB0
+  .text:00000001802A0D94                 test    rax, rax
+  .text:00000001802A0D97                 jz      short loc_1802A0DA2
+  .text:00000001802A0D99                 cmp     [rbp+0C0h+arg_0], 0
+  .text:00000001802A0DA0                 jz      short loc_1802A0DEA
+  .text:00000001802A0DA2                 mov     rax, [rbp+0C0h+var_E0]
+  .text:00000001802A0DA6                 mov     rcx, [rax+50h]
+  .text:00000001802A0DAA                 mov     rbx, [rcx]
+  .text:00000001802A0DAD                 test    rbx, rbx
+  .text:00000001802A0DB0                 jz      short loc_1802A0DEA
+  .text:00000001802A0DB2                 mov     r14, [rbp+0C0h+var_F0]
+  .text:00000001802A0DB6                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A0DBB                 mov     rcx, r14
+  .text:00000001802A0DBE                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFC61B1C62h
+  .text:00000001802A0DC7                 mov     [rsp+1C0h+var_178], r15
+  .text:00000001802A0DCC                 call    sub_1811FFFC0
+  .text:00000001802A0DD1                 test    rax, rax
+  .text:00000001802A0DD4                 jz      short loc_1802A0DE4
+  .text:00000001802A0DD6                 mov     r8, rbx
+  .text:00000001802A0DD9                 mov     rdx, rax
+  .text:00000001802A0DDC                 mov     rcx, r14
+  .text:00000001802A0DDF                 call    sub_181200E20
+  .text:00000001802A0DE4                 mov     r14d, 0FFFFFFFFh
+  .text:00000001802A0DEA                 mov     rcx, [rbp+0C0h+var_D8]
+  .text:00000001802A0DEE                 lea     r9, byte_18159B988
+  .text:00000001802A0DF5                 mov     edx, dword ptr [rbp+0C0h+var_68+4]
+  .text:00000001802A0DF8                 test    rcx, rcx
+  .text:00000001802A0DFB                 mov     r8d, [rbp+0C0h+var_D0]
+  .text:00000001802A0DFF                 mov     eax, dword ptr [rbp+0C0h+var_68]
+  .text:00000001802A0E02                 cmovnz  r9, rcx
+  .text:00000001802A0E06                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A0E0D                 mov     byte ptr [rsp+1C0h+var_188], 0
+  .text:00000001802A0E12                 mov     dword ptr [rsp+1C0h+var_190], edx
+  .text:00000001802A0E16                 mov     edx, [rbp+0C0h+var_CC]
+  .text:00000001802A0E19                 mov     [rsp+1C0h+var_198], eax
+  .text:00000001802A0E1D                 mov     [rsp+1C0h+var_1A0], r8d
+  .text:00000001802A0E22                 mov     r8, [rbp+0C0h+var_E0]
+  .text:00000001802A0E26                 call    CEntitySystem_CreateEntity
+  .text:00000001802A0E2B                 mov     r15, rax
+  .text:00000001802A0E2E                 test    rax, rax
+  .text:00000001802A0E31                 jz      loc_1802A13C5
+  .text:00000001802A0E37                 mov     rdx, [rax+10h]
+  .text:00000001802A0E3B                 test    rdx, rdx
+  .text:00000001802A0E3E                 jz      short loc_1802A0E6E
+  .text:00000001802A0E40                 mov     ecx, [rdx+30h]
+  .text:00000001802A0E43                 mov     ebx, 7FFFh
+  .text:00000001802A0E48                 mov     edx, [rdx+10h]
+  .text:00000001802A0E4B                 and     ecx, 1
+  .text:00000001802A0E4E                 mov     r8d, edx
+  .text:00000001802A0E51                 mov     eax, edx
+  .text:00000001802A0E53                 shr     r8d, 0Fh
+  .text:00000001802A0E57                 and     eax, 7FFFh
+  .text:00000001802A0E5C                 sub     r8d, ecx
+  .text:00000001802A0E5F                 cmp     edx, r12d
+  .text:00000001802A0E62                 cmovnz  ebx, eax
+  .text:00000001802A0E65                 shl     r8d, 0Fh
+  .text:00000001802A0E69                 or      ebx, r8d
+  .text:00000001802A0E6C                 jmp     short loc_1802A0E71
+  .text:00000001802A0E6E                 mov     ebx, r12d
+  .text:00000001802A0E71                 mov     rcx, cs:g_pGameResourceService
+  .text:00000001802A0E78                 lea     rdx, [rbp+0C0h+var_C0]
+  .text:00000001802A0E7C                 mov     [rbp+0C0h+var_110], r14d
+  .text:00000001802A0E80                 lea     r9, [rbp+0C0h+var_120]
+  .text:00000001802A0E84                 mov     [rbp+0C0h+var_10C], 1FFFFh
+  .text:00000001802A0E8B                 mov     r8d, 1
+  .text:00000001802A0E91                 mov     rax, [r15+10h]
+  .text:00000001802A0E95                 mov     [rbp+0C0h+var_120], rax
+  .text:00000001802A0E99                 mov     rax, [rbp+0C0h+var_F0]
+  .text:00000001802A0E9D                 mov     [rbp+0C0h+var_118], rax
+  .text:00000001802A0EA1                 mov     rax, [rcx]
+  .text:00000001802A0EA4                 mov     qword ptr [rsp+1C0h+var_1A0], rdx
+  .text:00000001802A0EA9                 mov     edx, [rbp+0C0h+var_CC]
+  .text:00000001802A0EAC                 call    qword ptr [rax+118h]
+  .text:00000001802A0EB2                 mov     rax, [r15+10h]
+  .text:00000001802A0EB6                 mov     ecx, [rax+30h]
+  .text:00000001802A0EB9                 shr     ecx, 9
+  .text:00000001802A0EBC                 test    cl, 1
+  .text:00000001802A0EBF                 jnz     loc_1802A13C5
+  .text:00000001802A0EC5                 mov     r8, [rbp+0C0h+var_F0]
+  .text:00000001802A0EC9                 mov     rdx, r15
+  .text:00000001802A0ECC                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A0ED3                 call    CEntitySystem_QueueSpawnEntity
+  .text:00000001802A0ED8                 cmp     [rbp+0C0h+var_70], 0
+  .text:00000001802A0EDD                 jnz     short loc_1802A0EEB
+  .text:00000001802A0EDF                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A0EE6                 call    CEntitySystem_ExecuteQueuedCreation
+  .text:00000001802A0EEB                 mov     r14, [rbp+0C0h+var_88]
+  .text:00000001802A0EEF                 mov     r12, [rbp+0C0h+var_F0]
+  .text:00000001802A0EF3                 test    r14, r14
+  .text:00000001802A0EF6                 jz      short loc_1802A0F24
+  .text:00000001802A0EF8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001802A0F00                 mov     rcx, [r14+48h]
+  .text:00000001802A0F04                 test    rcx, rcx
+  .text:00000001802A0F07                 jnz     short loc_1802A0F0F
+  .text:00000001802A0F09                 cmp     [r14+50h], rcx
+  .text:00000001802A0F0D                 jz      short loc_1802A0F1B
+  .text:00000001802A0F0F                 mov     rax, [r14+50h]
+  .text:00000001802A0F13                 mov     r8, r12
+  .text:00000001802A0F16                 mov     rdx, r15
+  .text:00000001802A0F19                 call    rax
+  .text:00000001802A0F1B                 mov     r14, [r14+38h]
+  .text:00000001802A0F1F                 test    r14, r14
+  .text:00000001802A0F22                 jnz     short loc_1802A0F00
+  .text:00000001802A0F24                 mov     rax, [rbp+0C0h+var_100]
+  .text:00000001802A0F28                 mov     r8, [rax+8]
+  .text:00000001802A0F2C                 lea     rax, nullsub_30
+  .text:00000001802A0F33                 cmp     r8, rax
+  .text:00000001802A0F36                 jz      short loc_1802A0F42
+  .text:00000001802A0F38                 mov     rdx, r15
+  .text:00000001802A0F3B                 lea     rcx, [rbp+0C0h+var_100]
+  .text:00000001802A0F3F                 call    r8
+  .text:00000001802A0F42                 call    rdi
+  .text:00000001802A0F44                 mov     r15d, 0FFFFFFFFh
+  .text:00000001802A0F4A                 cmp     ebx, r15d
+  .text:00000001802A0F4D                 jz      loc_1802A13C7
+  .text:00000001802A0F53                 mov     rcx, cs:qword_181D958F8
+  .text:00000001802A0F5A                 test    rcx, rcx
+  .text:00000001802A0F5D                 jz      loc_1802A13C7
+  .text:00000001802A0F63                 cmp     ebx, 0FFFFFFFEh
+  .text:00000001802A0F66                 jz      short loc_1802A0F9C
+  .text:00000001802A0F68                 mov     eax, ebx
+  .text:00000001802A0F6A                 and     eax, 7FFFh
+  .text:00000001802A0F6F                 mov     edx, eax
+  .text:00000001802A0F71                 shr     rax, 9
+  .text:00000001802A0F75                 mov     r8, [rcx+rax*8]
+  .text:00000001802A0F79                 test    r8, r8
+  .text:00000001802A0F7C                 jz      short loc_1802A0F9C
+  .text:00000001802A0F7E                 mov     eax, edx
+  .text:00000001802A0F80                 and     eax, 1FFh
+  .text:00000001802A0F85                 imul    rdi, rax, 70h ; 'p'
+  .text:00000001802A0F89                 add     rdi, r8
+  .text:00000001802A0F8C                 jz      short loc_1802A0F9C
+  .text:00000001802A0F8E                 cmp     [rdi+10h], ebx
+  .text:00000001802A0F91                 mov     eax, 0
+  .text:00000001802A0F96                 cmovnz  rdi, rax
+  .text:00000001802A0F9A                 jmp     short loc_1802A0FA0
+  .text:00000001802A0F9C                 xor     eax, eax
+  .text:00000001802A0F9E                 mov     edi, eax
+  .text:00000001802A0FA0                 test    rdi, rdi
+  .text:00000001802A0FA3                 jz      loc_1802A13C7
+  .text:00000001802A0FA9                 mov     rdi, [rdi]
+  .text:00000001802A0FAC                 test    rdi, rdi
+  .text:00000001802A0FAF                 jz      loc_1802A13C7
+  .text:00000001802A0FB5                 mov     r14d, [rsi]
+  .text:00000001802A0FB8                 mov     r12d, 0FFFFFFFFh
+  .text:00000001802A0FBE                 movaps  [rsp+1C0h+var_38+8], xmm6
+  .text:00000001802A0FC6                 cmp     [rdi+76Ch], r14d
+  .text:00000001802A0FCD                 jz      short loc_1802A0FE8
+  .text:00000001802A0FCF                 mov     r8d, r15d
+  .text:00000001802A0FD2                 lea     rcx, [rdi+76Ch]
+  .text:00000001802A0FD9                 mov     edx, r12d
+  .text:00000001802A0FDC                 call    sub_1802B2220
+  .text:00000001802A0FE1                 mov     [rdi+76Ch], r14d
+  .text:00000001802A0FE8                 mov     r14d, [rsi+4]
+  .text:00000001802A0FEC                 cmp     [rdi+770h], r14d
+  .text:00000001802A0FF3                 jz      short loc_1802A100E
+  .text:00000001802A0FF5                 mov     r8d, r15d
+  .text:00000001802A0FF8                 lea     rcx, [rdi+770h]
+  .text:00000001802A0FFF                 mov     edx, r12d
+  .text:00000001802A1002                 call    sub_1802B2360
+  .text:00000001802A1007                 mov     [rdi+770h], r14d
+  .text:00000001802A100E                 mov     r14d, [rsi+50h]
+  .text:00000001802A1012                 cmp     [rdi+774h], r14d
+  .text:00000001802A1019                 jz      short loc_1802A1034
+  .text:00000001802A101B                 mov     r8d, r15d
+  .text:00000001802A101E                 lea     rcx, [rdi+774h]
+  .text:00000001802A1025                 mov     edx, r12d
+  .text:00000001802A1028                 call    sub_1802B20E0
+  .text:00000001802A102D                 mov     [rdi+774h], r14d
+  .text:00000001802A1034                 mov     r14d, [rsi+3Ch]
+  .text:00000001802A1038                 cmp     [rdi+7A8h], r14d
+  .text:00000001802A103F                 jz      short loc_1802A105A
+  .text:00000001802A1041                 mov     r8d, r15d
+  .text:00000001802A1044                 lea     rcx, [rdi+7A8h]
+  .text:00000001802A104B                 mov     edx, r12d
+  .text:00000001802A104E                 call    sub_1802B1830
+  .text:00000001802A1053                 mov     [rdi+7A8h], r14d
+  .text:00000001802A105A                 movss   xmm0, dword ptr [rsi+8]
+  .text:00000001802A105F                 lea     rbx, [rdi+778h]
+  .text:00000001802A1066                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A1069                 jp      short loc_1802A1087
+  .text:00000001802A106B                 jnz     short loc_1802A1087
+  .text:00000001802A106D                 movss   xmm0, dword ptr [rsi+0Ch]
+  .text:00000001802A1072                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A1076                 jp      short loc_1802A1087
+  .text:00000001802A1078                 jnz     short loc_1802A1087
+  .text:00000001802A107A                 movss   xmm0, dword ptr [rsi+10h]
+  .text:00000001802A107F                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A1083                 jp      short loc_1802A1087
+  .text:00000001802A1085                 jz      short loc_1802A10A4
+  .text:00000001802A1087                 mov     r8d, r15d
+  .text:00000001802A108A                 mov     edx, r12d
+  .text:00000001802A108D                 mov     rcx, rbx
+  .text:00000001802A1090                 call    sub_1802B24A0
+  .text:00000001802A1095                 movsd   xmm0, qword ptr [rsi+8]
+  .text:00000001802A109A                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A109E                 mov     eax, [rsi+10h]
+  .text:00000001802A10A1                 mov     [rbx+8], eax
+  .text:00000001802A10A4                 movss   xmm0, dword ptr [rsi+14h]
+  .text:00000001802A10A9                 lea     rbx, [rdi+784h]
+  .text:00000001802A10B0                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A10B3                 jp      short loc_1802A10D1
+  .text:00000001802A10B5                 jnz     short loc_1802A10D1
+  .text:00000001802A10B7                 movss   xmm0, dword ptr [rsi+18h]
+  .text:00000001802A10BC                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A10C0                 jp      short loc_1802A10D1
+  .text:00000001802A10C2                 jnz     short loc_1802A10D1
+  .text:00000001802A10C4                 movss   xmm0, dword ptr [rsi+1Ch]
+  .text:00000001802A10C9                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A10CD                 jp      short loc_1802A10D1
+  .text:00000001802A10CF                 jz      short loc_1802A10EE
+  .text:00000001802A10D1                 mov     r8d, r15d
+  .text:00000001802A10D4                 mov     edx, r12d
+  .text:00000001802A10D7                 mov     rcx, rbx
+  .text:00000001802A10DA                 call    sub_1802B29A0
+  .text:00000001802A10DF                 movsd   xmm0, qword ptr [rsi+14h]
+  .text:00000001802A10E4                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A10E8                 mov     eax, [rsi+1Ch]
+  .text:00000001802A10EB                 mov     [rbx+8], eax
+  .text:00000001802A10EE                 movss   xmm0, dword ptr [rsi+20h]
+  .text:00000001802A10F3                 lea     rbx, [rdi+790h]
+  .text:00000001802A10FA                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A10FD                 jp      short loc_1802A111B
+  .text:00000001802A10FF                 jnz     short loc_1802A111B
+  .text:00000001802A1101                 movss   xmm0, dword ptr [rsi+24h]
+  .text:00000001802A1106                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A110A                 jp      short loc_1802A111B
+  .text:00000001802A110C                 jnz     short loc_1802A111B
+  .text:00000001802A110E                 movss   xmm0, dword ptr [rsi+28h]
+  .text:00000001802A1113                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A1117                 jp      short loc_1802A111B
+  .text:00000001802A1119                 jz      short loc_1802A1138
+  .text:00000001802A111B                 mov     r8d, r15d
+  .text:00000001802A111E                 mov     edx, r12d
+  .text:00000001802A1121                 mov     rcx, rbx
+  .text:00000001802A1124                 call    sub_1802B25E0
+  .text:00000001802A1129                 movsd   xmm0, qword ptr [rsi+20h]
+  .text:00000001802A112E                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A1132                 mov     eax, [rsi+28h]
+  .text:00000001802A1135                 mov     [rbx+8], eax
+  .text:00000001802A1138                 movss   xmm0, dword ptr [rsi+2Ch]
+  .text:00000001802A113D                 lea     rbx, [rdi+79Ch]
+  .text:00000001802A1144                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A1147                 jp      short loc_1802A1165
+  .text:00000001802A1149                 jnz     short loc_1802A1165
+  .text:00000001802A114B                 movss   xmm0, dword ptr [rsi+30h]
+  .text:00000001802A1150                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A1154                 jp      short loc_1802A1165
+  .text:00000001802A1156                 jnz     short loc_1802A1165
+  .text:00000001802A1158                 movss   xmm0, dword ptr [rsi+34h]
+  .text:00000001802A115D                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A1161                 jp      short loc_1802A1165
+  .text:00000001802A1163                 jz      short loc_1802A1182
+  .text:00000001802A1165                 mov     r8d, r15d
+  .text:00000001802A1168                 mov     edx, r12d
+  .text:00000001802A116B                 mov     rcx, rbx
+  .text:00000001802A116E                 call    sub_1802B2860
+  .text:00000001802A1173                 movsd   xmm0, qword ptr [rsi+2Ch]
+  .text:00000001802A1178                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A117C                 mov     eax, [rsi+34h]
+  .text:00000001802A117F                 mov     [rbx+8], eax
+  .text:00000001802A1182                 mov     r14d, [rsi+40h]
+  .text:00000001802A1186                 cmp     [rdi+7ACh], r14d
+  .text:00000001802A118D                 jz      short loc_1802A11A8
+  .text:00000001802A118F                 mov     r8d, r15d
+  .text:00000001802A1192                 lea     rcx, [rdi+7ACh]
+  .text:00000001802A1199                 mov     edx, r12d
+  .text:00000001802A119C                 call    sub_1802B1470
+  .text:00000001802A11A1                 mov     [rdi+7ACh], r14d
+  .text:00000001802A11A8                 mov     r14d, [rsi+44h]
+  .text:00000001802A11AC                 cmp     [rdi+7B0h], r14d
+  .text:00000001802A11B3                 jz      short loc_1802A11CE
+  .text:00000001802A11B5                 mov     r8d, r15d
+  .text:00000001802A11B8                 lea     rcx, [rdi+7B0h]
+  .text:00000001802A11BF                 mov     edx, r12d
+  .text:00000001802A11C2                 call    sub_1802B15B0
+  .text:00000001802A11C7                 mov     [rdi+7B0h], r14d
+  .text:00000001802A11CE                 mov     r14d, [rsi+48h]
+  .text:00000001802A11D2                 cmp     [rdi+7B8h], r14d
+  .text:00000001802A11D9                 jz      short loc_1802A11F4
+  .text:00000001802A11DB                 mov     r8d, r15d
+  .text:00000001802A11DE                 lea     rcx, [rdi+7B8h]
+  .text:00000001802A11E5                 mov     edx, r12d
+  .text:00000001802A11E8                 call    sub_1802B1970
+  .text:00000001802A11ED                 mov     [rdi+7B8h], r14d
+  .text:00000001802A11F4                 movss   xmm6, dword ptr [rsi+4Ch]
+  .text:00000001802A11F9                 movss   xmm0, dword ptr [rdi+7B4h]
+  .text:00000001802A1201                 ucomiss xmm0, xmm6
+  .text:00000001802A1204                 jp      short loc_1802A1208
+  .text:00000001802A1206                 jz      short loc_1802A1222
+  .text:00000001802A1208                 mov     r8d, r15d
+  .text:00000001802A120B                 lea     rcx, [rdi+7B4h]
+  .text:00000001802A1212                 mov     edx, r12d
+  .text:00000001802A1215                 call    sub_1802B0E20
+  .text:00000001802A121A                 movss   dword ptr [rdi+7B4h], xmm6
+  .text:00000001802A1222                 cmp     byte ptr [rdi+7BCh], 1
+  .text:00000001802A1229                 movaps  xmm6, [rsp+1C0h+var_38+8]
+  .text:00000001802A1231                 jz      short loc_1802A124C
+  .text:00000001802A1233                 mov     r8d, r15d
+  .text:00000001802A1236                 lea     rcx, [rdi+7BCh]
+  .text:00000001802A123D                 mov     edx, r12d
+  .text:00000001802A1240                 call    sub_1802B1E70
+  .text:00000001802A1245                 mov     byte ptr [rdi+7BCh], 1
+  .text:00000001802A124C                 cmp     qword ptr [r13+10h], 80h
+  .text:00000001802A1254                 jnz     loc_1802A13C7
+  .text:00000001802A125A                 xor     ebx, ebx
+  .text:00000001802A125C                 mov     r14d, ebx
+  .text:00000001802A125F                 mov     esi, ebx
+  .text:00000001802A1261                 mov     r15d, ebx
+  .text:00000001802A1264                 cmp     qword ptr [r13+18h], 0Fh
+  .text:00000001802A1269                 mov     rax, r13
+  .text:00000001802A126C                 jbe     short loc_1802A1272
+  .text:00000001802A126E                 mov     rax, [r13+0]
+  .text:00000001802A1272                 movzx   r12d, byte ptr [rsi+rax]
+  .text:00000001802A1277                 cmp     [r15+rdi+7BDh], r12b
+  .text:00000001802A127F                 jz      loc_1802A13AD
+  .text:00000001802A1285                 xorps   xmm0, xmm0
+  .text:00000001802A1288                 mov     [rsp+1C0h+var_160], 1
+  .text:00000001802A1290                 mov     eax, 0FFFFFFFFh
+  .text:00000001802A1295                 movdqa  [rbp+0C0h+var_140], xmm0
+  .text:00000001802A129A                 xor     edx, edx
+  .text:00000001802A129C                 mov     [rbp+0C0h+var_128], eax
+  .text:00000001802A129F                 xor     ecx, ecx
+  .text:00000001802A12A1                 mov     [rsp+1C0h+var_150], rbx
+  .text:00000001802A12A6                 mov     r9d, 4
+  .text:00000001802A12AC                 mov     [rsp+1C0h+var_148], 0
+  .text:00000001802A12B5                 mov     r8d, 1
+  .text:00000001802A12BB                 mov     dword ptr [rsp+1C0h+var_158], ebx
+  .text:00000001802A12BF                 mov     [rbp+0C0h+var_130], 0FFFFFFFFh
+  .text:00000001802A12C6                 mov     [rbp+0C0h+var_12C], r14d
+  .text:00000001802A12CA                 mov     [rbp+0C0h+var_124], 0
+  .text:00000001802A12D0                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001802A12D6                 mov     ebx, eax
+  .text:00000001802A12D8                 cmp     eax, 1
+  .text:00000001802A12DB                 jge     short loc_1802A12EF
+  .text:00000001802A12DD                 nop     dword ptr [rax]
+  .text:00000001802A12E0                 lea     eax, [rbx+1]
+  .text:00000001802A12E3                 cdq
+  .text:00000001802A12E4                 sub     eax, edx
+  .text:00000001802A12E6                 sar     eax, 1
+  .text:00000001802A12E8                 mov     ebx, eax
+  .text:00000001802A12EA                 cmp     eax, 1
+  .text:00000001802A12ED                 jl      short loc_1802A12E0
+  .text:00000001802A12EF                 movsxd  r9, dword ptr [rsp+1C0h+var_148]
+  .text:00000001802A12F4                 mov     rcx, [rsp+1C0h+var_150]
+  .text:00000001802A12F9                 shl     r9, 2
+  .text:00000001802A12FD                 test    dword ptr [rsp+1C0h+var_148+4], 0C0000000h
+  .text:00000001802A1305                 mov     r8d, ebx
+  .text:00000001802A1308                 setz    dl
+  .text:00000001802A130B                 shl     r8, 2
+  .text:00000001802A130F                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001802A1315                 mov     ecx, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A1319                 mov     [rsp+1C0h+var_150], rax
+  .text:00000001802A131E                 test    ecx, 0C0000000h
+  .text:00000001802A1324                 jz      short loc_1802A1330
+  .text:00000001802A1326                 and     ecx, 3FFFFFFFh
+  .text:00000001802A132C                 mov     dword ptr [rsp+1C0h+var_148+4], ecx
+  .text:00000001802A1330                 inc     dword ptr [rsp+1C0h+var_158]
+  .text:00000001802A1334                 lea     rdx, [rsp+1C0h+var_160]
+  .text:00000001802A1339                 mov     dword ptr [rsp+1C0h+var_148], ebx
+  .text:00000001802A133D                 mov     rcx, rdi
+  .text:00000001802A1340                 mov     dword ptr [rax], 7BDh
+  .text:00000001802A1346                 mov     rax, [rdi]
+  .text:00000001802A1349                 call    qword ptr [rax+0E0h]
+  .text:00000001802A134F                 mov     eax, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A1353                 xor     ebx, ebx
+  .text:00000001802A1355                 mov     rdx, [rsp+1C0h+var_150]
+  .text:00000001802A135A                 mov     dword ptr [rsp+1C0h+var_158], ebx
+  .text:00000001802A135E                 test    eax, 0C0000000h
+  .text:00000001802A1363                 jnz     short loc_1802A13A5
+  .text:00000001802A1365                 test    rdx, rdx
+  .text:00000001802A1368                 jz      short loc_1802A1385
+  .text:00000001802A136A                 mov     rax, cs:g_pMemAlloc
+  .text:00000001802A1371                 mov     rcx, [rax]
+  .text:00000001802A1374                 mov     rax, [rcx]
+  .text:00000001802A1377                 call    qword ptr [rax+18h]
+  .text:00000001802A137A                 mov     eax, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A137E                 mov     edx, ebx
+  .text:00000001802A1380                 mov     [rsp+1C0h+var_150], rbx
+  .text:00000001802A1385                 mov     dword ptr [rsp+1C0h+var_148], ebx
+  .text:00000001802A1389                 test    eax, 0C0000000h
+  .text:00000001802A138E                 jnz     short loc_1802A13A5
+  .text:00000001802A1390                 test    rdx, rdx
+  .text:00000001802A1393                 jz      short loc_1802A13A5
+  .text:00000001802A1395                 mov     rax, cs:g_pMemAlloc
+  .text:00000001802A139C                 mov     rcx, [rax]
+  .text:00000001802A139F                 mov     rax, [rcx]
+  .text:00000001802A13A2                 call    qword ptr [rax+18h]
+  .text:00000001802A13A5                 mov     [rsi+rdi+7BDh], r12b
+  .text:00000001802A13AD                 inc     r14d
+  .text:00000001802A13B0                 inc     r15
+  .text:00000001802A13B3                 inc     rsi
+  .text:00000001802A13B6                 cmp     r14d, 80h
+  .text:00000001802A13BD                 jl      loc_1802A1264
+  .text:00000001802A13C3                 jmp     short loc_1802A13C7
+  .text:00000001802A13C5                 call    rdi
+  .text:00000001802A13C7                 mov     r15, [rsp+1C0h+var_20]
+  .text:00000001802A13CF                 mov     rbx, [rbp+0C0h+var_F0]
+  .text:00000001802A13D3                 lea     rax, ??_7?$CEntitySpawnerBase@VCPlayerSprayDecal@@@@6B@; const CEntitySpawnerBase<CPlayerSprayDecal>::`vftable'
+  .text:00000001802A13DA                 mov     r14, [rsp+1C0h+var_18]
+  .text:00000001802A13E2                 mov     r13, [rsp+1C0h+var_10]
+  .text:00000001802A13EA                 mov     r12, [rsp+1B8h]
+  .text:00000001802A13F2                 mov     rdi, [rsp+1C0h+arg_18]
+  .text:00000001802A13FA                 mov     rsi, [rsp+1C0h+arg_10]
+  .text:00000001802A1402                 mov     [rbp+0C0h+var_100], rax
+  .text:00000001802A1406                 test    rbx, rbx
+  .text:00000001802A1409                 jz      short loc_1802A1471
+  .text:00000001802A140B                 cmp     byte ptr [rbx+24h], 0
+  .text:00000001802A140F                 jz      short loc_1802A1451
+  .text:00000001802A1411                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001802A1418                 mov     edx, 2
+  .text:00000001802A141D                 mov     ecx, [rcx]
+  .text:00000001802A141F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001802A1425                 test    al, al
+  .text:00000001802A1427                 jz      short loc_1802A1451
+  .text:00000001802A1429                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001802A1430                 lea     r8, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:00000001802A1437                 movsx   eax, word ptr [rbx+20h]
+  .text:00000001802A143B                 mov     r9, rbx
+  .text:00000001802A143E                 dec     eax
+  .text:00000001802A1440                 mov     edx, 2
+  .text:00000001802A1445                 mov     [rsp+1C0h+var_1A0], eax
+  .text:00000001802A1449                 mov     ecx, [rcx]
+  .text:00000001802A144B                 call    cs:LoggingSystem_Log
+  .text:00000001802A1451                 dec     word ptr [rbx+20h]
+  .text:00000001802A1455                 cmp     word ptr [rbx+20h], 0
+  .text:00000001802A145A                 jg      short loc_1802A1471
+  .text:00000001802A145C                 mov     rcx, rbx
+  .text:00000001802A145F                 call    sub_1811FF380
+  .text:00000001802A1464                 mov     edx, 38h ; '8'
+  .text:00000001802A1469                 mov     rcx, rbx
+  .text:00000001802A146C                 call    sub_180E77290
+  .text:00000001802A1471                 cmp     [rbp+0C0h+var_D8], 0
+  .text:00000001802A1476                 mov     rbx, [rsp+1C0h+arg_8]
+  .text:00000001802A147E                 jz      short loc_1802A148A
+  .text:00000001802A1480                 lea     rcx, [rbp+0C0h+var_D8]
+  .text:00000001802A1484                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:00000001802A148A                 add     rsp, 1C0h
+  .text:00000001802A1491                 pop     rbp
+  .text:00000001802A1492                 retn
+procedure: |-
+  void __fastcall CEntitySpawner_CPlayerSprayDecal_Spawn(int *a1, _QWORD *a2)
+  {
+    __int64 v4; // rbx
+    _OWORD *v5; // rax
+    __int128 v6; // xmm0
+    char v7; // al
+    __int64 v8; // rax
+    __int64 v9; // r9
+    __int64 v10; // rax
+    int v11; // edx
+    int v12; // r8d
+    __int64 v13; // rbx
+    __int64 v14; // rax
+    void (*v15)(void); // rdi
+    __int64 v16; // rbx
+    __int64 v17; // r14
+    __int64 v18; // rax
+    char *v19; // r9
+    __int64 Entity; // rax
+    __int64 v21; // r15
+    __int64 v22; // rdx
+    int v23; // ecx
+    int v24; // ebx
+    unsigned int v25; // edx
+    int v26; // ebx
+    __int64 v27; // r14
+    __int64 i; // r12
+    __int64 v29; // rcx
+    __int64 (__fastcall *v30)(); // r8
+    __int64 v31; // r8
+    __int64 *v32; // rdi
+    __int64 v33; // rdi
+    int v34; // r14d
+    int v35; // r14d
+    int v36; // r14d
+    int v37; // r14d
+    int v38; // r14d
+    int v39; // r14d
+    int v40; // r14d
+    float v41; // xmm6_4
+    int v42; // r14d
+    __int64 v43; // rsi
+    __int64 v44; // r15
+    _QWORD *v45; // rax
+    char v46; // r12
+    __int64 v47; // rdx
+    int j; // ebx
+    _DWORD *v49; // rax
+    int v50; // eax
+    _DWORD *v51; // rdx
+    __int16 *v52; // rbx
+    __int128 v53; // [rsp+48h] [rbp-C0h] BYREF
+    const char *v54; // [rsp+58h] [rbp-B0h]
+    int v55; // [rsp+68h] [rbp-A0h] BYREF
+    __int64 v56; // [rsp+70h] [rbp-98h]
+    _DWORD *v57; // [rsp+78h] [rbp-90h]
+    __int64 v58; // [rsp+80h] [rbp-88h]
+    __int128 v59; // [rsp+88h] [rbp-80h]
+    int v60; // [rsp+98h] [rbp-70h]
+    int v61; // [rsp+9Ch] [rbp-6Ch]
+    int v62; // [rsp+A0h] [rbp-68h]
+    __int16 v63; // [rsp+A4h] [rbp-64h]
+    _QWORD v64[2]; // [rsp+A8h] [rbp-60h] BYREF
+    int v65; // [rsp+B8h] [rbp-50h]
+    int v66; // [rsp+BCh] [rbp-4Ch]
+    _QWORD v67[2]; // [rsp+C8h] [rbp-40h] BYREF
+    __int64 v68; // [rsp+D8h] [rbp-30h]
+    __int64 v69; // [rsp+E0h] [rbp-28h]
+    __int64 v70; // [rsp+E8h] [rbp-20h]
+    char *v71; // [rsp+F0h] [rbp-18h] BYREF
+    int v72; // [rsp+F8h] [rbp-10h]
+    unsigned int v73; // [rsp+FCh] [rbp-Ch]
+    _OWORD v74[3]; // [rsp+108h] [rbp+0h] BYREF
+    char v75; // [rsp+138h] [rbp+30h]
+    char v76; // [rsp+139h] [rbp+31h]
+    __int64 v77; // [rsp+140h] [rbp+38h]
+    __int64 v78; // [rsp+158h] [rbp+50h]
+    __int64 v79; // [rsp+160h] [rbp+58h]
+    char v80; // [rsp+168h] [rbp+60h]
+    __int128 v81; // [rsp+178h] [rbp+70h] BYREF
+    const char *v82; // [rsp+188h] [rbp+80h]
+    char v83; // [rsp+1D8h] [rbp+D0h] BYREF
+
+    v4 = g_pEntitySystem + 3272;  // 3272 = 0xCC8 = CEntitySystem::m_EntityKeyValuesAllocator (structmember, struct=CEntitySystem, member=m_EntityKeyValuesAllocator)
+    v71 = nullptr;
+    v67[0] = &CEntitySpawner<CPlayerSprayDecal>::`vftable';
+    v76 = 0;
+    v77 = 0;
+    v78 = 0;
+    v79 = -1;
+    v80 = 0;
+    v73 = sub_1811F0000(g_pEntitySystem);
+    v5 = (_OWORD *)sub_1811F0300(g_pEntitySystem);
+    v74[0] = *v5;
+    v74[1] = v5[1];
+    v6 = v5[2];
+    v70 = qword_181DE6248;
+    v74[2] = v6;
+    v68 = 0;
+    v69 = v4;
+    if ( !qword_182117A80
+      || (v7 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_182117A80 + 200LL))(qword_182117A80), v75 = 1, !v7) )
+    {
+      v75 = 0;
+    }
+    v72 = 0;
+    if ( *(__int64 (__fastcall **)())v67[0] == sub_1802B65D0 )
+      sub_1802B6690(v67);
+    else
+      (*(void (__fastcall **)(_QWORD *))v67[0])(v67);
+    sub_1801B26C0(v64, a1 + 2);
+    *((_QWORD *)&v53 + 1) = "origin";
+    *(_QWORD *)&v53 = -467664362;
+    sub_1802B5B20(v68, &v53, v64);
+    *((_QWORD *)&v53 + 1) = "angles";
+    *(_QWORD *)&v53 = -1164387633;
+    v8 = sub_1811FFFC0(v68, &v53);
+    if ( v8 )
+    {
+      LOBYTE(v9) = 34;
+      sub_1814DC620(v8, 3, &qword_18159B9F0, v9);
+    }
+    *((_QWORD *)&v53 + 1) = "owner";
+    *(_QWORD *)&v53 = -1104771937;
+    v10 = sub_1811FFFC0(v68, &v53);
+    v13 = v10;
+    if ( v10 )
+    {
+      LOBYTE(v12) = 38;
+      LOBYTE(v11) = 4;
+      sub_1814D79A0(v10, v11, v12, 0, 0, 0, 0);
+      *(_QWORD *)(v13 + 8) = 0xFFFFFFFFLL;
+    }
+    if ( v68 )
+    {
+      *((_QWORD *)&v53 + 1) = 1211;
+      *(_QWORD *)&v53 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\shared\\entityspawner.h";
+      v54 = "Spawn";
+      v82 = "Spawn";
+      v81 = v53;
+      v14 = VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(
+              "CEntitySpawner<class CPlayerSprayDecal>::Spawn",
+              &off_181B756B8,
+              &v81);
+      *((_QWORD *)&v53 + 1) = "classname";
+      *(_QWORD *)&v53 = -971301790;
+      v15 = (void (*)(void))v14;
+      if ( !sub_1811FFEB0(v68, &v53, &v83) || v83 )
+      {
+        v16 = **(_QWORD **)(v70 + 80);
+        if ( v16 )
+        {
+          v17 = v68;
+          *(_QWORD *)&v53 = -971301790;
+          *((_QWORD *)&v53 + 1) = "classname";
+          v18 = sub_1811FFFC0(v68, &v53);
+          if ( v18 )
+            sub_181200E20(v17, v18, v16);
+        }
+      }
+      v19 = byte_18159B988;
+      if ( v71 )
+        v19 = v71;
+      Entity = CEntitySystem_CreateEntity((_DWORD *)g_pEntitySystem, v73, v70, v19, v72, v79, HIDWORD(v79), 0);
+      v21 = Entity;
+      if ( !Entity )
+        goto LABEL_98;
+      v22 = *(_QWORD *)(Entity + 16);
+      if ( v22 )
+      {
+        v23 = *(_DWORD *)(v22 + 48);
+        v24 = 0x7FFF;
+        v25 = *(_DWORD *)(v22 + 16);
+        if ( v25 != -1 )
+          v24 = v25 & 0x7FFF;
+        v26 = (((v25 >> 15) - (v23 & 1)) << 15) | v24;
+      }
+      else
+      {
+        v26 = -1;
+      }
+      v65 = -1;
+      v66 = 0x1FFFF;
+      v64[0] = *(_QWORD *)(Entity + 16);
+      v64[1] = v68;
+      (*(void (__fastcall **)(__int64, _QWORD, __int64, _QWORD *, _OWORD *))(*(_QWORD *)g_pGameResourceService + 280LL))(
+        g_pGameResourceService,
+        v73,
+        1,
+        v64,
+        v74);
+      if ( (*(_DWORD *)(*(_QWORD *)(v21 + 16) + 48LL) & 0x200) != 0 )
+      {
+  LABEL_98:
+        v15();
+      }
+      else
+      {
+        CEntitySystem_QueueSpawnEntity(g_pEntitySystem, v21);
+        if ( !v78 )
+          CEntitySystem_ExecuteQueuedCreation(g_pEntitySystem);
+        v27 = v77;
+        for ( i = v68; v27; v27 = *(_QWORD *)(v27 + 56) )
+        {
+          v29 = *(_QWORD *)(v27 + 72);
+          if ( v29 || *(_QWORD *)(v27 + 80) )
+            (*(void (__fastcall **)(__int64, __int64, __int64))(v27 + 80))(v29, v21, i);
+        }
+        v30 = *(__int64 (__fastcall **)())(v67[0] + 8LL);
+        if ( v30 != nullsub_30 )
+          ((void (__fastcall *)(_QWORD *, __int64))v30)(v67, v21);
+        v15();
+        if ( v26 != -1 && qword_181D958F8 )
+        {
+          if ( v26 != -2
+            && (v31 = *(_QWORD *)(qword_181D958F8 + 8 * ((unsigned __int64)(v26 & 0x7FFF) >> 9))) != 0
+            && (v32 = (__int64 *)(v31 + 112LL * (v26 & 0x1FF))) != nullptr )
+          {
+            if ( *((_DWORD *)v32 + 4) != v26 )
+              v32 = nullptr;
+          }
+          else
+          {
+            v32 = nullptr;
+          }
+          if ( v32 )
+          {
+            v33 = *v32;
+            if ( v33 )
+            {
+              v34 = *a1;
+              if ( *(_DWORD *)(v33 + 1900) != *a1 )
+              {
+                sub_1802B2220(v33 + 1900, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1900) = v34;
+              }
+              v35 = a1[1];
+              if ( *(_DWORD *)(v33 + 1904) != v35 )
+              {
+                sub_1802B2360(v33 + 1904, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1904) = v35;
+              }
+              v36 = a1[20];
+              if ( *(_DWORD *)(v33 + 1908) != v36 )
+              {
+                sub_1802B20E0(v33 + 1908, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1908) = v36;
+              }
+              v37 = a1[15];
+              if ( *(_DWORD *)(v33 + 1960) != v37 )
+              {
+                sub_1802B1830(v33 + 1960, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1960) = v37;
+              }
+              if ( *((float *)a1 + 2) != *(float *)(v33 + 1912)
+                || *((float *)a1 + 3) != *(float *)(v33 + 1916)
+                || *((float *)a1 + 4) != *(float *)(v33 + 1920) )
+              {
+                sub_1802B24A0(v33 + 1912, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v33 + 1912) = *((_QWORD *)a1 + 1);
+                *(_DWORD *)(v33 + 1920) = a1[4];
+              }
+              if ( *((float *)a1 + 5) != *(float *)(v33 + 1924)
+                || *((float *)a1 + 6) != *(float *)(v33 + 1928)
+                || *((float *)a1 + 7) != *(float *)(v33 + 1932) )
+              {
+                sub_1802B29A0(v33 + 1924, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v33 + 1924) = *(_QWORD *)(a1 + 5);
+                *(_DWORD *)(v33 + 1932) = a1[7];
+              }
+              if ( *((float *)a1 + 8) != *(float *)(v33 + 1936)
+                || *((float *)a1 + 9) != *(float *)(v33 + 1940)
+                || *((float *)a1 + 10) != *(float *)(v33 + 1944) )
+              {
+                sub_1802B25E0(v33 + 1936, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v33 + 1936) = *((_QWORD *)a1 + 4);
+                *(_DWORD *)(v33 + 1944) = a1[10];
+              }
+              if ( *((float *)a1 + 11) != *(float *)(v33 + 1948)
+                || *((float *)a1 + 12) != *(float *)(v33 + 1952)
+                || *((float *)a1 + 13) != *(float *)(v33 + 1956) )
+              {
+                sub_1802B2860(v33 + 1948, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v33 + 1948) = *(_QWORD *)(a1 + 11);
+                *(_DWORD *)(v33 + 1956) = a1[13];
+              }
+              v38 = a1[16];
+              if ( *(_DWORD *)(v33 + 1964) != v38 )
+              {
+                sub_1802B1470(v33 + 1964, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1964) = v38;
+              }
+              v39 = a1[17];
+              if ( *(_DWORD *)(v33 + 1968) != v39 )
+              {
+                sub_1802B15B0(v33 + 1968, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1968) = v39;
+              }
+              v40 = a1[18];
+              if ( *(_DWORD *)(v33 + 1976) != v40 )
+              {
+                sub_1802B1970(v33 + 1976, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v33 + 1976) = v40;
+              }
+              v41 = *((float *)a1 + 19);
+              if ( *(float *)(v33 + 1972) != v41 )
+              {
+                sub_1802B0E20(v33 + 1972, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(float *)(v33 + 1972) = v41;
+              }
+              if ( *(_BYTE *)(v33 + 1980) != 1 )
+              {
+                sub_1802B1E70(v33 + 1980, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_BYTE *)(v33 + 1980) = 1;
+              }
+              if ( a2[2] == 128 )
+              {
+                v42 = 0;
+                v43 = 0;
+                v44 = 0;
+                do
+                {
+                  v45 = a2;
+                  if ( a2[3] > 0xFu )
+                    v45 = (_QWORD *)*a2;
+                  v46 = *((_BYTE *)v45 + v43);
+                  if ( *(_BYTE *)(v44 + v33 + 1981) != v46 )
+                  {
+                    v55 = 1;
+                    v59 = 0;
+                    v62 = -1;
+                    v57 = nullptr;
+                    v58 = 0;
+                    LODWORD(v56) = 0;
+                    v60 = -1;
+                    v61 = v42;
+                    v63 = 0;
+                    for ( j = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4); j < 1; j = (j + 1) / 2 )
+                      v47 = (unsigned int)((j + 1) >> 31);
+                    LOBYTE(v47) = (v58 & 0xC000000000000000uLL) == 0;
+                    v49 = (_DWORD *)UtlVectorMemory_Alloc(v57, v47, 4LL * (unsigned int)j, 4LL * (int)v58);
+                    v57 = v49;
+                    if ( (v58 & 0xC000000000000000uLL) != 0 )
+                      HIDWORD(v58) &= 0x3FFFFFFFu;
+                    LODWORD(v56) = v56 + 1;
+                    LODWORD(v58) = j;
+                    *v49 = 1981;
+                    (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)v33 + 224LL))(v33, &v55);
+                    v50 = HIDWORD(v58);
+                    v51 = v57;
+                    LODWORD(v56) = 0;
+                    if ( (v58 & 0xC000000000000000uLL) == 0 )
+                    {
+                      if ( v57 )
+                      {
+                        (*(void (__fastcall **)(_QWORD, _DWORD *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v57);
+                        v50 = HIDWORD(v58);
+                        v51 = nullptr;
+                        v57 = nullptr;
+                      }
+                      LODWORD(v58) = 0;
+                      if ( (v50 & 0xC0000000) == 0 && v51 )
+                        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+                    }
+                    *(_BYTE *)(v43 + v33 + 1981) = v46;
+                  }
+                  ++v42;
+                  ++v44;
+                  ++v43;
+                }
+                while ( v42 < 128 );
+              }
+            }
+          }
+        }
+      }
+    }
+    v52 = (__int16 *)v68;
+    v67[0] = &CEntitySpawnerBase<CPlayerSprayDecal>::`vftable';
+    if ( v68 )
+    {
+      if ( *(_BYTE *)(v68 + 36) && (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        LoggingSystem_Log(LOG_GENERAL, 2, "kv 0x%p Release refcount == %d\n", v52, v52[16] - 1);
+      if ( --v52[16] <= 0 )
+      {
+        sub_1811FF380(v52);
+        sub_180E77290((__int64)v52);
+      }
+    }
+    if ( v71 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v71);
+  }


### PR DESCRIPTION
﻿## Summary
- Adds find-CEntitySpawner_CPlayerSprayDecal_Spawn preprocessor script (Pattern A)
- Adds find-CEntitySystem_m_EntityKeyValuesAllocator preprocessor script (Pattern E, LLM_DECOMPILE via CEntitySpawner_CPlayerSprayDecal_Spawn)
- Adds Windows reference YAML for CEntitySpawner_CPlayerSprayDecal_Spawn with m_EntityKeyValuesAllocator annotation at offset 0xCC8

## Known limitation
Linux path for find-CEntitySystem_m_EntityKeyValuesAllocator is blocked: the xref string for CEntitySpawner_CPlayerSprayDecal_Spawn does not appear in the Linux server binary. A Linux-specific discovery method is needed.

## Test plan
- Windows: CEntitySystem_m_EntityKeyValuesAllocator.windows.yaml created successfully at offset 0xCC8
- Linux: blocked pending Linux xref fix for CEntitySpawner_CPlayerSprayDecal_Spawn
