### PR TITLE
feat: add find-CEntitySystem_m_ComponentUnserializerInfoAllocator

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6312,6 +6312,7 @@ modules:
           - CEntitySystem_m_sEntSystemName.{platform}.yaml
           - CEntitySystem_m_eNetworkSerializationMode.{platform}.yaml
           - CEntitySystem_m_Symbols.{platform}.yaml
+          - CEntitySystem_m_ComponentUnserializerInfoAllocator.{platform}.yaml
         expected_input:
           - CEntitySystem_Init.{platform}.yaml
 
@@ -9886,6 +9887,11 @@ modules:
         member: m_Symbols
         alias:
           - CEntitySystem::m_Symbols
+
+      - name: CEntitySystem_m_ComponentUnserializerInfoAllocator
+        category: structmember
+        struct: CEntitySystem
+        member: m_ComponentUnserializerInfoAllocator
 
       - name: CEntitySystem_m_nSuppressDestroyImmediateCount
         category: structmember

--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -12,6 +12,7 @@ TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_sEntSystemName",
     "CEntitySystem_m_eNetworkSerializationMode",
     "CEntitySystem_m_Symbols",
+    "CEntitySystem_m_ComponentUnserializerInfoAllocator",
 ]
 
 LLM_DECOMPILE = [
@@ -38,6 +39,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_Symbols",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -95,6 +101,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_Symbols",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -1,584 +1,540 @@
 func_name: CEntitySystem_Init
-func_va: '0x1e73880'
+func_va: '0x1e7c3c0'
 disasm_code: |-
-  .text:0000000001E73880                 push    rbp
-  .text:0000000001E73881                 mov     rbp, rsp
-  .text:0000000001E73884                 push    r15
-  .text:0000000001E73886                 push    r14
-  .text:0000000001E73888                 mov     r14d, r8d
-  .text:0000000001E7388B                 push    r13
-  .text:0000000001E7388D                 mov     r13d, ecx
-  .text:0000000001E73890                 push    r12
-  .text:0000000001E73892                 mov     r12d, edx
-  .text:0000000001E73895                 push    rbx
-  .text:0000000001E73896                 mov     rbx, rdi
-  .text:0000000001E73899                 add     rdi, 0A88h  ; 0A88h = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
-  .text:0000000001E738A0                 sub     rsp, 68h
-  .text:0000000001E738A4                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
-  .text:0000000001E738A9                 lea     rax, unk_27BB9F1
-  .text:0000000001E738B0                 mov     [rbx+0BBCh], r13d
-  .text:0000000001E738B7                 mov     [rax], r14b
-  .text:0000000001E738BA                 cmp     r12d, 1
-  .text:0000000001E738BE                 jz      loc_1E73C08
-  .text:0000000001E738C4                 lea     r13, qword_2743670
-  .text:0000000001E738CB                 xor     eax, eax
-  .text:0000000001E738CD                 mov     [rbx+0BDAh], al  ; 0BDAh = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
-  .text:0000000001E738D3                 ; bool
-  .text:0000000001E738D3                 xor     r8d, r8d; bool
-  .text:0000000001E738D6                 ; void *
-  .text:0000000001E738D6                 xor     ecx, ecx; void *
-  .text:0000000001E738D8                 ; unsigned int
-  .text:0000000001E738D8                 xor     edx, edx; unsigned int
-  .text:0000000001E738DA                 ; this
-  .text:0000000001E738DA                 lea     rdi, [rbx+0CC0h]; this
-  .text:0000000001E738E1                 ; unsigned int
-  .text:0000000001E738E1                 mov     esi, 400h; unsigned int
-  .text:0000000001E738E6                 call    __ZN21CUtlScratchMemoryPool4InitEjjPvb; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
-  .text:0000000001E738EB                 lea     r14, qword_27BB928
-  .text:0000000001E738F2                 lea     rax, [rbx+10h]
-  .text:0000000001E738F6                 mov     cs:qword_25669A8, rbx
-  .text:0000000001E738FD                 mov     cs:qword_25669A0, rax
-  .text:0000000001E73904                 mov     r12, [r14]
-  .text:0000000001E73907                 test    r12, r12
-  .text:0000000001E7390A                 jz      short loc_1E73979
-  .text:0000000001E7390C                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73917                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73920                 test    byte ptr [r12+68h], 2
-  .text:0000000001E73926                 jz      loc_1E73B70
-  .text:0000000001E7392C                 mov     r12, [r12+120h]
-  .text:0000000001E73934                 test    r12, r12
-  .text:0000000001E73937                 jnz     short loc_1E73920
-  .text:0000000001E73939                 mov     r12, [r14]
-  .text:0000000001E7393C                 test    r12, r12
-  .text:0000000001E7393F                 jz      short loc_1E73979
-  .text:0000000001E73941                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E7394C                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73957                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73960                 test    byte ptr [r12+68h], 2
-  .text:0000000001E73966                 jnz     loc_1E73B48
-  .text:0000000001E7396C                 mov     r12, [r12+120h]
-  .text:0000000001E73974                 test    r12, r12
-  .text:0000000001E73977                 jnz     short loc_1E73960
-  .text:0000000001E73979                 mov     r12, cs:qword_256D370
-  .text:0000000001E73980                 xor     r14d, r14d
-  .text:0000000001E73983                 lea     r15, nullsub_1669
-  .text:0000000001E7398A                 test    r12, r12
-  .text:0000000001E7398D                 jz      short loc_1E739D6
-  .text:0000000001E7398F                 nop
-  .text:0000000001E73990                 mov     rsi, r12
-  .text:0000000001E73993                 mov     rdi, rbx
-  .text:0000000001E73996                 add     r14d, 1
-  .text:0000000001E7399A                 call    sub_1E73380
-  .text:0000000001E7399F                 mov     rdx, [r12+10h]
-  .text:0000000001E739A4                 mov     [rdx+20h], eax
-  .text:0000000001E739A7                 mov     rax, [r12+10h]
-  .text:0000000001E739AC                 test    byte ptr [rax+24h], 1
-  .text:0000000001E739B0                 jz      short loc_1E739BB
-  .text:0000000001E739B2                 or      dword ptr [r12+8], 20000h
-  .text:0000000001E739BB                 mov     rax, [r12]
-  .text:0000000001E739BF                 mov     rax, [rax+8]
-  .text:0000000001E739C3                 cmp     rax, r15
-  .text:0000000001E739C6                 jnz     loc_1E73B98
-  .text:0000000001E739CC                 mov     r12, [r12+20h]
-  .text:0000000001E739D1                 test    r12, r12
-  .text:0000000001E739D4                 jnz     short loc_1E73990
-  .text:0000000001E739D6                 lea     r15, qword_27BB8F0
-  .text:0000000001E739DD                 mov     eax, r14d
-  .text:0000000001E739E0                 sub     eax, [r15]
-  .text:0000000001E739E3                 test    eax, eax
-  .text:0000000001E739E5                 jg      loc_1E73B30
-  .text:0000000001E739EB                 jnz     loc_1E73B3D
-  .text:0000000001E739F1                 mov     r12, cs:qword_256D370
-  .text:0000000001E739F8                 test    r12, r12
-  .text:0000000001E739FB                 jz      short loc_1E73A32
-  .text:0000000001E739FD                 nop     dword ptr [rax]
-  .text:0000000001E73A00                 mov     rdi, [r13+0]
-  .text:0000000001E73A04                 test    rdi, rdi
-  .text:0000000001E73A07                 jz      short loc_1E73A17
-  .text:0000000001E73A09                 mov     rax, [rdi]
-  .text:0000000001E73A0C                 mov     esi, [r12+18h]
-  .text:0000000001E73A11                 call    qword ptr [rax+0E8h]
-  .text:0000000001E73A17                 mov     rax, [r12+10h]
-  .text:0000000001E73A1C                 mov     rdx, [r15+8]
-  .text:0000000001E73A20                 movsxd  rcx, dword ptr [rax+20h]
-  .text:0000000001E73A24                 mov     [rdx+rcx*8], rax
-  .text:0000000001E73A28                 mov     r12, [r12+20h]
-  .text:0000000001E73A2D                 test    r12, r12
-  .text:0000000001E73A30                 jnz     short loc_1E73A00
-  .text:0000000001E73A32                 cmp     word ptr [rbx+0AAAh], 0
-  .text:0000000001E73A3A                 jz      short loc_1E73A75
-  .text:0000000001E73A3C                 movzx   eax, word ptr [rbx+0AA8h]
-  .text:0000000001E73A43                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001E73A4C                 jz      loc_1E73BB0
-  .text:0000000001E73A52                 cmp     ax, 0FFFFh
-  .text:0000000001E73A56                 jnz     loc_1E73EBD
-  .text:0000000001E73A5C                 mov     rcx, [rbx+0AA0h]
-  .text:0000000001E73A63                 mov     edx, offset stru_17FFE8
-  .text:0000000001E73A68                 mov     rsi, [rcx+rdx+10h]
-  .text:0000000001E73A6D                 mov     rdi, rbx
-  .text:0000000001E73A70                 call    sub_1E54FC0
-  .text:0000000001E73A75                 cmp     cs:byte_27BBA40, 0
-  .text:0000000001E73A7C                 jnz     short loc_1E73A91
-  .text:0000000001E73A7E                 movzx   r12d, word ptr [rbx+0AA8h]
-  .text:0000000001E73A86                 cmp     r12w, 0FFFFh
-  .text:0000000001E73A8B                 jnz     loc_1E73EFE
-  .text:0000000001E73A91                 lea     rdi, aEntitysystemCl; "EntitySystem - Class Tables"
-  .text:0000000001E73A98                 xor     eax, eax
-  .text:0000000001E73A9A                 call    _COM_TimestampedLog
-  .text:0000000001E73A9F                 mov     rdi, [r13+0]
-  .text:0000000001E73AA3                 test    rdi, rdi
-  .text:0000000001E73AA6                 jz      short loc_1E73AF7
-  .text:0000000001E73AA8                 mov     rax, [rdi]
-  .text:0000000001E73AAB                 lea     rsi, aStringTTable; "string_t_table"
-  .text:0000000001E73AB2                 mov     edx, [rbx+0BBCh]
-  .text:0000000001E73AB8                 lea     rcx, [rbx+1ED0h]  ; 1ED0h = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols)
-  .text:0000000001E73ABF                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-  .text:0000000001E73ABF                 call    qword ptr [rax+0A0h]; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-  .text:0000000001E73AC5                 mov     rdi, [r13+0]
-  .text:0000000001E73AC9                 lea     rsi, [rbp+var_50]
-  .text:0000000001E73ACD                 mov     qword ptr [rbp+var_68], 121h
-  .text:0000000001E73AD5                 mov     qword ptr [rbp+var_68+8], 0
-  .text:0000000001E73ADD                 movdqu  xmm0, [rbp+var_68]
-  .text:0000000001E73AE2                 mov     rax, [rdi]
-  .text:0000000001E73AE5                 mov     [rbp+var_50], 0
-  .text:0000000001E73AED                 movups  [rbp+var_48], xmm0
-  .text:0000000001E73AF1                 call    qword ptr [rax+0B8h]
-  .text:0000000001E73AF7                 mov     rdi, rbx
-  .text:0000000001E73AFA                 call    sub_1E72200
-  .text:0000000001E73AFF                 cmp     byte ptr [rbx+0BDAh], 0
-  .text:0000000001E73B06                 jnz     loc_1E73C48
-  .text:0000000001E73B0C                 cmp     cs:byte_27BBA40, 0
-  .text:0000000001E73B13                 jz      loc_1E73C20
-  .text:0000000001E73B19                 mov     cs:byte_27BBA40, 1
-  .text:0000000001E73B20                 add     rsp, 68h
-  .text:0000000001E73B24                 pop     rbx
-  .text:0000000001E73B25                 pop     r12
-  .text:0000000001E73B27                 pop     r13
-  .text:0000000001E73B29                 pop     r14
-  .text:0000000001E73B2B                 pop     r15
-  .text:0000000001E73B2D                 pop     rbp
-  .text:0000000001E73B2E                 retn
-  .text:0000000001E73B30                 ; _QWORD
-  .text:0000000001E73B30                 mov     edi, [r15+10h]; _QWORD
-  .text:0000000001E73B34                 cmp     r14d, edi
-  .text:0000000001E73B37                 jg      loc_1E73DF8
-  .text:0000000001E73B3D                 mov     [r15], r14d
-  .text:0000000001E73B40                 jmp     loc_1E739F1
-  .text:0000000001E73B48                 mov     rsi, r12
-  .text:0000000001E73B4B                 mov     rdi, rbx
-  .text:0000000001E73B4E                 call    sub_1E67AC0
-  .text:0000000001E73B53                 mov     r12, [r12+120h]
-  .text:0000000001E73B5B                 test    r12, r12
-  .text:0000000001E73B5E                 jnz     loc_1E73960
-  .text:0000000001E73B64                 jmp     loc_1E73979
-  .text:0000000001E73B70                 mov     rsi, r12
-  .text:0000000001E73B73                 mov     rdi, rbx
-  .text:0000000001E73B76                 call    sub_1E67830
-  .text:0000000001E73B7B                 mov     r12, [r12+120h]
-  .text:0000000001E73B83                 test    r12, r12
-  .text:0000000001E73B86                 jnz     loc_1E73920
-  .text:0000000001E73B8C                 jmp     loc_1E73939
-  .text:0000000001E73B98                 mov     rdi, r12
-  .text:0000000001E73B9B                 call    rax
-  .text:0000000001E73B9D                 mov     r12, [r12+20h]
-  .text:0000000001E73BA2                 test    r12, r12
-  .text:0000000001E73BA5                 jnz     loc_1E73990
-  .text:0000000001E73BAB                 jmp     loc_1E739D6
-  .text:0000000001E73BB0                 mov     edx, offset stru_17FFE8
-  .text:0000000001E73BB5                 xor     ecx, ecx
-  .text:0000000001E73BB7                 cmp     ax, 0FFFFh
-  .text:0000000001E73BBB                 jz      loc_1E73A68
-  .text:0000000001E73BC1                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73BCC                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73BD7                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73BE0                 movzx   eax, ax
-  .text:0000000001E73BE3                 lea     rax, [rax+rax*2]
-  .text:0000000001E73BE7                 lea     rdx, ds:0[rax*8]
-  .text:0000000001E73BEF                 movzx   eax, word ptr ds:dword_0[rax*8]
-  .text:0000000001E73BF7                 cmp     ax, 0FFFFh
-  .text:0000000001E73BFB                 jnz     short loc_1E73BE0
-  .text:0000000001E73BFD                 xor     ecx, ecx
-  .text:0000000001E73BFF                 jmp     loc_1E73A68
-  .text:0000000001E73C08                 lea     r13, qword_2743670
-  .text:0000000001E73C0F                 cmp     qword ptr [r13+0], 0
-  .text:0000000001E73C14                 setnz   al
-  .text:0000000001E73C17                 jmp     loc_1E738CD
-  .text:0000000001E73C20                 movzx   r12d, word ptr [rbx+0AA8h]
-  .text:0000000001E73C28                 cmp     r12w, 0FFFFh
-  .text:0000000001E73C2D                 jnz     loc_1E74177
-  .text:0000000001E73C33                 call    sub_1E8FFB0
-  .text:0000000001E73C38                 mov     rdi, rbx
-  .text:0000000001E73C3B                 call    sub_1E5FD40
-  .text:0000000001E73C40                 jmp     loc_1E73B19
-  .text:0000000001E73C48                 ; _QWORD
-  .text:0000000001E73C48                 mov     edi, 58h ; 'X'; _QWORD
-  .text:0000000001E73C4D                 call    __Znwm; operator new(ulong)
-  .text:0000000001E73C52                 ; _QWORD
-  .text:0000000001E73C52                 mov     ecx, 1; _QWORD
-  .text:0000000001E73C57                 ; _QWORD
-  .text:0000000001E73C57                 xor     esi, esi; _QWORD
-  .text:0000000001E73C59                 ; _QWORD
-  .text:0000000001E73C59                 xor     edi, edi; _QWORD
-  .text:0000000001E73C5B                 mov     r12, rax
-  .text:0000000001E73C5E                 ; _QWORD
-  .text:0000000001E73C5E                 mov     edx, 4E200h; _QWORD
-  .text:0000000001E73C63                 lea     rax, off_24156E8
-  .text:0000000001E73C6A                 mov     [rbx+0C90h], r12
-  .text:0000000001E73C71                 mov     [r12], rax
-  .text:0000000001E73C75                 mov     rax, 0C8000000000000h
-  .text:0000000001E73C7F                 mov     [r12+48h], rax
-  .text:0000000001E73C84                 lea     rax, dword_27BBCDC
-  .text:0000000001E73C8B                 mov     qword ptr [r12+8], 0
-  .text:0000000001E73C94                 mov     qword ptr [r12+10h], 0
-  .text:0000000001E73C9D                 mov     qword ptr [r12+18h], 0
-  .text:0000000001E73CA6                 mov     dword ptr [r12+20h], 0
-  .text:0000000001E73CAF                 mov     r14d, [rax]
-  .text:0000000001E73CB2                 mov     qword ptr [r12+30h], 0
-  .text:0000000001E73CBB                 mov     dword ptr [r12+38h], 0
-  .text:0000000001E73CC4                 mov     dword ptr [r12+28h], 0
-  .text:0000000001E73CCD                 mov     qword ptr [r12+3Ch], 0
-  .text:0000000001E73CD6                 mov     qword ptr [r12+50h], 0
-  .text:0000000001E73CDF                 call    _UtlVectorMemory_CalcNewAllocationCount
-  .text:0000000001E73CE4                 mov     r13d, eax
-  .text:0000000001E73CE7                 cmp     eax, 4E1FFh
-  .text:0000000001E73CEC                 jle     loc_1E73DF2
-  .text:0000000001E73CF2                 xor     esi, esi
-  .text:0000000001E73CF4                 ; _QWORD
-  .text:0000000001E73CF4                 movsxd  rcx, dword ptr [r12+18h]; _QWORD
-  .text:0000000001E73CF9                 ; _QWORD
-  .text:0000000001E73CF9                 movsxd  rdx, eax; _QWORD
-  .text:0000000001E73CFC                 cmp     dword ptr [r12+1Ch], 3FFFFFFFh
-  .text:0000000001E73D05                 ; _QWORD
-  .text:0000000001E73D05                 mov     rdi, [r12+10h]; _QWORD
-  .text:0000000001E73D0A                 ; _QWORD
-  .text:0000000001E73D0A                 setbe   sil; _QWORD
-  .text:0000000001E73D0E                 call    _UtlVectorMemory_Alloc
-  .text:0000000001E73D13                 mov     [r12+10h], rax
-  .text:0000000001E73D18                 mov     eax, [r12+1Ch]
-  .text:0000000001E73D1D                 cmp     eax, 3FFFFFFFh
-  .text:0000000001E73D22                 jbe     short loc_1E73D2E
-  .text:0000000001E73D24                 and     eax, 3FFFFFFFh
-  .text:0000000001E73D29                 mov     [r12+1Ch], eax
-  .text:0000000001E73D2E                 mov     [r12+18h], r13d
-  .text:0000000001E73D33                 lea     rdx, [r12+20h]
-  .text:0000000001E73D38                 xor     eax, eax
-  .text:0000000001E73D3A                 mov     dword ptr [r12+8], 4E200h
-  .text:0000000001E73D43                 xchg    eax, [rdx]
-  .text:0000000001E73D45                 ; _QWORD
-  .text:0000000001E73D45                 mov     edi, 50h ; 'P'; _QWORD
-  .text:0000000001E73D4A                 mov     [r12+44h], r14d
-  .text:0000000001E73D4F                 mov     eax, [r12+20h]
-  .text:0000000001E73D54                 mov     dword ptr [r12+40h], 10000h
-  .text:0000000001E73D5D                 call    __Znwm; operator new(ulong)
-  .text:0000000001E73D62                 ; this
-  .text:0000000001E73D62                 mov     rdi, rax; this
-  .text:0000000001E73D65                 mov     r13, rax
-  .text:0000000001E73D68                 call    __ZN12CMemoryStackC1Ev; CMemoryStack::CMemoryStack(void)
-  .text:0000000001E73D6D                 ; unsigned int
-  .text:0000000001E73D6D                 mov     edx, [r12+40h]; unsigned int
-  .text:0000000001E73D72                 ; unsigned int
-  .text:0000000001E73D72                 mov     r9d, 10h; unsigned int
-  .text:0000000001E73D78                 ; this
-  .text:0000000001E73D78                 mov     rdi, r13; this
-  .text:0000000001E73D7B                 ; unsigned int
-  .text:0000000001E73D7B                 mov     r8d, 1000h; unsigned int
-  .text:0000000001E73D81                 ; unsigned int
-  .text:0000000001E73D81                 mov     ecx, 1000h; unsigned int
-  .text:0000000001E73D86                 lea     rsi, aCnetworkfields; "CNetworkFieldScratchData.m_MemoryStacks"...
-  .text:0000000001E73D8D                 call    __ZN12CMemoryStack4InitEPKcjjjj; CMemoryStack::Init(char const*,uint,uint,uint,uint)
-  .text:0000000001E73D92                 test    al, al
-  .text:0000000001E73D94                 jz      loc_1E7427B
-  .text:0000000001E73D9A                 mov     r14d, [r12+28h]
-  .text:0000000001E73D9F                 ; _QWORD
-  .text:0000000001E73D9F                 mov     edi, [r12+38h]; _QWORD
-  .text:0000000001E73DA4                 cmp     r14d, edi
-  .text:0000000001E73DA7                 jz      loc_1E740B7
-  .text:0000000001E73DAD                 mov     rax, [r12+30h]
-  .text:0000000001E73DB2                 mov     edx, r14d
-  .text:0000000001E73DB5                 add     edx, 1
-  .text:0000000001E73DB8                 mov     [r12+28h], edx
-  .text:0000000001E73DBD                 movsxd  rdx, r14d
-  .text:0000000001E73DC0                 mov     [rax+rdx*8], r13
-  .text:0000000001E73DC4                 lea     rax, qword_2743668
-  .text:0000000001E73DCB                 mov     rdx, [rbx+0C98h]
-  .text:0000000001E73DD2                 mov     rsi, [rbx+0C90h]
-  .text:0000000001E73DD9                 mov     rdi, [rax]
-  .text:0000000001E73DDC                 mov     rax, [rdi]
-  .text:0000000001E73DDF                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:0000000001E73DDF                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:0000000001E73DE5                 mov     [rbx+0C88h], rax
-  .text:0000000001E73DEC                 jmp     loc_1E73B0C
-  .text:0000000001E73DF2                 jmp     short loc_1E73DF2
-  .text:0000000001E73DF8                 mov     esi, [r15+14h]
-  .text:0000000001E73DFC                 cmp     esi, 3FFFFFFFh
-  .text:0000000001E73E02                 jbe     short loc_1E73E16
-  .text:0000000001E73E04                 mov     eax, esi
-  .text:0000000001E73E06                 and     eax, 0C0000000h
-  .text:0000000001E73E0B                 cmp     eax, 80000000h
-  .text:0000000001E73E10                 jnz     loc_1E73B3D
-  .text:0000000001E73E16                 mov     r12d, r14d
-  .text:0000000001E73E19                 movsxd  rax, edi
-  .text:0000000001E73E1C                 sub     r12d, edi
-  .text:0000000001E73E1F                 movsxd  rdx, r12d
-  .text:0000000001E73E22                 add     rax, rdx
-  .text:0000000001E73E25                 ; _QWORD
-  .text:0000000001E73E25                 mov     edx, r14d; _QWORD
-  .text:0000000001E73E28                 cmp     rax, 7FFFFFFFh
-  .text:0000000001E73E2E                 jg      loc_1E74061
-  .text:0000000001E73E34                 ; _QWORD
-  .text:0000000001E73E34                 and     esi, 3FFFFFFFh; _QWORD
-  .text:0000000001E73E3A                 ; _QWORD
-  .text:0000000001E73E3A                 mov     ecx, 8; _QWORD
-  .text:0000000001E73E3F                 mov     [rbp+var_78], edx
-  .text:0000000001E73E42                 call    _UtlVectorMemory_CalcNewAllocationCount
-  .text:0000000001E73E47                 mov     edx, [rbp+var_78]
-  .text:0000000001E73E4A                 mov     r12d, eax
-  .text:0000000001E73E4D                 cmp     eax, edx
-  .text:0000000001E73E4F                 jge     short loc_1E73E76
-  .text:0000000001E73E51                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73E5C                 nop     dword ptr [rax+00h]
-  .text:0000000001E73E60                 lea     eax, [r12+rdx]
-  .text:0000000001E73E64                 mov     r12d, eax
-  .text:0000000001E73E67                 shr     r12d, 1Fh
-  .text:0000000001E73E6B                 add     r12d, eax
-  .text:0000000001E73E6E                 sar     r12d, 1
-  .text:0000000001E73E71                 cmp     r12d, edx
-  .text:0000000001E73E74                 jl      short loc_1E73E60
-  .text:0000000001E73E76                 movsxd  rcx, dword ptr [r15+10h]
-  .text:0000000001E73E7A                 movsxd  rdx, r12d
-  .text:0000000001E73E7D                 xor     esi, esi
-  .text:0000000001E73E7F                 ; _QWORD
-  .text:0000000001E73E7F                 shl     rdx, 3; _QWORD
-  .text:0000000001E73E83                 ; _QWORD
-  .text:0000000001E73E83                 mov     rdi, [r15+8]; _QWORD
-  .text:0000000001E73E87                 ; _QWORD
-  .text:0000000001E73E87                 shl     rcx, 3; _QWORD
-  .text:0000000001E73E8B                 cmp     dword ptr [r15+14h], 3FFFFFFFh
-  .text:0000000001E73E93                 ; _QWORD
-  .text:0000000001E73E93                 setbe   sil; _QWORD
-  .text:0000000001E73E97                 call    _UtlVectorMemory_Alloc
-  .text:0000000001E73E9C                 mov     [r15+8], rax
-  .text:0000000001E73EA0                 mov     eax, [r15+14h]
-  .text:0000000001E73EA4                 cmp     eax, 3FFFFFFFh
-  .text:0000000001E73EA9                 jbe     short loc_1E73EB4
-  .text:0000000001E73EAB                 and     eax, 3FFFFFFFh
-  .text:0000000001E73EB0                 mov     [r15+14h], eax
-  .text:0000000001E73EB4                 mov     [r15+10h], r12d
-  .text:0000000001E73EB8                 jmp     loc_1E73B3D
-  .text:0000000001E73EBD                 mov     rcx, [rbx+0AA0h]
-  .text:0000000001E73EC4                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73ECF                 nop     word ptr [rax+rax+00000000h]
-  .text:0000000001E73EDA                 nop     word ptr [rax+rax+00h]
-  .text:0000000001E73EE0                 movzx   eax, ax
-  .text:0000000001E73EE3                 lea     rax, [rax+rax*2]
-  .text:0000000001E73EE7                 lea     rdx, ds:0[rax*8]
-  .text:0000000001E73EEF                 movzx   eax, word ptr [rcx+rax*8]
-  .text:0000000001E73EF3                 cmp     ax, 0FFFFh
-  .text:0000000001E73EF7                 jnz     short loc_1E73EE0
-  .text:0000000001E73EF9                 jmp     loc_1E73A68
-  .text:0000000001E73EFE                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001E73F05                 mov     esi, ecx
-  .text:0000000001E73F07                 and     si, 7FFFh
-  .text:0000000001E73F0C                 jmp     short loc_1E73F57
-  .text:0000000001E73F40                 mov     rdi, [rbx+0AA0h]
-  .text:0000000001E73F47                 lea     rdx, [rdi+rdx*8]
-  .text:0000000001E73F4B                 movzx   edx, word ptr [rdx]
-  .text:0000000001E73F4E                 cmp     dx, 0FFFFh
-  .text:0000000001E73F52                 jz      short loc_1E73F72
-  .text:0000000001E73F54                 mov     r12d, edx
-  .text:0000000001E73F57                 movzx   eax, r12w
-  .text:0000000001E73F5B                 lea     rdx, [rax+rax*2]
-  .text:0000000001E73F5F                 test    si, si
-  .text:0000000001E73F62                 jnz     short loc_1E73F40
-  .text:0000000001E73F64                 movzx   edx, word ptr ds:dword_0[rdx*8]
-  .text:0000000001E73F6C                 cmp     dx, 0FFFFh
-  .text:0000000001E73F70                 jnz     short loc_1E73F54
-  .text:0000000001E73F72                 lea     rsi, [rbx+0A98h]
-  .text:0000000001E73F79                 mov     qword ptr [rbp+var_78], rsi
-  .text:0000000001E73F7D                 jmp     short loc_1E73FA9
-  .text:0000000001E73F80                 call    sub_1E623C0
-  .text:0000000001E73F85                 mov     rdi, qword ptr [rbp+var_78]
-  .text:0000000001E73F89                 movzx   esi, r12w
-  .text:0000000001E73F8D                 call    sub_1E5ADC0
-  .text:0000000001E73F92                 mov     r12d, eax
-  .text:0000000001E73F95                 cmp     ax, 0FFFFh
-  .text:0000000001E73F99                 jz      loc_1E73A91
-  .text:0000000001E73F9F                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001E73FA6                 movzx   eax, ax
-  .text:0000000001E73FA9                 movzx   edx, word ptr [rbx+0AEAh]
-  .text:0000000001E73FB0                 xor     esi, esi
-  .text:0000000001E73FB2                 and     cx, 7FFFh
-  .text:0000000001E73FB7                 mov     r15d, edx
-  .text:0000000001E73FBA                 jz      short loc_1E73FC3
-  .text:0000000001E73FBC                 mov     rsi, [rbx+0AA0h]
-  .text:0000000001E73FC3                 lea     r8, [rax+rax*2]
-  .text:0000000001E73FC7                 lea     r14, ds:0[r8*8]
-  .text:0000000001E73FCF                 mov     rax, [rsi+r14+10h]
-  .text:0000000001E73FD4                 mov     esi, edx
-  .text:0000000001E73FD6                 sub     esi, [rax+78h]
-  .text:0000000001E73FD9                 test    esi, esi
-  .text:0000000001E73FDB                 jg      loc_1E74080
-  .text:0000000001E73FE1                 jz      short loc_1E73FF2
-  .text:0000000001E73FE3                 mov     [rax+78h], edx
-  .text:0000000001E73FE6                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001E73FED                 and     cx, 7FFFh
-  .text:0000000001E73FF2                 movzx   edx, r15w
-  .text:0000000001E73FF6                 xor     eax, eax
-  .text:0000000001E73FF8                 ; n
-  .text:0000000001E73FF8                 add     rdx, rdx; n
-  .text:0000000001E73FFB                 test    cx, cx
-  .text:0000000001E73FFE                 jz      short loc_1E74007
-  .text:0000000001E74000                 mov     rax, [rbx+0AA0h]
-  .text:0000000001E74007                 mov     rax, [rax+r14+10h]
-  .text:0000000001E7400C                 ; c
-  .text:0000000001E7400C                 mov     esi, 0FFh; c
-  .text:0000000001E74011                 ; s
-  .text:0000000001E74011                 mov     rdi, [rax+80h]; s
-  .text:0000000001E74018                 call    _memset
-  .text:0000000001E7401D                 xor     eax, eax
-  .text:0000000001E7401F                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001E74028                 jz      short loc_1E74031
-  .text:0000000001E7402A                 mov     rax, [rbx+0AA0h]
-  .text:0000000001E74031                 mov     r15, [rax+r14+10h]
-  .text:0000000001E74036                 call    _CommandLine
-  .text:0000000001E7403B                 mov     esi, 46F20F89h
-  .text:0000000001E74040                 mov     rdi, rax
-  .text:0000000001E74043                 mov     rax, [rax]
-  .text:0000000001E74046                 call    qword ptr [rax+20h]
-  .text:0000000001E74049                 mov     rsi, r15
-  .text:0000000001E7404C                 mov     rdi, rbx
-  .text:0000000001E7404F                 test    al, al
-  .text:0000000001E74051                 jnz     loc_1E73F80
-  .text:0000000001E74057                 call    sub_1E61B40
-  .text:0000000001E7405C                 jmp     loc_1E73F85
-  .text:0000000001E74061                 ; _QWORD
-  .text:0000000001E74061                 mov     esi, r12d; _QWORD
-  .text:0000000001E74064                 call    _UtlVectorMemory_FailedAllocation
-  .text:0000000001E74069                 mov     edi, [r15+10h]
-  .text:0000000001E7406D                 mov     esi, [r15+14h]
-  .text:0000000001E74071                 lea     edx, [r12+rdi]
-  .text:0000000001E74075                 jmp     loc_1E73E34
-  .text:0000000001E74080                 mov     ecx, [rax+88h]
-  .text:0000000001E74086                 cmp     edx, ecx
-  .text:0000000001E74088                 jle     loc_1E73FE3
-  .text:0000000001E7408E                 lea     rdi, [rax+80h]
-  .text:0000000001E74095                 mov     esi, edx
-  .text:0000000001E74097                 mov     [rbp+var_84], edx
-  .text:0000000001E7409D                 sub     esi, ecx
-  .text:0000000001E7409F                 mov     [rbp+var_80], rax
-  .text:0000000001E740A3                 call    sub_1E66A60
-  .text:0000000001E740A8                 mov     edx, [rbp+var_84]
-  .text:0000000001E740AE                 mov     rax, [rbp+var_80]
-  .text:0000000001E740B2                 jmp     loc_1E73FE3
-  .text:0000000001E740B7                 mov     esi, [r12+3Ch]
-  .text:0000000001E740BC                 cmp     esi, 3FFFFFFFh
-  .text:0000000001E740C2                 jbe     short loc_1E740D6
-  .text:0000000001E740C4                 mov     eax, esi
-  .text:0000000001E740C6                 and     eax, 0C0000000h
-  .text:0000000001E740CB                 cmp     eax, 80000000h
-  .text:0000000001E740D0                 jnz     loc_1E73DAD
-  .text:0000000001E740D6                 cmp     edi, 7FFFFFFFh
-  .text:0000000001E740DC                 jz      loc_1E74262
-  .text:0000000001E740E2                 lea     r8d, [rdi+1]
-  .text:0000000001E740E6                 ; _QWORD
-  .text:0000000001E740E6                 and     esi, 3FFFFFFFh; _QWORD
-  .text:0000000001E740EC                 ; _QWORD
-  .text:0000000001E740EC                 mov     ecx, 8; _QWORD
-  .text:0000000001E740F1                 ; _QWORD
-  .text:0000000001E740F1                 mov     edx, r8d; _QWORD
-  .text:0000000001E740F4                 mov     [rbp+var_78], r8d
-  .text:0000000001E740F8                 call    _UtlVectorMemory_CalcNewAllocationCount
-  .text:0000000001E740FD                 mov     r8d, [rbp+var_78]
-  .text:0000000001E74101                 mov     r15d, eax
-  .text:0000000001E74104                 cmp     r8d, eax
-  .text:0000000001E74107                 jg      short loc_1E74160
-  .text:0000000001E74109                 movsxd  rcx, dword ptr [r12+38h]
-  .text:0000000001E7410E                 movsxd  rdx, r15d
-  .text:0000000001E74111                 xor     esi, esi
-  .text:0000000001E74113                 ; _QWORD
-  .text:0000000001E74113                 shl     rdx, 3; _QWORD
-  .text:0000000001E74117                 ; _QWORD
-  .text:0000000001E74117                 mov     rdi, [r12+30h]; _QWORD
-  .text:0000000001E7411C                 ; _QWORD
-  .text:0000000001E7411C                 shl     rcx, 3; _QWORD
-  .text:0000000001E74120                 cmp     dword ptr [r12+3Ch], 3FFFFFFFh
-  .text:0000000001E74129                 ; _QWORD
-  .text:0000000001E74129                 setbe   sil; _QWORD
-  .text:0000000001E7412D                 call    _UtlVectorMemory_Alloc
-  .text:0000000001E74132                 mov     edx, [r12+3Ch]
-  .text:0000000001E74137                 mov     [r12+30h], rax
-  .text:0000000001E7413C                 cmp     edx, 3FFFFFFFh
-  .text:0000000001E74142                 jbe     short loc_1E7414F
-  .text:0000000001E74144                 and     edx, 3FFFFFFFh
-  .text:0000000001E7414A                 mov     [r12+3Ch], edx
-  .text:0000000001E7414F                 mov     edx, [r12+28h]
-  .text:0000000001E74154                 mov     [r12+38h], r15d
-  .text:0000000001E74159                 jmp     loc_1E73DB5
-  .text:0000000001E74160                 lea     edx, [r15+r8]
-  .text:0000000001E74164                 mov     eax, edx
-  .text:0000000001E74166                 shr     eax, 1Fh
-  .text:0000000001E74169                 add     eax, edx
-  .text:0000000001E7416B                 sar     eax, 1
-  .text:0000000001E7416D                 mov     r15d, eax
-  .text:0000000001E74170                 cmp     r8d, eax
-  .text:0000000001E74173                 jg      short loc_1E74160
-  .text:0000000001E74175                 jmp     short loc_1E74109
-  .text:0000000001E74177                 movzx   ecx, word ptr [rbx+0A9Ah]
-  .text:0000000001E7417E                 and     cx, 7FFFh
-  .text:0000000001E74183                 jmp     short loc_1E741D5
-  .text:0000000001E741C0                 mov     rdx, [rbx+0AA0h]
-  .text:0000000001E741C7                 movzx   eax, word ptr [rdx+rax*8]
-  .text:0000000001E741CB                 cmp     ax, 0FFFFh
-  .text:0000000001E741CF                 jz      short loc_1E741FA
-  .text:0000000001E741D1                 movzx   r12d, ax
-  .text:0000000001E741D5                 movzx   eax, r12w
-  .text:0000000001E741D9                 lea     rax, [rax+rax*2]
-  .text:0000000001E741DD                 lea     rsi, ds:0[rax*8]
-  .text:0000000001E741E5                 test    cx, cx
-  .text:0000000001E741E8                 jnz     short loc_1E741C0
-  .text:0000000001E741EA                 movzx   eax, word ptr ds:dword_0[rax*8]
-  .text:0000000001E741F2                 cmp     ax, 0FFFFh
-  .text:0000000001E741F6                 jnz     short loc_1E741D1
-  .text:0000000001E741F8                 xor     edx, edx
-  .text:0000000001E741FA                 mov     r13, 0FFFFFFFF00000000h
-  .text:0000000001E74204                 mov     rdi, [rsi+rdx+10h]
-  .text:0000000001E74209                 jmp     short loc_1E74239
-  .text:0000000001E74210                 movzx   edx, ax
-  .text:0000000001E74213                 and     r12, r13
-  .text:0000000001E74216                 or      r12, rdx
-  .text:0000000001E74219                 xor     edx, edx
-  .text:0000000001E7421B                 test    word ptr [rbx+0A9Ah], 7FFFh
-  .text:0000000001E74224                 jz      short loc_1E7422D
-  .text:0000000001E74226                 mov     rdx, [rbx+0AA0h]
-  .text:0000000001E7422D                 movzx   eax, ax
-  .text:0000000001E74230                 lea     rax, [rax+rax*2]
-  .text:0000000001E74234                 mov     rdi, [rdx+rax*8+10h]
-  .text:0000000001E74239                 test    rdi, rdi
-  .text:0000000001E7423C                 jz      loc_1E73C33
-  .text:0000000001E74242                 call    sub_1E3FFE0
-  .text:0000000001E74247                 lea     rdi, [rbx+0A98h]
-  .text:0000000001E7424E                 movzx   esi, r12w
-  .text:0000000001E74252                 call    sub_1E5ADC0
-  .text:0000000001E74257                 cmp     ax, 0FFFFh
-  .text:0000000001E7425B                 jnz     short loc_1E74210
-  .text:0000000001E7425D                 jmp     loc_1E73C33
-  .text:0000000001E74262                 ; _QWORD
-  .text:0000000001E74262                 mov     esi, 1; _QWORD
-  .text:0000000001E74267                 call    _UtlVectorMemory_FailedAllocation
-  .text:0000000001E7426C                 mov     edi, [r12+38h]
-  .text:0000000001E74271                 mov     esi, [r12+3Ch]
-  .text:0000000001E74276                 jmp     loc_1E740E2
-  .text:0000000001E7427B                 mov     esi, [r12+40h]
-  .text:0000000001E74280                 lea     rdi, aCnetworkfields_0; "CNetworkFieldScratchData::Init failed o"...
-  .text:0000000001E74287                 call    _Plat_FatalError
+  .text:0000000001E7C3C0                 push    rbp
+  .text:0000000001E7C3C1                 mov     rbp, rsp
+  .text:0000000001E7C3C4                 push    r15
+  .text:0000000001E7C3C6                 push    r14
+  .text:0000000001E7C3C8                 mov     r14d, r8d
+  .text:0000000001E7C3CB                 push    r13
+  .text:0000000001E7C3CD                 mov     r13d, ecx
+  .text:0000000001E7C3D0                 push    r12
+  .text:0000000001E7C3D2                 mov     r12d, edx
+  .text:0000000001E7C3D5                 push    rbx
+  .text:0000000001E7C3D6                 mov     rbx, rdi
+  .text:0000000001E7C3D9                 add     rdi, 0A88h
+  .text:0000000001E7C3E0                 sub     rsp, 68h
+  .text:0000000001E7C3E4                 call    sub_9849D0
+  .text:0000000001E7C3E9                 lea     rax, unk_27C4271
+  .text:0000000001E7C3F0                 mov     [rbx+0BBCh], r13d
+  .text:0000000001E7C3F7                 mov     [rax], r14b
+  .text:0000000001E7C3FA                 cmp     r12d, 1
+  .text:0000000001E7C3FE                 jz      loc_1E7C748
+  .text:0000000001E7C404                 lea     r13, unk_274BEF0
+  .text:0000000001E7C40B                 xor     eax, eax
+  .text:0000000001E7C40D                 mov     [rbx+0BDAh], al
+  .text:0000000001E7C413                 xor     r8d, r8d
+  .text:0000000001E7C416                 xor     ecx, ecx
+  .text:0000000001E7C418                 xor     edx, edx
+  .text:0000000001E7C41A                 lea     rdi, [rbx+0CC0h]
+  .text:0000000001E7C421                 mov     esi, 400h
+  .text:0000000001E7C426                 call    sub_984120
+  .text:0000000001E7C42B                 lea     r14, qword_27C41A8
+  .text:0000000001E7C432                 lea     rax, [rbx+10h]
+  .text:0000000001E7C436                 mov     cs:qword_256F1A8, rbx
+  .text:0000000001E7C43D                 mov     cs:qword_256F1A0, rax
+  .text:0000000001E7C444                 mov     r12, [r14]
+  .text:0000000001E7C447                 test    r12, r12
+  .text:0000000001E7C44A                 jz      short loc_1E7C4B9
+  .text:0000000001E7C44C                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C457                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C460                 test    byte ptr [r12+68h], 2
+  .text:0000000001E7C466                 jz      loc_1E7C6B0
+  .text:0000000001E7C46C                 mov     r12, [r12+120h]
+  .text:0000000001E7C474                 test    r12, r12
+  .text:0000000001E7C477                 jnz     short loc_1E7C460
+  .text:0000000001E7C479                 mov     r12, [r14]
+  .text:0000000001E7C47C                 test    r12, r12
+  .text:0000000001E7C47F                 jz      short loc_1E7C4B9
+  .text:0000000001E7C481                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C48C                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C497                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C4A0                 test    byte ptr [r12+68h], 2
+  .text:0000000001E7C4A6                 jnz     loc_1E7C688
+  .text:0000000001E7C4AC                 mov     r12, [r12+120h]
+  .text:0000000001E7C4B4                 test    r12, r12
+  .text:0000000001E7C4B7                 jnz     short loc_1E7C4A0
+  .text:0000000001E7C4B9                 mov     r12, cs:qword_2575B70
+  .text:0000000001E7C4C0                 xor     r14d, r14d
+  .text:0000000001E7C4C3                 lea     r15, nullsub_1668
+  .text:0000000001E7C4CA                 test    r12, r12
+  .text:0000000001E7C4CD                 jz      short loc_1E7C516
+  .text:0000000001E7C4CF                 nop
+  .text:0000000001E7C4D0                 mov     rsi, r12
+  .text:0000000001E7C4D3                 mov     rdi, rbx
+  .text:0000000001E7C4D6                 add     r14d, 1
+  .text:0000000001E7C4DA                 call    sub_1E7BEC0
+  .text:0000000001E7C4DF                 mov     rdx, [r12+10h]
+  .text:0000000001E7C4E4                 mov     [rdx+20h], eax
+  .text:0000000001E7C4E7                 mov     rax, [r12+10h]
+  .text:0000000001E7C4EC                 test    byte ptr [rax+24h], 1
+  .text:0000000001E7C4F0                 jz      short loc_1E7C4FB
+  .text:0000000001E7C4F2                 or      dword ptr [r12+8], 20000h
+  .text:0000000001E7C4FB                 mov     rax, [r12]
+  .text:0000000001E7C4FF                 mov     rax, [rax+8]
+  .text:0000000001E7C503                 cmp     rax, r15
+  .text:0000000001E7C506                 jnz     loc_1E7C6D8
+  .text:0000000001E7C50C                 mov     r12, [r12+20h]
+  .text:0000000001E7C511                 test    r12, r12
+  .text:0000000001E7C514                 jnz     short loc_1E7C4D0
+  .text:0000000001E7C516                 lea     r15, qword_27C4170
+  .text:0000000001E7C51D                 mov     eax, r14d
+  .text:0000000001E7C520                 sub     eax, [r15]
+  .text:0000000001E7C523                 test    eax, eax
+  .text:0000000001E7C525                 jg      loc_1E7C670
+  .text:0000000001E7C52B                 jnz     loc_1E7C67D
+  .text:0000000001E7C531                 mov     r12, cs:qword_2575B70
+  .text:0000000001E7C538                 test    r12, r12
+  .text:0000000001E7C53B                 jz      short loc_1E7C572
+  .text:0000000001E7C53D                 nop     dword ptr [rax]
+  .text:0000000001E7C540                 mov     rdi, [r13+0]
+  .text:0000000001E7C544                 test    rdi, rdi
+  .text:0000000001E7C547                 jz      short loc_1E7C557
+  .text:0000000001E7C549                 mov     rax, [rdi]
+  .text:0000000001E7C54C                 mov     esi, [r12+18h]
+  .text:0000000001E7C551                 call    qword ptr [rax+0E8h]
+  .text:0000000001E7C557                 mov     rax, [r12+10h]
+  .text:0000000001E7C55C                 mov     rdx, [r15+8]
+  .text:0000000001E7C560                 movsxd  rcx, dword ptr [rax+20h]
+  .text:0000000001E7C564                 mov     [rdx+rcx*8], rax
+  .text:0000000001E7C568                 mov     r12, [r12+20h]
+  .text:0000000001E7C56D                 test    r12, r12
+  .text:0000000001E7C570                 jnz     short loc_1E7C540
+  .text:0000000001E7C572                 cmp     word ptr [rbx+0AAAh], 0
+  .text:0000000001E7C57A                 jz      short loc_1E7C5B5
+  .text:0000000001E7C57C                 movzx   eax, word ptr [rbx+0AA8h]
+  .text:0000000001E7C583                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E7C58C                 jz      loc_1E7C6F0
+  .text:0000000001E7C592                 cmp     ax, 0FFFFh
+  .text:0000000001E7C596                 jnz     loc_1E7C9FD
+  .text:0000000001E7C59C                 mov     rcx, [rbx+0AA0h]
+  .text:0000000001E7C5A3                 mov     edx, offset stru_17FFE8
+  .text:0000000001E7C5A8                 mov     rsi, [rcx+rdx+10h]
+  .text:0000000001E7C5AD                 mov     rdi, rbx
+  .text:0000000001E7C5B0                 call    sub_1E5DB00
+  .text:0000000001E7C5B5                 cmp     cs:byte_27C42C0, 0
+  .text:0000000001E7C5BC                 jnz     short loc_1E7C5D1
+  .text:0000000001E7C5BE                 movzx   r12d, word ptr [rbx+0AA8h]
+  .text:0000000001E7C5C6                 cmp     r12w, 0FFFFh
+  .text:0000000001E7C5CB                 jnz     loc_1E7CA3E
+  .text:0000000001E7C5D1                 lea     rdi, aEntitysystemCl; "EntitySystem - Class Tables"
+  .text:0000000001E7C5D8                 xor     eax, eax
+  .text:0000000001E7C5DA                 call    sub_985030
+  .text:0000000001E7C5DF                 mov     rdi, [r13+0]
+  .text:0000000001E7C5E3                 test    rdi, rdi
+  .text:0000000001E7C5E6                 jz      short loc_1E7C637
+  .text:0000000001E7C5E8                 mov     rax, [rdi]
+  .text:0000000001E7C5EB                 lea     rsi, aStringTTable; "string_t_table"
+  .text:0000000001E7C5F2                 mov     edx, [rbx+0BBCh]
+  .text:0000000001E7C5F8                 lea     rcx, [rbx+1ED0h]
+  .text:0000000001E7C5FF                 call    qword ptr [rax+0A0h]
+  .text:0000000001E7C605                 mov     rdi, [r13+0]
+  .text:0000000001E7C609                 lea     rsi, [rbp+var_50]
+  .text:0000000001E7C60D                 mov     qword ptr [rbp+var_68], 121h
+  .text:0000000001E7C615                 mov     qword ptr [rbp+var_68+8], 0
+  .text:0000000001E7C61D                 movdqu  xmm0, [rbp+var_68]
+  .text:0000000001E7C622                 mov     rax, [rdi]
+  .text:0000000001E7C625                 mov     [rbp+var_50], 0
+  .text:0000000001E7C62D                 movups  [rbp+var_48], xmm0
+  .text:0000000001E7C631                 call    qword ptr [rax+0B8h]
+  .text:0000000001E7C637                 mov     rdi, rbx
+  .text:0000000001E7C63A                 call    sub_1E7AD40
+  .text:0000000001E7C63F                 cmp     byte ptr [rbx+0BDAh], 0
+  .text:0000000001E7C646                 jnz     loc_1E7C788
+  .text:0000000001E7C64C                 cmp     cs:byte_27C42C0, 0
+  .text:0000000001E7C653                 jz      loc_1E7C760
+  .text:0000000001E7C659                 mov     cs:byte_27C42C0, 1
+  .text:0000000001E7C660                 add     rsp, 68h
+  .text:0000000001E7C664                 pop     rbx
+  .text:0000000001E7C665                 pop     r12
+  .text:0000000001E7C667                 pop     r13
+  .text:0000000001E7C669                 pop     r14
+  .text:0000000001E7C66B                 pop     r15
+  .text:0000000001E7C66D                 pop     rbp
+  .text:0000000001E7C66E                 retn
+  .text:0000000001E7C670                 mov     edi, [r15+10h]
+  .text:0000000001E7C674                 cmp     r14d, edi
+  .text:0000000001E7C677                 jg      loc_1E7C938
+  .text:0000000001E7C67D                 mov     [r15], r14d
+  .text:0000000001E7C680                 jmp     loc_1E7C531
+  .text:0000000001E7C688                 mov     rsi, r12
+  .text:0000000001E7C68B                 mov     rdi, rbx
+  .text:0000000001E7C68E                 call    sub_1E70600
+  .text:0000000001E7C693                 mov     r12, [r12+120h]
+  .text:0000000001E7C69B                 test    r12, r12
+  .text:0000000001E7C69E                 jnz     loc_1E7C4A0
+  .text:0000000001E7C6A4                 jmp     loc_1E7C4B9
+  .text:0000000001E7C6B0                 mov     rsi, r12
+  .text:0000000001E7C6B3                 mov     rdi, rbx
+  .text:0000000001E7C6B6                 call    sub_1E70370
+  .text:0000000001E7C6BB                 mov     r12, [r12+120h]
+  .text:0000000001E7C6C3                 test    r12, r12
+  .text:0000000001E7C6C6                 jnz     loc_1E7C460
+  .text:0000000001E7C6CC                 jmp     loc_1E7C479
+  .text:0000000001E7C6D8                 mov     rdi, r12
+  .text:0000000001E7C6DB                 call    rax
+  .text:0000000001E7C6DD                 mov     r12, [r12+20h]
+  .text:0000000001E7C6E2                 test    r12, r12
+  .text:0000000001E7C6E5                 jnz     loc_1E7C4D0
+  .text:0000000001E7C6EB                 jmp     loc_1E7C516
+  .text:0000000001E7C6F0                 mov     edx, offset stru_17FFE8
+  .text:0000000001E7C6F5                 xor     ecx, ecx
+  .text:0000000001E7C6F7                 cmp     ax, 0FFFFh
+  .text:0000000001E7C6FB                 jz      loc_1E7C5A8
+  .text:0000000001E7C701                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C70C                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C717                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C720                 movzx   eax, ax
+  .text:0000000001E7C723                 lea     rax, [rax+rax*2]
+  .text:0000000001E7C727                 lea     rdx, ds:0[rax*8]
+  .text:0000000001E7C72F                 movzx   eax, word ptr ds:dword_0[rax*8]
+  .text:0000000001E7C737                 cmp     ax, 0FFFFh
+  .text:0000000001E7C73B                 jnz     short loc_1E7C720
+  .text:0000000001E7C73D                 xor     ecx, ecx
+  .text:0000000001E7C73F                 jmp     loc_1E7C5A8
+  .text:0000000001E7C748                 lea     r13, unk_274BEF0
+  .text:0000000001E7C74F                 cmp     qword ptr [r13+0], 0
+  .text:0000000001E7C754                 setnz   al
+  .text:0000000001E7C757                 jmp     loc_1E7C40D
+  .text:0000000001E7C760                 movzx   r12d, word ptr [rbx+0AA8h]
+  .text:0000000001E7C768                 cmp     r12w, 0FFFFh
+  .text:0000000001E7C76D                 jnz     loc_1E7CCB7
+  .text:0000000001E7C773                 call    sub_1E98AF0
+  .text:0000000001E7C778                 mov     rdi, rbx
+  .text:0000000001E7C77B                 call    sub_1E68880
+  .text:0000000001E7C780                 jmp     loc_1E7C659
+  .text:0000000001E7C788                 mov     edi, 58h ; 'X'
+  .text:0000000001E7C78D                 call    sub_97A1D0
+  .text:0000000001E7C792                 mov     ecx, 1
+  .text:0000000001E7C797                 xor     esi, esi
+  .text:0000000001E7C799                 xor     edi, edi
+  .text:0000000001E7C79B                 mov     r12, rax
+  .text:0000000001E7C79E                 mov     edx, 4E200h
+  .text:0000000001E7C7A3                 lea     rax, off_241DF48
+  .text:0000000001E7C7AA                 mov     [rbx+0C90h], r12
+  .text:0000000001E7C7B1                 mov     [r12], rax
+  .text:0000000001E7C7B5                 mov     rax, 0C8000000000000h
+  .text:0000000001E7C7BF                 mov     [r12+48h], rax
+  .text:0000000001E7C7C4                 lea     rax, dword_27C455C
+  .text:0000000001E7C7CB                 mov     qword ptr [r12+8], 0
+  .text:0000000001E7C7D4                 mov     qword ptr [r12+10h], 0
+  .text:0000000001E7C7DD                 mov     qword ptr [r12+18h], 0
+  .text:0000000001E7C7E6                 mov     dword ptr [r12+20h], 0
+  .text:0000000001E7C7EF                 mov     r14d, [rax]
+  .text:0000000001E7C7F2                 mov     qword ptr [r12+30h], 0
+  .text:0000000001E7C7FB                 mov     dword ptr [r12+38h], 0
+  .text:0000000001E7C804                 mov     dword ptr [r12+28h], 0
+  .text:0000000001E7C80D                 mov     qword ptr [r12+3Ch], 0
+  .text:0000000001E7C816                 mov     qword ptr [r12+50h], 0
+  .text:0000000001E7C81F                 call    sub_984790
+  .text:0000000001E7C824                 mov     r13d, eax
+  .text:0000000001E7C827                 cmp     eax, 4E1FFh
+  .text:0000000001E7C82C                 jle     loc_1E7C932
+  .text:0000000001E7C832                 xor     esi, esi
+  .text:0000000001E7C834                 movsxd  rcx, dword ptr [r12+18h]
+  .text:0000000001E7C839                 movsxd  rdx, eax
+  .text:0000000001E7C83C                 cmp     dword ptr [r12+1Ch], 3FFFFFFFh
+  .text:0000000001E7C845                 mov     rdi, [r12+10h]
+  .text:0000000001E7C84A                 setbe   sil
+  .text:0000000001E7C84E                 call    sub_9843C0
+  .text:0000000001E7C853                 mov     [r12+10h], rax
+  .text:0000000001E7C858                 mov     eax, [r12+1Ch]
+  .text:0000000001E7C85D                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E7C862                 jbe     short loc_1E7C86E
+  .text:0000000001E7C864                 and     eax, 3FFFFFFFh
+  .text:0000000001E7C869                 mov     [r12+1Ch], eax
+  .text:0000000001E7C86E                 mov     [r12+18h], r13d
+  .text:0000000001E7C873                 lea     rdx, [r12+20h]
+  .text:0000000001E7C878                 xor     eax, eax
+  .text:0000000001E7C87A                 mov     dword ptr [r12+8], 4E200h
+  .text:0000000001E7C883                 xchg    eax, [rdx]
+  .text:0000000001E7C885                 mov     edi, 50h ; 'P'
+  .text:0000000001E7C88A                 mov     [r12+44h], r14d
+  .text:0000000001E7C88F                 mov     eax, [r12+20h]
+  .text:0000000001E7C894                 mov     dword ptr [r12+40h], 10000h
+  .text:0000000001E7C89D                 call    sub_97A1D0
+  .text:0000000001E7C8A2                 mov     rdi, rax
+  .text:0000000001E7C8A5                 mov     r13, rax
+  .text:0000000001E7C8A8                 call    sub_984550
+  .text:0000000001E7C8AD                 mov     edx, [r12+40h]
+  .text:0000000001E7C8B2                 mov     r9d, 10h
+  .text:0000000001E7C8B8                 mov     rdi, r13
+  .text:0000000001E7C8BB                 mov     r8d, 1000h
+  .text:0000000001E7C8C1                 mov     ecx, 1000h
+  .text:0000000001E7C8C6                 lea     rsi, aCnetworkfields; "CNetworkFieldScratchData.m_MemoryStacks"...
+  .text:0000000001E7C8CD                 call    sub_983FE0
+  .text:0000000001E7C8D2                 test    al, al
+  .text:0000000001E7C8D4                 jz      loc_1E7CDBB
+  .text:0000000001E7C8DA                 mov     r14d, [r12+28h]
+  .text:0000000001E7C8DF                 mov     edi, [r12+38h]
+  .text:0000000001E7C8E4                 cmp     r14d, edi
+  .text:0000000001E7C8E7                 jz      loc_1E7CBF7
+  .text:0000000001E7C8ED                 mov     rax, [r12+30h]
+  .text:0000000001E7C8F2                 mov     edx, r14d
+  .text:0000000001E7C8F5                 add     edx, 1
+  .text:0000000001E7C8F8                 mov     [r12+28h], edx
+  .text:0000000001E7C8FD                 movsxd  rdx, r14d
+  .text:0000000001E7C900                 mov     [rax+rdx*8], r13
+  .text:0000000001E7C904                 lea     rax, unk_274BEE8
+  .text:0000000001E7C90B                 mov     rdx, [rbx+0C98h]
+  .text:0000000001E7C912                 mov     rsi, [rbx+0C90h]
+  .text:0000000001E7C919                 mov     rdi, [rax]
+  .text:0000000001E7C91C                 mov     rax, [rdi]
+  .text:0000000001E7C91F                 call    qword ptr [rax+118h]
+  .text:0000000001E7C925                 mov     [rbx+0C88h], rax
+  .text:0000000001E7C92C                 jmp     loc_1E7C64C
+  .text:0000000001E7C932                 jmp     short loc_1E7C932
+  .text:0000000001E7C938                 mov     esi, [r15+14h]
+  .text:0000000001E7C93C                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E7C942                 jbe     short loc_1E7C956
+  .text:0000000001E7C944                 mov     eax, esi
+  .text:0000000001E7C946                 and     eax, 0C0000000h
+  .text:0000000001E7C94B                 cmp     eax, 80000000h
+  .text:0000000001E7C950                 jnz     loc_1E7C67D
+  .text:0000000001E7C956                 mov     r12d, r14d
+  .text:0000000001E7C959                 movsxd  rax, edi
+  .text:0000000001E7C95C                 sub     r12d, edi
+  .text:0000000001E7C95F                 movsxd  rdx, r12d
+  .text:0000000001E7C962                 add     rax, rdx
+  .text:0000000001E7C965                 mov     edx, r14d
+  .text:0000000001E7C968                 cmp     rax, 7FFFFFFFh
+  .text:0000000001E7C96E                 jg      loc_1E7CBA1
+  .text:0000000001E7C974                 and     esi, 3FFFFFFFh
+  .text:0000000001E7C97A                 mov     ecx, 8
+  .text:0000000001E7C97F                 mov     dword ptr [rbp+var_78], edx
+  .text:0000000001E7C982                 call    sub_984790
+  .text:0000000001E7C987                 mov     edx, dword ptr [rbp+var_78]
+  .text:0000000001E7C98A                 mov     r12d, eax
+  .text:0000000001E7C98D                 cmp     eax, edx
+  .text:0000000001E7C98F                 jge     short loc_1E7C9B6
+  .text:0000000001E7C991                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7C99C                 nop     dword ptr [rax+00h]
+  .text:0000000001E7C9A0                 lea     eax, [r12+rdx]
+  .text:0000000001E7C9A4                 mov     r12d, eax
+  .text:0000000001E7C9A7                 shr     r12d, 1Fh
+  .text:0000000001E7C9AB                 add     r12d, eax
+  .text:0000000001E7C9AE                 sar     r12d, 1
+  .text:0000000001E7C9B1                 cmp     r12d, edx
+  .text:0000000001E7C9B4                 jl      short loc_1E7C9A0
+  .text:0000000001E7C9B6                 movsxd  rcx, dword ptr [r15+10h]
+  .text:0000000001E7C9BA                 movsxd  rdx, r12d
+  .text:0000000001E7C9BD                 xor     esi, esi
+  .text:0000000001E7C9BF                 shl     rdx, 3
+  .text:0000000001E7C9C3                 mov     rdi, [r15+8]
+  .text:0000000001E7C9C7                 shl     rcx, 3
+  .text:0000000001E7C9CB                 cmp     dword ptr [r15+14h], 3FFFFFFFh
+  .text:0000000001E7C9D3                 setbe   sil
+  .text:0000000001E7C9D7                 call    sub_9843C0
+  .text:0000000001E7C9DC                 mov     [r15+8], rax
+  .text:0000000001E7C9E0                 mov     eax, [r15+14h]
+  .text:0000000001E7C9E4                 cmp     eax, 3FFFFFFFh
+  .text:0000000001E7C9E9                 jbe     short loc_1E7C9F4
+  .text:0000000001E7C9EB                 and     eax, 3FFFFFFFh
+  .text:0000000001E7C9F0                 mov     [r15+14h], eax
+  .text:0000000001E7C9F4                 mov     [r15+10h], r12d
+  .text:0000000001E7C9F8                 jmp     loc_1E7C67D
+  .text:0000000001E7C9FD                 mov     rcx, [rbx+0AA0h]
+  .text:0000000001E7CA04                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7CA0F                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E7CA1A                 nop     word ptr [rax+rax+00h]
+  .text:0000000001E7CA20                 movzx   eax, ax
+  .text:0000000001E7CA23                 lea     rax, [rax+rax*2]
+  .text:0000000001E7CA27                 lea     rdx, ds:0[rax*8]
+  .text:0000000001E7CA2F                 movzx   eax, word ptr [rcx+rax*8]
+  .text:0000000001E7CA33                 cmp     ax, 0FFFFh
+  .text:0000000001E7CA37                 jnz     short loc_1E7CA20
+  .text:0000000001E7CA39                 jmp     loc_1E7C5A8
+  .text:0000000001E7CA3E                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E7CA45                 mov     esi, ecx
+  .text:0000000001E7CA47                 and     si, 7FFFh
+  .text:0000000001E7CA4C                 jmp     short loc_1E7CA97
+  .text:0000000001E7CA80                 mov     rdi, [rbx+0AA0h]
+  .text:0000000001E7CA87                 lea     rdx, [rdi+rdx*8]
+  .text:0000000001E7CA8B                 movzx   edx, word ptr [rdx]
+  .text:0000000001E7CA8E                 cmp     dx, 0FFFFh
+  .text:0000000001E7CA92                 jz      short loc_1E7CAB2
+  .text:0000000001E7CA94                 mov     r12d, edx
+  .text:0000000001E7CA97                 movzx   eax, r12w
+  .text:0000000001E7CA9B                 lea     rdx, [rax+rax*2]
+  .text:0000000001E7CA9F                 test    si, si
+  .text:0000000001E7CAA2                 jnz     short loc_1E7CA80
+  .text:0000000001E7CAA4                 movzx   edx, word ptr ds:dword_0[rdx*8]
+  .text:0000000001E7CAAC                 cmp     dx, 0FFFFh
+  .text:0000000001E7CAB0                 jnz     short loc_1E7CA94
+  .text:0000000001E7CAB2                 lea     rsi, [rbx+0A98h]
+  .text:0000000001E7CAB9                 mov     [rbp+var_78], rsi
+  .text:0000000001E7CABD                 jmp     short loc_1E7CAE9
+  .text:0000000001E7CAC0                 call    sub_1E6AF00
+  .text:0000000001E7CAC5                 mov     rdi, [rbp+var_78]
+  .text:0000000001E7CAC9                 movzx   esi, r12w
+  .text:0000000001E7CACD                 call    sub_1E63900
+  .text:0000000001E7CAD2                 mov     r12d, eax
+  .text:0000000001E7CAD5                 cmp     ax, 0FFFFh
+  .text:0000000001E7CAD9                 jz      loc_1E7C5D1
+  .text:0000000001E7CADF                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E7CAE6                 movzx   eax, ax
+  .text:0000000001E7CAE9                 movzx   edx, word ptr [rbx+0AEAh]
+  .text:0000000001E7CAF0                 xor     esi, esi
+  .text:0000000001E7CAF2                 and     cx, 7FFFh
+  .text:0000000001E7CAF7                 mov     r15d, edx
+  .text:0000000001E7CAFA                 jz      short loc_1E7CB03
+  .text:0000000001E7CAFC                 mov     rsi, [rbx+0AA0h]
+  .text:0000000001E7CB03                 lea     r8, [rax+rax*2]
+  .text:0000000001E7CB07                 lea     r14, ds:0[r8*8]
+  .text:0000000001E7CB0F                 mov     rax, [rsi+r14+10h]
+  .text:0000000001E7CB14                 mov     esi, edx
+  .text:0000000001E7CB16                 sub     esi, [rax+78h]
+  .text:0000000001E7CB19                 test    esi, esi
+  .text:0000000001E7CB1B                 jg      loc_1E7CBC0
+  .text:0000000001E7CB21                 jz      short loc_1E7CB32
+  .text:0000000001E7CB23                 mov     [rax+78h], edx
+  .text:0000000001E7CB26                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E7CB2D                 and     cx, 7FFFh
+  .text:0000000001E7CB32                 movzx   edx, r15w
+  .text:0000000001E7CB36                 xor     eax, eax
+  .text:0000000001E7CB38                 add     rdx, rdx
+  .text:0000000001E7CB3B                 test    cx, cx
+  .text:0000000001E7CB3E                 jz      short loc_1E7CB47
+  .text:0000000001E7CB40                 mov     rax, [rbx+0AA0h]
+  .text:0000000001E7CB47                 mov     rax, [rax+r14+10h]
+  .text:0000000001E7CB4C                 mov     esi, 0FFh
+  .text:0000000001E7CB51                 mov     rdi, [rax+80h]
+  .text:0000000001E7CB58                 call    sub_985C30
+  .text:0000000001E7CB5D                 xor     eax, eax
+  .text:0000000001E7CB5F                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E7CB68                 jz      short loc_1E7CB71
+  .text:0000000001E7CB6A                 mov     rax, [rbx+0AA0h]
+  .text:0000000001E7CB71                 mov     r15, [rax+r14+10h]
+  .text:0000000001E7CB76                 call    sub_984890
+  .text:0000000001E7CB7B                 mov     esi, 46F20F89h
+  .text:0000000001E7CB80                 mov     rdi, rax
+  .text:0000000001E7CB83                 mov     rax, [rax]
+  .text:0000000001E7CB86                 call    qword ptr [rax+20h]
+  .text:0000000001E7CB89                 mov     rsi, r15
+  .text:0000000001E7CB8C                 mov     rdi, rbx
+  .text:0000000001E7CB8F                 test    al, al
+  .text:0000000001E7CB91                 jnz     loc_1E7CAC0
+  .text:0000000001E7CB97                 call    sub_1E6A680
+  .text:0000000001E7CB9C                 jmp     loc_1E7CAC5
+  .text:0000000001E7CBA1                 mov     esi, r12d
+  .text:0000000001E7CBA4                 call    sub_984EE0
+  .text:0000000001E7CBA9                 mov     edi, [r15+10h]
+  .text:0000000001E7CBAD                 mov     esi, [r15+14h]
+  .text:0000000001E7CBB1                 lea     edx, [r12+rdi]
+  .text:0000000001E7CBB5                 jmp     loc_1E7C974
+  .text:0000000001E7CBC0                 mov     ecx, [rax+88h]
+  .text:0000000001E7CBC6                 cmp     edx, ecx
+  .text:0000000001E7CBC8                 jle     loc_1E7CB23
+  .text:0000000001E7CBCE                 lea     rdi, [rax+80h]
+  .text:0000000001E7CBD5                 mov     esi, edx
+  .text:0000000001E7CBD7                 mov     [rbp+var_84], edx
+  .text:0000000001E7CBDD                 sub     esi, ecx
+  .text:0000000001E7CBDF                 mov     [rbp+var_80], rax
+  .text:0000000001E7CBE3                 call    sub_1E6F5A0
+  .text:0000000001E7CBE8                 mov     edx, [rbp+var_84]
+  .text:0000000001E7CBEE                 mov     rax, [rbp+var_80]
+  .text:0000000001E7CBF2                 jmp     loc_1E7CB23
+  .text:0000000001E7CBF7                 mov     esi, [r12+3Ch]
+  .text:0000000001E7CBFC                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E7CC02                 jbe     short loc_1E7CC16
+  .text:0000000001E7CC04                 mov     eax, esi
+  .text:0000000001E7CC06                 and     eax, 0C0000000h
+  .text:0000000001E7CC0B                 cmp     eax, 80000000h
+  .text:0000000001E7CC10                 jnz     loc_1E7C8ED
+  .text:0000000001E7CC16                 cmp     edi, 7FFFFFFFh
+  .text:0000000001E7CC1C                 jz      loc_1E7CDA2
+  .text:0000000001E7CC22                 lea     r8d, [rdi+1]
+  .text:0000000001E7CC26                 and     esi, 3FFFFFFFh
+  .text:0000000001E7CC2C                 mov     ecx, 8
+  .text:0000000001E7CC31                 mov     edx, r8d
+  .text:0000000001E7CC34                 mov     dword ptr [rbp+var_78], r8d
+  .text:0000000001E7CC38                 call    sub_984790
+  .text:0000000001E7CC3D                 mov     r8d, dword ptr [rbp+var_78]
+  .text:0000000001E7CC41                 mov     r15d, eax
+  .text:0000000001E7CC44                 cmp     r8d, eax
+  .text:0000000001E7CC47                 jg      short loc_1E7CCA0
+  .text:0000000001E7CC49                 movsxd  rcx, dword ptr [r12+38h]
+  .text:0000000001E7CC4E                 movsxd  rdx, r15d
+  .text:0000000001E7CC51                 xor     esi, esi
+  .text:0000000001E7CC53                 shl     rdx, 3
+  .text:0000000001E7CC57                 mov     rdi, [r12+30h]
+  .text:0000000001E7CC5C                 shl     rcx, 3
+  .text:0000000001E7CC60                 cmp     dword ptr [r12+3Ch], 3FFFFFFFh
+  .text:0000000001E7CC69                 setbe   sil
+  .text:0000000001E7CC6D                 call    sub_9843C0
+  .text:0000000001E7CC72                 mov     edx, [r12+3Ch]
+  .text:0000000001E7CC77                 mov     [r12+30h], rax
+  .text:0000000001E7CC7C                 cmp     edx, 3FFFFFFFh
+  .text:0000000001E7CC82                 jbe     short loc_1E7CC8F
+  .text:0000000001E7CC84                 and     edx, 3FFFFFFFh
+  .text:0000000001E7CC8A                 mov     [r12+3Ch], edx
+  .text:0000000001E7CC8F                 mov     edx, [r12+28h]
+  .text:0000000001E7CC94                 mov     [r12+38h], r15d
+  .text:0000000001E7CC99                 jmp     loc_1E7C8F5
+  .text:0000000001E7CCA0                 lea     edx, [r15+r8]
+  .text:0000000001E7CCA4                 mov     eax, edx
+  .text:0000000001E7CCA6                 shr     eax, 1Fh
+  .text:0000000001E7CCA9                 add     eax, edx
+  .text:0000000001E7CCAB                 sar     eax, 1
+  .text:0000000001E7CCAD                 mov     r15d, eax
+  .text:0000000001E7CCB0                 cmp     r8d, eax
+  .text:0000000001E7CCB3                 jg      short loc_1E7CCA0
+  .text:0000000001E7CCB5                 jmp     short loc_1E7CC49
+  .text:0000000001E7CCB7                 movzx   ecx, word ptr [rbx+0A9Ah]
+  .text:0000000001E7CCBE                 and     cx, 7FFFh
+  .text:0000000001E7CCC3                 jmp     short loc_1E7CD15
+  .text:0000000001E7CD00                 mov     rdx, [rbx+0AA0h]
+  .text:0000000001E7CD07                 movzx   eax, word ptr [rdx+rax*8]
+  .text:0000000001E7CD0B                 cmp     ax, 0FFFFh
+  .text:0000000001E7CD0F                 jz      short loc_1E7CD3A
+  .text:0000000001E7CD11                 movzx   r12d, ax
+  .text:0000000001E7CD15                 movzx   eax, r12w
+  .text:0000000001E7CD19                 lea     rax, [rax+rax*2]
+  .text:0000000001E7CD1D                 lea     rsi, ds:0[rax*8]
+  .text:0000000001E7CD25                 test    cx, cx
+  .text:0000000001E7CD28                 jnz     short loc_1E7CD00
+  .text:0000000001E7CD2A                 movzx   eax, word ptr ds:dword_0[rax*8]
+  .text:0000000001E7CD32                 cmp     ax, 0FFFFh
+  .text:0000000001E7CD36                 jnz     short loc_1E7CD11
+  .text:0000000001E7CD38                 xor     edx, edx
+  .text:0000000001E7CD3A                 mov     r13, 0FFFFFFFF00000000h
+  .text:0000000001E7CD44                 mov     rdi, [rsi+rdx+10h]
+  .text:0000000001E7CD49                 jmp     short loc_1E7CD79
+  .text:0000000001E7CD50                 movzx   edx, ax
+  .text:0000000001E7CD53                 and     r12, r13
+  .text:0000000001E7CD56                 or      r12, rdx
+  .text:0000000001E7CD59                 xor     edx, edx
+  .text:0000000001E7CD5B                 test    word ptr [rbx+0A9Ah], 7FFFh
+  .text:0000000001E7CD64                 jz      short loc_1E7CD6D
+  .text:0000000001E7CD66                 mov     rdx, [rbx+0AA0h]
+  .text:0000000001E7CD6D                 movzx   eax, ax
+  .text:0000000001E7CD70                 lea     rax, [rax+rax*2]
+  .text:0000000001E7CD74                 mov     rdi, [rdx+rax*8+10h]
+  .text:0000000001E7CD79                 test    rdi, rdi
+  .text:0000000001E7CD7C                 jz      loc_1E7C773
+  .text:0000000001E7CD82                 call    sub_1E48B20
+  .text:0000000001E7CD87                 lea     rdi, [rbx+0A98h]
+  .text:0000000001E7CD8E                 movzx   esi, r12w
+  .text:0000000001E7CD92                 call    sub_1E63900
+  .text:0000000001E7CD97                 cmp     ax, 0FFFFh
+  .text:0000000001E7CD9B                 jnz     short loc_1E7CD50
+  .text:0000000001E7CD9D                 jmp     loc_1E7C773
+  .text:0000000001E7CDA2                 mov     esi, 1
+  .text:0000000001E7CDA7                 call    sub_984EE0
+  .text:0000000001E7CDAC                 mov     edi, [r12+38h]
+  .text:0000000001E7CDB1                 mov     esi, [r12+3Ch]
+  .text:0000000001E7CDB6                 jmp     loc_1E7CC22
+  .text:0000000001E7CDBB                 mov     esi, [r12+40h]
+  .text:0000000001E7CDC0                 lea     rdi, aCnetworkfields_0; "CNetworkFieldScratchData::Init failed o"...
+  .text:0000000001E7CDC7                 call    sub_984D60
 procedure: |-
-  __int64 __fastcall CEntitySystem_Init(__int64 a1, const char *a2, int a3, int a4, char a5)
+  __int64 __fastcall sub_1E7C3C0(__int64 a1, __int64 a2, int a3, int a4, char a5)
   {
     bool v9; // al
     __int64 v10; // r12
     __int64 i; // r12
     __int64 v12; // r12
-    int j; // r14d
+    unsigned int j; // r14d
     __int64 (__fastcall *v14)(); // rax
     __int64 m; // r12
     unsigned __int16 v16; // ax
@@ -595,56 +551,57 @@ procedure: |-
     int v27; // eax
     int v28; // r13d
     unsigned int v29; // eax
-    CMemoryStack *v30; // r13
-    int v31; // r14d
-    __int64 v32; // rdi
-    __int64 v33; // rax
-    int v34; // edx
-    int v35; // esi
-    unsigned int v36; // r12d
-    __int64 v37; // rdx
+    __int64 v30; // r13
+    __int64 v31; // rdx
+    int v32; // r14d
+    __int64 v33; // rdi
+    __int64 v34; // rax
+    int v35; // edx
+    int v36; // esi
+    unsigned int v37; // r12d
+    __int64 v38; // rdx
     int k; // r12d
-    __int16 v39; // cx
-    unsigned __int16 v40; // dx
-    __int64 v41; // rax
-    int v42; // edx
-    __int64 v43; // rsi
-    __int16 v44; // cx
-    unsigned __int16 v45; // r15
-    __int64 v46; // r14
-    __int64 v47; // rax
+    __int16 v40; // cx
+    unsigned __int16 v41; // dx
+    __int64 v42; // rax
+    int v43; // edx
+    __int64 v44; // rsi
+    __int16 v45; // cx
+    unsigned __int16 v46; // r15
+    __int64 v47; // r14
     __int64 v48; // rax
     __int64 v49; // rax
-    __int64 v50; // r15
-    __int64 v51; // rax
-    int v52; // ecx
-    unsigned int v53; // esi
-    int v54; // eax
-    int v55; // r8d
+    __int64 v50; // rax
+    __int64 v51; // r15
+    __int64 v52; // rax
+    int v53; // ecx
+    unsigned int v54; // esi
+    int v55; // eax
+    int v56; // r8d
     int n; // r15d
-    unsigned int v57; // edx
-    __int64 v58; // rdx
-    unsigned __int16 v59; // ax
+    unsigned int v58; // edx
+    __int64 v59; // rdx
+    unsigned __int16 v60; // ax
     __int64 ii; // rdi
-    __int64 v61; // rdx
-    unsigned __int16 v62; // ax
-    int v63; // [rsp+Ch] [rbp-84h]
-    __int64 v64; // [rsp+10h] [rbp-80h]
-    int v65; // [rsp+18h] [rbp-78h]
-    __m128i v66; // [rsp+28h] [rbp-68h] BYREF
-    __int64 v67; // [rsp+40h] [rbp-50h] BYREF
-    __m128i v68; // [rsp+48h] [rbp-48h]
+    __int64 v62; // rdx
+    unsigned __int16 v63; // ax
+    int v64; // [rsp+Ch] [rbp-84h]
+    __int64 v65; // [rsp+10h] [rbp-80h]
+    int v66; // [rsp+18h] [rbp-78h]
+    __m128i v67; // [rsp+28h] [rbp-68h] BYREF
+    __int64 v68; // [rsp+40h] [rbp-50h] BYREF
+    __m128i v69; // [rsp+48h] [rbp-48h]
 
-    CUtlString::Set((CUtlString *)(a1 + 2696), a2);  // 2696 = 0xA88 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
+    sub_9849D0(a1 + 2696);
     *(_DWORD *)(a1 + 3004) = a4;
-    unk_27BB9F1 = a5;
-    v9 = a3 == 1 && qword_2743670 != nullptr;
-    *(_BYTE *)(a1 + 3034) = v9;  // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
-    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3264), 0x400u, 0, nullptr, 0);
-    qword_25669A8 = a1;
-    qword_25669A0 = a1 + 16;
-    v10 = qword_27BB928;
-    if ( qword_27BB928 )
+    unk_27C4271 = a5;
+    v9 = a3 == 1 && qword_274BEF0 != nullptr;
+    *(_BYTE *)(a1 + 3034) = v9;
+    sub_984120(a1 + 3264, 1024, 0, 0, 0);
+    qword_256F1A8 = a1;
+    qword_256F1A0 = a1 + 16;
+    v10 = qword_27C41A8;
+    if ( qword_27C41A8 )
     {
       do
       {
@@ -654,12 +611,12 @@ procedure: |-
           if ( !v10 )
             goto LABEL_6;
         }
-        sub_1E67830(a1, v10);
+        sub_1E70370(a1, v10);
         v10 = *(_QWORD *)(v10 + 288);
       }
       while ( v10 );
   LABEL_6:
-      for ( i = qword_27BB928; i; i = *(_QWORD *)(i + 288) )
+      for ( i = qword_27C41A8; i; i = *(_QWORD *)(i + 288) )
       {
         while ( (*(_BYTE *)(i + 104) & 2) == 0 )
         {
@@ -667,21 +624,21 @@ procedure: |-
           if ( !i )
             goto LABEL_9;
         }
-        sub_1E67AC0(a1, i);
+        sub_1E70600(a1, i);
       }
     }
   LABEL_9:
-    v12 = qword_256D370;
+    v12 = qword_2575B70;
     for ( j = 0; v12; v12 = *(_QWORD *)(v12 + 32) )
     {
       while ( 1 )
       {
         ++j;
-        *(_DWORD *)(*(_QWORD *)(v12 + 16) + 32LL) = sub_1E73380(a1, v12);
+        *(_DWORD *)(*(_QWORD *)(v12 + 16) + 32LL) = sub_1E7BEC0(a1, v12);
         if ( (*(_BYTE *)(*(_QWORD *)(v12 + 16) + 36LL) & 1) != 0 )
           *(_DWORD *)(v12 + 8) |= 0x20000u;
         v14 = *(__int64 (__fastcall **)())(*(_QWORD *)v12 + 8LL);
-        if ( v14 != nullsub_1669 )
+        if ( v14 != nullsub_1668 )
           break;
         v12 = *(_QWORD *)(v12 + 32);
         if ( !v12 )
@@ -690,48 +647,48 @@ procedure: |-
       ((void (__fastcall *)(__int64))v14)(v12);
     }
   LABEL_14:
-    if ( j - (int)qword_27BB8F0 > 0 )
+    if ( (int)(j - qword_27C4170) > 0 )
     {
-      v23 = (unsigned int)qword_27BB900;
-      if ( j > (int)qword_27BB900 )
+      v23 = (unsigned int)qword_27C4180;
+      if ( (int)j > (int)qword_27C4180 )
       {
-        v35 = HIDWORD(qword_27BB900);
-        if ( HIDWORD(qword_27BB900) <= 0x3FFFFFFF || (HIDWORD(qword_27BB900) & 0xC0000000) == 0x80000000 )
+        v36 = HIDWORD(qword_27C4180);
+        if ( HIDWORD(qword_27C4180) <= 0x3FFFFFFF || (HIDWORD(qword_27C4180) & 0xC0000000) == 0x80000000 )
         {
-          v36 = j - qword_27BB900;
-          v37 = (unsigned int)j;
-          if ( j - (int)qword_27BB900 + (__int64)(int)qword_27BB900 > 0x7FFFFFFF )
+          v37 = j - qword_27C4180;
+          v38 = j;
+          if ( (int)(j - qword_27C4180) + (__int64)(int)qword_27C4180 > 0x7FFFFFFF )
           {
-            UtlVectorMemory_FailedAllocation((unsigned int)qword_27BB900, v36);
-            v23 = (unsigned int)qword_27BB900;
-            v35 = HIDWORD(qword_27BB900);
-            v37 = v36 + (unsigned int)qword_27BB900;
+            sub_984EE0((unsigned int)qword_27C4180, v37, j);
+            v23 = (unsigned int)qword_27C4180;
+            v36 = HIDWORD(qword_27C4180);
+            v38 = v37 + (unsigned int)qword_27C4180;
           }
-          v65 = v37;
-          for ( k = UtlVectorMemory_CalcNewAllocationCount(v23, v35 & 0x3FFFFFFF, v37, 8); k < v65; k = (k + v65) / 2 )
+          v66 = v38;
+          for ( k = sub_984790(v23, v36 & 0x3FFFFFFF, v38, 8); k < v66; k = (k + v66) / 2 )
             ;
-          qword_27BB8F8 = UtlVectorMemory_Alloc(
-                            qword_27BB8F8,
-                            HIDWORD(qword_27BB900) <= 0x3FFFFFFF,
+          qword_27C4178 = sub_9843C0(
+                            qword_27C4178,
+                            HIDWORD(qword_27C4180) <= 0x3FFFFFFF,
                             8LL * k,
-                            8LL * (int)qword_27BB900);
-          if ( HIDWORD(qword_27BB900) > 0x3FFFFFFF )
-            HIDWORD(qword_27BB900) &= 0x3FFFFFFFu;
-          LODWORD(qword_27BB900) = k;
+                            8LL * (int)qword_27C4180);
+          if ( HIDWORD(qword_27C4180) > 0x3FFFFFFF )
+            HIDWORD(qword_27C4180) &= 0x3FFFFFFFu;
+          LODWORD(qword_27C4180) = k;
         }
       }
     }
-    else if ( j == (_DWORD)qword_27BB8F0 )
+    else if ( j == (_DWORD)qword_27C4170 )
     {
       goto LABEL_16;
     }
-    LODWORD(qword_27BB8F0) = j;
+    LODWORD(qword_27C4170) = j;
   LABEL_16:
-    for ( m = qword_256D370; m; m = *(_QWORD *)(m + 32) )
+    for ( m = qword_2575B70; m; m = *(_QWORD *)(m + 32) )
     {
-      if ( qword_2743670 )
-        (*(void (__fastcall **)(_QWORD *, _QWORD))(*qword_2743670 + 232LL))(qword_2743670, *(unsigned int *)(m + 24));
-      *(_QWORD *)(qword_27BB8F8 + 8LL * *(int *)(*(_QWORD *)(m + 16) + 32LL)) = *(_QWORD *)(m + 16);
+      if ( qword_274BEF0 )
+        (*(void (__fastcall **)(_QWORD *, _QWORD))(*qword_274BEF0 + 232LL))(qword_274BEF0, *(unsigned int *)(m + 24));
+      *(_QWORD *)(qword_27C4178 + 8LL * *(int *)(*(_QWORD *)(m + 16) + 32LL)) = *(_QWORD *)(m + 16);
     }
     if ( *(_WORD *)(a1 + 2730) )
     {
@@ -769,125 +726,125 @@ procedure: |-
           v17 = 0;
         }
       }
-      sub_1E54FC0(a1, *(_QWORD *)(v17 + v18 + 16));
+      sub_1E5DB00(a1, *(_QWORD *)(v17 + v18 + 16));
     }
-    if ( !byte_27BBA40 )
+    if ( !byte_27C42C0 )
     {
       v19 = *(_WORD *)(a1 + 2728);
       if ( v19 != 0xFFFF )
       {
-        v39 = *(_WORD *)(a1 + 2714);
+        v40 = *(_WORD *)(a1 + 2714);
         while ( 1 )
         {
-          v41 = v19;
+          v42 = v19;
           if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
           {
-            v40 = *(_WORD *)(*(_QWORD *)(a1 + 2720) + 24LL * v19);
-            if ( v40 == 0xFFFF )
+            v41 = *(_WORD *)(*(_QWORD *)(a1 + 2720) + 24LL * v19);
+            if ( v41 == 0xFFFF )
               goto LABEL_75;
           }
           else
           {
-            v40 = *(_WORD *)(24LL * v19);
-            if ( v40 == 0xFFFF )
+            v41 = *(_WORD *)(24LL * v19);
+            if ( v41 == 0xFFFF )
             {
               while ( 1 )
               {
   LABEL_75:
-                v42 = *(unsigned __int16 *)(a1 + 2794);
-                v43 = 0;
-                v44 = v39 & 0x7FFF;
-                v45 = *(_WORD *)(a1 + 2794);
-                if ( v44 )
-                  v43 = *(_QWORD *)(a1 + 2720);
-                v46 = 24 * v41;
-                v47 = *(_QWORD *)(v43 + 24 * v41 + 16);
-                if ( v42 - *(_DWORD *)(v47 + 120) > 0 )
+                v43 = *(unsigned __int16 *)(a1 + 2794);
+                v44 = 0;
+                v45 = v40 & 0x7FFF;
+                v46 = *(_WORD *)(a1 + 2794);
+                if ( v45 )
+                  v44 = *(_QWORD *)(a1 + 2720);
+                v47 = 24 * v42;
+                v48 = *(_QWORD *)(v44 + 24 * v42 + 16);
+                if ( v43 - *(_DWORD *)(v48 + 120) > 0 )
                 {
-                  v52 = *(_DWORD *)(v47 + 136);
-                  if ( v42 > v52 )
+                  v53 = *(_DWORD *)(v48 + 136);
+                  if ( v43 > v53 )
                   {
-                    v63 = *(unsigned __int16 *)(a1 + 2794);
-                    v64 = v47;
-                    sub_1E66A60(v47 + 128, (unsigned int)(v42 - v52));
-                    v42 = v63;
-                    v47 = v64;
+                    v64 = *(unsigned __int16 *)(a1 + 2794);
+                    v65 = v48;
+                    sub_1E6F5A0(v48 + 128, (unsigned int)(v43 - v53));
+                    v43 = v64;
+                    v48 = v65;
                   }
                 }
-                else if ( v42 == *(_DWORD *)(v47 + 120) )
+                else if ( v43 == *(_DWORD *)(v48 + 120) )
                 {
                   goto LABEL_80;
                 }
-                *(_DWORD *)(v47 + 120) = v42;
-                v44 = *(_WORD *)(a1 + 2714) & 0x7FFF;
+                *(_DWORD *)(v48 + 120) = v43;
+                v45 = *(_WORD *)(a1 + 2714) & 0x7FFF;
   LABEL_80:
-                v48 = 0;
-                if ( v44 )
-                  v48 = *(_QWORD *)(a1 + 2720);
-                memset(*(void **)(*(_QWORD *)(v48 + v46 + 16) + 128LL), 255, 2LL * v45);
                 v49 = 0;
-                if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
+                if ( v45 )
                   v49 = *(_QWORD *)(a1 + 2720);
-                v50 = *(_QWORD *)(v49 + v46 + 16);
-                v51 = CommandLine();
-                if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v51 + 32LL))(v51, 1190268809) )
-                  sub_1E623C0(a1, v50);
+                sub_985C30(*(_QWORD *)(*(_QWORD *)(v49 + v47 + 16) + 128LL), 255, 2LL * v46);
+                v50 = 0;
+                if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
+                  v50 = *(_QWORD *)(a1 + 2720);
+                v51 = *(_QWORD *)(v50 + v47 + 16);
+                v52 = sub_984890();
+                if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v52 + 32LL))(v52, 1190268809) )
+                  sub_1E6AF00(a1, v51);
                 else
-                  sub_1E61B40(a1, v50);
-                LOWORD(v41) = sub_1E5ADC0(a1 + 2712, v19);
-                v19 = v41;
-                if ( (_WORD)v41 == 0xFFFF )
+                  sub_1E6A680(a1, v51);
+                LOWORD(v42) = sub_1E63900(a1 + 2712, v19);
+                v19 = v42;
+                if ( (_WORD)v42 == 0xFFFF )
                   goto LABEL_27;
-                v39 = *(_WORD *)(a1 + 2714);
-                v41 = (unsigned __int16)v41;
+                v40 = *(_WORD *)(a1 + 2714);
+                v42 = (unsigned __int16)v42;
               }
             }
           }
-          v19 = v40;
+          v19 = v41;
         }
       }
     }
   LABEL_27:
-    COM_TimestampedLog("EntitySystem - Class Tables");
-    if ( qword_2743670 )
+    sub_985030("EntitySystem - Class Tables");
+    if ( qword_274BEF0 )
     {
-      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_2743670 + 160LL))(
-        qword_2743670,
+      (*(void (__fastcall **)(_QWORD *, const char *, _QWORD, __int64))(*qword_274BEF0 + 160LL))(
+        qword_274BEF0,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7888);                               // 7888 = 0x1ED0 = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols); 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-      v66 = (__m128i)0x121uLL;
-      v20 = _mm_loadu_si128(&v66);
-      v21 = *qword_2743670;
-      v67 = 0;
-      v68 = v20;
-      (*(void (__fastcall **)(_QWORD *, __int64 *))(v21 + 184))(qword_2743670, &v67);
+        a1 + 7888);
+      v67 = (__m128i)0x121uLL;
+      v20 = _mm_loadu_si128(&v67);
+      v21 = *qword_274BEF0;
+      v68 = 0;
+      v69 = v20;
+      (*(void (__fastcall **)(_QWORD *, __int64 *))(v21 + 184))(qword_274BEF0, &v68);
     }
-    result = sub_1E72200(a1);
+    result = sub_1E7AD40(a1);
     if ( *(_BYTE *)(a1 + 3034) )
     {
-      v25 = operator new(88);
+      v25 = sub_97A1D0(88);
       *(_QWORD *)(a1 + 3216) = v25;
-      *(_QWORD *)v25 = off_24156E8;
+      *(_QWORD *)v25 = off_241DF48;
       *(_QWORD *)(v25 + 72) = 0xC8000000000000LL;
       *(_QWORD *)(v25 + 8) = 0;
       *(_QWORD *)(v25 + 16) = 0;
       *(_QWORD *)(v25 + 24) = 0;
       *(_DWORD *)(v25 + 32) = 0;
-      v26 = dword_27BBCDC;
+      v26 = dword_27C455C;
       *(_QWORD *)(v25 + 48) = 0;
       *(_DWORD *)(v25 + 56) = 0;
       *(_DWORD *)(v25 + 40) = 0;
       *(_QWORD *)(v25 + 60) = 0;
       *(_QWORD *)(v25 + 80) = 0;
-      v27 = UtlVectorMemory_CalcNewAllocationCount(0, 0, 320000, 1);
+      v27 = sub_984790(0, 0, 320000, 1);
       v28 = v27;
       if ( v27 <= 319999 )
       {
         while ( 1 )
           ;
       }
-      *(_QWORD *)(v25 + 16) = UtlVectorMemory_Alloc(
+      *(_QWORD *)(v25 + 16) = sub_9843C0(
                                 *(_QWORD *)(v25 + 16),
                                 *(_DWORD *)(v25 + 28) <= 0x3FFFFFFFu,
                                 v27,
@@ -900,92 +857,88 @@ procedure: |-
       _InterlockedExchange((volatile __int32 *)(v25 + 32), 0);
       *(_DWORD *)(v25 + 68) = v26;
       *(_DWORD *)(v25 + 64) = 0x10000;
-      v30 = (CMemoryStack *)operator new(80);
-      CMemoryStack::CMemoryStack(v30);
-      if ( !(unsigned __int8)CMemoryStack::Init(
+      v30 = sub_97A1D0(80);
+      sub_984550(v30);
+      if ( !(unsigned __int8)sub_983FE0(
                                v30,
                                "CNetworkFieldScratchData.m_MemoryStacks[ 0 ]",
-                               *(_DWORD *)(v25 + 64),
-                               0x1000u,
-                               0x1000u,
-                               0x10u) )
+                               *(unsigned int *)(v25 + 64),
+                               4096,
+                               4096,
+                               16) )
       {
-        Plat_FatalError("CNetworkFieldScratchData::Init failed on buffer of %u bytes.", *(_DWORD *)(v25 + 64));
-        JUMPOUT(0x1E7428C);
+        sub_984D60("CNetworkFieldScratchData::Init failed on buffer of %u bytes.", *(_DWORD *)(v25 + 64));
+        JUMPOUT(0x1E7CDCC);
       }
-      v31 = *(_DWORD *)(v25 + 40);
-      v32 = *(unsigned int *)(v25 + 56);
-      if ( v31 == (_DWORD)v32 && ((v53 = *(_DWORD *)(v25 + 60), v53 <= 0x3FFFFFFF) || (v53 & 0xC0000000) == 0x80000000) )
+      v32 = *(_DWORD *)(v25 + 40);
+      v33 = *(unsigned int *)(v25 + 56);
+      if ( v32 == (_DWORD)v33 && ((v54 = *(_DWORD *)(v25 + 60), v54 <= 0x3FFFFFFF) || (v54 & 0xC0000000) == 0x80000000) )
       {
-        if ( (_DWORD)v32 == 0x7FFFFFFF )
+        if ( (_DWORD)v33 == 0x7FFFFFFF )
         {
-          UtlVectorMemory_FailedAllocation(v32, 1);
-          v32 = *(unsigned int *)(v25 + 56);
-          v53 = *(_DWORD *)(v25 + 60);
+          sub_984EE0(v33, 1, v31);
+          v33 = *(unsigned int *)(v25 + 56);
+          v54 = *(_DWORD *)(v25 + 60);
         }
-        v54 = UtlVectorMemory_CalcNewAllocationCount(v32, v53 & 0x3FFFFFFF, (unsigned int)(v32 + 1), 8);
-        v55 = v32 + 1;
-        for ( n = v54; v55 > n; n = (n + v55) / 2 )
+        v55 = sub_984790(v33, v54 & 0x3FFFFFFF, (unsigned int)(v33 + 1), 8);
+        v56 = v33 + 1;
+        for ( n = v55; v56 > n; n = (n + v56) / 2 )
           ;
-        v33 = UtlVectorMemory_Alloc(
-                *(_QWORD *)(v25 + 48),
-                *(_DWORD *)(v25 + 60) <= 0x3FFFFFFFu,
-                8LL * n,
-                8LL * *(int *)(v25 + 56));
-        v57 = *(_DWORD *)(v25 + 60);
-        *(_QWORD *)(v25 + 48) = v33;
-        if ( v57 > 0x3FFFFFFF )
-          *(_DWORD *)(v25 + 60) = v57 & 0x3FFFFFFF;
-        v34 = *(_DWORD *)(v25 + 40);
+        v34 = sub_9843C0(*(_QWORD *)(v25 + 48), *(_DWORD *)(v25 + 60) <= 0x3FFFFFFFu, 8LL * n, 8LL * *(int *)(v25 + 56));
+        v58 = *(_DWORD *)(v25 + 60);
+        *(_QWORD *)(v25 + 48) = v34;
+        if ( v58 > 0x3FFFFFFF )
+          *(_DWORD *)(v25 + 60) = v58 & 0x3FFFFFFF;
+        v35 = *(_DWORD *)(v25 + 40);
         *(_DWORD *)(v25 + 56) = n;
       }
       else
       {
-        v33 = *(_QWORD *)(v25 + 48);
-        v34 = *(_DWORD *)(v25 + 40);
+        v34 = *(_QWORD *)(v25 + 48);
+        v35 = *(_DWORD *)(v25 + 40);
       }
-      *(_DWORD *)(v25 + 40) = v34 + 1;
-      *(_QWORD *)(v33 + 8LL * v31) = v30;
-      result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*qword_2743668 + 280LL))(
-                 qword_2743668,
+      *(_DWORD *)(v25 + 40) = v35 + 1;
+      *(_QWORD *)(v34 + 8LL * v32) = v30;
+      result = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*qword_274BEE8 + 280LL))(
+                 qword_274BEE8,
                  *(_QWORD *)(a1 + 3216),
-                 *(_QWORD *)(a1 + 3224));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+                 *(_QWORD *)(a1 + 3224));
       *(_QWORD *)(a1 + 3208) = result;
     }
-    if ( byte_27BBA40 )
+    if ( byte_27C42C0 )
       goto LABEL_31;
     v24 = *(_WORD *)(a1 + 2728);
     if ( v24 == 0xFFFF )
       goto LABEL_45;
     while ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
     {
-      v58 = *(_QWORD *)(a1 + 2720);
-      v59 = *(_WORD *)(v58 + 24LL * v24);
-      if ( v59 == 0xFFFF )
+      v59 = *(_QWORD *)(a1 + 2720);
+      v60 = *(_WORD *)(v59 + 24LL * v24);
+      if ( v60 == 0xFFFF )
         goto LABEL_104;
   LABEL_100:
-      v24 = v59;
+      v24 = v60;
     }
-    v59 = *(_WORD *)(24LL * v24);
-    if ( v59 != 0xFFFF )
+    v60 = *(_WORD *)(24LL * v24);
+    if ( v60 != 0xFFFF )
       goto LABEL_100;
-    v58 = 0;
+    v59 = 0;
   LABEL_104:
-    for ( ii = *(_QWORD *)(24LL * v24 + v58 + 16); ii; ii = *(_QWORD *)(v61 + 24LL * v62 + 16) )
+    for ( ii = *(_QWORD *)(24LL * v24 + v59 + 16); ii; ii = *(_QWORD *)(v62 + 24LL * v63 + 16) )
     {
-      sub_1E3FFE0();
-      v62 = sub_1E5ADC0(a1 + 2712, v24);
-      if ( v62 == 0xFFFF )
+      sub_1E48B20();
+      v63 = sub_1E63900(a1 + 2712, v24);
+      if ( v63 == 0xFFFF )
         break;
-      v24 = v62;
-      v61 = 0;
+      v24 = v63;
+      v62 = 0;
       if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
-        v61 = *(_QWORD *)(a1 + 2720);
+        v62 = *(_QWORD *)(a1 + 2720);
     }
   LABEL_45:
-    sub_1E8FFB0();
-    result = sub_1E5FD40(a1);
+    sub_1E98AF0();
+    result = sub_1E68880(a1);
   LABEL_31:
-    byte_27BBA40 = 1;
+    byte_27C42C0 = 1;
     return result;
   }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -1,441 +1,439 @@
 func_name: CEntitySystem_Init
-func_va: '0x1811f0ad0'
+func_va: '0x1811f8260'
 disasm_code: |-
-  .text:00000001811F0AD0                 mov     [rsp+arg_18], rbx
-  .text:00000001811F0AD5                 push    rsi
-  .text:00000001811F0AD6                 push    rdi
-  .text:00000001811F0AD7                 push    r12
-  .text:00000001811F0AD9                 push    r13
-  .text:00000001811F0ADB                 push    r15
-  .text:00000001811F0ADD                 sub     rsp, 0A0h
-  .text:00000001811F0AE4                 mov     rsi, rcx
-  .text:00000001811F0AE7                 mov     ebx, r9d
-  .text:00000001811F0AEA                 add     rcx, 0A88h  ; 0A88h = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
-  .text:00000001811F0AF1                 mov     edi, r8d
-  .text:00000001811F0AF4                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
-  .text:00000001811F0AFA                 movzx   eax, [rsp+0C8h+arg_20]
-  .text:00000001811F0B02                 mov     cs:byte_1820B15C0, al
-  .text:00000001811F0B08                 mov     [rsi+0BBCh], ebx
-  .text:00000001811F0B0E                 cmp     edi, 1
-  .text:00000001811F0B11                 jnz     short loc_1811F0B23
-  .text:00000001811F0B13                 cmp     cs:qword_182117C88, 0
-  .text:00000001811F0B1B                 jz      short loc_1811F0B23
-  .text:00000001811F0B1D                 movzx   eax, dil
-  .text:00000001811F0B21                 jmp     short loc_1811F0B25
-  .text:00000001811F0B23                 xor     al, al
-  .text:00000001811F0B25                 lea     rcx, [rsi+0CB8h]
-  .text:00000001811F0B2C                 mov     [rsi+0BDAh], al  ; 0BDAh = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
-  .text:00000001811F0B32                 xor     r9d, r9d
-  .text:00000001811F0B35                 mov     byte ptr [rsp+0C8h+var_A8], 0
-  .text:00000001811F0B3A                 xor     r8d, r8d
-  .text:00000001811F0B3D                 mov     edx, 400h
-  .text:00000001811F0B42                 call    cs:?Init@CUtlScratchMemoryPool@@QEAAXIIPEAX_N@Z; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
-  .text:00000001811F0B48                 mov     rbx, cs:qword_1820B13B8
-  .text:00000001811F0B4F                 lea     rax, [rsi+10h]
-  .text:00000001811F0B53                 xor     r15d, r15d
-  .text:00000001811F0B56                 mov     cs:qword_181E14800, rsi
-  .text:00000001811F0B5D                 test    rsi, rsi
-  .text:00000001811F0B60                 cmovz   rax, r15
-  .text:00000001811F0B64                 mov     cs:qword_181D958F8, rax
-  .text:00000001811F0B6B                 test    rbx, rbx
-  .text:00000001811F0B6E                 jz      short loc_1811F0BBD
-  .text:00000001811F0B70                 test    byte ptr [rbx+68h], 2
-  .text:00000001811F0B74                 jnz     short loc_1811F0B81
-  .text:00000001811F0B76                 mov     rdx, rbx
-  .text:00000001811F0B79                 mov     rcx, rsi
-  .text:00000001811F0B7C                 call    CEntitySystem_RegisterEntityClass
-  .text:00000001811F0B81                 mov     rbx, [rbx+120h]
-  .text:00000001811F0B88                 test    rbx, rbx
-  .text:00000001811F0B8B                 jnz     short loc_1811F0B70
-  .text:00000001811F0B8D                 mov     rbx, cs:qword_1820B13B8
-  .text:00000001811F0B94                 test    rbx, rbx
-  .text:00000001811F0B97                 jz      short loc_1811F0BBD
-  .text:00000001811F0B99                 nop     dword ptr [rax+00000000h]
-  .text:00000001811F0BA0                 test    byte ptr [rbx+68h], 2
-  .text:00000001811F0BA4                 jz      short loc_1811F0BB1
-  .text:00000001811F0BA6                 mov     rdx, rbx
-  .text:00000001811F0BA9                 mov     rcx, rsi
-  .text:00000001811F0BAC                 call    sub_1811F5460
-  .text:00000001811F0BB1                 mov     rbx, [rbx+120h]
-  .text:00000001811F0BB8                 test    rbx, rbx
-  .text:00000001811F0BBB                 jnz     short loc_1811F0BA0
-  .text:00000001811F0BBD                 mov     rbx, cs:qword_181D985D0
-  .text:00000001811F0BC4                 mov     edi, r15d
-  .text:00000001811F0BC7                 mov     [rsp+0C8h+arg_8], rbp
-  .text:00000001811F0BCF                 mov     r13d, 0FFFFh
-  .text:00000001811F0BD5                 mov     [rsp+0C8h+arg_10], r14
-  .text:00000001811F0BDD                 test    rbx, rbx
-  .text:00000001811F0BE0                 jz      loc_1811F0D0E
-  .text:00000001811F0BE6                 lea     r14, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
-  .text:00000001811F0BED                 lea     r12, aCentitysystemR; "CEntitySystem::RegisterComponentType"
-  .text:00000001811F0BF4                 nop     dword ptr [rax+00h]
-  .text:00000001811F0BF8                 nop     dword ptr [rax+rax+00000000h]
-  .text:00000001811F0C00                 mov     rax, [rbx+10h]
-  .text:00000001811F0C04                 lea     rbp, [rsi+0AD0h]
-  .text:00000001811F0C0B                 lea     r8, [rsp+0C8h+var_80]
-  .text:00000001811F0C10                 mov     [rsp+0C8h+var_80], rbp
-  .text:00000001811F0C15                 lea     rdx, [rsp+0C8h+arg_0]
-  .text:00000001811F0C1D                 mov     [rsp+0C8h+var_70], rbp
-  .text:00000001811F0C22                 inc     edi
-  .text:00000001811F0C24                 mov     rcx, [rax]
-  .text:00000001811F0C27                 lea     rax, [rsp+0C8h+var_98]
-  .text:00000001811F0C2C                 mov     [rsp+0C8h+var_98], rcx
-  .text:00000001811F0C31                 lea     rcx, [rbp+8]
-  .text:00000001811F0C35                 mov     [rsp+0C8h+var_78], rax
-  .text:00000001811F0C3A                 call    sub_1811E2D10
-  .text:00000001811F0C3F                 cmp     [rax+2], r13w
-  .text:00000001811F0C44                 jz      short loc_1811F0CB8
-  .text:00000001811F0C46                 mov     ecx, cs:dword_1820B1848
-  .text:00000001811F0C4C                 mov     edx, 5
-  .text:00000001811F0C51                 call    cs:LoggingSystem_IsChannelEnabled
-  .text:00000001811F0C57                 test    al, al
-  .text:00000001811F0C59                 jz      short loc_1811F0CB1
-  .text:00000001811F0C5B                 mov     rax, [rsp+0C8h+var_98]
-  .text:00000001811F0C60                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
-  .text:00000001811F0C67                 mov     ecx, cs:dword_1820B1848
-  .text:00000001811F0C6D                 lea     r8, [rsp+0C8h+var_68]
-  .text:00000001811F0C72                 xorps   xmm0, xmm0
-  .text:00000001811F0C75                 mov     [rsp+0C8h+var_A8], rax
-  .text:00000001811F0C7A                 xorps   xmm1, xmm1
-  .text:00000001811F0C7D                 mov     [rsp+0C8h+var_68], r14
-  .text:00000001811F0C82                 mov     edx, 5
-  .text:00000001811F0C87                 mov     [rsp+0C8h+var_60], 67Dh
-  .text:00000001811F0C8F                 movdqu  [rsp+0C8h+var_50], xmm0
-  .text:00000001811F0C95                 mov     [rsp+0C8h+var_58], r12
-  .text:00000001811F0C9A                 movdqu  [rsp+0C8h+var_40], xmm1
-  .text:00000001811F0CA3                 mov     [rsp+0C8h+var_30], r15d
-  .text:00000001811F0CAB                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
-  .text:00000001811F0CB1                 mov     ecx, 0FFFFFFFFh
-  .text:00000001811F0CB6                 jmp     short loc_1811F0CD7
-  .text:00000001811F0CB8                 mov     rax, [rsp+0C8h+var_98]
-  .text:00000001811F0CBD                 lea     rdx, [rsp+0C8h+var_90]
-  .text:00000001811F0CC2                 mov     rcx, rbp
-  .text:00000001811F0CC5                 mov     [rsp+0C8h+var_90], rax
-  .text:00000001811F0CCA                 mov     [rsp+0C8h+var_88], rbx
-  .text:00000001811F0CCF                 call    sub_1811F1870
-  .text:00000001811F0CD4                 movzx   ecx, ax
-  .text:00000001811F0CD7                 mov     r8d, 10h
-  .text:00000001811F0CDD                 mov     rdx, rbx
-  .text:00000001811F0CE0                 mov     rax, [rbx+r8]
-  .text:00000001811F0CE4                 mov     [rax+20h], ecx
-  .text:00000001811F0CE7                 mov     rax, [rbx+r8]
-  .text:00000001811F0CEB                 test    byte ptr [rax+24h], 1
-  .text:00000001811F0CEF                 jz      short loc_1811F0CF8
-  .text:00000001811F0CF1                 or      dword ptr [rbx+8], 20000h
-  .text:00000001811F0CF8                 mov     rax, [rbx]
-  .text:00000001811F0CFB                 mov     rcx, rbx
-  .text:00000001811F0CFE                 call    qword ptr [rax+8]
-  .text:00000001811F0D01                 mov     rbx, [rbx+20h]
-  .text:00000001811F0D05                 test    rbx, rbx
-  .text:00000001811F0D08                 jnz     loc_1811F0C00
-  .text:00000001811F0D0E                 mov     eax, cs:dword_1820B13E0
-  .text:00000001811F0D14                 sub     edi, eax
-  .text:00000001811F0D16                 test    edi, edi
-  .text:00000001811F0D18                 jle     short loc_1811F0D2D
-  .text:00000001811F0D1A                 mov     r8d, edi
-  .text:00000001811F0D1D                 lea     rcx, dword_1820B13E0
-  .text:00000001811F0D24                 mov     edx, eax
-  .text:00000001811F0D26                 call    sub_1811F1A10
-  .text:00000001811F0D2B                 jmp     short loc_1811F0D37
-  .text:00000001811F0D2D                 jns     short loc_1811F0D37
-  .text:00000001811F0D2F                 add     eax, edi
-  .text:00000001811F0D31                 mov     cs:dword_1820B13E0, eax
-  .text:00000001811F0D37                 mov     rbx, cs:qword_181D985D0
-  .text:00000001811F0D3E                 test    rbx, rbx
-  .text:00000001811F0D41                 jz      short loc_1811F0D77
-  .text:00000001811F0D43                 mov     rcx, cs:qword_182117C88
-  .text:00000001811F0D4A                 test    rcx, rcx
-  .text:00000001811F0D4D                 jz      short loc_1811F0D5B
-  .text:00000001811F0D4F                 mov     rax, [rcx]
-  .text:00000001811F0D52                 mov     edx, [rbx+18h]
-  .text:00000001811F0D55                 call    qword ptr [rax+0E8h]
-  .text:00000001811F0D5B                 mov     rdx, [rbx+10h]
-  .text:00000001811F0D5F                 mov     rax, cs:qword_1820B13E8
-  .text:00000001811F0D66                 movsxd  rcx, dword ptr [rdx+20h]
-  .text:00000001811F0D6A                 mov     [rax+rcx*8], rdx
-  .text:00000001811F0D6E                 mov     rbx, [rbx+20h]
-  .text:00000001811F0D72                 test    rbx, rbx
-  .text:00000001811F0D75                 jnz     short loc_1811F0D43
-  .text:00000001811F0D77                 mov     r12d, 7FFFh
-  .text:00000001811F0D7D                 cmp     [rsi+0AAAh], r15w
-  .text:00000001811F0D85                 jz      short loc_1811F0E00
-  .text:00000001811F0D87                 movzx   ebx, word ptr [rsi+0AEAh]
-  .text:00000001811F0D8E                 mov     edx, cs:dword_1820B13C8
-  .text:00000001811F0D94                 mov     eax, ebx
-  .text:00000001811F0D96                 sub     eax, edx
-  .text:00000001811F0D98                 test    eax, eax
-  .text:00000001811F0D9A                 jle     short loc_1811F0DAD
-  .text:00000001811F0D9C                 mov     r8d, eax
-  .text:00000001811F0D9F                 lea     rcx, dword_1820B13C8
-  .text:00000001811F0DA6                 call    sub_1808C4180
-  .text:00000001811F0DAB                 jmp     short loc_1811F0DB5
-  .text:00000001811F0DAD                 jns     short loc_1811F0DB5
-  .text:00000001811F0DAF                 mov     cs:dword_1820B13C8, ebx
-  .text:00000001811F0DB5                 movzx   r8d, r15w
-  .text:00000001811F0DB9                 cmp     r15w, bx
-  .text:00000001811F0DBD                 jnb     short loc_1811F0E00
-  .text:00000001811F0DBF                 nop
-  .text:00000001811F0DC0                 mov     rcx, r15
-  .text:00000001811F0DC3                 test    [rsi+0ADAh], r12w
-  .text:00000001811F0DCB                 jz      short loc_1811F0DD4
-  .text:00000001811F0DCD                 mov     rcx, [rsi+0AE0h]
-  .text:00000001811F0DD4                 movzx   edx, r8w
-  .text:00000001811F0DD8                 inc     r8w
-  .text:00000001811F0DDC                 lea     rax, [rdx+rdx*2]
-  .text:00000001811F0DE0                 mov     rcx, [rcx+rax*8+10h]
-  .text:00000001811F0DE5                 mov     rax, [rcx+10h]
-  .text:00000001811F0DE9                 movzx   ecx, byte ptr [rax+24h]
-  .text:00000001811F0DED                 mov     rax, cs:qword_1820B13D0
-  .text:00000001811F0DF4                 and     cl, 1
-  .text:00000001811F0DF7                 mov     [rdx+rax], cl
-  .text:00000001811F0DFA                 cmp     r8w, bx
-  .text:00000001811F0DFE                 jb      short loc_1811F0DC0
-  .text:00000001811F0E00                 cmp     cs:byte_1820B151C, r15b
-  .text:00000001811F0E07                 jnz     loc_1811F0F2F
-  .text:00000001811F0E0D                 movzx   ebx, word ptr [rsi+0AA8h]
-  .text:00000001811F0E14                 cmp     bx, r13w
-  .text:00000001811F0E18                 jz      loc_1811F0F2F
-  .text:00000001811F0E1E                 mov     rdx, r15
-  .text:00000001811F0E21                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F0E29                 jz      short loc_1811F0E32
-  .text:00000001811F0E2B                 mov     rdx, [rsi+0AA0h]
-  .text:00000001811F0E32                 movzx   eax, bx
-  .text:00000001811F0E35                 lea     rcx, [rax+rax*2]
-  .text:00000001811F0E39                 movzx   eax, word ptr [rdx+rcx*8]
-  .text:00000001811F0E3D                 cmp     ax, r13w
-  .text:00000001811F0E41                 jz      short loc_1811F0E50
-  .text:00000001811F0E43                 movzx   ebx, ax
-  .text:00000001811F0E46                 jmp     short loc_1811F0E14
-  .text:00000001811F0E50                 mov     rdx, r15
-  .text:00000001811F0E53                 movzx   edi, word ptr [rsi+0AEAh]
-  .text:00000001811F0E5A                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F0E62                 jz      short loc_1811F0E6B
-  .text:00000001811F0E64                 mov     rdx, [rsi+0AA0h]
-  .text:00000001811F0E6B                 movzx   eax, bx
-  .text:00000001811F0E6E                 lea     rcx, [rax+rax*2]
-  .text:00000001811F0E72                 mov     eax, edi
-  .text:00000001811F0E74                 lea     rbp, ds:0[rcx*8]
-  .text:00000001811F0E7C                 mov     rcx, [rdx+rcx*8+10h]
-  .text:00000001811F0E81                 mov     edx, [rcx+78h]
-  .text:00000001811F0E84                 add     rcx, 78h ; 'x'
-  .text:00000001811F0E88                 sub     eax, edx
-  .text:00000001811F0E8A                 test    eax, eax
-  .text:00000001811F0E8C                 jle     short loc_1811F0E98
-  .text:00000001811F0E8E                 mov     r8d, eax
-  .text:00000001811F0E91                 call    sub_1811F1CB0
-  .text:00000001811F0E96                 jmp     short loc_1811F0E9C
-  .text:00000001811F0E98                 jns     short loc_1811F0E9C
-  .text:00000001811F0E9A                 mov     [rcx], edi
-  .text:00000001811F0E9C                 mov     rcx, r15
-  .text:00000001811F0E9F                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F0EA7                 jz      short loc_1811F0EB0
-  .text:00000001811F0EA9                 mov     rcx, [rsi+0AA0h]
-  .text:00000001811F0EB0                 mov     rcx, [rcx+rbp+10h]
-  .text:00000001811F0EB5                 mov     r8, rdi
-  .text:00000001811F0EB8                 add     r8, r8
-  .text:00000001811F0EBB                 mov     edx, 0FFh
-  .text:00000001811F0EC0                 mov     rcx, [rcx+80h]
-  .text:00000001811F0EC7                 call    sub_18154A730
-  .text:00000001811F0ECC                 mov     rax, r15
-  .text:00000001811F0ECF                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F0ED7                 jz      short loc_1811F0EE0
-  .text:00000001811F0ED9                 mov     rax, [rsi+0AA0h]
-  .text:00000001811F0EE0                 mov     rdi, [rax+rbp+10h]
-  .text:00000001811F0EE5                 call    cs:CommandLine
-  .text:00000001811F0EEB                 mov     edx, 46F20F89h
-  .text:00000001811F0EF0                 mov     rcx, [rax]
-  .text:00000001811F0EF3                 mov     r8, [rcx+20h]
-  .text:00000001811F0EF7                 mov     rcx, rax
-  .text:00000001811F0EFA                 call    r8
-  .text:00000001811F0EFD                 mov     rdx, rdi
-  .text:00000001811F0F00                 mov     rcx, rsi
-  .text:00000001811F0F03                 test    al, al
-  .text:00000001811F0F05                 jz      short loc_1811F0F0E
-  .text:00000001811F0F07                 call    sub_1811F9240
-  .text:00000001811F0F0C                 jmp     short loc_1811F0F13
-  .text:00000001811F0F0E                 call    sub_1811EB3C0
-  .text:00000001811F0F13                 movzx   edx, bx
-  .text:00000001811F0F16                 lea     rcx, [rsi+0A98h]
-  .text:00000001811F0F1D                 call    sub_1811F4150
-  .text:00000001811F0F22                 movzx   ebx, ax
-  .text:00000001811F0F25                 cmp     ax, r13w
-  .text:00000001811F0F29                 jnz     loc_1811F0E50
-  .text:00000001811F0F2F                 lea     rcx, aEntitysystemCl; "EntitySystem - Class Tables"
-  .text:00000001811F0F36                 call    cs:COM_TimestampedLog
-  .text:00000001811F0F3C                 mov     rcx, cs:qword_182117C88
-  .text:00000001811F0F43                 mov     r14, [rsp+0C8h+arg_10]
-  .text:00000001811F0F4B                 test    rcx, rcx
-  .text:00000001811F0F4E                 jz      short loc_1811F0F94
-  .text:00000001811F0F50                 mov     rax, [rcx]
-  .text:00000001811F0F53                 lea     r9, [rsi+1EC8h]  ; 1EC8h = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols)
-  .text:00000001811F0F5A                 mov     r8d, [rsi+0BBCh]
-  .text:00000001811F0F61                 lea     rdx, aStringTTable; "string_t_table"
-  .text:00000001811F0F68                 ; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-  .text:00000001811F0F68                 call    qword ptr [rax+0A0h]; 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-  .text:00000001811F0F6E                 mov     rcx, cs:qword_182117C88
-  .text:00000001811F0F75                 lea     rdx, sub_1811E4FA0
-  .text:00000001811F0F7C                 mov     rax, [rcx]
-  .text:00000001811F0F7F                 mov     [rsp+0C8h+var_88], rdx
-  .text:00000001811F0F84                 lea     rdx, [rsp+0C8h+var_90]
-  .text:00000001811F0F89                 mov     [rsp+0C8h+var_90], r15
-  .text:00000001811F0F8E                 call    qword ptr [rax+0B8h]
-  .text:00000001811F0F94                 mov     rcx, rsi
-  .text:00000001811F0F97                 call    sub_1811EAC10
-  .text:00000001811F0F9C                 cmp     [rsi+0BDAh], r15b
-  .text:00000001811F0FA3                 jz      loc_1811F1035
-  .text:00000001811F0FA9                 mov     ecx, 58h ; 'X'
-  .text:00000001811F0FAE                 call    sub_180E77230
-  .text:00000001811F0FB3                 mov     rcx, rax
-  .text:00000001811F0FB6                 test    rax, rax
-  .text:00000001811F0FB9                 jz      short loc_1811F0FF4
-  .text:00000001811F0FBB                 lea     rax, ??_7CNetworkFieldScratchData@@6B@; const CNetworkFieldScratchData::`vftable'
-  .text:00000001811F0FC2                 mov     [rcx], rax
-  .text:00000001811F0FC5                 xor     eax, eax
-  .text:00000001811F0FC7                 mov     [rcx+10h], r15
-  .text:00000001811F0FCB                 mov     [rcx+18h], r15
-  .text:00000001811F0FCF                 mov     [rcx+8], r15d
-  .text:00000001811F0FD3                 mov     [rcx+20h], r15d
-  .text:00000001811F0FD7                 mov     [rcx+30h], r15
-  .text:00000001811F0FDB                 mov     [rcx+38h], r15
-  .text:00000001811F0FDF                 mov     [rcx+28h], r15d
-  .text:00000001811F0FE3                 mov     [rcx+40h], r15d
-  .text:00000001811F0FE7                 mov     [rcx+48h], eax
-  .text:00000001811F0FEA                 mov     qword ptr [rcx+4Ch], 0C80000h
-  .text:00000001811F0FF2                 jmp     short loc_1811F0FF7
-  .text:00000001811F0FF4                 mov     rcx, r15
-  .text:00000001811F0FF7                 mov     [rsi+0C88h], rcx
-  .text:00000001811F0FFE                 mov     edx, 10000h
-  .text:00000001811F1003                 mov     rax, [rcx]
-  .text:00000001811F1006                 mov     r8d, cs:dword_1820B1848
-  .text:00000001811F100D                 call    qword ptr [rax+8]
-  .text:00000001811F1010                 mov     rcx, cs:qword_182117C90
-  .text:00000001811F1017                 mov     r8, [rsi+0C90h]
-  .text:00000001811F101E                 mov     rdx, [rsi+0C88h]
-  .text:00000001811F1025                 mov     rax, [rcx]
-  .text:00000001811F1028                 ; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:00000001811F1028                 call    qword ptr [rax+118h]; 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
-  .text:00000001811F102E                 mov     [rsi+0C80h], rax
-  .text:00000001811F1035                 cmp     cs:byte_1820B151C, r15b
-  .text:00000001811F103C                 jnz     loc_1811F11EE
-  .text:00000001811F1042                 movzx   ecx, word ptr [rsi+0AA8h]
-  .text:00000001811F1049                 nop     dword ptr [rax+00000000h]
-  .text:00000001811F1050                 cmp     cx, r13w
-  .text:00000001811F1054                 jz      loc_1811F10F2
-  .text:00000001811F105A                 mov     rdx, r15
-  .text:00000001811F105D                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F1065                 jz      short loc_1811F106E
-  .text:00000001811F1067                 mov     rdx, [rsi+0AA0h]
-  .text:00000001811F106E                 movzx   r8d, cx
-  .text:00000001811F1072                 lea     rax, [r8+r8*2]
-  .text:00000001811F1076                 movzx   r9d, word ptr [rdx+rax*8]
-  .text:00000001811F107B                 cmp     r9w, r13w
-  .text:00000001811F107F                 jz      short loc_1811F1087
-  .text:00000001811F1081                 movzx   ecx, r9w
-  .text:00000001811F1085                 jmp     short loc_1811F1050
-  .text:00000001811F1087                 movzx   ebx, cx
-  .text:00000001811F108A                 mov     rcx, r15
-  .text:00000001811F108D                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F1095                 jz      short loc_1811F109E
-  .text:00000001811F1097                 mov     rcx, [rsi+0AA0h]
-  .text:00000001811F109E                 lea     rax, [r8+r8*2]
-  .text:00000001811F10A2                 mov     rcx, [rcx+rax*8+10h]
-  .text:00000001811F10A7                 test    rcx, rcx
-  .text:00000001811F10AA                 jz      short loc_1811F10F2
-  .text:00000001811F10AC                 nop     dword ptr [rax+00h]
-  .text:00000001811F10B0                 call    sub_1811DDA40
-  .text:00000001811F10B5                 movzx   edx, bx
-  .text:00000001811F10B8                 lea     rcx, [rsi+0A98h]
-  .text:00000001811F10BF                 call    sub_1811F4150
-  .text:00000001811F10C4                 cmp     ax, r13w
-  .text:00000001811F10C8                 jz      short loc_1811F10F2
-  .text:00000001811F10CA                 mov     rdx, r15
-  .text:00000001811F10CD                 movzx   ebx, ax
-  .text:00000001811F10D0                 test    [rsi+0A9Ah], r12w
-  .text:00000001811F10D8                 jz      short loc_1811F10E1
-  .text:00000001811F10DA                 mov     rdx, [rsi+0AA0h]
-  .text:00000001811F10E1                 movzx   eax, ax
-  .text:00000001811F10E4                 lea     rcx, [rax+rax*2]
-  .text:00000001811F10E8                 mov     rcx, [rdx+rcx*8+10h]
-  .text:00000001811F10ED                 test    rcx, rcx
-  .text:00000001811F10F0                 jnz     short loc_1811F10B0
-  .text:00000001811F10F2                 call    sub_18121DD60
-  .text:00000001811F10F7                 mov     rbx, cs:qword_1820B1498
-  .text:00000001811F10FE                 test    rbx, rbx
-  .text:00000001811F1101                 jz      loc_1811F11E7
-  .text:00000001811F1107                 lea     rbp, [rsi+2070h]
-  .text:00000001811F110E                 xchg    ax, ax
-  .text:00000001811F1110                 call    qword ptr [rbx]
-  .text:00000001811F1112                 lea     rdx, byte_18159B988
-  .text:00000001811F1119                 mov     r9d, 811C9DC5h
-  .text:00000001811F111F                 mov     rsi, rax
-  .text:00000001811F1122                 mov     rcx, [rax+10h]
-  .text:00000001811F1126                 test    rcx, rcx
-  .text:00000001811F1129                 cmovnz  rdx, rcx
-  .text:00000001811F112D                 movzx   ecx, byte ptr [rdx]
-  .text:00000001811F1130                 test    cl, cl
-  .text:00000001811F1132                 jz      short loc_1811F1158
-  .text:00000001811F1134                 nop     dword ptr [rax+00h]
-  .text:00000001811F1138                 nop     dword ptr [rax+rax+00000000h]
-  .text:00000001811F1140                 movzx   eax, cl
-  .text:00000001811F1143                 lea     rdx, [rdx+1]
-  .text:00000001811F1147                 movzx   ecx, byte ptr [rdx]
-  .text:00000001811F114A                 xor     eax, r9d
-  .text:00000001811F114D                 imul    r9d, eax, 1000193h
-  .text:00000001811F1154                 test    cl, cl
-  .text:00000001811F1156                 jnz     short loc_1811F1140
-  .text:00000001811F1158                 mov     r8d, r9d
-  .text:00000001811F115B                 lea     rdx, [rsi+10h]
-  .text:00000001811F115F                 shl     r8d, 11h
-  .text:00000001811F1163                 mov     rcx, rbp
-  .text:00000001811F1166                 xor     r8d, r9d
-  .text:00000001811F1169                 shr     r9d, 15h
-  .text:00000001811F116D                 add     r8d, r9d
-  .text:00000001811F1170                 xor     r9d, r9d
-  .text:00000001811F1173                 call    sub_1811E1B50
-  .text:00000001811F1178                 cmp     eax, 0FFFFFFFFh
-  .text:00000001811F117B                 jnz     short loc_1811F11DA
-  .text:00000001811F117D                 mov     rax, [rsi+10h]
-  .text:00000001811F1181                 lea     rcx, byte_18159B988
-  .text:00000001811F1188                 test    rax, rax
-  .text:00000001811F118B                 mov     edx, 811C9DC5h
-  .text:00000001811F1190                 cmovnz  rcx, rax
-  .text:00000001811F1194                 movzx   eax, byte ptr [rcx]
-  .text:00000001811F1197                 test    al, al
-  .text:00000001811F1199                 jz      short loc_1811F11B6
-  .text:00000001811F119B                 nop     dword ptr [rax+rax+00h]
-  .text:00000001811F11A0                 movzx   eax, al
-  .text:00000001811F11A3                 lea     rcx, [rcx+1]
-  .text:00000001811F11A7                 xor     eax, edx
-  .text:00000001811F11A9                 imul    edx, eax, 1000193h
-  .text:00000001811F11AF                 movzx   eax, byte ptr [rcx]
-  .text:00000001811F11B2                 test    al, al
-  .text:00000001811F11B4                 jnz     short loc_1811F11A0
-  .text:00000001811F11B6                 mov     r9d, edx
-  .text:00000001811F11B9                 mov     [rsp+0C8h+var_A8], r15
-  .text:00000001811F11BE                 shl     r9d, 11h
-  .text:00000001811F11C2                 mov     r8, rsi
-  .text:00000001811F11C5                 xor     r9d, edx
-  .text:00000001811F11C8                 mov     rcx, rbp
-  .text:00000001811F11CB                 shr     edx, 15h
-  .text:00000001811F11CE                 add     r9d, edx
-  .text:00000001811F11D1                 lea     rdx, [rsi+10h]
-  .text:00000001811F11D5                 call    sub_1811E1800
-  .text:00000001811F11DA                 mov     rbx, [rbx+8]
-  .text:00000001811F11DE                 test    rbx, rbx
-  .text:00000001811F11E1                 jnz     loc_1811F1110
-  .text:00000001811F11E7                 mov     cs:qword_1820B1498, r15
-  .text:00000001811F11EE                 mov     rbp, [rsp+0C8h+arg_8]
-  .text:00000001811F11F6                 mov     rbx, [rsp+0C8h+arg_18]
-  .text:00000001811F11FE                 mov     cs:byte_1820B151C, 1
-  .text:00000001811F1205                 add     rsp, 0A0h
-  .text:00000001811F120C                 pop     r15
-  .text:00000001811F120E                 pop     r13
-  .text:00000001811F1210                 pop     r12
-  .text:00000001811F1212                 pop     rdi
-  .text:00000001811F1213                 pop     rsi
-  .text:00000001811F1214                 retn
+  .text:00000001811F8260                 mov     [rsp+arg_18], rbx
+  .text:00000001811F8265                 push    rsi
+  .text:00000001811F8266                 push    rdi
+  .text:00000001811F8267                 push    r12
+  .text:00000001811F8269                 push    r13
+  .text:00000001811F826B                 push    r15
+  .text:00000001811F826D                 sub     rsp, 0A0h
+  .text:00000001811F8274                 mov     rsi, rcx
+  .text:00000001811F8277                 mov     ebx, r9d
+  .text:00000001811F827A                 add     rcx, 0A88h
+  .text:00000001811F8281                 mov     edi, r8d
+  .text:00000001811F8284                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:00000001811F828A                 movzx   eax, [rsp+0C8h+arg_20]
+  .text:00000001811F8292                 mov     cs:byte_1820B9640, al
+  .text:00000001811F8298                 mov     [rsi+0BBCh], ebx
+  .text:00000001811F829E                 cmp     edi, 1
+  .text:00000001811F82A1                 jnz     short loc_1811F82B3
+  .text:00000001811F82A3                 cmp     cs:qword_18211FD28, 0
+  .text:00000001811F82AB                 jz      short loc_1811F82B3
+  .text:00000001811F82AD                 movzx   eax, dil
+  .text:00000001811F82B1                 jmp     short loc_1811F82B5
+  .text:00000001811F82B3                 xor     al, al
+  .text:00000001811F82B5                 lea     rcx, [rsi+0CB8h]
+  .text:00000001811F82BC                 mov     [rsi+0BDAh], al
+  .text:00000001811F82C2                 xor     r9d, r9d
+  .text:00000001811F82C5                 mov     byte ptr [rsp+0C8h+var_A8], 0
+  .text:00000001811F82CA                 xor     r8d, r8d
+  .text:00000001811F82CD                 mov     edx, 400h
+  .text:00000001811F82D2                 call    cs:?Init@CUtlScratchMemoryPool@@QEAAXIIPEAX_N@Z; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
+  .text:00000001811F82D8                 mov     rbx, cs:qword_1820B9438
+  .text:00000001811F82DF                 lea     rax, [rsi+10h]
+  .text:00000001811F82E3                 xor     r15d, r15d
+  .text:00000001811F82E6                 mov     cs:qword_181E1C888, rsi
+  .text:00000001811F82ED                 test    rsi, rsi
+  .text:00000001811F82F0                 cmovz   rax, r15
+  .text:00000001811F82F4                 mov     cs:qword_181D9D980, rax
+  .text:00000001811F82FB                 test    rbx, rbx
+  .text:00000001811F82FE                 jz      short loc_1811F834D
+  .text:00000001811F8300                 test    byte ptr [rbx+68h], 2
+  .text:00000001811F8304                 jnz     short loc_1811F8311
+  .text:00000001811F8306                 mov     rdx, rbx
+  .text:00000001811F8309                 mov     rcx, rsi
+  .text:00000001811F830C                 call    sub_1811FCE50
+  .text:00000001811F8311                 mov     rbx, [rbx+120h]
+  .text:00000001811F8318                 test    rbx, rbx
+  .text:00000001811F831B                 jnz     short loc_1811F8300
+  .text:00000001811F831D                 mov     rbx, cs:qword_1820B9438
+  .text:00000001811F8324                 test    rbx, rbx
+  .text:00000001811F8327                 jz      short loc_1811F834D
+  .text:00000001811F8329                 nop     dword ptr [rax+00000000h]
+  .text:00000001811F8330                 test    byte ptr [rbx+68h], 2
+  .text:00000001811F8334                 jz      short loc_1811F8341
+  .text:00000001811F8336                 mov     rdx, rbx
+  .text:00000001811F8339                 mov     rcx, rsi
+  .text:00000001811F833C                 call    sub_1811FCBF0
+  .text:00000001811F8341                 mov     rbx, [rbx+120h]
+  .text:00000001811F8348                 test    rbx, rbx
+  .text:00000001811F834B                 jnz     short loc_1811F8330
+  .text:00000001811F834D                 mov     rbx, cs:qword_181DA0660
+  .text:00000001811F8354                 mov     edi, r15d
+  .text:00000001811F8357                 mov     [rsp+0C8h+arg_8], rbp
+  .text:00000001811F835F                 mov     r13d, 0FFFFh
+  .text:00000001811F8365                 mov     [rsp+0C8h+arg_10], r14
+  .text:00000001811F836D                 test    rbx, rbx
+  .text:00000001811F8370                 jz      loc_1811F849E
+  .text:00000001811F8376                 lea     r14, aCBuildworkerCs_62; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001811F837D                 lea     r12, aCentitysystemR; "CEntitySystem::RegisterComponentType"
+  .text:00000001811F8384                 nop     dword ptr [rax+00h]
+  .text:00000001811F8388                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811F8390                 mov     rax, [rbx+10h]
+  .text:00000001811F8394                 lea     rbp, [rsi+0AD0h]
+  .text:00000001811F839B                 lea     r8, [rsp+0C8h+var_80]
+  .text:00000001811F83A0                 mov     [rsp+0C8h+var_80], rbp
+  .text:00000001811F83A5                 lea     rdx, [rsp+0C8h+arg_0]
+  .text:00000001811F83AD                 mov     [rsp+0C8h+var_70], rbp
+  .text:00000001811F83B2                 inc     edi
+  .text:00000001811F83B4                 mov     rcx, [rax]
+  .text:00000001811F83B7                 lea     rax, [rsp+0C8h+var_98]
+  .text:00000001811F83BC                 mov     [rsp+0C8h+var_98], rcx
+  .text:00000001811F83C1                 lea     rcx, [rbp+8]
+  .text:00000001811F83C5                 mov     [rsp+0C8h+var_78], rax
+  .text:00000001811F83CA                 call    sub_1811EA4A0
+  .text:00000001811F83CF                 cmp     [rax+2], r13w
+  .text:00000001811F83D4                 jz      short loc_1811F8448
+  .text:00000001811F83D6                 mov     ecx, cs:dword_1820B98C8
+  .text:00000001811F83DC                 mov     edx, 5
+  .text:00000001811F83E1                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F83E7                 test    al, al
+  .text:00000001811F83E9                 jz      short loc_1811F8441
+  .text:00000001811F83EB                 mov     rax, [rsp+0C8h+var_98]
+  .text:00000001811F83F0                 lea     r9, aMultipleRegist; "Multiple registration of class %s\n"
+  .text:00000001811F83F7                 mov     ecx, cs:dword_1820B98C8
+  .text:00000001811F83FD                 lea     r8, [rsp+0C8h+var_68]
+  .text:00000001811F8402                 xorps   xmm0, xmm0
+  .text:00000001811F8405                 mov     [rsp+0C8h+var_A8], rax
+  .text:00000001811F840A                 xorps   xmm1, xmm1
+  .text:00000001811F840D                 mov     [rsp+0C8h+var_68], r14
+  .text:00000001811F8412                 mov     edx, 5
+  .text:00000001811F8417                 mov     [rsp+0C8h+var_60], 67Dh
+  .text:00000001811F841F                 movdqu  [rsp+0C8h+var_50], xmm0
+  .text:00000001811F8425                 mov     [rsp+0C8h+var_58], r12
+  .text:00000001811F842A                 movdqu  [rsp+0C8h+var_40], xmm1
+  .text:00000001811F8433                 mov     [rsp+0C8h+var_30], r15d
+  .text:00000001811F843B                 call    cs:?LoggingSystem_Log@@YA?AW4LoggingResponse_t@@HW4LoggingSeverity_t@@AEBULoggingRareOptions_t@@PEBDZZ; LoggingSystem_Log(int,LoggingSeverity_t,LoggingRareOptions_t const &,char const *,...)
+  .text:00000001811F8441                 mov     ecx, 0FFFFFFFFh
+  .text:00000001811F8446                 jmp     short loc_1811F8467
+  .text:00000001811F8448                 mov     rax, [rsp+0C8h+var_98]
+  .text:00000001811F844D                 lea     rdx, [rsp+0C8h+var_90]
+  .text:00000001811F8452                 mov     rcx, rbp
+  .text:00000001811F8455                 mov     [rsp+0C8h+var_90], rax
+  .text:00000001811F845A                 mov     [rsp+0C8h+var_88], rbx
+  .text:00000001811F845F                 call    sub_1811F9000
+  .text:00000001811F8464                 movzx   ecx, ax
+  .text:00000001811F8467                 mov     r8d, 10h
+  .text:00000001811F846D                 mov     rdx, rbx
+  .text:00000001811F8470                 mov     rax, [rbx+r8]
+  .text:00000001811F8474                 mov     [rax+20h], ecx
+  .text:00000001811F8477                 mov     rax, [rbx+r8]
+  .text:00000001811F847B                 test    byte ptr [rax+24h], 1
+  .text:00000001811F847F                 jz      short loc_1811F8488
+  .text:00000001811F8481                 or      dword ptr [rbx+8], 20000h
+  .text:00000001811F8488                 mov     rax, [rbx]
+  .text:00000001811F848B                 mov     rcx, rbx
+  .text:00000001811F848E                 call    qword ptr [rax+8]
+  .text:00000001811F8491                 mov     rbx, [rbx+20h]
+  .text:00000001811F8495                 test    rbx, rbx
+  .text:00000001811F8498                 jnz     loc_1811F8390
+  .text:00000001811F849E                 mov     eax, cs:dword_1820B9460
+  .text:00000001811F84A4                 sub     edi, eax
+  .text:00000001811F84A6                 test    edi, edi
+  .text:00000001811F84A8                 jle     short loc_1811F84BD
+  .text:00000001811F84AA                 mov     r8d, edi
+  .text:00000001811F84AD                 lea     rcx, dword_1820B9460
+  .text:00000001811F84B4                 mov     edx, eax
+  .text:00000001811F84B6                 call    sub_1811F91A0
+  .text:00000001811F84BB                 jmp     short loc_1811F84C7
+  .text:00000001811F84BD                 jns     short loc_1811F84C7
+  .text:00000001811F84BF                 add     eax, edi
+  .text:00000001811F84C1                 mov     cs:dword_1820B9460, eax
+  .text:00000001811F84C7                 mov     rbx, cs:qword_181DA0660
+  .text:00000001811F84CE                 test    rbx, rbx
+  .text:00000001811F84D1                 jz      short loc_1811F8507
+  .text:00000001811F84D3                 mov     rcx, cs:qword_18211FD28
+  .text:00000001811F84DA                 test    rcx, rcx
+  .text:00000001811F84DD                 jz      short loc_1811F84EB
+  .text:00000001811F84DF                 mov     rax, [rcx]
+  .text:00000001811F84E2                 mov     edx, [rbx+18h]
+  .text:00000001811F84E5                 call    qword ptr [rax+0E8h]
+  .text:00000001811F84EB                 mov     rdx, [rbx+10h]
+  .text:00000001811F84EF                 mov     rax, cs:qword_1820B9468
+  .text:00000001811F84F6                 movsxd  rcx, dword ptr [rdx+20h]
+  .text:00000001811F84FA                 mov     [rax+rcx*8], rdx
+  .text:00000001811F84FE                 mov     rbx, [rbx+20h]
+  .text:00000001811F8502                 test    rbx, rbx
+  .text:00000001811F8505                 jnz     short loc_1811F84D3
+  .text:00000001811F8507                 mov     r12d, 7FFFh
+  .text:00000001811F850D                 cmp     [rsi+0AAAh], r15w
+  .text:00000001811F8515                 jz      short loc_1811F8590
+  .text:00000001811F8517                 movzx   ebx, word ptr [rsi+0AEAh]
+  .text:00000001811F851E                 mov     edx, cs:dword_1820B9448
+  .text:00000001811F8524                 mov     eax, ebx
+  .text:00000001811F8526                 sub     eax, edx
+  .text:00000001811F8528                 test    eax, eax
+  .text:00000001811F852A                 jle     short loc_1811F853D
+  .text:00000001811F852C                 mov     r8d, eax
+  .text:00000001811F852F                 lea     rcx, dword_1820B9448
+  .text:00000001811F8536                 call    sub_1808C9680
+  .text:00000001811F853B                 jmp     short loc_1811F8545
+  .text:00000001811F853D                 jns     short loc_1811F8545
+  .text:00000001811F853F                 mov     cs:dword_1820B9448, ebx
+  .text:00000001811F8545                 movzx   r8d, r15w
+  .text:00000001811F8549                 cmp     r15w, bx
+  .text:00000001811F854D                 jnb     short loc_1811F8590
+  .text:00000001811F854F                 nop
+  .text:00000001811F8550                 mov     rcx, r15
+  .text:00000001811F8553                 test    [rsi+0ADAh], r12w
+  .text:00000001811F855B                 jz      short loc_1811F8564
+  .text:00000001811F855D                 mov     rcx, [rsi+0AE0h]
+  .text:00000001811F8564                 movzx   edx, r8w
+  .text:00000001811F8568                 inc     r8w
+  .text:00000001811F856C                 lea     rax, [rdx+rdx*2]
+  .text:00000001811F8570                 mov     rcx, [rcx+rax*8+10h]
+  .text:00000001811F8575                 mov     rax, [rcx+10h]
+  .text:00000001811F8579                 movzx   ecx, byte ptr [rax+24h]
+  .text:00000001811F857D                 mov     rax, cs:qword_1820B9450
+  .text:00000001811F8584                 and     cl, 1
+  .text:00000001811F8587                 mov     [rdx+rax], cl
+  .text:00000001811F858A                 cmp     r8w, bx
+  .text:00000001811F858E                 jb      short loc_1811F8550
+  .text:00000001811F8590                 cmp     cs:byte_1820B959C, r15b
+  .text:00000001811F8597                 jnz     loc_1811F86BF
+  .text:00000001811F859D                 movzx   ebx, word ptr [rsi+0AA8h]
+  .text:00000001811F85A4                 cmp     bx, r13w
+  .text:00000001811F85A8                 jz      loc_1811F86BF
+  .text:00000001811F85AE                 mov     rdx, r15
+  .text:00000001811F85B1                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F85B9                 jz      short loc_1811F85C2
+  .text:00000001811F85BB                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F85C2                 movzx   eax, bx
+  .text:00000001811F85C5                 lea     rcx, [rax+rax*2]
+  .text:00000001811F85C9                 movzx   eax, word ptr [rdx+rcx*8]
+  .text:00000001811F85CD                 cmp     ax, r13w
+  .text:00000001811F85D1                 jz      short loc_1811F85E0
+  .text:00000001811F85D3                 movzx   ebx, ax
+  .text:00000001811F85D6                 jmp     short loc_1811F85A4
+  .text:00000001811F85E0                 mov     rdx, r15
+  .text:00000001811F85E3                 movzx   edi, word ptr [rsi+0AEAh]
+  .text:00000001811F85EA                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F85F2                 jz      short loc_1811F85FB
+  .text:00000001811F85F4                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F85FB                 movzx   eax, bx
+  .text:00000001811F85FE                 lea     rcx, [rax+rax*2]
+  .text:00000001811F8602                 mov     eax, edi
+  .text:00000001811F8604                 lea     rbp, ds:0[rcx*8]
+  .text:00000001811F860C                 mov     rcx, [rdx+rcx*8+10h]
+  .text:00000001811F8611                 mov     edx, [rcx+78h]
+  .text:00000001811F8614                 add     rcx, 78h ; 'x'
+  .text:00000001811F8618                 sub     eax, edx
+  .text:00000001811F861A                 test    eax, eax
+  .text:00000001811F861C                 jle     short loc_1811F8628
+  .text:00000001811F861E                 mov     r8d, eax
+  .text:00000001811F8621                 call    sub_1811F9440
+  .text:00000001811F8626                 jmp     short loc_1811F862C
+  .text:00000001811F8628                 jns     short loc_1811F862C
+  .text:00000001811F862A                 mov     [rcx], edi
+  .text:00000001811F862C                 mov     rcx, r15
+  .text:00000001811F862F                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F8637                 jz      short loc_1811F8640
+  .text:00000001811F8639                 mov     rcx, [rsi+0AA0h]
+  .text:00000001811F8640                 mov     rcx, [rcx+rbp+10h]
+  .text:00000001811F8645                 mov     r8, rdi
+  .text:00000001811F8648                 add     r8, r8
+  .text:00000001811F864B                 mov     edx, 0FFh
+  .text:00000001811F8650                 mov     rcx, [rcx+80h]
+  .text:00000001811F8657                 call    sub_181551B90
+  .text:00000001811F865C                 mov     rax, r15
+  .text:00000001811F865F                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F8667                 jz      short loc_1811F8670
+  .text:00000001811F8669                 mov     rax, [rsi+0AA0h]
+  .text:00000001811F8670                 mov     rdi, [rax+rbp+10h]
+  .text:00000001811F8675                 call    cs:CommandLine
+  .text:00000001811F867B                 mov     edx, 46F20F89h
+  .text:00000001811F8680                 mov     rcx, [rax]
+  .text:00000001811F8683                 mov     r8, [rcx+20h]
+  .text:00000001811F8687                 mov     rcx, rax
+  .text:00000001811F868A                 call    r8
+  .text:00000001811F868D                 mov     rdx, rdi
+  .text:00000001811F8690                 mov     rcx, rsi
+  .text:00000001811F8693                 test    al, al
+  .text:00000001811F8695                 jz      short loc_1811F869E
+  .text:00000001811F8697                 call    sub_1812009D0
+  .text:00000001811F869C                 jmp     short loc_1811F86A3
+  .text:00000001811F869E                 call    sub_1811F2B50
+  .text:00000001811F86A3                 movzx   edx, bx
+  .text:00000001811F86A6                 lea     rcx, [rsi+0A98h]
+  .text:00000001811F86AD                 call    sub_1811FB8E0
+  .text:00000001811F86B2                 movzx   ebx, ax
+  .text:00000001811F86B5                 cmp     ax, r13w
+  .text:00000001811F86B9                 jnz     loc_1811F85E0
+  .text:00000001811F86BF                 lea     rcx, aEntitysystemCl; "EntitySystem - Class Tables"
+  .text:00000001811F86C6                 call    cs:COM_TimestampedLog
+  .text:00000001811F86CC                 mov     rcx, cs:qword_18211FD28
+  .text:00000001811F86D3                 mov     r14, [rsp+0C8h+arg_10]
+  .text:00000001811F86DB                 test    rcx, rcx
+  .text:00000001811F86DE                 jz      short loc_1811F8724
+  .text:00000001811F86E0                 mov     rax, [rcx]
+  .text:00000001811F86E3                 lea     r9, [rsi+1EC8h]
+  .text:00000001811F86EA                 mov     r8d, [rsi+0BBCh]
+  .text:00000001811F86F1                 lea     rdx, aStringTTable; "string_t_table"
+  .text:00000001811F86F8                 call    qword ptr [rax+0A0h]
+  .text:00000001811F86FE                 mov     rcx, cs:qword_18211FD28
+  .text:00000001811F8705                 lea     rdx, sub_1811EC730
+  .text:00000001811F870C                 mov     rax, [rcx]
+  .text:00000001811F870F                 mov     [rsp+0C8h+var_88], rdx
+  .text:00000001811F8714                 lea     rdx, [rsp+0C8h+var_90]
+  .text:00000001811F8719                 mov     [rsp+0C8h+var_90], r15
+  .text:00000001811F871E                 call    qword ptr [rax+0B8h]
+  .text:00000001811F8724                 mov     rcx, rsi
+  .text:00000001811F8727                 call    sub_1811F23A0
+  .text:00000001811F872C                 cmp     [rsi+0BDAh], r15b
+  .text:00000001811F8733                 jz      loc_1811F87C5
+  .text:00000001811F8739                 mov     ecx, 58h ; 'X'
+  .text:00000001811F873E                 call    sub_180E7C960
+  .text:00000001811F8743                 mov     rcx, rax
+  .text:00000001811F8746                 test    rax, rax
+  .text:00000001811F8749                 jz      short loc_1811F8784
+  .text:00000001811F874B                 lea     rax, ??_7CNetworkFieldScratchData@@6B@; const CNetworkFieldScratchData::`vftable'
+  .text:00000001811F8752                 mov     [rcx], rax
+  .text:00000001811F8755                 xor     eax, eax
+  .text:00000001811F8757                 mov     [rcx+10h], r15
+  .text:00000001811F875B                 mov     [rcx+18h], r15
+  .text:00000001811F875F                 mov     [rcx+8], r15d
+  .text:00000001811F8763                 mov     [rcx+20h], r15d
+  .text:00000001811F8767                 mov     [rcx+30h], r15
+  .text:00000001811F876B                 mov     [rcx+38h], r15
+  .text:00000001811F876F                 mov     [rcx+28h], r15d
+  .text:00000001811F8773                 mov     [rcx+40h], r15d
+  .text:00000001811F8777                 mov     [rcx+48h], eax
+  .text:00000001811F877A                 mov     qword ptr [rcx+4Ch], 0C80000h
+  .text:00000001811F8782                 jmp     short loc_1811F8787
+  .text:00000001811F8784                 mov     rcx, r15
+  .text:00000001811F8787                 mov     [rsi+0C88h], rcx
+  .text:00000001811F878E                 mov     edx, 10000h
+  .text:00000001811F8793                 mov     rax, [rcx]
+  .text:00000001811F8796                 mov     r8d, cs:dword_1820B98C8
+  .text:00000001811F879D                 call    qword ptr [rax+8]
+  .text:00000001811F87A0                 mov     rcx, cs:qword_18211FD30
+  .text:00000001811F87A7                 mov     r8, [rsi+0C90h]
+  .text:00000001811F87AE                 mov     rdx, [rsi+0C88h]
+  .text:00000001811F87B5                 mov     rax, [rcx]
+  .text:00000001811F87B8                 call    qword ptr [rax+118h]
+  .text:00000001811F87BE                 mov     [rsi+0C80h], rax
+  .text:00000001811F87C5                 cmp     cs:byte_1820B959C, r15b
+  .text:00000001811F87CC                 jnz     loc_1811F897E
+  .text:00000001811F87D2                 movzx   ecx, word ptr [rsi+0AA8h]
+  .text:00000001811F87D9                 nop     dword ptr [rax+00000000h]
+  .text:00000001811F87E0                 cmp     cx, r13w
+  .text:00000001811F87E4                 jz      loc_1811F8882
+  .text:00000001811F87EA                 mov     rdx, r15
+  .text:00000001811F87ED                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F87F5                 jz      short loc_1811F87FE
+  .text:00000001811F87F7                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F87FE                 movzx   r8d, cx
+  .text:00000001811F8802                 lea     rax, [r8+r8*2]
+  .text:00000001811F8806                 movzx   r9d, word ptr [rdx+rax*8]
+  .text:00000001811F880B                 cmp     r9w, r13w
+  .text:00000001811F880F                 jz      short loc_1811F8817
+  .text:00000001811F8811                 movzx   ecx, r9w
+  .text:00000001811F8815                 jmp     short loc_1811F87E0
+  .text:00000001811F8817                 movzx   ebx, cx
+  .text:00000001811F881A                 mov     rcx, r15
+  .text:00000001811F881D                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F8825                 jz      short loc_1811F882E
+  .text:00000001811F8827                 mov     rcx, [rsi+0AA0h]
+  .text:00000001811F882E                 lea     rax, [r8+r8*2]
+  .text:00000001811F8832                 mov     rcx, [rcx+rax*8+10h]
+  .text:00000001811F8837                 test    rcx, rcx
+  .text:00000001811F883A                 jz      short loc_1811F8882
+  .text:00000001811F883C                 nop     dword ptr [rax+00h]
+  .text:00000001811F8840                 call    sub_1811E51D0
+  .text:00000001811F8845                 movzx   edx, bx
+  .text:00000001811F8848                 lea     rcx, [rsi+0A98h]
+  .text:00000001811F884F                 call    sub_1811FB8E0
+  .text:00000001811F8854                 cmp     ax, r13w
+  .text:00000001811F8858                 jz      short loc_1811F8882
+  .text:00000001811F885A                 mov     rdx, r15
+  .text:00000001811F885D                 movzx   ebx, ax
+  .text:00000001811F8860                 test    [rsi+0A9Ah], r12w
+  .text:00000001811F8868                 jz      short loc_1811F8871
+  .text:00000001811F886A                 mov     rdx, [rsi+0AA0h]
+  .text:00000001811F8871                 movzx   eax, ax
+  .text:00000001811F8874                 lea     rcx, [rax+rax*2]
+  .text:00000001811F8878                 mov     rcx, [rdx+rcx*8+10h]
+  .text:00000001811F887D                 test    rcx, rcx
+  .text:00000001811F8880                 jnz     short loc_1811F8840
+  .text:00000001811F8882                 call    sub_1812254F0
+  .text:00000001811F8887                 mov     rbx, cs:qword_1820B9518
+  .text:00000001811F888E                 test    rbx, rbx
+  .text:00000001811F8891                 jz      loc_1811F8977
+  .text:00000001811F8897                 lea     rbp, [rsi+2070h]
+  .text:00000001811F889E                 xchg    ax, ax
+  .text:00000001811F88A0                 call    qword ptr [rbx]
+  .text:00000001811F88A2                 lea     rdx, unk_1815A2980
+  .text:00000001811F88A9                 mov     r9d, 811C9DC5h
+  .text:00000001811F88AF                 mov     rsi, rax
+  .text:00000001811F88B2                 mov     rcx, [rax+10h]
+  .text:00000001811F88B6                 test    rcx, rcx
+  .text:00000001811F88B9                 cmovnz  rdx, rcx
+  .text:00000001811F88BD                 movzx   ecx, byte ptr [rdx]
+  .text:00000001811F88C0                 test    cl, cl
+  .text:00000001811F88C2                 jz      short loc_1811F88E8
+  .text:00000001811F88C4                 nop     dword ptr [rax+00h]
+  .text:00000001811F88C8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811F88D0                 movzx   eax, cl
+  .text:00000001811F88D3                 lea     rdx, [rdx+1]
+  .text:00000001811F88D7                 movzx   ecx, byte ptr [rdx]
+  .text:00000001811F88DA                 xor     eax, r9d
+  .text:00000001811F88DD                 imul    r9d, eax, 1000193h
+  .text:00000001811F88E4                 test    cl, cl
+  .text:00000001811F88E6                 jnz     short loc_1811F88D0
+  .text:00000001811F88E8                 mov     r8d, r9d
+  .text:00000001811F88EB                 lea     rdx, [rsi+10h]
+  .text:00000001811F88EF                 shl     r8d, 11h
+  .text:00000001811F88F3                 mov     rcx, rbp
+  .text:00000001811F88F6                 xor     r8d, r9d
+  .text:00000001811F88F9                 shr     r9d, 15h
+  .text:00000001811F88FD                 add     r8d, r9d
+  .text:00000001811F8900                 xor     r9d, r9d
+  .text:00000001811F8903                 call    sub_1811E92E0
+  .text:00000001811F8908                 cmp     eax, 0FFFFFFFFh
+  .text:00000001811F890B                 jnz     short loc_1811F896A
+  .text:00000001811F890D                 mov     rax, [rsi+10h]
+  .text:00000001811F8911                 lea     rcx, unk_1815A2980
+  .text:00000001811F8918                 test    rax, rax
+  .text:00000001811F891B                 mov     edx, 811C9DC5h
+  .text:00000001811F8920                 cmovnz  rcx, rax
+  .text:00000001811F8924                 movzx   eax, byte ptr [rcx]
+  .text:00000001811F8927                 test    al, al
+  .text:00000001811F8929                 jz      short loc_1811F8946
+  .text:00000001811F892B                 nop     dword ptr [rax+rax+00h]
+  .text:00000001811F8930                 movzx   eax, al
+  .text:00000001811F8933                 lea     rcx, [rcx+1]
+  .text:00000001811F8937                 xor     eax, edx
+  .text:00000001811F8939                 imul    edx, eax, 1000193h
+  .text:00000001811F893F                 movzx   eax, byte ptr [rcx]
+  .text:00000001811F8942                 test    al, al
+  .text:00000001811F8944                 jnz     short loc_1811F8930
+  .text:00000001811F8946                 mov     r9d, edx
+  .text:00000001811F8949                 mov     [rsp+0C8h+var_A8], r15
+  .text:00000001811F894E                 shl     r9d, 11h
+  .text:00000001811F8952                 mov     r8, rsi
+  .text:00000001811F8955                 xor     r9d, edx
+  .text:00000001811F8958                 mov     rcx, rbp
+  .text:00000001811F895B                 shr     edx, 15h
+  .text:00000001811F895E                 add     r9d, edx
+  .text:00000001811F8961                 lea     rdx, [rsi+10h]
+  .text:00000001811F8965                 call    sub_1811E8F90
+  .text:00000001811F896A                 mov     rbx, [rbx+8]
+  .text:00000001811F896E                 test    rbx, rbx
+  .text:00000001811F8971                 jnz     loc_1811F88A0
+  .text:00000001811F8977                 mov     cs:qword_1820B9518, r15
+  .text:00000001811F897E                 mov     rbp, [rsp+0C8h+arg_8]
+  .text:00000001811F8986                 mov     rbx, [rsp+0C8h+arg_18]
+  .text:00000001811F898E                 mov     cs:byte_1820B959C, 1
+  .text:00000001811F8995                 add     rsp, 0A0h
+  .text:00000001811F899C                 pop     r15
+  .text:00000001811F899E                 pop     r13
+  .text:00000001811F89A0                 pop     r12
+  .text:00000001811F89A2                 pop     rdi
+  .text:00000001811F89A3                 pop     rsi
+  .text:00000001811F89A4                 retn
 procedure: |-
-  __int64 __fastcall CEntitySystem_Init(__int64 a1, const char *a2, int a3, int a4, char a5)
+  __int64 __fastcall sub_1811F8260(__int64 a1, const char *a2, int a3, int a4, char a5)
   {
     bool v8; // al
     __int64 v9; // rdx
@@ -478,12 +476,12 @@ procedure: |-
     __int64 v46; // rbx
     __int64 v47; // rbp
     __int64 v48; // rax
-    char *v49; // rdx
+    unsigned __int8 *v49; // rdx
     unsigned int v50; // r9d
     __int64 v51; // rsi
     unsigned __int8 jj; // cl
     int v53; // eax
-    char *v54; // rcx
+    unsigned __int8 *v54; // rcx
     unsigned int v55; // edx
     unsigned __int8 kk; // al
     const char *v57; // [rsp+30h] [rbp-98h] BYREF
@@ -498,34 +496,34 @@ procedure: |-
     int v66; // [rsp+98h] [rbp-30h]
     char v67; // [rsp+D0h] [rbp+8h] BYREF
 
-    CUtlString::Set((CUtlString *)(a1 + 2696), a2);  // 2696 = 0xA88 = CEntitySystem::m_sEntSystemName (structmember, struct=CEntitySystem, member=m_sEntSystemName)
-    byte_1820B15C0 = a5;
+    CUtlString::Set((CUtlString *)(a1 + 2696), a2);
+    byte_1820B9640 = a5;
     *(_DWORD *)(a1 + 3004) = a4;
-    v8 = a3 == 1 && qword_182117C88;
-    *(_BYTE *)(a1 + 3034) = v8;  // 3034 = 0xBDA = CEntitySystem::m_eNetworkSerializationMode (structmember, struct=CEntitySystem, member=m_eNetworkSerializationMode)
+    v8 = a3 == 1 && qword_18211FD28;
+    *(_BYTE *)(a1 + 3034) = v8;
     CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);
-    v11 = qword_1820B13B8;
+    v11 = qword_1820B9438;
     v12 = a1 + 16;
-    qword_181E14800 = a1;
+    qword_181E1C888 = a1;
     if ( !a1 )
       v12 = 0;
-    qword_181D958F8 = v12;
-    if ( qword_1820B13B8 )
+    qword_181D9D980 = v12;
+    if ( qword_1820B9438 )
     {
       do
       {
         if ( (*(_BYTE *)(v11 + 104) & 2) == 0 )
-          CEntitySystem_RegisterEntityClass(a1, v11);
+          sub_1811FCE50(a1, v11);
         v11 = *(_QWORD *)(v11 + 288);
       }
       while ( v11 );
-      for ( i = qword_1820B13B8; i; i = *(_QWORD *)(i + 288) )
+      for ( i = qword_1820B9438; i; i = *(_QWORD *)(i + 288) )
       {
         if ( (*(_BYTE *)(i + 104) & 2) != 0 )
-          sub_1811F5460(a1, i);
+          sub_1811FCBF0(a1, i);
       }
     }
-    v14 = qword_181D985D0;
+    v14 = qword_181DA0660;
     for ( j = 0; v14; v14 = *(_QWORD *)(v14 + 32) )
     {
       v16 = *(const char ***)(v14 + 16);
@@ -534,15 +532,15 @@ procedure: |-
       ++j;
       v57 = *v16;
       v60[1] = &v57;
-      if ( *(_WORD *)(sub_1811E2D10(a1 + 2776, &v67, v60) + 2) == 0xFFFF )
+      if ( *(_WORD *)(sub_1811EA4A0(a1 + 2776, &v67, v60) + 2) == 0xFFFF )
       {
         v58 = v57;
         v59 = (__int64 (__fastcall *)())v14;
-        v17 = (unsigned __int16)sub_1811F1870(a1 + 2768, &v58);
+        v17 = (unsigned __int16)sub_1811F9000(a1 + 2768, &v58);
       }
       else
       {
-        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B1848, 5) )
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1820B98C8, 5) )
         {
           v61 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitysystem.cpp";
           v62 = 1661;
@@ -550,7 +548,7 @@ procedure: |-
           v63 = "CEntitySystem::RegisterComponentType";
           v65 = 0;
           v66 = 0;
-          LoggingSystem_Log((unsigned int)dword_1820B1848, 5, &v61, "Multiple registration of class %s\n", v57);
+          LoggingSystem_Log((unsigned int)dword_1820B98C8, 5, &v61, "Multiple registration of class %s\n", v57);
         }
         v17 = -1;
       }
@@ -559,42 +557,42 @@ procedure: |-
         *(_DWORD *)(v14 + 8) |= 0x20000u;
       (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v14 + 8LL))(v14, v14);
     }
-    v18 = j - dword_1820B13E0;
+    v18 = j - dword_1820B9460;
     if ( v18 <= 0 )
     {
       if ( v18 < 0 )
-        dword_1820B13E0 += v18;
+        dword_1820B9460 += v18;
     }
     else
     {
-      sub_1811F1A10(&dword_1820B13E0, (unsigned int)dword_1820B13E0, (unsigned int)v18);
+      sub_1811F91A0(&dword_1820B9460, (unsigned int)dword_1820B9460, (unsigned int)v18);
     }
-    for ( k = qword_181D985D0; k; k = *(_QWORD *)(k + 32) )
+    for ( k = qword_181DA0660; k; k = *(_QWORD *)(k + 32) )
     {
-      if ( qword_182117C88 )
-        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)qword_182117C88 + 232LL))(
-          qword_182117C88,
+      if ( qword_18211FD28 )
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)qword_18211FD28 + 232LL))(
+          qword_18211FD28,
           *(unsigned int *)(k + 24));
       v9 = *(_QWORD *)(k + 16);
-      *(_QWORD *)(qword_1820B13E8 + 8LL * *(int *)(v9 + 32)) = v9;
+      *(_QWORD *)(qword_1820B9468 + 8LL * *(int *)(v9 + 32)) = v9;
     }
     if ( *(_WORD *)(a1 + 2730) )
     {
       v20 = *(_WORD *)(a1 + 2794);
-      v9 = (unsigned int)dword_1820B13C8;
-      v21 = v20 - dword_1820B13C8;
+      v9 = (unsigned int)dword_1820B9448;
+      v21 = v20 - dword_1820B9448;
       if ( v21 <= 0 )
       {
         if ( v21 < 0 )
-          dword_1820B13C8 = *(unsigned __int16 *)(a1 + 2794);
+          dword_1820B9448 = *(unsigned __int16 *)(a1 + 2794);
       }
       else
       {
-        sub_1808C4180(&dword_1820B13C8, (unsigned int)dword_1820B13C8, (unsigned int)v21);
+        sub_1808C9680(&dword_1820B9448, (unsigned int)dword_1820B9448, (unsigned int)v21);
       }
       for ( m = 0;
             (unsigned __int16)m < v20;
-            *(_BYTE *)(v9 + qword_1820B13D0) = *(_BYTE *)(*(_QWORD *)(*(_QWORD *)(v22 + 24 * v9 + 16) + 16LL) + 36LL) & 1 )
+            *(_BYTE *)(v9 + qword_1820B9450) = *(_BYTE *)(*(_QWORD *)(*(_QWORD *)(v22 + 24 * v9 + 16) + 16LL) + 36LL) & 1 )
       {
         v22 = 0;
         if ( (*(_WORD *)(a1 + 2778) & 0x7FFF) != 0 )
@@ -603,7 +601,7 @@ procedure: |-
         LOWORD(m) = m + 1;
       }
     }
-    if ( !byte_1820B151C )
+    if ( !byte_1820B959C )
     {
       for ( n = *(_WORD *)(a1 + 2728); n != 0xFFFF; n = *(_WORD *)(v9 + 24LL * n) )
       {
@@ -630,22 +628,22 @@ procedure: |-
             }
             else
             {
-              sub_1811F1CB0(v29, v28, (unsigned int)v30);
+              sub_1811F9440(v29, v28, (unsigned int)v30);
             }
             v31 = 0;
             if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
               v31 = *(_QWORD *)(a1 + 2720);
-            sub_18154A730(*(_QWORD *)(*(_QWORD *)(v31 + v26 + 16) + 128LL), 255, 2 * v25);
+            sub_181551B90(*(_QWORD *)(*(_QWORD *)(v31 + v26 + 16) + 128LL), 255, 2 * v25);
             v32 = 0;
             if ( (*(_WORD *)(a1 + 2714) & 0x7FFF) != 0 )
               v32 = *(_QWORD *)(a1 + 2720);
             v33 = *(_QWORD *)(v32 + v26 + 16);
             v34 = CommandLine();
             if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v34 + 32LL))(v34, 1190268809) )
-              sub_1811F9240(a1, v33);
+              sub_1812009D0(a1, v33);
             else
-              sub_1811EB3C0(a1, v33);
-            n = sub_1811F4150(a1 + 2712, n);
+              sub_1811F2B50(a1, v33);
+            n = sub_1811FB8E0(a1 + 2712, n);
           }
           while ( n != 0xFFFF );
           break;
@@ -653,22 +651,22 @@ procedure: |-
       }
     }
     COM_TimestampedLog("EntitySystem - Class Tables", v9, m);
-    if ( qword_182117C88 )
+    if ( qword_18211FD28 )
     {
-      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_182117C88 + 160LL))(
-        qword_182117C88,
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, __int64))(*(_QWORD *)qword_18211FD28 + 160LL))(
+        qword_18211FD28,
         "string_t_table",
         *(unsigned int *)(a1 + 3004),
-        a1 + 7880);                               // 7880 = 0x1EC8 = CEntitySystem::m_Symbols (structmember, struct=CEntitySystem, member=m_Symbols); 0xA0 = 160LL = INetworkMessages_SetNetworkSerializationContextData
-      v35 = *(_QWORD *)qword_182117C88;
-      v59 = sub_1811E4FA0;
+        a1 + 7880);
+      v35 = *(_QWORD *)qword_18211FD28;
+      v59 = sub_1811EC730;
       v58 = nullptr;
-      (*(void (__fastcall **)(__int64, const char **))(v35 + 184))(qword_182117C88, &v58);
+      (*(void (__fastcall **)(__int64, const char **))(v35 + 184))(qword_18211FD28, &v58);
     }
-    result = sub_1811EAC10(a1);
+    result = sub_1811F23A0(a1);
     if ( *(_BYTE *)(a1 + 3034) )
     {
-      v37 = sub_180E77230(88);
+      v37 = sub_180E7C960(88);
       v38 = v37;
       if ( v37 )
       {
@@ -692,14 +690,14 @@ procedure: |-
       (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v38 + 8LL))(
         v38,
         0x10000,
-        (unsigned int)dword_1820B1848);
-      result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)qword_182117C90 + 280LL))(
-                 qword_182117C90,
+        (unsigned int)dword_1820B98C8);
+      result = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD))(*(_QWORD *)qword_18211FD30 + 280LL))(
+                 qword_18211FD30,
                  *(_QWORD *)(a1 + 3208),
-                 *(_QWORD *)(a1 + 3216));         // 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
+                 *(_QWORD *)(a1 + 3216));
       *(_QWORD *)(a1 + 3200) = result;
     }
-    if ( !byte_1820B151C )
+    if ( !byte_1820B959C )
     {
       for ( ii = *(_WORD *)(a1 + 2728); ii != 0xFFFF; ii = *(_WORD *)(v40 + 24LL * ii) )
       {
@@ -717,8 +715,8 @@ procedure: |-
           {
             do
             {
-              sub_1811DDA40();
-              v44 = sub_1811F4150(a1 + 2712, v42);
+              sub_1811E51D0();
+              v44 = sub_1811FB8E0(a1 + 2712, v42);
               if ( v44 == 0xFFFF )
                 break;
               v45 = 0;
@@ -731,44 +729,44 @@ procedure: |-
           break;
         }
       }
-      result = sub_18121DD60();
-      v46 = qword_1820B1498;
-      if ( qword_1820B1498 )
+      result = sub_1812254F0();
+      v46 = qword_1820B9518;
+      if ( qword_1820B9518 )
       {
         v47 = a1 + 8304;
         do
         {
           v48 = (*(__int64 (**)(void))v46)();
-          v49 = byte_18159B988;
+          v49 = (unsigned __int8 *)&unk_1815A2980;
           v50 = -2128831035;
           v51 = v48;
           if ( *(_QWORD *)(v48 + 16) )
-            v49 = *(char **)(v48 + 16);
+            v49 = *(unsigned __int8 **)(v48 + 16);
           for ( jj = *v49; *v49; v50 = 16777619 * (v50 ^ v53) )
           {
             v53 = jj;
             jj = *++v49;
           }
-          result = sub_1811E1B50(v47, v51 + 16, (v50 >> 21) + (v50 ^ (v50 << 17)), 0);
+          result = sub_1811E92E0(v47, v51 + 16, (v50 >> 21) + (v50 ^ (v50 << 17)), 0);
           if ( (_DWORD)result == -1 )
           {
-            v54 = byte_18159B988;
+            v54 = (unsigned __int8 *)&unk_1815A2980;
             v55 = -2128831035;
             if ( *(_QWORD *)(v51 + 16) )
-              v54 = *(char **)(v51 + 16);
+              v54 = *(unsigned __int8 **)(v51 + 16);
             for ( kk = *v54; *v54; kk = *v54 )
             {
               ++v54;
               v55 = 16777619 * (v55 ^ kk);
             }
-            result = sub_1811E1800(v47, (int)v51 + 16, v51, (v55 >> 21) + (v55 ^ (v55 << 17)), 0);
+            result = sub_1811E8F90(v47, (int)v51 + 16, v51, (v55 >> 21) + (v55 ^ (v55 << 17)), 0);
           }
           v46 = *(_QWORD *)(v46 + 8);
         }
         while ( v46 );
       }
-      qword_1820B1498 = 0;
+      qword_1820B9518 = 0;
     }
-    byte_1820B151C = 1;
+    byte_1820B959C = 1;
     return result;
   }


### PR DESCRIPTION
## Summary
- Add `CEntitySystem_m_ComponentUnserializerInfoAllocator` as a struct member of `CEntitySystem` to the `find-CEntitySystem_Init-decompiles` skill (LLM_DECOMPILE via `CEntitySystem_Init`)
- Update `config.yaml` with expected output and symbol definition
- Regenerate reference YAMLs for `CEntitySystem_Init` (windows + linux) from gamever 14165

## Test plan
- [ ] Run `find-CEntitySystem_Init-decompiles` skill on a new gamever and verify `CEntitySystem_m_ComponentUnserializerInfoAllocator.{platform}.yaml` is generated with correct offset/signature