### PR TITLE
Add CCSPlayerPawn_SprayPaint, CEntitySpawner_CPlayerSprayDecal_Spawn, CEntitySystem_m_EntityKeyValuesAllocator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5369,6 +5369,12 @@ modules:
         expected_output:
           - CCSPlayerPawn_SprayPaint.{platform}.yaml
 
+      - name: find-CEntitySpawner_CPlayerSprayDecal_Spawn
+        expected_output:
+          - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
+        expected_input:
+          - CCSPlayerPawn_SprayPaint.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8629,6 +8635,11 @@ modules:
         category: func
         alias:
           - CCSPlayerPawn::SprayPaint
+
+      - name: CEntitySpawner_CPlayerSprayDecal_Spawn
+        category: func
+        alias:
+          - CEntitySpawner<CPlayerSprayDecal>::Spawn
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5375,6 +5375,12 @@ modules:
         expected_input:
           - CCSPlayerPawn_SprayPaint.{platform}.yaml
 
+      - name: find-CEntitySystem_m_EntityKeyValuesAllocator
+        expected_output:
+          - CEntitySystem_m_EntityKeyValuesAllocator.{platform}.yaml
+        expected_input:
+          - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8640,6 +8646,11 @@ modules:
         category: func
         alias:
           - CEntitySpawner<CPlayerSprayDecal>::Spawn
+
+      - name: CEntitySystem_m_EntityKeyValuesAllocator
+        category: structmember
+        struct: CEntitySystem
+        member: m_EntityKeyValuesAllocator
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5365,6 +5365,10 @@ modules:
         expected_input:
           - CCSPlayerPawn_vtable.{platform}.yaml
 
+      - name: find-CCSPlayerPawn_SprayPaint
+        expected_output:
+          - CCSPlayerPawn_SprayPaint.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8620,6 +8624,11 @@ modules:
         category: vfunc
         alias:
           - CCSPlayerPawn::ClientCommand
+
+      - name: CCSPlayerPawn_SprayPaint
+        category: func
+        alias:
+          - CCSPlayerPawn::SprayPaint
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/ida_preprocessor_scripts/find-CCSPlayerPawn_SprayPaint.py
+++ b/ida_preprocessor_scripts/find-CCSPlayerPawn_SprayPaint.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CCSPlayerPawn_SprayPaint skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CCSPlayerPawn_SprayPaint",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CCSPlayerPawn_SprayPaint",
+        "xref_strings": [
+            "SprayCan.Paint",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CCSPlayerPawn_SprayPaint",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySpawner_CPlayerSprayDecal_Spawn.py
+++ b/ida_preprocessor_scripts/find-CEntitySpawner_CPlayerSprayDecal_Spawn.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySpawner_CPlayerSprayDecal_Spawn skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySpawner_CPlayerSprayDecal_Spawn",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntitySpawner_CPlayerSprayDecal_Spawn",
+        "prompt/call_llm_decompile.md",
+        "references/server/CCSPlayerPawn_SprayPaint.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySpawner_CPlayerSprayDecal_Spawn",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_EntityKeyValuesAllocator.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_EntityKeyValuesAllocator.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_EntityKeyValuesAllocator skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_EntityKeyValuesAllocator",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntitySystem_m_EntityKeyValuesAllocator",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_m_EntityKeyValuesAllocator",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "offset_sig",
+            "offset_sig_disp",
+            "offset_sig_max_match:2",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CCSPlayerPawn_SprayPaint.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CCSPlayerPawn_SprayPaint.linux.yaml
@@ -1,0 +1,1816 @@
+func_name: CCSPlayerPawn_SprayPaint
+func_va: '0xa5cec0'
+disasm_code: |-
+  .text:0000000000A5CEC0                 push    rbp
+  .text:0000000000A5CEC1                 mov     rbp, rsp
+  .text:0000000000A5CEC4                 push    r15
+  .text:0000000000A5CEC6                 push    r14
+  .text:0000000000A5CEC8                 push    r13
+  .text:0000000000A5CECA                 push    r12
+  .text:0000000000A5CECC                 mov     r12, rsi
+  .text:0000000000A5CECF                 push    rbx
+  .text:0000000000A5CED0                 mov     rbx, rdi
+  .text:0000000000A5CED3                 sub     rsp, 218h
+  .text:0000000000A5CEDA                 call    sub_A8C4D0
+  .text:0000000000A5CEDF                 test    eax, eax
+  .text:0000000000A5CEE1                 jz      loc_A5D76B
+  .text:0000000000A5CEE7                 lea     rax, g_pGameRules
+  .text:0000000000A5CEEE                 cmp     qword ptr [rax], 0
+  .text:0000000000A5CEF2                 jz      loc_A5D76B
+  .text:0000000000A5CEF8                 test    byte ptr [r12+40h], 1
+  .text:0000000000A5CEFE                 jz      loc_A5D76B
+  .text:0000000000A5CF04                 mov     rax, [r12+48h]
+  .text:0000000000A5CF09                 test    rax, rax
+  .text:0000000000A5CF0C                 jz      loc_A5D870
+  .text:0000000000A5CF12                 mov     r8d, [rax+7Ch]
+  .text:0000000000A5CF16                 test    r8d, r8d
+  .text:0000000000A5CF19                 jz      loc_A5D76B
+  .text:0000000000A5CF1F                 mov     edi, [rax+18h]
+  .text:0000000000A5CF22                 test    edi, edi
+  .text:0000000000A5CF24                 jz      loc_A5D780
+  .text:0000000000A5CF2A                 lea     rdi, [rbp+var_F0]
+  .text:0000000000A5CF31                 xor     eax, eax
+  .text:0000000000A5CF33                 mov     ecx, 0Ah
+  .text:0000000000A5CF38                 mov     [rbp+var_228], rdi
+  .text:0000000000A5CF3F                 rep stosq
+  .text:0000000000A5CF42                 mov     dword ptr [rdi], 0
+  .text:0000000000A5CF48                 mov     rdi, rbx
+  .text:0000000000A5CF4B                 call    sub_A8C4D0
+  .text:0000000000A5CF50                 mov     rdi, [rbp+var_228]
+  .text:0000000000A5CF57                 mov     rsi, r12
+  .text:0000000000A5CF5A                 mov     [rbp+var_F0], eax
+  .text:0000000000A5CF60                 call    sub_A8AC30
+  .text:0000000000A5CF65                 lea     rax, g_pGameRules
+  .text:0000000000A5CF6C                 mov     rax, [rax]
+  .text:0000000000A5CF6F                 mov     ecx, [rax+0E58h]
+  .text:0000000000A5CF75                 mov     [rbp+var_240], rax
+  .text:0000000000A5CF7C                 mov     dword ptr [rbp+var_230], ecx
+  .text:0000000000A5CF82                 test    ecx, ecx
+  .text:0000000000A5CF84                 jle     loc_A5D76B
+  .text:0000000000A5CF8A                 mov     rax, [rax+0E60h]
+  .text:0000000000A5CF91                 xor     r14d, r14d
+  .text:0000000000A5CF94                 xor     r15d, r15d
+  .text:0000000000A5CF97                 mov     [rbp+var_238], rax
+  .text:0000000000A5CF9E                 jmp     short loc_A5CFB7
+  .text:0000000000A5CFA0                 mov     eax, dword ptr [rbp+var_230]
+  .text:0000000000A5CFA6                 add     r15d, 1
+  .text:0000000000A5CFAA                 add     r14, 54h ; 'T'
+  .text:0000000000A5CFAE                 cmp     r15d, eax
+  .text:0000000000A5CFB1                 jz      loc_A5D76B
+  .text:0000000000A5CFB7                 mov     rax, [rbp+var_238]
+  .text:0000000000A5CFBE                 mov     edx, 50h ; 'P'
+  .text:0000000000A5CFC3                 mov     rsi, [rbp+var_228]
+  .text:0000000000A5CFCA                 lea     r13, [rax+r14]
+  .text:0000000000A5CFCE                 mov     rdi, r13
+  .text:0000000000A5CFD1                 call    sub_985C90
+  .text:0000000000A5CFD6                 test    eax, eax
+  .text:0000000000A5CFD8                 jnz     short loc_A5CFA0
+  .text:0000000000A5CFDA                 mov     r14d, dword ptr [rbp+var_230]
+  .text:0000000000A5CFE1                 sub     r14d, 1
+  .text:0000000000A5CFE5                 cmp     r14d, r15d
+  .text:0000000000A5CFE8                 jnz     loc_A5D880
+  .text:0000000000A5CFEE                 mov     rax, [rbp+var_240]
+  .text:0000000000A5CFF5                 mov     [rax+0E58h], r14d
+  .text:0000000000A5CFFC                 mov     r14, [r12+48h]
+  .text:0000000000A5D001                 test    r14, r14
+  .text:0000000000A5D004                 jz      loc_A5D960
+  .text:0000000000A5D00A                 lea     r13, [rbp+var_150]
+  .text:0000000000A5D011                 xor     ecx, ecx
+  .text:0000000000A5D013                 xor     edx, edx
+  .text:0000000000A5D015                 xor     esi, esi
+  .text:0000000000A5D017                 mov     rdi, r13
+  .text:0000000000A5D01A                 call    sub_984970
+  .text:0000000000A5D01F                 mov     esi, 80h
+  .text:0000000000A5D024                 mov     rdi, r13
+  .text:0000000000A5D027                 call    sub_983A40
+  .text:0000000000A5D02C                 cmp     dword ptr [r14+18h], 3
+  .text:0000000000A5D031                 jnz     loc_A5D750
+  .text:0000000000A5D037                 xor     r15d, r15d
+  .text:0000000000A5D03A                 mov     rax, [r14+20h]
+  .text:0000000000A5D03E                 movss   xmm0, dword ptr [rax+r15]
+  .text:0000000000A5D044                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D04B                 jnz     loc_A5D920
+  .text:0000000000A5D051                 mov     esi, 4
+  .text:0000000000A5D056                 mov     rdi, r13
+  .text:0000000000A5D059                 movss   dword ptr [rbp+var_230], xmm0
+  .text:0000000000A5D061                 call    sub_983AC0
+  .text:0000000000A5D066                 test    al, al
+  .text:0000000000A5D068                 jz      short loc_A5D0CA
+  .text:0000000000A5D06A                 movzx   r8d, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D072                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D078                 mov     esi, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D07E                 movss   xmm0, dword ptr [rbp+var_230]
+  .text:0000000000A5D086                 mov     ecx, eax
+  .text:0000000000A5D088                 sub     ecx, [rbp+var_12C]
+  .text:0000000000A5D08E                 and     esi, 7FFFFFFFh
+  .text:0000000000A5D094                 test    r8b, 1
+  .text:0000000000A5D098                 jnz     loc_A5D970
+  .text:0000000000A5D09E                 xor     eax, eax
+  .text:0000000000A5D0A0                 test    esi, esi
+  .text:0000000000A5D0A2                 jz      short loc_A5D0AB
+  .text:0000000000A5D0A4                 mov     rax, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D0AB                 movsxd  rcx, ecx
+  .text:0000000000A5D0AE                 movss   dword ptr [rax+rcx], xmm0
+  .text:0000000000A5D0B3                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D0B9                 add     eax, 4
+  .text:0000000000A5D0BC                 mov     rdi, r13
+  .text:0000000000A5D0BF                 mov     dword ptr [rbp+var_140+4], eax
+  .text:0000000000A5D0C5                 call    sub_984CD0
+  .text:0000000000A5D0CA                 add     r15, 4
+  .text:0000000000A5D0CE                 cmp     r15, 0Ch
+  .text:0000000000A5D0D2                 jnz     loc_A5D03A
+  .text:0000000000A5D0D8                 cmp     dword ptr [r14+28h], 3
+  .text:0000000000A5D0DD                 jnz     loc_A5D750
+  .text:0000000000A5D0E3                 xor     r15d, r15d
+  .text:0000000000A5D0E6                 mov     rax, [r14+30h]
+  .text:0000000000A5D0EA                 movss   xmm0, dword ptr [rax+r15]
+  .text:0000000000A5D0F0                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D0F7                 jnz     loc_A5D940
+  .text:0000000000A5D0FD                 mov     esi, 4
+  .text:0000000000A5D102                 mov     rdi, r13
+  .text:0000000000A5D105                 movss   dword ptr [rbp+var_230], xmm0
+  .text:0000000000A5D10D                 call    sub_983AC0
+  .text:0000000000A5D112                 test    al, al
+  .text:0000000000A5D114                 jz      short loc_A5D176
+  .text:0000000000A5D116                 movzx   r8d, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D11E                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D124                 mov     esi, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D12A                 movss   xmm0, dword ptr [rbp+var_230]
+  .text:0000000000A5D132                 mov     ecx, eax
+  .text:0000000000A5D134                 sub     ecx, [rbp+var_12C]
+  .text:0000000000A5D13A                 and     esi, 7FFFFFFFh
+  .text:0000000000A5D140                 test    r8b, 1
+  .text:0000000000A5D144                 jnz     loc_A5DD24
+  .text:0000000000A5D14A                 xor     eax, eax
+  .text:0000000000A5D14C                 test    esi, esi
+  .text:0000000000A5D14E                 jz      short loc_A5D157
+  .text:0000000000A5D150                 mov     rax, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D157                 movsxd  rcx, ecx
+  .text:0000000000A5D15A                 movss   dword ptr [rax+rcx], xmm0
+  .text:0000000000A5D15F                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D165                 add     eax, 4
+  .text:0000000000A5D168                 mov     rdi, r13
+  .text:0000000000A5D16B                 mov     dword ptr [rbp+var_140+4], eax
+  .text:0000000000A5D171                 call    sub_984CD0
+  .text:0000000000A5D176                 add     r15, 4
+  .text:0000000000A5D17A                 cmp     r15, 0Ch
+  .text:0000000000A5D17E                 jnz     loc_A5D0E6
+  .text:0000000000A5D184                 cmp     dword ptr [r14+38h], 3
+  .text:0000000000A5D189                 jnz     loc_A5D750
+  .text:0000000000A5D18F                 xor     r15d, r15d
+  .text:0000000000A5D192                 mov     rax, [r14+40h]
+  .text:0000000000A5D196                 movss   xmm0, dword ptr [rax+r15]
+  .text:0000000000A5D19C                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D1A3                 jnz     loc_A5D9B0
+  .text:0000000000A5D1A9                 mov     esi, 4
+  .text:0000000000A5D1AE                 mov     rdi, r13
+  .text:0000000000A5D1B1                 movss   dword ptr [rbp+var_230], xmm0
+  .text:0000000000A5D1B9                 call    sub_983AC0
+  .text:0000000000A5D1BE                 test    al, al
+  .text:0000000000A5D1C0                 jz      short loc_A5D222
+  .text:0000000000A5D1C2                 movzx   r8d, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D1CA                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D1D0                 mov     esi, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D1D6                 movss   xmm0, dword ptr [rbp+var_230]
+  .text:0000000000A5D1DE                 mov     ecx, eax
+  .text:0000000000A5D1E0                 sub     ecx, [rbp+var_12C]
+  .text:0000000000A5D1E6                 and     esi, 7FFFFFFFh
+  .text:0000000000A5D1EC                 test    r8b, 1
+  .text:0000000000A5D1F0                 jnz     loc_A5DD94
+  .text:0000000000A5D1F6                 xor     eax, eax
+  .text:0000000000A5D1F8                 test    esi, esi
+  .text:0000000000A5D1FA                 jz      short loc_A5D203
+  .text:0000000000A5D1FC                 mov     rax, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D203                 movsxd  rcx, ecx
+  .text:0000000000A5D206                 movss   dword ptr [rax+rcx], xmm0
+  .text:0000000000A5D20B                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D211                 add     eax, 4
+  .text:0000000000A5D214                 mov     rdi, r13
+  .text:0000000000A5D217                 mov     dword ptr [rbp+var_140+4], eax
+  .text:0000000000A5D21D                 call    sub_984CD0
+  .text:0000000000A5D222                 add     r15, 4
+  .text:0000000000A5D226                 cmp     r15, 0Ch
+  .text:0000000000A5D22A                 jnz     loc_A5D192
+  .text:0000000000A5D230                 cmp     dword ptr [r14+48h], 3
+  .text:0000000000A5D235                 jnz     loc_A5D750
+  .text:0000000000A5D23B                 xor     r15d, r15d
+  .text:0000000000A5D23E                 mov     rax, [r14+50h]
+  .text:0000000000A5D242                 movss   xmm0, dword ptr [rax+r15]
+  .text:0000000000A5D248                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D24F                 jnz     loc_A5DD5F
+  .text:0000000000A5D255                 mov     esi, 4
+  .text:0000000000A5D25A                 mov     rdi, r13
+  .text:0000000000A5D25D                 movss   dword ptr [rbp+var_230], xmm0
+  .text:0000000000A5D265                 call    sub_983AC0
+  .text:0000000000A5D26A                 test    al, al
+  .text:0000000000A5D26C                 jz      short loc_A5D2C2
+  .text:0000000000A5D26E                 movzx   edi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D275                 xor     esi, esi
+  .text:0000000000A5D277                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D27D                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D283                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D289                 movss   xmm0, dword ptr [rbp+var_230]
+  .text:0000000000A5D291                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D297                 test    dil, 1
+  .text:0000000000A5D29B                 jnz     loc_A5DF5F
+  .text:0000000000A5D2A1                 test    ecx, ecx
+  .text:0000000000A5D2A3                 jz      short loc_A5D2AC
+  .text:0000000000A5D2A5                 mov     rsi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D2AC                 cdqe
+  .text:0000000000A5D2AE                 movss   dword ptr [rsi+rax], xmm0
+  .text:0000000000A5D2B3                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D2BA                 mov     rdi, r13
+  .text:0000000000A5D2BD                 call    sub_984CD0
+  .text:0000000000A5D2C2                 add     r15, 4
+  .text:0000000000A5D2C6                 cmp     r15, 0Ch
+  .text:0000000000A5D2CA                 jnz     loc_A5D23E
+  .text:0000000000A5D2D0                 mov     r15d, [r14+68h]
+  .text:0000000000A5D2D4                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D2DB                 jnz     loc_A5DEC9
+  .text:0000000000A5D2E1                 mov     esi, 4
+  .text:0000000000A5D2E6                 mov     rdi, r13
+  .text:0000000000A5D2E9                 call    sub_983AC0
+  .text:0000000000A5D2EE                 test    al, al
+  .text:0000000000A5D2F0                 jz      short loc_A5D33F
+  .text:0000000000A5D2F2                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D2F8                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D2FF                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D305                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D30B                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D311                 test    sil, 1
+  .text:0000000000A5D315                 jnz     loc_A5E0D4
+  .text:0000000000A5D31B                 test    ecx, ecx
+  .text:0000000000A5D31D                 jz      loc_A5E18C
+  .text:0000000000A5D323                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D32A                 cdqe
+  .text:0000000000A5D32C                 mov     [rcx+rax], r15d
+  .text:0000000000A5D330                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D337                 mov     rdi, r13
+  .text:0000000000A5D33A                 call    sub_984CD0
+  .text:0000000000A5D33F                 mov     r15d, [r14+80h]
+  .text:0000000000A5D346                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D34D                 jnz     loc_A5DEB0
+  .text:0000000000A5D353                 mov     esi, 4
+  .text:0000000000A5D358                 mov     rdi, r13
+  .text:0000000000A5D35B                 call    sub_983AC0
+  .text:0000000000A5D360                 test    al, al
+  .text:0000000000A5D362                 jz      short loc_A5D3B1
+  .text:0000000000A5D364                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D36A                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D371                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D377                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D37D                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D383                 test    sil, 1
+  .text:0000000000A5D387                 jnz     loc_A5DFE8
+  .text:0000000000A5D38D                 test    ecx, ecx
+  .text:0000000000A5D38F                 jz      loc_A5E1C4
+  .text:0000000000A5D395                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D39C                 cdqe
+  .text:0000000000A5D39E                 mov     [rcx+rax], r15d
+  .text:0000000000A5D3A2                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D3A9                 mov     rdi, r13
+  .text:0000000000A5D3AC                 call    sub_984CD0
+  .text:0000000000A5D3B1                 mov     r15d, [r14+6Ch]
+  .text:0000000000A5D3B5                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D3BC                 jnz     loc_A5DF46
+  .text:0000000000A5D3C2                 mov     esi, 4
+  .text:0000000000A5D3C7                 mov     rdi, r13
+  .text:0000000000A5D3CA                 call    sub_983AC0
+  .text:0000000000A5D3CF                 test    al, al
+  .text:0000000000A5D3D1                 jz      short loc_A5D420
+  .text:0000000000A5D3D3                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D3D9                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D3E0                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D3E6                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D3EC                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D3F2                 test    sil, 1
+  .text:0000000000A5D3F6                 jnz     loc_A5E099
+  .text:0000000000A5D3FC                 test    ecx, ecx
+  .text:0000000000A5D3FE                 jz      loc_A5E185
+  .text:0000000000A5D404                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D40B                 cdqe
+  .text:0000000000A5D40D                 mov     [rcx+rax], r15d
+  .text:0000000000A5D411                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D418                 mov     rdi, r13
+  .text:0000000000A5D41B                 call    sub_984CD0
+  .text:0000000000A5D420                 mov     r15d, [r14+70h]
+  .text:0000000000A5D424                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D42B                 jnz     loc_A5DF2D
+  .text:0000000000A5D431                 mov     esi, 4
+  .text:0000000000A5D436                 mov     rdi, r13
+  .text:0000000000A5D439                 call    sub_983AC0
+  .text:0000000000A5D43E                 test    al, al
+  .text:0000000000A5D440                 jz      short loc_A5D48F
+  .text:0000000000A5D442                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D448                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D44F                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D455                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D45B                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D461                 test    sil, 1
+  .text:0000000000A5D465                 jnz     loc_A5E10F
+  .text:0000000000A5D46B                 test    ecx, ecx
+  .text:0000000000A5D46D                 jz      loc_A5E170
+  .text:0000000000A5D473                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D47A                 cdqe
+  .text:0000000000A5D47C                 mov     [rcx+rax], r15d
+  .text:0000000000A5D480                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D487                 mov     rdi, r13
+  .text:0000000000A5D48A                 call    sub_984CD0
+  .text:0000000000A5D48F                 movss   xmm0, dword ptr [r14+74h]
+  .text:0000000000A5D495                 mov     rdi, r13
+  .text:0000000000A5D498                 call    sub_A51370
+  .text:0000000000A5D49D                 mov     r15d, [r14+60h]
+  .text:0000000000A5D4A1                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D4A8                 jnz     loc_A5DF14
+  .text:0000000000A5D4AE                 mov     esi, 4
+  .text:0000000000A5D4B3                 mov     rdi, r13
+  .text:0000000000A5D4B6                 call    sub_983AC0
+  .text:0000000000A5D4BB                 test    al, al
+  .text:0000000000A5D4BD                 jz      short loc_A5D50C
+  .text:0000000000A5D4BF                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D4C5                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D4CC                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D4D2                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D4D8                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D4DE                 test    sil, 1
+  .text:0000000000A5D4E2                 jnz     loc_A5E05E
+  .text:0000000000A5D4E8                 test    ecx, ecx
+  .text:0000000000A5D4EA                 jz      loc_A5E17E
+  .text:0000000000A5D4F0                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D4F7                 cdqe
+  .text:0000000000A5D4F9                 mov     [rcx+rax], r15d
+  .text:0000000000A5D4FD                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D504                 mov     rdi, r13
+  .text:0000000000A5D507                 call    sub_984CD0
+  .text:0000000000A5D50C                 mov     r15d, [r14+64h]
+  .text:0000000000A5D510                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D517                 jnz     loc_A5DEFB
+  .text:0000000000A5D51D                 mov     esi, 4
+  .text:0000000000A5D522                 mov     rdi, r13
+  .text:0000000000A5D525                 call    sub_983AC0
+  .text:0000000000A5D52A                 test    al, al
+  .text:0000000000A5D52C                 jz      short loc_A5D57B
+  .text:0000000000A5D52E                 mov     ecx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D534                 movzx   esi, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D53B                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D541                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D547                 and     ecx, 7FFFFFFFh
+  .text:0000000000A5D54D                 test    sil, 1
+  .text:0000000000A5D551                 jnz     loc_A5E023
+  .text:0000000000A5D557                 test    ecx, ecx
+  .text:0000000000A5D559                 jz      loc_A5E177
+  .text:0000000000A5D55F                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D566                 cdqe
+  .text:0000000000A5D568                 mov     [rcx+rax], r15d
+  .text:0000000000A5D56C                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D573                 mov     rdi, r13
+  .text:0000000000A5D576                 call    sub_984CD0
+  .text:0000000000A5D57B                 mov     r14d, [r14+7Ch]
+  .text:0000000000A5D57F                 test    byte ptr [rbp+var_140+9], 1
+  .text:0000000000A5D586                 jnz     loc_A5DEE2
+  .text:0000000000A5D58C                 mov     esi, 4
+  .text:0000000000A5D591                 mov     rdi, r13
+  .text:0000000000A5D594                 call    sub_983AC0
+  .text:0000000000A5D599                 test    al, al
+  .text:0000000000A5D59B                 jz      short loc_A5D5E9
+  .text:0000000000A5D59D                 mov     edx, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D5A3                 movzx   ecx, byte ptr [rbp+var_110+8]
+  .text:0000000000A5D5AA                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D5B0                 sub     eax, [rbp+var_12C]
+  .text:0000000000A5D5B6                 and     edx, 7FFFFFFFh
+  .text:0000000000A5D5BC                 test    cl, 1
+  .text:0000000000A5D5BF                 jnz     loc_A5DFAE
+  .text:0000000000A5D5C5                 test    edx, edx
+  .text:0000000000A5D5C7                 jz      loc_A5E1BD
+  .text:0000000000A5D5CD                 mov     rdx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D5D4                 cdqe
+  .text:0000000000A5D5D6                 mov     [rdx+rax], r14d
+  .text:0000000000A5D5DA                 add     dword ptr [rbp+var_140+4], 4
+  .text:0000000000A5D5E1                 mov     rdi, r13
+  .text:0000000000A5D5E4                 call    sub_984CD0
+  .text:0000000000A5D5E9                 mov     eax, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D5EF                 mov     dword ptr [rbp+var_150], 0
+  .text:0000000000A5D5F9                 test    eax, 7FFFFFFFh
+  .text:0000000000A5D5FE                 jz      short loc_A5D61B
+  .text:0000000000A5D600                 test    eax, eax
+  .text:0000000000A5D602                 js      short loc_A5D61B
+  .text:0000000000A5D604                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000A5D60B                 mov     rsi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D612                 mov     rdi, [rax]
+  .text:0000000000A5D615                 mov     rax, [rdi]
+  .text:0000000000A5D618                 call    qword ptr [rax+20h]
+  .text:0000000000A5D61B                 mov     rdi, r13
+  .text:0000000000A5D61E                 call    sub_161EB40
+  .text:0000000000A5D623                 lea     rax, off_2242788
+  .text:0000000000A5D62A                 mov     rdi, r13
+  .text:0000000000A5D62D                 mov     qword ptr [rbp+var_150], rax
+  .text:0000000000A5D634                 call    sub_161EC10
+  .text:0000000000A5D639                 mov     rdi, rbx
+  .text:0000000000A5D63C                 call    sub_1E51490
+  .text:0000000000A5D641                 xor     r9d, r9d
+  .text:0000000000A5D644                 xor     r8d, r8d
+  .text:0000000000A5D647                 mov     rsi, r13
+  .text:0000000000A5D64A                 movss   xmm1, dword ptr cs:xmmword_86C220
+  .text:0000000000A5D652                 mov     edx, eax
+  .text:0000000000A5D654                 pxor    xmm0, xmm0
+  .text:0000000000A5D658                 lea     rdi, [rbp+var_220]
+  .text:0000000000A5D65F                 lea     rcx, aSpraycanPaint; "SprayCan.Paint"
+  .text:0000000000A5D666                 call    sub_18F2A60
+  .text:0000000000A5D66B                 mov     rax, [r12+48h]
+  .text:0000000000A5D670                 test    rax, rax
+  .text:0000000000A5D673                 jz      loc_A5DD18
+  .text:0000000000A5D679                 mov     rsi, [rax+58h]
+  .text:0000000000A5D67D                 mov     rdi, [rbp+var_228]
+  .text:0000000000A5D684                 ; CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:0000000000A5D684                 and     rsi, 0FFFFFFFFFFFFFFFCh; CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:0000000000A5D688                 call    CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:0000000000A5D68D                 lea     rax, g_pGameRules
+  .text:0000000000A5D694                 mov     r8, [rax]
+  .text:0000000000A5D697                 mov     ecx, [r8+0E58h]
+  .text:0000000000A5D69E                 test    ecx, ecx
+  .text:0000000000A5D6A0                 jle     loc_A5D76B
+  .text:0000000000A5D6A6                 lea     r14, off_2503B68
+  .text:0000000000A5D6AD                 xor     edx, edx
+  .text:0000000000A5D6AF                 movss   xmm2, cs:dword_86D7C4
+  .text:0000000000A5D6B7                 jmp     short loc_A5D6CB
+  .text:0000000000A5D6C0                 add     edx, 1
+  .text:0000000000A5D6C3                 cmp     ecx, edx
+  .text:0000000000A5D6C5                 jle     loc_A5D76B
+  .text:0000000000A5D6CB                 movsxd  rax, edx
+  .text:0000000000A5D6CE                 mov     rsi, [r8+0E60h]
+  .text:0000000000A5D6D5                 imul    rax, 54h ; 'T'
+  .text:0000000000A5D6D9                 mov     rdi, [r14]
+  .text:0000000000A5D6DC                 movss   xmm1, dword ptr [rdi+30h]
+  .text:0000000000A5D6E1                 add     rax, rsi
+  .text:0000000000A5D6E4                 movss   xmm0, dword ptr [rax+4Ch]
+  .text:0000000000A5D6E9                 addss   xmm0, xmm2
+  .text:0000000000A5D6ED                 comiss  xmm1, xmm0
+  .text:0000000000A5D6F0                 jbe     short loc_A5D6C0
+  .text:0000000000A5D6F2                 sub     ecx, 1
+  .text:0000000000A5D6F5                 cmp     ecx, edx
+  .text:0000000000A5D6F7                 jz      short loc_A5D734
+  .text:0000000000A5D6F9                 movsxd  rcx, ecx
+  .text:0000000000A5D6FC                 imul    rcx, 54h ; 'T'
+  .text:0000000000A5D700                 add     rsi, rcx
+  .text:0000000000A5D703                 movdqu  xmm0, xmmword ptr [rsi]
+  .text:0000000000A5D707                 movups  xmmword ptr [rax], xmm0
+  .text:0000000000A5D70A                 movdqu  xmm0, xmmword ptr [rsi+10h]
+  .text:0000000000A5D70F                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000000A5D713                 movdqu  xmm0, xmmword ptr [rsi+20h]
+  .text:0000000000A5D718                 movups  xmmword ptr [rax+20h], xmm0
+  .text:0000000000A5D71C                 movdqu  xmm0, xmmword ptr [rsi+30h]
+  .text:0000000000A5D721                 movups  xmmword ptr [rax+30h], xmm0
+  .text:0000000000A5D725                 movdqu  xmm0, xmmword ptr [rsi+40h]
+  .text:0000000000A5D72A                 movups  xmmword ptr [rax+40h], xmm0
+  .text:0000000000A5D72E                 mov     ecx, [rsi+50h]
+  .text:0000000000A5D731                 mov     [rax+50h], ecx
+  .text:0000000000A5D734                 mov     eax, [r8+0E58h]
+  .text:0000000000A5D73B                 lea     ecx, [rax-1]
+  .text:0000000000A5D73E                 mov     [r8+0E58h], ecx
+  .text:0000000000A5D745                 jmp     loc_A5D6C3
+  .text:0000000000A5D750                 mov     dword ptr [rbp+var_150], 0
+  .text:0000000000A5D75A                 mov     eax, dword ptr [rbp+var_150+4]
+  .text:0000000000A5D760                 test    eax, 7FFFFFFFh
+  .text:0000000000A5D765                 jnz     loc_A5D8E8
+  .text:0000000000A5D76B                 lea     rsp, [rbp-28h]
+  .text:0000000000A5D76F                 pop     rbx
+  .text:0000000000A5D770                 pop     r12
+  .text:0000000000A5D772                 pop     r13
+  .text:0000000000A5D774                 pop     r14
+  .text:0000000000A5D776                 pop     r15
+  .text:0000000000A5D778                 pop     rbp
+  .text:0000000000A5D779                 retn
+  .text:0000000000A5D780                 mov     rax, [rbx+10h]
+  .text:0000000000A5D784                 mov     edi, [rax+38h]
+  .text:0000000000A5D787                 call    sub_11D6AF0
+  .text:0000000000A5D78C                 movss   xmm1, dword ptr [rbx+119Ch]
+  .text:0000000000A5D794                 comiss  xmm1, xmm0
+  .text:0000000000A5D797                 ja      short loc_A5D76B
+  .text:0000000000A5D799                 movss   xmm0, dword ptr cs:qword_86F770
+  .text:0000000000A5D7A1                 mov     rdi, rbx
+  .text:0000000000A5D7A4                 call    sub_A5CBD0
+  .text:0000000000A5D7A9                 lea     r14, off_2503B68
+  .text:0000000000A5D7B0                 mov     rax, [r14]
+  .text:0000000000A5D7B3                 movss   xmm0, dword ptr [rax+30h]
+  .text:0000000000A5D7B8                 mov     rax, [r12+48h]
+  .text:0000000000A5D7BD                 test    rax, rax
+  .text:0000000000A5D7C0                 jz      loc_A5D910
+  .text:0000000000A5D7C6                 subss   xmm0, dword ptr [rax+74h]
+  .text:0000000000A5D7CB                 andps   xmm0, cs:xmmword_86CB50
+  .text:0000000000A5D7D2                 comiss  xmm0, dword ptr cs:xmmword_86A8D0
+  .text:0000000000A5D7D9                 ja      short loc_A5D76B
+  .text:0000000000A5D7DB                 mov     rax, qword ptr cs:xmmword_86B990
+  .text:0000000000A5D7E2                 pxor    xmm0, xmm0
+  .text:0000000000A5D7E6                 mov     [rbp+var_90], 0
+  .text:0000000000A5D7F1                 movaps  [rbp+var_A0], xmm0
+  .text:0000000000A5D7F8                 mov     [rbp+var_88], rax
+  .text:0000000000A5D7FF                 mov     rax, 700000000000000h
+  .text:0000000000A5D809                 mov     [rbp+var_80], rax
+  .text:0000000000A5D80D                 lea     rax, [rbp+var_F0]
+  .text:0000000000A5D814                 mov     r15, rax
+  .text:0000000000A5D817                 mov     rdi, rax
+  .text:0000000000A5D81A                 mov     [rbp+var_228], rax
+  .text:0000000000A5D821                 call    sub_1BFB3C0
+  .text:0000000000A5D826                 mov     rsi, r15
+  .text:0000000000A5D829                 mov     rdi, rbx
+  .text:0000000000A5D82C                 lea     rcx, [rbp+var_1EC]
+  .text:0000000000A5D833                 lea     rdx, [rbp+var_1F8]
+  .text:0000000000A5D83A                 call    sub_13F70B0
+  .text:0000000000A5D83F                 mov     r15, rax
+  .text:0000000000A5D842                 test    rax, rax
+  .text:0000000000A5D845                 jz      loc_A5D9D0
+  .text:0000000000A5D84B                 sub     rsp, 8
+  .text:0000000000A5D84F                 xor     ecx, ecx
+  .text:0000000000A5D851                 mov     esi, 4
+  .text:0000000000A5D856                 push    0
+  .text:0000000000A5D858                 xor     r9d, r9d
+  .text:0000000000A5D85B                 xor     r8d, r8d
+  .text:0000000000A5D85E                 mov     rdx, rax
+  .text:0000000000A5D861                 mov     rdi, rbx
+  .text:0000000000A5D864                 call    ClientPrint
+  .text:0000000000A5D869                 pop     rcx
+  .text:0000000000A5D86A                 pop     rsi
+  .text:0000000000A5D86B                 jmp     loc_A5D76B
+  .text:0000000000A5D870                 lea     rax, off_2493EA0
+  .text:0000000000A5D877                 jmp     loc_A5CF12
+  .text:0000000000A5D880                 movsxd  r14, r14d
+  .text:0000000000A5D883                 mov     rdx, [rbp+var_238]
+  .text:0000000000A5D88A                 imul    rax, r14, 54h ; 'T'
+  .text:0000000000A5D88E                 add     rdx, rax
+  .text:0000000000A5D891                 movdqu  xmm0, xmmword ptr [rdx]
+  .text:0000000000A5D895                 movups  xmmword ptr [r13+0], xmm0
+  .text:0000000000A5D89A                 movdqu  xmm0, xmmword ptr [rdx+10h]
+  .text:0000000000A5D89F                 movups  xmmword ptr [r13+10h], xmm0
+  .text:0000000000A5D8A4                 movdqu  xmm0, xmmword ptr [rdx+20h]
+  .text:0000000000A5D8A9                 movups  xmmword ptr [r13+20h], xmm0
+  .text:0000000000A5D8AE                 movdqu  xmm0, xmmword ptr [rdx+30h]
+  .text:0000000000A5D8B3                 movups  xmmword ptr [r13+30h], xmm0
+  .text:0000000000A5D8B8                 movdqu  xmm0, xmmword ptr [rdx+40h]
+  .text:0000000000A5D8BD                 movups  xmmword ptr [r13+40h], xmm0
+  .text:0000000000A5D8C2                 mov     eax, [rdx+50h]
+  .text:0000000000A5D8C5                 mov     [r13+50h], eax
+  .text:0000000000A5D8C9                 mov     rax, [rbp+var_240]
+  .text:0000000000A5D8D0                 mov     eax, [rax+0E58h]
+  .text:0000000000A5D8D6                 mov     dword ptr [rbp+var_230], eax
+  .text:0000000000A5D8DC                 lea     r14d, [rax-1]
+  .text:0000000000A5D8E0                 jmp     loc_A5CFEE
+  .text:0000000000A5D8E8                 test    eax, eax
+  .text:0000000000A5D8EA                 js      loc_A5D76B
+  .text:0000000000A5D8F0                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000A5D8F7                 mov     rsi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D8FE                 mov     rdi, [rax]
+  .text:0000000000A5D901                 mov     rax, [rdi]
+  .text:0000000000A5D904                 call    qword ptr [rax+20h]
+  .text:0000000000A5D907                 jmp     loc_A5D76B
+  .text:0000000000A5D910                 lea     rax, off_2493EA0
+  .text:0000000000A5D917                 jmp     loc_A5D7C6
+  .text:0000000000A5D920                 lea     rsi, asc_8DC009; "%f"
+  .text:0000000000A5D927                 mov     rdi, r13
+  .text:0000000000A5D92A                 mov     eax, 1
+  .text:0000000000A5D92F                 cvtss2sd xmm0, xmm0
+  .text:0000000000A5D933                 call    sub_984910
+  .text:0000000000A5D938                 jmp     loc_A5D0CA
+  .text:0000000000A5D940                 lea     rsi, asc_8DC009; "%f"
+  .text:0000000000A5D947                 mov     rdi, r13
+  .text:0000000000A5D94A                 mov     eax, 1
+  .text:0000000000A5D94F                 cvtss2sd xmm0, xmm0
+  .text:0000000000A5D953                 call    sub_984910
+  .text:0000000000A5D958                 jmp     loc_A5D176
+  .text:0000000000A5D960                 lea     r14, off_2493EA0
+  .text:0000000000A5D967                 jmp     loc_A5D00A
+  .text:0000000000A5D970                 xor     edi, edi
+  .text:0000000000A5D972                 test    esi, esi
+  .text:0000000000A5D974                 jz      short loc_A5D97D
+  .text:0000000000A5D976                 mov     rdi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5D97D                 movsxd  rcx, ecx
+  .text:0000000000A5D980                 add     rdi, rcx
+  .text:0000000000A5D983                 jz      loc_A5D0B9
+  .text:0000000000A5D989                 and     r8d, 1
+  .text:0000000000A5D98D                 jz      loc_A5DDCF
+  .text:0000000000A5D993                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5D99C                 movd    dword ptr [rdi], xmm0
+  .text:0000000000A5D9A0                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5D9A6                 jmp     loc_A5D0B9
+  .text:0000000000A5D9B0                 lea     rsi, asc_8DC009; "%f"
+  .text:0000000000A5D9B7                 mov     rdi, r13
+  .text:0000000000A5D9BA                 mov     eax, 1
+  .text:0000000000A5D9BF                 cvtss2sd xmm0, xmm0
+  .text:0000000000A5D9C3                 call    sub_984910
+  .text:0000000000A5D9C8                 jmp     loc_A5D222
+  .text:0000000000A5D9D0                 movss   xmm0, cs:dword_86D8C8
+  .text:0000000000A5D9D8                 mov     rdi, rbx
+  .text:0000000000A5D9DB                 lea     r13, [rbp+var_150]
+  .text:0000000000A5D9E2                 call    sub_A5CBD0
+  .text:0000000000A5D9E7                 mov     rax, r15
+  .text:0000000000A5D9EA                 mov     ecx, 0Ah
+  .text:0000000000A5D9EF                 mov     rdi, r13
+  .text:0000000000A5D9F2                 rep stosq
+  .text:0000000000A5D9F5                 mov     dword ptr [rdi], 0
+  .text:0000000000A5D9FB                 mov     rdi, rbx
+  .text:0000000000A5D9FE                 call    sub_A8C4D0
+  .text:0000000000A5DA03                 mov     dword ptr [rbp+var_150], eax
+  .text:0000000000A5DA09                 mov     rax, [r12+48h]
+  .text:0000000000A5DA0E                 test    rax, rax
+  .text:0000000000A5DA11                 jz      loc_A5DD88
+  .text:0000000000A5DA17                 mov     edx, [rax+7Ch]
+  .text:0000000000A5DA1A                 mov     rdi, [rbp+var_E8]
+  .text:0000000000A5DA21                 mov     dword ptr [rbp+var_150+4], edx
+  .text:0000000000A5DA27                 mov     rdx, [rbp+var_6C]
+  .text:0000000000A5DA2B                 mov     qword ptr [rbp+var_150+8], rdx
+  .text:0000000000A5DA32                 mov     edx, [rbp+var_64]
+  .text:0000000000A5DA35                 mov     dword ptr [rbp+var_140], edx
+  .text:0000000000A5DA3B                 mov     rdx, [rbp+var_1EC]
+  .text:0000000000A5DA42                 mov     [rbp-130h], rdx
+  .text:0000000000A5DA49                 mov     edx, [rbp+var_1E4]
+  .text:0000000000A5DA4F                 mov     [rbp+var_128], edx
+  .text:0000000000A5DA55                 mov     rdx, [rbp+var_60]
+  .text:0000000000A5DA59                 mov     qword ptr [rbp+var_124], rdx
+  .text:0000000000A5DA60                 mov     edx, [rbp+var_58]
+  .text:0000000000A5DA63                 mov     dword ptr [rbp+var_124+8], edx
+  .text:0000000000A5DA69                 movd    xmm0, dword ptr [rax+78h]
+  .text:0000000000A5DA6E                 pinsrd  xmm0, dword ptr [rax+68h], 1
+  .text:0000000000A5DA75                 movq    qword ptr [rbp+var_124+0Ch], xmm0
+  .text:0000000000A5DA7D                 call    sub_1E51490
+  .text:0000000000A5DA82                 mov     rdi, [rbp+var_228]
+  .text:0000000000A5DA89                 mov     dword ptr [rbp+var_110], eax
+  .text:0000000000A5DA8F                 call    sub_1647600
+  .text:0000000000A5DA94                 mov     dword ptr [rbp+var_110+4], eax
+  .text:0000000000A5DA9A                 mov     rax, [r12+48h]
+  .text:0000000000A5DA9F                 test    rax, rax
+  .text:0000000000A5DAA2                 jz      loc_A5DD7C
+  .text:0000000000A5DAA8                 mov     edx, [rax+80h]
+  .text:0000000000A5DAAE                 movss   xmm1, [rbp+var_64]
+  .text:0000000000A5DAB3                 movq    xmm2, [rbp+var_60]
+  .text:0000000000A5DAB8                 mov     dword ptr [rbp+var_110+8], edx
+  .text:0000000000A5DABE                 mov     rdx, [r14]
+  .text:0000000000A5DAC1                 movss   xmm0, dword ptr [rdx+30h]
+  .text:0000000000A5DAC6                 movss   dword ptr [rbp+var_110+0Ch], xmm0
+  .text:0000000000A5DACE                 mov     eax, [rax+64h]
+  .text:0000000000A5DAD1                 movss   xmm0, [rbp+var_58]
+  .text:0000000000A5DAD6                 addss   xmm1, xmm0
+  .text:0000000000A5DADA                 movq    xmm0, [rbp+var_6C]
+  .text:0000000000A5DADF                 mov     [rbp+var_100], eax
+  .text:0000000000A5DAE5                 lea     rax, g_pGameRules
+  .text:0000000000A5DAEC                 addps   xmm0, xmm2
+  .text:0000000000A5DAEF                 movss   dword ptr [rbp+var_140+0Ch], xmm1
+  .text:0000000000A5DAF7                 mov     r14, [rax]
+  .text:0000000000A5DAFA                 movlps  qword ptr [rbp+var_140+4], xmm0
+  .text:0000000000A5DB01                 mov     r12d, [r14+0E58h]
+  .text:0000000000A5DB08                 mov     edi, [r14+0E68h]
+  .text:0000000000A5DB0F                 cmp     r12d, edi
+  .text:0000000000A5DB12                 jz      loc_A5DDDE
+  .text:0000000000A5DB18                 mov     rax, [r14+0E60h]
+  .text:0000000000A5DB1F                 mov     edx, r12d
+  .text:0000000000A5DB22                 lea     r15, [rbp+var_170]
+  .text:0000000000A5DB29                 add     edx, 1
+  .text:0000000000A5DB2C                 mov     [r14+0E58h], edx
+  .text:0000000000A5DB33                 movsxd  rdx, r12d
+  .text:0000000000A5DB36                 movdqa  xmm0, [rbp+var_150]
+  .text:0000000000A5DB3E                 imul    rdx, 54h ; 'T'
+  .text:0000000000A5DB42                 lea     r12, [rbp+var_1E0]
+  .text:0000000000A5DB49                 lea     r14, [rbp+var_1A0]
+  .text:0000000000A5DB50                 mov     rdi, r12
+  .text:0000000000A5DB53                 add     rax, rdx
+  .text:0000000000A5DB56                 movups  xmmword ptr [rax], xmm0
+  .text:0000000000A5DB59                 movdqa  xmm0, [rbp+var_140]
+  .text:0000000000A5DB61                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000000A5DB65                 movdqa  xmm0, xmmword ptr [rbp-130h]
+  .text:0000000000A5DB6D                 movups  xmmword ptr [rax+20h], xmm0
+  .text:0000000000A5DB71                 movdqa  xmm0, [rbp+var_124+4]
+  .text:0000000000A5DB79                 movups  xmmword ptr [rax+30h], xmm0
+  .text:0000000000A5DB7D                 movdqa  xmm0, [rbp+var_110]
+  .text:0000000000A5DB85                 movups  xmmword ptr [rax+40h], xmm0
+  .text:0000000000A5DB89                 mov     edx, [rbp+var_100]
+  .text:0000000000A5DB8F                 mov     [rax+50h], edx
+  .text:0000000000A5DB92                 call    sub_161EB40
+  .text:0000000000A5DB97                 lea     rax, off_2246398
+  .text:0000000000A5DB9E                 ; _QWORD
+  .text:0000000000A5DB9E                 mov     rdi, rbx; _QWORD
+  .text:0000000000A5DBA1                 mov     [rbp+var_1E0], rax
+  .text:0000000000A5DBA8                 call    j_UTIL_GetPlayerControllerForEntity
+  .text:0000000000A5DBAD                 mov     rdi, r12
+  .text:0000000000A5DBB0                 mov     rsi, rax
+  .text:0000000000A5DBB3                 call    sub_161EC40
+  .text:0000000000A5DBB8                 xor     edx, edx
+  .text:0000000000A5DBBA                 xor     esi, esi
+  .text:0000000000A5DBBC                 mov     rdi, r15
+  .text:0000000000A5DBBF                 lea     rax, unk_22357F8
+  .text:0000000000A5DBC6                 mov     [rbp+var_18C], 0FFh
+  .text:0000000000A5DBCD                 mov     [rbp+var_1A0], rax
+  .text:0000000000A5DBD4                 mov     [rbp+var_198], 0
+  .text:0000000000A5DBDF                 mov     [rbp+var_190], 0
+  .text:0000000000A5DBE9                 mov     [rbp+var_188], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000A5DBF4                 mov     [rbp+var_180], 0BF800000h
+  .text:0000000000A5DBFE                 mov     [rbp+var_178], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000A5DC09                 call    sub_102A830
+  .text:0000000000A5DC0E                 lea     rax, off_22429C8
+  .text:0000000000A5DC15                 mov     rdi, r13
+  .text:0000000000A5DC18                 mov     rsi, r14
+  .text:0000000000A5DC1B                 mov     [rbp+var_1A0], rax
+  .text:0000000000A5DC22                 add     rax, 40h ; '@'
+  .text:0000000000A5DC26                 mov     [rbp+var_170], rax
+  .text:0000000000A5DC2D                 call    sub_A8A700
+  .text:0000000000A5DC32                 lea     rax, qword_2700E80
+  .text:0000000000A5DC39                 mov     r8, cs:qword_256F928
+  .text:0000000000A5DC40                 mov     r13, [rax]
+  .text:0000000000A5DC43                 mov     rsi, r8
+  .text:0000000000A5DC46                 mov     [rbp+var_228], r8
+  .text:0000000000A5DC4D                 mov     rax, [r13+0]
+  .text:0000000000A5DC51                 mov     r10, [rax+80h]
+  .text:0000000000A5DC58                 lea     rax, g_pNetworkMessages
+  .text:0000000000A5DC5F                 mov     [rbp+var_230], r10
+  .text:0000000000A5DC66                 mov     rdi, [rax]
+  .text:0000000000A5DC69                 mov     rax, [rdi]
+  .text:0000000000A5DC6C                 call    qword ptr [rax+60h]
+  .text:0000000000A5DC6F                 sub     rsp, 8
+  .text:0000000000A5DC73                 mov     rcx, r12
+  .text:0000000000A5DC76                 mov     r9, r14
+  .text:0000000000A5DC79                 lea     r12, [rbp+var_1C0]
+  .text:0000000000A5DC80                 push    50h ; 'P'
+  .text:0000000000A5DC82                 xor     edx, edx
+  .text:0000000000A5DC84                 xor     esi, esi
+  .text:0000000000A5DC86                 mov     r10, [rbp+var_230]
+  .text:0000000000A5DC8D                 mov     rdi, r13
+  .text:0000000000A5DC90                 mov     r8, [rbp+var_228]
+  .text:0000000000A5DC97                 call    r10
+  .text:0000000000A5DC9A                 mov     rdi, r12
+  .text:0000000000A5DC9D                 call    sub_161EB40
+  .text:0000000000A5DCA2                 lea     rax, off_2242788
+  .text:0000000000A5DCA9                 mov     rdi, r12
+  .text:0000000000A5DCAC                 mov     [rbp+var_1C0], rax
+  .text:0000000000A5DCB3                 call    sub_161EC10
+  .text:0000000000A5DCB8                 mov     rdi, rbx
+  .text:0000000000A5DCBB                 call    sub_1E51490
+  .text:0000000000A5DCC0                 xor     r9d, r9d
+  .text:0000000000A5DCC3                 xor     r8d, r8d
+  .text:0000000000A5DCC6                 mov     rsi, r12
+  .text:0000000000A5DCC9                 movss   xmm1, dword ptr cs:xmmword_86C220
+  .text:0000000000A5DCD1                 mov     edx, eax
+  .text:0000000000A5DCD3                 pxor    xmm0, xmm0
+  .text:0000000000A5DCD7                 lea     rdi, [rbp+var_220]
+  .text:0000000000A5DCDE                 lea     rcx, aSpraycanShake; "SprayCan.Shake"
+  .text:0000000000A5DCE5                 call    sub_18F2A60
+  .text:0000000000A5DCEA                 lea     rax, off_2237708
+  .text:0000000000A5DCF1                 mov     rdi, r15
+  .text:0000000000A5DCF4                 mov     [rbp+var_1A0], rax
+  .text:0000000000A5DCFB                 add     rax, 40h ; '@'
+  .text:0000000000A5DCFF                 mov     [rbp+var_170], rax
+  .text:0000000000A5DD06                 call    sub_10A1A70
+  .text:0000000000A5DD0B                 pop     rax
+  .text:0000000000A5DD0C                 pop     rdx
+  .text:0000000000A5DD0D                 jmp     loc_A5D68D
+  .text:0000000000A5DD18                 lea     rax, off_2493EA0
+  .text:0000000000A5DD1F                 jmp     loc_A5D679
+  .text:0000000000A5DD24                 xor     edi, edi
+  .text:0000000000A5DD26                 test    esi, esi
+  .text:0000000000A5DD28                 jz      short loc_A5DD31
+  .text:0000000000A5DD2A                 mov     rdi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5DD31                 movsxd  rcx, ecx
+  .text:0000000000A5DD34                 add     rdi, rcx
+  .text:0000000000A5DD37                 jz      loc_A5D165
+  .text:0000000000A5DD3D                 and     r8d, 1
+  .text:0000000000A5DD41                 jz      loc_A5DF90
+  .text:0000000000A5DD47                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5DD50                 movd    dword ptr [rdi], xmm0
+  .text:0000000000A5DD54                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5DD5A                 jmp     loc_A5D165
+  .text:0000000000A5DD5F                 lea     rsi, asc_8DC009; "%f"
+  .text:0000000000A5DD66                 mov     rdi, r13
+  .text:0000000000A5DD69                 mov     eax, 1
+  .text:0000000000A5DD6E                 cvtss2sd xmm0, xmm0
+  .text:0000000000A5DD72                 call    sub_984910
+  .text:0000000000A5DD77                 jmp     loc_A5D2C2
+  .text:0000000000A5DD7C                 lea     rax, off_2493EA0
+  .text:0000000000A5DD83                 jmp     loc_A5DAA8
+  .text:0000000000A5DD88                 lea     rax, off_2493EA0
+  .text:0000000000A5DD8F                 jmp     loc_A5DA17
+  .text:0000000000A5DD94                 xor     edi, edi
+  .text:0000000000A5DD96                 test    esi, esi
+  .text:0000000000A5DD98                 jz      short loc_A5DDA1
+  .text:0000000000A5DD9A                 mov     rdi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5DDA1                 movsxd  rcx, ecx
+  .text:0000000000A5DDA4                 add     rdi, rcx
+  .text:0000000000A5DDA7                 jz      loc_A5D211
+  .text:0000000000A5DDAD                 and     r8d, 1
+  .text:0000000000A5DDB1                 jz      loc_A5DF9F
+  .text:0000000000A5DDB7                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5DDC0                 movd    dword ptr [rdi], xmm0
+  .text:0000000000A5DDC4                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5DDCA                 jmp     loc_A5D211
+  .text:0000000000A5DDCF                 movss   dword ptr [rdi], xmm0
+  .text:0000000000A5DDD3                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5DDD9                 jmp     loc_A5D0B9
+  .text:0000000000A5DDDE                 mov     eax, [r14+0E6Ch]
+  .text:0000000000A5DDE5                 cmp     eax, 3FFFFFFFh
+  .text:0000000000A5DDEA                 jbe     short loc_A5DE00
+  .text:0000000000A5DDEC                 mov     edx, eax
+  .text:0000000000A5DDEE                 and     edx, 0C0000000h
+  .text:0000000000A5DDF4                 cmp     edx, 80000000h
+  .text:0000000000A5DDFA                 jnz     loc_A5DB18
+  .text:0000000000A5DE00                 cmp     edi, 7FFFFFFFh
+  .text:0000000000A5DE06                 jz      loc_A5E14A
+  .text:0000000000A5DE0C                 lea     edx, [rdi+1]
+  .text:0000000000A5DE0F                 and     eax, 3FFFFFFFh
+  .text:0000000000A5DE14                 mov     ecx, 54h ; 'T'
+  .text:0000000000A5DE19                 mov     esi, eax
+  .text:0000000000A5DE1B                 mov     dword ptr [rbp+var_228], edx
+  .text:0000000000A5DE21                 call    sub_984790
+  .text:0000000000A5DE26                 mov     edx, dword ptr [rbp+var_228]
+  .text:0000000000A5DE2C                 mov     r15d, eax
+  .text:0000000000A5DE2F                 cmp     edx, eax
+  .text:0000000000A5DE31                 jg      short loc_A5DE98
+  .text:0000000000A5DE33                 movsxd  rcx, dword ptr [r14+0E68h]
+  .text:0000000000A5DE3A                 movsxd  rdx, r15d
+  .text:0000000000A5DE3D                 xor     esi, esi
+  .text:0000000000A5DE3F                 imul    rdx, 54h ; 'T'
+  .text:0000000000A5DE43                 mov     rdi, [r14+0E60h]
+  .text:0000000000A5DE4A                 imul    rcx, 54h ; 'T'
+  .text:0000000000A5DE4E                 cmp     dword ptr [r14+0E6Ch], 3FFFFFFFh
+  .text:0000000000A5DE59                 setbe   sil
+  .text:0000000000A5DE5D                 call    sub_9843C0
+  .text:0000000000A5DE62                 mov     edx, [r14+0E6Ch]
+  .text:0000000000A5DE69                 mov     [r14+0E60h], rax
+  .text:0000000000A5DE70                 cmp     edx, 3FFFFFFFh
+  .text:0000000000A5DE76                 jbe     short loc_A5DE85
+  .text:0000000000A5DE78                 and     edx, 3FFFFFFFh
+  .text:0000000000A5DE7E                 mov     [r14+0E6Ch], edx
+  .text:0000000000A5DE85                 mov     edx, [r14+0E58h]
+  .text:0000000000A5DE8C                 mov     [r14+0E68h], r15d
+  .text:0000000000A5DE93                 jmp     loc_A5DB22
+  .text:0000000000A5DE98                 lea     eax, [rdx+r15]
+  .text:0000000000A5DE9C                 mov     r15d, eax
+  .text:0000000000A5DE9F                 shr     r15d, 1Fh
+  .text:0000000000A5DEA3                 add     r15d, eax
+  .text:0000000000A5DEA6                 sar     r15d, 1
+  .text:0000000000A5DEA9                 cmp     edx, r15d
+  .text:0000000000A5DEAC                 jg      short loc_A5DE98
+  .text:0000000000A5DEAE                 jmp     short loc_A5DE33
+  .text:0000000000A5DEB0                 mov     edx, r15d
+  .text:0000000000A5DEB3                 mov     rdi, r13
+  .text:0000000000A5DEB6                 xor     eax, eax
+  .text:0000000000A5DEB8                 lea     rsi, aD_1; "%d"
+  .text:0000000000A5DEBF                 call    sub_984910
+  .text:0000000000A5DEC4                 jmp     loc_A5D3B1
+  .text:0000000000A5DEC9                 mov     edx, r15d
+  .text:0000000000A5DECC                 mov     rdi, r13
+  .text:0000000000A5DECF                 xor     eax, eax
+  .text:0000000000A5DED1                 lea     rsi, aD_1; "%d"
+  .text:0000000000A5DED8                 call    sub_984910
+  .text:0000000000A5DEDD                 jmp     loc_A5D33F
+  .text:0000000000A5DEE2                 mov     edx, r14d
+  .text:0000000000A5DEE5                 mov     rdi, r13
+  .text:0000000000A5DEE8                 xor     eax, eax
+  .text:0000000000A5DEEA                 lea     rsi, aU_0; "%u"
+  .text:0000000000A5DEF1                 call    sub_984910
+  .text:0000000000A5DEF6                 jmp     loc_A5D5E9
+  .text:0000000000A5DEFB                 mov     edx, r15d
+  .text:0000000000A5DEFE                 mov     rdi, r13
+  .text:0000000000A5DF01                 xor     eax, eax
+  .text:0000000000A5DF03                 lea     rsi, aU_0; "%u"
+  .text:0000000000A5DF0A                 call    sub_984910
+  .text:0000000000A5DF0F                 jmp     loc_A5D57B
+  .text:0000000000A5DF14                 mov     edx, r15d
+  .text:0000000000A5DF17                 mov     rdi, r13
+  .text:0000000000A5DF1A                 xor     eax, eax
+  .text:0000000000A5DF1C                 lea     rsi, aU_0; "%u"
+  .text:0000000000A5DF23                 call    sub_984910
+  .text:0000000000A5DF28                 jmp     loc_A5D50C
+  .text:0000000000A5DF2D                 mov     edx, r15d
+  .text:0000000000A5DF30                 mov     rdi, r13
+  .text:0000000000A5DF33                 xor     eax, eax
+  .text:0000000000A5DF35                 lea     rsi, aD_1; "%d"
+  .text:0000000000A5DF3C                 call    sub_984910
+  .text:0000000000A5DF41                 jmp     loc_A5D48F
+  .text:0000000000A5DF46                 mov     edx, r15d
+  .text:0000000000A5DF49                 mov     rdi, r13
+  .text:0000000000A5DF4C                 xor     eax, eax
+  .text:0000000000A5DF4E                 lea     rsi, aD_1; "%d"
+  .text:0000000000A5DF55                 call    sub_984910
+  .text:0000000000A5DF5A                 jmp     loc_A5D420
+  .text:0000000000A5DF5F                 test    ecx, ecx
+  .text:0000000000A5DF61                 jz      short loc_A5DF6A
+  .text:0000000000A5DF63                 mov     rsi, qword ptr [rbp+var_150+8]
+  .text:0000000000A5DF6A                 cdqe
+  .text:0000000000A5DF6C                 add     rsi, rax
+  .text:0000000000A5DF6F                 jz      loc_A5D2B3
+  .text:0000000000A5DF75                 and     edi, 1
+  .text:0000000000A5DF78                 jz      loc_A5E167
+  .text:0000000000A5DF7E                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5DF87                 movd    dword ptr [rsi], xmm0
+  .text:0000000000A5DF8B                 jmp     loc_A5D2B3
+  .text:0000000000A5DF90                 movss   dword ptr [rdi], xmm0
+  .text:0000000000A5DF94                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5DF9A                 jmp     loc_A5D165
+  .text:0000000000A5DF9F                 movss   dword ptr [rdi], xmm0
+  .text:0000000000A5DFA3                 mov     eax, dword ptr [rbp+var_140+4]
+  .text:0000000000A5DFA9                 jmp     loc_A5D211
+  .text:0000000000A5DFAE                 test    edx, edx
+  .text:0000000000A5DFB0                 jz      loc_A5E1AF
+  .text:0000000000A5DFB6                 mov     rdx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5DFBD                 cdqe
+  .text:0000000000A5DFBF                 add     rdx, rax
+  .text:0000000000A5DFC2                 jz      loc_A5D5DA
+  .text:0000000000A5DFC8                 and     cl, 1
+  .text:0000000000A5DFCB                 jz      loc_A5E1DA
+  .text:0000000000A5DFD1                 movd    xmm0, r14d
+  .text:0000000000A5DFD6                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5DFDF                 movd    dword ptr [rdx], xmm0
+  .text:0000000000A5DFE3                 jmp     loc_A5D5DA
+  .text:0000000000A5DFE8                 test    ecx, ecx
+  .text:0000000000A5DFEA                 jz      loc_A5E1B6
+  .text:0000000000A5DFF0                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5DFF7                 cdqe
+  .text:0000000000A5DFF9                 add     rcx, rax
+  .text:0000000000A5DFFC                 jz      loc_A5D3A2
+  .text:0000000000A5E002                 and     sil, 1
+  .text:0000000000A5E006                 jz      loc_A5E1E2
+  .text:0000000000A5E00C                 movd    xmm0, r15d
+  .text:0000000000A5E011                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E01A                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E01E                 jmp     loc_A5D3A2
+  .text:0000000000A5E023                 test    ecx, ecx
+  .text:0000000000A5E025                 jz      loc_A5E193
+  .text:0000000000A5E02B                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5E032                 cdqe
+  .text:0000000000A5E034                 add     rcx, rax
+  .text:0000000000A5E037                 jz      loc_A5D56C
+  .text:0000000000A5E03D                 and     sil, 1
+  .text:0000000000A5E041                 jz      loc_A5E1FA
+  .text:0000000000A5E047                 movd    xmm0, r15d
+  .text:0000000000A5E04C                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E055                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E059                 jmp     loc_A5D56C
+  .text:0000000000A5E05E                 test    ecx, ecx
+  .text:0000000000A5E060                 jz      loc_A5E1A1
+  .text:0000000000A5E066                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5E06D                 cdqe
+  .text:0000000000A5E06F                 add     rcx, rax
+  .text:0000000000A5E072                 jz      loc_A5D4FD
+  .text:0000000000A5E078                 and     sil, 1
+  .text:0000000000A5E07C                 jz      loc_A5E1EA
+  .text:0000000000A5E082                 movd    xmm0, r15d
+  .text:0000000000A5E087                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E090                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E094                 jmp     loc_A5D4FD
+  .text:0000000000A5E099                 test    ecx, ecx
+  .text:0000000000A5E09B                 jz      loc_A5E19A
+  .text:0000000000A5E0A1                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5E0A8                 cdqe
+  .text:0000000000A5E0AA                 add     rcx, rax
+  .text:0000000000A5E0AD                 jz      loc_A5D411
+  .text:0000000000A5E0B3                 and     sil, 1
+  .text:0000000000A5E0B7                 jz      loc_A5E202
+  .text:0000000000A5E0BD                 movd    xmm0, r15d
+  .text:0000000000A5E0C2                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E0CB                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E0CF                 jmp     loc_A5D411
+  .text:0000000000A5E0D4                 test    ecx, ecx
+  .text:0000000000A5E0D6                 jz      loc_A5E1A8
+  .text:0000000000A5E0DC                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5E0E3                 cdqe
+  .text:0000000000A5E0E5                 add     rcx, rax
+  .text:0000000000A5E0E8                 jz      loc_A5D330
+  .text:0000000000A5E0EE                 and     sil, 1
+  .text:0000000000A5E0F2                 jz      loc_A5E1F2
+  .text:0000000000A5E0F8                 movd    xmm0, r15d
+  .text:0000000000A5E0FD                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E106                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E10A                 jmp     loc_A5D330
+  .text:0000000000A5E10F                 test    ecx, ecx
+  .text:0000000000A5E111                 jz      loc_A5E1CB
+  .text:0000000000A5E117                 mov     rcx, qword ptr [rbp+var_150+8]
+  .text:0000000000A5E11E                 cdqe
+  .text:0000000000A5E120                 add     rcx, rax
+  .text:0000000000A5E123                 jz      loc_A5D480
+  .text:0000000000A5E129                 and     sil, 1
+  .text:0000000000A5E12D                 jz      loc_A5E1D2
+  .text:0000000000A5E133                 movd    xmm0, r15d
+  .text:0000000000A5E138                 pshufb  xmm0, cs:xmmword_86A900
+  .text:0000000000A5E141                 movd    dword ptr [rcx], xmm0
+  .text:0000000000A5E145                 jmp     loc_A5D480
+  .text:0000000000A5E14A                 mov     esi, 1
+  .text:0000000000A5E14F                 call    sub_984EE0
+  .text:0000000000A5E154                 mov     edi, [r14+0E68h]
+  .text:0000000000A5E15B                 mov     eax, [r14+0E6Ch]
+  .text:0000000000A5E162                 jmp     loc_A5DE0C
+  .text:0000000000A5E167                 movss   dword ptr [rsi], xmm0
+  .text:0000000000A5E16B                 jmp     loc_A5D2B3
+  .text:0000000000A5E170                 xor     ecx, ecx
+  .text:0000000000A5E172                 jmp     loc_A5D47A
+  .text:0000000000A5E177                 xor     ecx, ecx
+  .text:0000000000A5E179                 jmp     loc_A5D566
+  .text:0000000000A5E17E                 xor     ecx, ecx
+  .text:0000000000A5E180                 jmp     loc_A5D4F7
+  .text:0000000000A5E185                 xor     ecx, ecx
+  .text:0000000000A5E187                 jmp     loc_A5D40B
+  .text:0000000000A5E18C                 xor     ecx, ecx
+  .text:0000000000A5E18E                 jmp     loc_A5D32A
+  .text:0000000000A5E193                 xor     ecx, ecx
+  .text:0000000000A5E195                 jmp     loc_A5E032
+  .text:0000000000A5E19A                 xor     ecx, ecx
+  .text:0000000000A5E19C                 jmp     loc_A5E0A8
+  .text:0000000000A5E1A1                 xor     ecx, ecx
+  .text:0000000000A5E1A3                 jmp     loc_A5E06D
+  .text:0000000000A5E1A8                 xor     ecx, ecx
+  .text:0000000000A5E1AA                 jmp     loc_A5E0E3
+  .text:0000000000A5E1AF                 xor     edx, edx
+  .text:0000000000A5E1B1                 jmp     loc_A5DFBD
+  .text:0000000000A5E1B6                 xor     ecx, ecx
+  .text:0000000000A5E1B8                 jmp     loc_A5DFF7
+  .text:0000000000A5E1BD                 xor     edx, edx
+  .text:0000000000A5E1BF                 jmp     loc_A5D5D4
+  .text:0000000000A5E1C4                 xor     ecx, ecx
+  .text:0000000000A5E1C6                 jmp     loc_A5D39C
+  .text:0000000000A5E1CB                 xor     ecx, ecx
+  .text:0000000000A5E1CD                 jmp     loc_A5E11E
+  .text:0000000000A5E1D2                 mov     [rcx], r15d
+  .text:0000000000A5E1D5                 jmp     loc_A5D480
+  .text:0000000000A5E1DA                 mov     [rdx], r14d
+  .text:0000000000A5E1DD                 jmp     loc_A5D5DA
+  .text:0000000000A5E1E2                 mov     [rcx], r15d
+  .text:0000000000A5E1E5                 jmp     loc_A5D3A2
+  .text:0000000000A5E1EA                 mov     [rcx], r15d
+  .text:0000000000A5E1ED                 jmp     loc_A5D4FD
+  .text:0000000000A5E1F2                 mov     [rcx], r15d
+  .text:0000000000A5E1F5                 jmp     loc_A5D330
+  .text:0000000000A5E1FA                 mov     [rcx], r15d
+  .text:0000000000A5E1FD                 jmp     loc_A5D56C
+  .text:0000000000A5E202                 mov     [rcx], r15d
+  .text:0000000000A5E205                 jmp     loc_A5D411
+procedure: |-
+  void __fastcall CCSPlayerPawn_SprayPaint(__int64 a1, __int64 a2)
+  {
+    __int64 (__fastcall ***v4)(); // rax
+    __int64 v5; // r14
+    int v6; // r15d
+    __m128i *v7; // r13
+    int v8; // r14d
+    __int64 (__fastcall ***v9)(); // r14
+    __int64 i; // r15
+    float v11; // xmm0_4
+    __int32 v12; // eax
+    __int32 v13; // ecx
+    __int32 v14; // esi
+    __int64 v15; // rax
+    __int64 j; // r15
+    float v17; // xmm0_4
+    __int32 v18; // eax
+    __int32 v19; // ecx
+    __int32 v20; // esi
+    __int64 v21; // rax
+    __int64 k; // r15
+    float v23; // xmm0_4
+    __int32 v24; // eax
+    __int32 v25; // ecx
+    __int32 v26; // esi
+    __int64 v27; // rax
+    __int64 m; // r15
+    float v29; // xmm0_4
+    __int64 v30; // rsi
+    __int32 v31; // eax
+    __int32 v32; // ecx
+    unsigned int v33; // r15d
+    __int32 v34; // eax
+    __int32 v35; // ecx
+    __int64 v36; // rcx
+    unsigned int v37; // r15d
+    __int32 v38; // eax
+    __int32 v39; // ecx
+    __int64 v40; // rcx
+    unsigned int v41; // r15d
+    __int32 v42; // eax
+    __int32 v43; // ecx
+    __int64 v44; // rcx
+    unsigned int v45; // r15d
+    __int32 v46; // eax
+    __int32 v47; // ecx
+    __int64 v48; // rcx
+    unsigned int v49; // r15d
+    __int32 v50; // eax
+    __int32 v51; // ecx
+    __int64 v52; // rcx
+    unsigned int v53; // r15d
+    __int32 v54; // eax
+    __int32 v55; // ecx
+    __int64 v56; // rcx
+    unsigned int v57; // r14d
+    __int32 v58; // eax
+    __int32 v59; // edx
+    __int64 v60; // rdx
+    unsigned int v61; // eax
+    __int64 (__fastcall ***v62)(); // rax
+    __int64 v63; // r8
+    int v64; // ecx
+    int v65; // edx
+    __int64 v66; // rsi
+    __int64 v67; // rax
+    int v68; // ecx
+    const __m128i *v69; // rsi
+    double v70; // xmm0_8
+    __int64 (__fastcall ***v71)(); // rax
+    __int64 v72; // rax
+    __int64 v73; // rax
+    __int64 v74; // rdi
+    float *v75; // rdi
+    __int64 (__fastcall ***v76)(); // rax
+    __int64 (__fastcall ***v77)(); // rax
+    __m128 v78; // xmm2
+    void *v79; // rdx
+    __m128 v80; // xmm0
+    __int64 v81; // r14
+    int v82; // r12d
+    __int64 v83; // rdi
+    __int64 v84; // rax
+    int v85; // edx
+    __m128i *v86; // rax
+    __int64 PlayerControllerForEntity; // rax
+    __int64 v88; // r13
+    unsigned int v89; // eax
+    __int64 v90; // rdi
+    float *v91; // rdi
+    __int64 v92; // rdi
+    float *v93; // rdi
+    unsigned int v94; // eax
+    int v95; // eax
+    int v96; // edx
+    int n; // r15d
+    unsigned int v98; // edx
+    float *v99; // rsi
+    __int64 v100; // rdx
+    unsigned int *v101; // rdx
+    __int64 v102; // rcx
+    unsigned int *v103; // rcx
+    __int64 v104; // rcx
+    unsigned int *v105; // rcx
+    __int64 v106; // rcx
+    unsigned int *v107; // rcx
+    __int64 v108; // rcx
+    unsigned int *v109; // rcx
+    __int64 v110; // rcx
+    unsigned int *v111; // rcx
+    __int64 v112; // rcx
+    unsigned int *v113; // rcx
+    __int64 v114; // [rsp+0h] [rbp-240h]
+    __int64 v115; // [rsp+8h] [rbp-238h]
+    int v116; // [rsp+10h] [rbp-230h]
+    void (__fastcall *v117)(__int64, _QWORD, _QWORD, _QWORD *, __int64, _QWORD *, __int64); // [rsp+10h] [rbp-230h]
+    __int64 v118; // [rsp+18h] [rbp-228h]
+    _BYTE v119[40]; // [rsp+20h] [rbp-220h] BYREF
+    _BYTE v120[12]; // [rsp+48h] [rbp-1F8h] BYREF
+    __int64 v121; // [rsp+54h] [rbp-1ECh] BYREF
+    __int32 v122; // [rsp+5Ch] [rbp-1E4h]
+    _QWORD v123[4]; // [rsp+60h] [rbp-1E0h] BYREF
+    _QWORD v124[4]; // [rsp+80h] [rbp-1C0h] BYREF
+    _QWORD v125[2]; // [rsp+A0h] [rbp-1A0h] BYREF
+    int v126; // [rsp+B0h] [rbp-190h]
+    char v127; // [rsp+B4h] [rbp-18Ch]
+    __int64 v128; // [rsp+B8h] [rbp-188h]
+    int v129; // [rsp+C0h] [rbp-180h]
+    __int64 v130; // [rsp+C8h] [rbp-178h]
+    _QWORD v131[4]; // [rsp+D0h] [rbp-170h] BYREF
+    __m128i v132[5]; // [rsp+F0h] [rbp-150h] BYREF
+    __int32 v133; // [rsp+140h] [rbp-100h]
+    _QWORD v134[10]; // [rsp+150h] [rbp-F0h] BYREF
+    __int128 v135; // [rsp+1A0h] [rbp-A0h]
+    __int64 v136; // [rsp+1B0h] [rbp-90h]
+    unsigned __int64 v137; // [rsp+1B8h] [rbp-88h]
+    __int64 v138; // [rsp+1C0h] [rbp-80h]
+    __int64 v139; // [rsp+1D4h] [rbp-6Ch] BYREF
+    float v140; // [rsp+1DCh] [rbp-64h]
+    __m128i v141; // [rsp+1E0h] [rbp-60h] BYREF
+
+    if ( (unsigned int)sub_A8C4D0(a1) && g_pGameRules && (*(_BYTE *)(a2 + 64) & 1) != 0 )
+    {
+      v4 = *(__int64 (__fastcall ****)())(a2 + 72);
+      if ( !v4 )
+        v4 = &off_2493EA0;
+      if ( *((_DWORD *)v4 + 31) )
+      {
+        if ( *((_DWORD *)v4 + 6) )
+        {
+          memset(v134, 0, sizeof(v134));
+          LODWORD(v135) = 0;
+          LODWORD(v134[0]) = sub_A8C4D0(a1);
+          sub_A8AC30(v134, a2);
+          v114 = g_pGameRules;
+          v116 = *(_DWORD *)(g_pGameRules + 3672);
+          if ( v116 <= 0 )
+            return;
+          v5 = 0;
+          v6 = 0;
+          v115 = *(_QWORD *)(g_pGameRules + 3680);
+          while ( 1 )
+          {
+            v7 = (__m128i *)(v115 + v5);
+            if ( !(unsigned int)sub_985C90(v115 + v5, v134, 80) )
+              break;
+            ++v6;
+            v5 += 84;
+            if ( v6 == v116 )
+              return;
+          }
+          v8 = v116 - 1;
+          if ( v116 - 1 != v6 )
+          {
+            v73 = 84LL * v8;
+            *v7 = _mm_loadu_si128((const __m128i *)(v73 + v115));
+            v7[1] = _mm_loadu_si128((const __m128i *)(v73 + v115 + 16));
+            v7[2] = _mm_loadu_si128((const __m128i *)(v73 + v115 + 32));
+            v7[3] = _mm_loadu_si128((const __m128i *)(v73 + v115 + 48));
+            v7[4] = _mm_loadu_si128((const __m128i *)(v73 + v115 + 64));
+            v7[5].m128i_i32[0] = *(_DWORD *)(v73 + v115 + 80);
+            v8 = *(_DWORD *)(v114 + 3672) - 1;
+          }
+          *(_DWORD *)(v114 + 3672) = v8;
+          v9 = *(__int64 (__fastcall ****)())(a2 + 72);
+          if ( !v9 )
+            v9 = &off_2493EA0;
+          sub_984970(v132, 0, 0, 0);
+          sub_983A40(v132, 128);
+          if ( *((_DWORD *)v9 + 6) == 3 )
+          {
+            for ( i = 0; i != 12; i += 4 )
+            {
+              v11 = *(float *)((char *)v9[4] + i);
+              if ( (v132[1].m128i_i8[9] & 1) != 0 )
+              {
+                sub_984910(v132, "%f", v11);
+              }
+              else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+              {
+                v12 = v132[1].m128i_i32[1];
+                v13 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                v14 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                {
+                  v74 = 0;
+                  if ( v14 )
+                    v74 = v132[0].m128i_i64[1];
+                  v75 = (float *)(v13 + v74);
+                  if ( v75 )
+                  {
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                      *(_DWORD *)v75 = _mm_cvtsi128_si32(_mm_shuffle_epi8((__m128i)LODWORD(v11), (__m128i)xmmword_86A900));
+                    else
+                      *v75 = v11;
+                    v12 = v132[1].m128i_i32[1];
+                  }
+                }
+                else
+                {
+                  v15 = 0;
+                  if ( v14 )
+                    v15 = v132[0].m128i_i64[1];
+                  *(float *)(v15 + v13) = v11;
+                  v12 = v132[1].m128i_i32[1];
+                }
+                v132[1].m128i_i32[1] = v12 + 4;
+                sub_984CD0(v132);
+              }
+            }
+            if ( *((_DWORD *)v9 + 10) == 3 )
+            {
+              for ( j = 0; j != 12; j += 4 )
+              {
+                v17 = *(float *)((char *)v9[6] + j);
+                if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                {
+                  sub_984910(v132, "%f", v17);
+                }
+                else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                {
+                  v18 = v132[1].m128i_i32[1];
+                  v19 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                  v20 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                  if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                  {
+                    v90 = 0;
+                    if ( v20 )
+                      v90 = v132[0].m128i_i64[1];
+                    v91 = (float *)(v19 + v90);
+                    if ( v91 )
+                    {
+                      if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                        *(_DWORD *)v91 = _mm_cvtsi128_si32(_mm_shuffle_epi8((__m128i)LODWORD(v17), (__m128i)xmmword_86A900));
+                      else
+                        *v91 = v17;
+                      v18 = v132[1].m128i_i32[1];
+                    }
+                  }
+                  else
+                  {
+                    v21 = 0;
+                    if ( v20 )
+                      v21 = v132[0].m128i_i64[1];
+                    *(float *)(v21 + v19) = v17;
+                    v18 = v132[1].m128i_i32[1];
+                  }
+                  v132[1].m128i_i32[1] = v18 + 4;
+                  sub_984CD0(v132);
+                }
+              }
+              if ( *((_DWORD *)v9 + 14) == 3 )
+              {
+                for ( k = 0; k != 12; k += 4 )
+                {
+                  v23 = *(float *)((char *)v9[8] + k);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%f", v23);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v24 = v132[1].m128i_i32[1];
+                    v25 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v26 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      v92 = 0;
+                      if ( v26 )
+                        v92 = v132[0].m128i_i64[1];
+                      v93 = (float *)(v25 + v92);
+                      if ( v93 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *(_DWORD *)v93 = _mm_cvtsi128_si32(_mm_shuffle_epi8((__m128i)LODWORD(v23), (__m128i)xmmword_86A900));
+                        else
+                          *v93 = v23;
+                        v24 = v132[1].m128i_i32[1];
+                      }
+                    }
+                    else
+                    {
+                      v27 = 0;
+                      if ( v26 )
+                        v27 = v132[0].m128i_i64[1];
+                      *(float *)(v27 + v25) = v23;
+                      v24 = v132[1].m128i_i32[1];
+                    }
+                    v132[1].m128i_i32[1] = v24 + 4;
+                    sub_984CD0(v132);
+                  }
+                }
+                if ( *((_DWORD *)v9 + 18) == 3 )
+                {
+                  for ( m = 0; m != 12; m += 4 )
+                  {
+                    v29 = *(float *)((char *)v9[10] + m);
+                    if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                    {
+                      sub_984910(v132, "%f", v29);
+                    }
+                    else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                    {
+                      v30 = 0;
+                      v31 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                      v32 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                      if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                      {
+                        if ( v32 )
+                          v30 = v132[0].m128i_i64[1];
+                        v99 = (float *)(v31 + v30);
+                        if ( v99 )
+                        {
+                          if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                            *(_DWORD *)v99 = _mm_cvtsi128_si32(_mm_shuffle_epi8((__m128i)LODWORD(v29), (__m128i)xmmword_86A900));
+                          else
+                            *v99 = v29;
+                        }
+                      }
+                      else
+                      {
+                        if ( v32 )
+                          v30 = v132[0].m128i_i64[1];
+                        *(float *)(v30 + v31) = v29;
+                      }
+                      v132[1].m128i_i32[1] += 4;
+                      sub_984CD0(v132);
+                    }
+                  }
+                  v33 = *((_DWORD *)v9 + 26);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%d", v33);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v34 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v35 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v35 )
+                        v110 = v132[0].m128i_i64[1];
+                      else
+                        v110 = 0;
+                      v111 = (unsigned int *)(v34 + v110);
+                      if ( v111 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v111 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v33), (__m128i)xmmword_86A900));
+                        else
+                          *v111 = v33;
+                      }
+                    }
+                    else
+                    {
+                      if ( v35 )
+                        v36 = v132[0].m128i_i64[1];
+                      else
+                        v36 = 0;
+                      *(_DWORD *)(v36 + v34) = v33;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v37 = *((_DWORD *)v9 + 32);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%d", v37);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v38 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v39 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v39 )
+                        v102 = v132[0].m128i_i64[1];
+                      else
+                        v102 = 0;
+                      v103 = (unsigned int *)(v38 + v102);
+                      if ( v103 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v103 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v37), (__m128i)xmmword_86A900));
+                        else
+                          *v103 = v37;
+                      }
+                    }
+                    else
+                    {
+                      if ( v39 )
+                        v40 = v132[0].m128i_i64[1];
+                      else
+                        v40 = 0;
+                      *(_DWORD *)(v40 + v38) = v37;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v41 = *((_DWORD *)v9 + 27);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%d", v41);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v42 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v43 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v43 )
+                        v108 = v132[0].m128i_i64[1];
+                      else
+                        v108 = 0;
+                      v109 = (unsigned int *)(v42 + v108);
+                      if ( v109 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v109 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v41), (__m128i)xmmword_86A900));
+                        else
+                          *v109 = v41;
+                      }
+                    }
+                    else
+                    {
+                      if ( v43 )
+                        v44 = v132[0].m128i_i64[1];
+                      else
+                        v44 = 0;
+                      *(_DWORD *)(v44 + v42) = v41;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v45 = *((_DWORD *)v9 + 28);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%d", v45);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v46 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v47 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v47 )
+                        v112 = v132[0].m128i_i64[1];
+                      else
+                        v112 = 0;
+                      v113 = (unsigned int *)(v46 + v112);
+                      if ( v113 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v113 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v45), (__m128i)xmmword_86A900));
+                        else
+                          *v113 = v45;
+                      }
+                    }
+                    else
+                    {
+                      if ( v47 )
+                        v48 = v132[0].m128i_i64[1];
+                      else
+                        v48 = 0;
+                      *(_DWORD *)(v48 + v46) = v45;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  sub_A51370(v132, *((float *)v9 + 29));
+                  v49 = *((_DWORD *)v9 + 24);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%u", v49);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v50 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v51 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v51 )
+                        v106 = v132[0].m128i_i64[1];
+                      else
+                        v106 = 0;
+                      v107 = (unsigned int *)(v50 + v106);
+                      if ( v107 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v107 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v49), (__m128i)xmmword_86A900));
+                        else
+                          *v107 = v49;
+                      }
+                    }
+                    else
+                    {
+                      if ( v51 )
+                        v52 = v132[0].m128i_i64[1];
+                      else
+                        v52 = 0;
+                      *(_DWORD *)(v52 + v50) = v49;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v53 = *((_DWORD *)v9 + 25);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%u", v53);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v54 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v55 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v55 )
+                        v104 = v132[0].m128i_i64[1];
+                      else
+                        v104 = 0;
+                      v105 = (unsigned int *)(v54 + v104);
+                      if ( v105 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v105 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v53), (__m128i)xmmword_86A900));
+                        else
+                          *v105 = v53;
+                      }
+                    }
+                    else
+                    {
+                      if ( v55 )
+                        v56 = v132[0].m128i_i64[1];
+                      else
+                        v56 = 0;
+                      *(_DWORD *)(v56 + v54) = v53;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v57 = *((_DWORD *)v9 + 31);
+                  if ( (v132[1].m128i_i8[9] & 1) != 0 )
+                  {
+                    sub_984910(v132, "%u", v57);
+                  }
+                  else if ( (unsigned __int8)sub_983AC0(v132, 4) )
+                  {
+                    v58 = v132[1].m128i_i32[1] - v132[2].m128i_i32[1];
+                    v59 = v132[0].m128i_i32[1] & 0x7FFFFFFF;
+                    if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                    {
+                      if ( v59 )
+                        v100 = v132[0].m128i_i64[1];
+                      else
+                        v100 = 0;
+                      v101 = (unsigned int *)(v58 + v100);
+                      if ( v101 )
+                      {
+                        if ( (v132[4].m128i_i8[8] & 1) != 0 )
+                          *v101 = _mm_cvtsi128_si32(_mm_shuffle_epi8(_mm_cvtsi32_si128(v57), (__m128i)xmmword_86A900));
+                        else
+                          *v101 = v57;
+                      }
+                    }
+                    else
+                    {
+                      if ( v59 )
+                        v60 = v132[0].m128i_i64[1];
+                      else
+                        v60 = 0;
+                      *(_DWORD *)(v60 + v58) = v57;
+                    }
+                    v132[1].m128i_i32[1] += 4;
+                    sub_984CD0(v132);
+                  }
+                  v132[0].m128i_i32[0] = 0;
+                  if ( (v132[0].m128i_i32[1] & 0x7FFFFFFF) != 0 && v132[0].m128i_i32[1] >= 0 )
+                    (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v132[0].m128i_i64[1]);
+                  sub_161EB40(v132);
+                  v132[0].m128i_i64[0] = (__int64)off_2242788;
+                  sub_161EC10(v132);
+                  v61 = sub_1E51490(a1);
+                  sub_18F2A60(v119, v132, v61, "SprayCan.Paint", 0, 0, 0.0, 1.0);
+                  v62 = *(__int64 (__fastcall ****)())(a2 + 72);
+                  if ( !v62 )
+                    v62 = &off_2493EA0;
+                  CEntitySpawner_CPlayerSprayDecal_Spawn((int *)v134, (_QWORD *)((unsigned __int64)v62[11] & 0xFFFFFFFFFFFFFFFCLL));
+  LABEL_111:
+                  v63 = g_pGameRules;
+                  v64 = *(_DWORD *)(g_pGameRules + 3672);
+                  if ( v64 > 0 )
+                  {
+                    v65 = 0;
+                    do
+                    {
+                      v66 = *(_QWORD *)(v63 + 3680);
+                      v67 = v66 + 84LL * v65;
+                      if ( *((float *)off_2503B68 + 12) <= (float)(*(float *)(v67 + 76) + 300.0) )
+                      {
+                        ++v65;
+                      }
+                      else
+                      {
+                        v68 = v64 - 1;
+                        if ( v68 != v65 )
+                        {
+                          v69 = (const __m128i *)(84LL * v68 + v66);
+                          *(__m128i *)v67 = _mm_loadu_si128(v69);
+                          *(__m128i *)(v67 + 16) = _mm_loadu_si128(v69 + 1);
+                          *(__m128i *)(v67 + 32) = _mm_loadu_si128(v69 + 2);
+                          *(__m128i *)(v67 + 48) = _mm_loadu_si128(v69 + 3);
+                          *(__m128i *)(v67 + 64) = _mm_loadu_si128(v69 + 4);
+                          *(_DWORD *)(v67 + 80) = v69[5].m128i_i32[0];
+                        }
+                        v64 = *(_DWORD *)(v63 + 3672) - 1;
+                        *(_DWORD *)(v63 + 3672) = v64;
+                      }
+                    }
+                    while ( v64 > v65 );
+                  }
+                  return;
+                }
+              }
+            }
+          }
+          v132[0].m128i_i32[0] = 0;
+          if ( (v132[0].m128i_i32[1] & 0x7FFFFFFF) != 0 && v132[0].m128i_i32[1] >= 0 )
+            (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v132[0].m128i_i64[1]);
+        }
+        else
+        {
+          v70 = sub_11D6AF0(*(unsigned int *)(*(_QWORD *)(a1 + 16) + 56LL));
+          if ( *(float *)(a1 + 4508) <= *(float *)&v70 )
+          {
+            sub_A5CBD0(a1, 0.2);
+            v71 = *(__int64 (__fastcall ****)())(a2 + 72);
+            if ( !v71 )
+              v71 = &off_2493EA0;
+            if ( fabs(*((float *)off_2503B68 + 12) - *((float *)v71 + 29)) <= 10.0 )
+            {
+              v136 = 0;
+              v135 = 0;
+              v137 = 0xFFFFFFFF00000000LL;
+              v138 = 0x700000000000000LL;
+              sub_1BFB3C0(v134);
+              v72 = sub_13F70B0(a1, v134, v120, &v121);
+              if ( v72 )
+              {
+                ClientPrint(a1, 4, v72, 0, 0, 0, 0);
+                return;
+              }
+              sub_A5CBD0(a1, 45.0);
+              memset(v132, 0, sizeof(v132));
+              v133 = 0;
+              v132[0].m128i_i32[0] = sub_A8C4D0(a1);
+              v76 = *(__int64 (__fastcall ****)())(a2 + 72);
+              if ( !v76 )
+                v76 = &off_2493EA0;
+              v132[0].m128i_i32[1] = *((_DWORD *)v76 + 31);
+              v132[0].m128i_i64[1] = v139;
+              *(float *)v132[1].m128i_i32 = v140;
+              v132[2].m128i_i64[0] = v121;
+              v132[2].m128i_i32[2] = v122;
+              *(__int64 *)((char *)&v132[2].m128i_i64[1] + 4) = v141.m128i_i64[0];
+              v132[3].m128i_i32[1] = v141.m128i_i32[2];
+              v132[3].m128i_i64[1] = _mm_insert_epi32(_mm_cvtsi32_si128(*((_DWORD *)v76 + 30)), *((_DWORD *)v76 + 26), 1).m128i_u64[0];
+              v132[4].m128i_i32[0] = sub_1E51490(v134[1]);
+              v132[4].m128i_i32[1] = sub_1647600(v134);
+              v77 = *(__int64 (__fastcall ****)())(a2 + 72);
+              if ( !v77 )
+                v77 = &off_2493EA0;
+              v78 = (__m128)_mm_loadl_epi64(&v141);
+              v132[4].m128i_i32[2] = *((_DWORD *)v77 + 32);
+              v79 = off_2503B68;
+              v132[4].m128i_i32[3] = *((_DWORD *)off_2503B68 + 12);
+              v80 = (__m128)_mm_loadl_epi64((const __m128i *)&v139);
+              v133 = *((_DWORD *)v77 + 25);
+              *(float *)&v132[1].m128i_i32[3] = v140 + *(float *)&v141.m128i_i32[2];
+              v81 = g_pGameRules;
+              _mm_storel_ps((double *)((char *)v132[1].m128i_i64 + 4), _mm_add_ps(v80, v78));
+              v82 = *(_DWORD *)(v81 + 3672);
+              v83 = *(unsigned int *)(v81 + 3688);
+              if ( v82 == (_DWORD)v83
+                && ((v94 = *(_DWORD *)(v81 + 3692), v94 <= 0x3FFFFFFF)
+                 || (v79 = (void *)(v94 & 0xC0000000), (_DWORD)v79 == 0x80000000)) )
+              {
+                if ( (_DWORD)v83 == 0x7FFFFFFF )
+                {
+                  sub_984EE0(v83, 1, v79);
+                  v83 = *(unsigned int *)(v81 + 3688);
+                  v94 = *(_DWORD *)(v81 + 3692);
+                }
+                v95 = sub_984790(v83, v94 & 0x3FFFFFFF, (unsigned int)(v83 + 1), 84);
+                v96 = v83 + 1;
+                for ( n = v95; v96 > n; n = (v96 + n) / 2 )
+                  ;
+                v84 = sub_9843C0(
+                        *(_QWORD *)(v81 + 3680),
+                        *(_DWORD *)(v81 + 3692) <= 0x3FFFFFFFu,
+                        84LL * n,
+                        84LL * *(int *)(v81 + 3688));
+                v98 = *(_DWORD *)(v81 + 3692);
+                *(_QWORD *)(v81 + 3680) = v84;
+                if ( v98 > 0x3FFFFFFF )
+                  *(_DWORD *)(v81 + 3692) = v98 & 0x3FFFFFFF;
+                v85 = *(_DWORD *)(v81 + 3672);
+                *(_DWORD *)(v81 + 3688) = n;
+              }
+              else
+              {
+                v84 = *(_QWORD *)(v81 + 3680);
+                v85 = *(_DWORD *)(v81 + 3672);
+              }
+              *(_DWORD *)(v81 + 3672) = v85 + 1;
+              v86 = (__m128i *)(84LL * v82 + v84);
+              *v86 = _mm_load_si128(v132);
+              v86[1] = _mm_load_si128(&v132[1]);
+              v86[2] = _mm_load_si128(&v132[2]);
+              v86[3] = _mm_load_si128(&v132[3]);
+              v86[4] = _mm_load_si128(&v132[4]);
+              v86[5].m128i_i32[0] = v133;
+              sub_161EB40(v123);
+              v123[0] = off_2246398;
+              PlayerControllerForEntity = j_UTIL_GetPlayerControllerForEntity(a1);
+              sub_161EC40(v123, PlayerControllerForEntity);
+              v127 = -1;
+              v125[0] = &unk_22357F8;
+              v125[1] = 0;
+              v126 = 0;
+              v128 = -1;
+              v129 = -1082130432;
+              v130 = -1;
+              sub_102A830(v131, 0, 0);
+              v125[0] = off_22429C8;
+              v131[0] = off_2242A08;
+              sub_A8A700(v132, v125);
+              v88 = qword_2700E80;
+              v118 = qword_256F928;
+              v117 = *(void (__fastcall **)(__int64, _QWORD, _QWORD, _QWORD *, __int64, _QWORD *, __int64))(*(_QWORD *)qword_2700E80 + 128LL);
+              (*(void (__fastcall **)(_QWORD *, __int64))(*g_pNetworkMessages + 96LL))(g_pNetworkMessages, qword_256F928);
+              v117(v88, 0, 0, v123, v118, v125, 80);
+              sub_161EB40(v124);
+              v124[0] = off_2242788;
+              sub_161EC10(v124);
+              v89 = sub_1E51490(a1);
+              sub_18F2A60(v119, v124, v89, "SprayCan.Shake", 0, 0, 0.0, 1.0);
+              v125[0] = off_2237708;
+              v131[0] = off_2237748;
+              sub_10A1A70(v131);
+              goto LABEL_111;
+            }
+          }
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CCSPlayerPawn_SprayPaint.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CCSPlayerPawn_SprayPaint.windows.yaml
@@ -1,0 +1,681 @@
+func_name: CCSPlayerPawn_SprayPaint
+func_va: '0x18020d8e0'
+disasm_code: |-
+  .text:000000018020D8E0                 push    rbp
+  .text:000000018020D8E2                 push    rdi
+  .text:000000018020D8E3                 push    r14
+  .text:000000018020D8E5                 push    r15
+  .text:000000018020D8E7                 lea     rbp, [rsp-128h]
+  .text:000000018020D8EF                 sub     rsp, 228h
+  .text:000000018020D8F6                 mov     rdi, rdx
+  .text:000000018020D8F9                 mov     r15, rcx
+  .text:000000018020D8FC                 xor     r14d, r14d
+  .text:000000018020D8FF                 call    sub_180252EB0
+  .text:000000018020D904                 test    eax, eax
+  .text:000000018020D906                 jz      loc_18020DFCB
+  .text:000000018020D90C                 cmp     cs:g_pGameRules, r14
+  .text:000000018020D913                 jz      loc_18020DFCB
+  .text:000000018020D919                 test    byte ptr [rdi+40h], 1
+  .text:000000018020D91D                 jz      loc_18020DFCB
+  .text:000000018020D923                 mov     rax, [rdi+48h]
+  .text:000000018020D927                 test    rax, rax
+  .text:000000018020D92A                 mov     [rsp+240h+arg_8], rsi
+  .text:000000018020D932                 lea     rsi, off_181BE3CB0
+  .text:000000018020D939                 mov     rcx, rsi
+  .text:000000018020D93C                 cmovnz  rcx, rax
+  .text:000000018020D940                 cmp     [rcx+7Ch], r14d
+  .text:000000018020D944                 jz      loc_18020DFC3
+  .text:000000018020D94A                 mov     [rsp+240h+arg_0], rbx
+  .text:000000018020D952                 add     rcx, 18h
+  .text:000000018020D956                 mov     [rsp+240h+arg_18], r12
+  .text:000000018020D95E                 mov     [rsp+240h+var_20], r13
+  .text:000000018020D966                 call    sub_180FC7A40
+  .text:000000018020D96B                 test    eax, eax
+  .text:000000018020D96D                 jnz     loc_18020DD9C
+  .text:000000018020D973                 mov     rdx, [r15+10h]
+  .text:000000018020D977                 lea     rcx, [rbp+140h+arg_10]
+  .text:000000018020D97E                 mov     edx, [rdx+38h]
+  .text:000000018020D981                 call    sub_1808B37D0
+  .text:000000018020D986                 lea     rdx, [r15+0ECCh]
+  .text:000000018020D98D                 lea     rcx, [rbp+140h+arg_10]
+  .text:000000018020D994                 call    sub_1801E3760
+  .text:000000018020D999                 test    al, al
+  .text:000000018020D99B                 jnz     loc_18020DFAB
+  .text:000000018020D9A1                 movss   xmm1, cs:dword_1815ABC20
+  .text:000000018020D9A9                 mov     rcx, r15
+  .text:000000018020D9AC                 call    sub_180205E00
+  .text:000000018020D9B1                 mov     rax, [rdi+48h]
+  .text:000000018020D9B5                 mov     rcx, rsi
+  .text:000000018020D9B8                 test    rax, rax
+  .text:000000018020D9BB                 cmovnz  rcx, rax
+  .text:000000018020D9BF                 mov     rax, cs:off_181C4FC68
+  .text:000000018020D9C6                 movss   xmm0, dword ptr [rax+30h]
+  .text:000000018020D9CB                 subss   xmm0, dword ptr [rcx+74h]
+  .text:000000018020D9D0                 andps   xmm0, cs:xmmword_1815ABCA0
+  .text:000000018020D9D7                 comiss  xmm0, cs:dword_1815ABC38
+  .text:000000018020D9DE                 ja      loc_18020DFAB
+  .text:000000018020D9E4                 lea     rcx, [rbp+140h+var_160]
+  .text:000000018020D9E8                 mov     [rbp+140h+var_110], r14
+  .text:000000018020D9EC                 mov     [rbp+140h+var_108], r14
+  .text:000000018020D9F0                 mov     [rbp+140h+var_100], r14
+  .text:000000018020D9F4                 mov     [rbp+140h+var_EC], 7000000h
+  .text:000000018020D9FB                 mov     [rbp+140h+var_F8], r14d
+  .text:000000018020D9FF                 mov     [rbp+140h+var_F4], 0FFFFFFFFh
+  .text:000000018020DA06                 mov     [rbp+140h+var_F0], r14d
+  .text:000000018020DA0A                 call    sub_18130EF60
+  .text:000000018020DA0F                 lea     r9, [rbp+140h+var_188]
+  .text:000000018020DA13                 mov     rcx, r15
+  .text:000000018020DA16                 lea     r8, [rbp+140h+var_88]
+  .text:000000018020DA1D                 lea     rdx, [rbp+140h+var_160]
+  .text:000000018020DA21                 call    sub_180A43CE0
+  .text:000000018020DA26                 mov     rcx, r15
+  .text:000000018020DA29                 test    rax, rax
+  .text:000000018020DA2C                 jz      short loc_18020DA52
+  .text:000000018020DA2E                 mov     [rsp+240h+var_210], r14
+  .text:000000018020DA33                 xor     r9d, r9d
+  .text:000000018020DA36                 mov     [rsp+240h+var_218], r14
+  .text:000000018020DA3B                 mov     r8, rax
+  .text:000000018020DA3E                 mov     edx, 4
+  .text:000000018020DA43                 mov     [rsp+240h+var_220], r14
+  .text:000000018020DA48                 call    ClientPrint
+  .text:000000018020DA4D                 jmp     loc_18020DFAB
+  .text:000000018020DA52                 movss   xmm1, cs:dword_1815BA200
+  .text:000000018020DA5A                 call    sub_180205E00
+  .text:000000018020DA5F                 mov     rcx, r15
+  .text:000000018020DA62                 call    sub_180252EB0
+  .text:000000018020DA67                 movsd   xmm0, [rbp+140h+var_DC]
+  .text:000000018020DA6C                 lea     rdx, [rbp+140h+arg_10]
+  .text:000000018020DA73                 mov     dword ptr [rsp+240h+var_200], eax
+  .text:000000018020DA77                 mov     rcx, rsi
+  .text:000000018020DA7A                 mov     rax, [rdi+48h]
+  .text:000000018020DA7E                 test    rax, rax
+  .text:000000018020DA81                 cmovnz  rcx, rax
+  .text:000000018020DA85                 mov     eax, [rcx+7Ch]
+  .text:000000018020DA88                 mov     dword ptr [rsp+240h+var_200+4], eax
+  .text:000000018020DA8C                 mov     eax, [rbp+140h+var_D4]
+  .text:000000018020DA8F                 movsd   qword ptr [rsp+240h+var_200+8], xmm0
+  .text:000000018020DA95                 movsd   xmm0, [rbp+140h+var_188]
+  .text:000000018020DA9A                 mov     dword ptr [rsp+240h+var_1F0], eax
+  .text:000000018020DA9E                 mov     eax, [rbp+140h+var_180]
+  .text:000000018020DAA1                 movsd   qword ptr [rsp+240h+var_1E0], xmm0
+  .text:000000018020DAA7                 movsd   xmm0, [rbp+140h+var_D0]
+  .text:000000018020DAAC                 mov     dword ptr [rsp+240h+var_1E0+8], eax
+  .text:000000018020DAB0                 mov     eax, [rbp+140h+var_C8]
+  .text:000000018020DAB3                 movsd   qword ptr [rsp+240h+var_1E0+0Ch], xmm0
+  .text:000000018020DAB9                 mov     dword ptr [rsp+240h+var_1CC], eax
+  .text:000000018020DABD                 mov     eax, [rcx+78h]
+  .text:000000018020DAC0                 mov     dword ptr [rsp+240h+var_1CC+4], eax
+  .text:000000018020DAC4                 mov     eax, [rcx+68h]
+  .text:000000018020DAC7                 mov     rcx, [rbp+140h+var_158]
+  .text:000000018020DACB                 mov     dword ptr [rsp+240h+var_1CC+8], eax
+  .text:000000018020DACF                 call    sub_181213DB0
+  .text:000000018020DAD4                 mov     eax, [rbp+140h+arg_10]
+  .text:000000018020DADA                 lea     rcx, [rbp+140h+var_160]
+  .text:000000018020DADE                 mov     dword ptr [rbp+140h+var_1CC+0Ch], eax
+  .text:000000018020DAE1                 call    sub_180C037E0
+  .text:000000018020DAE6                 movss   xmm1, dword ptr [rbp+140h+var_DC+4]
+  .text:000000018020DAEB                 addss   xmm1, dword ptr [rbp+140h+var_D0+4]
+  .text:000000018020DAF0                 movss   xmm2, [rbp+140h+var_D4]
+  .text:000000018020DAF5                 addss   xmm2, [rbp+140h+var_C8]
+  .text:000000018020DAFA                 mov     [rbp-7Ch], eax
+  .text:000000018020DAFD                 mov     rax, [rdi+48h]
+  .text:000000018020DB01                 test    rax, rax
+  .text:000000018020DB04                 cmovnz  rsi, rax
+  .text:000000018020DB08                 mov     eax, [rsi+80h]
+  .text:000000018020DB0E                 mov     [rbp-78h], eax
+  .text:000000018020DB11                 mov     rax, cs:off_181C4FC68
+  .text:000000018020DB18                 movss   xmm0, dword ptr [rax+30h]
+  .text:000000018020DB1D                 movss   dword ptr [rbp-74h], xmm0
+  .text:000000018020DB22                 mov     eax, [rsi+64h]
+  .text:000000018020DB25                 movss   xmm0, dword ptr [rbp+140h+var_D0]
+  .text:000000018020DB2A                 mov     rsi, cs:g_pGameRules
+  .text:000000018020DB31                 addss   xmm0, dword ptr [rbp+140h+var_DC]
+  .text:000000018020DB36                 movss   dword ptr [rsp+240h+var_1F0+0Ch], xmm2
+  .text:000000018020DB3C                 mov     [rbp+140h+var_1B0], eax
+  .text:000000018020DB3F                 unpcklps xmm0, xmm1
+  .text:000000018020DB42                 movsd   qword ptr [rsp+240h+var_1F0+4], xmm0
+  .text:000000018020DB48                 movsxd  r12, dword ptr [rsi+0E58h]
+  .text:000000018020DB4F                 cmp     r12d, [rsi+0E68h]
+  .text:000000018020DB56                 jnz     loc_18020DC1F
+  .text:000000018020DB5C                 test    dword ptr [rsi+0E6Ch], 40000000h
+  .text:000000018020DB66                 jnz     loc_18020DC1F
+  .text:000000018020DB6C                 mov     ecx, [rsi+0E68h]
+  .text:000000018020DB72                 cmp     ecx, 7FFFFFFEh
+  .text:000000018020DB78                 jle     short loc_18020DB85
+  .text:000000018020DB7A                 mov     edx, 1
+  .text:000000018020DB7F                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:000000018020DB85                 mov     ecx, [rsi+0E68h]
+  .text:000000018020DB8B                 mov     r9d, 54h ; 'T'
+  .text:000000018020DB91                 mov     edx, [rsi+0E6Ch]
+  .text:000000018020DB97                 and     edx, 3FFFFFFFh
+  .text:000000018020DB9D                 lea     edi, [rcx+1]
+  .text:000000018020DBA0                 mov     r8d, edi
+  .text:000000018020DBA3                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:000000018020DBA9                 mov     ebx, eax
+  .text:000000018020DBAB                 cmp     eax, edi
+  .text:000000018020DBAD                 jge     short loc_18020DBCE
+  .text:000000018020DBAF                 test    eax, eax
+  .text:000000018020DBB1                 jnz     short loc_18020DBC0
+  .text:000000018020DBB3                 cmp     edi, 0FFFFFFFFh
+  .text:000000018020DBB6                 jg      short loc_18020DBC0
+  .text:000000018020DBB8                 mov     ebx, 0FFFFFFFFh
+  .text:000000018020DBBD                 jmp     short loc_18020DBCE
+  .text:000000018020DBC0                 lea     eax, [rdi+rbx]
+  .text:000000018020DBC3                 cdq
+  .text:000000018020DBC4                 sub     eax, edx
+  .text:000000018020DBC6                 sar     eax, 1
+  .text:000000018020DBC8                 mov     ebx, eax
+  .text:000000018020DBCA                 cmp     eax, edi
+  .text:000000018020DBCC                 jl      short loc_18020DBC0
+  .text:000000018020DBCE                 movsxd  rax, dword ptr [rsi+0E68h]
+  .text:000000018020DBD5                 mov     rcx, [rsi+0E60h]
+  .text:000000018020DBDC                 imul    r9, rax, 54h ; 'T'
+  .text:000000018020DBE0                 test    dword ptr [rsi+0E6Ch], 0C0000000h
+  .text:000000018020DBEA                 movsxd  rax, ebx
+  .text:000000018020DBED                 setz    dl
+  .text:000000018020DBF0                 imul    r8, rax, 54h ; 'T'
+  .text:000000018020DBF4                 call    cs:UtlVectorMemory_Alloc
+  .text:000000018020DBFA                 mov     [rsi+0E60h], rax
+  .text:000000018020DC01                 mov     eax, [rsi+0E6Ch]
+  .text:000000018020DC07                 test    eax, 0C0000000h
+  .text:000000018020DC0C                 jz      short loc_18020DC19
+  .text:000000018020DC0E                 and     eax, 3FFFFFFFh
+  .text:000000018020DC13                 mov     [rsi+0E6Ch], eax
+  .text:000000018020DC19                 mov     [rsi+0E68h], ebx
+  .text:000000018020DC1F                 inc     dword ptr [rsi+0E58h]
+  .text:000000018020DC25                 mov     rcx, [rsi+0E60h]
+  .text:000000018020DC2C                 movaps  xmm0, [rsp+240h+var_200]
+  .text:000000018020DC31                 imul    rdx, r12, 54h ; 'T'
+  .text:000000018020DC35                 movups  xmmword ptr [rdx+rcx], xmm0
+  .text:000000018020DC39                 movaps  xmm1, [rsp+240h+var_1F0]
+  .text:000000018020DC3E                 movups  xmmword ptr [rdx+rcx+10h], xmm1
+  .text:000000018020DC43                 movaps  xmm0, [rsp+240h+var_1E0]
+  .text:000000018020DC48                 movups  xmmword ptr [rdx+rcx+20h], xmm0
+  .text:000000018020DC4D                 movaps  xmm1, xmmword ptr [rsp+70h]
+  .text:000000018020DC52                 movups  xmmword ptr [rdx+rcx+30h], xmm1
+  .text:000000018020DC57                 movaps  xmm0, [rbp+140h+var_1CC+0Ch]
+  .text:000000018020DC5B                 movups  xmmword ptr [rdx+rcx+40h], xmm0
+  .text:000000018020DC60                 mov     eax, [rbp+140h+var_1B0]
+  .text:000000018020DC63                 mov     [rdx+rcx+50h], eax
+  .text:000000018020DC67                 lea     rcx, [rbp+140h+var_1A0]
+  .text:000000018020DC6B                 call    sub_180BDB420
+  .text:000000018020DC70                 lea     rax, ??_7CSingleUserRecipientFilter@@6B@; const CSingleUserRecipientFilter::`vftable'
+  .text:000000018020DC77                 mov     rcx, r15
+  .text:000000018020DC7A                 mov     [rbp+140h+var_1A0], rax
+  .text:000000018020DC7E                 call    j_UTIL_GetPlayerControllerForEntity
+  .text:000000018020DC83                 mov     rdx, rax
+  .text:000000018020DC86                 lea     rcx, [rbp+140h+var_1A0]
+  .text:000000018020DC8A                 call    sub_180BDC440
+  .text:000000018020DC8F                 lea     rcx, [rbp+140h+var_70]
+  .text:000000018020DC96                 call    sub_1801E1FB0
+  .text:000000018020DC9B                 lea     rdx, [rbp+140h+var_70]
+  .text:000000018020DCA2                 lea     rcx, [rsp+240h+var_200]
+  .text:000000018020DCA7                 call    sub_1802419F0
+  .text:000000018020DCAC                 mov     rsi, cs:qword_181F7F838
+  .text:000000018020DCB3                 mov     rcx, cs:g_pNetworkMessages
+  .text:000000018020DCBA                 mov     rbx, cs:qword_181DEA8B8
+  .text:000000018020DCC1                 mov     rdx, rbx
+  .text:000000018020DCC4                 mov     rax, [rsi]
+  .text:000000018020DCC7                 mov     rdi, [rax+78h]
+  .text:000000018020DCCB                 mov     rax, [rcx]
+  .text:000000018020DCCE                 call    qword ptr [rax+60h]
+  .text:000000018020DCD1                 lea     rax, [rbp+140h+var_70]
+  .text:000000018020DCD8                 mov     [rsp+240h+var_210], 50h ; 'P'
+  .text:000000018020DCE1                 mov     [rsp+240h+var_218], rax
+  .text:000000018020DCE6                 lea     r9, [rbp+140h+var_1A0]
+  .text:000000018020DCEA                 xor     edx, edx
+  .text:000000018020DCEC                 mov     [rsp+240h+var_220], rbx
+  .text:000000018020DCF1                 xor     r8d, r8d
+  .text:000000018020DCF4                 mov     rcx, rsi
+  .text:000000018020DCF7                 call    rdi
+  .text:000000018020DCF9                 lea     rcx, [rbp+140h+var_178]
+  .text:000000018020DCFD                 call    sub_180BDB420
+  .text:000000018020DD02                 lea     rax, ??_7CBroadcastRecipientFilter@@6B@; const CBroadcastRecipientFilter::`vftable'
+  .text:000000018020DD09                 lea     rcx, [rbp+140h+var_178]
+  .text:000000018020DD0D                 mov     [rbp+140h+var_178], rax
+  .text:000000018020DD11                 call    sub_180BDBED0
+  .text:000000018020DD16                 lea     rdx, [rbp+140h+arg_10]
+  .text:000000018020DD1D                 mov     rcx, r15
+  .text:000000018020DD20                 call    sub_181213DB0
+  .text:000000018020DD25                 movss   xmm0, cs:dword_1815A77C0
+  .text:000000018020DD2D                 lea     r9, aSpraycanShake; "SprayCan.Shake"
+  .text:000000018020DD34                 mov     r8d, [rbp+140h+arg_10]
+  .text:000000018020DD3B                 lea     rdx, [rbp+140h+var_178]
+  .text:000000018020DD3F                 movss   [rsp+240h+var_208], xmm0
+  .text:000000018020DD45                 lea     rcx, [rbp+140h+var_A0]
+  .text:000000018020DD4C                 xorps   xmm1, xmm1
+  .text:000000018020DD4F                 mov     [rsp+240h+var_210], r14
+  .text:000000018020DD54                 movss   dword ptr [rsp+240h+var_218], xmm1
+  .text:000000018020DD5A                 mov     [rsp+240h+var_220], r14
+  .text:000000018020DD5F                 call    sub_180E0D200
+  .text:000000018020DD64                 lea     rax, ??_7IRecipientFilter@@6B@; const IRecipientFilter::`vftable'
+  .text:000000018020DD6B                 mov     [rbp+140h+var_178], rax
+  .text:000000018020DD6F                 lea     rcx, [rbp+140h+var_40]
+  .text:000000018020DD76                 lea     rax, ??_7?$CNetMessagePB@$0BHA@VCCSUsrMsg_PlayerDecalDigitalSignature@@$0N@$00$00@@6B@; const CNetMessagePB<368,CCSUsrMsg_PlayerDecalDigitalSignature,13,1,1>::`vftable'
+  .text:000000018020DD7D                 mov     [rbp+140h+var_70], rax
+  .text:000000018020DD84                 lea     rax, ??_7?$CNetMessagePB@$0BHA@VCCSUsrMsg_PlayerDecalDigitalSignature@@$0N@$00$00@@6B@_0; const CNetMessagePB<368,CCSUsrMsg_PlayerDecalDigitalSignature,13,1,1>::`vftable'
+  .text:000000018020DD8B                 mov     [rbp+140h+var_40], rax
+  .text:000000018020DD92                 call    sub_180781900
+  .text:000000018020DD97                 jmp     loc_18020DEDB
+  .text:000000018020DD9C                 xorps   xmm0, xmm0
+  .text:000000018020DD9F                 mov     rcx, r15
+  .text:000000018020DDA2                 movups  [rsp+240h+var_200+4], xmm0
+  .text:000000018020DDA7                 movups  [rsp+240h+var_1F0+4], xmm0
+  .text:000000018020DDAC                 movups  [rsp+240h+var_1E0+4], xmm0
+  .text:000000018020DDB1                 movups  [rsp+240h+var_1CC], xmm0
+  .text:000000018020DDB6                 movups  xmmword ptr [rbp-7Ch], xmm0
+  .text:000000018020DDBA                 call    sub_180252EB0
+  .text:000000018020DDBF                 mov     rdx, rdi
+  .text:000000018020DDC2                 mov     dword ptr [rsp+240h+var_200], eax
+  .text:000000018020DDC6                 lea     rcx, [rsp+240h+var_200]
+  .text:000000018020DDCB                 call    sub_180260250
+  .text:000000018020DDD0                 mov     rax, cs:g_pGameRules
+  .text:000000018020DDD7                 mov     ebx, r14d
+  .text:000000018020DDDA                 mov     r12d, [rax+0E58h]
+  .text:000000018020DDE1                 test    r12d, r12d
+  .text:000000018020DDE4                 jle     loc_18020DFAB
+  .text:000000018020DDEA                 mov     r13, [rax+0E60h]
+  .text:000000018020DDF1                 movsxd  rax, ebx
+  .text:000000018020DDF4                 lea     rdx, [rsp+240h+var_200]
+  .text:000000018020DDF9                 imul    rcx, rax, 54h ; 'T'
+  .text:000000018020DDFD                 mov     r8d, 50h ; 'P'
+  .text:000000018020DE03                 add     rcx, r13
+  .text:000000018020DE06                 call    sub_1815512D0
+  .text:000000018020DE0B                 test    eax, eax
+  .text:000000018020DE0D                 jz      short loc_18020DE1B
+  .text:000000018020DE0F                 inc     ebx
+  .text:000000018020DE11                 cmp     ebx, r12d
+  .text:000000018020DE14                 jl      short loc_18020DDF1
+  .text:000000018020DE16                 jmp     loc_18020DFAB
+  .text:000000018020DE1B                 test    ebx, ebx
+  .text:000000018020DE1D                 js      loc_18020DFAB
+  .text:000000018020DE23                 mov     rcx, cs:g_pGameRules
+  .text:000000018020DE2A                 mov     edx, ebx
+  .text:000000018020DE2C                 add     rcx, 0E58h
+  .text:000000018020DE33                 call    sub_1801F0610
+  .text:000000018020DE38                 mov     rax, [rdi+48h]
+  .text:000000018020DE3C                 mov     rcx, rsi
+  .text:000000018020DE3F                 test    rax, rax
+  .text:000000018020DE42                 cmovnz  rcx, rax
+  .text:000000018020DE46                 call    sub_1801E64A0
+  .text:000000018020DE4B                 test    al, al
+  .text:000000018020DE4D                 jz      loc_18020DFAB
+  .text:000000018020DE53                 lea     rcx, [rbp+140h+var_1A0]
+  .text:000000018020DE57                 call    sub_180BDB420
+  .text:000000018020DE5C                 lea     rax, ??_7CBroadcastRecipientFilter@@6B@; const CBroadcastRecipientFilter::`vftable'
+  .text:000000018020DE63                 lea     rcx, [rbp+140h+var_1A0]
+  .text:000000018020DE67                 mov     [rbp+140h+var_1A0], rax
+  .text:000000018020DE6B                 call    sub_180BDBED0
+  .text:000000018020DE70                 lea     rdx, [rbp+140h+arg_10]
+  .text:000000018020DE77                 mov     rcx, r15
+  .text:000000018020DE7A                 call    sub_181213DB0
+  .text:000000018020DE7F                 movss   xmm0, cs:dword_1815A77C0
+  .text:000000018020DE87                 lea     r9, aSpraycanPaint; "SprayCan.Paint"
+  .text:000000018020DE8E                 mov     r8d, [rbp+140h+arg_10]
+  .text:000000018020DE95                 lea     rdx, [rbp+140h+var_1A0]
+  .text:000000018020DE99                 movss   [rsp+240h+var_208], xmm0
+  .text:000000018020DE9F                 lea     rcx, [rbp+140h+var_A0]
+  .text:000000018020DEA6                 xorps   xmm1, xmm1
+  .text:000000018020DEA9                 mov     [rsp+240h+var_210], r14
+  .text:000000018020DEAE                 movss   dword ptr [rsp+240h+var_218], xmm1
+  .text:000000018020DEB4                 mov     [rsp+240h+var_220], r14
+  .text:000000018020DEB9                 call    sub_180E0D200
+  .text:000000018020DEBE                 mov     rax, [rdi+48h]
+  .text:000000018020DEC2                 lea     rcx, [rsp+240h+var_200]
+  .text:000000018020DEC7                 test    rax, rax
+  .text:000000018020DECA                 cmovnz  rsi, rax
+  .text:000000018020DECE                 mov     rdx, [rsi+58h]
+  .text:000000018020DED2                 ; CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:000000018020DED2                 and     rdx, 0FFFFFFFFFFFFFFFCh; CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:000000018020DED6                 call    CEntitySpawner_CPlayerSprayDecal_Spawn
+  .text:000000018020DEDB                 mov     r10, cs:g_pGameRules
+  .text:000000018020DEE2                 mov     ecx, [r10+0E58h]
+  .text:000000018020DEE9                 test    ecx, ecx
+  .text:000000018020DEEB                 jle     loc_18020DFAB
+  .text:000000018020DEF1                 movss   xmm2, cs:dword_1815BA220
+  .text:000000018020DEF9                 mov     r9, r14
+  .text:000000018020DEFC                 nop     dword ptr [rax+00h]
+  .text:000000018020DF00                 mov     r8, [r10+0E60h]
+  .text:000000018020DF07                 mov     edx, ecx
+  .text:000000018020DF09                 mov     rax, cs:off_181C4FC68
+  .text:000000018020DF10                 movss   xmm1, dword ptr [r9+r8+4Ch]
+  .text:000000018020DF17                 movss   xmm0, dword ptr [rax+30h]
+  .text:000000018020DF1C                 addss   xmm1, xmm2
+  .text:000000018020DF20                 comiss  xmm0, xmm1
+  .text:000000018020DF23                 jbe     short loc_18020DF99
+  .text:000000018020DF25                 movsxd  r11, r14d
+  .text:000000018020DF28                 sub     r9, 54h ; 'T'
+  .text:000000018020DF2C                 dec     r14d
+  .text:000000018020DF2F                 test    ecx, ecx
+  .text:000000018020DF31                 jle     short loc_18020DF99
+  .text:000000018020DF33                 lea     eax, [rcx-1]
+  .text:000000018020DF36                 cmp     r11d, eax
+  .text:000000018020DF39                 jz      short loc_18020DF8B
+  .text:000000018020DF3B                 movsxd  rax, ecx
+  .text:000000018020DF3E                 imul    rdx, rax, 54h ; 'T'
+  .text:000000018020DF42                 imul    rcx, r11, 54h ; 'T'
+  .text:000000018020DF46                 movups  xmm0, xmmword ptr [rdx+r8-54h]
+  .text:000000018020DF4C                 movups  xmmword ptr [rcx+r8], xmm0
+  .text:000000018020DF51                 movups  xmm1, xmmword ptr [rdx+r8-44h]
+  .text:000000018020DF57                 movups  xmmword ptr [rcx+r8+10h], xmm1
+  .text:000000018020DF5D                 movups  xmm0, xmmword ptr [rdx+r8-34h]
+  .text:000000018020DF63                 movups  xmmword ptr [rcx+r8+20h], xmm0
+  .text:000000018020DF69                 movups  xmm1, xmmword ptr [rdx+r8-24h]
+  .text:000000018020DF6F                 movups  xmmword ptr [rcx+r8+30h], xmm1
+  .text:000000018020DF75                 movups  xmm0, xmmword ptr [rdx+r8-14h]
+  .text:000000018020DF7B                 movups  xmmword ptr [rcx+r8+40h], xmm0
+  .text:000000018020DF81                 mov     eax, [rdx+r8-4]
+  .text:000000018020DF86                 mov     [rcx+r8+50h], eax
+  .text:000000018020DF8B                 dec     dword ptr [r10+0E58h]
+  .text:000000018020DF92                 mov     edx, [r10+0E58h]
+  .text:000000018020DF99                 inc     r14d
+  .text:000000018020DF9C                 add     r9, 54h ; 'T'
+  .text:000000018020DFA0                 mov     ecx, edx
+  .text:000000018020DFA2                 cmp     r14d, edx
+  .text:000000018020DFA5                 jl      loc_18020DF00
+  .text:000000018020DFAB                 mov     r12, [rsp+240h+arg_18]
+  .text:000000018020DFB3                 mov     rbx, [rsp+240h+arg_0]
+  .text:000000018020DFBB                 mov     r13, [rsp+240h+var_20]
+  .text:000000018020DFC3                 mov     rsi, [rsp+240h+arg_8]
+  .text:000000018020DFCB                 add     rsp, 228h
+  .text:000000018020DFD2                 pop     r15
+  .text:000000018020DFD4                 pop     r14
+  .text:000000018020DFD6                 pop     rdi
+  .text:000000018020DFD7                 pop     rbp
+  .text:000000018020DFD8                 retn
+procedure: |-
+  void __fastcall sub_18020D8E0(__int64 a1, __int64 a2)
+  {
+    int v4; // r14d
+    void ***v5; // rsi
+    void ***v6; // rcx
+    void ***v7; // rcx
+    __int64 v8; // rax
+    void ***v9; // rcx
+    int v10; // eax
+    __m128 v11; // xmm1
+    int v12; // eax
+    __m128 v13; // xmm0
+    __int64 v14; // rsi
+    __int64 v15; // r12
+    __int64 v16; // rcx
+    __int64 v17; // rcx
+    int v18; // edi
+    int v19; // eax
+    __int64 v20; // rdx
+    int v21; // ebx
+    int v22; // eax
+    __int64 v23; // rcx
+    __int64 v24; // rdx
+    __int64 PlayerControllerForEntity; // rax
+    __int64 v26; // rsi
+    __int64 v27; // rbx
+    void (__fastcall *v28)(__int64, _QWORD, _QWORD, _QWORD *, __int64, _QWORD *, __int64); // rdi
+    int v29; // ebx
+    int v30; // r12d
+    __int64 v31; // r13
+    void ***v32; // rcx
+    __int64 v33; // r10
+    int v34; // ecx
+    __int64 v35; // r9
+    __int64 v36; // r8
+    int v37; // edx
+    __int64 v38; // r11
+    __int64 v39; // rdx
+    __int64 v40; // rcx
+    _OWORD v41[6]; // [rsp+40h] [rbp-C0h] BYREF
+    _QWORD v42[3]; // [rsp+A0h] [rbp-60h] BYREF
+    __int64 v43; // [rsp+B8h] [rbp-48h] BYREF
+    int v44; // [rsp+C0h] [rbp-40h]
+    _QWORD v45[3]; // [rsp+C8h] [rbp-38h] BYREF
+    char v46[8]; // [rsp+E0h] [rbp-20h] BYREF
+    __int64 v47; // [rsp+E8h] [rbp-18h]
+    __int64 v48; // [rsp+130h] [rbp+30h]
+    __int64 v49; // [rsp+138h] [rbp+38h]
+    __int64 v50; // [rsp+140h] [rbp+40h]
+    int v51; // [rsp+148h] [rbp+48h]
+    int v52; // [rsp+14Ch] [rbp+4Ch]
+    int v53; // [rsp+150h] [rbp+50h]
+    int v54; // [rsp+154h] [rbp+54h]
+    __int64 v55; // [rsp+164h] [rbp+64h]
+    float v56; // [rsp+16Ch] [rbp+6Ch]
+    __int64 v57; // [rsp+170h] [rbp+70h]
+    float v58; // [rsp+178h] [rbp+78h]
+    _BYTE v59[24]; // [rsp+1A0h] [rbp+A0h] BYREF
+    char v60[24]; // [rsp+1B8h] [rbp+B8h] BYREF
+    _QWORD v61[6]; // [rsp+1D0h] [rbp+D0h] BYREF
+    void **v62; // [rsp+200h] [rbp+100h] BYREF
+    int v63; // [rsp+260h] [rbp+160h] BYREF
+
+    v4 = 0;
+    if ( (unsigned int)((__int64 (*)(void))sub_180252EB0)() && g_pGameRules && (*(_BYTE *)(a2 + 64) & 1) != 0 )
+    {
+      v5 = &off_181BE3CB0;
+      v6 = &off_181BE3CB0;
+      if ( *(_QWORD *)(a2 + 72) )
+        v6 = *(void ****)(a2 + 72);
+      if ( *((_DWORD *)v6 + 31) )
+      {
+        if ( (unsigned int)sub_180FC7A40(v6 + 3) )
+        {
+          memset((char *)v41 + 4, 0, 80);
+          LODWORD(v41[0]) = sub_180252EB0(a1);
+          sub_180260250(v41, a2);
+          v29 = 0;
+          v30 = *(_DWORD *)(g_pGameRules + 3672);
+          if ( v30 > 0 )
+          {
+            v31 = *(_QWORD *)(g_pGameRules + 3680);
+            while ( (unsigned int)sub_1815512D0(v31 + 84LL * v29, v41, 80) )
+            {
+              if ( ++v29 >= v30 )
+                return;
+            }
+            if ( v29 >= 0 )
+            {
+              sub_1801F0610(g_pGameRules + 3672, (unsigned int)v29);
+              v32 = &off_181BE3CB0;
+              if ( *(_QWORD *)(a2 + 72) )
+                v32 = *(void ****)(a2 + 72);
+              if ( (unsigned __int8)sub_1801E64A0(v32) )
+              {
+                sub_180BDB420(v42);
+                v42[0] = &CBroadcastRecipientFilter::`vftable';
+                sub_180BDBED0(v42);
+                sub_181213DB0(a1, &v63);
+                sub_180E0D200(
+                  (unsigned int)v59,
+                  (unsigned int)v42,
+                  v63,
+                  (unsigned int)"SprayCan.Paint",
+                  0,
+                  0,
+                  0,
+                  1065353216);
+                if ( *(_QWORD *)(a2 + 72) )
+                  v5 = *(void ****)(a2 + 72);
+                CEntitySpawner_CPlayerSprayDecal_Spawn((int *)v41, (_QWORD *)((unsigned __int64)v5[11] & 0xFFFFFFFFFFFFFFFCuLL));
+  LABEL_43:
+                v33 = g_pGameRules;
+                v34 = *(_DWORD *)(g_pGameRules + 3672);
+                if ( v34 > 0 )
+                {
+                  v35 = 0;
+                  do
+                  {
+                    v36 = *(_QWORD *)(v33 + 3680);
+                    v37 = v34;
+                    if ( *((float *)off_181C4FC68 + 12) > (float)(*(float *)(v35 + v36 + 76) + 300.0) )
+                    {
+                      v38 = v4;
+                      v35 -= 84;
+                      --v4;
+                      if ( v34 > 0 )
+                      {
+                        if ( (_DWORD)v38 != v34 - 1 )
+                        {
+                          v39 = 84LL * v34;
+                          v40 = 84 * v38;
+                          *(_OWORD *)(v40 + v36) = *(_OWORD *)(v39 + v36 - 84);
+                          *(_OWORD *)(v40 + v36 + 16) = *(_OWORD *)(v39 + v36 - 68);
+                          *(_OWORD *)(v40 + v36 + 32) = *(_OWORD *)(v39 + v36 - 52);
+                          *(_OWORD *)(v40 + v36 + 48) = *(_OWORD *)(v39 + v36 - 36);
+                          *(_OWORD *)(v40 + v36 + 64) = *(_OWORD *)(v39 + v36 - 20);
+                          *(_DWORD *)(v40 + v36 + 80) = *(_DWORD *)(v39 + v36 - 4);
+                        }
+                        v37 = --*(_DWORD *)(v33 + 3672);
+                      }
+                    }
+                    ++v4;
+                    v35 += 84;
+                    v34 = v37;
+                  }
+                  while ( v4 < v37 );
+                }
+              }
+            }
+          }
+        }
+        else
+        {
+          sub_1808B37D0(&v63, *(unsigned int *)(*(_QWORD *)(a1 + 16) + 56LL));
+          if ( !(unsigned __int8)sub_1801E3760(&v63, a1 + 3788) )
+          {
+            sub_180205E00(a1);
+            v7 = &off_181BE3CB0;
+            if ( *(_QWORD *)(a2 + 72) )
+              v7 = *(void ****)(a2 + 72);
+            if ( fabs(*((float *)off_181C4FC68 + 12) - *((float *)v7 + 29)) <= 10.0 )
+            {
+              v48 = 0;
+              v49 = 0;
+              v50 = 0;
+              v54 = 117440512;
+              v51 = 0;
+              v52 = -1;
+              v53 = 0;
+              sub_18130EF60(v46);
+              v8 = sub_180A43CE0(a1, v46, v60, &v43);
+              if ( v8 )
+              {
+                ClientPrint(a1, 4, v8, 0, 0, 0, 0);
+                return;
+              }
+              sub_180205E00(a1);
+              LODWORD(v41[0]) = sub_180252EB0(a1);
+              v9 = &off_181BE3CB0;
+              if ( *(_QWORD *)(a2 + 72) )
+                v9 = *(void ****)(a2 + 72);
+              DWORD1(v41[0]) = *((_DWORD *)v9 + 31);
+              *((_QWORD *)&v41[0] + 1) = v55;
+              *(float *)&v41[1] = v56;
+              *(_QWORD *)&v41[2] = v43;
+              DWORD2(v41[2]) = v44;
+              *(_QWORD *)((char *)&v41[2] + 12) = v57;
+              *((float *)&v41[3] + 1) = v58;
+              DWORD2(v41[3]) = *((_DWORD *)v9 + 30);
+              HIDWORD(v41[3]) = *((_DWORD *)v9 + 26);
+              sub_181213DB0(v47, &v63);
+              LODWORD(v41[4]) = v63;
+              v10 = sub_180C037E0(v46);
+              v11 = (__m128)HIDWORD(v55);
+              DWORD1(v41[4]) = v10;
+              if ( *(_QWORD *)(a2 + 72) )
+                v5 = *(void ****)(a2 + 72);
+              DWORD2(v41[4]) = *((_DWORD *)v5 + 32);
+              HIDWORD(v41[4]) = *((_DWORD *)off_181C4FC68 + 12);
+              v12 = *((_DWORD *)v5 + 25);
+              v13 = (__m128)(unsigned int)v57;
+              v14 = g_pGameRules;
+              v13.m128_f32[0] = *(float *)&v57 + *(float *)&v55;
+              *((float *)&v41[1] + 3) = v56 + v58;
+              LODWORD(v41[5]) = v12;
+              v11.m128_f32[0] = *((float *)&v55 + 1) + *((float *)&v57 + 1);
+              *(_QWORD *)((char *)&v41[1] + 4) = _mm_unpacklo_ps(v13, v11).m128_u64[0];
+              v15 = *(int *)(g_pGameRules + 3672);
+              if ( (_DWORD)v15 == *(_DWORD *)(g_pGameRules + 3688) && (*(_DWORD *)(g_pGameRules + 3692) & 0x40000000) == 0 )
+              {
+                v16 = *(unsigned int *)(g_pGameRules + 3688);
+                if ( (_DWORD)v16 == 0x7FFFFFFF )
+                  UtlVectorMemory_FailedAllocation(v16, 1);
+                v17 = *(unsigned int *)(v14 + 3688);
+                v18 = v17 + 1;
+                v19 = UtlVectorMemory_CalcNewAllocationCount(
+                        v17,
+                        *(_DWORD *)(v14 + 3692) & 0x3FFFFFFF,
+                        (unsigned int)(v17 + 1),
+                        84);
+                v21 = v19;
+                if ( v19 < v18 )
+                {
+                  if ( v19 || v18 > -1 )
+                  {
+                    do
+                    {
+                      v20 = (unsigned int)((v18 + v21) >> 31);
+                      v21 = (v18 + v21) / 2;
+                    }
+                    while ( v21 < v18 );
+                  }
+                  else
+                  {
+                    v21 = -1;
+                  }
+                }
+                LOBYTE(v20) = (*(_DWORD *)(v14 + 3692) & 0xC0000000) == 0;
+                *(_QWORD *)(v14 + 3680) = UtlVectorMemory_Alloc(
+                                            *(_QWORD *)(v14 + 3680),
+                                            v20,
+                                            84LL * v21,
+                                            84LL * *(int *)(v14 + 3688));
+                v22 = *(_DWORD *)(v14 + 3692);
+                if ( (v22 & 0xC0000000) != 0 )
+                  *(_DWORD *)(v14 + 3692) = v22 & 0x3FFFFFFF;
+                *(_DWORD *)(v14 + 3688) = v21;
+              }
+              ++*(_DWORD *)(v14 + 3672);
+              v23 = *(_QWORD *)(v14 + 3680);
+              v24 = 84 * v15;
+              *(_OWORD *)(v24 + v23) = v41[0];
+              *(_OWORD *)(v24 + v23 + 16) = v41[1];
+              *(_OWORD *)(v24 + v23 + 32) = v41[2];
+              *(_OWORD *)(v24 + v23 + 48) = v41[3];
+              *(_OWORD *)(v24 + v23 + 64) = v41[4];
+              *(_DWORD *)(v24 + v23 + 80) = v41[5];
+              sub_180BDB420(v42);
+              v42[0] = &CSingleUserRecipientFilter::`vftable';
+              PlayerControllerForEntity = j_UTIL_GetPlayerControllerForEntity(a1);
+              sub_180BDC440(v42, PlayerControllerForEntity);
+              sub_1801E1FB0(v61);
+              sub_1802419F0(v41, v61);
+              v26 = qword_181F7F838;
+              v27 = qword_181DEA8B8;
+              v28 = *(void (__fastcall **)(__int64, _QWORD, _QWORD, _QWORD *, __int64, _QWORD *, __int64))(*(_QWORD *)qword_181F7F838 + 120LL);
+              (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pNetworkMessages + 96LL))(
+                g_pNetworkMessages,
+                qword_181DEA8B8);
+              v28(v26, 0, 0, v42, v27, v61, 80);
+              sub_180BDB420(v45);
+              v45[0] = &CBroadcastRecipientFilter::`vftable';
+              sub_180BDBED0(v45);
+              sub_181213DB0(a1, &v63);
+              sub_180E0D200(
+                (unsigned int)v59,
+                (unsigned int)v45,
+                v63,
+                (unsigned int)"SprayCan.Shake",
+                0,
+                0,
+                0,
+                1065353216);
+              v45[0] = &IRecipientFilter::`vftable';
+              v61[0] = &CNetMessagePB<368,CCSUsrMsg_PlayerDecalDigitalSignature,13,1,1>::`vftable';
+              v62 = &CNetMessagePB<368,CCSUsrMsg_PlayerDecalDigitalSignature,13,1,1>::`vftable';
+              sub_180781900(&v62);
+              goto LABEL_43;
+            }
+          }
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.linux.yaml
@@ -1,0 +1,1630 @@
+func_name: CEntitySpawner_CPlayerSprayDecal_Spawn
+func_va: '0xb172f0'
+disasm_code: |-
+  .text:0000000000B172F0                 push    rbp
+  .text:0000000000B172F1                 lea     rax, off_2255B38
+  .text:0000000000B172F8                 mov     rbp, rsp
+  .text:0000000000B172FB                 push    r15
+  .text:0000000000B172FD                 push    r14
+  .text:0000000000B172FF                 push    r13
+  .text:0000000000B17301                 push    r12
+  .text:0000000000B17303                 mov     r12, rdi
+  .text:0000000000B17306                 push    rbx
+  .text:0000000000B17307                 mov     rbx, rsi
+  .text:0000000000B1730A                 sub     rsp, 218h
+  .text:0000000000B17311                 mov     [rbp+var_1D0], rax
+  .text:0000000000B17318                 lea     rax, g_pEntitySystem
+  .text:0000000000B1731F                 mov     r14, qword ptr cs:xmmword_86C470
+  .text:0000000000B17326                 mov     [rbp+var_1B0], 0
+  .text:0000000000B17331                 mov     [rbp+var_16F], 0
+  .text:0000000000B17338                 mov     [rbp+var_168], 0
+  .text:0000000000B17343                 mov     r13, [rax]
+  .text:0000000000B17346                 mov     [rbp+var_148], 0
+  .text:0000000000B1734D                 mov     [rbp+var_158], 0
+  .text:0000000000B17358                 mov     [rbp+var_150], r14
+  .text:0000000000B1735F                 mov     rdi, r13
+  .text:0000000000B17362                 ; 0xCD0 = 3280 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+  .text:0000000000B17362                 add     r13, 0CD0h; 0xCD0 = 3280 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+  .text:0000000000B17369                 call    sub_1E62130
+  .text:0000000000B1736E                 mov     [rbp+var_1A4], eax
+  .text:0000000000B17374                 lea     rax, g_pEntitySystem
+  .text:0000000000B1737B                 mov     rdi, [rax]
+  .text:0000000000B1737E                 call    sub_1E62140
+  .text:0000000000B17383                 movdqa  xmm0, xmmword ptr [rax]
+  .text:0000000000B17387                 mov     [rbp+var_1C8], 0
+  .text:0000000000B17392                 movaps  [rbp+var_1A0], xmm0
+  .text:0000000000B17399                 movdqa  xmm0, xmmword ptr [rax+10h]
+  .text:0000000000B1739E                 mov     [rbp+var_1C0], r13
+  .text:0000000000B173A5                 movaps  [rbp+var_190], xmm0
+  .text:0000000000B173AC                 movdqa  xmm0, xmmword ptr [rax+20h]
+  .text:0000000000B173B1                 mov     rax, cs:qword_25C50C0
+  .text:0000000000B173B8                 movaps  [rbp+var_180], xmm0
+  .text:0000000000B173BF                 mov     [rbp+var_1B8], rax
+  .text:0000000000B173C6                 lea     rax, g_pVApplication
+  .text:0000000000B173CD                 mov     rdi, [rax]
+  .text:0000000000B173D0                 xor     eax, eax
+  .text:0000000000B173D2                 test    rdi, rdi
+  .text:0000000000B173D5                 jz      short loc_B173E0
+  .text:0000000000B173D7                 mov     rax, [rdi]
+  .text:0000000000B173DA                 call    qword ptr [rax+0D0h]
+  .text:0000000000B173E0                 mov     edi, 38h ; '8'
+  .text:0000000000B173E5                 mov     [rbp+var_170], al
+  .text:0000000000B173EB                 mov     [rbp+var_1A8], 0
+  .text:0000000000B173F5                 call    sub_97A1D0
+  .text:0000000000B173FA                 mov     rsi, [rbp+var_1C0]
+  .text:0000000000B17401                 mov     edx, 3
+  .text:0000000000B17406                 mov     r15, rax
+  .text:0000000000B17409                 mov     rdi, rax
+  .text:0000000000B1740C                 call    sub_1E57610
+  .text:0000000000B17411                 mov     [rbp+var_1C8], r15
+  .text:0000000000B17418                 add     word ptr [r15+20h], 1
+  .text:0000000000B1741E                 cmp     byte ptr [r15+24h], 0
+  .text:0000000000B17423                 jnz     loc_B184E0
+  .text:0000000000B17429                 mov     r13, [rbp+var_168]
+  .text:0000000000B17430                 test    r13, r13
+  .text:0000000000B17433                 jz      short loc_B1745F
+  .text:0000000000B17435                 mov     rdi, r15
+  .text:0000000000B17438                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000000B17440                 mov     rsi, r13
+  .text:0000000000B17443                 xor     ecx, ecx
+  .text:0000000000B17445                 xor     edx, edx
+  .text:0000000000B17447                 call    sub_1E58BB0
+  .text:0000000000B1744C                 mov     r13, [r13+38h]
+  .text:0000000000B17450                 mov     rdi, [rbp+var_1C8]
+  .text:0000000000B17457                 test    r13, r13
+  .text:0000000000B1745A                 jnz     short loc_B17440
+  .text:0000000000B1745C                 mov     r15, rdi
+  .text:0000000000B1745F                 mov     rax, [r12+8]
+  .text:0000000000B17464                 lea     r13, aOrigin_0; "origin"
+  .text:0000000000B1746B                 mov     esi, 31415920h
+  .text:0000000000B17470                 movss   xmm3, dword ptr [r12+10h]
+  .text:0000000000B17477                 mov     rdi, r13
+  .text:0000000000B1747A                 movss   dword ptr [rbp+var_220], xmm3
+  .text:0000000000B17482                 mov     [rbp+var_228], rax
+  .text:0000000000B17489                 call    sub_987340
+  .text:0000000000B1748E                 mov     qword ptr [rbp+var_140+8], r13
+  .text:0000000000B17495                 mov     rdi, r15
+  .text:0000000000B17498                 lea     r13, [rbp+var_140]
+  .text:0000000000B1749F                 xor     eax, 6E69h
+  .text:0000000000B174A4                 mov     dword ptr [rbp+var_140+4], 0FFFFFFFFh
+  .text:0000000000B174AE                 imul    eax, 5BD1E995h
+  .text:0000000000B174B4                 mov     rsi, r13
+  .text:0000000000B174B7                 mov     [rbp+var_218], r13
+  .text:0000000000B174BE                 mov     edx, eax
+  .text:0000000000B174C0                 shr     edx, 0Dh
+  .text:0000000000B174C3                 xor     eax, edx
+  .text:0000000000B174C5                 imul    eax, 5BD1E995h
+  .text:0000000000B174CB                 mov     edx, eax
+  .text:0000000000B174CD                 shr     edx, 0Fh
+  .text:0000000000B174D0                 xor     eax, edx
+  .text:0000000000B174D2                 mov     dword ptr [rbp+var_140], eax
+  .text:0000000000B174D8                 call    sub_1E57E00
+  .text:0000000000B174DD                 mov     rdi, rax
+  .text:0000000000B174E0                 test    rax, rax
+  .text:0000000000B174E3                 jz      short loc_B17515
+  .text:0000000000B174E5                 mov     rax, [rbp+var_228]
+  .text:0000000000B174EC                 mov     ecx, 1Dh
+  .text:0000000000B174F1                 mov     rdx, r13
+  .text:0000000000B174F4                 mov     esi, 3
+  .text:0000000000B174F9                 movss   xmm3, dword ptr [rbp+var_220]
+  .text:0000000000B17501                 movss   dword ptr [rbp+var_140+8], xmm3
+  .text:0000000000B17509                 mov     qword ptr [rbp+var_140], rax
+  .text:0000000000B17510                 call    sub_1B18100
+  .text:0000000000B17515                 lea     r15, aAngles; "angles"
+  .text:0000000000B1751C                 mov     esi, 31415920h
+  .text:0000000000B17521                 mov     rdi, r15
+  .text:0000000000B17524                 call    sub_987340
+  .text:0000000000B17529                 mov     rdi, [rbp+var_1C8]
+  .text:0000000000B17530                 mov     dword ptr [rbp+var_140+4], 0FFFFFFFFh
+  .text:0000000000B1753A                 xor     eax, 7365h
+  .text:0000000000B1753F                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17546                 mov     qword ptr [rbp+var_140+8], r15
+  .text:0000000000B1754D                 imul    eax, 5BD1E995h
+  .text:0000000000B17553                 mov     edx, eax
+  .text:0000000000B17555                 shr     edx, 0Dh
+  .text:0000000000B17558                 xor     eax, edx
+  .text:0000000000B1755A                 imul    eax, 5BD1E995h
+  .text:0000000000B17560                 mov     edx, eax
+  .text:0000000000B17562                 shr     edx, 0Fh
+  .text:0000000000B17565                 xor     eax, edx
+  .text:0000000000B17567                 mov     dword ptr [rbp+var_140], eax
+  .text:0000000000B1756D                 call    sub_1E57E00
+  .text:0000000000B17572                 mov     rdi, rax
+  .text:0000000000B17575                 test    rax, rax
+  .text:0000000000B17578                 jz      short loc_B17590
+  .text:0000000000B1757A                 mov     ecx, 22h ; '"'
+  .text:0000000000B1757F                 mov     esi, 3
+  .text:0000000000B17584                 lea     rdx, qword_784F20
+  .text:0000000000B1758B                 call    sub_1B18100
+  .text:0000000000B17590                 lea     r15, aOwner; "owner"
+  .text:0000000000B17597                 mov     esi, 31415923h
+  .text:0000000000B1759C                 mov     rdi, r15
+  .text:0000000000B1759F                 call    sub_987340
+  .text:0000000000B175A4                 mov     rsi, [rbp+var_218]
+  .text:0000000000B175AB                 mov     qword ptr [rbp+var_140+8], r15
+  .text:0000000000B175B2                 xor     eax, 72h
+  .text:0000000000B175B5                 mov     rdi, [rbp+var_1C8]
+  .text:0000000000B175BC                 mov     dword ptr [rbp+var_140+4], 0FFFFFFFFh
+  .text:0000000000B175C6                 imul    eax, 5BD1E995h
+  .text:0000000000B175CC                 mov     edx, eax
+  .text:0000000000B175CE                 shr     edx, 0Dh
+  .text:0000000000B175D1                 xor     eax, edx
+  .text:0000000000B175D3                 imul    eax, 5BD1E995h
+  .text:0000000000B175D9                 mov     edx, eax
+  .text:0000000000B175DB                 shr     edx, 0Fh
+  .text:0000000000B175DE                 xor     eax, edx
+  .text:0000000000B175E0                 mov     dword ptr [rbp+var_140], eax
+  .text:0000000000B175E6                 call    sub_1E57E00
+  .text:0000000000B175EB                 mov     r15, rax
+  .text:0000000000B175EE                 test    rax, rax
+  .text:0000000000B175F1                 jz      short loc_B1761F
+  .text:0000000000B175F3                 sub     rsp, 8
+  .text:0000000000B175F7                 mov     rdi, rax
+  .text:0000000000B175FA                 xor     r8d, r8d
+  .text:0000000000B175FD                 push    0
+  .text:0000000000B175FF                 xor     r9d, r9d
+  .text:0000000000B17602                 xor     ecx, ecx
+  .text:0000000000B17604                 mov     edx, 26h ; '&'
+  .text:0000000000B17609                 mov     esi, 4
+  .text:0000000000B1760E                 call    sub_1B161C0
+  .text:0000000000B17613                 mov     eax, 0FFFFFFFFh
+  .text:0000000000B17618                 mov     [r15+8], rax
+  .text:0000000000B1761C                 pop     rdi
+  .text:0000000000B1761D                 pop     r8
+  .text:0000000000B1761F                 cmp     [rbp+var_1C8], 0
+  .text:0000000000B17627                 jz      loc_B18410
+  .text:0000000000B1762D                 mov     rdx, [rbp+var_218]
+  .text:0000000000B17634                 lea     rdi, aSpawn; "Spawn"
+  .text:0000000000B1763B                 mov     dword ptr [rbp+var_140+8], 4BBh
+  .text:0000000000B17645                 lea     r15, aClassname; "classname"
+  .text:0000000000B1764C                 mov     [rbp+var_130], rdi
+  .text:0000000000B17653                 lea     rax, aGameSharedEnti; "../../game/shared/entityspawner.h"
+  .text:0000000000B1765A                 lea     rsi, off_244CB60; "Server Simulation"
+  .text:0000000000B17661                 mov     qword ptr [rbp+var_140], rax
+  .text:0000000000B17668                 call    sub_985250
+  .text:0000000000B1766D                 mov     esi, 3141592Fh
+  .text:0000000000B17672                 mov     rdi, r15
+  .text:0000000000B17675                 mov     [rbp+var_220], rax
+  .text:0000000000B1767C                 call    sub_987340
+  .text:0000000000B17681                 lea     rdi, [r15+4]
+  .text:0000000000B17685                 mov     esi, eax
+  .text:0000000000B17687                 call    sub_987340
+  .text:0000000000B1768C                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17693                 mov     dword ptr [rbp+var_140+4], 0FFFFFFFFh
+  .text:0000000000B1769D                 xor     eax, 65h
+  .text:0000000000B176A0                 mov     rdi, [rbp+var_1C8]
+  .text:0000000000B176A7                 mov     qword ptr [rbp+var_140+8], r15
+  .text:0000000000B176AE                 imul    eax, 5BD1E995h
+  .text:0000000000B176B4                 mov     ecx, eax
+  .text:0000000000B176B6                 shr     ecx, 0Dh
+  .text:0000000000B176B9                 xor     eax, ecx
+  .text:0000000000B176BB                 imul    eax, 5BD1E995h
+  .text:0000000000B176C1                 mov     ecx, eax
+  .text:0000000000B176C3                 shr     ecx, 0Fh
+  .text:0000000000B176C6                 xor     eax, ecx
+  .text:0000000000B176C8                 mov     dword ptr [rbp+var_140], eax
+  .text:0000000000B176CE                 mov     r13d, eax
+  .text:0000000000B176D1                 lea     rax, [rbp+var_210]
+  .text:0000000000B176D8                 mov     rdx, rax
+  .text:0000000000B176DB                 mov     [rbp+var_230], rax
+  .text:0000000000B176E2                 call    sub_1E57D00
+  .text:0000000000B176E7                 mov     rdx, [rbp+var_1B8]
+  .text:0000000000B176EE                 test    rax, rax
+  .text:0000000000B176F1                 jz      loc_B18470
+  .text:0000000000B176F7                 cmp     byte ptr [rbp+var_210], 0
+  .text:0000000000B176FE                 jnz     loc_B18470
+  .text:0000000000B17704                 mov     rcx, [rbp+var_1B0]
+  .text:0000000000B1770B                 lea     rax, g_pEntitySystem
+  .text:0000000000B17712                 test    rcx, rcx
+  .text:0000000000B17715                 mov     rdi, [rax]
+  .text:0000000000B17718                 lea     rax, byte_8D7E1C
+  .text:0000000000B1771F                 push    0
+  .text:0000000000B17721                 cmovz   rcx, rax
+  .text:0000000000B17725                 mov     eax, dword ptr [rbp+var_150+4]
+  .text:0000000000B1772B                 push    rax
+  .text:0000000000B1772C                 mov     r9d, dword ptr [rbp+var_150]
+  .text:0000000000B17733                 mov     esi, [rbp+var_1A4]
+  .text:0000000000B17739                 mov     r8d, [rbp+var_1A8]
+  .text:0000000000B17740                 call    CEntitySystem_CreateEntity
+  .text:0000000000B17745                 pop     rcx
+  .text:0000000000B17746                 mov     r9, rax
+  .text:0000000000B17749                 pop     rsi
+  .text:0000000000B1774A                 test    rax, rax
+  .text:0000000000B1774D                 jz      loc_B18400
+  .text:0000000000B17753                 mov     rdx, [rax+10h]
+  .text:0000000000B17757                 mov     r13d, 0FFFFFFFFh
+  .text:0000000000B1775D                 test    rdx, rdx
+  .text:0000000000B17760                 jz      short loc_B1778E
+  .text:0000000000B17762                 mov     eax, [rdx+10h]
+  .text:0000000000B17765                 mov     ecx, [rdx+30h]
+  .text:0000000000B17768                 shr     eax, 0Fh
+  .text:0000000000B1776B                 and     ecx, 1
+  .text:0000000000B1776E                 sub     eax, ecx
+  .text:0000000000B17770                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000000B17774                 jz      loc_B1875A
+  .text:0000000000B1777A                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000000B1777E                 and     dx, 7FFFh
+  .text:0000000000B17783                 shl     eax, 0Fh
+  .text:0000000000B17786                 movzx   edx, dx
+  .text:0000000000B17789                 or      eax, edx
+  .text:0000000000B1778B                 mov     r13d, eax
+  .text:0000000000B1778E                 lea     rdx, g_pGameResourceService
+  .text:0000000000B17795                 mov     [rbp+var_228], r9
+  .text:0000000000B1779C                 mov     rax, 1FFFFFFFFFFFFh
+  .text:0000000000B177A6                 mov     [rbp+var_130], rax
+  .text:0000000000B177AD                 movq    xmm0, qword ptr [r9+10h]
+  .text:0000000000B177B3                 pinsrq  xmm0, [rbp+var_1C8], 1
+  .text:0000000000B177BE                 lea     r8, [rbp+var_1A0]
+  .text:0000000000B177C5                 movaps  [rbp+var_140], xmm0
+  .text:0000000000B177CC                 mov     rcx, [rbp+var_218]
+  .text:0000000000B177D3                 mov     esi, [rbp+var_1A4]
+  .text:0000000000B177D9                 mov     rdi, [rdx]
+  .text:0000000000B177DC                 mov     edx, 1
+  .text:0000000000B177E1                 mov     r10, [rdi]
+  .text:0000000000B177E4                 call    qword ptr [r10+118h]
+  .text:0000000000B177EB                 mov     r9, [rbp+var_228]
+  .text:0000000000B177F2                 mov     rdx, [r9+10h]
+  .text:0000000000B177F6                 test    byte ptr [rdx+31h], 2
+  .text:0000000000B177FA                 jnz     loc_B18400
+  .text:0000000000B17800                 lea     rax, g_pEntitySystem
+  .text:0000000000B17807                 mov     rsi, r9
+  .text:0000000000B1780A                 mov     rdx, [rbp+var_1C8]
+  .text:0000000000B17811                 mov     rdi, [rax]
+  .text:0000000000B17814                 call    CEntitySystem_QueueSpawnEntity
+  .text:0000000000B17819                 cmp     [rbp+var_158], 0
+  .text:0000000000B17821                 mov     r9, [rbp+var_228]
+  .text:0000000000B17828                 jz      loc_B1873F
+  .text:0000000000B1782E                 mov     r15, [rbp+var_168]
+  .text:0000000000B17835                 mov     r8, [rbp+var_1C8]
+  .text:0000000000B1783C                 test    r15, r15
+  .text:0000000000B1783F                 jz      short loc_B178B0
+  .text:0000000000B17841                 mov     dword ptr [rbp+var_228], r13d
+  .text:0000000000B17848                 mov     r13, r9
+  .text:0000000000B1784B                 mov     [rbp+var_238], rbx
+  .text:0000000000B17852                 mov     rbx, r15
+  .text:0000000000B17855                 mov     r15, r8
+  .text:0000000000B17858                 jmp     short loc_B17889
+  .text:0000000000B17860                 mov     rdx, [rbx+50h]
+  .text:0000000000B17864                 add     rdi, [rbx+58h]
+  .text:0000000000B17868                 mov     rcx, rdx
+  .text:0000000000B1786B                 test    dl, 1
+  .text:0000000000B1786E                 jz      short loc_B17878
+  .text:0000000000B17870                 mov     rcx, [rdi]
+  .text:0000000000B17873                 mov     rcx, [rcx+rdx-1]
+  .text:0000000000B17878                 mov     rdx, r15
+  .text:0000000000B1787B                 mov     rsi, r13
+  .text:0000000000B1787E                 call    rcx
+  .text:0000000000B17880                 mov     rbx, [rbx+38h]
+  .text:0000000000B17884                 test    rbx, rbx
+  .text:0000000000B17887                 jz      short loc_B178A2
+  .text:0000000000B17889                 mov     rdi, [rbx+48h]
+  .text:0000000000B1788D                 test    rdi, rdi
+  .text:0000000000B17890                 jnz     short loc_B17860
+  .text:0000000000B17892                 cmp     qword ptr [rbx+50h], 0
+  .text:0000000000B17897                 jnz     short loc_B17860
+  .text:0000000000B17899                 mov     rbx, [rbx+38h]
+  .text:0000000000B1789D                 test    rbx, rbx
+  .text:0000000000B178A0                 jnz     short loc_B17889
+  .text:0000000000B178A2                 mov     r13d, dword ptr [rbp+var_228]
+  .text:0000000000B178A9                 mov     rbx, [rbp+var_238]
+  .text:0000000000B178B0                 mov     rax, [rbp+var_220]
+  .text:0000000000B178B7                 call    rax
+  .text:0000000000B178B9                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000000B178BD                 jz      loc_B18410
+  .text:0000000000B178C3                 mov     rcx, cs:qword_256F420
+  .text:0000000000B178CA                 cmp     r13d, 0FFFFFFFEh
+  .text:0000000000B178CE                 jz      loc_B18410
+  .text:0000000000B178D4                 test    rcx, rcx
+  .text:0000000000B178D7                 jz      loc_B18410
+  .text:0000000000B178DD                 mov     rdx, r13
+  .text:0000000000B178E0                 shr     rdx, 9
+  .text:0000000000B178E4                 and     edx, 3Fh
+  .text:0000000000B178E7                 mov     rdx, [rcx+rdx*8]
+  .text:0000000000B178EB                 test    rdx, rdx
+  .text:0000000000B178EE                 jz      loc_B18410
+  .text:0000000000B178F4                 mov     ecx, r13d
+  .text:0000000000B178F7                 and     ecx, 1FFh
+  .text:0000000000B178FD                 imul    rcx, 70h ; 'p'
+  .text:0000000000B17901                 add     rdx, rcx
+  .text:0000000000B17904                 cmp     r13d, [rdx+10h]
+  .text:0000000000B17908                 jnz     loc_B18410
+  .text:0000000000B1790E                 mov     r13, [rdx]
+  .text:0000000000B17911                 test    r13, r13
+  .text:0000000000B17914                 jz      loc_B18410
+  .text:0000000000B1791A                 mov     r15d, [r12]
+  .text:0000000000B1791E                 cmp     r15d, [r13+0A48h]
+  .text:0000000000B17925                 jz      loc_B179C8
+  .text:0000000000B1792B                 xor     edx, edx
+  .text:0000000000B1792D                 mov     esi, 1
+  .text:0000000000B17932                 pxor    xmm0, xmm0
+  .text:0000000000B17936                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17941                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17948                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B1794F                 mov     [rbp+var_104], dx
+  .text:0000000000B17956                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17961                 mov     [rbp+var_130], 0
+  .text:0000000000B1796C                 mov     [rbp+var_128], 0
+  .text:0000000000B17977                 mov     [rbp+var_110], r14
+  .text:0000000000B1797E                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17988                 call    sub_9B9C80
+  .text:0000000000B1798D                 mov     rax, [rbp+var_130]
+  .text:0000000000B17994                 mov     rdi, r13
+  .text:0000000000B17997                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B1799E                 mov     rsi, [rbp+var_218]
+  .text:0000000000B179A5                 mov     dword ptr [rax], 0A48h
+  .text:0000000000B179AB                 mov     rax, [r13+0]
+  .text:0000000000B179AF                 call    qword ptr [rax+0E8h]
+  .text:0000000000B179B5                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B179BC                 call    sub_9B9650
+  .text:0000000000B179C1                 mov     [r13+0A48h], r15d
+  .text:0000000000B179C8                 mov     r15d, [r12+4]
+  .text:0000000000B179CD                 cmp     r15d, [r13+0A4Ch]
+  .text:0000000000B179D4                 jz      loc_B17A77
+  .text:0000000000B179DA                 xor     eax, eax
+  .text:0000000000B179DC                 mov     esi, 1
+  .text:0000000000B179E1                 pxor    xmm0, xmm0
+  .text:0000000000B179E5                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B179F0                 lea     rdi, [rbp+var_130]
+  .text:0000000000B179F7                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B179FE                 mov     [rbp+var_104], ax
+  .text:0000000000B17A05                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17A10                 mov     [rbp+var_130], 0
+  .text:0000000000B17A1B                 mov     [rbp+var_128], 0
+  .text:0000000000B17A26                 mov     [rbp+var_110], r14
+  .text:0000000000B17A2D                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17A37                 call    sub_9B9C80
+  .text:0000000000B17A3C                 mov     rax, [rbp+var_130]
+  .text:0000000000B17A43                 mov     rdi, r13
+  .text:0000000000B17A46                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17A4D                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17A54                 mov     dword ptr [rax], 0A4Ch
+  .text:0000000000B17A5A                 mov     rax, [r13+0]
+  .text:0000000000B17A5E                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17A64                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17A6B                 call    sub_9B9650
+  .text:0000000000B17A70                 mov     [r13+0A4Ch], r15d
+  .text:0000000000B17A77                 mov     r15d, [r12+50h]
+  .text:0000000000B17A7C                 cmp     r15d, [r13+0A50h]
+  .text:0000000000B17A83                 jz      loc_B17B26
+  .text:0000000000B17A89                 xor     eax, eax
+  .text:0000000000B17A8B                 mov     esi, 1
+  .text:0000000000B17A90                 pxor    xmm0, xmm0
+  .text:0000000000B17A94                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17A9F                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17AA6                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17AAD                 mov     [rbp+var_104], ax
+  .text:0000000000B17AB4                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17ABF                 mov     [rbp+var_130], 0
+  .text:0000000000B17ACA                 mov     [rbp+var_128], 0
+  .text:0000000000B17AD5                 mov     [rbp+var_110], r14
+  .text:0000000000B17ADC                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17AE6                 call    sub_9B9C80
+  .text:0000000000B17AEB                 mov     rax, [rbp+var_130]
+  .text:0000000000B17AF2                 mov     rdi, r13
+  .text:0000000000B17AF5                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17AFC                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17B03                 mov     dword ptr [rax], 0A50h
+  .text:0000000000B17B09                 mov     rax, [r13+0]
+  .text:0000000000B17B0D                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17B13                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17B1A                 call    sub_9B9650
+  .text:0000000000B17B1F                 mov     [r13+0A50h], r15d
+  .text:0000000000B17B26                 mov     r15d, [r12+3Ch]
+  .text:0000000000B17B2B                 cmp     r15d, [r13+0A84h]
+  .text:0000000000B17B32                 jz      loc_B17BD5
+  .text:0000000000B17B38                 xor     eax, eax
+  .text:0000000000B17B3A                 mov     esi, 1
+  .text:0000000000B17B3F                 pxor    xmm0, xmm0
+  .text:0000000000B17B43                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17B4E                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17B55                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17B5C                 mov     [rbp+var_104], ax
+  .text:0000000000B17B63                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17B6E                 mov     [rbp+var_130], 0
+  .text:0000000000B17B79                 mov     [rbp+var_128], 0
+  .text:0000000000B17B84                 mov     [rbp+var_110], r14
+  .text:0000000000B17B8B                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17B95                 call    sub_9B9C80
+  .text:0000000000B17B9A                 mov     rax, [rbp+var_130]
+  .text:0000000000B17BA1                 mov     rdi, r13
+  .text:0000000000B17BA4                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17BAB                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17BB2                 mov     dword ptr [rax], 0A84h
+  .text:0000000000B17BB8                 mov     rax, [r13+0]
+  .text:0000000000B17BBC                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17BC2                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17BC9                 call    sub_9B9650
+  .text:0000000000B17BCE                 mov     [r13+0A84h], r15d
+  .text:0000000000B17BD5                 movss   xmm0, dword ptr [r13+0A54h]
+  .text:0000000000B17BDE                 ucomiss xmm0, dword ptr [r12+8]
+  .text:0000000000B17BE4                 jp      short loc_B17C18
+  .text:0000000000B17BE6                 jnz     short loc_B17C18
+  .text:0000000000B17BE8                 movss   xmm0, dword ptr [r13+0A58h]
+  .text:0000000000B17BF1                 ucomiss xmm0, dword ptr [r12+0Ch]
+  .text:0000000000B17BF7                 jp      short loc_B17C18
+  .text:0000000000B17BF9                 jnz     short loc_B17C18
+  .text:0000000000B17BFB                 movss   xmm0, dword ptr [r13+0A5Ch]
+  .text:0000000000B17C04                 ucomiss xmm0, dword ptr [r12+10h]
+  .text:0000000000B17C0A                 jp      short loc_B17C18
+  .text:0000000000B17C0C                 jz      loc_B17CC6
+  .text:0000000000B17C12                 nop     word ptr [rax+rax+00h]
+  .text:0000000000B17C18                 xor     eax, eax
+  .text:0000000000B17C1A                 mov     esi, 1
+  .text:0000000000B17C1F                 pxor    xmm0, xmm0
+  .text:0000000000B17C23                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17C2E                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17C35                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17C3C                 mov     [rbp+var_104], ax
+  .text:0000000000B17C43                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17C4E                 mov     [rbp+var_130], 0
+  .text:0000000000B17C59                 mov     [rbp+var_128], 0
+  .text:0000000000B17C64                 mov     [rbp+var_110], r14
+  .text:0000000000B17C6B                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17C75                 call    sub_9B9C80
+  .text:0000000000B17C7A                 mov     rax, [rbp+var_130]
+  .text:0000000000B17C81                 mov     rdi, r13
+  .text:0000000000B17C84                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17C8B                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17C92                 mov     dword ptr [rax], 0A54h
+  .text:0000000000B17C98                 mov     rax, [r13+0]
+  .text:0000000000B17C9C                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17CA2                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17CA9                 call    sub_9B9650
+  .text:0000000000B17CAE                 mov     rax, [r12+8]
+  .text:0000000000B17CB3                 mov     [r13+0A54h], rax
+  .text:0000000000B17CBA                 mov     eax, [r12+10h]
+  .text:0000000000B17CBF                 mov     [r13+0A5Ch], eax
+  .text:0000000000B17CC6                 movss   xmm0, dword ptr [r13+0A60h]
+  .text:0000000000B17CCF                 ucomiss xmm0, dword ptr [r12+14h]
+  .text:0000000000B17CD5                 jp      short loc_B17D08
+  .text:0000000000B17CD7                 jnz     short loc_B17D08
+  .text:0000000000B17CD9                 movss   xmm0, dword ptr [r13+0A64h]
+  .text:0000000000B17CE2                 ucomiss xmm0, dword ptr [r12+18h]
+  .text:0000000000B17CE8                 jp      short loc_B17D08
+  .text:0000000000B17CEA                 jnz     short loc_B17D08
+  .text:0000000000B17CEC                 movss   xmm0, dword ptr [r13+0A68h]
+  .text:0000000000B17CF5                 ucomiss xmm0, dword ptr [r12+1Ch]
+  .text:0000000000B17CFB                 jp      short loc_B17D08
+  .text:0000000000B17CFD                 jz      loc_B17DB6
+  .text:0000000000B17D03                 nop     dword ptr [rax+rax+00h]
+  .text:0000000000B17D08                 xor     eax, eax
+  .text:0000000000B17D0A                 mov     esi, 1
+  .text:0000000000B17D0F                 pxor    xmm0, xmm0
+  .text:0000000000B17D13                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17D1E                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17D25                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17D2C                 mov     [rbp+var_104], ax
+  .text:0000000000B17D33                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17D3E                 mov     [rbp+var_130], 0
+  .text:0000000000B17D49                 mov     [rbp+var_128], 0
+  .text:0000000000B17D54                 mov     [rbp+var_110], r14
+  .text:0000000000B17D5B                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17D65                 call    sub_9B9C80
+  .text:0000000000B17D6A                 mov     rax, [rbp+var_130]
+  .text:0000000000B17D71                 mov     rdi, r13
+  .text:0000000000B17D74                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17D7B                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17D82                 mov     dword ptr [rax], 0A60h
+  .text:0000000000B17D88                 mov     rax, [r13+0]
+  .text:0000000000B17D8C                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17D92                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17D99                 call    sub_9B9650
+  .text:0000000000B17D9E                 mov     rax, [r12+14h]
+  .text:0000000000B17DA3                 mov     [r13+0A60h], rax
+  .text:0000000000B17DAA                 mov     eax, [r12+1Ch]
+  .text:0000000000B17DAF                 mov     [r13+0A68h], eax
+  .text:0000000000B17DB6                 movss   xmm0, dword ptr [r13+0A6Ch]
+  .text:0000000000B17DBF                 ucomiss xmm0, dword ptr [r12+20h]
+  .text:0000000000B17DC5                 jp      short loc_B17DF8
+  .text:0000000000B17DC7                 jnz     short loc_B17DF8
+  .text:0000000000B17DC9                 movss   xmm0, dword ptr [r13+0A70h]
+  .text:0000000000B17DD2                 ucomiss xmm0, dword ptr [r12+24h]
+  .text:0000000000B17DD8                 jp      short loc_B17DF8
+  .text:0000000000B17DDA                 jnz     short loc_B17DF8
+  .text:0000000000B17DDC                 movss   xmm0, dword ptr [r13+0A74h]
+  .text:0000000000B17DE5                 ucomiss xmm0, dword ptr [r12+28h]
+  .text:0000000000B17DEB                 jp      short loc_B17DF8
+  .text:0000000000B17DED                 jz      loc_B17EA8
+  .text:0000000000B17DF3                 nop     dword ptr [rax+rax+00h]
+  .text:0000000000B17DF8                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17DFF                 mov     esi, 1
+  .text:0000000000B17E04                 xor     r15d, r15d
+  .text:0000000000B17E07                 pxor    xmm0, xmm0
+  .text:0000000000B17E0B                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17E16                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17E1D                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17E28                 mov     [rbp+var_130], 0
+  .text:0000000000B17E33                 mov     [rbp+var_128], 0
+  .text:0000000000B17E3E                 mov     [rbp+var_110], r14
+  .text:0000000000B17E45                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17E4F                 mov     [rbp+var_104], r15w
+  .text:0000000000B17E57                 call    sub_9B9C80
+  .text:0000000000B17E5C                 mov     rax, [rbp+var_130]
+  .text:0000000000B17E63                 mov     rdi, r13
+  .text:0000000000B17E66                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17E6D                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17E74                 mov     dword ptr [rax], 0A6Ch
+  .text:0000000000B17E7A                 mov     rax, [r13+0]
+  .text:0000000000B17E7E                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17E84                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17E8B                 call    sub_9B9650
+  .text:0000000000B17E90                 mov     rax, [r12+20h]
+  .text:0000000000B17E95                 mov     [r13+0A6Ch], rax
+  .text:0000000000B17E9C                 mov     eax, [r12+28h]
+  .text:0000000000B17EA1                 mov     [r13+0A74h], eax
+  .text:0000000000B17EA8                 movss   xmm0, dword ptr [r13+0A78h]
+  .text:0000000000B17EB1                 ucomiss xmm0, dword ptr [r12+2Ch]
+  .text:0000000000B17EB7                 jp      short loc_B17EE8
+  .text:0000000000B17EB9                 jnz     short loc_B17EE8
+  .text:0000000000B17EBB                 movss   xmm0, dword ptr [r13+0A7Ch]
+  .text:0000000000B17EC4                 ucomiss xmm0, dword ptr [r12+30h]
+  .text:0000000000B17ECA                 jp      short loc_B17EE8
+  .text:0000000000B17ECC                 jnz     short loc_B17EE8
+  .text:0000000000B17ECE                 movss   xmm0, dword ptr [r13+0A80h]
+  .text:0000000000B17ED7                 ucomiss xmm0, dword ptr [r12+34h]
+  .text:0000000000B17EDD                 jp      short loc_B17EE8
+  .text:0000000000B17EDF                 jz      loc_B17F98
+  .text:0000000000B17EE5                 nop     dword ptr [rax]
+  .text:0000000000B17EE8                 xor     r11d, r11d
+  .text:0000000000B17EEB                 mov     esi, 1
+  .text:0000000000B17EF0                 pxor    xmm0, xmm0
+  .text:0000000000B17EF4                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17EFF                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17F06                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17F0D                 mov     [rbp+var_104], r11w
+  .text:0000000000B17F15                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17F20                 mov     [rbp+var_130], 0
+  .text:0000000000B17F2B                 mov     [rbp+var_128], 0
+  .text:0000000000B17F36                 mov     [rbp+var_110], r14
+  .text:0000000000B17F3D                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B17F47                 call    sub_9B9C80
+  .text:0000000000B17F4C                 mov     rax, [rbp+var_130]
+  .text:0000000000B17F53                 mov     rdi, r13
+  .text:0000000000B17F56                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B17F5D                 mov     rsi, [rbp+var_218]
+  .text:0000000000B17F64                 mov     dword ptr [rax], 0A78h
+  .text:0000000000B17F6A                 mov     rax, [r13+0]
+  .text:0000000000B17F6E                 call    qword ptr [rax+0E8h]
+  .text:0000000000B17F74                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B17F7B                 call    sub_9B9650
+  .text:0000000000B17F80                 mov     rax, [r12+2Ch]
+  .text:0000000000B17F85                 mov     [r13+0A78h], rax
+  .text:0000000000B17F8C                 mov     eax, [r12+34h]
+  .text:0000000000B17F91                 mov     [r13+0A80h], eax
+  .text:0000000000B17F98                 mov     r15d, [r12+40h]
+  .text:0000000000B17F9D                 cmp     r15d, [r13+0A88h]
+  .text:0000000000B17FA4                 jz      loc_B18049
+  .text:0000000000B17FAA                 xor     r10d, r10d
+  .text:0000000000B17FAD                 mov     esi, 1
+  .text:0000000000B17FB2                 pxor    xmm0, xmm0
+  .text:0000000000B17FB6                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B17FC1                 lea     rdi, [rbp+var_130]
+  .text:0000000000B17FC8                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B17FCF                 mov     [rbp+var_104], r10w
+  .text:0000000000B17FD7                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B17FE2                 mov     [rbp+var_130], 0
+  .text:0000000000B17FED                 mov     [rbp+var_128], 0
+  .text:0000000000B17FF8                 mov     [rbp+var_110], r14
+  .text:0000000000B17FFF                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B18009                 call    sub_9B9C80
+  .text:0000000000B1800E                 mov     rax, [rbp+var_130]
+  .text:0000000000B18015                 mov     rdi, r13
+  .text:0000000000B18018                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B1801F                 mov     rsi, [rbp+var_218]
+  .text:0000000000B18026                 mov     dword ptr [rax], 0A88h
+  .text:0000000000B1802C                 mov     rax, [r13+0]
+  .text:0000000000B18030                 call    qword ptr [rax+0E8h]
+  .text:0000000000B18036                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B1803D                 call    sub_9B9650
+  .text:0000000000B18042                 mov     [r13+0A88h], r15d
+  .text:0000000000B18049                 mov     r15d, [r12+44h]
+  .text:0000000000B1804E                 cmp     r15d, [r13+0A8Ch]
+  .text:0000000000B18055                 jz      loc_B180FA
+  .text:0000000000B1805B                 xor     r9d, r9d
+  .text:0000000000B1805E                 mov     esi, 1
+  .text:0000000000B18063                 pxor    xmm0, xmm0
+  .text:0000000000B18067                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B18072                 lea     rdi, [rbp+var_130]
+  .text:0000000000B18079                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B18080                 mov     [rbp+var_104], r9w
+  .text:0000000000B18088                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B18093                 mov     [rbp+var_130], 0
+  .text:0000000000B1809E                 mov     [rbp+var_128], 0
+  .text:0000000000B180A9                 mov     [rbp+var_110], r14
+  .text:0000000000B180B0                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B180BA                 call    sub_9B9C80
+  .text:0000000000B180BF                 mov     rax, [rbp+var_130]
+  .text:0000000000B180C6                 mov     rdi, r13
+  .text:0000000000B180C9                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B180D0                 mov     rsi, [rbp+var_218]
+  .text:0000000000B180D7                 mov     dword ptr [rax], 0A8Ch
+  .text:0000000000B180DD                 mov     rax, [r13+0]
+  .text:0000000000B180E1                 call    qword ptr [rax+0E8h]
+  .text:0000000000B180E7                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B180EE                 call    sub_9B9650
+  .text:0000000000B180F3                 mov     [r13+0A8Ch], r15d
+  .text:0000000000B180FA                 mov     r15d, [r12+48h]
+  .text:0000000000B180FF                 cmp     r15d, [r13+0A94h]
+  .text:0000000000B18106                 jz      loc_B181AB
+  .text:0000000000B1810C                 xor     r8d, r8d
+  .text:0000000000B1810F                 mov     esi, 1
+  .text:0000000000B18114                 pxor    xmm0, xmm0
+  .text:0000000000B18118                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B18123                 lea     rdi, [rbp+var_130]
+  .text:0000000000B1812A                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B18131                 mov     [rbp+var_104], r8w
+  .text:0000000000B18139                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B18144                 mov     [rbp+var_130], 0
+  .text:0000000000B1814F                 mov     [rbp+var_128], 0
+  .text:0000000000B1815A                 mov     [rbp+var_110], r14
+  .text:0000000000B18161                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B1816B                 call    sub_9B9C80
+  .text:0000000000B18170                 mov     rax, [rbp+var_130]
+  .text:0000000000B18177                 mov     rdi, r13
+  .text:0000000000B1817A                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B18181                 mov     rsi, [rbp+var_218]
+  .text:0000000000B18188                 mov     dword ptr [rax], 0A94h
+  .text:0000000000B1818E                 mov     rax, [r13+0]
+  .text:0000000000B18192                 call    qword ptr [rax+0E8h]
+  .text:0000000000B18198                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B1819F                 call    sub_9B9650
+  .text:0000000000B181A4                 mov     [r13+0A94h], r15d
+  .text:0000000000B181AB                 movss   xmm0, dword ptr [r12+4Ch]
+  .text:0000000000B181B2                 ucomiss xmm0, dword ptr [r13+0A90h]
+  .text:0000000000B181BA                 jp      loc_B18667
+  .text:0000000000B181C0                 jnz     loc_B18667
+  .text:0000000000B181C6                 cmp     byte ptr [r13+0A98h], 1
+  .text:0000000000B181CE                 jz      loc_B18272
+  .text:0000000000B181D4                 xor     esi, esi
+  .text:0000000000B181D6                 pxor    xmm0, xmm0
+  .text:0000000000B181DA                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B181E5                 mov     [rbp+var_104], si
+  .text:0000000000B181EC                 mov     esi, 1
+  .text:0000000000B181F1                 lea     rdi, [rbp+var_130]
+  .text:0000000000B181F8                 movaps  [rbp+var_120], xmm0
+  .text:0000000000B181FF                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B1820A                 mov     [rbp+var_130], 0
+  .text:0000000000B18215                 mov     [rbp+var_128], 0
+  .text:0000000000B18220                 mov     [rbp+var_110], r14
+  .text:0000000000B18227                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B18231                 call    sub_9B9C80
+  .text:0000000000B18236                 mov     rax, [rbp+var_130]
+  .text:0000000000B1823D                 mov     rdi, r13
+  .text:0000000000B18240                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B18247                 mov     rsi, [rbp+var_218]
+  .text:0000000000B1824E                 mov     dword ptr [rax], 0A98h
+  .text:0000000000B18254                 mov     rax, [r13+0]
+  .text:0000000000B18258                 call    qword ptr [rax+0E8h]
+  .text:0000000000B1825E                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B18265                 call    sub_9B9650
+  .text:0000000000B1826A                 mov     byte ptr [r13+0A98h], 1
+  .text:0000000000B18272                 mov     rax, [rbx]
+  .text:0000000000B18275                 cmp     qword ptr [rax-18h], 80h
+  .text:0000000000B1827D                 jnz     loc_B18410
+  .text:0000000000B18283                 lea     r14, CBaseEntity_SetStateChanged
+  .text:0000000000B1828A                 xor     r12d, r12d
+  .text:0000000000B1828D                 jmp     short loc_B182DE
+  .text:0000000000B18290                 cmp     [rbp+var_1F4], 3FFFFFFFh
+  .text:0000000000B1829A                 mov     dword ptr [rbp+var_208], 0
+  .text:0000000000B182A4                 ja      short loc_B182C2
+  .text:0000000000B182A6                 mov     rsi, [rbp+var_200]
+  .text:0000000000B182AD                 test    rsi, rsi
+  .text:0000000000B182B0                 jz      short loc_B182C2
+  .text:0000000000B182B2                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000000B182B9                 mov     rdi, [rax]
+  .text:0000000000B182BC                 mov     rax, [rdi]
+  .text:0000000000B182BF                 call    qword ptr [rax+20h]
+  .text:0000000000B182C2                 mov     [r13+r12+0A99h], r15b
+  .text:0000000000B182CA                 add     r12, 1
+  .text:0000000000B182CE                 cmp     r12, 80h
+  .text:0000000000B182D5                 jz      loc_B18410
+  .text:0000000000B182DB                 mov     rax, [rbx]
+  .text:0000000000B182DE                 movzx   r15d, byte ptr [rax+r12]
+  .text:0000000000B182E3                 cmp     [r13+r12+0A99h], r15b
+  .text:0000000000B182EB                 jz      short loc_B182CA
+  .text:0000000000B182ED                 mov     eax, 0FFFFFFFFh
+  .text:0000000000B182F2                 xor     ecx, ecx
+  .text:0000000000B182F4                 pxor    xmm2, xmm2
+  .text:0000000000B182F8                 mov     [rbp+var_210], 1
+  .text:0000000000B18303                 lea     rdi, [rbp+var_200]
+  .text:0000000000B1830A                 mov     esi, 1
+  .text:0000000000B1830F                 mov     [rbp+var_1E0], rax
+  .text:0000000000B18316                 mov     [rbp+var_208], 0
+  .text:0000000000B18321                 mov     [rbp+var_200], 0
+  .text:0000000000B1832C                 mov     qword ptr [rbp-1F8h], 0
+  .text:0000000000B18337                 movaps  [rbp+var_1F0], xmm2
+  .text:0000000000B1833E                 mov     dword ptr [rbp+var_1E0+4], r12d
+  .text:0000000000B18345                 mov     [rbp+var_1D8], 0FFFFFFFFh
+  .text:0000000000B1834F                 mov     [rbp+var_1D4], cx
+  .text:0000000000B18356                 call    sub_9B9C80
+  .text:0000000000B1835B                 mov     rax, [rbp+var_200]
+  .text:0000000000B18362                 add     dword ptr [rbp+var_208], 1
+  .text:0000000000B18369                 mov     dword ptr [rax], 0A99h
+  .text:0000000000B1836F                 mov     rax, [r13+0]
+  .text:0000000000B18373                 mov     rax, [rax+0E8h]
+  .text:0000000000B1837A                 cmp     rax, r14
+  .text:0000000000B1837D                 jnz     loc_B18638
+  .text:0000000000B18383                 mov     edx, dword ptr [rbp+var_210]
+  .text:0000000000B18389                 lea     r11, [r13+38h]
+  .text:0000000000B1838D                 test    edx, edx
+  .text:0000000000B1838F                 jnz     loc_B18650
+  .text:0000000000B18395                 cmp     byte ptr [r13+318h], 0
+  .text:0000000000B1839D                 jnz     short loc_B183C0
+  .text:0000000000B1839F                 mov     rax, [r13+48h]
+  .text:0000000000B183A3                 test    rax, rax
+  .text:0000000000B183A6                 jz      loc_B18570
+  .text:0000000000B183AC                 cmp     byte ptr [rax+18h], 0
+  .text:0000000000B183B0                 jz      loc_B18570
+  .text:0000000000B183B6                 mov     byte ptr [r13+315h], 1
+  .text:0000000000B183BE                 xchg    ax, ax
+  .text:0000000000B183C0                 lea     rax, off_2503B68
+  .text:0000000000B183C7                 mov     rax, [rax]
+  .text:0000000000B183CA                 movss   xmm0, dword ptr [rax+30h]
+  .text:0000000000B183CF                 comiss  xmm0, dword ptr [r13+538h]
+  .text:0000000000B183D7                 jbe     loc_B18290
+  .text:0000000000B183DD                 movss   dword ptr [r13+538h], xmm0
+  .text:0000000000B183E6                 mov     qword ptr [r13+530h], 0
+  .text:0000000000B183F1                 jmp     loc_B18290
+  .text:0000000000B18400                 mov     rax, [rbp+var_220]
+  .text:0000000000B18407                 call    rax
+  .text:0000000000B18409                 nop     dword ptr [rax+00000000h]
+  .text:0000000000B18410                 mov     rbx, [rbp+var_1C8]
+  .text:0000000000B18417                 lea     rax, off_2255B18
+  .text:0000000000B1841E                 mov     [rbp+var_1D0], rax
+  .text:0000000000B18425                 test    rbx, rbx
+  .text:0000000000B18428                 jz      short loc_B18448
+  .text:0000000000B1842A                 cmp     byte ptr [rbx+24h], 0
+  .text:0000000000B1842E                 jnz     loc_B18509
+  .text:0000000000B18434                 movzx   eax, word ptr [rbx+20h]
+  .text:0000000000B18438                 sub     eax, 1
+  .text:0000000000B1843B                 mov     [rbx+20h], ax
+  .text:0000000000B1843F                 test    ax, ax
+  .text:0000000000B18442                 jle     loc_B1854D
+  .text:0000000000B18448                 cmp     [rbp+var_1B0], 0
+  .text:0000000000B18450                 jz      short loc_B1845E
+  .text:0000000000B18452                 lea     rdi, [rbp+var_1B0]
+  .text:0000000000B18459                 call    sub_984EB0
+  .text:0000000000B1845E                 lea     rsp, [rbp-28h]
+  .text:0000000000B18462                 pop     rbx
+  .text:0000000000B18463                 pop     r12
+  .text:0000000000B18465                 pop     r13
+  .text:0000000000B18467                 pop     r14
+  .text:0000000000B18469                 pop     r15
+  .text:0000000000B1846B                 pop     rbp
+  .text:0000000000B1846C                 retn
+  .text:0000000000B18470                 mov     rax, [rdx+50h]
+  .text:0000000000B18474                 mov     rcx, [rax]
+  .text:0000000000B18477                 test    rcx, rcx
+  .text:0000000000B1847A                 mov     [rbp+var_228], rcx
+  .text:0000000000B18481                 jz      loc_B17704
+  .text:0000000000B18487                 mov     rdi, [rbp+var_1C8]
+  .text:0000000000B1848E                 mov     dword ptr [rbp+var_140], r13d
+  .text:0000000000B18495                 mov     rsi, [rbp+var_218]
+  .text:0000000000B1849C                 mov     qword ptr [rbp+var_140+8], r15
+  .text:0000000000B184A3                 mov     dword ptr [rbp+var_140+4], 0FFFFFFFFh
+  .text:0000000000B184AD                 mov     [rbp+var_238], rdi
+  .text:0000000000B184B4                 call    sub_1E57E00
+  .text:0000000000B184B9                 test    rax, rax
+  .text:0000000000B184BC                 jz      short loc_B184D4
+  .text:0000000000B184BE                 mov     rdx, [rbp+var_228]
+  .text:0000000000B184C5                 mov     rsi, rax
+  .text:0000000000B184C8                 mov     rdi, [rbp+var_238]
+  .text:0000000000B184CF                 call    sub_1E57C30
+  .text:0000000000B184D4                 mov     rdx, [rbp+var_1B8]
+  .text:0000000000B184DB                 jmp     loc_B17704
+  .text:0000000000B184E0                 mov     r13, cs:LOG_GENERAL_ptr
+  .text:0000000000B184E7                 mov     esi, 2
+  .text:0000000000B184EC                 mov     edi, [r13+0]
+  .text:0000000000B184F0                 call    sub_983F70
+  .text:0000000000B184F5                 test    al, al
+  .text:0000000000B184F7                 jnz     loc_B1871B
+  .text:0000000000B184FD                 mov     r15, [rbp+var_1C8]
+  .text:0000000000B18504                 jmp     loc_B17429
+  .text:0000000000B18509                 mov     r12, cs:LOG_GENERAL_ptr
+  .text:0000000000B18510                 mov     esi, 2
+  .text:0000000000B18515                 mov     edi, [r12]
+  .text:0000000000B18519                 call    sub_983F70
+  .text:0000000000B1851E                 test    al, al
+  .text:0000000000B18520                 jz      loc_B18434
+  .text:0000000000B18526                 movsx   eax, word ptr [rbx+20h]
+  .text:0000000000B1852A                 mov     rcx, rbx
+  .text:0000000000B1852D                 mov     esi, 2
+  .text:0000000000B18532                 mov     edi, [r12]
+  .text:0000000000B18536                 lea     rdx, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:0000000000B1853D                 lea     r8d, [rax-1]
+  .text:0000000000B18541                 xor     eax, eax
+  .text:0000000000B18543                 call    sub_983550
+  .text:0000000000B18548                 jmp     loc_B18434
+  .text:0000000000B1854D                 mov     rdi, rbx
+  .text:0000000000B18550                 call    sub_1E576D0
+  .text:0000000000B18555                 mov     esi, 38h ; '8'
+  .text:0000000000B1855A                 mov     rdi, rbx
+  .text:0000000000B1855D                 call    sub_97A200
+  .text:0000000000B18562                 jmp     loc_B18448
+  .text:0000000000B18570                 mov     rdi, qword ptr [rbp+var_1F0+8]
+  .text:0000000000B18577                 lea     rax, byte_8D7E1C
+  .text:0000000000B1857E                 mov     [rbp+var_228], r11
+  .text:0000000000B18585                 mov     r8d, dword ptr [rbp+var_1E0]
+  .text:0000000000B1858C                 test    rdi, rdi
+  .text:0000000000B1858F                 cmovz   rdi, rax
+  .text:0000000000B18593                 mov     dword ptr [rbp+var_220], r8d
+  .text:0000000000B1859A                 call    sub_984870
+  .text:0000000000B1859F                 mov     rdx, qword ptr [rbp+var_1F0]
+  .text:0000000000B185A6                 lea     rsi, aCnetworktransm; "CNetworkTransmitComponent::StateChanged"...
+  .text:0000000000B185AD                 mov     r8d, dword ptr [rbp+var_220]
+  .text:0000000000B185B4                 mov     rcx, rax
+  .text:0000000000B185B7                 mov     rdi, [rbp+var_218]
+  .text:0000000000B185BE                 lea     rax, byte_8D7E1C
+  .text:0000000000B185C5                 test    rdx, rdx
+  .text:0000000000B185C8                 cmovz   rdx, rax
+  .text:0000000000B185CC                 xor     eax, eax
+  .text:0000000000B185CE                 call    sub_9A70A0
+  .text:0000000000B185D3                 test    byte ptr [rbp+var_140+7], 40h
+  .text:0000000000B185DA                 lea     rsi, [rbp+var_140+8]
+  .text:0000000000B185E1                 mov     r11, [rbp+var_228]
+  .text:0000000000B185E8                 jnz     short loc_B18604
+  .text:0000000000B185EA                 lea     rsi, byte_8D7E1C
+  .text:0000000000B185F1                 test    dword ptr [rbp+var_140+4], 3FFFFFFFh
+  .text:0000000000B185FB                 jz      short loc_B18604
+  .text:0000000000B185FD                 mov     rsi, qword ptr [rbp+var_140+8]
+  .text:0000000000B18604                 mov     rdi, r11
+  .text:0000000000B18607                 call    sub_9F8540
+  .text:0000000000B1860C                 mov     rdi, [rbp+var_218]
+  .text:0000000000B18613                 xor     esi, esi
+  .text:0000000000B18615                 call    sub_984310
+  .text:0000000000B1861A                 lock or dword ptr [r13+310h], 3
+  .text:0000000000B18623                 xor     eax, eax
+  .text:0000000000B18625                 mov     [r13+32Eh], ax
+  .text:0000000000B1862D                 jmp     loc_B183C0
+  .text:0000000000B18638                 mov     rsi, [rbp+var_230]
+  .text:0000000000B1863F                 mov     rdi, r13
+  .text:0000000000B18642                 call    rax
+  .text:0000000000B18644                 jmp     loc_B18290
+  .text:0000000000B18650                 mov     rdx, [rbp+var_230]
+  .text:0000000000B18657                 mov     rsi, r13
+  .text:0000000000B1865A                 mov     rdi, r11
+  .text:0000000000B1865D                 call    CNetworkTransmitComponent_StateChanged
+  .text:0000000000B18662                 jmp     loc_B183C0
+  .text:0000000000B18667                 xor     edi, edi
+  .text:0000000000B18669                 mov     esi, 1
+  .text:0000000000B1866E                 pxor    xmm1, xmm1
+  .text:0000000000B18672                 movss   dword ptr [rbp+var_220], xmm0
+  .text:0000000000B1867A                 mov     [rbp+var_104], di
+  .text:0000000000B18681                 lea     rdi, [rbp+var_130]
+  .text:0000000000B18688                 movaps  [rbp+var_120], xmm1
+  .text:0000000000B1868F                 mov     qword ptr [rbp+var_140], 1
+  .text:0000000000B1869A                 mov     qword ptr [rbp+var_140+8], 0
+  .text:0000000000B186A5                 mov     [rbp+var_130], 0
+  .text:0000000000B186B0                 mov     [rbp+var_128], 0
+  .text:0000000000B186BB                 mov     [rbp+var_110], r14
+  .text:0000000000B186C2                 mov     [rbp+var_108], 0FFFFFFFFh
+  .text:0000000000B186CC                 call    sub_9B9C80
+  .text:0000000000B186D1                 mov     rax, [rbp+var_130]
+  .text:0000000000B186D8                 mov     rdi, r13
+  .text:0000000000B186DB                 add     dword ptr [rbp+var_140+8], 1
+  .text:0000000000B186E2                 mov     rsi, [rbp+var_218]
+  .text:0000000000B186E9                 mov     dword ptr [rax], 0A90h
+  .text:0000000000B186EF                 mov     rax, [r13+0]
+  .text:0000000000B186F3                 call    qword ptr [rax+0E8h]
+  .text:0000000000B186F9                 lea     rdi, [rbp+var_140+8]
+  .text:0000000000B18700                 call    sub_9B9650
+  .text:0000000000B18705                 movss   xmm0, dword ptr [rbp+var_220]
+  .text:0000000000B1870D                 movss   dword ptr [r13+0A90h], xmm0
+  .text:0000000000B18716                 jmp     loc_B181C6
+  .text:0000000000B1871B                 mov     edi, [r13+0]
+  .text:0000000000B1871F                 mov     rcx, r15
+  .text:0000000000B18722                 mov     esi, 2
+  .text:0000000000B18727                 xor     eax, eax
+  .text:0000000000B18729                 movsx   r8d, word ptr [r15+20h]
+  .text:0000000000B1872E                 lea     rdx, aKv0xPAddrefRef; "kv 0x%p AddRef refcount == %d\n"
+  .text:0000000000B18735                 call    sub_983550
+  .text:0000000000B1873A                 jmp     loc_B184FD
+  .text:0000000000B1873F                 lea     rax, g_pEntitySystem
+  .text:0000000000B18746                 mov     rdi, [rax]
+  .text:0000000000B18749                 call    CEntitySystem_ExecuteQueuedCreation
+  .text:0000000000B1874E                 mov     r9, [rbp+var_228]
+  .text:0000000000B18755                 jmp     loc_B1782E
+  .text:0000000000B1875A                 mov     edx, 7FFFh
+  .text:0000000000B1875F                 jmp     loc_B17783
+procedure: |-
+  __int64 __fastcall sub_B172F0(int *a1, _QWORD *a2)
+  {
+    __int64 v4; // r13
+    const __m128i *v5; // rax
+    char v6; // al
+    __int64 v7; // r15
+    _QWORD *v8; // r13
+    __int64 v9; // rdi
+    int v10; // eax
+    unsigned int v11; // eax
+    __int64 v12; // rdi
+    int v13; // eax
+    unsigned int v14; // eax
+    __int64 v15; // rdi
+    int v16; // eax
+    __int64 p_inserted; // rsi
+    unsigned int v18; // eax
+    __int64 v19; // rax
+    __int64 v20; // rdx
+    __int64 v21; // r15
+    unsigned int v22; // eax
+    int v23; // eax
+    unsigned int v24; // eax
+    unsigned __int32 v25; // r13d
+    __int64 v26; // rax
+    __int64 v27; // rdx
+    const char *v28; // rcx
+    __int64 v29; // rdi
+    __int64 Entity; // rax
+    __int64 v31; // rdx
+    __int64 v32; // r8
+    __int64 v33; // rcx
+    const __m128i *v34; // r9
+    __int64 v35; // rdx
+    unsigned __int64 v36; // r13
+    int v37; // eax
+    unsigned __int16 v38; // dx
+    _QWORD *v39; // rdi
+    __int64 v40; // rdx
+    __int64 v41; // rcx
+    __int64 v42; // r9
+    __int64 v43; // r8
+    __int64 v44; // r13
+    _QWORD *v45; // rbx
+    __int64 v46; // r15
+    char *v47; // rdx
+    void (__fastcall *v48)(_QWORD *, __int64, __int64); // rcx
+    __int64 v49; // r13
+    int v50; // r15d
+    int v51; // r15d
+    int v52; // r15d
+    int v53; // r15d
+    int v54; // r15d
+    int v55; // r15d
+    int v56; // r15d
+    __int64 v57; // rax
+    __int64 v58; // r12
+    char v59; // r15
+    __int64 v60; // rcx
+    int v61; // r8d
+    int v62; // r9d
+    void *(__fastcall *v63)(__int64, __int64 *); // rax
+    __int64 v64; // rax
+    float v65; // xmm0_4
+    __int16 *v66; // rbx
+    __int64 result; // rax
+    __int64 v68; // rax
+    const char *v69; // rdi
+    int v70; // eax
+    int v71; // r9d
+    const char *v72; // rdx
+    const char *v73; // rsi
+    __int64 v74; // [rsp-10h] [rbp-250h]
+    __int64 v75; // [rsp-8h] [rbp-248h]
+    _QWORD *v76; // [rsp+8h] [rbp-238h]
+    __int64 v77; // [rsp+8h] [rbp-238h]
+    __int64 v78; // [rsp+18h] [rbp-228h]
+    __int64 v79; // [rsp+18h] [rbp-228h]
+    unsigned int v80; // [rsp+18h] [rbp-228h]
+    __int64 v81; // [rsp+18h] [rbp-228h]
+    __int32 v82; // [rsp+20h] [rbp-220h]
+    void (__fastcall *v83)(__int64, __int64, __int64, __int64, __int64, const __m128i *); // [rsp+20h] [rbp-220h]
+    int v84; // [rsp+20h] [rbp-220h]
+    int v85; // [rsp+20h] [rbp-220h]
+    __int64 v86; // [rsp+30h] [rbp-210h] BYREF
+    __int64 v87; // [rsp+38h] [rbp-208h]
+    _DWORD *v88; // [rsp+40h] [rbp-200h] BYREF
+    __int64 v89; // [rsp+48h] [rbp-1F8h]
+    __int128 v90; // [rsp+50h] [rbp-1F0h]
+    int v91; // [rsp+60h] [rbp-1E0h]
+    int v92; // [rsp+64h] [rbp-1DCh]
+    int v93; // [rsp+68h] [rbp-1D8h]
+    __int16 v94; // [rsp+6Ch] [rbp-1D4h]
+    __int64 (__fastcall **v95)(); // [rsp+70h] [rbp-1D0h]
+    __int64 v96; // [rsp+78h] [rbp-1C8h]
+    __int64 v97; // [rsp+80h] [rbp-1C0h]
+    __int64 v98; // [rsp+88h] [rbp-1B8h]
+    const char *v99; // [rsp+90h] [rbp-1B0h] BYREF
+    int v100; // [rsp+98h] [rbp-1A8h]
+    unsigned int v101; // [rsp+9Ch] [rbp-1A4h]
+    _OWORD v102[3]; // [rsp+A0h] [rbp-1A0h] BYREF
+    char v103; // [rsp+D0h] [rbp-170h]
+    char v104; // [rsp+D1h] [rbp-16Fh]
+    _QWORD *v105; // [rsp+D8h] [rbp-168h]
+    __int64 v106; // [rsp+E8h] [rbp-158h]
+    __int64 v107; // [rsp+F0h] [rbp-150h]
+    char v108; // [rsp+F8h] [rbp-148h]
+    __m128i inserted; // [rsp+100h] [rbp-140h] BYREF
+    __int64 v110; // [rsp+110h] [rbp-130h] BYREF
+    __int64 v111; // [rsp+118h] [rbp-128h]
+    __int128 v112; // [rsp+120h] [rbp-120h]
+    __int64 v113; // [rsp+130h] [rbp-110h]
+    int v114; // [rsp+138h] [rbp-108h]
+    __int16 v115; // [rsp+13Ch] [rbp-104h]
+
+    v95 = off_2255B38;
+    v99 = nullptr;
+    v104 = 0;
+    v105 = nullptr;
+    v108 = 0;
+    v106 = 0;
+    v107 = -1;
+    v4 = g_pEntitySystem + 3280;                  // 0xCD0 = 3280 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+    v101 = sub_1E62130(g_pEntitySystem);
+    v5 = (const __m128i *)sub_1E62140(g_pEntitySystem);
+    v96 = 0;
+    v102[0] = _mm_load_si128(v5);
+    v97 = v4;
+    v102[1] = _mm_load_si128(v5 + 1);
+    v102[2] = _mm_load_si128(v5 + 2);
+    v98 = qword_25C50C0;
+    v6 = 0;
+    if ( g_pVApplication )
+      v6 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pVApplication + 208LL))(g_pVApplication);
+    v103 = v6;
+    v100 = 0;
+    v7 = sub_97A1D0(56);
+    sub_1E57610(v7, v97, 3);
+    v96 = v7;
+    ++*(_WORD *)(v7 + 32);
+    if ( *(_BYTE *)(v7 + 36) )
+    {
+      if ( (unsigned __int8)sub_983F70(LOG_GENERAL, 2) )
+        sub_983550(LOG_GENERAL, 2, "kv 0x%p AddRef refcount == %d\n", (const void *)v7, *(__int16 *)(v7 + 32));
+      v7 = v96;
+    }
+    v8 = v105;
+    if ( v105 )
+    {
+      v9 = v7;
+      do
+      {
+        sub_1E58BB0(v9, v8, 0, 0);
+        v8 = (_QWORD *)v8[7];
+        v9 = v96;
+      }
+      while ( v8 );
+      v7 = v96;
+    }
+    v82 = a1[4];
+    v78 = *((_QWORD *)a1 + 1);
+    v10 = sub_987340("origin", 826366240);
+    inserted.m128i_i64[1] = (__int64)"origin";
+    inserted.m128i_i32[1] = -1;
+    v11 = 1540483477 * (((1540483477 * (v10 ^ 0x6E69u)) >> 13) ^ (1540483477 * (v10 ^ 0x6E69)));
+    inserted.m128i_i32[0] = (v11 >> 15) ^ v11;
+    v12 = sub_1E57E00(v7, &inserted);
+    if ( v12 )
+    {
+      inserted.m128i_i32[2] = v82;
+      inserted.m128i_i64[0] = v78;
+      sub_1B18100(v12, 3, &inserted, 29);
+    }
+    v13 = sub_987340("angles", 826366240);
+    inserted.m128i_i32[1] = -1;
+    inserted.m128i_i64[1] = (__int64)"angles";
+    v14 = 1540483477 * (((1540483477 * (v13 ^ 0x7365u)) >> 13) ^ (1540483477 * (v13 ^ 0x7365)));
+    inserted.m128i_i32[0] = (v14 >> 15) ^ v14;
+    v15 = sub_1E57E00(v96, &inserted);
+    if ( v15 )
+      sub_1B18100(v15, 3, &qword_784F20, 34);
+    v16 = sub_987340("owner", 826366243);
+    p_inserted = (__int64)&inserted;
+    inserted.m128i_i64[1] = (__int64)"owner";
+    inserted.m128i_i32[1] = -1;
+    v18 = 1540483477 * (((1540483477 * (v16 ^ 0x72u)) >> 13) ^ (1540483477 * (v16 ^ 0x72)));
+    inserted.m128i_i32[0] = (v18 >> 15) ^ v18;
+    v19 = sub_1E57E00(v96, &inserted);
+    v21 = v19;
+    if ( v19 )
+    {
+      p_inserted = 4;
+      sub_1B161C0(v19, 4, 38, 0, 0, 0, 0);
+      *(_QWORD *)(v21 + 8) = 0xFFFFFFFFLL;
+    }
+    if ( v96 )
+    {
+      inserted.m128i_i32[2] = 1211;
+      v110 = (__int64)"Spawn";
+      inserted.m128i_i64[0] = (__int64)"../../game/shared/entityspawner.h";
+      v83 = (void (__fastcall *)(__int64, __int64, __int64, __int64, __int64, const __m128i *))sub_985250(
+                                                                                                 "Spawn",
+                                                                                                 &off_244CB60,
+                                                                                                 &inserted);
+      v22 = sub_987340("classname", 826366255);
+      v23 = sub_987340("sname", v22);
+      inserted.m128i_i32[1] = -1;
+      inserted.m128i_i64[1] = (__int64)"classname";
+      v24 = 1540483477 * (((1540483477 * (v23 ^ 0x65u)) >> 13) ^ (1540483477 * (v23 ^ 0x65)));
+      inserted.m128i_i32[0] = (v24 >> 15) ^ v24;
+      v25 = inserted.m128i_i32[0];
+      v26 = sub_1E57D00(v96, &inserted, &v86);
+      v27 = v98;
+      if ( !v26 || (_BYTE)v86 )
+      {
+        v81 = **(_QWORD **)(v98 + 80);
+        if ( v81 )
+        {
+          inserted.m128i_i64[0] = v25 | 0xFFFFFFFF00000000LL;
+          inserted.m128i_i64[1] = (__int64)"classname";
+          v77 = v96;
+          v68 = sub_1E57E00(v96, &inserted);
+          if ( v68 )
+            sub_1E57C30(v77, v68, v81);
+          v27 = v98;
+        }
+      }
+      v28 = v99;
+      v29 = g_pEntitySystem;
+      if ( !v99 )
+        v28 = &byte_8D7E1C;
+      Entity = CEntitySystem_CreateEntity(
+                 (_DWORD *)g_pEntitySystem,
+                 v101,
+                 v27,
+                 (__int64)v28,
+                 v100,
+                 v107,
+                 HIDWORD(v107),
+                 0);
+      v33 = v74;
+      v34 = (const __m128i *)Entity;
+      p_inserted = v75;
+      if ( !Entity )
+        goto LABEL_93;
+      v35 = *(_QWORD *)(Entity + 16);
+      v36 = 0xFFFFFFFFLL;
+      if ( v35 )
+      {
+        v37 = (*(_DWORD *)(v35 + 16) >> 15) - (*(_DWORD *)(v35 + 48) & 1);
+        if ( *(_DWORD *)(v35 + 16) == -1 )
+          v38 = 0x7FFF;
+        else
+          v38 = *(_WORD *)(v35 + 16) & 0x7FFF;
+        v36 = v38 | (unsigned int)(v37 << 15);
+      }
+      v79 = (__int64)v34;
+      v110 = 0x1FFFFFFFFFFFFLL;
+      inserted = _mm_insert_epi64(_mm_loadl_epi64(v34 + 1), v96, 1);
+      p_inserted = v101;
+      v29 = g_pGameResourceService;
+      (*(void (__fastcall **)(__int64, _QWORD, __int64, __m128i *, _OWORD *))(*(_QWORD *)g_pGameResourceService + 280LL))(
+        g_pGameResourceService,
+        v101,
+        1,
+        &inserted,
+        v102);
+      v34 = (const __m128i *)v79;
+      v31 = *(_QWORD *)(v79 + 16);
+      if ( (*(_BYTE *)(v31 + 49) & 2) != 0 )
+      {
+  LABEL_93:
+        v83(v29, p_inserted, v31, v33, v32, v34);
+      }
+      else
+      {
+        p_inserted = v79;
+        v39 = (_QWORD *)g_pEntitySystem;
+        CEntitySystem_QueueSpawnEntity(g_pEntitySystem, v79, v96);
+        v42 = v79;
+        if ( !v106 )
+        {
+          v39 = (_QWORD *)g_pEntitySystem;
+          CEntitySystem_ExecuteQueuedCreation(g_pEntitySystem);
+          v42 = v79;
+        }
+        v43 = v96;
+        if ( v105 )
+        {
+          v80 = v36;
+          v44 = v42;
+          v76 = a2;
+          v45 = v105;
+          v46 = v96;
+          do
+          {
+            while ( 1 )
+            {
+              v39 = (_QWORD *)v45[9];
+              if ( v39 || v45[10] )
+                break;
+              v45 = (_QWORD *)v45[7];
+              if ( !v45 )
+                goto LABEL_35;
+            }
+            v47 = (char *)v45[10];
+            v39 = (_QWORD *)((char *)v39 + v45[11]);
+            v48 = (void (__fastcall *)(_QWORD *, __int64, __int64))v47;
+            if ( ((unsigned __int8)v47 & 1) != 0 )
+              v48 = *(void (__fastcall **)(_QWORD *, __int64, __int64))&v47[*v39 - 1];
+            p_inserted = v44;
+            v48(v39, v44, v46);
+            v45 = (_QWORD *)v45[7];
+          }
+          while ( v45 );
+  LABEL_35:
+          v36 = v80;
+          a2 = v76;
+        }
+        v83((__int64)v39, p_inserted, v40, v41, v43, (const __m128i *)v42);
+        if ( (_DWORD)v36 != -1 && (_DWORD)v36 != -2 )
+        {
+          if ( qword_256F420 )
+          {
+            v20 = *(_QWORD *)(qword_256F420 + 8 * ((v36 >> 9) & 0x3F));
+            if ( v20 )
+            {
+              v20 += 112 * (v36 & 0x1FF);
+              if ( (_DWORD)v36 == *(_DWORD *)(v20 + 16) )
+              {
+                v49 = *(_QWORD *)v20;
+                if ( *(_QWORD *)v20 )
+                {
+                  v50 = *a1;
+                  if ( *a1 != *(_DWORD *)(v49 + 2632) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2632;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2632) = v50;
+                  }
+                  v51 = a1[1];
+                  if ( v51 != *(_DWORD *)(v49 + 2636) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2636;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2636) = v51;
+                  }
+                  v52 = a1[20];
+                  if ( v52 != *(_DWORD *)(v49 + 2640) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2640;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2640) = v52;
+                  }
+                  v53 = a1[15];
+                  if ( v53 != *(_DWORD *)(v49 + 2692) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2692;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2692) = v53;
+                  }
+                  if ( *(float *)(v49 + 2644) != *((float *)a1 + 2)
+                    || *(float *)(v49 + 2648) != *((float *)a1 + 3)
+                    || *(float *)(v49 + 2652) != *((float *)a1 + 4) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2644;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_QWORD *)(v49 + 2644) = *((_QWORD *)a1 + 1);
+                    *(_DWORD *)(v49 + 2652) = a1[4];
+                  }
+                  if ( *(float *)(v49 + 2656) != *((float *)a1 + 5)
+                    || *(float *)(v49 + 2660) != *((float *)a1 + 6)
+                    || *(float *)(v49 + 2664) != *((float *)a1 + 7) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2656;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_QWORD *)(v49 + 2656) = *(_QWORD *)(a1 + 5);
+                    *(_DWORD *)(v49 + 2664) = a1[7];
+                  }
+                  if ( *(float *)(v49 + 2668) != *((float *)a1 + 8)
+                    || *(float *)(v49 + 2672) != *((float *)a1 + 9)
+                    || *(float *)(v49 + 2676) != *((float *)a1 + 10) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    v115 = 0;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2668;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_QWORD *)(v49 + 2668) = *((_QWORD *)a1 + 4);
+                    *(_DWORD *)(v49 + 2676) = a1[10];
+                  }
+                  if ( *(float *)(v49 + 2680) != *((float *)a1 + 11)
+                    || *(float *)(v49 + 2684) != *((float *)a1 + 12)
+                    || *(float *)(v49 + 2688) != *((float *)a1 + 13) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2680;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_QWORD *)(v49 + 2680) = *(_QWORD *)(a1 + 11);
+                    *(_DWORD *)(v49 + 2688) = a1[13];
+                  }
+                  v54 = a1[16];
+                  if ( v54 != *(_DWORD *)(v49 + 2696) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2696;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2696) = v54;
+                  }
+                  v55 = a1[17];
+                  if ( v55 != *(_DWORD *)(v49 + 2700) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2700;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2700) = v55;
+                  }
+                  v56 = a1[18];
+                  if ( v56 != *(_DWORD *)(v49 + 2708) )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v112 = 0;
+                    v115 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2708;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2708) = v56;
+                  }
+                  if ( *((float *)a1 + 19) != *(float *)(v49 + 2704) )
+                  {
+                    v85 = a1[19];
+                    v115 = 0;
+                    v112 = 0;
+                    inserted = (__m128i)1uLL;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2704;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_DWORD *)(v49 + 2704) = v85;
+                  }
+                  if ( *(_BYTE *)(v49 + 2712) != 1 )
+                  {
+                    inserted = (__m128i)1uLL;
+                    v115 = 0;
+                    v112 = 0;
+                    v110 = 0;
+                    v111 = 0;
+                    v113 = -1;
+                    v114 = -1;
+                    sub_9B9C80(&v110, 1);
+                    ++inserted.m128i_i32[2];
+                    p_inserted = (__int64)&inserted;
+                    *(_DWORD *)v110 = 2712;
+                    (*(void (__fastcall **)(__int64, __m128i *))(*(_QWORD *)v49 + 232LL))(v49, &inserted);
+                    sub_9B9650(&inserted.m128i_u64[1]);
+                    *(_BYTE *)(v49 + 2712) = 1;
+                  }
+                  v57 = *a2;
+                  if ( *(_QWORD *)(*a2 - 24LL) == 128 )
+                  {
+                    v58 = 0;
+                    while ( 1 )
+                    {
+                      v59 = *(_BYTE *)(v57 + v58);
+                      if ( *(_BYTE *)(v49 + v58 + 2713) != v59 )
+                      {
+                        v86 = 1;
+                        p_inserted = 1;
+                        v91 = -1;
+                        v87 = 0;
+                        v88 = nullptr;
+                        v89 = 0;
+                        v90 = 0;
+                        v92 = v58;
+                        v93 = -1;
+                        v94 = 0;
+                        sub_9B9C80(&v88, 1);
+                        LODWORD(v87) = v87 + 1;
+                        *v88 = 2713;
+                        v63 = *(void *(__fastcall **)(__int64, __int64 *))(*(_QWORD *)v49 + 232LL);
+                        if ( (char *)v63 == (char *)CBaseEntity_SetStateChanged )
+                        {
+                          v20 = (unsigned int)v86;
+                          if ( (_DWORD)v86 )
+                          {
+                            p_inserted = v49;
+                            CNetworkTransmitComponent_StateChanged(v49 + 56, v49, (__int64)&v86, v60, v61, v62);
+                          }
+                          else if ( !*(_BYTE *)(v49 + 792) )
+                          {
+                            v64 = *(_QWORD *)(v49 + 72);
+                            if ( v64 && *(_BYTE *)(v64 + 24) )
+                            {
+                              *(_BYTE *)(v49 + 789) = 1;
+                            }
+                            else
+                            {
+                              v69 = *((const char **)&v90 + 1);
+                              if ( !*((_QWORD *)&v90 + 1) )
+                                v69 = &byte_8D7E1C;
+                              v84 = v91;
+                              v70 = sub_984870(v69);
+                              LODWORD(v72) = v90;
+                              if ( !(_QWORD)v90 )
+                                v72 = &byte_8D7E1C;
+                              sub_9A70A0(
+                                (unsigned int)&inserted,
+                                (unsigned int)"CNetworkTransmitComponent::StateChanged(%s) @%s:%d",
+                                (_DWORD)v72,
+                                v70,
+                                v84,
+                                v71);
+                              v73 = &inserted.m128i_i8[8];
+                              if ( (inserted.m128i_i8[7] & 0x40) == 0 )
+                              {
+                                v73 = &byte_8D7E1C;
+                                if ( (inserted.m128i_i32[1] & 0x3FFFFFFF) != 0 )
+                                  v73 = (const char *)inserted.m128i_i64[1];
+                              }
+                              sub_9F8540(v49 + 56, v73);
+                              p_inserted = 0;
+                              sub_984310(&inserted, 0);
+                              _InterlockedOr((volatile signed __int32 *)(v49 + 784), 3u);
+                              *(_WORD *)(v49 + 814) = 0;
+                            }
+                          }
+                          v65 = *((float *)off_2503B68 + 12);
+                          if ( v65 > *(float *)(v49 + 1336) )
+                          {
+                            *(float *)(v49 + 1336) = v65;
+                            *(_QWORD *)(v49 + 1328) = 0;
+                          }
+                        }
+                        else
+                        {
+                          p_inserted = (__int64)&v86;
+                          v63(v49, &v86);
+                        }
+                        LODWORD(v87) = 0;
+                        if ( HIDWORD(v89) <= 0x3FFFFFFF )
+                        {
+                          p_inserted = (__int64)v88;
+                          if ( v88 )
+                            (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+                        }
+                        *(_BYTE *)(v49 + v58 + 2713) = v59;
+                      }
+                      if ( ++v58 == 128 )
+                        break;
+                      v57 = *a2;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    v66 = (__int16 *)v96;
+    result = (__int64)off_2255B18;
+    v95 = off_2255B18;
+    if ( v96 )
+    {
+      if ( *(_BYTE *)(v96 + 36) )
+      {
+        p_inserted = 2;
+        if ( (unsigned __int8)sub_983F70(LOG_GENERAL, 2) )
+        {
+          p_inserted = 2;
+          sub_983550(LOG_GENERAL, 2, "kv 0x%p Release refcount == %d\n", v66, v66[16] - 1);
+        }
+      }
+      result = (unsigned int)(unsigned __int16)v66[16]-- - 1;
+      if ( (__int16)result <= 0 )
+      {
+        sub_1E576D0(v66, p_inserted, v20);
+        result = sub_97A200(v66, 56);
+      }
+    }
+    if ( v99 )
+      return sub_984EB0(&v99);
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
@@ -1,0 +1,960 @@
+func_name: CEntitySpawner_CPlayerSprayDecal_Spawn
+func_va: '0x1802a4c70'
+disasm_code: |-
+  .text:00000001802A4C70                 mov     rax, rsp
+  .text:00000001802A4C73                 push    rbp
+  .text:00000001802A4C74                 lea     rbp, [rax-0C8h]
+  .text:00000001802A4C7B                 sub     rsp, 1C0h
+  .text:00000001802A4C82                 mov     [rax+10h], rbx
+  .text:00000001802A4C86                 mov     [rax+18h], rsi
+  .text:00000001802A4C8A                 mov     rsi, rcx
+  .text:00000001802A4C8D                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A4C94                 mov     [rax+20h], rdi
+  .text:00000001802A4C98                 xor     edi, edi
+  .text:00000001802A4C9A                 mov     [rax-10h], r12
+  .text:00000001802A4C9E                 mov     [rax-18h], r13
+  .text:00000001802A4CA2                 mov     r13, rdx
+  .text:00000001802A4CA5                 mov     [rax-20h], r14
+  .text:00000001802A4CA9                 ; 0xCC8 = 3272 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+  .text:00000001802A4CA9                 lea     rbx, [rcx+0CC8h]; 0xCC8 = 3272 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+  .text:00000001802A4CB0                 lea     rax, ??_7?$CEntitySpawner@VCPlayerSprayDecal@@@@6B@; const CEntitySpawner<CPlayerSprayDecal>::`vftable'
+  .text:00000001802A4CB7                 mov     [rbp+0C0h+var_D8], rdi
+  .text:00000001802A4CBB                 mov     [rbp+0C0h+var_100], rax
+  .text:00000001802A4CBF                 mov     r14d, 0FFFFFFFFh
+  .text:00000001802A4CC5                 mov     [rbp+0C0h+var_8F], dil
+  .text:00000001802A4CC9                 mov     [rbp+0C0h+var_88], rdi
+  .text:00000001802A4CCD                 mov     [rbp+0C0h+var_70], rdi
+  .text:00000001802A4CD1                 mov     [rbp+0C0h+var_68], 0FFFFFFFFFFFFFFFFh
+  .text:00000001802A4CD9                 mov     [rbp+0C0h+var_60], dil
+  .text:00000001802A4CDD                 call    sub_1811F7750
+  .text:00000001802A4CE2                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A4CE9                 mov     [rbp+0C0h+var_CC], eax
+  .text:00000001802A4CEC                 call    sub_1811F7A50
+  .text:00000001802A4CF1                 mov     rcx, cs:g_pVApplication
+  .text:00000001802A4CF8                 movaps  xmm0, xmmword ptr [rax]
+  .text:00000001802A4CFB                 movaps  [rbp+0C0h+var_C0], xmm0
+  .text:00000001802A4CFF                 movaps  xmm1, xmmword ptr [rax+10h]
+  .text:00000001802A4D03                 movaps  [rbp+0C0h+var_B0], xmm1
+  .text:00000001802A4D07                 movaps  xmm0, xmmword ptr [rax+20h]
+  .text:00000001802A4D0B                 mov     rax, cs:qword_181DEE7D8
+  .text:00000001802A4D12                 mov     [rbp+0C0h+var_E0], rax
+  .text:00000001802A4D16                 movaps  [rbp+0C0h+var_A0], xmm0
+  .text:00000001802A4D1A                 mov     [rbp+0C0h+var_F0], rdi
+  .text:00000001802A4D1E                 mov     [rbp+0C0h+var_E8], rbx
+  .text:00000001802A4D22                 test    rcx, rcx
+  .text:00000001802A4D25                 jz      short loc_1802A4D38
+  .text:00000001802A4D27                 mov     rax, [rcx]
+  .text:00000001802A4D2A                 call    qword ptr [rax+0C8h]
+  .text:00000001802A4D30                 mov     [rbp+0C0h+var_90], 1
+  .text:00000001802A4D34                 test    al, al
+  .text:00000001802A4D36                 jnz     short loc_1802A4D3C
+  .text:00000001802A4D38                 mov     [rbp+0C0h+var_90], dil
+  .text:00000001802A4D3C                 mov     rax, [rbp+0C0h+var_100]
+  .text:00000001802A4D40                 lea     rcx, [rbp+0C0h+var_100]
+  .text:00000001802A4D44                 mov     [rbp+0C0h+var_D0], edi
+  .text:00000001802A4D47                 mov     rdx, [rax]
+  .text:00000001802A4D4A                 lea     rax, sub_1802BA6F0
+  .text:00000001802A4D51                 cmp     rdx, rax
+  .text:00000001802A4D54                 jnz     short loc_1802A4D5D
+  .text:00000001802A4D56                 call    sub_1802BA7B0
+  .text:00000001802A4D5B                 jmp     short loc_1802A4D5F
+  .text:00000001802A4D5D                 call    rdx
+  .text:00000001802A4D5F                 lea     rdx, [rsi+8]
+  .text:00000001802A4D63                 lea     rcx, [rbp+0C0h+var_120]
+  .text:00000001802A4D67                 call    sub_1801B27B0
+  .text:00000001802A4D6C                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A4D70                 lea     rax, aOrigin; "origin"
+  .text:00000001802A4D77                 lea     r8, [rbp+0C0h+var_120]
+  .text:00000001802A4D7B                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A4D80                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A4D85                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFE4200216h
+  .text:00000001802A4D8E                 mov     r12d, 0FFFFFFFFh
+  .text:00000001802A4D94                 call    sub_1802B9C40
+  .text:00000001802A4D99                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A4D9D                 lea     rax, aAngles; "angles"
+  .text:00000001802A4DA4                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A4DA9                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A4DAE                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFBA98DACFh
+  .text:00000001802A4DB7                 call    sub_181207710
+  .text:00000001802A4DBC                 test    rax, rax
+  .text:00000001802A4DBF                 jz      short loc_1802A4DD8
+  .text:00000001802A4DC1                 mov     r9b, 22h ; '"'
+  .text:00000001802A4DC4                 lea     r8, qword_1815A29E8
+  .text:00000001802A4DCB                 mov     edx, 3
+  .text:00000001802A4DD0                 mov     rcx, rax
+  .text:00000001802A4DD3                 call    sub_1814E38C0
+  .text:00000001802A4DD8                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A4DDC                 lea     rax, aOwner; "owner"
+  .text:00000001802A4DE3                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A4DE8                 mov     [rsp+1C0h+var_178], rax
+  .text:00000001802A4DED                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFBE26849Fh
+  .text:00000001802A4DF6                 call    sub_181207710
+  .text:00000001802A4DFB                 mov     rbx, rax
+  .text:00000001802A4DFE                 test    rax, rax
+  .text:00000001802A4E01                 jz      short loc_1802A4E25
+  .text:00000001802A4E03                 mov     [rsp+1C0h+var_190], dil
+  .text:00000001802A4E08                 xor     r9d, r9d
+  .text:00000001802A4E0B                 mov     [rsp+1C0h+var_198], edi
+  .text:00000001802A4E0F                 mov     r8b, 26h ; '&'
+  .text:00000001802A4E12                 mov     dl, 4
+  .text:00000001802A4E14                 mov     qword ptr [rsp+1C0h+var_1A0], rdi
+  .text:00000001802A4E19                 mov     rcx, rax
+  .text:00000001802A4E1C                 call    sub_1814DEC40
+  .text:00000001802A4E21                 mov     [rbx+8], r12
+  .text:00000001802A4E25                 cmp     [rbp+0C0h+var_F0], rdi
+  .text:00000001802A4E29                 jz      loc_1802A54EF
+  .text:00000001802A4E2F                 lea     rax, aCBuildworkerCs_3; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001802A4E36                 mov     [rsp+1C0h+var_178], 4BBh
+  .text:00000001802A4E3F                 mov     qword ptr [rsp+1C0h+var_188+8], rax
+  .text:00000001802A4E44                 lea     r8, [rbp+0C0h+var_50]
+  .text:00000001802A4E48                 movups  xmm0, [rsp+1C0h+var_188+8]
+  .text:00000001802A4E4D                 lea     rax, aSpawn; "Spawn"
+  .text:00000001802A4E54                 mov     [rsp+1C0h+var_20], r15
+  .text:00000001802A4E5C                 mov     [rsp+1C0h+var_170], rax
+  .text:00000001802A4E61                 lea     rdx, off_181B7D698; "Server Simulation"
+  .text:00000001802A4E68                 movsd   xmm1, [rsp+1C0h+var_170]
+  .text:00000001802A4E6E                 lea     rcx, aCentityspawner_0; "CEntitySpawner<class CPlayerSprayDecal>"...
+  .text:00000001802A4E75                 movsd   [rbp+0C0h+var_40], xmm1
+  .text:00000001802A4E7D                 movaps  [rbp+0C0h+var_50], xmm0
+  .text:00000001802A4E81                 call    cs:?EnterScopeInternalBudgetFlags@?$VProfScopeHelper@$0A@$0A@@@SAP6AXXZPEBDAEAUVProfBudgetGroupCallSite@@AEBVCUtlSourceLocation@@@Z; VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(char const *,VProfBudgetGroupCallSite &,CUtlSourceLocation const &)
+  .text:00000001802A4E87                 mov     rcx, [rbp+0C0h+var_F0]
+  .text:00000001802A4E8B                 lea     r15, aClassname; "classname"
+  .text:00000001802A4E92                 lea     r8, [rbp+0C0h+arg_0]
+  .text:00000001802A4E99                 mov     [rsp+1C0h+var_178], r15
+  .text:00000001802A4E9E                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A4EA3                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFC61B1C62h
+  .text:00000001802A4EAC                 mov     rdi, rax
+  .text:00000001802A4EAF                 call    sub_181207600
+  .text:00000001802A4EB4                 test    rax, rax
+  .text:00000001802A4EB7                 jz      short loc_1802A4EC2
+  .text:00000001802A4EB9                 cmp     [rbp+0C0h+arg_0], 0
+  .text:00000001802A4EC0                 jz      short loc_1802A4F0A
+  .text:00000001802A4EC2                 mov     rax, [rbp+0C0h+var_E0]
+  .text:00000001802A4EC6                 mov     rcx, [rax+50h]
+  .text:00000001802A4ECA                 mov     rbx, [rcx]
+  .text:00000001802A4ECD                 test    rbx, rbx
+  .text:00000001802A4ED0                 jz      short loc_1802A4F0A
+  .text:00000001802A4ED2                 mov     r14, [rbp+0C0h+var_F0]
+  .text:00000001802A4ED6                 lea     rdx, [rsp+1C0h+var_188+8]
+  .text:00000001802A4EDB                 mov     rcx, r14
+  .text:00000001802A4EDE                 mov     qword ptr [rsp+1C0h+var_188+8], 0FFFFFFFFC61B1C62h
+  .text:00000001802A4EE7                 mov     [rsp+1C0h+var_178], r15
+  .text:00000001802A4EEC                 call    sub_181207710
+  .text:00000001802A4EF1                 test    rax, rax
+  .text:00000001802A4EF4                 jz      short loc_1802A4F04
+  .text:00000001802A4EF6                 mov     r8, rbx
+  .text:00000001802A4EF9                 mov     rdx, rax
+  .text:00000001802A4EFC                 mov     rcx, r14
+  .text:00000001802A4EFF                 call    sub_181208570
+  .text:00000001802A4F04                 mov     r14d, 0FFFFFFFFh
+  .text:00000001802A4F0A                 mov     rcx, [rbp+0C0h+var_D8]
+  .text:00000001802A4F0E                 lea     r9, byte_1815A2980
+  .text:00000001802A4F15                 mov     edx, dword ptr [rbp+0C0h+var_68+4]
+  .text:00000001802A4F18                 test    rcx, rcx
+  .text:00000001802A4F1B                 mov     r8d, [rbp+0C0h+var_D0]
+  .text:00000001802A4F1F                 mov     eax, dword ptr [rbp+0C0h+var_68]
+  .text:00000001802A4F22                 cmovnz  r9, rcx
+  .text:00000001802A4F26                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A4F2D                 mov     byte ptr [rsp+1C0h+var_188], 0
+  .text:00000001802A4F32                 mov     dword ptr [rsp+1C0h+var_190], edx
+  .text:00000001802A4F36                 mov     edx, [rbp+0C0h+var_CC]
+  .text:00000001802A4F39                 mov     [rsp+1C0h+var_198], eax
+  .text:00000001802A4F3D                 mov     [rsp+1C0h+var_1A0], r8d
+  .text:00000001802A4F42                 mov     r8, [rbp+0C0h+var_E0]
+  .text:00000001802A4F46                 call    CEntitySystem_CreateEntity
+  .text:00000001802A4F4B                 mov     r15, rax
+  .text:00000001802A4F4E                 test    rax, rax
+  .text:00000001802A4F51                 jz      loc_1802A54E5
+  .text:00000001802A4F57                 mov     rdx, [rax+10h]
+  .text:00000001802A4F5B                 test    rdx, rdx
+  .text:00000001802A4F5E                 jz      short loc_1802A4F8E
+  .text:00000001802A4F60                 mov     ecx, [rdx+30h]
+  .text:00000001802A4F63                 mov     ebx, 7FFFh
+  .text:00000001802A4F68                 mov     edx, [rdx+10h]
+  .text:00000001802A4F6B                 and     ecx, 1
+  .text:00000001802A4F6E                 mov     r8d, edx
+  .text:00000001802A4F71                 mov     eax, edx
+  .text:00000001802A4F73                 shr     r8d, 0Fh
+  .text:00000001802A4F77                 and     eax, 7FFFh
+  .text:00000001802A4F7C                 sub     r8d, ecx
+  .text:00000001802A4F7F                 cmp     edx, r12d
+  .text:00000001802A4F82                 cmovnz  ebx, eax
+  .text:00000001802A4F85                 shl     r8d, 0Fh
+  .text:00000001802A4F89                 or      ebx, r8d
+  .text:00000001802A4F8C                 jmp     short loc_1802A4F91
+  .text:00000001802A4F8E                 mov     ebx, r12d
+  .text:00000001802A4F91                 mov     rcx, cs:g_pGameResourceService
+  .text:00000001802A4F98                 lea     rdx, [rbp+0C0h+var_C0]
+  .text:00000001802A4F9C                 mov     [rbp+0C0h+var_110], r14d
+  .text:00000001802A4FA0                 lea     r9, [rbp+0C0h+var_120]
+  .text:00000001802A4FA4                 mov     [rbp+0C0h+var_10C], 1FFFFh
+  .text:00000001802A4FAB                 mov     r8d, 1
+  .text:00000001802A4FB1                 mov     rax, [r15+10h]
+  .text:00000001802A4FB5                 mov     [rbp+0C0h+var_120], rax
+  .text:00000001802A4FB9                 mov     rax, [rbp+0C0h+var_F0]
+  .text:00000001802A4FBD                 mov     [rbp+0C0h+var_118], rax
+  .text:00000001802A4FC1                 mov     rax, [rcx]
+  .text:00000001802A4FC4                 mov     qword ptr [rsp+1C0h+var_1A0], rdx
+  .text:00000001802A4FC9                 mov     edx, [rbp+0C0h+var_CC]
+  .text:00000001802A4FCC                 call    qword ptr [rax+118h]
+  .text:00000001802A4FD2                 mov     rax, [r15+10h]
+  .text:00000001802A4FD6                 mov     ecx, [rax+30h]
+  .text:00000001802A4FD9                 shr     ecx, 9
+  .text:00000001802A4FDC                 test    cl, 1
+  .text:00000001802A4FDF                 jnz     loc_1802A54E5
+  .text:00000001802A4FE5                 mov     r8, [rbp+0C0h+var_F0]
+  .text:00000001802A4FE9                 mov     rdx, r15
+  .text:00000001802A4FEC                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A4FF3                 call    CEntitySystem_QueueSpawnEntity
+  .text:00000001802A4FF8                 cmp     [rbp+0C0h+var_70], 0
+  .text:00000001802A4FFD                 jnz     short loc_1802A500B
+  .text:00000001802A4FFF                 mov     rcx, cs:g_pEntitySystem
+  .text:00000001802A5006                 call    CEntitySystem_ExecuteQueuedCreation
+  .text:00000001802A500B                 mov     r14, [rbp+0C0h+var_88]
+  .text:00000001802A500F                 mov     r12, [rbp+0C0h+var_F0]
+  .text:00000001802A5013                 test    r14, r14
+  .text:00000001802A5016                 jz      short loc_1802A5044
+  .text:00000001802A5018                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001802A5020                 mov     rcx, [r14+48h]
+  .text:00000001802A5024                 test    rcx, rcx
+  .text:00000001802A5027                 jnz     short loc_1802A502F
+  .text:00000001802A5029                 cmp     [r14+50h], rcx
+  .text:00000001802A502D                 jz      short loc_1802A503B
+  .text:00000001802A502F                 mov     rax, [r14+50h]
+  .text:00000001802A5033                 mov     r8, r12
+  .text:00000001802A5036                 mov     rdx, r15
+  .text:00000001802A5039                 call    rax
+  .text:00000001802A503B                 mov     r14, [r14+38h]
+  .text:00000001802A503F                 test    r14, r14
+  .text:00000001802A5042                 jnz     short loc_1802A5020
+  .text:00000001802A5044                 mov     rax, [rbp+0C0h+var_100]
+  .text:00000001802A5048                 mov     r8, [rax+8]
+  .text:00000001802A504C                 lea     rax, nullsub_31
+  .text:00000001802A5053                 cmp     r8, rax
+  .text:00000001802A5056                 jz      short loc_1802A5062
+  .text:00000001802A5058                 mov     rdx, r15
+  .text:00000001802A505B                 lea     rcx, [rbp+0C0h+var_100]
+  .text:00000001802A505F                 call    r8
+  .text:00000001802A5062                 call    rdi
+  .text:00000001802A5064                 mov     r15d, 0FFFFFFFFh
+  .text:00000001802A506A                 cmp     ebx, r15d
+  .text:00000001802A506D                 jz      loc_1802A54E7
+  .text:00000001802A5073                 mov     rcx, cs:qword_181D9D980
+  .text:00000001802A507A                 test    rcx, rcx
+  .text:00000001802A507D                 jz      loc_1802A54E7
+  .text:00000001802A5083                 cmp     ebx, 0FFFFFFFEh
+  .text:00000001802A5086                 jz      short loc_1802A50BC
+  .text:00000001802A5088                 mov     eax, ebx
+  .text:00000001802A508A                 and     eax, 7FFFh
+  .text:00000001802A508F                 mov     edx, eax
+  .text:00000001802A5091                 shr     rax, 9
+  .text:00000001802A5095                 mov     r8, [rcx+rax*8]
+  .text:00000001802A5099                 test    r8, r8
+  .text:00000001802A509C                 jz      short loc_1802A50BC
+  .text:00000001802A509E                 mov     eax, edx
+  .text:00000001802A50A0                 and     eax, 1FFh
+  .text:00000001802A50A5                 imul    rdi, rax, 70h ; 'p'
+  .text:00000001802A50A9                 add     rdi, r8
+  .text:00000001802A50AC                 jz      short loc_1802A50BC
+  .text:00000001802A50AE                 cmp     [rdi+10h], ebx
+  .text:00000001802A50B1                 mov     eax, 0
+  .text:00000001802A50B6                 cmovnz  rdi, rax
+  .text:00000001802A50BA                 jmp     short loc_1802A50C0
+  .text:00000001802A50BC                 xor     eax, eax
+  .text:00000001802A50BE                 mov     edi, eax
+  .text:00000001802A50C0                 test    rdi, rdi
+  .text:00000001802A50C3                 jz      loc_1802A54E7
+  .text:00000001802A50C9                 mov     rdi, [rdi]
+  .text:00000001802A50CC                 test    rdi, rdi
+  .text:00000001802A50CF                 jz      loc_1802A54E7
+  .text:00000001802A50D5                 mov     r14d, [rsi]
+  .text:00000001802A50D8                 mov     r12d, 0FFFFFFFFh
+  .text:00000001802A50DE                 movaps  [rsp+1C0h+var_38+8], xmm6
+  .text:00000001802A50E6                 cmp     [rdi+76Ch], r14d
+  .text:00000001802A50ED                 jz      short loc_1802A5108
+  .text:00000001802A50EF                 mov     r8d, r15d
+  .text:00000001802A50F2                 lea     rcx, [rdi+76Ch]
+  .text:00000001802A50F9                 mov     edx, r12d
+  .text:00000001802A50FC                 call    sub_1802B6340
+  .text:00000001802A5101                 mov     [rdi+76Ch], r14d
+  .text:00000001802A5108                 mov     r14d, [rsi+4]
+  .text:00000001802A510C                 cmp     [rdi+770h], r14d
+  .text:00000001802A5113                 jz      short loc_1802A512E
+  .text:00000001802A5115                 mov     r8d, r15d
+  .text:00000001802A5118                 lea     rcx, [rdi+770h]
+  .text:00000001802A511F                 mov     edx, r12d
+  .text:00000001802A5122                 call    sub_1802B6480
+  .text:00000001802A5127                 mov     [rdi+770h], r14d
+  .text:00000001802A512E                 mov     r14d, [rsi+50h]
+  .text:00000001802A5132                 cmp     [rdi+774h], r14d
+  .text:00000001802A5139                 jz      short loc_1802A5154
+  .text:00000001802A513B                 mov     r8d, r15d
+  .text:00000001802A513E                 lea     rcx, [rdi+774h]
+  .text:00000001802A5145                 mov     edx, r12d
+  .text:00000001802A5148                 call    sub_1802B6200
+  .text:00000001802A514D                 mov     [rdi+774h], r14d
+  .text:00000001802A5154                 mov     r14d, [rsi+3Ch]
+  .text:00000001802A5158                 cmp     [rdi+7A8h], r14d
+  .text:00000001802A515F                 jz      short loc_1802A517A
+  .text:00000001802A5161                 mov     r8d, r15d
+  .text:00000001802A5164                 lea     rcx, [rdi+7A8h]
+  .text:00000001802A516B                 mov     edx, r12d
+  .text:00000001802A516E                 call    sub_1802B5950
+  .text:00000001802A5173                 mov     [rdi+7A8h], r14d
+  .text:00000001802A517A                 movss   xmm0, dword ptr [rsi+8]
+  .text:00000001802A517F                 lea     rbx, [rdi+778h]
+  .text:00000001802A5186                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A5189                 jp      short loc_1802A51A7
+  .text:00000001802A518B                 jnz     short loc_1802A51A7
+  .text:00000001802A518D                 movss   xmm0, dword ptr [rsi+0Ch]
+  .text:00000001802A5192                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A5196                 jp      short loc_1802A51A7
+  .text:00000001802A5198                 jnz     short loc_1802A51A7
+  .text:00000001802A519A                 movss   xmm0, dword ptr [rsi+10h]
+  .text:00000001802A519F                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A51A3                 jp      short loc_1802A51A7
+  .text:00000001802A51A5                 jz      short loc_1802A51C4
+  .text:00000001802A51A7                 mov     r8d, r15d
+  .text:00000001802A51AA                 mov     edx, r12d
+  .text:00000001802A51AD                 mov     rcx, rbx
+  .text:00000001802A51B0                 call    sub_1802B65C0
+  .text:00000001802A51B5                 movsd   xmm0, qword ptr [rsi+8]
+  .text:00000001802A51BA                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A51BE                 mov     eax, [rsi+10h]
+  .text:00000001802A51C1                 mov     [rbx+8], eax
+  .text:00000001802A51C4                 movss   xmm0, dword ptr [rsi+14h]
+  .text:00000001802A51C9                 lea     rbx, [rdi+784h]
+  .text:00000001802A51D0                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A51D3                 jp      short loc_1802A51F1
+  .text:00000001802A51D5                 jnz     short loc_1802A51F1
+  .text:00000001802A51D7                 movss   xmm0, dword ptr [rsi+18h]
+  .text:00000001802A51DC                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A51E0                 jp      short loc_1802A51F1
+  .text:00000001802A51E2                 jnz     short loc_1802A51F1
+  .text:00000001802A51E4                 movss   xmm0, dword ptr [rsi+1Ch]
+  .text:00000001802A51E9                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A51ED                 jp      short loc_1802A51F1
+  .text:00000001802A51EF                 jz      short loc_1802A520E
+  .text:00000001802A51F1                 mov     r8d, r15d
+  .text:00000001802A51F4                 mov     edx, r12d
+  .text:00000001802A51F7                 mov     rcx, rbx
+  .text:00000001802A51FA                 call    sub_1802B6AC0
+  .text:00000001802A51FF                 movsd   xmm0, qword ptr [rsi+14h]
+  .text:00000001802A5204                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A5208                 mov     eax, [rsi+1Ch]
+  .text:00000001802A520B                 mov     [rbx+8], eax
+  .text:00000001802A520E                 movss   xmm0, dword ptr [rsi+20h]
+  .text:00000001802A5213                 lea     rbx, [rdi+790h]
+  .text:00000001802A521A                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A521D                 jp      short loc_1802A523B
+  .text:00000001802A521F                 jnz     short loc_1802A523B
+  .text:00000001802A5221                 movss   xmm0, dword ptr [rsi+24h]
+  .text:00000001802A5226                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A522A                 jp      short loc_1802A523B
+  .text:00000001802A522C                 jnz     short loc_1802A523B
+  .text:00000001802A522E                 movss   xmm0, dword ptr [rsi+28h]
+  .text:00000001802A5233                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A5237                 jp      short loc_1802A523B
+  .text:00000001802A5239                 jz      short loc_1802A5258
+  .text:00000001802A523B                 mov     r8d, r15d
+  .text:00000001802A523E                 mov     edx, r12d
+  .text:00000001802A5241                 mov     rcx, rbx
+  .text:00000001802A5244                 call    sub_1802B6700
+  .text:00000001802A5249                 movsd   xmm0, qword ptr [rsi+20h]
+  .text:00000001802A524E                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A5252                 mov     eax, [rsi+28h]
+  .text:00000001802A5255                 mov     [rbx+8], eax
+  .text:00000001802A5258                 movss   xmm0, dword ptr [rsi+2Ch]
+  .text:00000001802A525D                 lea     rbx, [rdi+79Ch]
+  .text:00000001802A5264                 ucomiss xmm0, dword ptr [rbx]
+  .text:00000001802A5267                 jp      short loc_1802A5285
+  .text:00000001802A5269                 jnz     short loc_1802A5285
+  .text:00000001802A526B                 movss   xmm0, dword ptr [rsi+30h]
+  .text:00000001802A5270                 ucomiss xmm0, dword ptr [rbx+4]
+  .text:00000001802A5274                 jp      short loc_1802A5285
+  .text:00000001802A5276                 jnz     short loc_1802A5285
+  .text:00000001802A5278                 movss   xmm0, dword ptr [rsi+34h]
+  .text:00000001802A527D                 ucomiss xmm0, dword ptr [rbx+8]
+  .text:00000001802A5281                 jp      short loc_1802A5285
+  .text:00000001802A5283                 jz      short loc_1802A52A2
+  .text:00000001802A5285                 mov     r8d, r15d
+  .text:00000001802A5288                 mov     edx, r12d
+  .text:00000001802A528B                 mov     rcx, rbx
+  .text:00000001802A528E                 call    sub_1802B6980
+  .text:00000001802A5293                 movsd   xmm0, qword ptr [rsi+2Ch]
+  .text:00000001802A5298                 movsd   qword ptr [rbx], xmm0
+  .text:00000001802A529C                 mov     eax, [rsi+34h]
+  .text:00000001802A529F                 mov     [rbx+8], eax
+  .text:00000001802A52A2                 mov     r14d, [rsi+40h]
+  .text:00000001802A52A6                 cmp     [rdi+7ACh], r14d
+  .text:00000001802A52AD                 jz      short loc_1802A52C8
+  .text:00000001802A52AF                 mov     r8d, r15d
+  .text:00000001802A52B2                 lea     rcx, [rdi+7ACh]
+  .text:00000001802A52B9                 mov     edx, r12d
+  .text:00000001802A52BC                 call    sub_1802B5590
+  .text:00000001802A52C1                 mov     [rdi+7ACh], r14d
+  .text:00000001802A52C8                 mov     r14d, [rsi+44h]
+  .text:00000001802A52CC                 cmp     [rdi+7B0h], r14d
+  .text:00000001802A52D3                 jz      short loc_1802A52EE
+  .text:00000001802A52D5                 mov     r8d, r15d
+  .text:00000001802A52D8                 lea     rcx, [rdi+7B0h]
+  .text:00000001802A52DF                 mov     edx, r12d
+  .text:00000001802A52E2                 call    sub_1802B56D0
+  .text:00000001802A52E7                 mov     [rdi+7B0h], r14d
+  .text:00000001802A52EE                 mov     r14d, [rsi+48h]
+  .text:00000001802A52F2                 cmp     [rdi+7B8h], r14d
+  .text:00000001802A52F9                 jz      short loc_1802A5314
+  .text:00000001802A52FB                 mov     r8d, r15d
+  .text:00000001802A52FE                 lea     rcx, [rdi+7B8h]
+  .text:00000001802A5305                 mov     edx, r12d
+  .text:00000001802A5308                 call    sub_1802B5A90
+  .text:00000001802A530D                 mov     [rdi+7B8h], r14d
+  .text:00000001802A5314                 movss   xmm6, dword ptr [rsi+4Ch]
+  .text:00000001802A5319                 movss   xmm0, dword ptr [rdi+7B4h]
+  .text:00000001802A5321                 ucomiss xmm0, xmm6
+  .text:00000001802A5324                 jp      short loc_1802A5328
+  .text:00000001802A5326                 jz      short loc_1802A5342
+  .text:00000001802A5328                 mov     r8d, r15d
+  .text:00000001802A532B                 lea     rcx, [rdi+7B4h]
+  .text:00000001802A5332                 mov     edx, r12d
+  .text:00000001802A5335                 call    sub_1802B4F40
+  .text:00000001802A533A                 movss   dword ptr [rdi+7B4h], xmm6
+  .text:00000001802A5342                 cmp     byte ptr [rdi+7BCh], 1
+  .text:00000001802A5349                 movaps  xmm6, [rsp+1C0h+var_38+8]
+  .text:00000001802A5351                 jz      short loc_1802A536C
+  .text:00000001802A5353                 mov     r8d, r15d
+  .text:00000001802A5356                 lea     rcx, [rdi+7BCh]
+  .text:00000001802A535D                 mov     edx, r12d
+  .text:00000001802A5360                 call    sub_1802B5F90
+  .text:00000001802A5365                 mov     byte ptr [rdi+7BCh], 1
+  .text:00000001802A536C                 cmp     qword ptr [r13+10h], 80h
+  .text:00000001802A5374                 jnz     loc_1802A54E7
+  .text:00000001802A537A                 xor     ebx, ebx
+  .text:00000001802A537C                 mov     r14d, ebx
+  .text:00000001802A537F                 mov     esi, ebx
+  .text:00000001802A5381                 mov     r15d, ebx
+  .text:00000001802A5384                 cmp     qword ptr [r13+18h], 0Fh
+  .text:00000001802A5389                 mov     rax, r13
+  .text:00000001802A538C                 jbe     short loc_1802A5392
+  .text:00000001802A538E                 mov     rax, [r13+0]
+  .text:00000001802A5392                 movzx   r12d, byte ptr [rsi+rax]
+  .text:00000001802A5397                 cmp     [r15+rdi+7BDh], r12b
+  .text:00000001802A539F                 jz      loc_1802A54CD
+  .text:00000001802A53A5                 xorps   xmm0, xmm0
+  .text:00000001802A53A8                 mov     [rsp+1C0h+var_160], 1
+  .text:00000001802A53B0                 mov     eax, 0FFFFFFFFh
+  .text:00000001802A53B5                 movdqa  [rbp+0C0h+var_140], xmm0
+  .text:00000001802A53BA                 xor     edx, edx
+  .text:00000001802A53BC                 mov     [rbp+0C0h+var_128], eax
+  .text:00000001802A53BF                 xor     ecx, ecx
+  .text:00000001802A53C1                 mov     [rsp+1C0h+var_150], rbx
+  .text:00000001802A53C6                 mov     r9d, 4
+  .text:00000001802A53CC                 mov     [rsp+1C0h+var_148], 0
+  .text:00000001802A53D5                 mov     r8d, 1
+  .text:00000001802A53DB                 mov     dword ptr [rsp+1C0h+var_158], ebx
+  .text:00000001802A53DF                 mov     [rbp+0C0h+var_130], 0FFFFFFFFh
+  .text:00000001802A53E6                 mov     [rbp+0C0h+var_12C], r14d
+  .text:00000001802A53EA                 mov     [rbp+0C0h+var_124], 0
+  .text:00000001802A53F0                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001802A53F6                 mov     ebx, eax
+  .text:00000001802A53F8                 cmp     eax, 1
+  .text:00000001802A53FB                 jge     short loc_1802A540F
+  .text:00000001802A53FD                 nop     dword ptr [rax]
+  .text:00000001802A5400                 lea     eax, [rbx+1]
+  .text:00000001802A5403                 cdq
+  .text:00000001802A5404                 sub     eax, edx
+  .text:00000001802A5406                 sar     eax, 1
+  .text:00000001802A5408                 mov     ebx, eax
+  .text:00000001802A540A                 cmp     eax, 1
+  .text:00000001802A540D                 jl      short loc_1802A5400
+  .text:00000001802A540F                 movsxd  r9, dword ptr [rsp+1C0h+var_148]
+  .text:00000001802A5414                 mov     rcx, [rsp+1C0h+var_150]
+  .text:00000001802A5419                 shl     r9, 2
+  .text:00000001802A541D                 test    dword ptr [rsp+1C0h+var_148+4], 0C0000000h
+  .text:00000001802A5425                 mov     r8d, ebx
+  .text:00000001802A5428                 setz    dl
+  .text:00000001802A542B                 shl     r8, 2
+  .text:00000001802A542F                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001802A5435                 mov     ecx, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A5439                 mov     [rsp+1C0h+var_150], rax
+  .text:00000001802A543E                 test    ecx, 0C0000000h
+  .text:00000001802A5444                 jz      short loc_1802A5450
+  .text:00000001802A5446                 and     ecx, 3FFFFFFFh
+  .text:00000001802A544C                 mov     dword ptr [rsp+1C0h+var_148+4], ecx
+  .text:00000001802A5450                 inc     dword ptr [rsp+1C0h+var_158]
+  .text:00000001802A5454                 lea     rdx, [rsp+1C0h+var_160]
+  .text:00000001802A5459                 mov     dword ptr [rsp+1C0h+var_148], ebx
+  .text:00000001802A545D                 mov     rcx, rdi
+  .text:00000001802A5460                 mov     dword ptr [rax], 7BDh
+  .text:00000001802A5466                 mov     rax, [rdi]
+  .text:00000001802A5469                 call    qword ptr [rax+0E0h]
+  .text:00000001802A546F                 mov     eax, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A5473                 xor     ebx, ebx
+  .text:00000001802A5475                 mov     rdx, [rsp+1C0h+var_150]
+  .text:00000001802A547A                 mov     dword ptr [rsp+1C0h+var_158], ebx
+  .text:00000001802A547E                 test    eax, 0C0000000h
+  .text:00000001802A5483                 jnz     short loc_1802A54C5
+  .text:00000001802A5485                 test    rdx, rdx
+  .text:00000001802A5488                 jz      short loc_1802A54A5
+  .text:00000001802A548A                 mov     rax, cs:g_pMemAlloc
+  .text:00000001802A5491                 mov     rcx, [rax]
+  .text:00000001802A5494                 mov     rax, [rcx]
+  .text:00000001802A5497                 call    qword ptr [rax+18h]
+  .text:00000001802A549A                 mov     eax, dword ptr [rsp+1C0h+var_148+4]
+  .text:00000001802A549E                 mov     edx, ebx
+  .text:00000001802A54A0                 mov     [rsp+1C0h+var_150], rbx
+  .text:00000001802A54A5                 mov     dword ptr [rsp+1C0h+var_148], ebx
+  .text:00000001802A54A9                 test    eax, 0C0000000h
+  .text:00000001802A54AE                 jnz     short loc_1802A54C5
+  .text:00000001802A54B0                 test    rdx, rdx
+  .text:00000001802A54B3                 jz      short loc_1802A54C5
+  .text:00000001802A54B5                 mov     rax, cs:g_pMemAlloc
+  .text:00000001802A54BC                 mov     rcx, [rax]
+  .text:00000001802A54BF                 mov     rax, [rcx]
+  .text:00000001802A54C2                 call    qword ptr [rax+18h]
+  .text:00000001802A54C5                 mov     [rsi+rdi+7BDh], r12b
+  .text:00000001802A54CD                 inc     r14d
+  .text:00000001802A54D0                 inc     r15
+  .text:00000001802A54D3                 inc     rsi
+  .text:00000001802A54D6                 cmp     r14d, 80h
+  .text:00000001802A54DD                 jl      loc_1802A5384
+  .text:00000001802A54E3                 jmp     short loc_1802A54E7
+  .text:00000001802A54E5                 call    rdi
+  .text:00000001802A54E7                 mov     r15, [rsp+1C0h+var_20]
+  .text:00000001802A54EF                 mov     rbx, [rbp+0C0h+var_F0]
+  .text:00000001802A54F3                 lea     rax, ??_7?$CEntitySpawnerBase@VCPlayerSprayDecal@@@@6B@; const CEntitySpawnerBase<CPlayerSprayDecal>::`vftable'
+  .text:00000001802A54FA                 mov     r14, [rsp+1C0h+var_18]
+  .text:00000001802A5502                 mov     r13, [rsp+1C0h+var_10]
+  .text:00000001802A550A                 mov     r12, [rsp+1B8h]
+  .text:00000001802A5512                 mov     rdi, [rsp+1C0h+arg_18]
+  .text:00000001802A551A                 mov     rsi, [rsp+1C0h+arg_10]
+  .text:00000001802A5522                 mov     [rbp+0C0h+var_100], rax
+  .text:00000001802A5526                 test    rbx, rbx
+  .text:00000001802A5529                 jz      short loc_1802A5591
+  .text:00000001802A552B                 cmp     byte ptr [rbx+24h], 0
+  .text:00000001802A552F                 jz      short loc_1802A5571
+  .text:00000001802A5531                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001802A5538                 mov     edx, 2
+  .text:00000001802A553D                 mov     ecx, [rcx]
+  .text:00000001802A553F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001802A5545                 test    al, al
+  .text:00000001802A5547                 jz      short loc_1802A5571
+  .text:00000001802A5549                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001802A5550                 lea     r8, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:00000001802A5557                 movsx   eax, word ptr [rbx+20h]
+  .text:00000001802A555B                 mov     r9, rbx
+  .text:00000001802A555E                 dec     eax
+  .text:00000001802A5560                 mov     edx, 2
+  .text:00000001802A5565                 mov     [rsp+1C0h+var_1A0], eax
+  .text:00000001802A5569                 mov     ecx, [rcx]
+  .text:00000001802A556B                 call    cs:LoggingSystem_Log
+  .text:00000001802A5571                 dec     word ptr [rbx+20h]
+  .text:00000001802A5575                 cmp     word ptr [rbx+20h], 0
+  .text:00000001802A557A                 jg      short loc_1802A5591
+  .text:00000001802A557C                 mov     rcx, rbx
+  .text:00000001802A557F                 call    sub_181206AD0
+  .text:00000001802A5584                 mov     edx, 38h ; '8'
+  .text:00000001802A5589                 mov     rcx, rbx
+  .text:00000001802A558C                 call    sub_180E7C980
+  .text:00000001802A5591                 cmp     [rbp+0C0h+var_D8], 0
+  .text:00000001802A5596                 mov     rbx, [rsp+1C0h+arg_8]
+  .text:00000001802A559E                 jz      short loc_1802A55AA
+  .text:00000001802A55A0                 lea     rcx, [rbp+0C0h+var_D8]
+  .text:00000001802A55A4                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:00000001802A55AA                 add     rsp, 1C0h
+  .text:00000001802A55B1                 pop     rbp
+  .text:00000001802A55B2                 retn
+procedure: |-
+  void __fastcall sub_1802A4C70(int *a1, _QWORD *a2)
+  {
+    __int64 v4; // rbx
+    _OWORD *v5; // rax
+    __int128 v6; // xmm0
+    char v7; // al
+    __int64 v8; // rax
+    __int64 v9; // r9
+    __int64 v10; // rax
+    int v11; // edx
+    int v12; // r8d
+    __int64 v13; // rbx
+    __int64 v14; // rax
+    void (*v15)(void); // rdi
+    __int64 v16; // rbx
+    __int64 v17; // r14
+    __int64 v18; // rax
+    char *v19; // r9
+    __int64 Entity; // rax
+    __int64 v21; // r15
+    __int64 v22; // rdx
+    int v23; // ecx
+    int v24; // ebx
+    unsigned int v25; // edx
+    int v26; // ebx
+    __int64 v27; // rdx
+    __int64 v28; // r14
+    __int64 i; // r12
+    __int64 v30; // rcx
+    __int64 (__fastcall *v31)(); // r8
+    __int64 v32; // r8
+    __int64 *v33; // rdi
+    __int64 v34; // rdi
+    int v35; // r14d
+    int v36; // r14d
+    int v37; // r14d
+    int v38; // r14d
+    int v39; // r14d
+    int v40; // r14d
+    int v41; // r14d
+    float v42; // xmm6_4
+    int v43; // r14d
+    __int64 v44; // rsi
+    __int64 v45; // r15
+    _QWORD *v46; // rax
+    char v47; // r12
+    __int64 v48; // rdx
+    int j; // ebx
+    _DWORD *v50; // rax
+    int v51; // eax
+    _DWORD *v52; // rdx
+    __int16 *v53; // rbx
+    __int128 v54; // [rsp+48h] [rbp-C0h] BYREF
+    const char *v55; // [rsp+58h] [rbp-B0h]
+    int v56; // [rsp+68h] [rbp-A0h] BYREF
+    __int64 v57; // [rsp+70h] [rbp-98h]
+    _DWORD *v58; // [rsp+78h] [rbp-90h]
+    __int64 v59; // [rsp+80h] [rbp-88h]
+    __int128 v60; // [rsp+88h] [rbp-80h]
+    int v61; // [rsp+98h] [rbp-70h]
+    int v62; // [rsp+9Ch] [rbp-6Ch]
+    int v63; // [rsp+A0h] [rbp-68h]
+    __int16 v64; // [rsp+A4h] [rbp-64h]
+    _QWORD v65[2]; // [rsp+A8h] [rbp-60h] BYREF
+    int v66; // [rsp+B8h] [rbp-50h]
+    int v67; // [rsp+BCh] [rbp-4Ch]
+    _QWORD v68[2]; // [rsp+C8h] [rbp-40h] BYREF
+    __int64 v69; // [rsp+D8h] [rbp-30h]
+    __int64 v70; // [rsp+E0h] [rbp-28h]
+    __int64 v71; // [rsp+E8h] [rbp-20h]
+    char *v72; // [rsp+F0h] [rbp-18h] BYREF
+    int v73; // [rsp+F8h] [rbp-10h]
+    unsigned int v74; // [rsp+FCh] [rbp-Ch]
+    _OWORD v75[3]; // [rsp+108h] [rbp+0h] BYREF
+    char v76; // [rsp+138h] [rbp+30h]
+    char v77; // [rsp+139h] [rbp+31h]
+    __int64 v78; // [rsp+140h] [rbp+38h]
+    __int64 v79; // [rsp+158h] [rbp+50h]
+    __int64 v80; // [rsp+160h] [rbp+58h]
+    char v81; // [rsp+168h] [rbp+60h]
+    __int128 v82; // [rsp+178h] [rbp+70h] BYREF
+    const char *v83; // [rsp+188h] [rbp+80h]
+    char v84; // [rsp+1D8h] [rbp+D0h] BYREF
+
+    v4 = g_pEntitySystem + 3272;                  // 0xCC8 = 3272 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
+    v72 = nullptr;
+    v68[0] = &CEntitySpawner<CPlayerSprayDecal>::`vftable';
+    v77 = 0;
+    v78 = 0;
+    v79 = 0;
+    v80 = -1;
+    v81 = 0;
+    v74 = sub_1811F7750(g_pEntitySystem);
+    v5 = (_OWORD *)sub_1811F7A50(g_pEntitySystem);
+    v75[0] = *v5;
+    v75[1] = v5[1];
+    v6 = v5[2];
+    v71 = qword_181DEE7D8;
+    v75[2] = v6;
+    v69 = 0;
+    v70 = v4;
+    if ( !g_pVApplication
+      || (v7 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 200LL))(g_pVApplication), v76 = 1, !v7) )
+    {
+      v76 = 0;
+    }
+    v73 = 0;
+    if ( *(__int64 (__fastcall **)())v68[0] == sub_1802BA6F0 )
+      sub_1802BA7B0(v68);
+    else
+      (*(void (__fastcall **)(_QWORD *))v68[0])(v68);
+    sub_1801B27B0(v65, a1 + 2);
+    *((_QWORD *)&v54 + 1) = "origin";
+    *(_QWORD *)&v54 = -467664362;
+    sub_1802B9C40(v69, &v54, v65);
+    *((_QWORD *)&v54 + 1) = "angles";
+    *(_QWORD *)&v54 = -1164387633;
+    v8 = sub_181207710(v69, &v54);
+    if ( v8 )
+    {
+      LOBYTE(v9) = 34;
+      sub_1814E38C0(v8, 3, &qword_1815A29E8, v9);
+    }
+    *((_QWORD *)&v54 + 1) = "owner";
+    *(_QWORD *)&v54 = -1104771937;
+    v10 = sub_181207710(v69, &v54);
+    v13 = v10;
+    if ( v10 )
+    {
+      LOBYTE(v12) = 38;
+      LOBYTE(v11) = 4;
+      sub_1814DEC40(v10, v11, v12, 0, 0, 0, 0);
+      *(_QWORD *)(v13 + 8) = 0xFFFFFFFFLL;
+    }
+    if ( v69 )
+    {
+      *((_QWORD *)&v54 + 1) = 1211;
+      *(_QWORD *)&v54 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\shared\\entityspawner.h";
+      v55 = "Spawn";
+      v83 = "Spawn";
+      v82 = v54;
+      v14 = VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(
+              "CEntitySpawner<class CPlayerSprayDecal>::Spawn",
+              &off_181B7D698,
+              &v82);
+      *((_QWORD *)&v54 + 1) = "classname";
+      *(_QWORD *)&v54 = -971301790;
+      v15 = (void (*)(void))v14;
+      if ( !sub_181207600(v69, &v54, &v84) || v84 )
+      {
+        v16 = **(_QWORD **)(v71 + 80);
+        if ( v16 )
+        {
+          v17 = v69;
+          *(_QWORD *)&v54 = -971301790;
+          *((_QWORD *)&v54 + 1) = "classname";
+          v18 = sub_181207710(v69, &v54);
+          if ( v18 )
+            sub_181208570(v17, v18, v16);
+        }
+      }
+      v19 = byte_1815A2980;
+      if ( v72 )
+        v19 = v72;
+      Entity = CEntitySystem_CreateEntity((_DWORD *)g_pEntitySystem, v74, v71, (__int64)v19, v73, v80, HIDWORD(v80), 0);
+      v21 = Entity;
+      if ( !Entity )
+        goto LABEL_98;
+      v22 = *(_QWORD *)(Entity + 16);
+      if ( v22 )
+      {
+        v23 = *(_DWORD *)(v22 + 48);
+        v24 = 0x7FFF;
+        v25 = *(_DWORD *)(v22 + 16);
+        if ( v25 != -1 )
+          v24 = v25 & 0x7FFF;
+        v26 = (((v25 >> 15) - (v23 & 1)) << 15) | v24;
+      }
+      else
+      {
+        v26 = -1;
+      }
+      v66 = -1;
+      v67 = 0x1FFFF;
+      v65[0] = *(_QWORD *)(Entity + 16);
+      v65[1] = v69;
+      (*(void (__fastcall **)(__int64, _QWORD, __int64, _QWORD *, _OWORD *))(*(_QWORD *)g_pGameResourceService + 280LL))(
+        g_pGameResourceService,
+        v74,
+        1,
+        v65,
+        v75);
+      if ( (*(_DWORD *)(*(_QWORD *)(v21 + 16) + 48LL) & 0x200) != 0 )
+      {
+  LABEL_98:
+        v15();
+      }
+      else
+      {
+        CEntitySystem_QueueSpawnEntity(g_pEntitySystem, v21);
+        if ( !v79 )
+          CEntitySystem_ExecuteQueuedCreation(g_pEntitySystem, v27);
+        v28 = v78;
+        for ( i = v69; v28; v28 = *(_QWORD *)(v28 + 56) )
+        {
+          v30 = *(_QWORD *)(v28 + 72);
+          if ( v30 || *(_QWORD *)(v28 + 80) )
+            (*(void (__fastcall **)(__int64, __int64, __int64))(v28 + 80))(v30, v21, i);
+        }
+        v31 = *(__int64 (__fastcall **)())(v68[0] + 8LL);
+        if ( v31 != nullsub_31 )
+          ((void (__fastcall *)(_QWORD *, __int64))v31)(v68, v21);
+        v15();
+        if ( v26 != -1 && qword_181D9D980 )
+        {
+          if ( v26 != -2
+            && (v32 = *(_QWORD *)(qword_181D9D980 + 8 * ((unsigned __int64)(v26 & 0x7FFF) >> 9))) != 0
+            && (v33 = (__int64 *)(v32 + 112LL * (v26 & 0x1FF))) != nullptr )
+          {
+            if ( *((_DWORD *)v33 + 4) != v26 )
+              v33 = nullptr;
+          }
+          else
+          {
+            v33 = nullptr;
+          }
+          if ( v33 )
+          {
+            v34 = *v33;
+            if ( v34 )
+            {
+              v35 = *a1;
+              if ( *(_DWORD *)(v34 + 1900) != *a1 )
+              {
+                sub_1802B6340(v34 + 1900, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1900) = v35;
+              }
+              v36 = a1[1];
+              if ( *(_DWORD *)(v34 + 1904) != v36 )
+              {
+                sub_1802B6480(v34 + 1904, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1904) = v36;
+              }
+              v37 = a1[20];
+              if ( *(_DWORD *)(v34 + 1908) != v37 )
+              {
+                sub_1802B6200(v34 + 1908, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1908) = v37;
+              }
+              v38 = a1[15];
+              if ( *(_DWORD *)(v34 + 1960) != v38 )
+              {
+                sub_1802B5950(v34 + 1960, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1960) = v38;
+              }
+              if ( *((float *)a1 + 2) != *(float *)(v34 + 1912)
+                || *((float *)a1 + 3) != *(float *)(v34 + 1916)
+                || *((float *)a1 + 4) != *(float *)(v34 + 1920) )
+              {
+                sub_1802B65C0(v34 + 1912, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v34 + 1912) = *((_QWORD *)a1 + 1);
+                *(_DWORD *)(v34 + 1920) = a1[4];
+              }
+              if ( *((float *)a1 + 5) != *(float *)(v34 + 1924)
+                || *((float *)a1 + 6) != *(float *)(v34 + 1928)
+                || *((float *)a1 + 7) != *(float *)(v34 + 1932) )
+              {
+                sub_1802B6AC0(v34 + 1924, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v34 + 1924) = *(_QWORD *)(a1 + 5);
+                *(_DWORD *)(v34 + 1932) = a1[7];
+              }
+              if ( *((float *)a1 + 8) != *(float *)(v34 + 1936)
+                || *((float *)a1 + 9) != *(float *)(v34 + 1940)
+                || *((float *)a1 + 10) != *(float *)(v34 + 1944) )
+              {
+                sub_1802B6700(v34 + 1936, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v34 + 1936) = *((_QWORD *)a1 + 4);
+                *(_DWORD *)(v34 + 1944) = a1[10];
+              }
+              if ( *((float *)a1 + 11) != *(float *)(v34 + 1948)
+                || *((float *)a1 + 12) != *(float *)(v34 + 1952)
+                || *((float *)a1 + 13) != *(float *)(v34 + 1956) )
+              {
+                sub_1802B6980(v34 + 1948, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_QWORD *)(v34 + 1948) = *(_QWORD *)(a1 + 11);
+                *(_DWORD *)(v34 + 1956) = a1[13];
+              }
+              v39 = a1[16];
+              if ( *(_DWORD *)(v34 + 1964) != v39 )
+              {
+                sub_1802B5590(v34 + 1964, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1964) = v39;
+              }
+              v40 = a1[17];
+              if ( *(_DWORD *)(v34 + 1968) != v40 )
+              {
+                sub_1802B56D0(v34 + 1968, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1968) = v40;
+              }
+              v41 = a1[18];
+              if ( *(_DWORD *)(v34 + 1976) != v41 )
+              {
+                sub_1802B5A90(v34 + 1976, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_DWORD *)(v34 + 1976) = v41;
+              }
+              v42 = *((float *)a1 + 19);
+              if ( *(float *)(v34 + 1972) != v42 )
+              {
+                sub_1802B4F40(v34 + 1972, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(float *)(v34 + 1972) = v42;
+              }
+              if ( *(_BYTE *)(v34 + 1980) != 1 )
+              {
+                sub_1802B5F90(v34 + 1980, 0xFFFFFFFFLL, 0xFFFFFFFFLL);
+                *(_BYTE *)(v34 + 1980) = 1;
+              }
+              if ( a2[2] == 128 )
+              {
+                v43 = 0;
+                v44 = 0;
+                v45 = 0;
+                do
+                {
+                  v46 = a2;
+                  if ( a2[3] > 0xFu )
+                    v46 = (_QWORD *)*a2;
+                  v47 = *((_BYTE *)v46 + v44);
+                  if ( *(_BYTE *)(v45 + v34 + 1981) != v47 )
+                  {
+                    v56 = 1;
+                    v60 = 0;
+                    v63 = -1;
+                    v58 = nullptr;
+                    v59 = 0;
+                    LODWORD(v57) = 0;
+                    v61 = -1;
+                    v62 = v43;
+                    v64 = 0;
+                    for ( j = UtlVectorMemory_CalcNewAllocationCount(0, 0, 1, 4); j < 1; j = (j + 1) / 2 )
+                      v48 = (unsigned int)((j + 1) >> 31);
+                    LOBYTE(v48) = (v59 & 0xC000000000000000uLL) == 0;
+                    v50 = (_DWORD *)UtlVectorMemory_Alloc(v58, v48, 4LL * (unsigned int)j, 4LL * (int)v59);
+                    v58 = v50;
+                    if ( (v59 & 0xC000000000000000uLL) != 0 )
+                      HIDWORD(v59) &= 0x3FFFFFFFu;
+                    LODWORD(v57) = v57 + 1;
+                    LODWORD(v59) = j;
+                    *v50 = 1981;
+                    (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)v34 + 224LL))(v34, &v56);
+                    v51 = HIDWORD(v59);
+                    v52 = v58;
+                    LODWORD(v57) = 0;
+                    if ( (v59 & 0xC000000000000000uLL) == 0 )
+                    {
+                      if ( v58 )
+                      {
+                        (*(void (__fastcall **)(_QWORD, _DWORD *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v58);
+                        v51 = HIDWORD(v59);
+                        v52 = nullptr;
+                        v58 = nullptr;
+                      }
+                      LODWORD(v59) = 0;
+                      if ( (v51 & 0xC0000000) == 0 && v52 )
+                        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+                    }
+                    *(_BYTE *)(v44 + v34 + 1981) = v47;
+                  }
+                  ++v43;
+                  ++v45;
+                  ++v44;
+                }
+                while ( v43 < 128 );
+              }
+            }
+          }
+        }
+      }
+    }
+    v53 = (__int16 *)v69;
+    v68[0] = &CEntitySpawnerBase<CPlayerSprayDecal>::`vftable';
+    if ( v69 )
+    {
+      if ( *(_BYTE *)(v69 + 36) && (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        LoggingSystem_Log(LOG_GENERAL, 2, "kv 0x%p Release refcount == %d\n", v53, v53[16] - 1);
+      if ( --v53[16] <= 0 )
+      {
+        sub_181206AD0((__int64 *)v53);
+        sub_180E7C980((__int64)v53);
+      }
+    }
+    if ( v72 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v72);
+  }


### PR DESCRIPTION
## Summary
- Add find-CCSPlayerPawn_SprayPaint (Pattern A, xref_string SprayCan.Paint)
- Add find-CEntitySpawner_CPlayerSprayDecal_Spawn (Pattern D, LLM_DECOMPILE via CCSPlayerPawn_SprayPaint)
- Add find-CEntitySystem_m_EntityKeyValuesAllocator (Pattern E, LLM_DECOMPILE via CEntitySpawner_CPlayerSprayDecal_Spawn)
- Register all three symbols and skills in config.yaml
- Generate reference YAMLs for CCSPlayerPawn_SprayPaint and CEntitySpawner_CPlayerSprayDecal_Spawn on both platforms

## Notes
- CEntitySystem_m_EntityKeyValuesAllocator uses offset_sig_max_match:2 because two Linux template instantiations of CEntitySpawner share identical byte patterns around the struct field access; both access the same field at the same offset