### PR TITLE
feat: add CEntitySystem_m_pNetworkFieldChangedEventQueue and CEntitySystem_m_pNetworkFieldScratchData

### DIFF
--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -12,6 +12,8 @@ TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_sEntSystemName",
     "CEntitySystem_m_eNetworkSerializationMode",
     "CEntitySystem_m_Symbols",
+    "CEntitySystem_m_pNetworkFieldChangedEventQueue",
+    "CEntitySystem_m_pNetworkFieldScratchData",
 ]
 
 LLM_DECOMPILE = [
@@ -38,6 +40,16 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_Symbols",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_pNetworkFieldChangedEventQueue",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_pNetworkFieldScratchData",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -95,6 +107,28 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_Symbols",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_pNetworkFieldChangedEventQueue",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_pNetworkFieldScratchData",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -223,7 +223,7 @@ disasm_code: |-
   .text:0000000001E73C5E                 ; _QWORD
   .text:0000000001E73C5E                 mov     edx, 4E200h; _QWORD
   .text:0000000001E73C63                 lea     rax, off_24156E8
-  .text:0000000001E73C6A                 mov     [rbx+0C90h], r12
+  .text:0000000001E73C6A                 mov     [rbx+0C90h], r12  ; 0C90h = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:0000000001E73C71                 mov     [r12], rax
   .text:0000000001E73C75                 mov     rax, 0C8000000000000h
   .text:0000000001E73C7F                 mov     [r12+48h], rax
@@ -306,7 +306,7 @@ disasm_code: |-
   .text:0000000001E73DDC                 mov     rax, [rdi]
   .text:0000000001E73DDF                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
   .text:0000000001E73DDF                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:0000000001E73DE5                 mov     [rbx+0C88h], rax
+  .text:0000000001E73DE5                 mov     [rbx+0C88h], rax  ; 0C88h = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
   .text:0000000001E73DEC                 jmp     loc_1E73B0C
   .text:0000000001E73DF2                 jmp     short loc_1E73DF2
   .text:0000000001E73DF8                 mov     esi, [r15+14h]
@@ -867,7 +867,7 @@ procedure: |-
     if ( *(_BYTE *)(a1 + 3034) )
     {
       v25 = operator new(88);
-      *(_QWORD *)(a1 + 3216) = v25;
+      *(_QWORD *)(a1 + 3216) = v25;  // 3216 = 0xC90 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
       *(_QWORD *)v25 = off_24156E8;
       *(_QWORD *)(v25 + 72) = 0xC8000000000000LL;
       *(_QWORD *)(v25 + 8) = 0;
@@ -950,7 +950,7 @@ procedure: |-
                  qword_2743668,
                  *(_QWORD *)(a1 + 3216),
                  *(_QWORD *)(a1 + 3224));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-      *(_QWORD *)(a1 + 3208) = result;
+      *(_QWORD *)(a1 + 3208) = result;  // 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
     }
     if ( byte_27BBA40 )
       goto LABEL_31;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -303,7 +303,7 @@ disasm_code: |-
   .text:00000001811F0FEA                 mov     qword ptr [rcx+4Ch], 0C80000h
   .text:00000001811F0FF2                 jmp     short loc_1811F0FF7
   .text:00000001811F0FF4                 mov     rcx, r15
-  .text:00000001811F0FF7                 mov     [rsi+0C88h], rcx
+  .text:00000001811F0FF7                 mov     [rsi+0C88h], rcx  ; 0C88h = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:00000001811F0FFE                 mov     edx, 10000h
   .text:00000001811F1003                 mov     rax, [rcx]
   .text:00000001811F1006                 mov     r8d, cs:dword_1820B1848
@@ -314,7 +314,7 @@ disasm_code: |-
   .text:00000001811F1025                 mov     rax, [rcx]
   .text:00000001811F1028                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
   .text:00000001811F1028                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:00000001811F102E                 mov     [rsi+0C80h], rax
+  .text:00000001811F102E                 mov     [rsi+0C80h], rax  ; 0C80h = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
   .text:00000001811F1035                 cmp     cs:byte_1820B151C, r15b
   .text:00000001811F103C                 jnz     loc_1811F11EE
   .text:00000001811F1042                 movzx   ecx, word ptr [rsi+0AA8h]
@@ -688,7 +688,7 @@ procedure: |-
       {
         v38 = 0;
       }
-      *(_QWORD *)(a1 + 3208) = v38;
+      *(_QWORD *)(a1 + 3208) = v38;  // 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
       (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v38 + 8LL))(
         v38,
         0x10000,
@@ -697,7 +697,7 @@ procedure: |-
                  qword_182117C90,
                  *(_QWORD *)(a1 + 3208),
                  *(_QWORD *)(a1 + 3216));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-      *(_QWORD *)(a1 + 3200) = result;
+      *(_QWORD *)(a1 + 3200) = result;  // 3200 = 0xC80 = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
     }
     if ( !byte_1820B151C )
     {


### PR DESCRIPTION
## Summary
- Added `CEntitySystem_m_pNetworkFieldChangedEventQueue` and `CEntitySystem_m_pNetworkFieldScratchData` as struct member targets in `find-CEntitySystem_Init-decompiles.py`
- Annotated reference YAML disasm and procedure sections with offset comments for both members on Windows and Linux

## Offsets
| Member | Windows | Linux |
|--------|---------|-------|
| `m_pNetworkFieldScratchData` | `0xC88` | `0xC90` |
| `m_pNetworkFieldChangedEventQueue` | `0xC80` | `0xC88` |