### PR TITLE
Add CGameEntitySystem_OnAddEntity, m_iNetworkedEntCount, and m_iNonNetworkedSavedEntCount

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5134,6 +5134,19 @@ modules:
           - CEntitySystem_vtable.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CGameEntitySystem_OnAddEntity
+        expected_output:
+          - CGameEntitySystem_OnAddEntity.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml
+          - CGameEntitySystem_vtable.{platform}.yaml
+
+      - name: find-CGameEntitySystem_m_iNetworkedEntCount
+        expected_output:
+          - CGameEntitySystem_m_iNetworkedEntCount.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_OnAddEntity.{platform}.yaml
+
       - name: find-CEntitySystem_PrecacheEntity
         expected_output:
           - CEntitySystem_PrecacheEntity.{platform}.yaml
@@ -9316,6 +9329,16 @@ modules:
 
       - name: CGameEntitySystem_vtable
         category: vtable
+
+      - name: CGameEntitySystem_OnAddEntity
+        category: vfunc
+        alias:
+          - CGameEntitySystem::OnAddEntity
+
+      - name: CGameEntitySystem_m_iNetworkedEntCount
+        category: structmember
+        struct: CGameEntitySystem
+        member: m_iNetworkedEntCount
 
       - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -5141,9 +5141,10 @@ modules:
           - CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml
           - CGameEntitySystem_vtable.{platform}.yaml
 
-      - name: find-CGameEntitySystem_m_iNetworkedEntCount
+      - name: find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount
         expected_output:
           - CGameEntitySystem_m_iNetworkedEntCount.{platform}.yaml
+          - CGameEntitySystem_m_iNonNetworkedSavedEntCount.{platform}.yaml
         expected_input:
           - CGameEntitySystem_OnAddEntity.{platform}.yaml
 
@@ -9339,6 +9340,11 @@ modules:
         category: structmember
         struct: CGameEntitySystem
         member: m_iNetworkedEntCount
+
+      - name: CGameEntitySystem_m_iNonNetworkedSavedEntCount
+        category: structmember
+        struct: CGameEntitySystem
+        member: m_iNonNetworkedSavedEntCount
 
       - name: CGameEntitySystem_BuildResourceManifest_ManifestNameOrGroupName
         category: vfunc

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_OnAddEntity.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_OnAddEntity.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_OnAddEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameEntitySystem_OnAddEntity",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameEntitySystem_OnAddEntity",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameEntitySystem_OnAddEntity", "CGameEntitySystem"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEntitySystem_OnAddEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",    # REQUIRED -- never omit for Pattern C
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CGameEntitySystem_m_iNetworkedEntCount skill."""
+"""Preprocess script for find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_STRUCT_MEMBER_NAMES = [
     "CGameEntitySystem_m_iNetworkedEntCount",
+    "CGameEntitySystem_m_iNonNetworkedSavedEntCount",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
         "CGameEntitySystem_m_iNetworkedEntCount",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_OnAddEntity.{platform}.yaml",
+    ),
+    (
+        "CGameEntitySystem_m_iNonNetworkedSavedEntCount",
         "prompt/call_llm_decompile.md",
         "references/server/CGameEntitySystem_OnAddEntity.{platform}.yaml",
     ),
@@ -29,13 +35,24 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "offset_sig_disp",
         ],
     ),
+    (
+        "CGameEntitySystem_m_iNonNetworkedSavedEntCount",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    """Reuse previous gamever offset_sig to locate target struct offsets and write YAMLs."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_m_iNetworkedEntCount.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_m_iNetworkedEntCount.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_m_iNetworkedEntCount skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CGameEntitySystem_m_iNetworkedEntCount",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CGameEntitySystem_m_iNetworkedEntCount",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_OnAddEntity.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEntitySystem_m_iNetworkedEntCount",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.linux.yaml
@@ -52,7 +52,7 @@ disasm_code: |-
   .text:0000000001534CA7                 call    rax
   .text:0000000001534CA9                 test    al, al
   .text:0000000001534CAB                 jz      short loc_1534C3E
-  .text:0000000001534CAD                 add     dword ptr [r14+20A4h], 1
+  .text:0000000001534CAD                 add     dword ptr [r14+20A4h], 1; 8356 = 0x20A4 = CGameEntitySystem::m_iNonNetworkedSavedEntCount (structmember, struct=CGameEntitySystem, member=m_iNonNetworkedSavedEntCount)
   .text:0000000001534CB5                 jmp     short loc_1534C3E
 procedure: |-
   void __fastcall CGameEntitySystem_OnAddEntity(__int64 a1, __int64 a2, int a3)
@@ -69,7 +69,7 @@ procedure: |-
         return;
       v8 = *(__int64 (__fastcall **)())(*(_QWORD *)a2 + 872LL);
       if ( v8 != sub_9B0860 && ((unsigned __int8 (__fastcall *)(__int64))v8)(a2) )
-        ++*(_DWORD *)(a1 + 8356);
+        ++*(_DWORD *)(a1 + 8356);// 8356 = 0x20A4 = CGameEntitySystem::m_iNonNetworkedSavedEntCount (structmember, struct=CGameEntitySystem, member=m_iNonNetworkedSavedEntCount)
     }
     else
     {

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.linux.yaml
@@ -1,0 +1,93 @@
+func_name: CGameEntitySystem_OnAddEntity
+func_va: '0x1534c10'
+disasm_code: |-
+  .text:0000000001534C10                 push    rbp
+  .text:0000000001534C11                 mov     rbp, rsp
+  .text:0000000001534C14                 push    r14
+  .text:0000000001534C16                 mov     r14, rdi
+  .text:0000000001534C19                 push    r13
+  .text:0000000001534C1B                 push    r12
+  .text:0000000001534C1D                 mov     r12, rsi
+  .text:0000000001534C20                 push    rbx
+  .text:0000000001534C21                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001534C24                 jz      short loc_1534C88
+  .text:0000000001534C26                 and     dx, 7FFFh
+  .text:0000000001534C2B                 cmp     dx, 3FFFh
+  .text:0000000001534C30                 ja      short loc_1534C88
+  .text:0000000001534C32                 ; 8352 = 0x20A0 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+  .text:0000000001534C32                 add     dword ptr [rdi+20A0h], 1; 8352 = 0x20A0 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+  .text:0000000001534C39                 test    rsi, rsi
+  .text:0000000001534C3C                 jz      short loc_1534C7C
+  .text:0000000001534C3E                 movsxd  rax, dword ptr [r14+20D0h]
+  .text:0000000001534C45                 mov     edx, eax
+  .text:0000000001534C47                 sub     edx, 1
+  .text:0000000001534C4A                 js      short loc_1534C7C
+  .text:0000000001534C4C                 movsxd  rbx, edx
+  .text:0000000001534C4F                 mov     edx, edx
+  .text:0000000001534C51                 sub     rax, rdx
+  .text:0000000001534C54                 shl     rbx, 3
+  .text:0000000001534C58                 lea     r13, ds:0FFFFFFFFFFFFFFF0h[rax*8]
+  .text:0000000001534C60                 mov     rax, [r14+20D8h]
+  .text:0000000001534C67                 mov     rsi, r12
+  .text:0000000001534C6A                 mov     rdi, [rax+rbx]
+  .text:0000000001534C6E                 sub     rbx, 8
+  .text:0000000001534C72                 mov     rax, [rdi]
+  .text:0000000001534C75                 call    qword ptr [rax]
+  .text:0000000001534C77                 cmp     r13, rbx
+  .text:0000000001534C7A                 jnz     short loc_1534C60
+  .text:0000000001534C7C                 pop     rbx
+  .text:0000000001534C7D                 pop     r12
+  .text:0000000001534C7F                 pop     r13
+  .text:0000000001534C81                 pop     r14
+  .text:0000000001534C83                 pop     rbp
+  .text:0000000001534C84                 retn
+  .text:0000000001534C88                 test    r12, r12
+  .text:0000000001534C8B                 jz      short loc_1534C7C
+  .text:0000000001534C8D                 mov     rax, [r12]
+  .text:0000000001534C91                 lea     rdx, sub_9B0860
+  .text:0000000001534C98                 mov     rax, [rax+368h]
+  .text:0000000001534C9F                 cmp     rax, rdx
+  .text:0000000001534CA2                 jz      short loc_1534C3E
+  .text:0000000001534CA4                 mov     rdi, r12
+  .text:0000000001534CA7                 call    rax
+  .text:0000000001534CA9                 test    al, al
+  .text:0000000001534CAB                 jz      short loc_1534C3E
+  .text:0000000001534CAD                 add     dword ptr [r14+20A4h], 1
+  .text:0000000001534CB5                 jmp     short loc_1534C3E
+procedure: |-
+  void __fastcall CGameEntitySystem_OnAddEntity(__int64 a1, __int64 a2, int a3)
+  {
+    int v4; // edx
+    __int64 v5; // rbx
+    unsigned __int64 v6; // r13
+    void (__fastcall ***v7)(_QWORD, __int64); // rdi
+    __int64 (__fastcall *v8)(); // rax
+
+    if ( a3 == -1 || (a3 & 0x7FFFu) > 0x3FFF )
+    {
+      if ( !a2 )
+        return;
+      v8 = *(__int64 (__fastcall **)())(*(_QWORD *)a2 + 872LL);
+      if ( v8 != sub_9B0860 && ((unsigned __int8 (__fastcall *)(__int64))v8)(a2) )
+        ++*(_DWORD *)(a1 + 8356);
+    }
+    else
+    {
+      ++*(_DWORD *)(a1 + 8352);// 8352 = 0x20A0 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+      if ( !a2 )
+        return;
+    }
+    v4 = *(_DWORD *)(a1 + 8400) - 1;
+    if ( v4 >= 0 )
+    {
+      v5 = 8LL * v4;
+      v6 = 8 * (*(int *)(a1 + 8400) - (unsigned __int64)(unsigned int)v4) - 16;
+      do
+      {
+        v7 = *(void (__fastcall ****)(_QWORD, __int64))(*(_QWORD *)(a1 + 8408) + v5);
+        v5 -= 8;
+        (**v7)(v7, a2);
+      }
+      while ( v6 != v5 );
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.windows.yaml
@@ -1,0 +1,79 @@
+func_name: CGameEntitySystem_OnAddEntity
+func_va: '0x180b6f470'
+disasm_code: |-
+  .text:0000000180B6F470                 mov     [rsp+arg_8], rsi
+  .text:0000000180B6F475                 push    rdi
+  .text:0000000180B6F476                 sub     rsp, 20h
+  .text:0000000180B6F47A                 mov     r9d, 7FFFh
+  .text:0000000180B6F480                 mov     eax, r8d
+  .text:0000000180B6F483                 and     eax, r9d
+  .text:0000000180B6F486                 mov     rsi, rdx
+  .text:0000000180B6F489                 cmp     r8d, 0FFFFFFFFh
+  .text:0000000180B6F48D                 mov     rdi, rcx
+  .text:0000000180B6F490                 cmovnz  r9d, eax
+  .text:0000000180B6F494                 cmp     r9d, 4000h
+  .text:0000000180B6F49B                 jnb     short loc_180B6F4AA
+  .text:0000000180B6F49D                 ; 8336 = 0x2090 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+  .text:0000000180B6F49D                 inc     dword ptr [rcx+2090h]; 8336 = 0x2090 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+  .text:0000000180B6F4A3                 test    rdx, rdx
+  .text:0000000180B6F4A6                 jz      short loc_180B6F4FE
+  .text:0000000180B6F4A8                 jmp     short loc_180B6F4C5
+  .text:0000000180B6F4AA                 test    rsi, rsi
+  .text:0000000180B6F4AD                 jz      short loc_180B6F4FE
+  .text:0000000180B6F4AF                 mov     rax, [rdx]
+  .text:0000000180B6F4B2                 mov     rcx, rsi
+  .text:0000000180B6F4B5                 call    qword ptr [rax+370h]
+  .text:0000000180B6F4BB                 test    al, al
+  .text:0000000180B6F4BD                 jz      short loc_180B6F4C5
+  .text:0000000180B6F4BF                 inc     dword ptr [rdi+2094h]
+  .text:0000000180B6F4C5                 mov     eax, [rdi+20C0h]
+  .text:0000000180B6F4CB                 sub     eax, 1
+  .text:0000000180B6F4CE                 mov     [rsp+28h+arg_0], rbx
+  .text:0000000180B6F4D3                 movsxd  rbx, eax
+  .text:0000000180B6F4D6                 js      short loc_180B6F4F9
+  .text:0000000180B6F4D8                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000180B6F4E0                 mov     rax, [rdi+20C8h]
+  .text:0000000180B6F4E7                 mov     rdx, rsi
+  .text:0000000180B6F4EA                 mov     rcx, [rax+rbx*8]
+  .text:0000000180B6F4EE                 mov     rax, [rcx]
+  .text:0000000180B6F4F1                 call    qword ptr [rax]
+  .text:0000000180B6F4F3                 sub     rbx, 1
+  .text:0000000180B6F4F7                 jns     short loc_180B6F4E0
+  .text:0000000180B6F4F9                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180B6F4FE                 mov     rsi, [rsp+28h+arg_8]
+  .text:0000000180B6F503                 add     rsp, 20h
+  .text:0000000180B6F507                 pop     rdi
+  .text:0000000180B6F508                 retn
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_OnAddEntity(__int64 a1, __int64 a2, int a3)
+  {
+    unsigned int v3; // r9d
+    __int64 result; // rax
+    __int64 i; // rbx
+    __int64 (__fastcall ***v8)(_QWORD, __int64); // rcx
+
+    v3 = 0x7FFF;
+    result = a3 & 0x7FFF;
+    if ( a3 != -1 )
+      v3 = a3 & 0x7FFF;
+    if ( v3 >= 0x4000 )
+    {
+      if ( !a2 )
+        return result;
+      if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a2 + 880LL))(a2) )
+        ++*(_DWORD *)(a1 + 8340);
+    }
+    else
+    {
+      ++*(_DWORD *)(a1 + 8336);// 8336 = 0x2090 = CGameEntitySystem::m_iNetworkedEntCount (structmember, struct=CGameEntitySystem, member=m_iNetworkedEntCount)
+      if ( !a2 )
+        return result;
+    }
+    result = (unsigned int)(*(_DWORD *)(a1 + 8384) - 1);
+    for ( i = (int)result; i >= 0; --i )
+    {
+      v8 = *(__int64 (__fastcall ****)(_QWORD, __int64))(*(_QWORD *)(a1 + 8392) + 8 * i);
+      result = (**v8)(v8, a2);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_OnAddEntity.windows.yaml
@@ -25,7 +25,7 @@ disasm_code: |-
   .text:0000000180B6F4B5                 call    qword ptr [rax+370h]
   .text:0000000180B6F4BB                 test    al, al
   .text:0000000180B6F4BD                 jz      short loc_180B6F4C5
-  .text:0000000180B6F4BF                 inc     dword ptr [rdi+2094h]
+  .text:0000000180B6F4BF                 inc     dword ptr [rdi+2094h]; 8340 = 0x2094 = CGameEntitySystem::m_iNonNetworkedSavedEntCount (structmember, struct=CGameEntitySystem, member=m_iNonNetworkedSavedEntCount)
   .text:0000000180B6F4C5                 mov     eax, [rdi+20C0h]
   .text:0000000180B6F4CB                 sub     eax, 1
   .text:0000000180B6F4CE                 mov     [rsp+28h+arg_0], rbx
@@ -61,7 +61,7 @@ procedure: |-
       if ( !a2 )
         return result;
       if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a2 + 880LL))(a2) )
-        ++*(_DWORD *)(a1 + 8340);
+        ++*(_DWORD *)(a1 + 8340);// 8340 = 0x2094 = CGameEntitySystem::m_iNonNetworkedSavedEntCount (structmember, struct=CGameEntitySystem, member=m_iNonNetworkedSavedEntCount)
     }
     else
     {


### PR DESCRIPTION
## Summary

- Add `find-CGameEntitySystem_OnAddEntity` (Pattern C) — vfunc of `CGameEntitySystem`, discovered by decompiling `CEntitySystem_AddEntityToEntityDataBase`
- Add `find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount` (Pattern E, multi-target) — both struct members of `CGameEntitySystem` discovered by decompiling `CGameEntitySystem_OnAddEntity`
  - Win offsets: `m_iNetworkedEntCount = 0x2090`, `m_iNonNetworkedSavedEntCount = 0x2094`
  - Linux offsets: `m_iNetworkedEntCount = 0x20A0`, `m_iNonNetworkedSavedEntCount = 0x20A4`
- Add annotated reference YAMLs for `CGameEntitySystem_OnAddEntity` (both platforms)
- Add `config.yaml` skill and symbol entries for all three new symbols

## Test plan

- [x] Windows: all 3 output YAMLs generated by `ida_analyze_bin.py`
- [x] Linux: `m_iNetworkedEntCount` generated by preprocessor; `m_iNonNetworkedSavedEntCount` YAML written with manually verified signature `41 83 86 ?? ?? ?? ?? 01 EB ?? CC` (unique to 1 hit at `0x1534CAD`, confirmed via IDA py_eval)
- [x] Final validation: 0 failures, 481 skipped