### PR TITLE
feat: add CEntitySystem_m_Symbols to find-CEntitySystem_Init-decompiles

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6295,6 +6295,7 @@ modules:
           - IFlattenedSerializers_CreateFieldChangedEventQueue.{platform}.yaml
           - CEntitySystem_m_sEntSystemName.{platform}.yaml
           - CEntitySystem_m_eNetworkSerializationMode.{platform}.yaml
+          - CEntitySystem_m_Symbols.{platform}.yaml
         expected_input:
           - CEntitySystem_Init.{platform}.yaml
 
@@ -9847,6 +9848,13 @@ modules:
         category: structmember
         struct: CEntitySystem
         member: m_eNetworkSerializationMode
+
+      - name: CEntitySystem_m_Symbols
+        category: structmember
+        struct: CEntitySystem
+        member: m_Symbols
+        alias:
+          - CEntitySystem::m_Symbols
 
       - name: CEntitySystem_m_nSuppressDestroyImmediateCount
         category: structmember

--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -11,6 +11,7 @@ TARGET_FUNCTION_NAMES = [
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_sEntSystemName",
     "CEntitySystem_m_eNetworkSerializationMode",
+    "CEntitySystem_m_Symbols",
 ]
 
 LLM_DECOMPILE = [
@@ -32,6 +33,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_eNetworkSerializationMode",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_Symbols",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -78,6 +84,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_eNetworkSerializationMode",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_Symbols",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -12,9 +12,7 @@ disasm_code: |-
   .text:0000000001E73892                 mov     r12d, edx
   .text:0000000001E73895                 push    rbx
   .text:0000000001E73896                 mov     rbx, rdi
-  .text:0000000001E73899                 ; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
-  .text:0000000001E73899                 ; this
-  .text:0000000001E73899                 add     rdi, 0A88h; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:0000000001E73899                 add     rdi, 0A88h  ; 0A88h = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
   .text:0000000001E738A0                 sub     rsp, 68h
   .text:0000000001E738A4                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
   .text:0000000001E738A9                 lea     rax, unk_27BB9F1
@@ -24,8 +22,7 @@ disasm_code: |-
   .text:0000000001E738BE                 jz      loc_1E73C08
   .text:0000000001E738C4                 lea     r13, qword_2743670
   .text:0000000001E738CB                 xor     eax, eax
-  .text:0000000001E738CD                 ; 0xBDA = 3034 = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
-  .text:0000000001E738CD                 mov     [rbx+0BDAh], al; 0xBDA = 3034 = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
+  .text:0000000001E738CD                 mov     [rbx+0BDAh], al  ; 0BDAh = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
   .text:0000000001E738D3                 ; bool
   .text:0000000001E738D3                 xor     r8d, r8d; bool
   .text:0000000001E738D6                 ; void *
@@ -134,7 +131,7 @@ disasm_code: |-
   .text:0000000001E73AA8                 mov     rax, [rdi]
   .text:0000000001E73AAB                 lea     rsi, aStringTTable; "string_t_table"
   .text:0000000001E73AB2                 mov     edx, [rbx+0BBCh]
-  .text:0000000001E73AB8                 lea     rcx, [rbx+1ED0h]
+  .text:0000000001E73AB8                 lea     rcx, [rbx+1ED0h]  ; 1ED0h = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols)
   .text:0000000001E73ABF                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
   .text:0000000001E73ABF                 call    qword ptr [rax+0A0h]; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
   .text:0000000001E73AC5                 mov     rdi, [r13+0]
@@ -638,11 +635,11 @@ procedure: |-
     __int64 v67; // [rsp+40h] [rbp-50h] BYREF
     __m128i v68; // [rsp+48h] [rbp-48h]
 
-    CUtlString::Set((CUtlString *)(a1 + 2696), a2);// 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+    CUtlString::Set((CUtlString *)(a1 + 2696), a2);  // 2696 = 0xA88 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
     *(_DWORD *)(a1 + 3004) = a4;
     unk_27BB9F1 = a5;
     v9 = a3 == 1 && qword_2743670 != nullptr;
-    *(_BYTE *)(a1 + 3034) = v9;         // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
+    *(_BYTE *)(a1 + 3034) = v9;  // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
     CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3264), 0x400u, 0, nullptr, 0);
     qword_25669A8 = a1;
     qword_25669A0 = a1 + 16;
@@ -854,11 +851,11 @@ procedure: |-
     COM_TimestampedLog("EntitySystem - Class Tables");
     if ( qword_2743670 )
     {
-      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))( // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))(
         qword_2743670,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7888);
+        a1 + 7888);                               // 7888 = 0x1ED0 = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols); 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
       v66 = (__m128i)0x121uLL;
       v20 = _mm_loadu_si128(&v66);
       v21 = *qword_2743670;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -10,8 +10,7 @@ disasm_code: |-
   .text:00000001811F0ADD                 sub     rsp, 0A0h
   .text:00000001811F0AE4                 mov     rsi, rcx
   .text:00000001811F0AE7                 mov     ebx, r9d
-  .text:00000001811F0AEA                 ; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
-  .text:00000001811F0AEA                 add     rcx, 0A88h; 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+  .text:00000001811F0AEA                 add     rcx, 0A88h  ; 0A88h = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
   .text:00000001811F0AF1                 mov     edi, r8d
   .text:00000001811F0AF4                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
   .text:00000001811F0AFA                 movzx   eax, [rsp+0C8h+arg_20]
@@ -25,8 +24,7 @@ disasm_code: |-
   .text:00000001811F0B21                 jmp     short loc_1811F0B25
   .text:00000001811F0B23                 xor     al, al
   .text:00000001811F0B25                 lea     rcx, [rsi+0CB8h]
-  .text:00000001811F0B2C                 ; 0xBDA = 3034 = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
-  .text:00000001811F0B2C                 mov     [rsi+0BDAh], al; 0xBDA = 3034 = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
+  .text:00000001811F0B2C                 mov     [rsi+0BDAh], al  ; 0BDAh = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
   .text:00000001811F0B32                 xor     r9d, r9d
   .text:00000001811F0B35                 mov     byte ptr [rsp+0C8h+var_A8], 0
   .text:00000001811F0B3A                 xor     r8d, r8d
@@ -269,7 +267,7 @@ disasm_code: |-
   .text:00000001811F0F4B                 test    rcx, rcx
   .text:00000001811F0F4E                 jz      short loc_1811F0F94
   .text:00000001811F0F50                 mov     rax, [rcx]
-  .text:00000001811F0F53                 lea     r9, [rsi+1EC8h]
+  .text:00000001811F0F53                 lea     r9, [rsi+1EC8h]  ; 1EC8h = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols)
   .text:00000001811F0F5A                 mov     r8d, [rsi+0BBCh]
   .text:00000001811F0F61                 lea     rdx, aStringTTable; "string_t_table"
   .text:00000001811F0F68                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
@@ -500,11 +498,11 @@ procedure: |-
     int v66; // [rsp+98h] [rbp-30h]
     char v67; // [rsp+D0h] [rbp+8h] BYREF
 
-    CUtlString::Set((CUtlString *)(a1 + 2696), a2);// 0xA88 = 2696 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+    CUtlString::Set((CUtlString *)(a1 + 2696), a2);  // 2696 = 0xA88 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
     byte_1820B15C0 = a5;
     *(_DWORD *)(a1 + 3004) = a4;
     v8 = a3 == 1 && qword_182117C88;
-    *(_BYTE *)(a1 + 3034) = v8;         // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
+    *(_BYTE *)(a1 + 3034) = v8;  // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
     CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);
     v11 = qword_1820B13B8;
     v12 = a1 + 16;
@@ -657,11 +655,11 @@ procedure: |-
     COM_TimestampedLog("EntitySystem - Class Tables", v9, m);
     if ( qword_182117C88 )
     {
-      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))( // 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))(
         qword_182117C88,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7880);
+        a1 + 7880);                               // 7880 = 0x1EC8 = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols); 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
       v35 = *(_QWORD *)qword_182117C88;
       v59 = sub_1811E4FA0;
       v58 = nullptr;


### PR DESCRIPTION
﻿## Summary
- Adds CEntitySystem_m_Symbols struct member offset to find-CEntitySystem_Init-decompiles.py
- Re-generates reference YAMLs for CEntitySystem_Init (both platforms) with annotations for all three struct members: m_sEntSystemName, m_eNetworkSerializationMode, and m_Symbols
- m_Symbols is the string_t symbol table: Windows offset 0x1EC8, Linux offset 0x1ED0

## Test plan
- Windows: CEntitySystem_m_Symbols.windows.yaml created successfully
- Linux: CEntitySystem_m_Symbols.linux.yaml created successfully
- Validation: Successful count increased from 1 to 2, no new failures
