### PR TITLE
feat: add find-CEntitySystem_m_hActiveSpawnGroup

### DIFF
--- a/ida_preprocessor_scripts/find-CEntitySystem_PrecacheEntity-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_PrecacheEntity-decompiles.py
@@ -15,6 +15,7 @@ TARGET_FUNCTION_NAMES = [
 
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_EntityList",
+    "CEntitySystem_m_hActiveSpawnGroup",
 ]
 
 LLM_DECOMPILE = [
@@ -46,6 +47,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_EntityList",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_hActiveSpawnGroup",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PrecacheEntity.{platform}.yaml",
     ),
@@ -131,6 +137,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "offset_sig",
             "offset_sig_disp",
             "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "CEntitySystem_m_hActiveSpawnGroup",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
         ],
     ),
     (

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.linux.yaml
@@ -73,7 +73,8 @@ disasm_code: |-
   .text:0000000001EACE0A                 jnz     loc_1EACED8
   .text:0000000001EACE10                 cmp     r12d, 0FFFFFFFFh
   .text:0000000001EACE14                 jnz     short loc_1EACE1D
-  .text:0000000001EACE16                 mov     r12d, [rbx+1F40h]
+  .text:0000000001EACE16                 ; 0x1F40 = 8000 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
+  .text:0000000001EACE16                 mov     r12d, [rbx+1F40h]; 0x1F40 = 8000 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
   .text:0000000001EACE1D                 and     eax, 400h
   .text:0000000001EACE22                 jnz     loc_1EACEE6
   .text:0000000001EACE28                 mov     rdx, [rbx]
@@ -182,7 +183,7 @@ procedure: |-
           else
           {
             if ( a3 == -1 )
-              a3 = a1[2000];
+              a3 = a1[2000];// 0x1F40 = 8000 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
             v10 = *(_DWORD *)(v13 + 104) & 0x400;
             if ( !v10 )
               goto LABEL_13;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PrecacheEntity.windows.yaml
@@ -99,7 +99,8 @@ disasm_code: |-
   .text:000000018121459E                 jmp     short loc_1812145AB
   .text:00000001812145A0                 cmp     esi, 0FFFFFFFFh
   .text:00000001812145A3                 jnz     short loc_1812145AB
-  .text:00000001812145A5                 mov     esi, [rdi+1F38h]
+  .text:00000001812145A5                 ; 0x1F38 = 7992 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
+  .text:00000001812145A5                 mov     esi, [rdi+1F38h]; 0x1F38 = 7992 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
   .text:00000001812145AB                 shr     ecx, 0Ah
   .text:00000001812145AE                 test    cl, 1
   .text:00000001812145B1                 jnz     short loc_1812145CE
@@ -255,7 +256,7 @@ procedure: |-
           }
           else if ( a3 == -1 )
           {
-            a3 = *(_DWORD *)(a1 + 7992);
+            a3 = *(_DWORD *)(a1 + 7992);// 0x1F38 = 7992 = CEntitySystem::m_hActiveSpawnGroup (structmember, struct=CEntitySystem, member=m_hActiveSpawnGroup)
           }
           if ( (v12 & 0x400) != 0 )
             v13 = 1;


### PR DESCRIPTION
## Summary
- Add `CEntitySystem_m_hActiveSpawnGroup` (struct member of `CEntitySystem`) to `find-CEntitySystem_PrecacheEntity-decompiles.py`
- Re-generate `CEntitySystem_PrecacheEntity` reference YAMLs with struct member annotations for the new field

## Details
- `TARGET_STRUCT_MEMBER_NAMES`: added `CEntitySystem_m_hActiveSpawnGroup`
- `LLM_DECOMPILE`: added entry using the existing `CEntitySystem_PrecacheEntity` reference
- `GENERATE_YAML_DESIRED_FIELDS`: added entry with `struct_name`, `member_name`, `offset`, `size`, `offset_sig`, `offset_sig_disp`
- Windows reference YAML: annotated `mov esi, [rdi+1F38h]` (offset `0x1F38` = 7992)
- Linux reference YAML: annotated `mov r12d, [rbx+1F40h]` (offset `0x1F40` = 8000)