### PR TITLE
Add CEntitySystem_AddComponentFieldUnserializer and CEntitySystem_m_DataDescKeyUnserializerss

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5094,6 +5094,10 @@ modules:
         expected_output:
           - CEntitySystem_RegisterEntityClass.{platform}.yaml
 
+      - name: find-CEntitySystem_AddComponentFieldUnserializer
+        expected_output:
+          - CEntitySystem_AddComponentFieldUnserializer.{platform}.yaml
+
       - name: find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname
         expected_output:
           - CEntitySystem_m_entClassesByCPPClassname.{platform}.yaml
@@ -8360,6 +8364,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::RegisterEntityClass
+
+      - name: CEntitySystem_AddComponentFieldUnserializer
+        category: func
+        alias:
+          - CEntitySystem::AddComponentFieldUnserializer
 
       - name: CEntitySystem_m_entClassesByCPPClassname
         category: structmember

--- a/config.yaml
+++ b/config.yaml
@@ -5098,6 +5098,12 @@ modules:
         expected_output:
           - CEntitySystem_AddComponentFieldUnserializer.{platform}.yaml
 
+      - name: find-CEntitySystem_m_DataDescKeyUnserializerss
+        expected_output:
+          - CEntitySystem_m_DataDescKeyUnserializerss.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddComponentFieldUnserializer.{platform}.yaml
+
       - name: find-CEntitySystem_m_entClassesByCPPClassname-AND-CEntitySystem_m_entClassesByClassname
         expected_output:
           - CEntitySystem_m_entClassesByCPPClassname.{platform}.yaml
@@ -8369,6 +8375,13 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddComponentFieldUnserializer
+
+      - name: CEntitySystem_m_DataDescKeyUnserializerss
+        category: structmember
+        struct: CEntitySystem
+        member: m_DataDescKeyUnserializerss
+        alias:
+          - CEntitySystem::m_DataDescKeyUnserializerss
 
       - name: CEntitySystem_m_entClassesByCPPClassname
         category: structmember

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddComponentFieldUnserializer.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddComponentFieldUnserializer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddComponentFieldUnserializer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddComponentFieldUnserializer",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CEntitySystem_AddComponentFieldUnserializer",
+        "xref_strings": [
+            "Field %s::%s cannot have sub-keyfields since it is an atomic type!\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CEntitySystem_AddComponentFieldUnserializer",
+        "xref_strings": [
+            "Field %s::%s cannot have sub-keyfields since it is an atomic type!\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        # Two funcs reference the string on Linux; exclude the wrong one by its prologue bytes
+        "exclude_signatures": ["55 4D 89 C2 48 89"],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_AddComponentFieldUnserializer",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_DataDescKeyUnserializerss.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_DataDescKeyUnserializerss.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_DataDescKeyUnserializerss skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_DataDescKeyUnserializerss",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntitySystem_m_DataDescKeyUnserializerss",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddComponentFieldUnserializer.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_m_DataDescKeyUnserializerss",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddComponentFieldUnserializer.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddComponentFieldUnserializer.linux.yaml
@@ -1,0 +1,2307 @@
+func_name: CEntitySystem_AddComponentFieldUnserializer
+func_va: '0x1e784c0'
+disasm_code: |-
+  .text:0000000001E784C0                 push    rbp
+  .text:0000000001E784C1                 mov     r10, rcx
+  .text:0000000001E784C4                 mov     rbp, rsp
+  .text:0000000001E784C7                 push    r15
+  .text:0000000001E784C9                 push    r14
+  .text:0000000001E784CB                 push    r13
+  .text:0000000001E784CD                 mov     r13, rsi
+  .text:0000000001E784D0                 push    r12
+  .text:0000000001E784D2                 push    rbx
+  .text:0000000001E784D3                 sub     rsp, 408h
+  .text:0000000001E784DA                 mov     r12d, [rsi+28h]
+  .text:0000000001E784DE                 mov     [rbp+var_3C8], rdi
+  .text:0000000001E784E5                 mov     r14d, [rsi+18h]
+  .text:0000000001E784E9                 mov     [rbp+var_400], rdx
+  .text:0000000001E784F0                 movzx   ebx, word ptr [rcx+14h]
+  .text:0000000001E784F4                 test    r12d, r12d
+  .text:0000000001E784F7                 jns     loc_1E79660
+  .text:0000000001E784FD                 mov     rax, [rsi+10h]
+  .text:0000000001E78501                 mov     [rbp+var_410], rax
+  .text:0000000001E78508                 cmp     bx, 1
+  .text:0000000001E7850C                 jbe     loc_1E78868
+  .text:0000000001E78512                 cmp     byte ptr [rcx], 8
+  .text:0000000001E78515                 jnz     loc_1E79D90
+  .text:0000000001E7851B                 movzx   eax, byte ptr [rcx+18h]
+  .text:0000000001E7851F                 mov     ebx, 1
+  .text:0000000001E78524                 xor     r12d, r12d
+  .text:0000000001E78527                 mov     [rbp+var_3D8], 0
+  .text:0000000001E78531                 mov     [rbp+var_3D1], 0
+  .text:0000000001E78538                 mov     [rbp+var_3C0], 0
+  .text:0000000001E78543                 shr     al, 4
+  .text:0000000001E78546                 and     eax, 1
+  .text:0000000001E78549                 mov     [rbp+var_3DD], al
+  .text:0000000001E7854F                 mov     rax, 0C00000C800000000h
+  .text:0000000001E78559                 mov     rdx, [r13+8]
+  .text:0000000001E7855D                 mov     [rbp+var_388], 0
+  .text:0000000001E78568                 mov     [rbp+var_390], rax
+  .text:0000000001E7856F                 test    rdx, rdx
+  .text:0000000001E78572                 jz      short loc_1E7857D
+  .text:0000000001E78574                 cmp     byte ptr [rdx], 0
+  .text:0000000001E78577                 jnz     loc_1E79718
+  .text:0000000001E7857D                 mov     r15, [rbp+var_410]
+  .text:0000000001E78584                 xor     r8d, r8d
+  .text:0000000001E78587                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E7858C                 xor     esi, esi
+  .text:0000000001E7858E                 lea     rax, [rbp+var_390]
+  .text:0000000001E78595                 mov     [rbp+var_3B8], r10
+  .text:0000000001E7859C                 mov     rdi, rax
+  .text:0000000001E7859F                 mov     [rbp+var_418], rax
+  .text:0000000001E785A6                 mov     rdx, r15
+  .text:0000000001E785A9                 call    sub_984B30
+  .text:0000000001E785AE                 mov     r10, [rbp+var_3B8]
+  .text:0000000001E785B5                 mov     [rbp+var_3F8], r15
+  .text:0000000001E785BC                 lea     r15, [rbp+var_388]
+  .text:0000000001E785C3                 test    byte ptr [rbp+var_390+7], 40h
+  .text:0000000001E785CA                 jnz     short loc_1E785E6
+  .text:0000000001E785CC                 lea     r15, byte_8D7E1C
+  .text:0000000001E785D3                 test    dword ptr [rbp+var_390+4], 3FFFFFFFh
+  .text:0000000001E785DD                 jz      short loc_1E785E6
+  .text:0000000001E785DF                 mov     r15, [rbp+var_388]
+  .text:0000000001E785E6                 mov     rax, 0C00000C800000000h
+  .text:0000000001E785F0                 mov     [rbp+var_2B8], 0
+  .text:0000000001E785FB                 mov     [rbp+var_2C0], rax
+  .text:0000000001E78602                 lea     eax, [rbx+r12]
+  .text:0000000001E78606                 mov     [rbp+var_3DC], eax
+  .text:0000000001E7860C                 lea     rax, [rbp+var_2C0]
+  .text:0000000001E78613                 mov     [rbp+var_3F0], rax
+  .text:0000000001E7861A                 test    ebx, ebx
+  .text:0000000001E7861C                 jz      loc_1E79170
+  .text:0000000001E78622                 mov     rax, [rbp+var_3C8]
+  .text:0000000001E78629                 mov     [rbp+var_3B8], r15
+  .text:0000000001E78630                 mov     [rbp+var_3E8], r10
+  .text:0000000001E78637                 add     rax, 0CC0h
+  .text:0000000001E7863D                 mov     [rbp+var_408], rax
+  .text:0000000001E78644                 lea     rax, [rbp+var_1F0]
+  .text:0000000001E7864B                 mov     [rbp+var_3D0], rax
+  .text:0000000001E78652                 jmp     loc_1E78707
+  .text:0000000001E78660                 mov     rdi, [rbp+var_3B8]
+  .text:0000000001E78667                 mov     r15d, 1
+  .text:0000000001E7866D                 test    rdi, rdi
+  .text:0000000001E78670                 jz      short loc_1E7867E
+  .text:0000000001E78672                 call    sub_985BF0
+  .text:0000000001E78677                 lea     r15d, [rax+1]
+  .text:0000000001E7867B                 movsxd  r15, r15d
+  .text:0000000001E7867E                 mov     r8, [r13+0]
+  .text:0000000001E78682                 movsxd  rbx, dword ptr [r8+1A0h]
+  .text:0000000001E78689                 mov     edi, [r8+1B0h]
+  .text:0000000001E78690                 cmp     ebx, edi
+  .text:0000000001E78692                 jz      loc_1E78FA0
+  .text:0000000001E78698                 mov     rdx, [r8+1A8h]
+  .text:0000000001E7869F                 mov     eax, ebx
+  .text:0000000001E786A1                 add     eax, 1
+  .text:0000000001E786A4                 shl     rbx, 5
+  .text:0000000001E786A8                 mov     rdi, r15
+  .text:0000000001E786AB                 mov     [r8+1A0h], eax
+  .text:0000000001E786B2                 add     r12d, 1
+  .text:0000000001E786B6                 mov     qword ptr [rdx+rbx+10h], 0
+  .text:0000000001E786BF                 mov     rax, [r13+0]
+  .text:0000000001E786C3                 add     rbx, [rax+1A8h]
+  .text:0000000001E786CA                 call    sub_97A220
+  .text:0000000001E786CF                 mov     rsi, [rbp+var_3B8]
+  .text:0000000001E786D6                 mov     rdx, r15
+  .text:0000000001E786D9                 mov     rdi, rax
+  .text:0000000001E786DC                 mov     [rbx], rax
+  .text:0000000001E786DF                 call    sub_985D80
+  .text:0000000001E786E4                 mov     eax, [rbp+var_3D8]
+  .text:0000000001E786EA                 mov     [rbx+18h], r14d
+  .text:0000000001E786EE                 mov     dword ptr [rbx+8], 0
+  .text:0000000001E786F5                 add     r14d, eax
+  .text:0000000001E786F8                 mov     eax, [rbp+var_3DC]
+  .text:0000000001E786FE                 cmp     r12d, eax
+  .text:0000000001E78701                 jz      loc_1E79170
+  .text:0000000001E78707                 cmp     [rbp+var_3D1], 0
+  .text:0000000001E7870E                 jnz     loc_1E787DE
+  .text:0000000001E78714                 cmp     [rbp+var_3DD], 0
+  .text:0000000001E7871B                 jnz     loc_1E78660
+  .text:0000000001E78721                 nop     dword ptr [rax+00000000h]
+  .text:0000000001E78728                 mov     rcx, [rbp+var_3C0]
+  .text:0000000001E7872F                 mov     rax, [rbp+var_3E8]
+  .text:0000000001E78736                 test    rcx, rcx
+  .text:0000000001E78739                 jz      loc_1E78C20
+  .text:0000000001E7873F                 mov     eax, [rax+18h]
+  .text:0000000001E78742                 test    al, 40h
+  .text:0000000001E78744                 jnz     loc_1E788C0
+  .text:0000000001E7874A                 test    eax, 40000h
+  .text:0000000001E7874F                 jnz     loc_1E78E28
+  .text:0000000001E78755                 mov     r15, [rcx+10h]
+  .text:0000000001E78759                 mov     ebx, 1
+  .text:0000000001E7875E                 mov     r8, rcx
+  .text:0000000001E78761                 push    qword ptr [r13+20h]
+  .text:0000000001E78765                 mov     r9d, r14d
+  .text:0000000001E78768                 mov     rcx, r15
+  .text:0000000001E7876B                 mov     esi, ebx
+  .text:0000000001E7876D                 push    qword ptr [r13+0]
+  .text:0000000001E78771                 mov     rdx, [rbp+var_3B8]
+  .text:0000000001E78778                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E7877F                 call    sub_1E78340
+  .text:0000000001E78784                 mov     r9d, 1
+  .text:0000000001E7878A                 mov     rcx, r15
+  .text:0000000001E7878D                 mov     esi, ebx
+  .text:0000000001E7878F                 push    qword ptr [r13+20h]
+  .text:0000000001E78793                 push    qword ptr [r13+0]
+  .text:0000000001E78797                 mov     r8, [rbp+var_3C0]
+  .text:0000000001E7879E                 mov     rdx, [rbp+var_3B8]
+  .text:0000000001E787A5                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E787AC                 call    sub_1E75800
+  .text:0000000001E787B1                 add     rsp, 20h
+  .text:0000000001E787B5                 mov     eax, [rbp+var_3D8]
+  .text:0000000001E787BB                 add     r12d, 1
+  .text:0000000001E787BF                 add     r14d, eax
+  .text:0000000001E787C2                 mov     eax, [rbp+var_3DC]
+  .text:0000000001E787C8                 cmp     r12d, eax
+  .text:0000000001E787CB                 jz      loc_1E79170
+  .text:0000000001E787D1                 cmp     [rbp+var_3D1], 0
+  .text:0000000001E787D8                 jz      loc_1E78728
+  .text:0000000001E787DE                 lea     rsi, [rbp+var_388]
+  .text:0000000001E787E5                 test    byte ptr [rbp+var_390+7], 40h
+  .text:0000000001E787EC                 jnz     short loc_1E78808
+  .text:0000000001E787EE                 lea     rsi, byte_8D7E1C
+  .text:0000000001E787F5                 test    dword ptr [rbp+var_390+4], 3FFFFFFFh
+  .text:0000000001E787FF                 jz      short loc_1E78808
+  .text:0000000001E78801                 mov     rsi, [rbp+var_388]
+  .text:0000000001E78808                 mov     rdi, [rbp+var_3F0]
+  .text:0000000001E7880F                 xor     eax, eax
+  .text:0000000001E78811                 mov     edx, r12d
+  .text:0000000001E78814                 call    sub_9844B0
+  .text:0000000001E78819                 test    byte ptr [rbp+var_2C0+7], 40h
+  .text:0000000001E78820                 jnz     loc_1E78DB8
+  .text:0000000001E78826                 test    dword ptr [rbp+var_2C0+4], 3FFFFFFFh
+  .text:0000000001E78830                 jnz     loc_1E78DF8
+  .text:0000000001E78836                 cmp     [rbp+var_3DD], 0
+  .text:0000000001E7883D                 jnz     loc_1E791A0
+  .text:0000000001E78843                 lea     rax, byte_8D7E1C
+  .text:0000000001E7884A                 mov     [rbp+var_3F8], 0
+  .text:0000000001E78855                 mov     [rbp+var_3B8], rax
+  .text:0000000001E7885C                 jmp     loc_1E78728
+  .text:0000000001E78868                 xor     r12d, r12d
+  .text:0000000001E7886B                 mov     ebx, 1
+  .text:0000000001E78870                 mov     [rbp+var_3D8], 0
+  .text:0000000001E7887A                 mov     [rbp+var_3D1], 0
+  .text:0000000001E78881                 mov     [rbp+var_3C0], 0
+  .text:0000000001E7888C                 movzx   eax, byte ptr [r10+18h]
+  .text:0000000001E78891                 shr     al, 4
+  .text:0000000001E78894                 and     eax, 1
+  .text:0000000001E78897                 cmp     byte ptr [r10], 0Ah
+  .text:0000000001E7889B                 mov     [rbp+var_3DD], al
+  .text:0000000001E788A1                 jnz     loc_1E7854F
+  .text:0000000001E788A7                 mov     rax, [r10+40h]
+  .text:0000000001E788AB                 mov     [rbp+var_3C0], rax
+  .text:0000000001E788B2                 jmp     loc_1E7854F
+  .text:0000000001E788C0                 mov     rdi, [rbp+var_408]
+  .text:0000000001E788C7                 call    sub_983720
+  .text:0000000001E788CC                 sub     rsp, 8
+  .text:0000000001E788D0                 xor     r9d, r9d
+  .text:0000000001E788D3                 mov     r8d, 2
+  .text:0000000001E788D9                 push    0
+  .text:0000000001E788DB                 mov     rdi, [rbp+var_3D0]
+  .text:0000000001E788E2                 mov     rbx, rdx
+  .text:0000000001E788E5                 mov     r15, rax
+  .text:0000000001E788E8                 mov     ecx, 8
+  .text:0000000001E788ED                 mov     edx, 4
+  .text:0000000001E788F2                 mov     esi, 28h ; '('
+  .text:0000000001E788F7                 call    sub_9840D0
+  .text:0000000001E788FC                 mov     r8, [rbp+var_3C0]
+  .text:0000000001E78903                 xor     r9d, r9d
+  .text:0000000001E78906                 pxor    xmm0, xmm0
+  .text:0000000001E7890A                 mov     [rbp+var_90], 0
+  .text:0000000001E78911                 mov     esi, 1
+  .text:0000000001E78916                 movaps  [rbp+var_190], xmm0
+  .text:0000000001E7891D                 movaps  [rbp+var_180], xmm0
+  .text:0000000001E78924                 movaps  [rbp+var_170], xmm0
+  .text:0000000001E7892B                 movaps  [rbp+var_160], xmm0
+  .text:0000000001E78932                 movaps  [rbp+var_150], xmm0
+  .text:0000000001E78939                 movaps  [rbp+var_140], xmm0
+  .text:0000000001E78940                 movaps  [rbp+var_130], xmm0
+  .text:0000000001E78947                 movaps  [rbp+var_120], xmm0
+  .text:0000000001E7894E                 movaps  [rbp+var_110], xmm0
+  .text:0000000001E78955                 movaps  [rbp+var_100], xmm0
+  .text:0000000001E7895C                 movaps  [rbp+var_F0], xmm0
+  .text:0000000001E78963                 movaps  [rbp+var_E0], xmm0
+  .text:0000000001E7896A                 movaps  [rbp+var_D0], xmm0
+  .text:0000000001E78971                 movaps  [rbp+var_C0], xmm0
+  .text:0000000001E78978                 movaps  [rbp+var_B0], xmm0
+  .text:0000000001E7897F                 movaps  [rbp+var_A0], xmm0
+  .text:0000000001E78986                 mov     [rbp+var_80], 0
+  .text:0000000001E7898E                 mov     [rbp+var_78], 0
+  .text:0000000001E78996                 mov     [rbp+var_70], 0
+  .text:0000000001E7899E                 mov     [rbp+var_68], 0
+  .text:0000000001E789A6                 mov     [rbp+var_60], 0
+  .text:0000000001E789AE                 mov     [rbp+var_58], 0
+  .text:0000000001E789B6                 mov     [rbp+var_50], 0
+  .text:0000000001E789BE                 mov     [rbp+var_48], 0
+  .text:0000000001E789C6                 mov     [rbp+var_40], 0
+  .text:0000000001E789CE                 mov     rcx, [r8+10h]
+  .text:0000000001E789D2                 push    qword ptr [r13+20h]
+  .text:0000000001E789D6                 push    [rbp+var_3D0]
+  .text:0000000001E789DC                 mov     rdx, [rbp+var_3B8]
+  .text:0000000001E789E3                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E789EA                 call    sub_1E78340
+  .text:0000000001E789EF                 mov     r8, [rbp+var_3C0]
+  .text:0000000001E789F6                 add     rsp, 20h
+  .text:0000000001E789FA                 mov     r9d, 1
+  .text:0000000001E78A00                 mov     esi, 1
+  .text:0000000001E78A05                 mov     rcx, [r8+10h]
+  .text:0000000001E78A09                 push    qword ptr [r13+20h]
+  .text:0000000001E78A0D                 push    [rbp+var_3D0]
+  .text:0000000001E78A13                 mov     rdx, [rbp+var_3B8]
+  .text:0000000001E78A1A                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E78A21                 call    sub_1E75800
+  .text:0000000001E78A26                 mov     eax, dword ptr [rbp+var_1E8+4]
+  .text:0000000001E78A2C                 or      eax, dword ptr [rbp+var_50]
+  .text:0000000001E78A2F                 or      eax, dword ptr [rbp+var_68]
+  .text:0000000001E78A32                 pop     rdx
+  .text:0000000001E78A33                 pop     rcx
+  .text:0000000001E78A34                 jnz     loc_1E78B78
+  .text:0000000001E78A3A                 mov     rdi, [rbp+var_408]
+  .text:0000000001E78A41                 mov     rsi, r15
+  .text:0000000001E78A44                 mov     rdx, rbx
+  .text:0000000001E78A47                 call    sub_984BC0
+  .text:0000000001E78A4C                 cmp     dword ptr [rbp+var_40+4], 3FFFFFFFh
+  .text:0000000001E78A53                 mov     dword ptr [rbp+var_50], 0
+  .text:0000000001E78A5A                 ja      short loc_1E78A79
+  .text:0000000001E78A5C                 nop     dword ptr [rax+00h]
+  .text:0000000001E78A60                 mov     rsi, [rbp+var_48]
+  .text:0000000001E78A64                 test    rsi, rsi
+  .text:0000000001E78A67                 jz      short loc_1E78A79
+  .text:0000000001E78A69                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E78A70                 mov     rdi, [rax]
+  .text:0000000001E78A73                 mov     rax, [rdi]
+  .text:0000000001E78A76                 call    qword ptr [rax+20h]
+  .text:0000000001E78A79                 cmp     dword ptr [rbp+var_58+4], 3FFFFFFFh
+  .text:0000000001E78A80                 mov     dword ptr [rbp+var_68], 0
+  .text:0000000001E78A87                 ja      short loc_1E78AA2
+  .text:0000000001E78A89                 mov     rsi, [rbp+var_60]
+  .text:0000000001E78A8D                 test    rsi, rsi
+  .text:0000000001E78A90                 jz      short loc_1E78AA2
+  .text:0000000001E78A92                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E78A99                 mov     rdi, [rax]
+  .text:0000000001E78A9C                 mov     rax, [rdi]
+  .text:0000000001E78A9F                 call    qword ptr [rax+20h]
+  .text:0000000001E78AA2                 cmp     dword ptr [rbp+var_70+4], 3FFFFFFFh
+  .text:0000000001E78AA9                 mov     dword ptr [rbp+var_80], 0
+  .text:0000000001E78AB0                 ja      short loc_1E78ACB
+  .text:0000000001E78AB2                 mov     rsi, [rbp+var_78]
+  .text:0000000001E78AB6                 test    rsi, rsi
+  .text:0000000001E78AB9                 jz      short loc_1E78ACB
+  .text:0000000001E78ABB                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E78AC2                 mov     rdi, [rax]
+  .text:0000000001E78AC5                 mov     rax, [rdi]
+  .text:0000000001E78AC8                 call    qword ptr [rax+20h]
+  .text:0000000001E78ACB                 mov     eax, dword ptr [rbp+var_1E8+4]
+  .text:0000000001E78AD1                 mov     [rbp+var_90], 0
+  .text:0000000001E78AD8                 test    eax, eax
+  .text:0000000001E78ADA                 jz      loc_1E78B62
+  .text:0000000001E78AE0                 mov     rdi, [rbp+var_3D0]
+  .text:0000000001E78AE7                 xor     esi, esi
+  .text:0000000001E78AE9                 pxor    xmm0, xmm0
+  .text:0000000001E78AED                 movaps  [rbp+var_190], xmm0
+  .text:0000000001E78AF4                 movaps  [rbp+var_180], xmm0
+  .text:0000000001E78AFB                 movaps  [rbp+var_170], xmm0
+  .text:0000000001E78B02                 movaps  [rbp+var_160], xmm0
+  .text:0000000001E78B09                 movaps  [rbp+var_150], xmm0
+  .text:0000000001E78B10                 movaps  [rbp+var_140], xmm0
+  .text:0000000001E78B17                 movaps  [rbp+var_130], xmm0
+  .text:0000000001E78B1E                 movaps  [rbp+var_120], xmm0
+  .text:0000000001E78B25                 movaps  [rbp+var_110], xmm0
+  .text:0000000001E78B2C                 movaps  [rbp+var_100], xmm0
+  .text:0000000001E78B33                 movaps  [rbp+var_F0], xmm0
+  .text:0000000001E78B3A                 movaps  [rbp+var_E0], xmm0
+  .text:0000000001E78B41                 movaps  [rbp+var_D0], xmm0
+  .text:0000000001E78B48                 movaps  [rbp+var_C0], xmm0
+  .text:0000000001E78B4F                 movaps  [rbp+var_B0], xmm0
+  .text:0000000001E78B56                 movaps  [rbp+var_A0], xmm0
+  .text:0000000001E78B5D                 call    sub_983FB0
+  .text:0000000001E78B62                 mov     rdi, [rbp+var_3D0]
+  .text:0000000001E78B69                 call    sub_985200
+  .text:0000000001E78B6E                 jmp     loc_1E787B5
+  .text:0000000001E78B78                 mov     rbx, [rbp+var_408]
+  .text:0000000001E78B7F                 mov     edx, 10h
+  .text:0000000001E78B84                 mov     esi, 30h ; '0'
+  .text:0000000001E78B89                 mov     rdi, rbx
+  .text:0000000001E78B8C                 call    sub_983910
+  .text:0000000001E78B91                 mov     rsi, [rbp+var_3D0]
+  .text:0000000001E78B98                 mov     rdx, rbx
+  .text:0000000001E78B9B                 pxor    xmm0, xmm0
+  .text:0000000001E78B9F                 movdqa  xmm1, cs:xmmword_86ACD0
+  .text:0000000001E78BA7                 mov     rdi, rax
+  .text:0000000001E78BAA                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000001E78BAE                 mov     r15, rax
+  .text:0000000001E78BB1                 mov     qword ptr [rax+20h], 0
+  .text:0000000001E78BB9                 movups  xmmword ptr [rax], xmm1
+  .text:0000000001E78BBC                 mov     qword ptr [rax+28h], 0
+  .text:0000000001E78BC4                 call    sub_1E5CDA0
+  .text:0000000001E78BC9                 mov     r8, [r13+0]
+  .text:0000000001E78BCD                 movsxd  rbx, dword ptr [r8+188h]  ; 188h = 392 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+  .text:0000000001E78BD4                 mov     edi, [r8+198h]
+  .text:0000000001E78BDB                 cmp     ebx, edi
+  .text:0000000001E78BDD                 jz      loc_1E791C8
+  .text:0000000001E78BE3                 mov     eax, ebx
+  .text:0000000001E78BE5                 add     eax, 1
+  .text:0000000001E78BE8                 shl     rbx, 4
+  .text:0000000001E78BEC                 mov     [r8+188h], eax  ; 188h = 392 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+  .text:0000000001E78BF3                 mov     rax, [r13+0]
+  .text:0000000001E78BF7                 add     rbx, [rax+190h]
+  .text:0000000001E78BFE                 mov     [rbx], r14d
+  .text:0000000001E78C01                 mov     [rbx+8], r15
+  .text:0000000001E78C05                 cmp     dword ptr [rbp+var_40+4], 3FFFFFFFh
+  .text:0000000001E78C0C                 mov     dword ptr [rbp+var_50], 0
+  .text:0000000001E78C13                 jbe     loc_1E78A60
+  .text:0000000001E78C19                 jmp     loc_1E78A79
+  .text:0000000001E78C20                 movzx   eax, byte ptr [rax]
+  .text:0000000001E78C23                 cmp     al, 3Ch ; '<'
+  .text:0000000001E78C25                 jz      loc_1E792E0
+  .text:0000000001E78C2B                 ja      loc_1E78E40
+  .text:0000000001E78C31                 cmp     al, 16h
+  .text:0000000001E78C33                 jz      loc_1E794C0
+  .text:0000000001E78C39                 cmp     al, 3Bh ; ';'
+  .text:0000000001E78C3B                 jnz     loc_1E79610
+  .text:0000000001E78C41                 mov     rax, 0C00000C800000000h
+  .text:0000000001E78C4B                 mov     qword ptr [rbp-1E8h], 0
+  .text:0000000001E78C56                 mov     [rbp+var_1F0], rax
+  .text:0000000001E78C5D                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E78C64                 test    rax, rax
+  .text:0000000001E78C67                 jz      loc_1E79E36
+  .text:0000000001E78C6D                 cmp     byte ptr [rax], 0
+  .text:0000000001E78C70                 jnz     loc_1E79AE0
+  .text:0000000001E78C76                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E78C7D                 xor     r8d, r8d
+  .text:0000000001E78C80                 xor     esi, esi
+  .text:0000000001E78C82                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E78C89                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E78C8E                 mov     rdi, rbx
+  .text:0000000001E78C91                 mov     rdx, r15
+  .text:0000000001E78C94                 call    sub_984B30
+  .text:0000000001E78C99                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78CA0                 jnz     loc_1E79A22
+  .text:0000000001E78CA6                 lea     r9, aOrigin_0; "origin"
+  .text:0000000001E78CAD                 lea     r8, byte_8D7E1C
+  .text:0000000001E78CB4                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78CBE                 jnz     loc_1E79820
+  .text:0000000001E78CC4                 push    0
+  .text:0000000001E78CC6                 mov     rdx, r13
+  .text:0000000001E78CC9                 mov     esi, 1
+  .text:0000000001E78CCE                 push    r14
+  .text:0000000001E78CD0                 push    3
+  .text:0000000001E78CD2                 push    0
+  .text:0000000001E78CD4                 mov     rcx, [rbp+var_400]
+  .text:0000000001E78CDB                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E78CE2                 call    sub_1E75140
+  .text:0000000001E78CE7                 add     rsp, 20h
+  .text:0000000001E78CEB                 cmp     [rbp+var_3B8], 0
+  .text:0000000001E78CF3                 jz      short loc_1E78D05
+  .text:0000000001E78CF5                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E78CFC                 cmp     byte ptr [rax], 0
+  .text:0000000001E78CFF                 jnz     loc_1E79A63
+  .text:0000000001E78D05                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78D0F                 jz      short loc_1E78D2B
+  .text:0000000001E78D11                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E78D18                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78D1F                 jnz     short loc_1E78D28
+  .text:0000000001E78D21                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E78D28                 mov     byte ptr [rax], 0
+  .text:0000000001E78D2B                 lea     r15, aAngles; "angles"
+  .text:0000000001E78D32                 xor     r8d, r8d
+  .text:0000000001E78D35                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E78D3A                 mov     rdx, r15
+  .text:0000000001E78D3D                 xor     esi, esi
+  .text:0000000001E78D3F                 mov     rdi, rbx
+  .text:0000000001E78D42                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E78D4C                 call    sub_984B30
+  .text:0000000001E78D51                 mov     r9, r15
+  .text:0000000001E78D54                 lea     eax, [r14+10h]
+  .text:0000000001E78D58                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E78D5F                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78D66                 jnz     short loc_1E78D7F
+  .text:0000000001E78D68                 lea     r8, byte_8D7E1C
+  .text:0000000001E78D6F                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78D79                 jnz     loc_1E797A0
+  .text:0000000001E78D7F                 push    0
+  .text:0000000001E78D81                 push    rax
+  .text:0000000001E78D82                 push    4
+  .text:0000000001E78D84                 push    0
+  .text:0000000001E78D86                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E78D8D                 mov     rdx, r13
+  .text:0000000001E78D90                 mov     esi, 1
+  .text:0000000001E78D95                 mov     rcx, [rbp+var_400]
+  .text:0000000001E78D9C                 call    sub_1E75140
+  .text:0000000001E78DA1                 add     rsp, 20h
+  .text:0000000001E78DA5                 xor     esi, esi
+  .text:0000000001E78DA7                 mov     rdi, rbx
+  .text:0000000001E78DAA                 call    sub_984310
+  .text:0000000001E78DAF                 jmp     loc_1E787B5
+  .text:0000000001E78DB8                 cmp     [rbp+var_3DD], 0
+  .text:0000000001E78DBF                 lea     rax, [rbp+var_2B8]
+  .text:0000000001E78DC6                 mov     [rbp+var_3F8], 0
+  .text:0000000001E78DD1                 mov     [rbp+var_3B8], rax
+  .text:0000000001E78DD8                 jz      loc_1E78728
+  .text:0000000001E78DDE                 mov     rdi, rax
+  .text:0000000001E78DE1                 call    sub_985BF0
+  .text:0000000001E78DE6                 lea     r15d, [rax+1]
+  .text:0000000001E78DEA                 movsxd  r15, r15d
+  .text:0000000001E78DED                 jmp     loc_1E7867E
+  .text:0000000001E78DF8                 mov     rax, [rbp+var_2B8]
+  .text:0000000001E78DFF                 mov     [rbp+var_3F8], 0
+  .text:0000000001E78E0A                 cmp     [rbp+var_3DD], 0
+  .text:0000000001E78E11                 mov     [rbp+var_3B8], rax
+  .text:0000000001E78E18                 jnz     loc_1E78660
+  .text:0000000001E78E1E                 jmp     loc_1E78728
+  .text:0000000001E78E28                 mov     r15, [rbp+var_400]
+  .text:0000000001E78E2F                 xor     ebx, ebx
+  .text:0000000001E78E31                 mov     r8, rcx
+  .text:0000000001E78E34                 jmp     loc_1E78761
+  .text:0000000001E78E40                 cmp     al, 40h ; '@'
+  .text:0000000001E78E42                 jz      loc_1E79430
+  .text:0000000001E78E48                 cmp     al, 41h ; 'A'
+  .text:0000000001E78E4A                 jnz     loc_1E79610
+  .text:0000000001E78E50                 mov     rax, 0C00000C800000000h
+  .text:0000000001E78E5A                 mov     [rbp+var_1E8], 0
+  .text:0000000001E78E65                 mov     [rbp+var_1F0], rax
+  .text:0000000001E78E6C                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E78E73                 test    rax, rax
+  .text:0000000001E78E76                 jz      loc_1E79F02
+  .text:0000000001E78E7C                 cmp     byte ptr [rax], 0
+  .text:0000000001E78E7F                 jnz     loc_1E79BE0
+  .text:0000000001E78E85                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E78E8C                 xor     r8d, r8d
+  .text:0000000001E78E8F                 xor     esi, esi
+  .text:0000000001E78E91                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E78E98                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E78E9D                 mov     rdi, rbx
+  .text:0000000001E78EA0                 mov     rdx, r15
+  .text:0000000001E78EA3                 call    sub_984B30
+  .text:0000000001E78EA8                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78EAF                 jnz     loc_1E79A12
+  .text:0000000001E78EB5                 lea     r9, aOrigin_0; "origin"
+  .text:0000000001E78EBC                 lea     r8, byte_8D7E1C
+  .text:0000000001E78EC3                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78ECD                 jnz     loc_1E79810
+  .text:0000000001E78ED3                 push    0
+  .text:0000000001E78ED5                 push    r14
+  .text:0000000001E78ED7                 push    0Eh
+  .text:0000000001E78ED9                 push    0
+  .text:0000000001E78EDB                 mov     rcx, [rbp+var_400]
+  .text:0000000001E78EE2                 mov     rdx, r13
+  .text:0000000001E78EE5                 mov     esi, 1
+  .text:0000000001E78EEA                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E78EF1                 call    sub_1E75140
+  .text:0000000001E78EF6                 add     rsp, 20h
+  .text:0000000001E78EFA                 cmp     [rbp+var_3B8], 0
+  .text:0000000001E78F02                 jz      short loc_1E78F14
+  .text:0000000001E78F04                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E78F0B                 cmp     byte ptr [rax], 0
+  .text:0000000001E78F0E                 jnz     loc_1E79698
+  .text:0000000001E78F14                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78F1E                 jz      short loc_1E78F3A
+  .text:0000000001E78F20                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E78F27                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78F2E                 jnz     short loc_1E78F37
+  .text:0000000001E78F30                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E78F37                 mov     byte ptr [rax], 0
+  .text:0000000001E78F3A                 lea     r15, aAngles; "angles"
+  .text:0000000001E78F41                 xor     r8d, r8d
+  .text:0000000001E78F44                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E78F49                 mov     rdx, r15
+  .text:0000000001E78F4C                 xor     esi, esi
+  .text:0000000001E78F4E                 mov     rdi, rbx
+  .text:0000000001E78F51                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E78F5B                 call    sub_984B30
+  .text:0000000001E78F60                 mov     r9, r15
+  .text:0000000001E78F63                 lea     eax, [r14+0Ch]
+  .text:0000000001E78F67                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E78F6E                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E78F75                 jnz     short loc_1E78F91
+  .text:0000000001E78F77                 lea     r8, byte_8D7E1C
+  .text:0000000001E78F7E                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E78F88                 jz      short loc_1E78F91
+  .text:0000000001E78F8A                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E78F91                 push    0
+  .text:0000000001E78F93                 push    rax
+  .text:0000000001E78F94                 push    1
+  .text:0000000001E78F96                 jmp     loc_1E78D84
+  .text:0000000001E78FA0                 mov     esi, [r8+1B4h]
+  .text:0000000001E78FA7                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E78FAD                 jbe     short loc_1E78FC1
+  .text:0000000001E78FAF                 mov     eax, esi
+  .text:0000000001E78FB1                 and     eax, 0C0000000h
+  .text:0000000001E78FB6                 cmp     eax, 80000000h
+  .text:0000000001E78FBB                 jnz     loc_1E78698
+  .text:0000000001E78FC1                 cmp     edi, 7FFFFFFFh
+  .text:0000000001E78FC7                 jz      loc_1E79770
+  .text:0000000001E78FCD                 lea     edx, [rdi+1]
+  .text:0000000001E78FD0                 and     esi, 3FFFFFFFh
+  .text:0000000001E78FD6                 mov     ecx, 20h ; ' '
+  .text:0000000001E78FDB                 mov     [rbp+var_428], r8
+  .text:0000000001E78FE2                 mov     dword ptr [rbp+var_420], edx
+  .text:0000000001E78FE8                 call    sub_984790
+  .text:0000000001E78FED                 mov     edx, dword ptr [rbp+var_420]
+  .text:0000000001E78FF3                 mov     r8, [rbp+var_428]
+  .text:0000000001E78FFA                 mov     r9d, eax
+  .text:0000000001E78FFD                 cmp     edx, eax
+  .text:0000000001E78FFF                 jg      loc_1E790A0
+  .text:0000000001E79005                 movsxd  rcx, dword ptr [r8+1B0h]
+  .text:0000000001E7900C                 movsxd  rdx, r9d
+  .text:0000000001E7900F                 xor     esi, esi
+  .text:0000000001E79011                 mov     dword ptr [rbp+var_428], r9d
+  .text:0000000001E79018                 shl     rdx, 5
+  .text:0000000001E7901C                 mov     rdi, [r8+1A8h]
+  .text:0000000001E79023                 mov     [rbp+var_420], r8
+  .text:0000000001E7902A                 shl     rcx, 5
+  .text:0000000001E7902E                 cmp     dword ptr [r8+1B4h], 3FFFFFFFh
+  .text:0000000001E79039                 setbe   sil
+  .text:0000000001E7903D                 call    sub_9843C0
+  .text:0000000001E79042                 mov     r8, [rbp+var_420]
+  .text:0000000001E79049                 mov     rdx, rax
+  .text:0000000001E7904C                 mov     r9d, dword ptr [rbp+var_428]
+  .text:0000000001E79053                 mov     [r8+1A8h], rax
+  .text:0000000001E7905A                 mov     eax, [r8+1B4h]
+  .text:0000000001E79061                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E79066                 jbe     short loc_1E79074
+  .text:0000000001E79068                 and     eax, 3FFFFFFFh
+  .text:0000000001E7906D                 mov     [r8+1B4h], eax
+  .text:0000000001E79074                 mov     eax, [r8+1A0h]
+  .text:0000000001E7907B                 mov     [r8+1B0h], r9d
+  .text:0000000001E79082                 jmp     loc_1E786A1
+  .text:0000000001E790A0                 add     r9d, edx
+  .text:0000000001E790A3                 mov     eax, r9d
+  .text:0000000001E790A6                 shr     eax, 1Fh
+  .text:0000000001E790A9                 add     r9d, eax
+  .text:0000000001E790AC                 sar     r9d, 1
+  .text:0000000001E790AF                 cmp     edx, r9d
+  .text:0000000001E790B2                 jg      short loc_1E790A0
+  .text:0000000001E790B4                 jmp     loc_1E79005
+  .text:0000000001E790B9                 lea     rbx, dword_27C47DC
+  .text:0000000001E790C0                 mov     esi, 5
+  .text:0000000001E790C5                 mov     r10, [rbp+var_3E8]
+  .text:0000000001E790CC                 mov     edi, [rbx]
+  .text:0000000001E790CE                 mov     [rbp+var_3B8], r10
+  .text:0000000001E790D5                 call    sub_983F70
+  .text:0000000001E790DA                 mov     r10, [rbp+var_3B8]
+  .text:0000000001E790E1                 test    al, al
+  .text:0000000001E790E3                 jz      loc_1E79170
+  .text:0000000001E790E9                 mov     edi, [rbx]
+  .text:0000000001E790EB                 lea     rax, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E790F2                 mov     esi, 5
+  .text:0000000001E790F7                 mov     dword ptr [rbp+var_1E8], 565h
+  .text:0000000001E79101                 mov     r9, [r10+8]
+  .text:0000000001E79105                 mov     [rbp+var_1F0], rax
+  .text:0000000001E7910C                 lea     rax, aDatadescAddcom_0; "DataDesc_AddComponentFieldUnserializer"
+  .text:0000000001E79113                 mov     r8, [rbp+var_400]
+  .text:0000000001E7911A                 mov     [rbp+var_1E0], rax
+  .text:0000000001E79121                 xor     eax, eax
+  .text:0000000001E79123                 lea     rdx, [rbp+var_1F0]
+  .text:0000000001E7912A                 mov     [rbp+var_1D8], 0
+  .text:0000000001E79135                 lea     rcx, aFieldSSCannotH; "Field %s::%s cannot have sub-keyfields "...
+  .text:0000000001E7913C                 mov     [rbp+var_1D0], 0
+  .text:0000000001E79147                 mov     [rbp+var_1C8], 0
+  .text:0000000001E79152                 mov     [rbp+var_1C0], 0
+  .text:0000000001E7915D                 mov     [rbp+var_1B8], 0
+  .text:0000000001E79167                 call    sub_983DB0
+  .text:0000000001E7916C                 nop     dword ptr [rax+00h]
+  .text:0000000001E79170                 mov     rdi, [rbp+var_3F0]
+  .text:0000000001E79177                 xor     esi, esi
+  .text:0000000001E79179                 call    sub_984310
+  .text:0000000001E7917E                 mov     rdi, [rbp+var_418]
+  .text:0000000001E79185                 xor     esi, esi
+  .text:0000000001E79187                 call    sub_984310
+  .text:0000000001E7918C                 lea     rsp, [rbp-28h]
+  .text:0000000001E79190                 pop     rbx
+  .text:0000000001E79191                 pop     r12
+  .text:0000000001E79193                 pop     r13
+  .text:0000000001E79195                 pop     r14
+  .text:0000000001E79197                 pop     r15
+  .text:0000000001E79199                 pop     rbp
+  .text:0000000001E7919A                 retn
+  .text:0000000001E791A0                 lea     rax, byte_8D7E1C
+  .text:0000000001E791A7                 mov     r15d, 1
+  .text:0000000001E791AD                 mov     [rbp+var_3F8], 0
+  .text:0000000001E791B8                 mov     [rbp+var_3B8], rax
+  .text:0000000001E791BF                 jmp     loc_1E7867E
+  .text:0000000001E791C8                 mov     esi, [r8+19Ch]
+  .text:0000000001E791CF                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E791D5                 jbe     short loc_1E791ED
+  .text:0000000001E791D7                 mov     edx, esi
+  .text:0000000001E791D9                 mov     eax, ebx
+  .text:0000000001E791DB                 and     edx, 0C0000000h
+  .text:0000000001E791E1                 cmp     edx, 80000000h
+  .text:0000000001E791E7                 jnz     loc_1E78BE5
+  .text:0000000001E791ED                 cmp     edi, 7FFFFFFFh
+  .text:0000000001E791F3                 jz      loc_1E79D60
+  .text:0000000001E791F9                 lea     edx, [rdi+1]
+  .text:0000000001E791FC                 and     esi, 3FFFFFFFh
+  .text:0000000001E79202                 mov     ecx, 10h
+  .text:0000000001E79207                 mov     [rbp+var_428], r8
+  .text:0000000001E7920E                 mov     dword ptr [rbp+var_420], edx
+  .text:0000000001E79214                 call    sub_984790
+  .text:0000000001E79219                 mov     edx, dword ptr [rbp+var_420]
+  .text:0000000001E7921F                 mov     r8, [rbp+var_428]
+  .text:0000000001E79226                 mov     r9d, eax
+  .text:0000000001E79229                 cmp     edx, eax
+  .text:0000000001E7922B                 jg      loc_1E792C0
+  .text:0000000001E79231                 movsxd  rcx, dword ptr [r8+198h]
+  .text:0000000001E79238                 movsxd  rdx, r9d
+  .text:0000000001E7923B                 xor     esi, esi
+  .text:0000000001E7923D                 mov     dword ptr [rbp+var_428], r9d
+  .text:0000000001E79244                 shl     rdx, 4
+  .text:0000000001E79248                 mov     rdi, [r8+190h]
+  .text:0000000001E7924F                 mov     [rbp+var_420], r8
+  .text:0000000001E79256                 shl     rcx, 4
+  .text:0000000001E7925A                 cmp     dword ptr [r8+19Ch], 3FFFFFFFh
+  .text:0000000001E79265                 setbe   sil
+  .text:0000000001E79269                 call    sub_9843C0
+  .text:0000000001E7926E                 mov     r8, [rbp+var_420]
+  .text:0000000001E79275                 mov     r9d, dword ptr [rbp+var_428]
+  .text:0000000001E7927C                 mov     [r8+190h], rax
+  .text:0000000001E79283                 mov     eax, [r8+19Ch]
+  .text:0000000001E7928A                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E7928F                 jbe     short loc_1E7929D
+  .text:0000000001E79291                 and     eax, 3FFFFFFFh
+  .text:0000000001E79296                 mov     [r8+19Ch], eax
+  .text:0000000001E7929D                 mov     eax, [r8+188h]  ; 188h = 392 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+  .text:0000000001E792A4                 mov     [r8+198h], r9d
+  .text:0000000001E792AB                 jmp     loc_1E78BE5
+  .text:0000000001E792C0                 add     r9d, edx
+  .text:0000000001E792C3                 mov     eax, r9d
+  .text:0000000001E792C6                 shr     eax, 1Fh
+  .text:0000000001E792C9                 add     r9d, eax
+  .text:0000000001E792CC                 sar     r9d, 1
+  .text:0000000001E792CF                 cmp     edx, r9d
+  .text:0000000001E792D2                 jg      short loc_1E792C0
+  .text:0000000001E792D4                 jmp     loc_1E79231
+  .text:0000000001E792E0                 mov     rax, 0C00000C800000000h
+  .text:0000000001E792EA                 mov     [rbp+var_1E8], 0
+  .text:0000000001E792F5                 mov     [rbp+var_1F0], rax
+  .text:0000000001E792FC                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E79303                 test    rax, rax
+  .text:0000000001E79306                 jz      loc_1E79E9C
+  .text:0000000001E7930C                 cmp     byte ptr [rax], 0
+  .text:0000000001E7930F                 jnz     loc_1E79CE0
+  .text:0000000001E79315                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E7931C                 xor     r8d, r8d
+  .text:0000000001E7931F                 xor     esi, esi
+  .text:0000000001E79321                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79328                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E7932D                 mov     rdi, rbx
+  .text:0000000001E79330                 mov     rdx, r15
+  .text:0000000001E79333                 call    sub_984B30
+  .text:0000000001E79338                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E7933F                 jnz     loc_1E79956
+  .text:0000000001E79345                 lea     r9, aOrigin_0; "origin"
+  .text:0000000001E7934C                 lea     r8, byte_8D7E1C
+  .text:0000000001E79353                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E7935D                 jnz     loc_1E79858
+  .text:0000000001E79363                 push    0
+  .text:0000000001E79365                 mov     rdx, r13
+  .text:0000000001E79368                 mov     esi, 1
+  .text:0000000001E7936D                 push    r14
+  .text:0000000001E7936F                 push    0Eh
+  .text:0000000001E79371                 push    0
+  .text:0000000001E79373                 mov     rcx, [rbp+var_400]
+  .text:0000000001E7937A                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79381                 call    sub_1E75140
+  .text:0000000001E79386                 add     rsp, 20h
+  .text:0000000001E7938A                 cmp     [rbp+var_3B8], 0
+  .text:0000000001E79392                 jz      short loc_1E793A4
+  .text:0000000001E79394                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E7939B                 cmp     byte ptr [rax], 0
+  .text:0000000001E7939E                 jnz     loc_1E79997
+  .text:0000000001E793A4                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E793AE                 jz      short loc_1E793CA
+  .text:0000000001E793B0                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E793B7                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E793BE                 jnz     short loc_1E793C7
+  .text:0000000001E793C0                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E793C7                 mov     byte ptr [rax], 0
+  .text:0000000001E793CA                 lea     r15, aAngles; "angles"
+  .text:0000000001E793D1                 xor     r8d, r8d
+  .text:0000000001E793D4                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E793D9                 mov     rdx, r15
+  .text:0000000001E793DC                 xor     esi, esi
+  .text:0000000001E793DE                 mov     rdi, rbx
+  .text:0000000001E793E1                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E793EB                 call    sub_984B30
+  .text:0000000001E793F0                 mov     r9, r15
+  .text:0000000001E793F3                 lea     eax, [r14+10h]
+  .text:0000000001E793F7                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E793FE                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79405                 jnz     short loc_1E79421
+  .text:0000000001E79407                 lea     r8, byte_8D7E1C
+  .text:0000000001E7940E                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79418                 jz      short loc_1E79421
+  .text:0000000001E7941A                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E79421                 push    0
+  .text:0000000001E79423                 push    rax
+  .text:0000000001E79424                 push    2Fh ; '/'
+  .text:0000000001E79426                 jmp     loc_1E78D84
+  .text:0000000001E79430                 mov     rax, 0C00000C800000000h
+  .text:0000000001E7943A                 mov     [rbp+var_1E8], 0
+  .text:0000000001E79445                 mov     [rbp+var_1F0], rax
+  .text:0000000001E7944C                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E79453                 test    rax, rax
+  .text:0000000001E79456                 jz      loc_1E79FA3
+  .text:0000000001E7945C                 cmp     byte ptr [rax], 0
+  .text:0000000001E7945F                 jnz     loc_1E79C60
+  .text:0000000001E79465                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E7946C                 xor     r8d, r8d
+  .text:0000000001E7946F                 xor     esi, esi
+  .text:0000000001E79471                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79478                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E7947D                 mov     rdi, rbx
+  .text:0000000001E79480                 mov     rdx, r15
+  .text:0000000001E79483                 call    sub_984B30
+  .text:0000000001E79488                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E7948F                 jnz     loc_1E79920
+  .text:0000000001E79495                 lea     r9, aOrigin_0; "origin"
+  .text:0000000001E7949C                 lea     r8, byte_8D7E1C
+  .text:0000000001E794A3                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E794AD                 jnz     loc_1E79840
+  .text:0000000001E794B3                 push    0
+  .text:0000000001E794B5                 push    r14
+  .text:0000000001E794B7                 push    3
+  .text:0000000001E794B9                 jmp     loc_1E78ED9
+  .text:0000000001E794C0                 mov     rax, 0C00000C800000000h
+  .text:0000000001E794CA                 mov     [rbp+var_1E8], 0
+  .text:0000000001E794D5                 mov     [rbp+var_1F0], rax
+  .text:0000000001E794DC                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E794E3                 test    rax, rax
+  .text:0000000001E794E6                 jz      loc_1E79F3D
+  .text:0000000001E794EC                 cmp     byte ptr [rax], 0
+  .text:0000000001E794EF                 jnz     loc_1E79B60
+  .text:0000000001E794F5                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E794FC                 xor     r8d, r8d
+  .text:0000000001E794FF                 xor     esi, esi
+  .text:0000000001E79501                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79508                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E7950D                 mov     rdi, rbx
+  .text:0000000001E79510                 mov     rdx, r15
+  .text:0000000001E79513                 call    sub_984B30
+  .text:0000000001E79518                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E7951F                 jnz     loc_1E79864
+  .text:0000000001E79525                 lea     r9, aOrigin_0; "origin"
+  .text:0000000001E7952C                 lea     r8, byte_8D7E1C
+  .text:0000000001E79533                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E7953D                 jnz     loc_1E79830
+  .text:0000000001E79543                 push    1
+  .text:0000000001E79545                 mov     rdx, r13
+  .text:0000000001E79548                 mov     esi, 1
+  .text:0000000001E7954D                 push    r14
+  .text:0000000001E7954F                 push    0Eh
+  .text:0000000001E79551                 push    0
+  .text:0000000001E79553                 mov     rcx, [rbp+var_400]
+  .text:0000000001E7955A                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79561                 call    sub_1E75140
+  .text:0000000001E79566                 add     rsp, 20h
+  .text:0000000001E7956A                 cmp     [rbp+var_3B8], 0
+  .text:0000000001E79572                 jz      short loc_1E79584
+  .text:0000000001E79574                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E7957B                 cmp     byte ptr [rax], 0
+  .text:0000000001E7957E                 jnz     loc_1E798A5
+  .text:0000000001E79584                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E7958E                 jz      short loc_1E795AA
+  .text:0000000001E79590                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E79597                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E7959E                 jnz     short loc_1E795A7
+  .text:0000000001E795A0                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E795A7                 mov     byte ptr [rax], 0
+  .text:0000000001E795AA                 lea     r15, aAngles; "angles"
+  .text:0000000001E795B1                 xor     r8d, r8d
+  .text:0000000001E795B4                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E795B9                 mov     rdx, r15
+  .text:0000000001E795BC                 xor     esi, esi
+  .text:0000000001E795BE                 mov     rdi, rbx
+  .text:0000000001E795C1                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E795CB                 call    sub_984B30
+  .text:0000000001E795D0                 mov     r9, r15
+  .text:0000000001E795D3                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E795DA                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E795E1                 jnz     short loc_1E795FD
+  .text:0000000001E795E3                 lea     r8, byte_8D7E1C
+  .text:0000000001E795EA                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E795F4                 jz      short loc_1E795FD
+  .text:0000000001E795F6                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E795FD                 push    1
+  .text:0000000001E795FF                 push    r14
+  .text:0000000001E79601                 push    2Fh ; '/'
+  .text:0000000001E79603                 jmp     loc_1E78D84
+  .text:0000000001E79610                 mov     rax, [rbp+var_410]
+  .text:0000000001E79617                 cmp     byte ptr [rax], 0
+  .text:0000000001E7961A                 jz      loc_1E790B9
+  .text:0000000001E79620                 push    0
+  .text:0000000001E79622                 mov     rdx, r13
+  .text:0000000001E79625                 xor     esi, esi
+  .text:0000000001E79627                 push    r14
+  .text:0000000001E79629                 push    0
+  .text:0000000001E7962B                 push    [rbp+var_3E8]
+  .text:0000000001E79631                 mov     r9, [rbp+var_3F8]
+  .text:0000000001E79638                 mov     r8, [rbp+var_3B8]
+  .text:0000000001E7963F                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79646                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E7964D                 call    sub_1E75140
+  .text:0000000001E79652                 add     rsp, 20h
+  .text:0000000001E79656                 jmp     loc_1E787B5
+  .text:0000000001E79660                 mov     rdi, rcx
+  .text:0000000001E79663                 mov     [rbp+var_3B8], rcx
+  .text:0000000001E7966A                 call    sub_2033F00
+  .text:0000000001E7966F                 mov     r10, [rbp+var_3B8]
+  .text:0000000001E79676                 mov     [rbp+var_3D1], 1
+  .text:0000000001E7967D                 mov     [rbp+var_3D8], eax
+  .text:0000000001E79683                 mov     rax, [r13+10h]
+  .text:0000000001E79687                 mov     [rbp+var_410], rax
+  .text:0000000001E7968E                 jmp     loc_1E78881
+  .text:0000000001E79698                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E796A2                 jz      short loc_1E796BE
+  .text:0000000001E796A4                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E796AB                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E796B2                 jnz     short loc_1E796BB
+  .text:0000000001E796B4                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E796BB                 mov     byte ptr [rax], 0
+  .text:0000000001E796BE                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E796C5                 xor     r8d, r8d
+  .text:0000000001E796C8                 xor     ecx, ecx
+  .text:0000000001E796CA                 mov     rdi, rbx
+  .text:0000000001E796CD                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E796D4                 mov     esi, 3
+  .text:0000000001E796D9                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E796E3                 mov     [rbp+var_3B0], rax
+  .text:0000000001E796EA                 lea     rax, asc_89AA52; "."
+  .text:0000000001E796F1                 mov     [rbp+var_3A8], rax
+  .text:0000000001E796F8                 lea     rax, aAngles; "angles"
+  .text:0000000001E796FF                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79706                 call    sub_984A00
+  .text:0000000001E7970B                 xor     r9d, r9d
+  .text:0000000001E7970E                 jmp     loc_1E78F63
+  .text:0000000001E79718                 mov     rax, [rbp+var_410]
+  .text:0000000001E7971F                 test    rax, rax
+  .text:0000000001E79722                 jz      short loc_1E7972D
+  .text:0000000001E79724                 cmp     byte ptr [rax], 0
+  .text:0000000001E79727                 jnz     loc_1E797B0
+  .text:0000000001E7972D                 lea     rax, [rbp+var_390]
+  .text:0000000001E79734                 xor     r8d, r8d
+  .text:0000000001E79737                 xor     esi, esi
+  .text:0000000001E79739                 mov     [rbp+var_3B8], r10
+  .text:0000000001E79740                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79745                 mov     rdi, rax
+  .text:0000000001E79748                 mov     [rbp+var_418], rax
+  .text:0000000001E7974F                 call    sub_984B30
+  .text:0000000001E79754                 mov     r10, [rbp+var_3B8]
+  .text:0000000001E7975B                 mov     [rbp+var_3F8], 0
+  .text:0000000001E79766                 jmp     loc_1E785BC
+  .text:0000000001E79770                 mov     esi, 1
+  .text:0000000001E79775                 mov     [rbp+var_420], r8
+  .text:0000000001E7977C                 call    sub_984EE0
+  .text:0000000001E79781                 mov     r8, [rbp+var_420]
+  .text:0000000001E79788                 mov     edi, [r8+1B0h]
+  .text:0000000001E7978F                 mov     esi, [r8+1B4h]
+  .text:0000000001E79796                 jmp     loc_1E78FCD
+  .text:0000000001E797A0                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E797A7                 jmp     loc_1E78D7F
+  .text:0000000001E797B0                 lea     rcx, asc_89AA52; "."
+  .text:0000000001E797B7                 mov     [rbp+var_1E0], rax
+  .text:0000000001E797BE                 xor     r8d, r8d
+  .text:0000000001E797C1                 mov     esi, 3
+  .text:0000000001E797C6                 lea     rax, [rbp+var_390]
+  .text:0000000001E797CD                 mov     [rbp+var_1F0], rdx
+  .text:0000000001E797D4                 mov     [rbp+var_1E8], rcx
+  .text:0000000001E797DB                 lea     rdx, [rbp+var_1F0]
+  .text:0000000001E797E2                 xor     ecx, ecx
+  .text:0000000001E797E4                 mov     rdi, rax
+  .text:0000000001E797E7                 mov     [rbp+var_3B8], r10
+  .text:0000000001E797EE                 mov     [rbp+var_418], rax
+  .text:0000000001E797F5                 call    sub_984A00
+  .text:0000000001E797FA                 mov     r10, [rbp+var_3B8]
+  .text:0000000001E79801                 jmp     loc_1E7975B
+  .text:0000000001E79810                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E79817                 jmp     loc_1E78ED3
+  .text:0000000001E79820                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E79827                 jmp     loc_1E78CC4
+  .text:0000000001E79830                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E79837                 jmp     loc_1E79543
+  .text:0000000001E79840                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E79847                 push    0
+  .text:0000000001E79849                 push    r14
+  .text:0000000001E7984B                 push    3
+  .text:0000000001E7984D                 jmp     loc_1E78ED9
+  .text:0000000001E79858                 mov     r8, [rbp+var_1E8]
+  .text:0000000001E7985F                 jmp     loc_1E79363
+  .text:0000000001E79864                 push    1
+  .text:0000000001E79866                 mov     r9, r15
+  .text:0000000001E79869                 push    r14
+  .text:0000000001E7986B                 push    0Eh
+  .text:0000000001E7986D                 push    0
+  .text:0000000001E7986F                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79876                 mov     rcx, [rbp+var_400]
+  .text:0000000001E7987D                 mov     rdx, r13
+  .text:0000000001E79880                 mov     esi, 1
+  .text:0000000001E79885                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E7988C                 call    sub_1E75140
+  .text:0000000001E79891                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E79898                 add     rsp, 20h
+  .text:0000000001E7989C                 cmp     byte ptr [rax], 0
+  .text:0000000001E7989F                 jz      loc_1E79584
+  .text:0000000001E798A5                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E798AF                 jz      short loc_1E798CB
+  .text:0000000001E798B1                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E798B8                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E798BF                 jnz     short loc_1E798C8
+  .text:0000000001E798C1                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E798C8                 mov     byte ptr [rax], 0
+  .text:0000000001E798CB                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E798D2                 xor     r8d, r8d
+  .text:0000000001E798D5                 xor     ecx, ecx
+  .text:0000000001E798D7                 mov     rdi, rbx
+  .text:0000000001E798DA                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E798E1                 mov     esi, 3
+  .text:0000000001E798E6                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E798F0                 mov     [rbp+var_3B0], rax
+  .text:0000000001E798F7                 lea     rax, asc_89AA52; "."
+  .text:0000000001E798FE                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79905                 lea     rax, aAngles; "angles"
+  .text:0000000001E7990C                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79913                 call    sub_984A00
+  .text:0000000001E79918                 xor     r9d, r9d
+  .text:0000000001E7991B                 jmp     loc_1E795D3
+  .text:0000000001E79920                 push    0
+  .text:0000000001E79922                 mov     r9, r15
+  .text:0000000001E79925                 push    r14
+  .text:0000000001E79927                 push    3
+  .text:0000000001E79929                 push    0
+  .text:0000000001E7992B                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79932                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79939                 mov     rdx, r13
+  .text:0000000001E7993C                 mov     esi, 1
+  .text:0000000001E79941                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79948                 call    sub_1E75140
+  .text:0000000001E7994D                 add     rsp, 20h
+  .text:0000000001E79951                 jmp     loc_1E78F04
+  .text:0000000001E79956                 push    0
+  .text:0000000001E79958                 mov     r9, r15
+  .text:0000000001E7995B                 push    r14
+  .text:0000000001E7995D                 push    0Eh
+  .text:0000000001E7995F                 push    0
+  .text:0000000001E79961                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79968                 mov     rcx, [rbp+var_400]
+  .text:0000000001E7996F                 mov     rdx, r13
+  .text:0000000001E79972                 mov     esi, 1
+  .text:0000000001E79977                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E7997E                 call    sub_1E75140
+  .text:0000000001E79983                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E7998A                 add     rsp, 20h
+  .text:0000000001E7998E                 cmp     byte ptr [rax], 0
+  .text:0000000001E79991                 jz      loc_1E793A4
+  .text:0000000001E79997                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E799A1                 jz      short loc_1E799BD
+  .text:0000000001E799A3                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E799AA                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E799B1                 jnz     short loc_1E799BA
+  .text:0000000001E799B3                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E799BA                 mov     byte ptr [rax], 0
+  .text:0000000001E799BD                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E799C4                 xor     r8d, r8d
+  .text:0000000001E799C7                 xor     ecx, ecx
+  .text:0000000001E799C9                 mov     rdi, rbx
+  .text:0000000001E799CC                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E799D3                 mov     esi, 3
+  .text:0000000001E799D8                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E799E2                 mov     [rbp+var_3B0], rax
+  .text:0000000001E799E9                 lea     rax, asc_89AA52; "."
+  .text:0000000001E799F0                 mov     [rbp+var_3A8], rax
+  .text:0000000001E799F7                 lea     rax, aAngles; "angles"
+  .text:0000000001E799FE                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79A05                 call    sub_984A00
+  .text:0000000001E79A0A                 xor     r9d, r9d
+  .text:0000000001E79A0D                 jmp     loc_1E793F3
+  .text:0000000001E79A12                 push    0
+  .text:0000000001E79A14                 mov     r9, r15
+  .text:0000000001E79A17                 push    r14
+  .text:0000000001E79A19                 push    0Eh
+  .text:0000000001E79A1B                 push    0
+  .text:0000000001E79A1D                 jmp     loc_1E7992B
+  .text:0000000001E79A22                 push    0
+  .text:0000000001E79A24                 mov     r9, r15
+  .text:0000000001E79A27                 push    r14
+  .text:0000000001E79A29                 push    3
+  .text:0000000001E79A2B                 push    0
+  .text:0000000001E79A2D                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79A34                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79A3B                 mov     rdx, r13
+  .text:0000000001E79A3E                 mov     esi, 1
+  .text:0000000001E79A43                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79A4A                 call    sub_1E75140
+  .text:0000000001E79A4F                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E79A56                 add     rsp, 20h
+  .text:0000000001E79A5A                 cmp     byte ptr [rax], 0
+  .text:0000000001E79A5D                 jz      loc_1E78D05
+  .text:0000000001E79A63                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79A6D                 jz      short loc_1E79A89
+  .text:0000000001E79A6F                 lea     rax, [rbp+var_1E8]
+  .text:0000000001E79A76                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79A7D                 jnz     short loc_1E79A86
+  .text:0000000001E79A7F                 mov     rax, [rbp+var_1E8]
+  .text:0000000001E79A86                 mov     byte ptr [rax], 0
+  .text:0000000001E79A89                 mov     rax, [rbp+var_3B8]
+  .text:0000000001E79A90                 xor     r8d, r8d
+  .text:0000000001E79A93                 xor     ecx, ecx
+  .text:0000000001E79A95                 mov     rdi, rbx
+  .text:0000000001E79A98                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79A9F                 mov     esi, 3
+  .text:0000000001E79AA4                 and     dword ptr [rbp+var_1F0], 0C0000000h
+  .text:0000000001E79AAE                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79AB5                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79ABC                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79AC3                 lea     rax, aAngles; "angles"
+  .text:0000000001E79ACA                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79AD1                 call    sub_984A00
+  .text:0000000001E79AD6                 xor     r9d, r9d
+  .text:0000000001E79AD9                 jmp     loc_1E78D54
+  .text:0000000001E79AE0                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79AE7                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79AEE                 xor     r8d, r8d
+  .text:0000000001E79AF1                 xor     ecx, ecx
+  .text:0000000001E79AF3                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79AFA                 mov     esi, 3
+  .text:0000000001E79AFF                 mov     rdi, rbx
+  .text:0000000001E79B02                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79B09                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79B10                 lea     rax, aOrigin_0; "origin"
+  .text:0000000001E79B17                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79B1E                 call    sub_984A00
+  .text:0000000001E79B23                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79B2A                 jnz     loc_1E7A009
+  .text:0000000001E79B30                 xor     r9d, r9d
+  .text:0000000001E79B33                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79B3D                 jnz     loc_1E79820
+  .text:0000000001E79B43                 push    0
+  .text:0000000001E79B45                 xor     r9d, r9d
+  .text:0000000001E79B48                 push    r14
+  .text:0000000001E79B4A                 lea     r8, byte_8D7E1C
+  .text:0000000001E79B51                 push    3
+  .text:0000000001E79B53                 push    0
+  .text:0000000001E79B55                 jmp     loc_1E79A34
+  .text:0000000001E79B60                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79B67                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79B6E                 xor     r8d, r8d
+  .text:0000000001E79B71                 xor     ecx, ecx
+  .text:0000000001E79B73                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79B7A                 mov     esi, 3
+  .text:0000000001E79B7F                 mov     rdi, rbx
+  .text:0000000001E79B82                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79B89                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79B90                 lea     rax, aOrigin_0; "origin"
+  .text:0000000001E79B97                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79B9E                 call    sub_984A00
+  .text:0000000001E79BA3                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79BAA                 jnz     loc_1E7A039
+  .text:0000000001E79BB0                 xor     r9d, r9d
+  .text:0000000001E79BB3                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79BBD                 jnz     loc_1E79830
+  .text:0000000001E79BC3                 push    1
+  .text:0000000001E79BC5                 xor     r9d, r9d
+  .text:0000000001E79BC8                 push    r14
+  .text:0000000001E79BCA                 lea     r8, byte_8D7E1C
+  .text:0000000001E79BD1                 push    0Eh
+  .text:0000000001E79BD3                 push    0
+  .text:0000000001E79BD5                 jmp     loc_1E79876
+  .text:0000000001E79BE0                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79BE7                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79BEE                 xor     r8d, r8d
+  .text:0000000001E79BF1                 xor     ecx, ecx
+  .text:0000000001E79BF3                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79BFA                 mov     esi, 3
+  .text:0000000001E79BFF                 mov     rdi, rbx
+  .text:0000000001E79C02                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79C09                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79C10                 lea     rax, aOrigin_0; "origin"
+  .text:0000000001E79C17                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79C1E                 call    sub_984A00
+  .text:0000000001E79C23                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79C2A                 jnz     loc_1E7A019
+  .text:0000000001E79C30                 xor     r9d, r9d
+  .text:0000000001E79C33                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79C3D                 jnz     loc_1E79810
+  .text:0000000001E79C43                 push    0
+  .text:0000000001E79C45                 xor     r9d, r9d
+  .text:0000000001E79C48                 push    r14
+  .text:0000000001E79C4A                 lea     r8, byte_8D7E1C
+  .text:0000000001E79C51                 push    0Eh
+  .text:0000000001E79C53                 push    0
+  .text:0000000001E79C55                 jmp     loc_1E79932
+  .text:0000000001E79C60                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79C67                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79C6E                 xor     r8d, r8d
+  .text:0000000001E79C71                 xor     ecx, ecx
+  .text:0000000001E79C73                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79C7A                 mov     esi, 3
+  .text:0000000001E79C7F                 mov     rdi, rbx
+  .text:0000000001E79C82                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79C89                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79C90                 lea     rax, aOrigin_0; "origin"
+  .text:0000000001E79C97                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79C9E                 call    sub_984A00
+  .text:0000000001E79CA3                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79CAA                 jnz     loc_1E7A049
+  .text:0000000001E79CB0                 xor     r9d, r9d
+  .text:0000000001E79CB3                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79CBD                 jnz     loc_1E79840
+  .text:0000000001E79CC3                 push    0
+  .text:0000000001E79CC5                 xor     r9d, r9d
+  .text:0000000001E79CC8                 push    r14
+  .text:0000000001E79CCA                 lea     r8, byte_8D7E1C
+  .text:0000000001E79CD1                 push    3
+  .text:0000000001E79CD3                 push    0
+  .text:0000000001E79CD5                 jmp     loc_1E79932
+  .text:0000000001E79CE0                 mov     [rbp+var_3B0], rax
+  .text:0000000001E79CE7                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79CEE                 xor     r8d, r8d
+  .text:0000000001E79CF1                 xor     ecx, ecx
+  .text:0000000001E79CF3                 lea     rax, asc_89AA52; "."
+  .text:0000000001E79CFA                 mov     esi, 3
+  .text:0000000001E79CFF                 mov     rdi, rbx
+  .text:0000000001E79D02                 mov     [rbp+var_3A8], rax
+  .text:0000000001E79D09                 lea     rdx, [rbp+var_3B0]
+  .text:0000000001E79D10                 lea     rax, aOrigin_0; "origin"
+  .text:0000000001E79D17                 mov     [rbp+var_3A0], rax
+  .text:0000000001E79D1E                 call    sub_984A00
+  .text:0000000001E79D23                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79D2A                 jnz     loc_1E7A029
+  .text:0000000001E79D30                 xor     r9d, r9d
+  .text:0000000001E79D33                 test    dword ptr [rbp+var_1F0+4], 3FFFFFFFh
+  .text:0000000001E79D3D                 jnz     loc_1E79858
+  .text:0000000001E79D43                 push    0
+  .text:0000000001E79D45                 xor     r9d, r9d
+  .text:0000000001E79D48                 push    r14
+  .text:0000000001E79D4A                 lea     r8, byte_8D7E1C
+  .text:0000000001E79D51                 push    0Eh
+  .text:0000000001E79D53                 push    0
+  .text:0000000001E79D55                 jmp     loc_1E79968
+  .text:0000000001E79D60                 mov     esi, 1
+  .text:0000000001E79D65                 mov     [rbp+var_420], r8
+  .text:0000000001E79D6C                 call    sub_984EE0
+  .text:0000000001E79D71                 mov     r8, [rbp+var_420]
+  .text:0000000001E79D78                 mov     edi, [r8+198h]
+  .text:0000000001E79D7F                 mov     esi, [r8+19Ch]
+  .text:0000000001E79D86                 jmp     loc_1E791F9
+  .text:0000000001E79D90                 lea     rbx, dword_27C47DC
+  .text:0000000001E79D97                 mov     esi, 5
+  .text:0000000001E79D9C                 mov     edi, [rbx]
+  .text:0000000001E79D9E                 call    sub_983F70
+  .text:0000000001E79DA3                 test    al, al
+  .text:0000000001E79DA5                 jz      loc_1E7918C
+  .text:0000000001E79DAB                 mov     edi, [rbx]
+  .text:0000000001E79DAD                 lea     rax, aEntitysystemCp; "entitysystem.cpp"
+  .text:0000000001E79DB4                 mov     esi, 5
+  .text:0000000001E79DB9                 mov     dword ptr [rbp+var_1E8], 4B9h
+  .text:0000000001E79DC3                 mov     r9, [rbp+var_400]
+  .text:0000000001E79DCA                 mov     [rbp+var_1F0], rax
+  .text:0000000001E79DD1                 lea     rax, aDatadescAddcom_0; "DataDesc_AddComponentFieldUnserializer"
+  .text:0000000001E79DD8                 mov     r8, [rbp+var_410]
+  .text:0000000001E79DDF                 mov     [rbp+var_1E0], rax
+  .text:0000000001E79DE6                 xor     eax, eax
+  .text:0000000001E79DE8                 lea     rdx, [rbp+var_1F0]
+  .text:0000000001E79DEF                 mov     [rbp+var_1D8], 0
+  .text:0000000001E79DFA                 lea     rcx, aFieldSOfClassS; "Field \"%s\" of class \"%s\" cannot be "...
+  .text:0000000001E79E01                 mov     [rbp+var_1D0], 0
+  .text:0000000001E79E0C                 mov     [rbp+var_1C8], 0
+  .text:0000000001E79E17                 mov     [rbp+var_1C0], 0
+  .text:0000000001E79E22                 mov     [rbp+var_1B8], 0
+  .text:0000000001E79E2C                 call    sub_983DB0
+  .text:0000000001E79E31                 jmp     loc_1E7918C
+  .text:0000000001E79E36                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79E3D                 xor     r8d, r8d
+  .text:0000000001E79E40                 xor     esi, esi
+  .text:0000000001E79E42                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79E49                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79E4E                 mov     rdi, rbx
+  .text:0000000001E79E51                 mov     rdx, r15
+  .text:0000000001E79E54                 call    sub_984B30
+  .text:0000000001E79E59                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79E60                 jz      loc_1E78CA6
+  .text:0000000001E79E66                 push    0
+  .text:0000000001E79E68                 mov     r9, r15
+  .text:0000000001E79E6B                 mov     rdx, r13
+  .text:0000000001E79E6E                 push    r14
+  .text:0000000001E79E70                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79E77                 mov     esi, 1
+  .text:0000000001E79E7C                 push    3
+  .text:0000000001E79E7E                 push    0
+  .text:0000000001E79E80                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79E87                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79E8E                 call    sub_1E75140
+  .text:0000000001E79E93                 add     rsp, 20h
+  .text:0000000001E79E97                 jmp     loc_1E78D05
+  .text:0000000001E79E9C                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79EA3                 xor     r8d, r8d
+  .text:0000000001E79EA6                 xor     esi, esi
+  .text:0000000001E79EA8                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79EAF                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79EB4                 mov     rdi, rbx
+  .text:0000000001E79EB7                 mov     rdx, r15
+  .text:0000000001E79EBA                 call    sub_984B30
+  .text:0000000001E79EBF                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79EC6                 jz      loc_1E79345
+  .text:0000000001E79ECC                 push    0
+  .text:0000000001E79ECE                 mov     r9, r15
+  .text:0000000001E79ED1                 mov     rdx, r13
+  .text:0000000001E79ED4                 push    r14
+  .text:0000000001E79ED6                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79EDD                 mov     esi, 1
+  .text:0000000001E79EE2                 push    0Eh
+  .text:0000000001E79EE4                 push    0
+  .text:0000000001E79EE6                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79EED                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79EF4                 call    sub_1E75140
+  .text:0000000001E79EF9                 add     rsp, 20h
+  .text:0000000001E79EFD                 jmp     loc_1E793A4
+  .text:0000000001E79F02                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79F09                 xor     r8d, r8d
+  .text:0000000001E79F0C                 xor     esi, esi
+  .text:0000000001E79F0E                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79F15                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79F1A                 mov     rdi, rbx
+  .text:0000000001E79F1D                 mov     rdx, r15
+  .text:0000000001E79F20                 call    sub_984B30
+  .text:0000000001E79F25                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79F2C                 jz      loc_1E78EB5
+  .text:0000000001E79F32                 push    0
+  .text:0000000001E79F34                 push    r14
+  .text:0000000001E79F36                 push    0Eh
+  .text:0000000001E79F38                 jmp     loc_1E79FD9
+  .text:0000000001E79F3D                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79F44                 xor     r8d, r8d
+  .text:0000000001E79F47                 xor     esi, esi
+  .text:0000000001E79F49                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79F50                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79F55                 mov     rdi, rbx
+  .text:0000000001E79F58                 mov     rdx, r15
+  .text:0000000001E79F5B                 call    sub_984B30
+  .text:0000000001E79F60                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79F67                 jz      loc_1E79525
+  .text:0000000001E79F6D                 push    1
+  .text:0000000001E79F6F                 mov     r9, r15
+  .text:0000000001E79F72                 mov     rdx, r13
+  .text:0000000001E79F75                 push    r14
+  .text:0000000001E79F77                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79F7E                 mov     esi, 1
+  .text:0000000001E79F83                 push    0Eh
+  .text:0000000001E79F85                 push    0
+  .text:0000000001E79F87                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79F8E                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79F95                 call    sub_1E75140
+  .text:0000000001E79F9A                 add     rsp, 20h
+  .text:0000000001E79F9E                 jmp     loc_1E79584
+  .text:0000000001E79FA3                 lea     rbx, [rbp+var_1F0]
+  .text:0000000001E79FAA                 xor     r8d, r8d
+  .text:0000000001E79FAD                 xor     esi, esi
+  .text:0000000001E79FAF                 lea     r15, aOrigin_0; "origin"
+  .text:0000000001E79FB6                 mov     ecx, 0FFFFFFFFh
+  .text:0000000001E79FBB                 mov     rdi, rbx
+  .text:0000000001E79FBE                 mov     rdx, r15
+  .text:0000000001E79FC1                 call    sub_984B30
+  .text:0000000001E79FC6                 test    byte ptr [rbp+var_1F0+7], 40h
+  .text:0000000001E79FCD                 jz      loc_1E79495
+  .text:0000000001E79FD3                 push    0
+  .text:0000000001E79FD5                 push    r14
+  .text:0000000001E79FD7                 push    3
+  .text:0000000001E79FD9                 push    0
+  .text:0000000001E79FDB                 mov     rcx, [rbp+var_400]
+  .text:0000000001E79FE2                 mov     r9, r15
+  .text:0000000001E79FE5                 mov     rdx, r13
+  .text:0000000001E79FE8                 mov     rdi, [rbp+var_3C8]
+  .text:0000000001E79FEF                 lea     r8, [rbp+var_1E8]
+  .text:0000000001E79FF6                 mov     esi, 1
+  .text:0000000001E79FFB                 call    sub_1E75140
+  .text:0000000001E7A000                 add     rsp, 20h
+  .text:0000000001E7A004                 jmp     loc_1E78F14
+  .text:0000000001E7A009                 push    0
+  .text:0000000001E7A00B                 xor     r9d, r9d
+  .text:0000000001E7A00E                 push    r14
+  .text:0000000001E7A010                 push    3
+  .text:0000000001E7A012                 push    0
+  .text:0000000001E7A014                 jmp     loc_1E79A2D
+  .text:0000000001E7A019                 push    0
+  .text:0000000001E7A01B                 xor     r9d, r9d
+  .text:0000000001E7A01E                 push    r14
+  .text:0000000001E7A020                 push    0Eh
+  .text:0000000001E7A022                 push    0
+  .text:0000000001E7A024                 jmp     loc_1E7992B
+  .text:0000000001E7A029                 push    0
+  .text:0000000001E7A02B                 xor     r9d, r9d
+  .text:0000000001E7A02E                 push    r14
+  .text:0000000001E7A030                 push    0Eh
+  .text:0000000001E7A032                 push    0
+  .text:0000000001E7A034                 jmp     loc_1E79961
+  .text:0000000001E7A039                 push    1
+  .text:0000000001E7A03B                 xor     r9d, r9d
+  .text:0000000001E7A03E                 push    r14
+  .text:0000000001E7A040                 push    0Eh
+  .text:0000000001E7A042                 push    0
+  .text:0000000001E7A044                 jmp     loc_1E7986F
+  .text:0000000001E7A049                 push    0
+  .text:0000000001E7A04B                 xor     r9d, r9d
+  .text:0000000001E7A04E                 push    r14
+  .text:0000000001E7A050                 push    3
+  .text:0000000001E7A052                 push    0
+  .text:0000000001E7A054                 jmp     loc_1E7992B
+procedure: |-
+  __int64 __fastcall CEntitySystem_AddComponentFieldUnserializer(__int64 a1, __int64 a2, const char *a3, __int64 a4)
+  {
+    __int64 v4; // r10
+    int v6; // r12d
+    int v7; // r14d
+    int v8; // ebx
+    const char *v9; // rdx
+    unsigned __int64 v10; // rsi
+    __int64 v11; // rdx
+    __int64 v12; // rcx
+    __int64 v13; // r10
+    const char *v14; // r15
+    __int64 v15; // r15
+    __int64 v16; // r8
+    __int64 v17; // rbx
+    __int64 v18; // rdi
+    __int64 v19; // rdx
+    int v20; // eax
+    __int64 v21; // rbx
+    __int64 v22; // rbx
+    __int64 v23; // rax
+    int v24; // eax
+    __int64 v25; // r15
+    int v26; // ebx
+    __int64 v27; // rax
+    __int64 v28; // rdx
+    __int64 v29; // rbx
+    __int64 v30; // r15
+    __int64 v31; // rax
+    __m128i si128; // xmm1
+    __int64 v33; // r15
+    __int64 v34; // rdx
+    __int64 v35; // r8
+    __int64 v36; // rbx
+    __int64 v37; // rdi
+    int v38; // eax
+    __int64 v39; // rbx
+    unsigned __int8 v40; // al
+    const char *v41; // r9
+    const char *v42; // r8
+    const char **v43; // rax
+    const char *v44; // r9
+    const char **v45; // r8
+    const char *v46; // r9
+    const char *v47; // r8
+    const char **v48; // rax
+    const char *v49; // r9
+    const char **v50; // r8
+    int v51; // eax
+    int v52; // edx
+    __int64 v53; // r8
+    int j; // r9d
+    __int64 v55; // rcx
+    __int64 v56; // rax
+    unsigned int v57; // eax
+    const char *v58; // r9
+    __int64 result; // rax
+    unsigned int v60; // esi
+    int v61; // eax
+    int v62; // edx
+    __int64 v63; // r8
+    int i; // r9d
+    __int64 v65; // rcx
+    __int64 v66; // rax
+    unsigned int v67; // eax
+    const char *v68; // r9
+    const char *v69; // r8
+    const char **v70; // rax
+    const char *v71; // r9
+    const char **v72; // r8
+    const char *v73; // r9
+    const char *v74; // r9
+    const char *v75; // r8
+    const char **v76; // rax
+    const char *v77; // r9
+    const char **v78; // r8
+    int v79; // eax
+    const char **v80; // rax
+    const char **v81; // rax
+    const char *v82; // r9
+    const char **v83; // rax
+    const char **v84; // rax
+    char v85; // [rsp-18h] [rbp-448h]
+    int v86; // [rsp-10h] [rbp-440h]
+    __int64 v87; // [rsp+8h] [rbp-428h]
+    int v88; // [rsp+8h] [rbp-428h]
+    __int64 v89; // [rsp+8h] [rbp-428h]
+    int v90; // [rsp+8h] [rbp-428h]
+    __int64 v91; // [rsp+10h] [rbp-420h]
+    __int64 v92; // [rsp+10h] [rbp-420h]
+    __int64 v93; // [rsp+10h] [rbp-420h]
+    __int64 v94; // [rsp+10h] [rbp-420h]
+    const char *v95; // [rsp+20h] [rbp-410h]
+    __int64 v96; // [rsp+28h] [rbp-408h]
+    int v98; // [rsp+38h] [rbp-3F8h]
+    __int64 v99; // [rsp+48h] [rbp-3E8h]
+    bool v100; // [rsp+53h] [rbp-3DDh]
+    int v101; // [rsp+54h] [rbp-3DCh]
+    int v102; // [rsp+58h] [rbp-3D8h]
+    char v103; // [rsp+5Fh] [rbp-3D1h]
+    int v104; // [rsp+68h] [rbp-3C8h]
+    __int64 v105; // [rsp+70h] [rbp-3C0h]
+    __int64 v106; // [rsp+78h] [rbp-3B8h]
+    const char *v107; // [rsp+78h] [rbp-3B8h]
+    __int64 v109; // [rsp+78h] [rbp-3B8h]
+    __int64 v110; // [rsp+78h] [rbp-3B8h]
+    const char *v111; // [rsp+80h] [rbp-3B0h] BYREF
+    const char *v112; // [rsp+88h] [rbp-3A8h]
+    const char *v113; // [rsp+90h] [rbp-3A0h]
+    unsigned __int64 v114; // [rsp+A0h] [rbp-390h] BYREF
+    _QWORD v115[25]; // [rsp+A8h] [rbp-388h] BYREF
+    unsigned __int64 v116; // [rsp+170h] [rbp-2C0h] BYREF
+    _QWORD v117[25]; // [rsp+178h] [rbp-2B8h] BYREF
+    const char *v118; // [rsp+240h] [rbp-1F0h] BYREF
+    const char *v119; // [rsp+248h] [rbp-1E8h] BYREF
+    const char *v120; // [rsp+250h] [rbp-1E0h]
+    __int64 v121; // [rsp+258h] [rbp-1D8h]
+    __int64 v122; // [rsp+260h] [rbp-1D0h]
+    __int64 v123; // [rsp+268h] [rbp-1C8h]
+    __int64 v124; // [rsp+270h] [rbp-1C0h]
+    int v125; // [rsp+278h] [rbp-1B8h]
+    __int128 v126; // [rsp+2A0h] [rbp-190h]
+    __int128 v127; // [rsp+2B0h] [rbp-180h]
+    __int128 v128; // [rsp+2C0h] [rbp-170h]
+    __int128 v129; // [rsp+2D0h] [rbp-160h]
+    __int128 v130; // [rsp+2E0h] [rbp-150h]
+    __int128 v131; // [rsp+2F0h] [rbp-140h]
+    __int128 v132; // [rsp+300h] [rbp-130h]
+    __int128 v133; // [rsp+310h] [rbp-120h]
+    __int128 v134; // [rsp+320h] [rbp-110h]
+    __int128 v135; // [rsp+330h] [rbp-100h]
+    __int128 v136; // [rsp+340h] [rbp-F0h]
+    __int128 v137; // [rsp+350h] [rbp-E0h]
+    __int128 v138; // [rsp+360h] [rbp-D0h]
+    __int128 v139; // [rsp+370h] [rbp-C0h]
+    __int128 v140; // [rsp+380h] [rbp-B0h]
+    __int128 v141; // [rsp+390h] [rbp-A0h]
+    char v142; // [rsp+3A0h] [rbp-90h]
+    __int64 v143; // [rsp+3B0h] [rbp-80h]
+    __int64 v144; // [rsp+3B8h] [rbp-78h]
+    __int64 v145; // [rsp+3C0h] [rbp-70h]
+    __int64 v146; // [rsp+3C8h] [rbp-68h]
+    __int64 v147; // [rsp+3D0h] [rbp-60h]
+    __int64 v148; // [rsp+3D8h] [rbp-58h]
+    __int64 v149; // [rsp+3E0h] [rbp-50h]
+    __int64 v150; // [rsp+3E8h] [rbp-48h]
+    __int64 v151; // [rsp+3F0h] [rbp-40h]
+
+    v4 = a4;
+    v6 = *(_DWORD *)(a2 + 40);
+    v104 = a1;
+    v7 = *(_DWORD *)(a2 + 24);
+    v8 = *(unsigned __int16 *)(a4 + 20);
+    if ( v6 >= 0 )
+    {
+      v79 = sub_2033F00(a4);
+      v4 = a4;
+      v103 = 1;
+      v102 = v79;
+      v95 = *(const char **)(a2 + 16);
+  LABEL_35:
+      v105 = 0;
+      v100 = (*(_BYTE *)(v4 + 24) & 0x10) != 0;
+      if ( *(_BYTE *)v4 == 10 )
+        v105 = *(_QWORD *)(v4 + 64);
+      goto LABEL_5;
+    }
+    v95 = *(const char **)(a2 + 16);
+    if ( (unsigned __int16)v8 <= 1u )
+    {
+      v6 = 0;
+      v8 = 1;
+      v102 = 0;
+      v103 = 0;
+      goto LABEL_35;
+    }
+    if ( *(_BYTE *)a4 != 8 )
+    {
+      result = sub_983F70((unsigned int)dword_27C47DC, 5);
+      if ( (_BYTE)result )
+      {
+        LODWORD(v119) = 1209;
+        v118 = "entitysystem.cpp";
+        v120 = "DataDesc_AddComponentFieldUnserializer";
+        v121 = 0;
+        v122 = 0;
+        v123 = 0;
+        v124 = 0;
+        v125 = 0;
+        return sub_983DB0(
+                 (unsigned int)dword_27C47DC,
+                 5,
+                 &v118,
+                 "Field \"%s\" of class \"%s\" cannot be unserialized yet (lacking array support)!\n",
+                 v95,
+                 a3);
+      }
+      return result;
+    }
+    v8 = 1;
+    v6 = 0;
+    v102 = 0;
+    v103 = 0;
+    v105 = 0;
+    v100 = (*(_BYTE *)(a4 + 24) & 0x10) != 0;
+  LABEL_5:
+    v9 = *(const char **)(a2 + 8);
+    v115[0] = 0;
+    v114 = 0xC00000C800000000LL;
+    if ( v9 && *v9 )
+    {
+      if ( v95 && *v95 )
+      {
+        v120 = v95;
+        v10 = 3;
+        v118 = v9;
+        v119 = ".";
+        v110 = v4;
+        sub_984A00(&v114, 3, &v118, 0, 0);
+        v13 = v110;
+      }
+      else
+      {
+        v10 = 0;
+        v109 = v4;
+        sub_984B30(&v114, 0, v9, 0xFFFFFFFFLL, 0);
+        v13 = v109;
+      }
+      v98 = 0;
+    }
+    else
+    {
+      v10 = 0;
+      v106 = v4;
+      sub_984B30(&v114, 0, v95, 0xFFFFFFFFLL, 0);
+      v13 = v106;
+      v98 = (int)v95;
+    }
+    v14 = (const char *)v115;
+    if ( (v114 & 0x4000000000000000LL) == 0 )
+    {
+      v14 = &byte_8D7E1C;
+      if ( (v114 & 0x3FFFFFFF00000000LL) != 0 )
+        v14 = (const char *)v115[0];
+    }
+    v117[0] = 0;
+    v116 = 0xC00000C800000000LL;
+    v101 = v8 + v6;
+    if ( v8 )
+    {
+      v107 = v14;
+      v99 = v13;
+      v96 = a1 + 3264;
+      do
+      {
+        if ( !v103 )
+        {
+          if ( !v100 )
+            goto LABEL_20;
+  LABEL_13:
+          v15 = 1;
+          if ( v107 )
+            v15 = (int)(sub_985BF0(v107) + 1);
+          goto LABEL_15;
+        }
+  LABEL_27:
+        v10 = (unsigned __int64)v115;
+        if ( (v114 & 0x4000000000000000LL) == 0 )
+        {
+          v10 = (unsigned __int64)&byte_8D7E1C;
+          if ( (v114 & 0x3FFFFFFF00000000LL) != 0 )
+            v10 = v115[0];
+        }
+        sub_9844B0(&v116, (const char *)v10, (unsigned int)v6);
+        if ( (v116 & 0x4000000000000000LL) != 0 )
+        {
+          v98 = 0;
+          v107 = (const char *)v117;
+          if ( !v100 )
+            goto LABEL_20;
+          v15 = (int)(sub_985BF0(v117) + 1);
+        }
+        else
+        {
+          if ( (v116 & 0x3FFFFFFF00000000LL) != 0 )
+          {
+            v98 = 0;
+            v107 = (const char *)v117[0];
+            if ( v100 )
+              goto LABEL_13;
+  LABEL_20:
+            if ( v105 )
+            {
+              v24 = *(_DWORD *)(v99 + 24);
+              if ( (v24 & 0x40) == 0 )
+              {
+                if ( (v24 & 0x40000) != 0 )
+                {
+                  LODWORD(v25) = (_DWORD)a3;
+                  v26 = 0;
+                }
+                else
+                {
+                  v25 = *(_QWORD *)(v105 + 16);
+                  v26 = 1;
+                }
+                sub_1E78340(v104, v26, (_DWORD)v107, v25, v105, v7, *(_QWORD *)a2, *(_QWORD *)(a2 + 32));
+                sub_1E75800(v104, v26, (_DWORD)v107, v25, v105, 1, *(_QWORD *)a2, *(_QWORD *)(a2 + 32));
+                goto LABEL_25;
+              }
+              v27 = sub_983720(v96);
+              v29 = v28;
+              v30 = v27;
+              sub_9840D0(&v118, 40, 4, 8, 2, 0, 0);
+              v142 = 0;
+              v126 = 0;
+              v127 = 0;
+              v128 = 0;
+              v129 = 0;
+              v130 = 0;
+              v131 = 0;
+              v132 = 0;
+              v133 = 0;
+              v134 = 0;
+              v135 = 0;
+              v136 = 0;
+              v137 = 0;
+              v138 = 0;
+              v139 = 0;
+              v140 = 0;
+              v141 = 0;
+              v143 = 0;
+              v144 = 0;
+              v145 = 0;
+              v146 = 0;
+              v147 = 0;
+              v148 = 0;
+              v149 = 0;
+              v150 = 0;
+              v151 = 0;
+              sub_1E78340(v104, 1, (_DWORD)v107, *(_QWORD *)(v105 + 16), v105, 0, (__int64)&v118, *(_QWORD *)(a2 + 32));
+              sub_1E75800(v104, 1, (_DWORD)v107, *(_QWORD *)(v105 + 16), v105, 1, (__int64)&v118, *(_QWORD *)(a2 + 32));
+              if ( (unsigned int)v146 | (unsigned int)v149 | HIDWORD(v119) )
+              {
+                v31 = sub_983910(v96, 48, 16);
+                si128 = _mm_load_si128((const __m128i *)&xmmword_86ACD0);
+                *(_OWORD *)(v31 + 16) = 0;
+                v33 = v31;
+                *(_QWORD *)(v31 + 32) = 0;
+                *(__m128i *)v31 = si128;
+                *(_QWORD *)(v31 + 40) = 0;
+                sub_1E5CDA0(v31, &v118, v96);
+                v35 = *(_QWORD *)a2;
+                v36 = *(int *)(*(_QWORD *)a2 + 392LL);  // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+                v37 = *(unsigned int *)(*(_QWORD *)a2 + 408LL);
+                if ( (_DWORD)v36 == (_DWORD)v37 )
+                {
+                  v60 = *(_DWORD *)(v35 + 412);
+                  if ( v60 <= 0x3FFFFFFF
+                    || (v38 = *(_DWORD *)(*(_QWORD *)a2 + 392LL), v34 = v60 & 0xC0000000, (_DWORD)v34 == 0x80000000) )  // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+                  {
+                    if ( (_DWORD)v37 == 0x7FFFFFFF )
+                    {
+                      v94 = *(_QWORD *)a2;
+                      sub_984EE0(v37, 1, v34);
+                      v35 = v94;
+                      v37 = *(unsigned int *)(v94 + 408);
+                      v60 = *(_DWORD *)(v94 + 412);
+                    }
+                    v89 = v35;
+                    v61 = sub_984790(v37, v60 & 0x3FFFFFFF, (unsigned int)(v37 + 1), 16);
+                    v62 = v37 + 1;
+                    v63 = v89;
+                    for ( i = v61; v62 > i; i = (v62 + i) / 2 )
+                      ;
+                    v65 = *(int *)(v89 + 408);
+                    v90 = i;
+                    v92 = v63;
+                    v66 = sub_9843C0(*(_QWORD *)(v63 + 400), *(_DWORD *)(v63 + 412) <= 0x3FFFFFFFu, 16LL * i, 16 * v65);
+                    v35 = v92;
+                    *(_QWORD *)(v92 + 400) = v66;
+                    v67 = *(_DWORD *)(v92 + 412);
+                    if ( v67 > 0x3FFFFFFF )
+                      *(_DWORD *)(v92 + 412) = v67 & 0x3FFFFFFF;
+                    v38 = *(_DWORD *)(v92 + 392);  // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+                    *(_DWORD *)(v92 + 408) = v90;
+                  }
+                }
+                else
+                {
+                  v38 = *(_DWORD *)(*(_QWORD *)a2 + 392LL);  // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+                }
+                *(_DWORD *)(v35 + 392) = v38 + 1;  // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+                v39 = *(_QWORD *)(*(_QWORD *)a2 + 400LL) + 16 * v36;
+                *(_DWORD *)v39 = v7;
+                *(_QWORD *)(v39 + 8) = v33;
+                LODWORD(v149) = 0;
+                if ( HIDWORD(v151) <= 0x3FFFFFFF )
+                {
+  LABEL_39:
+                  if ( v150 )
+                    (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+                }
+              }
+              else
+              {
+                sub_984BC0(v96, v30, v29);
+                LODWORD(v149) = 0;
+                if ( HIDWORD(v151) <= 0x3FFFFFFF )
+                  goto LABEL_39;
+              }
+              LODWORD(v146) = 0;
+              if ( HIDWORD(v148) <= 0x3FFFFFFF && v147 )
+                (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+              LODWORD(v143) = 0;
+              if ( HIDWORD(v145) <= 0x3FFFFFFF && v144 )
+                (*(void (__fastcall **)(_QWORD *))(*g_pMemAlloc + 32LL))(g_pMemAlloc);
+              v142 = 0;
+              if ( HIDWORD(v119) )
+              {
+                v126 = 0;
+                v127 = 0;
+                v128 = 0;
+                v129 = 0;
+                v130 = 0;
+                v131 = 0;
+                v132 = 0;
+                v133 = 0;
+                v134 = 0;
+                v135 = 0;
+                v136 = 0;
+                v137 = 0;
+                v138 = 0;
+                v139 = 0;
+                v140 = 0;
+                v141 = 0;
+                sub_983FB0(&v118, 0);
+              }
+              sub_985200(&v118);
+  LABEL_25:
+              ++v6;
+              v7 += v102;
+              if ( v6 == v101 )
+                break;
+              if ( v103 )
+                goto LABEL_27;
+              goto LABEL_20;
+            }
+            v40 = *(_BYTE *)v99;
+            if ( *(_BYTE *)v99 != 60 )
+            {
+              if ( v40 <= 0x3Cu )
+              {
+                if ( v40 != 22 )
+                {
+                  if ( v40 == 59 )
+                  {
+                    v119 = nullptr;
+                    v118 = (const char *)0xC00000C800000000LL;
+                    if ( v107 )
+                    {
+                      if ( !*v107 )
+                      {
+                        sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                        if ( (HIBYTE(v118) & 0x40) == 0 )
+                          goto LABEL_61;
+                        sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 3, v7, 0);
+  LABEL_193:
+                        if ( *v107 )
+                        {
+  LABEL_194:
+                          if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                          {
+                            v84 = &v119;
+                            if ( (HIBYTE(v118) & 0x40) == 0 )
+                              v84 = (const char **)v119;
+                            *(_BYTE *)v84 = 0;
+                          }
+                          LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                          v111 = v107;
+                          v112 = ".";
+                          v113 = "angles";
+                          sub_984A00(&v118, 3, &v111, 0, 0);
+                          LODWORD(v44) = 0;
+  LABEL_69:
+                          v45 = &v119;
+                          if ( (HIBYTE(v118) & 0x40) == 0 )
+                          {
+                            v45 = (const char **)&byte_8D7E1C;
+                            if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                              LODWORD(v45) = (_DWORD)v119;
+                          }
+                          sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v45, (_DWORD)v44, 0, 4, v7 + 16, 0);
+  LABEL_73:
+                          sub_984310(&v118, 0);
+                          goto LABEL_25;
+                        }
+  LABEL_64:
+                        if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                        {
+                          v43 = &v119;
+                          if ( (HIBYTE(v118) & 0x40) == 0 )
+                            v43 = (const char **)v119;
+                          *(_BYTE *)v43 = 0;
+                        }
+                        LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                        sub_984B30(&v118, 0, "angles", 0xFFFFFFFFLL, 0);
+                        v44 = "angles";
+                        goto LABEL_69;
+                      }
+                      v111 = v107;
+                      v112 = ".";
+                      v113 = "origin";
+                      sub_984A00(&v118, 3, &v111, 0, 0);
+                      if ( (HIBYTE(v118) & 0x40) != 0 )
+                      {
+                        sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, 0, 0, 3, v7, 0);
+                        goto LABEL_193;
+                      }
+                      LODWORD(v41) = 0;
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+                      {
+                        sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, 0, 0, 3, v7, 0);
+                        goto LABEL_193;
+                      }
+                      goto LABEL_171;
+                    }
+                    sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                    if ( (HIBYTE(v118) & 0x40) != 0 )
+                    {
+                      sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 3, v7, 0);
+                      goto LABEL_64;
+                    }
+  LABEL_61:
+                    v41 = "origin";
+                    v42 = &byte_8D7E1C;
+                    if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+  LABEL_171:
+                      LODWORD(v42) = (_DWORD)v119;
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v42, (_DWORD)v41, 0, 3, v7, 0);
+                    if ( v107 && *v107 )
+                      goto LABEL_194;
+                    goto LABEL_64;
+                  }
+  LABEL_157:
+                  if ( !*v95 )
+                  {
+                    if ( (unsigned __int8)sub_983F70((unsigned int)dword_27C47DC, 5) )
+                    {
+                      LODWORD(v119) = 1381;
+                      v58 = *(const char **)(v99 + 8);
+                      v118 = "entitysystem.cpp";
+                      v120 = "DataDesc_AddComponentFieldUnserializer";
+                      v121 = 0;
+                      v122 = 0;
+                      v123 = 0;
+                      v124 = 0;
+                      v125 = 0;
+                      sub_983DB0(
+                        (unsigned int)dword_27C47DC,
+                        5,
+                        &v118,
+                        "Field %s::%s cannot have sub-keyfields since it is an atomic type!\n",
+                        a3,
+                        v58);
+                    }
+                    break;
+                  }
+                  sub_1E75140(v104, 0, a2, (_DWORD)a3, (_DWORD)v107, v98, v99, 0, v7, 0);
+                  goto LABEL_25;
+                }
+                v119 = nullptr;
+                v118 = (const char *)0xC00000C800000000LL;
+                if ( v107 )
+                {
+                  if ( !*v107 )
+                  {
+                    sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                    if ( (HIBYTE(v118) & 0x40) == 0 )
+                      goto LABEL_145;
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 14, v7, 1);
+  LABEL_176:
+                    if ( *v107 )
+                    {
+  LABEL_177:
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                      {
+                        v81 = &v119;
+                        if ( (HIBYTE(v118) & 0x40) == 0 )
+                          v81 = (const char **)v119;
+                        *(_BYTE *)v81 = 0;
+                      }
+                      LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                      v111 = v107;
+                      v112 = ".";
+                      v113 = "angles";
+                      sub_984A00(&v118, 3, &v111, 0, 0);
+                      LODWORD(v77) = 0;
+                      goto LABEL_153;
+                    }
+  LABEL_148:
+                    if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                    {
+                      v76 = &v119;
+                      if ( (HIBYTE(v118) & 0x40) == 0 )
+                        v76 = (const char **)v119;
+                      *(_BYTE *)v76 = 0;
+                    }
+                    LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                    sub_984B30(&v118, 0, "angles", 0xFFFFFFFFLL, 0);
+                    v77 = "angles";
+  LABEL_153:
+                    v78 = &v119;
+                    if ( (HIBYTE(v118) & 0x40) == 0 )
+                    {
+                      v78 = (const char **)&byte_8D7E1C;
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                        LODWORD(v78) = (_DWORD)v119;
+                    }
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v78, (_DWORD)v77, 0, 47, v7, 1);
+                    goto LABEL_73;
+                  }
+                  v111 = v107;
+                  v112 = ".";
+                  v113 = "origin";
+                  sub_984A00(&v118, 3, &v111, 0, 0);
+                  if ( (HIBYTE(v118) & 0x40) != 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, 0, 0, 14, v7, 1);
+                    goto LABEL_176;
+                  }
+                  LODWORD(v74) = 0;
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, 0, 0, 14, v7, 1);
+                    goto LABEL_176;
+                  }
+                  goto LABEL_172;
+                }
+                sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                if ( (HIBYTE(v118) & 0x40) != 0 )
+                {
+                  sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 14, v7, 1);
+                  goto LABEL_148;
+                }
+  LABEL_145:
+                v74 = "origin";
+                v75 = &byte_8D7E1C;
+                if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+  LABEL_172:
+                  LODWORD(v75) = (_DWORD)v119;
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v75, (_DWORD)v74, 0, 14, v7, 1);
+                if ( v107 && *v107 )
+                  goto LABEL_177;
+                goto LABEL_148;
+              }
+              if ( v40 != 64 )
+              {
+                if ( v40 != 65 )
+                  goto LABEL_157;
+                v119 = nullptr;
+                v118 = (const char *)0xC00000C800000000LL;
+                if ( v107 )
+                {
+                  if ( !*v107 )
+                  {
+                    sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                    if ( (HIBYTE(v118) & 0x40) == 0 )
+                      goto LABEL_84;
+                    v82 = "origin";
+                    v86 = v7;
+                    v85 = 14;
+  LABEL_183:
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (_DWORD)v82, 0, v85, v86, 0);
+  LABEL_87:
+                    if ( *v107 )
+                    {
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                      {
+                        v80 = &v119;
+                        if ( (HIBYTE(v118) & 0x40) == 0 )
+                          v80 = (const char **)v119;
+                        *(_BYTE *)v80 = 0;
+                      }
+                      LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                      v111 = v107;
+                      v112 = ".";
+                      v113 = "angles";
+                      sub_984A00(&v118, 3, &v111, 0, 0);
+                      LODWORD(v49) = 0;
+                    }
+                    else
+                    {
+  LABEL_88:
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                      {
+                        v48 = &v119;
+                        if ( (HIBYTE(v118) & 0x40) == 0 )
+                          v48 = (const char **)v119;
+                        *(_BYTE *)v48 = 0;
+                      }
+                      LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                      sub_984B30(&v118, 0, "angles", 0xFFFFFFFFLL, 0);
+                      v49 = "angles";
+                    }
+                    v50 = &v119;
+                    if ( (HIBYTE(v118) & 0x40) == 0 )
+                    {
+                      v50 = (const char **)&byte_8D7E1C;
+                      if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                        LODWORD(v50) = (_DWORD)v119;
+                    }
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v50, (_DWORD)v49, 0, 1, v7 + 12, 0);
+                    goto LABEL_73;
+                  }
+                  v111 = v107;
+                  v112 = ".";
+                  v113 = "origin";
+                  sub_984A00(&v118, 3, &v111, 0, 0);
+                  if ( (HIBYTE(v118) & 0x40) != 0 )
+                  {
+                    LODWORD(v82) = 0;
+                    v86 = v7;
+                    v85 = 14;
+                    goto LABEL_183;
+                  }
+                  LODWORD(v46) = 0;
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, 0, 0, 14, v7, 0);
+                    goto LABEL_87;
+                  }
+  LABEL_170:
+                  LODWORD(v47) = (_DWORD)v119;
+                }
+                else
+                {
+                  sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                  if ( (HIBYTE(v118) & 0x40) != 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 14, v7, 0);
+                    goto LABEL_88;
+                  }
+  LABEL_84:
+                  v46 = "origin";
+                  v47 = &byte_8D7E1C;
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                    goto LABEL_170;
+                }
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v47, (_DWORD)v46, 0, 14, v7, 0);
+  LABEL_86:
+                if ( v107 )
+                  goto LABEL_87;
+                goto LABEL_88;
+              }
+              v119 = nullptr;
+              v118 = (const char *)0xC00000C800000000LL;
+              if ( v107 )
+              {
+                if ( *v107 )
+                {
+                  v111 = v107;
+                  v112 = ".";
+                  v113 = "origin";
+                  sub_984A00(&v118, 3, &v111, 0, 0);
+                  if ( (HIBYTE(v118) & 0x40) != 0 )
+                  {
+                    LODWORD(v82) = 0;
+                    v86 = v7;
+                    v85 = 3;
+                    goto LABEL_183;
+                  }
+                  LODWORD(v73) = 0;
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, 0, 0, 3, v7, 0);
+                    goto LABEL_87;
+                  }
+                }
+                else
+                {
+                  sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                  if ( (HIBYTE(v118) & 0x40) != 0 )
+                  {
+                    v82 = "origin";
+                    v86 = v7;
+                    v85 = 3;
+                    goto LABEL_183;
+                  }
+  LABEL_140:
+                  v73 = "origin";
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+                  {
+                    sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, (unsigned int)"origin", 0, 3, v7, 0);
+                    goto LABEL_86;
+                  }
+                }
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v119, (_DWORD)v73, 0, 3, v7, 0);
+                goto LABEL_86;
+              }
+              sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+              if ( (HIBYTE(v118) & 0x40) != 0 )
+              {
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 3, v7, 0);
+                goto LABEL_88;
+              }
+              goto LABEL_140;
+            }
+            v119 = nullptr;
+            v118 = (const char *)0xC00000C800000000LL;
+            if ( v107 )
+            {
+              if ( !*v107 )
+              {
+                sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+                if ( (HIBYTE(v118) & 0x40) == 0 )
+                  goto LABEL_125;
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 14, v7, 0);
+  LABEL_185:
+                if ( *v107 )
+                {
+  LABEL_186:
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                  {
+                    v83 = &v119;
+                    if ( (HIBYTE(v118) & 0x40) == 0 )
+                      v83 = (const char **)v119;
+                    *(_BYTE *)v83 = 0;
+                  }
+                  LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                  v111 = v107;
+                  v112 = ".";
+                  v113 = "angles";
+                  sub_984A00(&v118, 3, &v111, 0, 0);
+                  LODWORD(v71) = 0;
+                  goto LABEL_133;
+                }
+  LABEL_128:
+                if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                {
+                  v70 = &v119;
+                  if ( (HIBYTE(v118) & 0x40) == 0 )
+                    v70 = (const char **)v119;
+                  *(_BYTE *)v70 = 0;
+                }
+                LODWORD(v118) = (unsigned int)v118 & 0xC0000000;
+                sub_984B30(&v118, 0, "angles", 0xFFFFFFFFLL, 0);
+                v71 = "angles";
+  LABEL_133:
+                v72 = &v119;
+                if ( (HIBYTE(v118) & 0x40) == 0 )
+                {
+                  v72 = (const char **)&byte_8D7E1C;
+                  if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+                    LODWORD(v72) = (_DWORD)v119;
+                }
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v72, (_DWORD)v71, 0, 47, v7 + 16, 0);
+                goto LABEL_73;
+              }
+              v111 = v107;
+              v112 = ".";
+              v113 = "origin";
+              sub_984A00(&v118, 3, &v111, 0, 0);
+              if ( (HIBYTE(v118) & 0x40) != 0 )
+              {
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, 0, 0, 14, v7, 0);
+                goto LABEL_185;
+              }
+              LODWORD(v68) = 0;
+              if ( (HIDWORD(v118) & 0x3FFFFFFF) == 0 )
+              {
+                sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&byte_8D7E1C, 0, 0, 14, v7, 0);
+                goto LABEL_185;
+              }
+              goto LABEL_174;
+            }
+            sub_984B30(&v118, 0, "origin", 0xFFFFFFFFLL, 0);
+            if ( (HIBYTE(v118) & 0x40) != 0 )
+            {
+              sub_1E75140(v104, 1, a2, (_DWORD)a3, (unsigned int)&v119, (unsigned int)"origin", 0, 14, v7, 0);
+              goto LABEL_128;
+            }
+  LABEL_125:
+            v68 = "origin";
+            v69 = &byte_8D7E1C;
+            if ( (HIDWORD(v118) & 0x3FFFFFFF) != 0 )
+  LABEL_174:
+              LODWORD(v69) = (_DWORD)v119;
+            sub_1E75140(v104, 1, a2, (_DWORD)a3, (_DWORD)v69, (_DWORD)v68, 0, 14, v7, 0);
+            if ( v107 && *v107 )
+              goto LABEL_186;
+            goto LABEL_128;
+          }
+          if ( !v100 )
+          {
+            v98 = 0;
+            v107 = &byte_8D7E1C;
+            goto LABEL_20;
+          }
+          v15 = 1;
+          v98 = 0;
+          v107 = &byte_8D7E1C;
+        }
+  LABEL_15:
+        v16 = *(_QWORD *)a2;
+        v17 = *(int *)(*(_QWORD *)a2 + 416LL);
+        v18 = *(unsigned int *)(*(_QWORD *)a2 + 432LL);
+        if ( (_DWORD)v17 == (_DWORD)v18
+          && ((v10 = *(unsigned int *)(v16 + 436), (unsigned int)v10 <= 0x3FFFFFFF) || (v10 & 0xC0000000) == 0x80000000) )
+        {
+          if ( (_DWORD)v18 == 0x7FFFFFFF )
+          {
+            v93 = *(_QWORD *)a2;
+            sub_984EE0(v18, 1, v11);
+            v16 = v93;
+            v18 = *(unsigned int *)(v93 + 432);
+            LODWORD(v10) = *(_DWORD *)(v93 + 436);
+          }
+          v87 = v16;
+          v51 = sub_984790(v18, v10 & 0x3FFFFFFF, (unsigned int)(v18 + 1), 32);
+          v52 = v18 + 1;
+          v53 = v87;
+          for ( j = v51; v52 > j; j = (v52 + j) / 2 )
+            ;
+          v55 = *(int *)(v87 + 432);
+          v88 = j;
+          v91 = v53;
+          v10 = *(_DWORD *)(v53 + 436) <= 0x3FFFFFFFu;
+          v56 = sub_9843C0(*(_QWORD *)(v53 + 424), v10, 32LL * j, 32 * v55);
+          v16 = v91;
+          v19 = v56;
+          *(_QWORD *)(v91 + 424) = v56;
+          v57 = *(_DWORD *)(v91 + 436);
+          if ( v57 > 0x3FFFFFFF )
+            *(_DWORD *)(v91 + 436) = v57 & 0x3FFFFFFF;
+          v20 = *(_DWORD *)(v91 + 416);
+          *(_DWORD *)(v91 + 432) = v88;
+        }
+        else
+        {
+          v19 = *(_QWORD *)(v16 + 424);
+          v20 = *(_DWORD *)(*(_QWORD *)a2 + 416LL);
+        }
+        v21 = 32 * v17;
+        *(_DWORD *)(v16 + 416) = v20 + 1;
+        ++v6;
+        *(_QWORD *)(v19 + v21 + 16) = 0;
+        v22 = *(_QWORD *)(*(_QWORD *)a2 + 424LL) + v21;
+        v23 = sub_97A220(v15, v10, v19, v12, v16);
+        v10 = (unsigned __int64)v107;
+        *(_QWORD *)v22 = v23;
+        sub_985D80(v23);
+        *(_DWORD *)(v22 + 24) = v7;
+        *(_DWORD *)(v22 + 8) = 0;
+        v7 += v102;
+      }
+      while ( v6 != v101 );
+    }
+    sub_984310(&v116, 0);
+    return sub_984310(&v114, 0);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddComponentFieldUnserializer.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddComponentFieldUnserializer.windows.yaml
@@ -1,0 +1,1754 @@
+func_name: CEntitySystem_AddComponentFieldUnserializer
+func_va: '0x1811f0750'
+disasm_code: |-
+  .text:00000001811F0750                 mov     [rsp-8+arg_8], rbx
+  .text:00000001811F0755                 mov     [rsp-8+arg_18], r9
+  .text:00000001811F075A                 mov     [rsp-8+arg_10], r8
+  .text:00000001811F075F                 mov     [rsp-8+arg_0], rcx
+  .text:00000001811F0764                 push    rbp
+  .text:00000001811F0765                 push    rsi
+  .text:00000001811F0766                 push    rdi
+  .text:00000001811F0767                 push    r12
+  .text:00000001811F0769                 push    r13
+  .text:00000001811F076B                 push    r14
+  .text:00000001811F076D                 push    r15
+  .text:00000001811F076F                 lea     rbp, [rsp-370h]
+  .text:00000001811F0777                 sub     rsp, 470h
+  .text:00000001811F077E                 mov     r15d, [r8+18h]
+  .text:00000001811F0782                 xor     r10d, r10d
+  .text:00000001811F0785                 mov     rbx, [r8+10h]
+  .text:00000001811F0789                 mov     r13d, edx
+  .text:00000001811F078C                 mov     rdx, [rbp+3A0h+arg_20]
+  .text:00000001811F0793                 mov     r14, rcx
+  .text:00000001811F0796                 mov     ecx, [r8+28h]
+  .text:00000001811F079A                 mov     rdi, r9
+  .text:00000001811F079D                 mov     [rbp+3A0h+var_420], r15d
+  .text:00000001811F07A1                 mov     r12, r8
+  .text:00000001811F07A4                 mov     [rsp+4A0h+var_450], 0
+  .text:00000001811F07A9                 movzx   eax, word ptr [rdx+14h]
+  .text:00000001811F07AD                 mov     [rbp+3A0h+var_41C], 1
+  .text:00000001811F07B4                 mov     [rbp+3A0h+var_418], r10d
+  .text:00000001811F07B8                 mov     [rbp+3A0h+var_410], r10d
+  .text:00000001811F07BC                 test    ecx, ecx
+  .text:00000001811F07BE                 js      short loc_1811F07EA
+  .text:00000001811F07C0                 mov     [rbp+3A0h+var_418], ecx
+  .text:00000001811F07C3                 mov     rbx, rdx
+  .text:00000001811F07C6                 mov     rcx, rdx
+  .text:00000001811F07C9                 mov     [rsp+4A0h+var_450], 1
+  .text:00000001811F07CE                 mov     [rbp+3A0h+var_41C], eax
+  .text:00000001811F07D1                 call    sub_1814F89A0
+  .text:00000001811F07D6                 mov     rsi, [r12+10h]
+  .text:00000001811F07DB                 xor     r10d, r10d
+  .text:00000001811F07DE                 mov     [rbp+3A0h+var_3F0], rsi
+  .text:00000001811F07E2                 mov     [rbp+3A0h+var_410], eax
+  .text:00000001811F07E5                 jmp     loc_1811F0897
+  .text:00000001811F07EA                 mov     [rbp+3A0h+var_3F0], rbx
+  .text:00000001811F07EE                 mov     rsi, rbx
+  .text:00000001811F07F1                 cmp     eax, 1
+  .text:00000001811F07F4                 jbe     loc_1811F0894
+  .text:00000001811F07FA                 cmp     byte ptr [rdx], 8
+  .text:00000001811F07FD                 mov     [rbp+3A0h+var_3F0], rbx
+  .text:00000001811F0801                 jz      loc_1811F0894
+  .text:00000001811F0807                 mov     ecx, cs:dword_1820B9828
+  .text:00000001811F080D                 mov     edx, 5
+  .text:00000001811F0812                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F0818                 test    al, al
+  .text:00000001811F081A                 jz      loc_1811F17AA
+  .text:00000001811F0820                 mov     ecx, cs:dword_1820B9828
+  .text:00000001811F0826                 lea     rax, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F082D                 xor     r8d, r8d
+  .text:00000001811F0830                 mov     [rbp+3A0h+var_220], rax
+  .text:00000001811F0837                 lea     rax, aCentitysystemD; "CEntitySystem::DataDesc_AddComponentFie"...
+  .text:00000001811F083E                 mov     [rbp+3A0h+var_1E8], r8d
+  .text:00000001811F0845                 xorps   xmm0, xmm0
+  .text:00000001811F0848                 mov     [rsp+4A0h+var_478], rdi
+  .text:00000001811F084D                 xorps   xmm1, xmm1
+  .text:00000001811F0850                 mov     [rbp+3A0h+var_210], rax
+  .text:00000001811F0857                 lea     r9, aFieldSOfClassS; "Field \"%s\" of class \"%s\" cannot be "...
+  .text:00000001811F085E                 mov     [rbp+3A0h+var_218], 4BAh
+  .text:00000001811F0868                 lea     r8, [rbp+3A0h+var_220]
+  .text:00000001811F086F                 mov     [rsp+4A0h+var_480], rbx
+  .text:00000001811F0874                 mov     edx, 5
+  .text:00000001811F0879                 movdqu  [rbp+3A0h+var_208], xmm0
+  .text:00000001811F0881                 movdqu  [rbp+3A0h+var_1F8], xmm1
+  .text:00000001811F0889                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F088F                 jmp     loc_1811F17AA
+  .text:00000001811F0894                 mov     rbx, rdx
+  .text:00000001811F0897                 mov     eax, [rbx+18h]
+  .text:00000001811F089A                 and     eax, 10h
+  .text:00000001811F089D                 cmp     byte ptr [rbx], 0Ah
+  .text:00000001811F08A0                 mov     [rbp+3A0h+var_3F8], eax
+  .text:00000001811F08A3                 jnz     short loc_1811F08AF
+  .text:00000001811F08A5                 mov     r9, [rbx+38h]
+  .text:00000001811F08A9                 mov     [rbp+3A0h+var_408], r9
+  .text:00000001811F08AD                 jmp     short loc_1811F08B3
+  .text:00000001811F08AF                 mov     [rbp+3A0h+var_408], r10
+  .text:00000001811F08B3                 mov     r8, [r12+8]
+  .text:00000001811F08B8                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F08BF                 mov     qword ptr [rbp+3A0h+var_1C8], r10
+  .text:00000001811F08C6                 mov     [rbp+3A0h+var_1CC], 0C00000C8h
+  .text:00000001811F08D0                 test    r8, r8
+  .text:00000001811F08D3                 jz      short loc_1811F094B
+  .text:00000001811F08D5                 cmp     byte ptr [r8], 0
+  .text:00000001811F08D9                 jz      short loc_1811F094B
+  .text:00000001811F08DB                 test    rsi, rsi
+  .text:00000001811F08DE                 jz      short loc_1811F0922
+  .text:00000001811F08E0                 cmp     byte ptr [rsi], 0
+  .text:00000001811F08E3                 jz      short loc_1811F0922
+  .text:00000001811F08E5                 mov     qword ptr [rsp+4A0h+var_440], r8
+  .text:00000001811F08EA                 lea     rcx, [rbp+3A0h+var_1D0]
+  .text:00000001811F08F1                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F08F6                 mov     [rbp+3A0h+var_1D0], r10d
+  .text:00000001811F08FD                 xor     r9d, r9d
+  .text:00000001811F0900                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F0905                 mov     edx, 3
+  .text:00000001811F090A                 mov     [rsp+4A0h+var_430], rsi
+  .text:00000001811F090F                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0914                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F091A                 xor     r9d, r9d
+  .text:00000001811F091D                 mov     edx, r9d
+  .text:00000001811F0920                 jmp     short loc_1811F0975
+  .text:00000001811F0922                 xor     edx, edx
+  .text:00000001811F0924                 mov     [rbp+3A0h+var_1D0], r10d
+  .text:00000001811F092B                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F0931                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0936                 lea     rcx, [rbp+3A0h+var_1D0]
+  .text:00000001811F093D                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F0943                 xor     r9d, r9d
+  .text:00000001811F0946                 mov     edx, r9d
+  .text:00000001811F0949                 jmp     short loc_1811F0975
+  .text:00000001811F094B                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F0951                 mov     [rbp+3A0h+var_1D0], r10d
+  .text:00000001811F0958                 mov     r8, rsi
+  .text:00000001811F095B                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0960                 xor     edx, edx
+  .text:00000001811F0962                 lea     rcx, [rbp+3A0h+var_1D0]
+  .text:00000001811F0969                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F096F                 mov     rdx, rsi
+  .text:00000001811F0972                 xor     r9d, r9d
+  .text:00000001811F0975                 mov     eax, [rbp+3A0h+var_1CC]
+  .text:00000001811F097B                 mov     rcx, qword ptr [rbp+3A0h+var_1C8]
+  .text:00000001811F0982                 mov     [rbp+3A0h+var_400], rdx
+  .text:00000001811F0986                 bt      eax, 1Eh
+  .text:00000001811F098A                 jnb     short loc_1811F0995
+  .text:00000001811F098C                 lea     rsi, [rbp+3A0h+var_1C8]
+  .text:00000001811F0993                 jmp     short loc_1811F09A5
+  .text:00000001811F0995                 test    eax, 3FFFFFFFh
+  .text:00000001811F099A                 lea     rsi, byte_1815A2980
+  .text:00000001811F09A1                 cmova   rsi, rcx
+  .text:00000001811F09A5                 cmp     [rbp+3A0h+var_41C], 0
+  .text:00000001811F09A9                 mov     r8d, r9d
+  .text:00000001811F09AC                 mov     [rbp+3A0h+var_100], r9d
+  .text:00000001811F09B3                 mov     [rbp+3A0h+var_F8], r9
+  .text:00000001811F09BA                 mov     [rbp+3A0h+var_FC], 0C00000C8h
+  .text:00000001811F09C4                 mov     [rbp+3A0h+var_414], r9d
+  .text:00000001811F09C8                 jbe     loc_1811F178C
+  .text:00000001811F09CE                 cmp     [rsp+4A0h+var_450], 0
+  .text:00000001811F09D3                 lea     r10, aOrigin; "origin"
+  .text:00000001811F09DA                 jz      short loc_1811F0A46
+  .text:00000001811F09DC                 bt      eax, 1Eh
+  .text:00000001811F09E0                 jnb     short loc_1811F09EB
+  .text:00000001811F09E2                 lea     rdx, [rbp+3A0h+var_1C8]
+  .text:00000001811F09E9                 jmp     short loc_1811F09FB
+  .text:00000001811F09EB                 test    eax, 3FFFFFFFh
+  .text:00000001811F09F0                 lea     rdx, byte_1815A2980
+  .text:00000001811F09F7                 cmova   rdx, rcx
+  .text:00000001811F09FB                 add     r8d, [rbp+3A0h+var_418]
+  .text:00000001811F09FF                 lea     rcx, [rbp+3A0h+var_100]
+  .text:00000001811F0A06                 call    cs:?Format@CBufferString@@QEAAHPEBDZZ; CBufferString::Format(char const *,...)
+  .text:00000001811F0A0C                 mov     eax, [rbp+3A0h+var_FC]
+  .text:00000001811F0A12                 bt      eax, 1Eh
+  .text:00000001811F0A16                 jnb     short loc_1811F0A21
+  .text:00000001811F0A18                 lea     rsi, [rbp+3A0h+var_F8]
+  .text:00000001811F0A1F                 jmp     short loc_1811F0A35
+  .text:00000001811F0A21                 test    eax, 3FFFFFFFh
+  .text:00000001811F0A26                 lea     rsi, byte_1815A2980
+  .text:00000001811F0A2D                 cmova   rsi, [rbp+3A0h+var_F8]
+  .text:00000001811F0A35                 xor     r9d, r9d
+  .text:00000001811F0A38                 lea     r10, aOrigin; "origin"
+  .text:00000001811F0A3F                 mov     edx, r9d
+  .text:00000001811F0A42                 mov     [rbp+3A0h+var_400], rdx
+  .text:00000001811F0A46                 cmp     [rbp+3A0h+var_3F8], 0
+  .text:00000001811F0A4A                 jz      loc_1811F0B9F
+  .text:00000001811F0A50                 mov     r14, 0FFFFFFFFFFFFFFFFh
+  .text:00000001811F0A57                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811F0A60                 cmp     byte ptr [rsi+r14+1], 0
+  .text:00000001811F0A66                 lea     r14, [r14+1]
+  .text:00000001811F0A6A                 jnz     short loc_1811F0A60
+  .text:00000001811F0A6C                 mov     rdi, [r12]
+  .text:00000001811F0A70                 add     rdi, 1A0h
+  .text:00000001811F0A77                 movsxd  r12, dword ptr [rdi]
+  .text:00000001811F0A7A                 cmp     r12d, [rdi+10h]
+  .text:00000001811F0A7E                 jnz     loc_1811F0B30
+  .text:00000001811F0A84                 test    dword ptr [rdi+14h], 40000000h
+  .text:00000001811F0A8B                 jnz     loc_1811F0B30
+  .text:00000001811F0A91                 mov     ecx, [rdi+10h]
+  .text:00000001811F0A94                 cmp     ecx, 7FFFFFFEh
+  .text:00000001811F0A9A                 jle     short loc_1811F0AA7
+  .text:00000001811F0A9C                 mov     edx, 1
+  .text:00000001811F0AA1                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:00000001811F0AA7                 mov     ecx, [rdi+10h]
+  .text:00000001811F0AAA                 mov     r9d, 20h ; ' '
+  .text:00000001811F0AB0                 mov     edx, [rdi+14h]
+  .text:00000001811F0AB3                 and     edx, 3FFFFFFFh
+  .text:00000001811F0AB9                 lea     r15d, [rcx+1]
+  .text:00000001811F0ABD                 mov     r8d, r15d
+  .text:00000001811F0AC0                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001811F0AC6                 mov     ebx, eax
+  .text:00000001811F0AC8                 cmp     eax, r15d
+  .text:00000001811F0ACB                 jge     short loc_1811F0AF0
+  .text:00000001811F0ACD                 test    eax, eax
+  .text:00000001811F0ACF                 jnz     short loc_1811F0AE0
+  .text:00000001811F0AD1                 cmp     r15d, 0FFFFFFFFh
+  .text:00000001811F0AD5                 jg      short loc_1811F0AE0
+  .text:00000001811F0AD7                 mov     ebx, 0FFFFFFFFh
+  .text:00000001811F0ADC                 jmp     short loc_1811F0AF0
+  .text:00000001811F0AE0                 lea     eax, [rbx+r15]
+  .text:00000001811F0AE4                 cdq
+  .text:00000001811F0AE5                 sub     eax, edx
+  .text:00000001811F0AE7                 sar     eax, 1
+  .text:00000001811F0AE9                 mov     ebx, eax
+  .text:00000001811F0AEB                 cmp     eax, r15d
+  .text:00000001811F0AEE                 jl      short loc_1811F0AE0
+  .text:00000001811F0AF0                 movsxd  r9, dword ptr [rdi+10h]
+  .text:00000001811F0AF4                 mov     rcx, [rdi+8]
+  .text:00000001811F0AF8                 shl     r9, 5
+  .text:00000001811F0AFC                 test    dword ptr [rdi+14h], 0C0000000h
+  .text:00000001811F0B03                 movsxd  r8, ebx
+  .text:00000001811F0B06                 setz    dl
+  .text:00000001811F0B09                 shl     r8, 5
+  .text:00000001811F0B0D                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001811F0B13                 mov     [rdi+8], rax
+  .text:00000001811F0B17                 mov     eax, [rdi+14h]
+  .text:00000001811F0B1A                 test    eax, 0C0000000h
+  .text:00000001811F0B1F                 jz      short loc_1811F0B29
+  .text:00000001811F0B21                 and     eax, 3FFFFFFFh
+  .text:00000001811F0B26                 mov     [rdi+14h], eax
+  .text:00000001811F0B29                 mov     r15d, [rbp+3A0h+var_420]
+  .text:00000001811F0B2D                 mov     [rdi+10h], ebx
+  .text:00000001811F0B30                 inc     dword ptr [rdi]
+  .text:00000001811F0B32                 mov     rdx, r12
+  .text:00000001811F0B35                 mov     rax, [rdi+8]
+  .text:00000001811F0B39                 xor     r8d, r8d
+  .text:00000001811F0B3C                 mov     r12, [rbp+3A0h+arg_10]
+  .text:00000001811F0B43                 shl     rdx, 5
+  .text:00000001811F0B47                 mov     [rdx+rax+10h], r8
+  .text:00000001811F0B4C                 mov     rax, [r12]
+  .text:00000001811F0B50                 mov     rdi, [rax+1A8h]
+  .text:00000001811F0B57                 lea     eax, [r14+1]
+  .text:00000001811F0B5B                 movsxd  rbx, eax
+  .text:00000001811F0B5E                 add     rdi, rdx
+  .text:00000001811F0B61                 mov     rcx, rbx
+  .text:00000001811F0B64                 call    sub_180E7C9C0
+  .text:00000001811F0B69                 mov     r8, rbx
+  .text:00000001811F0B6C                 mov     [rdi], rax
+  .text:00000001811F0B6F                 mov     rdx, rsi
+  .text:00000001811F0B72                 mov     rcx, rax
+  .text:00000001811F0B75                 call    sub_1815513D0
+  .text:00000001811F0B7A                 mov     r14, [rbp+3A0h+arg_0]
+  .text:00000001811F0B81                 xor     r9d, r9d
+  .text:00000001811F0B84                 mov     rbx, [rbp+3A0h+arg_20]
+  .text:00000001811F0B8B                 mov     [rdi+8], r9d
+  .text:00000001811F0B8F                 mov     [rdi+18h], r15d
+  .text:00000001811F0B93                 mov     rdi, [rbp+3A0h+arg_18]
+  .text:00000001811F0B9A                 jmp     loc_1811F16D1
+  .text:00000001811F0B9F                 mov     rcx, [rbp+3A0h+var_408]
+  .text:00000001811F0BA3                 test    rcx, rcx
+  .text:00000001811F0BA6                 jz      loc_1811F0E7A
+  .text:00000001811F0BAC                 mov     eax, [rbx+18h]
+  .text:00000001811F0BAF                 test    al, 40h
+  .text:00000001811F0BB1                 jnz     loc_1811F0C41
+  .text:00000001811F0BB7                 shr     eax, 12h
+  .text:00000001811F0BBA                 test    al, 1
+  .text:00000001811F0BBC                 jz      short loc_1811F0BC3
+  .text:00000001811F0BBE                 mov     ebx, r13d
+  .text:00000001811F0BC1                 jmp     short loc_1811F0BCB
+  .text:00000001811F0BC3                 mov     rdi, [rcx+10h]
+  .text:00000001811F0BC7                 lea     ebx, [r13+1]
+  .text:00000001811F0BCB                 mov     rax, [r12+20h]
+  .text:00000001811F0BD0                 mov     r9, rdi
+  .text:00000001811F0BD3                 mov     [rsp+4A0h+var_460], rax
+  .text:00000001811F0BD8                 mov     r8, rsi
+  .text:00000001811F0BDB                 mov     rax, [r12]
+  .text:00000001811F0BDF                 mov     edx, ebx
+  .text:00000001811F0BE1                 mov     [rsp+4A0h+var_468], rax
+  .text:00000001811F0BE6                 mov     byte ptr [rsp+4A0h+var_470], 1
+  .text:00000001811F0BEB                 mov     dword ptr [rsp+4A0h+var_478], r15d
+  .text:00000001811F0BF0                 mov     [rsp+4A0h+var_480], rcx
+  .text:00000001811F0BF5                 mov     rcx, r14
+  .text:00000001811F0BF8                 call    sub_1811F2180
+  .text:00000001811F0BFD                 mov     rax, [r12+20h]
+  .text:00000001811F0C02                 mov     r8, rsi
+  .text:00000001811F0C05                 mov     r9, [rbp+3A0h+var_408]
+  .text:00000001811F0C09                 mov     edx, ebx
+  .text:00000001811F0C0B                 mov     [rsp+4A0h+var_468], rax
+  .text:00000001811F0C10                 mov     rcx, r14
+  .text:00000001811F0C13                 mov     rax, [r12]
+  .text:00000001811F0C17                 mov     [rsp+4A0h+var_470], rax
+  .text:00000001811F0C1C                 mov     byte ptr [rsp+4A0h+var_478], 1
+  .text:00000001811F0C21                 mov     [rsp+4A0h+var_480], r9
+  .text:00000001811F0C26                 mov     r9, rdi
+  .text:00000001811F0C29                 call    sub_1811F17D0
+  .text:00000001811F0C2E                 mov     rdi, [rbp+3A0h+arg_18]
+  .text:00000001811F0C35                 mov     rbx, [rbp+3A0h+arg_20]
+  .text:00000001811F0C3C                 jmp     loc_1811F16CE
+  .text:00000001811F0C41                 lea     rdx, [rbp+3A0h+var_1E0]
+  .text:00000001811F0C48                 lea     rcx, [r14+0CB8h]
+  .text:00000001811F0C4F                 call    cs:?GetCurrentAllocPoint@CUtlScratchMemoryPool@@QEBA?AUUtlScratchMemoryPoolMark_t@@XZ; CUtlScratchMemoryPool::GetCurrentAllocPoint(void)
+  .text:00000001811F0C55                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0C59                 call    sub_1811EBA10
+  .text:00000001811F0C5E                 mov     rax, [r12+20h]
+  .text:00000001811F0C63                 lea     edx, [r13+1]
+  .text:00000001811F0C67                 mov     r9, [rbp+3A0h+var_408]
+  .text:00000001811F0C6B                 xor     r8d, r8d
+  .text:00000001811F0C6E                 mov     [rsp+4A0h+var_460], rax
+  .text:00000001811F0C73                 mov     rcx, r14
+  .text:00000001811F0C76                 lea     rax, [rbp+3A0h+var_3E0]
+  .text:00000001811F0C7A                 mov     [rsp+4A0h+var_468], rax
+  .text:00000001811F0C7F                 mov     byte ptr [rsp+4A0h+var_470], 1
+  .text:00000001811F0C84                 mov     dword ptr [rsp+4A0h+var_478], r8d
+  .text:00000001811F0C89                 mov     r8, rsi
+  .text:00000001811F0C8C                 mov     [rsp+4A0h+var_480], r9
+  .text:00000001811F0C91                 mov     r9, [r9+10h]
+  .text:00000001811F0C95                 call    sub_1811F2180
+  .text:00000001811F0C9A                 mov     rax, [r12+20h]
+  .text:00000001811F0C9F                 lea     edx, [r13+1]
+  .text:00000001811F0CA3                 mov     [rsp+4A0h+var_468], rax
+  .text:00000001811F0CA8                 mov     r8, rsi
+  .text:00000001811F0CAB                 lea     rax, [rbp+3A0h+var_3E0]
+  .text:00000001811F0CAF                 mov     rcx, r14
+  .text:00000001811F0CB2                 mov     [rsp+4A0h+var_470], rax
+  .text:00000001811F0CB7                 mov     rax, [rbp+3A0h+var_408]
+  .text:00000001811F0CBB                 mov     byte ptr [rsp+4A0h+var_478], 1
+  .text:00000001811F0CC0                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F0CC5                 mov     r9, [rax+10h]
+  .text:00000001811F0CC9                 call    sub_1811F17D0
+  .text:00000001811F0CCE                 mov     eax, dword ptr [rbp+3A0h+var_3D8+4]
+  .text:00000001811F0CD1                 test    eax, eax
+  .text:00000001811F0CD3                 jnz     short loc_1811F0D20
+  .text:00000001811F0CD5                 cmp     [rbp+3A0h+var_240], eax
+  .text:00000001811F0CDB                 jnz     short loc_1811F0D20
+  .text:00000001811F0CDD                 cmp     [rbp+3A0h+var_258], eax
+  .text:00000001811F0CE3                 jnz     short loc_1811F0D20
+  .text:00000001811F0CE5                 movaps  xmm0, [rbp+3A0h+var_1E0]
+  .text:00000001811F0CEC                 lea     rdx, [rsp+4A0h+var_440]
+  .text:00000001811F0CF1                 lea     rcx, [r14+0CB8h]
+  .text:00000001811F0CF8                 movdqa  [rsp+4A0h+var_440], xmm0
+  .text:00000001811F0CFE                 call    cs:?FreeToAllocPoint@CUtlScratchMemoryPool@@QEAAXUUtlScratchMemoryPoolMark_t@@@Z; CUtlScratchMemoryPool::FreeToAllocPoint(UtlScratchMemoryPoolMark_t)
+  .text:00000001811F0D04                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0D08                 call    sub_1811EC450
+  .text:00000001811F0D0D                 mov     rdi, [rbp+3A0h+arg_18]
+  .text:00000001811F0D14                 mov     rbx, [rbp+3A0h+arg_20]
+  .text:00000001811F0D1B                 jmp     loc_1811F16CE
+  .text:00000001811F0D20                 mov     edx, 30h ; '0'
+  .text:00000001811F0D25                 lea     rcx, [r14+0CB8h]
+  .text:00000001811F0D2C                 mov     r8d, 10h
+  .text:00000001811F0D32                 call    cs:?AllocAligned@CUtlScratchMemoryPool@@QEAAPEAXHH@Z; CUtlScratchMemoryPool::AllocAligned(int,int)
+  .text:00000001811F0D38                 mov     r15, rax
+  .text:00000001811F0D3B                 lea     r8, [r14+0CB8h]
+  .text:00000001811F0D42                 xor     eax, eax
+  .text:00000001811F0D44                 lea     rdx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0D48                 mov     rcx, r15
+  .text:00000001811F0D4B                 mov     [r15], rax
+  .text:00000001811F0D4E                 mov     qword ptr [r15+8], 9
+  .text:00000001811F0D56                 mov     [r15+10h], rax
+  .text:00000001811F0D5A                 mov     [r15+18h], rax
+  .text:00000001811F0D5E                 mov     [r15+20h], rax
+  .text:00000001811F0D62                 mov     [r15+28h], rax
+  .text:00000001811F0D66                 call    sub_1811F8BC0
+  .text:00000001811F0D6B                 mov     r14, [r12]
+  .text:00000001811F0D6F                 ; 0x188 = 392 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+  .text:00000001811F0D6F                 add     r14, 188h  ; 0x188 = 392 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+  .text:00000001811F0D76                 movsxd  r12, dword ptr [r14]
+  .text:00000001811F0D79                 cmp     r12d, [r14+10h]
+  .text:00000001811F0D7D                 jnz     loc_1811F0E2E
+  .text:00000001811F0D83                 test    dword ptr [r14+14h], 40000000h
+  .text:00000001811F0D8B                 jnz     loc_1811F0E2E
+  .text:00000001811F0D91                 mov     ecx, [r14+10h]
+  .text:00000001811F0D95                 cmp     ecx, 7FFFFFFEh
+  .text:00000001811F0D9B                 jle     short loc_1811F0DA8
+  .text:00000001811F0D9D                 mov     edx, 1
+  .text:00000001811F0DA2                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:00000001811F0DA8                 mov     ecx, [r14+10h]
+  .text:00000001811F0DAC                 mov     r9d, 10h
+  .text:00000001811F0DB2                 mov     edx, [r14+14h]
+  .text:00000001811F0DB6                 and     edx, 3FFFFFFFh
+  .text:00000001811F0DBC                 lea     edi, [rcx+1]
+  .text:00000001811F0DBF                 mov     r8d, edi
+  .text:00000001811F0DC2                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001811F0DC8                 mov     ebx, eax
+  .text:00000001811F0DCA                 cmp     eax, edi
+  .text:00000001811F0DCC                 jge     short loc_1811F0DEE
+  .text:00000001811F0DCE                 test    eax, eax
+  .text:00000001811F0DD0                 jnz     short loc_1811F0DE0
+  .text:00000001811F0DD2                 cmp     edi, 0FFFFFFFFh
+  .text:00000001811F0DD5                 jg      short loc_1811F0DE0
+  .text:00000001811F0DD7                 mov     ebx, 0FFFFFFFFh
+  .text:00000001811F0DDC                 jmp     short loc_1811F0DEE
+  .text:00000001811F0DE0                 lea     eax, [rbx+rdi]
+  .text:00000001811F0DE3                 cdq
+  .text:00000001811F0DE4                 sub     eax, edx
+  .text:00000001811F0DE6                 sar     eax, 1
+  .text:00000001811F0DE8                 mov     ebx, eax
+  .text:00000001811F0DEA                 cmp     eax, edi
+  .text:00000001811F0DEC                 jl      short loc_1811F0DE0
+  .text:00000001811F0DEE                 movsxd  r9, dword ptr [r14+10h]
+  .text:00000001811F0DF2                 mov     rcx, [r14+8]
+  .text:00000001811F0DF6                 shl     r9, 4
+  .text:00000001811F0DFA                 test    dword ptr [r14+14h], 0C0000000h
+  .text:00000001811F0E02                 movsxd  r8, ebx
+  .text:00000001811F0E05                 setz    dl
+  .text:00000001811F0E08                 shl     r8, 4
+  .text:00000001811F0E0C                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001811F0E12                 mov     [r14+8], rax
+  .text:00000001811F0E16                 mov     eax, [r14+14h]
+  .text:00000001811F0E1A                 test    eax, 0C0000000h
+  .text:00000001811F0E1F                 jz      short loc_1811F0E2A
+  .text:00000001811F0E21                 and     eax, 3FFFFFFFh
+  .text:00000001811F0E26                 mov     [r14+14h], eax
+  .text:00000001811F0E2A                 mov     [r14+10h], ebx
+  .text:00000001811F0E2E                 inc     dword ptr [r14]
+  .text:00000001811F0E31                 mov     rcx, r12
+  .text:00000001811F0E34                 mov     r12, [rbp+3A0h+arg_10]
+  .text:00000001811F0E3B                 shl     rcx, 4
+  .text:00000001811F0E3F                 mov     rax, [r12]
+  .text:00000001811F0E43                 add     rcx, [rax+190h]
+  .text:00000001811F0E4A                 mov     eax, [rbp+3A0h+var_420]
+  .text:00000001811F0E4D                 mov     [rcx], eax
+  .text:00000001811F0E4F                 mov     [rcx+8], r15
+  .text:00000001811F0E53                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0E57                 call    sub_1811EC450
+  .text:00000001811F0E5C                 mov     r15d, [rbp+3A0h+var_420]
+  .text:00000001811F0E60                 mov     rdi, [rbp+3A0h+arg_18]
+  .text:00000001811F0E67                 mov     r14, [rbp+3A0h+arg_0]
+  .text:00000001811F0E6E                 mov     rbx, [rbp+3A0h+arg_20]
+  .text:00000001811F0E75                 jmp     loc_1811F16CE
+  .text:00000001811F0E7A                 movzx   eax, byte ptr [rbx]
+  .text:00000001811F0E7D                 cmp     al, 3Bh ; ';'
+  .text:00000001811F0E7F                 jnz     loc_1811F1075
+  .text:00000001811F0E85                 mov     [rbp-38h], r9
+  .text:00000001811F0E89                 mov     [rbp+3A0h+var_3DC], 0C00000C8h
+  .text:00000001811F0E90                 test    rsi, rsi
+  .text:00000001811F0E93                 jz      short loc_1811F0ED6
+  .text:00000001811F0E95                 cmp     byte ptr [rsi], 0
+  .text:00000001811F0E98                 jz      short loc_1811F0ED6
+  .text:00000001811F0E9A                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F0E9E                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F0EA5                 xor     r9d, r9d
+  .text:00000001811F0EA8                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F0EAD                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F0EB2                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F0EB7                 mov     edx, 3
+  .text:00000001811F0EBC                 mov     [rsp+4A0h+var_430], r10
+  .text:00000001811F0EC1                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0EC5                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0ECA                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F0ED0                 xor     edx, edx
+  .text:00000001811F0ED2                 mov     ecx, edx
+  .text:00000001811F0ED4                 jmp     short loc_1811F0EFD
+  .text:00000001811F0ED6                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F0EDA                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0EDE                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F0EE4                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0EE9                 mov     r8, r10
+  .text:00000001811F0EEC                 xor     edx, edx
+  .text:00000001811F0EEE                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F0EF4                 lea     rcx, aOrigin; "origin"
+  .text:00000001811F0EFB                 xor     edx, edx
+  .text:00000001811F0EFD                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F0F00                 bt      eax, 1Eh
+  .text:00000001811F0F04                 jnb     short loc_1811F0F0C
+  .text:00000001811F0F06                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0F0A                 jmp     short loc_1811F0F1D
+  .text:00000001811F0F0C                 test    eax, 3FFFFFFFh
+  .text:00000001811F0F11                 lea     rax, byte_1815A2980
+  .text:00000001811F0F18                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0F1D                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F0F22                 lea     ebx, [r13+1]
+  .text:00000001811F0F26                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F0F2B                 mov     r9, rdi
+  .text:00000001811F0F2E                 mov     byte ptr [rsp+4A0h+var_468], 3
+  .text:00000001811F0F33                 mov     r8, r12
+  .text:00000001811F0F36                 mov     [rsp+4A0h+var_470], rdx
+  .text:00000001811F0F3B                 mov     edx, ebx
+  .text:00000001811F0F3D                 mov     [rsp+4A0h+var_478], rcx
+  .text:00000001811F0F42                 mov     rcx, r14
+  .text:00000001811F0F45                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F0F4A                 call    sub_1811ED960
+  .text:00000001811F0F4F                 test    rsi, rsi
+  .text:00000001811F0F52                 jz      short loc_1811F0FBF
+  .text:00000001811F0F54                 cmp     byte ptr [rsi], 0
+  .text:00000001811F0F57                 jz      short loc_1811F0FBF
+  .text:00000001811F0F59                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F0F5C                 test    eax, 3FFFFFFFh
+  .text:00000001811F0F61                 jbe     short loc_1811F0F77
+  .text:00000001811F0F63                 bt      eax, 1Eh
+  .text:00000001811F0F67                 lea     ebx, [r13+1]
+  .text:00000001811F0F6B                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0F6F                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0F74                 mov     byte ptr [rax], 0
+  .text:00000001811F0F77                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F0F7E                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F0F85                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F0F8A                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F0F8F                 lea     rax, aAngles; "angles"
+  .text:00000001811F0F96                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F0F9B                 xor     r9d, r9d
+  .text:00000001811F0F9E                 mov     [rsp+4A0h+var_430], rax
+  .text:00000001811F0FA3                 mov     edx, 3
+  .text:00000001811F0FA8                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0FAD                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0FB1                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F0FB7                 xor     r8d, r8d
+  .text:00000001811F0FBA                 mov     edx, r8d
+  .text:00000001811F0FBD                 jmp     short loc_1811F100C
+  .text:00000001811F0FBF                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F0FC2                 test    eax, 3FFFFFFFh
+  .text:00000001811F0FC7                 jbe     short loc_1811F0FDD
+  .text:00000001811F0FC9                 bt      eax, 1Eh
+  .text:00000001811F0FCD                 lea     ebx, [r13+1]
+  .text:00000001811F0FD1                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0FD5                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F0FDA                 mov     byte ptr [rax], 0
+  .text:00000001811F0FDD                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F0FE4                 lea     r8, aAngles; "angles"
+  .text:00000001811F0FEB                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F0FF1                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F0FF6                 xor     edx, edx
+  .text:00000001811F0FF8                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F0FFC                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F1002                 lea     rdx, aAngles; "angles"
+  .text:00000001811F1009                 xor     r8d, r8d
+  .text:00000001811F100C                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F100F                 bt      eax, 1Eh
+  .text:00000001811F1013                 jnb     short loc_1811F101B
+  .text:00000001811F1015                 lea     rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F1019                 jmp     short loc_1811F102C
+  .text:00000001811F101B                 test    eax, 3FFFFFFFh
+  .text:00000001811F1020                 lea     rcx, byte_1815A2980
+  .text:00000001811F1027                 cmova   rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F102C                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F1031                 lea     eax, [r15+10h]
+  .text:00000001811F1035                 mov     dword ptr [rsp+4A0h+var_460], eax
+  .text:00000001811F1039                 mov     byte ptr [rsp+4A0h+var_468], 4
+  .text:00000001811F103E                 mov     [rsp+4A0h+var_470], r8
+  .text:00000001811F1043                 mov     [rsp+4A0h+var_478], rdx
+  .text:00000001811F1048                 mov     [rsp+4A0h+var_480], rcx
+  .text:00000001811F104D                 mov     r9, rdi
+  .text:00000001811F1050                 mov     r8, r12
+  .text:00000001811F1053                 mov     edx, ebx
+  .text:00000001811F1055                 mov     rcx, r14
+  .text:00000001811F1058                 call    sub_1811ED960
+  .text:00000001811F105D                 xor     edx, edx
+  .text:00000001811F105F                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1063                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001811F1069                 mov     rbx, [rbp+3A0h+arg_20]
+  .text:00000001811F1070                 jmp     loc_1811F16CE
+  .text:00000001811F1075                 cmp     al, 3Ch ; '<'
+  .text:00000001811F1077                 jnz     loc_1811F123B
+  .text:00000001811F107D                 mov     [rbp+3A0h+var_3D8], r9
+  .text:00000001811F1081                 mov     [rbp+3A0h+var_3DC], 0C00000C8h
+  .text:00000001811F1088                 test    rsi, rsi
+  .text:00000001811F108B                 jz      short loc_1811F10CE
+  .text:00000001811F108D                 cmp     byte ptr [rsi], 0
+  .text:00000001811F1090                 jz      short loc_1811F10CE
+  .text:00000001811F1092                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F1096                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F109D                 xor     r9d, r9d
+  .text:00000001811F10A0                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F10A5                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F10AA                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F10AF                 mov     edx, 3
+  .text:00000001811F10B4                 mov     [rsp+4A0h+var_430], r10
+  .text:00000001811F10B9                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F10BD                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F10C2                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F10C8                 xor     edx, edx
+  .text:00000001811F10CA                 mov     ecx, edx
+  .text:00000001811F10CC                 jmp     short loc_1811F10F5
+  .text:00000001811F10CE                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F10D2                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F10D6                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F10DC                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F10E1                 mov     r8, r10
+  .text:00000001811F10E4                 xor     edx, edx
+  .text:00000001811F10E6                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F10EC                 lea     rcx, aOrigin; "origin"
+  .text:00000001811F10F3                 xor     edx, edx
+  .text:00000001811F10F5                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F10F8                 bt      eax, 1Eh
+  .text:00000001811F10FC                 jnb     short loc_1811F1104
+  .text:00000001811F10FE                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1102                 jmp     short loc_1811F1115
+  .text:00000001811F1104                 test    eax, 3FFFFFFFh
+  .text:00000001811F1109                 lea     rax, byte_1815A2980
+  .text:00000001811F1110                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1115                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F111A                 lea     ebx, [r13+1]
+  .text:00000001811F111E                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F1123                 mov     r9, rdi
+  .text:00000001811F1126                 mov     byte ptr [rsp+4A0h+var_468], 0Eh
+  .text:00000001811F112B                 mov     r8, r12
+  .text:00000001811F112E                 mov     [rsp+4A0h+var_470], rdx
+  .text:00000001811F1133                 mov     edx, ebx
+  .text:00000001811F1135                 mov     [rsp+4A0h+var_478], rcx
+  .text:00000001811F113A                 mov     rcx, r14
+  .text:00000001811F113D                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F1142                 call    sub_1811ED960
+  .text:00000001811F1147                 test    rsi, rsi
+  .text:00000001811F114A                 jz      short loc_1811F11B7
+  .text:00000001811F114C                 cmp     byte ptr [rsi], 0
+  .text:00000001811F114F                 jz      short loc_1811F11B7
+  .text:00000001811F1151                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F1154                 test    eax, 3FFFFFFFh
+  .text:00000001811F1159                 jbe     short loc_1811F116F
+  .text:00000001811F115B                 bt      eax, 1Eh
+  .text:00000001811F115F                 lea     ebx, [r13+1]
+  .text:00000001811F1163                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1167                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F116C                 mov     byte ptr [rax], 0
+  .text:00000001811F116F                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F1176                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F117D                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F1182                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F1187                 lea     rax, aAngles; "angles"
+  .text:00000001811F118E                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F1193                 xor     r9d, r9d
+  .text:00000001811F1196                 mov     [rsp+4A0h+var_430], rax
+  .text:00000001811F119B                 mov     edx, 3
+  .text:00000001811F11A0                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F11A5                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F11A9                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F11AF                 xor     r8d, r8d
+  .text:00000001811F11B2                 mov     edx, r8d
+  .text:00000001811F11B5                 jmp     short loc_1811F1204
+  .text:00000001811F11B7                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F11BA                 test    eax, 3FFFFFFFh
+  .text:00000001811F11BF                 jbe     short loc_1811F11D5
+  .text:00000001811F11C1                 bt      eax, 1Eh
+  .text:00000001811F11C5                 lea     ebx, [r13+1]
+  .text:00000001811F11C9                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F11CD                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F11D2                 mov     byte ptr [rax], 0
+  .text:00000001811F11D5                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F11DC                 lea     r8, aAngles; "angles"
+  .text:00000001811F11E3                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F11E9                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F11EE                 xor     edx, edx
+  .text:00000001811F11F0                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F11F4                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F11FA                 lea     rdx, aAngles; "angles"
+  .text:00000001811F1201                 xor     r8d, r8d
+  .text:00000001811F1204                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F1207                 bt      eax, 1Eh
+  .text:00000001811F120B                 jnb     short loc_1811F1213
+  .text:00000001811F120D                 lea     rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F1211                 jmp     short loc_1811F1224
+  .text:00000001811F1213                 test    eax, 3FFFFFFFh
+  .text:00000001811F1218                 lea     rcx, byte_1815A2980
+  .text:00000001811F121F                 cmova   rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F1224                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F1229                 lea     eax, [r15+10h]
+  .text:00000001811F122D                 mov     dword ptr [rsp+4A0h+var_460], eax
+  .text:00000001811F1231                 mov     byte ptr [rsp+4A0h+var_468], 2Fh ; '/'
+  .text:00000001811F1236                 jmp     loc_1811F103E
+  .text:00000001811F123B                 cmp     al, 40h ; '@'
+  .text:00000001811F123D                 jnz     loc_1811F1401
+  .text:00000001811F1243                 mov     [rbp+3A0h+var_3D8], r9
+  .text:00000001811F1247                 mov     [rbp+3A0h+var_3DC], 0C00000C8h
+  .text:00000001811F124E                 test    rsi, rsi
+  .text:00000001811F1251                 jz      short loc_1811F1294
+  .text:00000001811F1253                 cmp     byte ptr [rsi], 0
+  .text:00000001811F1256                 jz      short loc_1811F1294
+  .text:00000001811F1258                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F125C                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F1263                 xor     r9d, r9d
+  .text:00000001811F1266                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F126B                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F1270                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F1275                 mov     edx, 3
+  .text:00000001811F127A                 mov     [rsp+4A0h+var_430], r10
+  .text:00000001811F127F                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1283                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F1288                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F128E                 xor     edx, edx
+  .text:00000001811F1290                 mov     ecx, edx
+  .text:00000001811F1292                 jmp     short loc_1811F12BB
+  .text:00000001811F1294                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F1298                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F129C                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F12A2                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F12A7                 mov     r8, r10
+  .text:00000001811F12AA                 xor     edx, edx
+  .text:00000001811F12AC                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F12B2                 lea     rcx, aOrigin; "origin"
+  .text:00000001811F12B9                 xor     edx, edx
+  .text:00000001811F12BB                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F12BE                 bt      eax, 1Eh
+  .text:00000001811F12C2                 jnb     short loc_1811F12CA
+  .text:00000001811F12C4                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F12C8                 jmp     short loc_1811F12DB
+  .text:00000001811F12CA                 test    eax, 3FFFFFFFh
+  .text:00000001811F12CF                 lea     rax, byte_1815A2980
+  .text:00000001811F12D6                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F12DB                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F12E0                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F12E5                 mov     byte ptr [rsp+4A0h+var_468], 3
+  .text:00000001811F12EA                 mov     [rsp+4A0h+var_470], rdx
+  .text:00000001811F12EF                 lea     ebx, [r13+1]
+  .text:00000001811F12F3                 mov     [rsp+4A0h+var_478], rcx
+  .text:00000001811F12F8                 mov     edx, ebx
+  .text:00000001811F12FA                 mov     rcx, r14
+  .text:00000001811F12FD                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F1302                 mov     r9, rdi
+  .text:00000001811F1305                 mov     r8, r12
+  .text:00000001811F1308                 call    sub_1811ED960
+  .text:00000001811F130D                 test    rsi, rsi
+  .text:00000001811F1310                 jz      short loc_1811F137D
+  .text:00000001811F1312                 cmp     byte ptr [rsi], 0
+  .text:00000001811F1315                 jz      short loc_1811F137D
+  .text:00000001811F1317                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F131A                 test    eax, 3FFFFFFFh
+  .text:00000001811F131F                 jbe     short loc_1811F1335
+  .text:00000001811F1321                 bt      eax, 1Eh
+  .text:00000001811F1325                 lea     ebx, [r13+1]
+  .text:00000001811F1329                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F132D                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1332                 mov     byte ptr [rax], 0
+  .text:00000001811F1335                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F133C                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F1343                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F1348                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F134D                 lea     rax, aAngles; "angles"
+  .text:00000001811F1354                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F1359                 xor     r9d, r9d
+  .text:00000001811F135C                 mov     [rsp+4A0h+var_430], rax
+  .text:00000001811F1361                 mov     edx, 3
+  .text:00000001811F1366                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F136B                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F136F                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F1375                 xor     r8d, r8d
+  .text:00000001811F1378                 mov     edx, r8d
+  .text:00000001811F137B                 jmp     short loc_1811F13CA
+  .text:00000001811F137D                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F1380                 test    eax, 3FFFFFFFh
+  .text:00000001811F1385                 jbe     short loc_1811F139B
+  .text:00000001811F1387                 bt      eax, 1Eh
+  .text:00000001811F138B                 lea     ebx, [r13+1]
+  .text:00000001811F138F                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1393                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1398                 mov     byte ptr [rax], 0
+  .text:00000001811F139B                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F13A2                 lea     r8, aAngles; "angles"
+  .text:00000001811F13A9                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F13AF                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F13B4                 xor     edx, edx
+  .text:00000001811F13B6                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F13BA                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F13C0                 lea     rdx, aAngles; "angles"
+  .text:00000001811F13C7                 xor     r8d, r8d
+  .text:00000001811F13CA                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F13CD                 bt      eax, 1Eh
+  .text:00000001811F13D1                 jnb     short loc_1811F13D9
+  .text:00000001811F13D3                 lea     rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F13D7                 jmp     short loc_1811F13EA
+  .text:00000001811F13D9                 test    eax, 3FFFFFFFh
+  .text:00000001811F13DE                 lea     rcx, byte_1815A2980
+  .text:00000001811F13E5                 cmova   rcx, [rbp+3A0h+var_3D8]
+  .text:00000001811F13EA                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F13EF                 lea     eax, [r15+0Ch]
+  .text:00000001811F13F3                 mov     dword ptr [rsp+4A0h+var_460], eax
+  .text:00000001811F13F7                 mov     byte ptr [rsp+4A0h+var_468], 1
+  .text:00000001811F13FC                 jmp     loc_1811F103E
+  .text:00000001811F1401                 cmp     al, 41h ; 'A'
+  .text:00000001811F1403                 jnz     loc_1811F14C7
+  .text:00000001811F1409                 mov     [rbp+3A0h+var_3D8], r9
+  .text:00000001811F140D                 mov     [rbp+3A0h+var_3DC], 0C00000C8h
+  .text:00000001811F1414                 test    rsi, rsi
+  .text:00000001811F1417                 jz      short loc_1811F145A
+  .text:00000001811F1419                 cmp     byte ptr [rsi], 0
+  .text:00000001811F141C                 jz      short loc_1811F145A
+  .text:00000001811F141E                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F1422                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F1429                 xor     r9d, r9d
+  .text:00000001811F142C                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F1431                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F1436                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F143B                 mov     edx, 3
+  .text:00000001811F1440                 mov     [rsp+4A0h+var_430], r10
+  .text:00000001811F1445                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1449                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F144E                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F1454                 xor     edx, edx
+  .text:00000001811F1456                 mov     ecx, edx
+  .text:00000001811F1458                 jmp     short loc_1811F1481
+  .text:00000001811F145A                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F145E                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1462                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F1468                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F146D                 mov     r8, r10
+  .text:00000001811F1470                 xor     edx, edx
+  .text:00000001811F1472                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F1478                 lea     rcx, aOrigin; "origin"
+  .text:00000001811F147F                 xor     edx, edx
+  .text:00000001811F1481                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F1484                 bt      eax, 1Eh
+  .text:00000001811F1488                 jnb     short loc_1811F14A2
+  .text:00000001811F148A                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F148F                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1493                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F1498                 mov     byte ptr [rsp+4A0h+var_468], 0Eh
+  .text:00000001811F149D                 jmp     loc_1811F12EA
+  .text:00000001811F14A2                 test    eax, 3FFFFFFFh
+  .text:00000001811F14A7                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F14AC                 lea     rax, byte_1815A2980
+  .text:00000001811F14B3                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F14B8                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F14BD                 mov     byte ptr [rsp+4A0h+var_468], 0Eh
+  .text:00000001811F14C2                 jmp     loc_1811F12EA
+  .text:00000001811F14C7                 cmp     al, 16h
+  .text:00000001811F14C9                 jnz     loc_1811F1696
+  .text:00000001811F14CF                 mov     [rbp+3A0h+var_3D8], r9
+  .text:00000001811F14D3                 mov     [rbp+3A0h+var_3DC], 0C00000C8h
+  .text:00000001811F14DA                 test    rsi, rsi
+  .text:00000001811F14DD                 jz      short loc_1811F1520
+  .text:00000001811F14DF                 cmp     byte ptr [rsi], 0
+  .text:00000001811F14E2                 jz      short loc_1811F1520
+  .text:00000001811F14E4                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F14E8                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F14EF                 xor     r9d, r9d
+  .text:00000001811F14F2                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F14F7                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F14FC                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F1501                 mov     edx, 3
+  .text:00000001811F1506                 mov     [rsp+4A0h+var_430], r10
+  .text:00000001811F150B                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F150F                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F1514                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F151A                 xor     edx, edx
+  .text:00000001811F151C                 mov     ecx, edx
+  .text:00000001811F151E                 jmp     short loc_1811F1547
+  .text:00000001811F1520                 mov     [rbp+3A0h+var_3E0], r9d
+  .text:00000001811F1524                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1528                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F152E                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F1533                 mov     r8, r10
+  .text:00000001811F1536                 xor     edx, edx
+  .text:00000001811F1538                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F153E                 lea     rcx, aOrigin; "origin"
+  .text:00000001811F1545                 xor     edx, edx
+  .text:00000001811F1547                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F154A                 bt      eax, 1Eh
+  .text:00000001811F154E                 jnb     short loc_1811F1556
+  .text:00000001811F1550                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1554                 jmp     short loc_1811F1567
+  .text:00000001811F1556                 test    eax, 3FFFFFFFh
+  .text:00000001811F155B                 lea     rax, byte_1815A2980
+  .text:00000001811F1562                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1567                 mov     [rsp+4A0h+var_458], 1
+  .text:00000001811F156C                 lea     ebx, [r13+1]
+  .text:00000001811F1570                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F1575                 mov     r9, rdi
+  .text:00000001811F1578                 mov     byte ptr [rsp+4A0h+var_468], 0Eh
+  .text:00000001811F157D                 mov     r8, r12
+  .text:00000001811F1580                 mov     [rsp+4A0h+var_470], rdx
+  .text:00000001811F1585                 mov     edx, ebx
+  .text:00000001811F1587                 mov     [rsp+4A0h+var_478], rcx
+  .text:00000001811F158C                 mov     rcx, r14
+  .text:00000001811F158F                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F1594                 call    sub_1811ED960
+  .text:00000001811F1599                 test    rsi, rsi
+  .text:00000001811F159C                 jz      short loc_1811F1607
+  .text:00000001811F159E                 cmp     byte ptr [rsi], 0
+  .text:00000001811F15A1                 jz      short loc_1811F1607
+  .text:00000001811F15A3                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F15A6                 test    eax, 3FFFFFFFh
+  .text:00000001811F15AB                 jbe     short loc_1811F15C1
+  .text:00000001811F15AD                 bt      eax, 1Eh
+  .text:00000001811F15B1                 lea     ebx, [r13+1]
+  .text:00000001811F15B5                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F15B9                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F15BE                 mov     byte ptr [rax], 0
+  .text:00000001811F15C1                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F15C8                 lea     rax, asc_1815EB398; "."
+  .text:00000001811F15CF                 mov     qword ptr [rsp+4A0h+var_440+8], rax
+  .text:00000001811F15D4                 lea     r8, [rsp+4A0h+var_440]
+  .text:00000001811F15D9                 lea     rax, aAngles; "angles"
+  .text:00000001811F15E0                 mov     qword ptr [rsp+4A0h+var_440], rsi
+  .text:00000001811F15E5                 xor     r9d, r9d
+  .text:00000001811F15E8                 mov     [rsp+4A0h+var_430], rax
+  .text:00000001811F15ED                 mov     edx, 3
+  .text:00000001811F15F2                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F15F7                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F15FB                 call    cs:?AppendConcat@CBufferString@@QEAAPEBDHPEBQEBDPEBH_N@Z; CBufferString::AppendConcat(int,char const * const *,int const *,bool)
+  .text:00000001811F1601                 xor     edx, edx
+  .text:00000001811F1603                 mov     ecx, edx
+  .text:00000001811F1605                 jmp     short loc_1811F1653
+  .text:00000001811F1607                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F160A                 test    eax, 3FFFFFFFh
+  .text:00000001811F160F                 jbe     short loc_1811F1625
+  .text:00000001811F1611                 bt      eax, 1Eh
+  .text:00000001811F1615                 lea     ebx, [r13+1]
+  .text:00000001811F1619                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F161D                 cmovnb  rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1622                 mov     byte ptr [rax], 0
+  .text:00000001811F1625                 and     [rbp+3A0h+var_3E0], 0C0000000h
+  .text:00000001811F162C                 lea     r8, aAngles; "angles"
+  .text:00000001811F1633                 mov     r9d, 0FFFFFFFFh
+  .text:00000001811F1639                 mov     byte ptr [rsp+4A0h+var_480], 0
+  .text:00000001811F163E                 xor     edx, edx
+  .text:00000001811F1640                 lea     rcx, [rbp+3A0h+var_3E0]
+  .text:00000001811F1644                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001811F164A                 lea     rcx, aAngles; "angles"
+  .text:00000001811F1651                 xor     edx, edx
+  .text:00000001811F1653                 mov     eax, [rbp+3A0h+var_3DC]
+  .text:00000001811F1656                 bt      eax, 1Eh
+  .text:00000001811F165A                 jnb     short loc_1811F1662
+  .text:00000001811F165C                 lea     rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1660                 jmp     short loc_1811F1673
+  .text:00000001811F1662                 test    eax, 3FFFFFFFh
+  .text:00000001811F1667                 lea     rax, byte_1815A2980
+  .text:00000001811F166E                 cmova   rax, [rbp+3A0h+var_3D8]
+  .text:00000001811F1673                 mov     [rsp+4A0h+var_458], 1
+  .text:00000001811F1678                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F167D                 mov     byte ptr [rsp+4A0h+var_468], 2Fh ; '/'
+  .text:00000001811F1682                 mov     [rsp+4A0h+var_470], rdx
+  .text:00000001811F1687                 mov     [rsp+4A0h+var_478], rcx
+  .text:00000001811F168C                 mov     [rsp+4A0h+var_480], rax
+  .text:00000001811F1691                 jmp     loc_1811F104D
+  .text:00000001811F1696                 mov     rax, [rbp+3A0h+var_3F0]
+  .text:00000001811F169A                 cmp     byte ptr [rax], 0
+  .text:00000001811F169D                 jz      short loc_1811F1704
+  .text:00000001811F169F                 mov     [rsp+4A0h+var_458], 0
+  .text:00000001811F16A4                 mov     r9, rdi
+  .text:00000001811F16A7                 mov     dword ptr [rsp+4A0h+var_460], r15d
+  .text:00000001811F16AC                 mov     r8, r12
+  .text:00000001811F16AF                 mov     byte ptr [rsp+4A0h+var_468], 0
+  .text:00000001811F16B4                 mov     rcx, r14
+  .text:00000001811F16B7                 mov     [rsp+4A0h+var_470], rbx
+  .text:00000001811F16BC                 mov     [rsp+4A0h+var_478], rdx
+  .text:00000001811F16C1                 mov     edx, r13d
+  .text:00000001811F16C4                 mov     [rsp+4A0h+var_480], rsi
+  .text:00000001811F16C9                 call    sub_1811ED960
+  .text:00000001811F16CE                 xor     r9d, r9d
+  .text:00000001811F16D1                 mov     r8d, [rbp+3A0h+var_414]
+  .text:00000001811F16D5                 add     r15d, [rbp+3A0h+var_410]
+  .text:00000001811F16D9                 inc     r8d
+  .text:00000001811F16DC                 mov     [rbp+3A0h+var_414], r8d
+  .text:00000001811F16E0                 mov     [rbp+3A0h+var_420], r15d
+  .text:00000001811F16E4                 cmp     r8d, [rbp+3A0h+var_41C]
+  .text:00000001811F16E8                 jge     loc_1811F178C
+  .text:00000001811F16EE                 mov     rcx, qword ptr [rbp+3A0h+var_1C8]
+  .text:00000001811F16F5                 mov     eax, [rbp+3A0h+var_1CC]
+  .text:00000001811F16FB                 mov     rdx, [rbp+3A0h+var_400]
+  .text:00000001811F16FF                 jmp     loc_1811F09CE
+  .text:00000001811F1704                 mov     ecx, cs:dword_1820B9828
+  .text:00000001811F170A                 mov     edx, 5
+  .text:00000001811F170F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F1715                 test    al, al
+  .text:00000001811F1717                 jz      short loc_1811F178C
+  .text:00000001811F1719                 mov     ecx, cs:dword_1820B9828
+  .text:00000001811F171F                 lea     rax, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F1726                 mov     [rbp+3A0h+var_220], rax
+  .text:00000001811F172D                 lea     r9, aFieldSSCannotH; "Field %s::%s cannot have sub-keyfields "...
+  .text:00000001811F1734                 xor     r8d, r8d
+  .text:00000001811F1737                 mov     [rbp+3A0h+var_218], 566h
+  .text:00000001811F1741                 lea     rax, aCentitysystemD; "CEntitySystem::DataDesc_AddComponentFie"...
+  .text:00000001811F1748                 mov     [rbp+3A0h+var_1E8], r8d
+  .text:00000001811F174F                 mov     [rbp+3A0h+var_210], rax
+  .text:00000001811F1756                 lea     r8, [rbp+3A0h+var_220]
+  .text:00000001811F175D                 mov     rax, [rbx+8]
+  .text:00000001811F1761                 xorps   xmm0, xmm0
+  .text:00000001811F1764                 xorps   xmm1, xmm1
+  .text:00000001811F1767                 mov     [rsp+4A0h+var_478], rax
+  .text:00000001811F176C                 mov     edx, 5
+  .text:00000001811F1771                 mov     [rsp+4A0h+var_480], rdi
+  .text:00000001811F1776                 movdqu  [rbp+3A0h+var_208], xmm0
+  .text:00000001811F177E                 movdqu  [rbp+3A0h+var_1F8], xmm1
+  .text:00000001811F1786                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F178C                 xor     edx, edx
+  .text:00000001811F178E                 lea     rcx, [rbp+3A0h+var_100]
+  .text:00000001811F1795                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001811F179B                 xor     edx, edx
+  .text:00000001811F179D                 lea     rcx, [rbp+3A0h+var_1D0]
+  .text:00000001811F17A4                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001811F17AA                 mov     rbx, [rsp+4A0h+arg_8]
+  .text:00000001811F17B2                 add     rsp, 470h
+  .text:00000001811F17B9                 pop     r15
+  .text:00000001811F17BB                 pop     r14
+  .text:00000001811F17BD                 pop     r13
+  .text:00000001811F17BF                 pop     r12
+  .text:00000001811F17C1                 pop     rdi
+  .text:00000001811F17C2                 pop     rsi
+  .text:00000001811F17C3                 pop     rbp
+  .text:00000001811F17C4                 retn
+procedure: |-
+  void __fastcall sub_1811F0750(__int64 a1, int a2, __int64 a3, const char *a4, __int64 a5)
+  {
+    int v5; // r15d
+    const char *v6; // rbx
+    __int64 v8; // r14
+    int v9; // ecx
+    const char *v10; // rdi
+    __int64 *v11; // r12
+    unsigned int v12; // eax
+    __int64 v13; // rbx
+    int v14; // eax
+    const char *v15; // rsi
+    bool v16; // zf
+    const char *v17; // r8
+    __int64 v18; // rdx
+    int v19; // eax
+    const char *v20; // rcx
+    char *v21; // rsi
+    __int64 v22; // r8
+    const char *v23; // rdx
+    __int64 v24; // r14
+    int *v25; // rdi
+    __int64 v26; // r12
+    __int64 v27; // rcx
+    __int64 v28; // rcx
+    int v29; // r15d
+    int v30; // eax
+    __int64 v31; // rdx
+    int v32; // ebx
+    int v33; // eax
+    __int64 v34; // rdx
+    __int64 v35; // rdi
+    __int64 v36; // rax
+    int v37; // eax
+    int v38; // ebx
+    _QWORD *v39; // r15
+    int *v40; // r14
+    __int64 v41; // r12
+    __int64 v42; // rcx
+    __int64 v43; // rcx
+    int v44; // edi
+    int v45; // eax
+    __int64 v46; // rdx
+    int v47; // ebx
+    int v48; // eax
+    __int64 v49; // rcx
+    __int64 v50; // rcx
+    char v51; // al
+    const char *v52; // rcx
+    char *v53; // rax
+    int v54; // ebx
+    _BYTE *v55; // rax
+    const char *v56; // rdx
+    _BYTE *v57; // rax
+    char *v58; // rcx
+    const char *v59; // rcx
+    char *v60; // rax
+    int v61; // ebx
+    _BYTE *v62; // rax
+    const char *v63; // rdx
+    _BYTE *v64; // rax
+    char *v65; // rcx
+    const char *v66; // rcx
+    char *v67; // rax
+    int v68; // ebx
+    _BYTE *v69; // rax
+    const char *v70; // rdx
+    _BYTE *v71; // rax
+    char *v72; // rcx
+    const char *v73; // rcx
+    char *v74; // rax
+    int v75; // ebx
+    _BYTE *v76; // rax
+    const char *v77; // rcx
+    _BYTE *v78; // rax
+    char *v79; // rax
+    const char *v80; // [rsp+28h] [rbp-D8h]
+    char v81; // [rsp+38h] [rbp-C8h]
+    __int16 v82; // [rsp+40h] [rbp-C0h]
+    char v83; // [rsp+50h] [rbp-B0h]
+    __int128 v84; // [rsp+60h] [rbp-A0h] BYREF
+    const char *v85; // [rsp+70h] [rbp-90h]
+    int v86; // [rsp+80h] [rbp-80h]
+    int v87; // [rsp+84h] [rbp-7Ch]
+    int v88; // [rsp+88h] [rbp-78h]
+    int v89; // [rsp+8Ch] [rbp-74h]
+    int v90; // [rsp+90h] [rbp-70h]
+    __int64 v91; // [rsp+98h] [rbp-68h]
+    __int64 v92; // [rsp+A0h] [rbp-60h]
+    int v93; // [rsp+A8h] [rbp-58h]
+    const char *v94; // [rsp+B0h] [rbp-50h]
+    int v95; // [rsp+C0h] [rbp-40h] BYREF
+    int v96; // [rsp+C4h] [rbp-3Ch]
+    _QWORD v97[48]; // [rsp+C8h] [rbp-38h] BYREF
+    int v98; // [rsp+248h] [rbp+148h]
+    int v99; // [rsp+260h] [rbp+160h]
+    const char *v100; // [rsp+280h] [rbp+180h] BYREF
+    int v101; // [rsp+288h] [rbp+188h]
+    const char *v102; // [rsp+290h] [rbp+190h]
+    __int128 v103; // [rsp+298h] [rbp+198h]
+    __int128 v104; // [rsp+2A8h] [rbp+1A8h]
+    int v105; // [rsp+2B8h] [rbp+1B8h]
+    __int128 v106; // [rsp+2C0h] [rbp+1C0h] BYREF
+    int v107; // [rsp+2D0h] [rbp+1D0h] BYREF
+    int v108; // [rsp+2D4h] [rbp+1D4h]
+    char v109[200]; // [rsp+2D8h] [rbp+1D8h] BYREF
+    int v110; // [rsp+3A0h] [rbp+2A0h] BYREF
+    int v111; // [rsp+3A4h] [rbp+2A4h]
+    char *v112; // [rsp+3A8h] [rbp+2A8h] BYREF
+
+    v5 = *(_DWORD *)(a3 + 24);
+    v6 = *(const char **)(a3 + 16);
+    v8 = a1;
+    v9 = *(_DWORD *)(a3 + 40);
+    v10 = a4;
+    v86 = v5;
+    v11 = (__int64 *)a3;
+    v83 = 0;
+    v12 = *(unsigned __int16 *)(a5 + 20);
+    v87 = 1;
+    v88 = 0;
+    v90 = 0;
+    if ( v9 < 0 )
+    {
+      v94 = v6;
+      v15 = v6;
+      if ( v12 > 1 )
+      {
+        v16 = *(_BYTE *)a5 == 8;
+        v94 = v6;
+        if ( !v16 )
+        {
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B9828, 5) )
+          {
+            v100 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+            v105 = 0;
+            v102 = "CEntitySystem::DataDesc_AddComponentFieldUnserializer";
+            v101 = 1210;
+            v103 = 0;
+            v104 = 0;
+            LoggingSystem_Log(
+              (unsigned int)dword_1820B9828,
+              5,
+              &v100,
+              "Field \"%s\" of class \"%s\" cannot be unserialized yet (lacking array support)!\n",
+              v6,
+              v10);
+          }
+          return;
+        }
+      }
+      v13 = a5;
+    }
+    else
+    {
+      v88 = v9;
+      v13 = a5;
+      v83 = 1;
+      v87 = v12;
+      v14 = sub_1814F89A0(a5);
+      v15 = (const char *)v11[2];
+      v94 = v15;
+      v90 = v14;
+    }
+    v16 = *(_BYTE *)v13 == 10;
+    v93 = *(_DWORD *)(v13 + 24) & 0x10;
+    if ( v16 )
+      v91 = *(_QWORD *)(v13 + 56);
+    else
+      v91 = 0;
+    v17 = (const char *)v11[1];
+    *(_QWORD *)v109 = 0;
+    v108 = -1073741624;
+    if ( v17 && *v17 )
+    {
+      if ( v15 && *v15 )
+      {
+        *(_QWORD *)&v84 = v17;
+        v107 = 0;
+        *((_QWORD *)&v84 + 1) = ".";
+        v85 = v15;
+        CBufferString::AppendConcat((CBufferString *)&v107, 3, (const char *const *)&v84, nullptr, 0);
+        v18 = 0;
+      }
+      else
+      {
+        v107 = 0;
+        CBufferString::Insert((CBufferString *)&v107, 0, v17, -1, 0);
+        v18 = 0;
+      }
+    }
+    else
+    {
+      v107 = 0;
+      CBufferString::Insert((CBufferString *)&v107, 0, v15, -1, 0);
+      v18 = (__int64)v15;
+    }
+    v19 = v108;
+    v20 = *(const char **)v109;
+    v92 = v18;
+    if ( (v108 & 0x40000000) != 0 )
+    {
+      v21 = v109;
+    }
+    else
+    {
+      v21 = byte_1815A2980;
+      if ( (v108 & 0x3FFFFFFF) != 0 )
+        v21 = *(char **)v109;
+    }
+    v22 = 0;
+    v110 = 0;
+    v112 = nullptr;
+    v111 = -1073741624;
+    v89 = 0;
+    if ( v87 )
+    {
+      while ( 1 )
+      {
+        if ( v83 )
+        {
+          if ( (v19 & 0x40000000) != 0 )
+          {
+            CBufferString::Format((CBufferString *)&v110, v109, (unsigned int)(v88 + v22));
+          }
+          else
+          {
+            v23 = byte_1815A2980;
+            if ( (v19 & 0x3FFFFFFF) != 0 )
+              v23 = v20;
+            CBufferString::Format((CBufferString *)&v110, v23, (unsigned int)(v88 + v22));
+          }
+          if ( (v111 & 0x40000000) != 0 )
+          {
+            v21 = (char *)&v112;
+          }
+          else
+          {
+            v21 = byte_1815A2980;
+            if ( (v111 & 0x3FFFFFFF) != 0 )
+              v21 = v112;
+          }
+          v18 = 0;
+          v92 = 0;
+        }
+        if ( v93 )
+        {
+          v24 = -1;
+          do
+            v16 = v21[++v24] == 0;
+          while ( !v16 );
+          v25 = (int *)(*v11 + 416);
+          v26 = *v25;
+          if ( (_DWORD)v26 == v25[4] && (v25[5] & 0x40000000) == 0 )
+          {
+            v27 = (unsigned int)v25[4];
+            if ( (_DWORD)v27 == 0x7FFFFFFF )
+              UtlVectorMemory_FailedAllocation(v27, 1);
+            v28 = (unsigned int)v25[4];
+            v29 = v28 + 1;
+            v30 = UtlVectorMemory_CalcNewAllocationCount(v28, v25[5] & 0x3FFFFFFF, (unsigned int)(v28 + 1), 32);
+            v32 = v30;
+            if ( v30 < v29 )
+            {
+              if ( v30 || v29 > -1 )
+              {
+                do
+                {
+                  v31 = (unsigned int)((v32 + v29) >> 31);
+                  v32 = (v32 + v29) / 2;
+                }
+                while ( v32 < v29 );
+              }
+              else
+              {
+                v32 = -1;
+              }
+            }
+            LOBYTE(v31) = (v25[5] & 0xC0000000) == 0;
+            *((_QWORD *)v25 + 1) = UtlVectorMemory_Alloc(*((_QWORD *)v25 + 1), v31, 32LL * v32, 32LL * v25[4]);
+            v33 = v25[5];
+            if ( (v33 & 0xC0000000) != 0 )
+              v25[5] = v33 & 0x3FFFFFFF;
+            v5 = v86;
+            v25[4] = v32;
+          }
+          ++*v25;
+          v34 = v26;
+          v11 = (__int64 *)a3;
+          v34 *= 32;
+          *(_QWORD *)(v34 + *((_QWORD *)v25 + 1) + 16) = 0;
+          v35 = v34 + *(_QWORD *)(*(_QWORD *)a3 + 424LL);
+          v36 = sub_180E7C9C0((int)v24 + 1);
+          *(_QWORD *)v35 = v36;
+          sub_1815513D0(v36, v21, (int)v24 + 1);
+          v8 = a1;
+          v13 = a5;
+          *(_DWORD *)(v35 + 8) = 0;
+          *(_DWORD *)(v35 + 24) = v5;
+          v10 = a4;
+        }
+        else if ( v91 )
+        {
+          v37 = *(_DWORD *)(v13 + 24);
+          if ( (v37 & 0x40) != 0 )
+          {
+            CUtlScratchMemoryPool::GetCurrentAllocPoint(v8 + 3256, &v106, v22);
+            sub_1811EBA10(&v95);
+            sub_1811F2180(v8, a2 + 1, (__int64)v21, *(const char **)(v91 + 16), v91, 0, 1, (__int64)&v95, v11[4]);
+            sub_1811F17D0(v8, a2 + 1, (_DWORD)v21, *(_QWORD *)(v91 + 16), v91, 1, (__int64)&v95, v11[4]);
+            if ( HIDWORD(v97[0]) || v99 || v98 != HIDWORD(v97[0]) )
+            {
+              v39 = CUtlScratchMemoryPool::AllocAligned((CUtlScratchMemoryPool *)(v8 + 3256), 48, 16);
+              *v39 = 0;
+              v39[1] = 9;
+              v39[2] = 0;
+              v39[3] = 0;
+              v39[4] = 0;
+              v39[5] = 0;
+              sub_1811F8BC0(v39, &v95, v8 + 3256);
+              v40 = (int *)(*v11 + 392);          // 392 = 0x188 = CEntitySystem::m_DataDescKeyUnserializerss (structmember, struct=CEntitySystem, member=m_DataDescKeyUnserializerss)
+              v41 = *v40;
+              if ( (_DWORD)v41 == v40[4] && (v40[5] & 0x40000000) == 0 )
+              {
+                v42 = (unsigned int)v40[4];
+                if ( (_DWORD)v42 == 0x7FFFFFFF )
+                  UtlVectorMemory_FailedAllocation(v42, 1);
+                v43 = (unsigned int)v40[4];
+                v44 = v43 + 1;
+                v45 = UtlVectorMemory_CalcNewAllocationCount(v43, v40[5] & 0x3FFFFFFF, (unsigned int)(v43 + 1), 16);
+                v47 = v45;
+                if ( v45 < v44 )
+                {
+                  if ( v45 || v44 > -1 )
+                  {
+                    do
+                    {
+                      v46 = (unsigned int)((v47 + v44) >> 31);
+                      v47 = (v47 + v44) / 2;
+                    }
+                    while ( v47 < v44 );
+                  }
+                  else
+                  {
+                    v47 = -1;
+                  }
+                }
+                LOBYTE(v46) = (v40[5] & 0xC0000000) == 0;
+                *((_QWORD *)v40 + 1) = UtlVectorMemory_Alloc(*((_QWORD *)v40 + 1), v46, 16LL * v47, 16LL * v40[4]);
+                v48 = v40[5];
+                if ( (v48 & 0xC0000000) != 0 )
+                  v40[5] = v48 & 0x3FFFFFFF;
+                v40[4] = v47;
+              }
+              ++*v40;
+              v49 = v41;
+              v11 = (__int64 *)a3;
+              v50 = *(_QWORD *)(*(_QWORD *)a3 + 400LL) + 16 * v49;
+              *(_DWORD *)v50 = v86;
+              *(_QWORD *)(v50 + 8) = v39;
+              sub_1811EC450(&v95);
+              v5 = v86;
+              v10 = a4;
+              v8 = a1;
+              v13 = a5;
+            }
+            else
+            {
+              v84 = v106;
+              CUtlScratchMemoryPool::FreeToAllocPoint(v8 + 3256, &v84);
+              sub_1811EC450(&v95);
+              v10 = a4;
+              v13 = a5;
+            }
+          }
+          else
+          {
+            if ( (v37 & 0x40000) != 0 )
+            {
+              v38 = a2;
+            }
+            else
+            {
+              v10 = *(const char **)(v91 + 16);
+              v38 = a2 + 1;
+            }
+            sub_1811F2180(v8, v38, (__int64)v21, v10, v91, v5, 1, *v11, v11[4]);
+            sub_1811F17D0(v8, v38, (_DWORD)v21, (_DWORD)v10, v91, 1, *v11, v11[4]);
+            v10 = a4;
+            v13 = a5;
+          }
+        }
+        else
+        {
+          v51 = *(_BYTE *)v13;
+          if ( *(_BYTE *)v13 == 59 )
+          {
+            v97[0] = 0;
+            v96 = -1073741624;
+            if ( v21 && *v21 )
+            {
+              v95 = 0;
+              *((_QWORD *)&v84 + 1) = ".";
+              *(_QWORD *)&v84 = v21;
+              v85 = "origin";
+              CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+              v52 = nullptr;
+            }
+            else
+            {
+              v95 = 0;
+              CBufferString::Insert((CBufferString *)&v95, 0, "origin", -1, 0);
+              v52 = "origin";
+            }
+            if ( (v96 & 0x40000000) != 0 )
+            {
+              v53 = (char *)v97;
+            }
+            else
+            {
+              v53 = byte_1815A2980;
+              if ( (v96 & 0x3FFFFFFF) != 0 )
+                v53 = (char *)v97[0];
+            }
+            v54 = a2 + 1;
+            sub_1811ED960(v8, a2 + 1, (_DWORD)v11, (_DWORD)v10, (__int64)v53, (__int64)v52, 0, 3, v5, 0);
+            if ( v21 && *v21 )
+            {
+              if ( (v96 & 0x3FFFFFFF) != 0 )
+              {
+                v54 = a2 + 1;
+                v55 = v97;
+                if ( (v96 & 0x40000000) == 0 )
+                  v55 = (_BYTE *)v97[0];
+                *v55 = 0;
+              }
+              v95 &= 0xC0000000;
+              *((_QWORD *)&v84 + 1) = ".";
+              *(_QWORD *)&v84 = v21;
+              v85 = "angles";
+              CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+              v56 = nullptr;
+            }
+            else
+            {
+              if ( (v96 & 0x3FFFFFFF) != 0 )
+              {
+                v54 = a2 + 1;
+                v57 = v97;
+                if ( (v96 & 0x40000000) == 0 )
+                  v57 = (_BYTE *)v97[0];
+                *v57 = 0;
+              }
+              v95 &= 0xC0000000;
+              CBufferString::Insert((CBufferString *)&v95, 0, "angles", -1, 0);
+              v56 = "angles";
+            }
+            if ( (v96 & 0x40000000) != 0 )
+            {
+              v58 = (char *)v97;
+            }
+            else
+            {
+              v58 = byte_1815A2980;
+              if ( (v96 & 0x3FFFFFFF) != 0 )
+                v58 = (char *)v97[0];
+            }
+            sub_1811ED960(v8, v54, (_DWORD)v11, (_DWORD)v10, (__int64)v58, (__int64)v56, 0, 4, v5 + 16, 0);
+            goto LABEL_99;
+          }
+          switch ( v51 )
+          {
+            case 60:
+              v97[0] = 0;
+              v96 = -1073741624;
+              if ( v21 && *v21 )
+              {
+                v95 = 0;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "origin";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v59 = nullptr;
+              }
+              else
+              {
+                v95 = 0;
+                CBufferString::Insert((CBufferString *)&v95, 0, "origin", -1, 0);
+                v59 = "origin";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v60 = (char *)v97;
+              }
+              else
+              {
+                v60 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v60 = (char *)v97[0];
+              }
+              v61 = a2 + 1;
+              sub_1811ED960(v8, a2 + 1, (_DWORD)v11, (_DWORD)v10, (__int64)v60, (__int64)v59, 0, 14, v5, 0);
+              if ( v21 && *v21 )
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v61 = a2 + 1;
+                  v62 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v62 = (_BYTE *)v97[0];
+                  *v62 = 0;
+                }
+                v95 &= 0xC0000000;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "angles";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v63 = nullptr;
+              }
+              else
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v61 = a2 + 1;
+                  v64 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v64 = (_BYTE *)v97[0];
+                  *v64 = 0;
+                }
+                v95 &= 0xC0000000;
+                CBufferString::Insert((CBufferString *)&v95, 0, "angles", -1, 0);
+                v63 = "angles";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v65 = (char *)v97;
+              }
+              else
+              {
+                v65 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v65 = (char *)v97[0];
+              }
+              sub_1811ED960(v8, v61, (_DWORD)v11, (_DWORD)v10, (__int64)v65, (__int64)v63, 0, 47, v5 + 16, 0);
+              goto LABEL_99;
+            case 64:
+              v97[0] = 0;
+              v96 = -1073741624;
+              if ( v21 && *v21 )
+              {
+                v95 = 0;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "origin";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v66 = nullptr;
+              }
+              else
+              {
+                v95 = 0;
+                CBufferString::Insert((CBufferString *)&v95, 0, "origin", -1, 0);
+                v66 = "origin";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v67 = (char *)v97;
+              }
+              else
+              {
+                v67 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v67 = (char *)v97[0];
+              }
+              v82 = v5;
+              v81 = 3;
+              goto LABEL_136;
+            case 65:
+              v97[0] = 0;
+              v96 = -1073741624;
+              if ( v21 && *v21 )
+              {
+                v95 = 0;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "origin";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v66 = nullptr;
+              }
+              else
+              {
+                v95 = 0;
+                CBufferString::Insert((CBufferString *)&v95, 0, "origin", -1, 0);
+                v66 = "origin";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v67 = (char *)v97;
+                v82 = v5;
+                v81 = 14;
+              }
+              else
+              {
+                v67 = byte_1815A2980;
+                v82 = v5;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v67 = (char *)v97[0];
+                v81 = 14;
+              }
+  LABEL_136:
+              v68 = a2 + 1;
+              sub_1811ED960(v8, a2 + 1, (_DWORD)v11, (_DWORD)v10, (__int64)v67, (__int64)v66, 0, v81, v82, 0);
+              if ( v21 && *v21 )
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v68 = a2 + 1;
+                  v69 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v69 = (_BYTE *)v97[0];
+                  *v69 = 0;
+                }
+                v95 &= 0xC0000000;
+                *((_QWORD *)&v84 + 1) = ".";
+                v85 = "angles";
+                *(_QWORD *)&v84 = v21;
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v70 = nullptr;
+              }
+              else
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v68 = a2 + 1;
+                  v71 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v71 = (_BYTE *)v97[0];
+                  *v71 = 0;
+                }
+                v95 &= 0xC0000000;
+                CBufferString::Insert((CBufferString *)&v95, 0, "angles", -1, 0);
+                v70 = "angles";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v72 = (char *)v97;
+              }
+              else
+              {
+                v72 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v72 = (char *)v97[0];
+              }
+              sub_1811ED960(v8, v68, (_DWORD)v11, (_DWORD)v10, (__int64)v72, (__int64)v70, 0, 1, v5 + 12, 0);
+  LABEL_99:
+              CBufferString::Purge((CBufferString *)&v95, 0);
+              v13 = a5;
+              goto LABEL_191;
+            case 22:
+              v97[0] = 0;
+              v96 = -1073741624;
+              if ( v21 && *v21 )
+              {
+                v95 = 0;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "origin";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v73 = nullptr;
+              }
+              else
+              {
+                v95 = 0;
+                CBufferString::Insert((CBufferString *)&v95, 0, "origin", -1, 0);
+                v73 = "origin";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v74 = (char *)v97;
+              }
+              else
+              {
+                v74 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v74 = (char *)v97[0];
+              }
+              v75 = a2 + 1;
+              sub_1811ED960(v8, a2 + 1, (_DWORD)v11, (_DWORD)v10, (__int64)v74, (__int64)v73, 0, 14, v5, 1);
+              if ( v21 && *v21 )
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v75 = a2 + 1;
+                  v76 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v76 = (_BYTE *)v97[0];
+                  *v76 = 0;
+                }
+                v95 &= 0xC0000000;
+                *((_QWORD *)&v84 + 1) = ".";
+                *(_QWORD *)&v84 = v21;
+                v85 = "angles";
+                CBufferString::AppendConcat((CBufferString *)&v95, 3, (const char *const *)&v84, nullptr, 0);
+                v77 = nullptr;
+              }
+              else
+              {
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                {
+                  v75 = a2 + 1;
+                  v78 = v97;
+                  if ( (v96 & 0x40000000) == 0 )
+                    v78 = (_BYTE *)v97[0];
+                  *v78 = 0;
+                }
+                v95 &= 0xC0000000;
+                CBufferString::Insert((CBufferString *)&v95, 0, "angles", -1, 0);
+                v77 = "angles";
+              }
+              if ( (v96 & 0x40000000) != 0 )
+              {
+                v79 = (char *)v97;
+              }
+              else
+              {
+                v79 = byte_1815A2980;
+                if ( (v96 & 0x3FFFFFFF) != 0 )
+                  v79 = (char *)v97[0];
+              }
+              sub_1811ED960(v8, v75, (_DWORD)v11, (_DWORD)v10, (__int64)v79, (__int64)v77, 0, 47, v5, 1);
+              goto LABEL_99;
+          }
+          if ( !*v94 )
+          {
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B9828, 5) )
+            {
+              v100 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
+              v101 = 1382;
+              v105 = 0;
+              v102 = "CEntitySystem::DataDesc_AddComponentFieldUnserializer";
+              v80 = *(const char **)(v13 + 8);
+              v103 = 0;
+              v104 = 0;
+              LoggingSystem_Log(
+                (unsigned int)dword_1820B9828,
+                5,
+                &v100,
+                "Field %s::%s cannot have sub-keyfields since it is an atomic type!\n",
+                v10,
+                v80);
+            }
+            break;
+          }
+          sub_1811ED960(v8, a2, (_DWORD)v11, (_DWORD)v10, (__int64)v21, v18, v13, 0, v5, 0);
+        }
+  LABEL_191:
+        v5 += v90;
+        v22 = (unsigned int)(v89 + 1);
+        v89 = v22;
+        v86 = v5;
+        if ( (int)v22 >= v87 )
+          break;
+        v20 = *(const char **)v109;
+        v19 = v108;
+        v18 = v92;
+      }
+    }
+    CBufferString::Purge((CBufferString *)&v110, 0);
+    CBufferString::Purge((CBufferString *)&v107, 0);
+  }


### PR DESCRIPTION
## Summary

- **Pattern A**: `find-CEntitySystem_AddComponentFieldUnserializer` — regular function discovered via xref string `"Field %s::%s cannot have sub-keyfields since it is an atomic type!\n"`. Added Linux `exclude_signatures` (`55 4D 89 C2 48 89`) to disambiguate two candidates on Linux.
- **Pattern E**: `find-CEntitySystem_m_DataDescKeyUnserializerss` — struct member offset of `CEntitySystem` at `0x188` (392), discovered via LLM_DECOMPILE of `CEntitySystem_AddComponentFieldUnserializer`. Reference YAMLs generated and annotated for both Windows and Linux.

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures (both scripts succeed on Windows and Linux)
- [x] Windows: `CEntitySystem_AddComponentFieldUnserializer` found at `0x1811f0750`
- [x] Linux: `CEntitySystem_AddComponentFieldUnserializer` found at `0x1e784c0`
- [x] `CEntitySystem_m_DataDescKeyUnserializerss` offset `0x188` resolved on both platforms via LLM_DECOMPILE