### PR TITLE
Add CGameEntitySystem_m_spawnGroupEntityFilters (Pattern E)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6349,8 +6349,15 @@ modules:
           - CEntitySystem_EnableAutoDeletionExecution.{platform}.yaml
           - CEntitySystem_InstallPostSpawnCallback.{platform}.yaml
           - CEntitySystem_InstallCreationWrapperCallbacks.{platform}.yaml
+          - CGameEntitySystem_RegisterSpawnGroupEntityFilter.{platform}.yaml
         expected_input:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
+
+      - name: find-CGameEntitySystem_m_spawnGroupEntityFilters
+        expected_output:
+          - CGameEntitySystem_m_spawnGroupEntityFilters.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_RegisterSpawnGroupEntityFilter.{platform}.yaml
 
       - name: find-CEntitySystem_m_EntityPostSpawnCallback
         expected_output:
@@ -9351,6 +9358,18 @@ modules:
         category: func
         alias:
           - CGameEntitySystem::CheckGlobalState
+
+      - name: CGameEntitySystem_RegisterSpawnGroupEntityFilter
+        category: func
+        alias:
+          - CGameEntitySystem::RegisterSpawnGroupEntityFilter
+
+      - name: CGameEntitySystem_m_spawnGroupEntityFilters
+        category: structmember
+        struct: CGameEntitySystem
+        member: m_spawnGroupEntityFilters
+        alias:
+          - CGameEntitySystem::m_spawnGroupEntityFilters
 
       - name: IGameSystem_OnBuildGameSessionManifest
         category: vfunc

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_m_spawnGroupEntityFilters.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_m_spawnGroupEntityFilters.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_m_spawnGroupEntityFilters skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CGameEntitySystem_m_spawnGroupEntityFilters",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CGameEntitySystem_m_spawnGroupEntityFilters",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CGameEntitySystem_m_spawnGroupEntityFilters",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -8,6 +8,7 @@ TARGET_FUNCTION_NAMES = [
     "CEntitySystem_EnableAutoDeletionExecution",
     "CEntitySystem_InstallPostSpawnCallback",
     "CEntitySystem_InstallCreationWrapperCallbacks",
+    "CGameEntitySystem_RegisterSpawnGroupEntityFilter",
 ]
 
 TARGET_GLOBALVAR_NAMES = [
@@ -103,6 +104,16 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_size",
         ],
     ),
+    (
+        "CGameEntitySystem_RegisterSpawnGroupEntityFilter",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
@@ -143,6 +154,11 @@ async def preprocess_skill(
         ),
         (
             "CEntitySystem_InstallCreationWrapperCallbacks",
+            "prompt/call_llm_decompile.md",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
+        ),
+        (
+            "CGameEntitySystem_RegisterSpawnGroupEntityFilter",
             "prompt/call_llm_decompile.md",
             "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),

--- a/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
@@ -1,289 +1,289 @@
 func_name: CSource2EntitySystem_StaticInit
-func_va: '0x18098f440'
+func_va: '0x18098f4c0'
 disasm_code: |-
-  .text:000000018098F440                 mov     [rsp-18h+arg_8], rbx
-  .text:000000018098F445                 mov     [rsp-18h+arg_10], rsi
-  .text:000000018098F44A                 mov     [rsp-18h+arg_18], rdi
-  .text:000000018098F44F                 push    rbp
-  .text:000000018098F450                 push    r14
-  .text:000000018098F452                 push    r15
-  .text:000000018098F454                 mov     rbp, rsp
-  .text:000000018098F457                 sub     rsp, 50h
-  .text:000000018098F45B                 mov     eax, cs:dword_1824E44E8
-  .text:000000018098F461                 xor     r15d, r15d
-  .text:000000018098F464                 mov     ecx, eax
-  .text:000000018098F466                 inc     eax
-  .text:000000018098F468                 mov     cs:dword_1824E44E8, eax
-  .text:000000018098F46E                 test    ecx, ecx
-  .text:000000018098F470                 jg      short loc_18098F4AB
-  .text:000000018098F472                 mov     ecx, 20F0h
-  .text:000000018098F477                 call    operator_new
-  .text:000000018098F47C                 test    rax, rax
-  .text:000000018098F47F                 jz      short loc_18098F48B
-  .text:000000018098F481                 mov     rcx, rax
-  .text:000000018098F484                 call    CGameEntitySystem_ctor
-  .text:000000018098F489                 jmp     short loc_18098F48E
-  .text:000000018098F48B                 mov     rax, r15
-  .text:000000018098F48E                 mov     r9d, 1
-  .text:000000018098F494                 mov     byte ptr [rsp+50h+var_30], r15b
-  .text:000000018098F499                 mov     r8d, r9d
-  .text:000000018098F49C                 lea     rdx, aClientEntities; "client_entities"
-  .text:000000018098F4A3                 mov     rcx, rax
-  .text:000000018098F4A6                 call    CEntitySystem_PostCreateEntitySystem
-  .text:000000018098F4AB                 mov     rbx, cs:g_pEntitySystem
-  .text:000000018098F4B2                 mov     cs:g_pGameEntitySystem, rbx
-  .text:000000018098F4B9                 movsxd  r14, dword ptr [rbx+0B90h]  ; 0B90h = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
-  .text:000000018098F4C0                 cmp     r14d, [rbx+0BA0h]
-  .text:000000018098F4C7                 jnz     loc_18098F58F
-  .text:000000018098F4CD                 test    dword ptr [rbx+0BA4h], 40000000h
-  .text:000000018098F4D7                 jnz     loc_18098F58F
-  .text:000000018098F4DD                 mov     ecx, [rbx+0BA0h]
-  .text:000000018098F4E3                 cmp     ecx, 7FFFFFFEh
-  .text:000000018098F4E9                 jle     short loc_18098F4F6
-  .text:000000018098F4EB                 mov     edx, 1
-  .text:000000018098F4F0                 call    cs:UtlVectorMemory_FailedAllocation
-  .text:000000018098F4F6                 mov     ecx, [rbx+0BA0h]
-  .text:000000018098F4FC                 mov     r9d, 8
-  .text:000000018098F502                 mov     edx, [rbx+0BA4h]
-  .text:000000018098F508                 and     edx, 3FFFFFFFh
-  .text:000000018098F50E                 lea     esi, [rcx+1]
-  .text:000000018098F511                 mov     r8d, esi
-  .text:000000018098F514                 call    cs:UtlVectorMemory_CalcNewAllocationCount
-  .text:000000018098F51A                 mov     edi, eax
-  .text:000000018098F51C                 cmp     eax, esi
-  .text:000000018098F51E                 jge     short loc_18098F53E
-  .text:000000018098F520                 test    eax, eax
-  .text:000000018098F522                 jnz     short loc_18098F530
-  .text:000000018098F524                 cmp     esi, 0FFFFFFFFh
-  .text:000000018098F527                 jg      short loc_18098F530
-  .text:000000018098F529                 mov     edi, 0FFFFFFFFh
-  .text:000000018098F52E                 jmp     short loc_18098F53E
-  .text:000000018098F530                 lea     eax, [rdi+rsi]
-  .text:000000018098F533                 cdq
-  .text:000000018098F534                 sub     eax, edx
-  .text:000000018098F536                 sar     eax, 1
-  .text:000000018098F538                 mov     edi, eax
-  .text:000000018098F53A                 cmp     eax, esi
-  .text:000000018098F53C                 jl      short loc_18098F530
-  .text:000000018098F53E                 movsxd  r9, dword ptr [rbx+0BA0h]
-  .text:000000018098F545                 mov     rcx, [rbx+0B98h]
-  .text:000000018098F54C                 shl     r9, 3
-  .text:000000018098F550                 movsxd  r8, edi
-  .text:000000018098F553                 shl     r8, 3
-  .text:000000018098F557                 test    dword ptr [rbx+0BA4h], 0C0000000h
-  .text:000000018098F561                 setz    dl
-  .text:000000018098F564                 call    cs:UtlVectorMemory_Alloc
-  .text:000000018098F56A                 mov     [rbx+0B98h], rax
-  .text:000000018098F571                 mov     eax, [rbx+0BA4h]
-  .text:000000018098F577                 test    eax, 0C0000000h
-  .text:000000018098F57C                 jz      short loc_18098F589
-  .text:000000018098F57E                 and     eax, 3FFFFFFFh
-  .text:000000018098F583                 mov     [rbx+0BA4h], eax
-  .text:000000018098F589                 mov     [rbx+0BA0h], edi
-  .text:000000018098F58F                 inc     dword ptr [rbx+0B90h]
-  .text:000000018098F595                 lea     rdx, off_182042A38
-  .text:000000018098F59C                 mov     rax, [rbx+0B98h]
-  .text:000000018098F5A3                 mov     ecx, 1338h
-  .text:000000018098F5A8                 mov     [rax+r14*8], rdx
-  .text:000000018098F5AC                 call    operator_new
-  .text:000000018098F5B1                 mov     rbx, rax
-  .text:000000018098F5B4                 test    rax, rax
-  .text:000000018098F5B7                 jz      loc_18098F707
-  .text:000000018098F5BD                 lea     rax, ??_7CEntity2SaveRestore@@6B@; const CEntity2SaveRestore::`vftable'
-  .text:000000018098F5C4                 mov     [rbp+arg_0], r15
-  .text:000000018098F5C8                 mov     [rbx], rax
-  .text:000000018098F5CB                 lea     rdx, aU02u02u; "%u:%02u:%02u"
-  .text:000000018098F5D2                 mov     [rbx+10h], r15
-  .text:000000018098F5D6                 lea     rcx, [rbp+arg_0]
-  .text:000000018098F5DA                 mov     [rbx+18h], r15
-  .text:000000018098F5DE                 xor     r9d, r9d
-  .text:000000018098F5E1                 mov     [rbx+8], r15d
-  .text:000000018098F5E5                 xor     r8d, r8d
-  .text:000000018098F5E8                 mov     [rbx+20h], r15b
-  .text:000000018098F5EC                 mov     [rbx+28h], r15
-  .text:000000018098F5F0                 mov     [rbx+30h], r15
-  .text:000000018098F5F4                 mov     [rbx+38h], r15
-  .text:000000018098F5F8                 mov     [rbx+40h], r15
-  .text:000000018098F5FC                 mov     [rbx+48h], r15
-  .text:000000018098F600                 mov     [rbx+50h], r15
-  .text:000000018098F604                 mov     word ptr [rbx+58h], 100h
-  .text:000000018098F60A                 mov     [rbx+60h], r15
-  .text:000000018098F60E                 mov     [rbx+68h], r15d
-  .text:000000018098F612                 mov     [rbx+70h], r15
-  .text:000000018098F616                 mov     [rsp+50h+var_30], r15d
-  .text:000000018098F61B                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
-  .text:000000018098F621                 mov     rsi, [rbp+arg_0]
-  .text:000000018098F625                 cmp     [rbx+70h], r15
-  .text:000000018098F629                 jz      short loc_18098F635
-  .text:000000018098F62B                 lea     rcx, [rbx+70h]
-  .text:000000018098F62F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
-  .text:000000018098F635                 mov     [rbx+70h], rsi
-  .text:000000018098F639                 lea     rcx, [rbx+130h]
-  .text:000000018098F640                 mov     [rbx+90h], r15b
-  .text:000000018098F647                 mov     edx, 1
-  .text:000000018098F64C                 mov     [rbx+98h], r15
-  .text:000000018098F653                 mov     [rbx+0A0h], r15
-  .text:000000018098F65A                 mov     [rbx+0A8h], r15
-  .text:000000018098F661                 mov     [rbx+0B0h], r15
-  .text:000000018098F668                 mov     [rbx+0B8h], r15
-  .text:000000018098F66F                 mov     [rbx+0C0h], r15
-  .text:000000018098F676                 mov     word ptr [rbx+0C8h], 100h
-  .text:000000018098F67F                 mov     [rbx+0D0h], r15
-  .text:000000018098F686                 mov     [rbx+0D8h], r15d
-  .text:000000018098F68D                 mov     [rbx+0E8h], r15
-  .text:000000018098F694                 mov     [rbx+0F0h], r15
-  .text:000000018098F69B                 mov     [rbx+100h], r15
-  .text:000000018098F6A2                 mov     [rbx+78h], r15d
-  .text:000000018098F6A6                 mov     dword ptr [rbx+7Ch], 1000000h
-  .text:000000018098F6AD                 mov     [rbx+80h], r15w
-  .text:000000018098F6B5                 mov     [rbx+88h], r15w
-  .text:000000018098F6BD                 mov     [rbx+0E0h], r15
-  .text:000000018098F6C4                 mov     [rbx+0F8h], r15d
-  .text:000000018098F6CB                 mov     [rbp+arg_0], r15
-  .text:000000018098F6CF                 mov     [rbx+84h], r15d
-  .text:000000018098F6D6                 mov     [rbx+110h], r15
-  .text:000000018098F6DD                 mov     [rbx+118h], r15
-  .text:000000018098F6E4                 mov     [rbx+108h], r15d
-  .text:000000018098F6EB                 mov     [rbx+120h], r15
-  .text:000000018098F6F2                 mov     [rbx+128h], r15b
-  .text:000000018098F6F9                 call    sub_181829DC0
-  .text:000000018098F6FE                 mov     [rbx+1330h], r15
-  .text:000000018098F705                 jmp     short loc_18098F70A
-  .text:000000018098F707                 mov     rbx, r15
-  .text:000000018098F70A                 mov     rax, cs:g_pGameEntitySystem
-  .text:000000018098F711                 mov     rcx, rbx
-  .text:000000018098F714                 mov     [rax+20D8h], rbx
-  .text:000000018098F71B                 mov     rax, [rbx]
-  .text:000000018098F71E                 mov     rdx, [rax]
-  .text:000000018098F721                 lea     rax, sub_18095E160
-  .text:000000018098F728                 cmp     rdx, rax
-  .text:000000018098F72B                 jnz     short loc_18098F734
-  .text:000000018098F72D                 call    sub_18095E160
-  .text:000000018098F732                 jmp     short loc_18098F736
-  .text:000000018098F734                 call    rdx
-  .text:000000018098F736                 mov     rax, [rbx]
-  .text:000000018098F739                 mov     rcx, cs:qword_1823275E8
-  .text:000000018098F740                 mov     rdi, [rax+88h]
-  .text:000000018098F747                 mov     rax, [rcx]
-  .text:000000018098F74A                 call    qword ptr [rax+0C0h]
-  .text:000000018098F750                 lea     rcx, sub_180988040
-  .text:000000018098F757                 mov     rdx, rax
-  .text:000000018098F75A                 cmp     rdi, rcx
-  .text:000000018098F75D                 jnz     short loc_18098F76E
-  .text:000000018098F75F                 lea     rcx, [rbx+100h]
-  .text:000000018098F766                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
-  .text:000000018098F76C                 jmp     short loc_18098F773
-  .text:000000018098F76E                 mov     rcx, rbx
-  .text:000000018098F771                 call    rdi
-  .text:000000018098F773                 call    sub_1809771B0
-  .text:000000018098F778                 mov     rcx, cs:g_pGameEntitySystem
-  .text:000000018098F77F                 mov     dl, 1
-  .text:000000018098F781                 call    CEntitySystem_EnableAutoDeletionExecution
-  .text:000000018098F786                 mov     rcx, cs:qword_1823275E8
-  .text:000000018098F78D                 add     rcx, 8
-  .text:000000018098F791                 mov     rax, [rcx]
-  .text:000000018098F794                 call    qword ptr [rax+0A8h]
-  .text:000000018098F79A                 test    al, al
-  .text:000000018098F79C                 jnz     short loc_18098F7B2
-  .text:000000018098F79E                 mov     rcx, cs:g_pVApplication
-  .text:000000018098F7A5                 mov     rax, [rcx]
-  .text:000000018098F7A8                 call    qword ptr [rax+0B0h]
-  .text:000000018098F7AE                 test    al, al
-  .text:000000018098F7B0                 jz      short loc_18098F7D8
-  .text:000000018098F7B2                 mov     rcx, cs:g_pGameEntitySystem
-  .text:000000018098F7B9                 lea     rax, sub_180964B60
-  .text:000000018098F7C0                 mov     [rbp+var_18], rax
-  .text:000000018098F7C4                 lea     rdx, [rbp+var_20]
-  .text:000000018098F7C8                 lea     rax, sub_180950550
-  .text:000000018098F7CF                 mov     [rbp+var_20], rax
-  .text:000000018098F7D3                 call    CEntitySystem_InstallPostSpawnCallback
-  .text:000000018098F7D8                 mov     rcx, cs:g_pGameResourceService
-  .text:000000018098F7DF                 test    rcx, rcx
-  .text:000000018098F7E2                 jz      short loc_18098F7F4
-  .text:000000018098F7E4                 mov     rax, [rcx]
-  .text:000000018098F7E7                 mov     rdx, cs:g_pGameEntitySystem
-  .text:000000018098F7EE                 call    qword ptr [rax+110h]
-  .text:000000018098F7F4                 mov     rax, cs:g_pEntitySystem
-  .text:000000018098F7FB                 lea     rcx, [rbp+var_20]
-  .text:000000018098F7FF                 mov     r14, cs:g_pGameEntitySystem
-  .text:000000018098F806                 mov     [rbp+var_18], 1388h
-  .text:000000018098F80E                 mov     [rbp+var_10], r15b
-  .text:000000018098F812                 mov     esi, [rax+278h]
-  .text:000000018098F818                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
-  .text:000000018098F81F                 mov     [rbp+var_20], rax
-  .text:000000018098F823                 call    cs:ToolsStallMonitorInternal_BeginScope
-  .text:000000018098F829                 mov     ecx, 48h ; 'H'
-  .text:000000018098F82E                 call    operator_new
-  .text:000000018098F833                 mov     rdi, rax
-  .text:000000018098F836                 test    rax, rax
-  .text:000000018098F839                 jz      short loc_18098F891
-  .text:000000018098F83B                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
-  .text:000000018098F842                 xor     edx, edx
-  .text:000000018098F844                 mov     [rdi], rax
-  .text:000000018098F847                 lea     rcx, [rdi+30h]
-  .text:000000018098F84B                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
-  .text:000000018098F852                 mov     r8d, 1
-  .text:000000018098F858                 mov     [rdi+8], rax
-  .text:000000018098F85C                 mov     [rdi+18h], r15
-  .text:000000018098F860                 mov     [rdi+20h], r15
-  .text:000000018098F864                 mov     [rdi+10h], r15d
-  .text:000000018098F868                 mov     [rdi+28h], r15b
-  .text:000000018098F86C                 mov     [rdi+30h], r15d
-  .text:000000018098F870                 mov     [rdi+38h], r15
-  .text:000000018098F874                 call    sub_18094D6C0
-  .text:000000018098F879                 mov     eax, 0FFFFh
-  .text:000000018098F87E                 mov     edx, esi
-  .text:000000018098F880                 mov     rcx, rdi
-  .text:000000018098F883                 mov     [rdi+40h], eax
-  .text:000000018098F886                 mov     [rdi+44h], ax
-  .text:000000018098F88A                 call    sub_18095E8D0
-  .text:000000018098F88F                 jmp     short loc_18098F894
-  .text:000000018098F891                 mov     rdi, r15
-  .text:000000018098F894                 lea     rcx, [rbp+var_20]
-  .text:000000018098F898                 mov     [r14+20E0h], rdi
-  .text:000000018098F89F                 call    cs:ToolsStallMonitorInternal_EndScope
-  .text:000000018098F8A5                 mov     rcx, cs:g_pEntitySystem
-  .text:000000018098F8AC                 lea     rax, sub_1809485C0
-  .text:000000018098F8B3                 lea     rbx, sub_180964BA0
-  .text:000000018098F8BA                 mov     [rbp+var_20], rax
-  .text:000000018098F8BE                 lea     r8, [rbp+var_20]
-  .text:000000018098F8C2                 mov     [rbp+var_18], rbx
-  .text:000000018098F8C6                 mov     dl, 28h ; '('
-  .text:000000018098F8C8                 call    sub_1814BBE30
-  .text:000000018098F8CD                 mov     rcx, cs:g_pEntitySystem
-  .text:000000018098F8D4                 lea     rax, sub_180948530
-  .text:000000018098F8DB                 lea     r8, [rbp+var_20]
-  .text:000000018098F8DF                 mov     [rbp+var_20], rax
-  .text:000000018098F8E3                 mov     dl, 36h ; '6'
-  .text:000000018098F8E5                 mov     [rbp+var_18], rbx
-  .text:000000018098F8E9                 call    sub_1814BBE30
-  .text:000000018098F8EE                 mov     rcx, cs:g_pEntitySystem
-  .text:000000018098F8F5                 lea     rax, sub_1809484E0
-  .text:000000018098F8FC                 lea     r8, [rbp+var_20]
-  .text:000000018098F900                 mov     [rbp+var_20], rax
-  .text:000000018098F904                 mov     dl, 43h ; 'C'
-  .text:000000018098F906                 mov     [rbp+var_18], rbx
-  .text:000000018098F90A                 call    sub_1814BBE30
-  .text:000000018098F90F                 mov     rcx, cs:g_pFlattenedSerializers
-  .text:000000018098F916                 lea     rdx, sub_180964B70
-  .text:000000018098F91D                 mov     rax, [rcx]
-  .text:000000018098F920                 mov     [rbp+var_18], rdx
-  .text:000000018098F924                 lea     rdx, unknown_libname_194; Microsoft VisualC v7/14 64bit runtime
-  .text:000000018098F92B                 mov     [rbp+var_20], rdx
-  .text:000000018098F92F                 lea     rdx, [rbp+var_20]
-  .text:000000018098F933                 call    qword ptr [rax+108h]
-  .text:000000018098F939                 lea     r11, [rsp+50h+var_s0]
-  .text:000000018098F93E                 mov     al, 1
-  .text:000000018098F940                 mov     rbx, [r11+28h]
-  .text:000000018098F944                 mov     rsi, [r11+30h]
-  .text:000000018098F948                 mov     rdi, [r11+38h]
-  .text:000000018098F94C                 mov     rsp, r11
-  .text:000000018098F94F                 pop     r15
-  .text:000000018098F951                 pop     r14
-  .text:000000018098F953                 pop     rbp
-  .text:000000018098F954                 retn
+  .text:000000018098F4C0                 mov     [rsp-18h+arg_8], rbx
+  .text:000000018098F4C5                 mov     [rsp-18h+arg_10], rsi
+  .text:000000018098F4CA                 mov     [rsp-18h+arg_18], rdi
+  .text:000000018098F4CF                 push    rbp
+  .text:000000018098F4D0                 push    r14
+  .text:000000018098F4D2                 push    r15
+  .text:000000018098F4D4                 mov     rbp, rsp
+  .text:000000018098F4D7                 sub     rsp, 50h
+  .text:000000018098F4DB                 mov     eax, cs:dword_1824E5598
+  .text:000000018098F4E1                 xor     r15d, r15d
+  .text:000000018098F4E4                 mov     ecx, eax
+  .text:000000018098F4E6                 inc     eax
+  .text:000000018098F4E8                 mov     cs:dword_1824E5598, eax
+  .text:000000018098F4EE                 test    ecx, ecx
+  .text:000000018098F4F0                 jg      short loc_18098F52B
+  .text:000000018098F4F2                 mov     ecx, 20F0h
+  .text:000000018098F4F7                 call    sub_180B93230
+  .text:000000018098F4FC                 test    rax, rax
+  .text:000000018098F4FF                 jz      short loc_18098F50B
+  .text:000000018098F501                 mov     rcx, rax
+  .text:000000018098F504                 call    sub_180933980
+  .text:000000018098F509                 jmp     short loc_18098F50E
+  .text:000000018098F50B                 mov     rax, r15
+  .text:000000018098F50E                 mov     r9d, 1
+  .text:000000018098F514                 mov     byte ptr [rsp+50h+var_30], r15b
+  .text:000000018098F519                 mov     r8d, r9d
+  .text:000000018098F51C                 lea     rdx, aClientEntities; "client_entities"
+  .text:000000018098F523                 mov     rcx, rax
+  .text:000000018098F526                 call    sub_1814BDC70
+  .text:000000018098F52B                 mov     rbx, cs:qword_1824E5590
+  .text:000000018098F532                 mov     cs:qword_182328490, rbx
+  .text:000000018098F539                 movsxd  r14, dword ptr [rbx+0B90h]
+  .text:000000018098F540                 cmp     r14d, [rbx+0BA0h]
+  .text:000000018098F547                 jnz     loc_18098F60F
+  .text:000000018098F54D                 test    dword ptr [rbx+0BA4h], 40000000h
+  .text:000000018098F557                 jnz     loc_18098F60F
+  .text:000000018098F55D                 mov     ecx, [rbx+0BA0h]
+  .text:000000018098F563                 cmp     ecx, 7FFFFFFEh
+  .text:000000018098F569                 jle     short loc_18098F576
+  .text:000000018098F56B                 mov     edx, 1
+  .text:000000018098F570                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:000000018098F576                 mov     ecx, [rbx+0BA0h]
+  .text:000000018098F57C                 mov     r9d, 8
+  .text:000000018098F582                 mov     edx, [rbx+0BA4h]
+  .text:000000018098F588                 and     edx, 3FFFFFFFh
+  .text:000000018098F58E                 lea     esi, [rcx+1]
+  .text:000000018098F591                 mov     r8d, esi
+  .text:000000018098F594                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:000000018098F59A                 mov     edi, eax
+  .text:000000018098F59C                 cmp     eax, esi
+  .text:000000018098F59E                 jge     short loc_18098F5BE
+  .text:000000018098F5A0                 test    eax, eax
+  .text:000000018098F5A2                 jnz     short loc_18098F5B0
+  .text:000000018098F5A4                 cmp     esi, 0FFFFFFFFh
+  .text:000000018098F5A7                 jg      short loc_18098F5B0
+  .text:000000018098F5A9                 mov     edi, 0FFFFFFFFh
+  .text:000000018098F5AE                 jmp     short loc_18098F5BE
+  .text:000000018098F5B0                 lea     eax, [rdi+rsi]
+  .text:000000018098F5B3                 cdq
+  .text:000000018098F5B4                 sub     eax, edx
+  .text:000000018098F5B6                 sar     eax, 1
+  .text:000000018098F5B8                 mov     edi, eax
+  .text:000000018098F5BA                 cmp     eax, esi
+  .text:000000018098F5BC                 jl      short loc_18098F5B0
+  .text:000000018098F5BE                 movsxd  r9, dword ptr [rbx+0BA0h]
+  .text:000000018098F5C5                 mov     rcx, [rbx+0B98h]
+  .text:000000018098F5CC                 shl     r9, 3
+  .text:000000018098F5D0                 movsxd  r8, edi
+  .text:000000018098F5D3                 shl     r8, 3
+  .text:000000018098F5D7                 test    dword ptr [rbx+0BA4h], 0C0000000h
+  .text:000000018098F5E1                 setz    dl
+  .text:000000018098F5E4                 call    cs:UtlVectorMemory_Alloc
+  .text:000000018098F5EA                 mov     [rbx+0B98h], rax
+  .text:000000018098F5F1                 mov     eax, [rbx+0BA4h]
+  .text:000000018098F5F7                 test    eax, 0C0000000h
+  .text:000000018098F5FC                 jz      short loc_18098F609
+  .text:000000018098F5FE                 and     eax, 3FFFFFFFh
+  .text:000000018098F603                 mov     [rbx+0BA4h], eax
+  .text:000000018098F609                 mov     [rbx+0BA0h], edi
+  .text:000000018098F60F                 inc     dword ptr [rbx+0B90h]
+  .text:000000018098F615                 lea     rdx, off_182043A48
+  .text:000000018098F61C                 mov     rax, [rbx+0B98h]
+  .text:000000018098F623                 mov     ecx, 1338h
+  .text:000000018098F628                 mov     [rax+r14*8], rdx
+  .text:000000018098F62C                 call    sub_180B93230
+  .text:000000018098F631                 mov     rbx, rax
+  .text:000000018098F634                 test    rax, rax
+  .text:000000018098F637                 jz      loc_18098F787
+  .text:000000018098F63D                 lea     rax, ??_7CEntity2SaveRestore@@6B@; const CEntity2SaveRestore::`vftable'
+  .text:000000018098F644                 mov     [rbp+arg_0], r15
+  .text:000000018098F648                 mov     [rbx], rax
+  .text:000000018098F64B                 lea     rdx, aU02u02u; "%u:%02u:%02u"
+  .text:000000018098F652                 mov     [rbx+10h], r15
+  .text:000000018098F656                 lea     rcx, [rbp+arg_0]
+  .text:000000018098F65A                 mov     [rbx+18h], r15
+  .text:000000018098F65E                 xor     r9d, r9d
+  .text:000000018098F661                 mov     [rbx+8], r15d
+  .text:000000018098F665                 xor     r8d, r8d
+  .text:000000018098F668                 mov     [rbx+20h], r15b
+  .text:000000018098F66C                 mov     [rbx+28h], r15
+  .text:000000018098F670                 mov     [rbx+30h], r15
+  .text:000000018098F674                 mov     [rbx+38h], r15
+  .text:000000018098F678                 mov     [rbx+40h], r15
+  .text:000000018098F67C                 mov     [rbx+48h], r15
+  .text:000000018098F680                 mov     [rbx+50h], r15
+  .text:000000018098F684                 mov     word ptr [rbx+58h], 100h
+  .text:000000018098F68A                 mov     [rbx+60h], r15
+  .text:000000018098F68E                 mov     [rbx+68h], r15d
+  .text:000000018098F692                 mov     [rbx+70h], r15
+  .text:000000018098F696                 mov     [rsp+50h+var_30], r15d
+  .text:000000018098F69B                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
+  .text:000000018098F6A1                 mov     rsi, [rbp+arg_0]
+  .text:000000018098F6A5                 cmp     [rbx+70h], r15
+  .text:000000018098F6A9                 jz      short loc_18098F6B5
+  .text:000000018098F6AB                 lea     rcx, [rbx+70h]
+  .text:000000018098F6AF                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018098F6B5                 mov     [rbx+70h], rsi
+  .text:000000018098F6B9                 lea     rcx, [rbx+130h]
+  .text:000000018098F6C0                 mov     [rbx+90h], r15b
+  .text:000000018098F6C7                 mov     edx, 1
+  .text:000000018098F6CC                 mov     [rbx+98h], r15
+  .text:000000018098F6D3                 mov     [rbx+0A0h], r15
+  .text:000000018098F6DA                 mov     [rbx+0A8h], r15
+  .text:000000018098F6E1                 mov     [rbx+0B0h], r15
+  .text:000000018098F6E8                 mov     [rbx+0B8h], r15
+  .text:000000018098F6EF                 mov     [rbx+0C0h], r15
+  .text:000000018098F6F6                 mov     word ptr [rbx+0C8h], 100h
+  .text:000000018098F6FF                 mov     [rbx+0D0h], r15
+  .text:000000018098F706                 mov     [rbx+0D8h], r15d
+  .text:000000018098F70D                 mov     [rbx+0E8h], r15
+  .text:000000018098F714                 mov     [rbx+0F0h], r15
+  .text:000000018098F71B                 mov     [rbx+100h], r15
+  .text:000000018098F722                 mov     [rbx+78h], r15d
+  .text:000000018098F726                 mov     dword ptr [rbx+7Ch], 1000000h
+  .text:000000018098F72D                 mov     [rbx+80h], r15w
+  .text:000000018098F735                 mov     [rbx+88h], r15w
+  .text:000000018098F73D                 mov     [rbx+0E0h], r15
+  .text:000000018098F744                 mov     [rbx+0F8h], r15d
+  .text:000000018098F74B                 mov     [rbp+arg_0], r15
+  .text:000000018098F74F                 mov     [rbx+84h], r15d
+  .text:000000018098F756                 mov     [rbx+110h], r15
+  .text:000000018098F75D                 mov     [rbx+118h], r15
+  .text:000000018098F764                 mov     [rbx+108h], r15d
+  .text:000000018098F76B                 mov     [rbx+120h], r15
+  .text:000000018098F772                 mov     [rbx+128h], r15b
+  .text:000000018098F779                 call    sub_18182A600
+  .text:000000018098F77E                 mov     [rbx+1330h], r15
+  .text:000000018098F785                 jmp     short loc_18098F78A
+  .text:000000018098F787                 mov     rbx, r15
+  .text:000000018098F78A                 mov     rax, cs:qword_182328490
+  .text:000000018098F791                 mov     rcx, rbx
+  .text:000000018098F794                 mov     [rax+20D8h], rbx
+  .text:000000018098F79B                 mov     rax, [rbx]
+  .text:000000018098F79E                 mov     rdx, [rax]
+  .text:000000018098F7A1                 lea     rax, sub_18095E1E0
+  .text:000000018098F7A8                 cmp     rdx, rax
+  .text:000000018098F7AB                 jnz     short loc_18098F7B4
+  .text:000000018098F7AD                 call    sub_18095E1E0
+  .text:000000018098F7B2                 jmp     short loc_18098F7B6
+  .text:000000018098F7B4                 call    rdx
+  .text:000000018098F7B6                 mov     rax, [rbx]
+  .text:000000018098F7B9                 mov     rcx, cs:qword_1823284E8
+  .text:000000018098F7C0                 mov     rdi, [rax+88h]
+  .text:000000018098F7C7                 mov     rax, [rcx]
+  .text:000000018098F7CA                 call    qword ptr [rax+0C0h]
+  .text:000000018098F7D0                 lea     rcx, sub_1809880C0
+  .text:000000018098F7D7                 mov     rdx, rax
+  .text:000000018098F7DA                 cmp     rdi, rcx
+  .text:000000018098F7DD                 jnz     short loc_18098F7EE
+  .text:000000018098F7DF                 lea     rcx, [rbx+100h]
+  .text:000000018098F7E6                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018098F7EC                 jmp     short loc_18098F7F3
+  .text:000000018098F7EE                 mov     rcx, rbx
+  .text:000000018098F7F1                 call    rdi
+  .text:000000018098F7F3                 call    sub_180977230
+  .text:000000018098F7F8                 mov     rcx, cs:qword_182328490
+  .text:000000018098F7FF                 mov     dl, 1
+  .text:000000018098F801                 call    sub_1814B56C0
+  .text:000000018098F806                 mov     rcx, cs:qword_1823284E8
+  .text:000000018098F80D                 add     rcx, 8
+  .text:000000018098F811                 mov     rax, [rcx]
+  .text:000000018098F814                 call    qword ptr [rax+0A8h]
+  .text:000000018098F81A                 test    al, al
+  .text:000000018098F81C                 jnz     short loc_18098F832
+  .text:000000018098F81E                 mov     rcx, cs:qword_182556200
+  .text:000000018098F825                 mov     rax, [rcx]
+  .text:000000018098F828                 call    qword ptr [rax+0B0h]
+  .text:000000018098F82E                 test    al, al
+  .text:000000018098F830                 jz      short loc_18098F858
+  .text:000000018098F832                 mov     rcx, cs:qword_182328490
+  .text:000000018098F839                 lea     rax, sub_180964BE0
+  .text:000000018098F840                 mov     [rbp+var_18], rax
+  .text:000000018098F844                 lea     rdx, [rbp+var_20]
+  .text:000000018098F848                 lea     rax, sub_1809505D0
+  .text:000000018098F84F                 mov     [rbp+var_20], rax
+  .text:000000018098F853                 call    sub_1814BC4B0
+  .text:000000018098F858                 mov     rcx, cs:qword_1824E8C30
+  .text:000000018098F85F                 test    rcx, rcx
+  .text:000000018098F862                 jz      short loc_18098F874
+  .text:000000018098F864                 mov     rax, [rcx]
+  .text:000000018098F867                 mov     rdx, cs:qword_182328490
+  .text:000000018098F86E                 call    qword ptr [rax+110h]
+  .text:000000018098F874                 mov     rax, cs:qword_1824E5590
+  .text:000000018098F87B                 lea     rcx, [rbp+var_20]
+  .text:000000018098F87F                 mov     r14, cs:qword_182328490
+  .text:000000018098F886                 mov     [rbp+var_18], 1388h
+  .text:000000018098F88E                 mov     [rbp+var_10], r15b
+  .text:000000018098F892                 mov     esi, [rax+278h]
+  .text:000000018098F898                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
+  .text:000000018098F89F                 mov     [rbp+var_20], rax
+  .text:000000018098F8A3                 call    cs:ToolsStallMonitorInternal_BeginScope
+  .text:000000018098F8A9                 mov     ecx, 48h ; 'H'
+  .text:000000018098F8AE                 call    sub_180B93230
+  .text:000000018098F8B3                 mov     rdi, rax
+  .text:000000018098F8B6                 test    rax, rax
+  .text:000000018098F8B9                 jz      short loc_18098F911
+  .text:000000018098F8BB                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
+  .text:000000018098F8C2                 xor     edx, edx
+  .text:000000018098F8C4                 mov     [rdi], rax
+  .text:000000018098F8C7                 lea     rcx, [rdi+30h]
+  .text:000000018098F8CB                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
+  .text:000000018098F8D2                 mov     r8d, 1
+  .text:000000018098F8D8                 mov     [rdi+8], rax
+  .text:000000018098F8DC                 mov     [rdi+18h], r15
+  .text:000000018098F8E0                 mov     [rdi+20h], r15
+  .text:000000018098F8E4                 mov     [rdi+10h], r15d
+  .text:000000018098F8E8                 mov     [rdi+28h], r15b
+  .text:000000018098F8EC                 mov     [rdi+30h], r15d
+  .text:000000018098F8F0                 mov     [rdi+38h], r15
+  .text:000000018098F8F4                 call    sub_18094D740
+  .text:000000018098F8F9                 mov     eax, 0FFFFh
+  .text:000000018098F8FE                 mov     edx, esi
+  .text:000000018098F900                 mov     rcx, rdi
+  .text:000000018098F903                 mov     [rdi+40h], eax
+  .text:000000018098F906                 mov     [rdi+44h], ax
+  .text:000000018098F90A                 call    sub_18095E950
+  .text:000000018098F90F                 jmp     short loc_18098F914
+  .text:000000018098F911                 mov     rdi, r15
+  .text:000000018098F914                 lea     rcx, [rbp+var_20]
+  .text:000000018098F918                 mov     [r14+20E0h], rdi
+  .text:000000018098F91F                 call    cs:ToolsStallMonitorInternal_EndScope
+  .text:000000018098F925                 mov     rcx, cs:qword_1824E5590
+  .text:000000018098F92C                 lea     rax, sub_180948640
+  .text:000000018098F933                 lea     rbx, sub_180964C20
+  .text:000000018098F93A                 mov     [rbp+var_20], rax
+  .text:000000018098F93E                 lea     r8, [rbp+var_20]
+  .text:000000018098F942                 mov     [rbp+var_18], rbx
+  .text:000000018098F946                 mov     dl, 28h ; '('
+  .text:000000018098F948                 call    sub_1814BC4D0
+  .text:000000018098F94D                 mov     rcx, cs:qword_1824E5590
+  .text:000000018098F954                 lea     rax, sub_1809485B0
+  .text:000000018098F95B                 lea     r8, [rbp+var_20]
+  .text:000000018098F95F                 mov     [rbp+var_20], rax
+  .text:000000018098F963                 mov     dl, 36h ; '6'
+  .text:000000018098F965                 mov     [rbp+var_18], rbx
+  .text:000000018098F969                 call    sub_1814BC4D0
+  .text:000000018098F96E                 mov     rcx, cs:qword_1824E5590
+  .text:000000018098F975                 lea     rax, sub_180948560
+  .text:000000018098F97C                 lea     r8, [rbp+var_20]
+  .text:000000018098F980                 mov     [rbp+var_20], rax
+  .text:000000018098F984                 mov     dl, 43h ; 'C'
+  .text:000000018098F986                 mov     [rbp+var_18], rbx
+  .text:000000018098F98A                 call    sub_1814BC4D0
+  .text:000000018098F98F                 mov     rcx, cs:qword_182556410
+  .text:000000018098F996                 lea     rdx, sub_180964BF0
+  .text:000000018098F99D                 mov     rax, [rcx]
+  .text:000000018098F9A0                 mov     [rbp+var_18], rdx
+  .text:000000018098F9A4                 lea     rdx, unknown_libname_194; Microsoft VisualC v7/14 64bit runtime
+  .text:000000018098F9AB                 mov     [rbp+var_20], rdx
+  .text:000000018098F9AF                 lea     rdx, [rbp+var_20]
+  .text:000000018098F9B3                 call    qword ptr [rax+108h]
+  .text:000000018098F9B9                 lea     r11, [rsp+50h+var_s0]
+  .text:000000018098F9BE                 mov     al, 1
+  .text:000000018098F9C0                 mov     rbx, [r11+28h]
+  .text:000000018098F9C4                 mov     rsi, [r11+30h]
+  .text:000000018098F9C8                 mov     rdi, [r11+38h]
+  .text:000000018098F9CC                 mov     rsp, r11
+  .text:000000018098F9CF                 pop     r15
+  .text:000000018098F9D1                 pop     r14
+  .text:000000018098F9D3                 pop     rbp
+  .text:000000018098F9D4                 retn
 procedure: |-
-  char sub_18098F440()
+  char sub_18098F4C0()
   {
     int v0; // ecx
     __int64 v1; // rax
@@ -316,22 +316,22 @@ procedure: |-
     char v29; // [rsp+40h] [rbp-10h]
     __int64 v30; // [rsp+70h] [rbp+20h] BYREF
 
-    v0 = dword_1824E44E8++;
+    v0 = dword_1824E5598++;
     if ( v0 <= 0 )
     {
-      v1 = operator_new(8432);
+      v1 = sub_180B93230(8432);
       if ( v1 )
-        v2 = CGameEntitySystem_ctor(v1);
+        v2 = sub_180933980(v1);
       else
         v2 = 0;
-      CEntitySystem_PostCreateEntitySystem(v2, (unsigned int)"client_entities", 1, 1, 0);
+      sub_1814BDC70(v2, (unsigned int)"client_entities", 1, 1, 0);
     }
-    v3 = g_pEntitySystem;
-    g_pGameEntitySystem = g_pEntitySystem;
-    v4 = *(int *)(g_pEntitySystem + 2960);  // 2960 = 0xB90 = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
-    if ( (_DWORD)v4 == *(_DWORD *)(g_pEntitySystem + 2976) && (*(_DWORD *)(g_pEntitySystem + 2980) & 0x40000000) == 0 )
+    v3 = qword_1824E5590;
+    qword_182328490 = qword_1824E5590;
+    v4 = *(int *)(qword_1824E5590 + 2960);
+    if ( (_DWORD)v4 == *(_DWORD *)(qword_1824E5590 + 2976) && (*(_DWORD *)(qword_1824E5590 + 2980) & 0x40000000) == 0 )
     {
-      v5 = *(unsigned int *)(g_pEntitySystem + 2976);
+      v5 = *(unsigned int *)(qword_1824E5590 + 2976);
       if ( (_DWORD)v5 == 0x7FFFFFFF )
         UtlVectorMemory_FailedAllocation(v5, 1);
       v6 = *(unsigned int *)(v3 + 2976);
@@ -362,8 +362,8 @@ procedure: |-
       *(_DWORD *)(v3 + 2976) = v10;
     }
     ++*(_DWORD *)(v3 + 2960);
-    *(_QWORD *)(*(_QWORD *)(v3 + 2968) + 8 * v4) = &off_182042A38;
-    v12 = operator_new(4920);
+    *(_QWORD *)(*(_QWORD *)(v3 + 2968) + 8 * v4) = &off_182043A48;
+    v12 = sub_180B93230(4920);
     if ( v12 )
     {
       v30 = 0;
@@ -413,46 +413,44 @@ procedure: |-
       *(_DWORD *)(v12 + 264) = 0;
       *(_QWORD *)(v12 + 288) = 0;
       *(_BYTE *)(v12 + 296) = 0;
-      sub_181829DC0(v12 + 304, 1);
+      sub_18182A600(v12 + 304, 1);
       *(_QWORD *)(v12 + 4912) = 0;
     }
     else
     {
       v12 = 0;
     }
-    *(_QWORD *)(g_pGameEntitySystem + 8408) = v12;
+    *(_QWORD *)(qword_182328490 + 8408) = v12;
     v14 = **(void (__fastcall ***)(__int64))v12;
-    if ( (char *)v14 == (char *)sub_18095E160 )
-      sub_18095E160(v12);
+    if ( (char *)v14 == (char *)sub_18095E1E0 )
+      sub_18095E1E0(v12);
     else
       v14(v12);
     v15 = *(__int64 (__fastcall **)())(*(_QWORD *)v12 + 136LL);
-    v16 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_1823275E8 + 192LL))(qword_1823275E8);
-    if ( v15 == sub_180988040 )
+    v16 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_1823284E8 + 192LL))(qword_1823284E8);
+    if ( v15 == sub_1809880C0 )
       CUtlString::Set((CUtlString *)(v12 + 256), v16);
     else
       ((void (__fastcall *)(__int64, const char *))v15)(v12, v16);
-    sub_1809771B0();
+    sub_180977230();
     LOBYTE(v17) = 1;
-    CEntitySystem_EnableAutoDeletionExecution(g_pGameEntitySystem, v17);
-    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_1823275E8 + 8) + 168LL))(qword_1823275E8 + 8)
-      || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 176LL))(g_pVApplication) )
+    sub_1814B56C0(qword_182328490, v17);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_1823284E8 + 8) + 168LL))(qword_1823284E8 + 8)
+      || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_182556200 + 176LL))(qword_182556200) )
     {
-      v28 = (__int64)sub_180964B60;
-      v27 = (const char *)sub_180950550;
-      CEntitySystem_InstallPostSpawnCallback(g_pGameEntitySystem, &v27);
+      v28 = (__int64)sub_180964BE0;
+      v27 = (const char *)sub_1809505D0;
+      sub_1814BC4B0(qword_182328490, &v27);
     }
-    if ( g_pGameResourceService )
-      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService + 272LL))(
-        g_pGameResourceService,
-        g_pGameEntitySystem);
-    v18 = g_pGameEntitySystem;
+    if ( qword_1824E8C30 )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_1824E8C30 + 272LL))(qword_1824E8C30, qword_182328490);
+    v18 = qword_182328490;
     v28 = 5000;
     v29 = 0;
-    v19 = *(_DWORD *)(g_pEntitySystem + 632);
+    v19 = *(_DWORD *)(qword_1824E5590 + 632);
     v27 = "CGameEntitySystem::InitEntity2NetworkClasses";
     ToolsStallMonitorInternal_BeginScope(&v27);
-    v20 = operator_new(72);
+    v20 = sub_180B93230(72);
     v21 = v20;
     if ( v20 )
     {
@@ -464,10 +462,10 @@ procedure: |-
       *(_BYTE *)(v20 + 40) = 0;
       *(_DWORD *)(v20 + 48) = 0;
       *(_QWORD *)(v20 + 56) = 0;
-      sub_18094D6C0(v20 + 48, 0, 1);
+      sub_18094D740(v20 + 48, 0, 1);
       *(_DWORD *)(v21 + 64) = 0xFFFF;
       *(_WORD *)(v21 + 68) = -1;
-      sub_18095E8D0(v21, v19);
+      sub_18095E950(v21, v19);
     }
     else
     {
@@ -475,21 +473,21 @@ procedure: |-
     }
     *(_QWORD *)(v18 + 8416) = v21;
     ToolsStallMonitorInternal_EndScope(&v27);
-    v27 = (const char *)sub_1809485C0;
-    v28 = (__int64)sub_180964BA0;
+    v27 = (const char *)sub_180948640;
+    v28 = (__int64)sub_180964C20;
     LOBYTE(v22) = 40;
-    sub_1814BBE30(g_pEntitySystem, v22, &v27);
-    v27 = (const char *)sub_180948530;
+    sub_1814BC4D0(qword_1824E5590, v22, &v27);
+    v27 = (const char *)sub_1809485B0;
     LOBYTE(v23) = 54;
-    v28 = (__int64)sub_180964BA0;
-    sub_1814BBE30(g_pEntitySystem, v23, &v27);
-    v27 = (const char *)sub_1809484E0;
+    v28 = (__int64)sub_180964C20;
+    sub_1814BC4D0(qword_1824E5590, v23, &v27);
+    v27 = (const char *)sub_180948560;
     LOBYTE(v24) = 67;
-    v28 = (__int64)sub_180964BA0;
-    sub_1814BBE30(g_pEntitySystem, v24, &v27);
-    v25 = *(_QWORD *)g_pFlattenedSerializers;
-    v28 = (__int64)sub_180964B70;
+    v28 = (__int64)sub_180964C20;
+    sub_1814BC4D0(qword_1824E5590, v24, &v27);
+    v25 = *(_QWORD *)qword_182556410;
+    v28 = (__int64)sub_180964BF0;
     v27 = (const char *)unknown_libname_194;
-    (*(void (__fastcall **)(__int64, const char **))(v25 + 264))(g_pFlattenedSerializers, &v27);
+    (*(void (__fastcall **)(__int64, const char **))(v25 + 264))(qword_182556410, &v27);
     return 1;
   }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.linux.yaml
@@ -1,0 +1,572 @@
+func_name: CGameEntitySystem_RegisterSpawnGroupEntityFilter
+func_va: '0x15b91d0'
+disasm_code: |-
+  .text:00000000015B912C                 movq    xmm0, cs:off_2363610; "../../public/tier0/utldict.h"
+  .text:00000000015B9134                 lea     rax, aInsert; "Insert"
+  .text:00000000015B913B                 mov     [rbp+var_38], 0E6h
+  .text:00000000015B9142                 mov     rdi, [rbp+var_A8]
+  .text:00000000015B9149                 lea     rsi, aFoundExistingV_0; "Found existing value when inserting int"...
+  .text:00000000015B9150                 pinsrq  xmm0, rax, 1
+  .text:00000000015B9157                 lea     rax, aFalse; "false"
+  .text:00000000015B915E                 movaps  [rbp+var_50], xmm0
+  .text:00000000015B9162                 mov     [rbp+var_40], rax
+  .text:00000000015B9166                 movzx   eax, [rbp+var_34]
+  .text:00000000015B916A                 and     eax, 0FFFFFF80h
+  .text:00000000015B916D                 or      eax, 14h
+  .text:00000000015B9170                 mov     [rbp+var_34], al
+  .text:00000000015B9173                 xor     eax, eax
+  .text:00000000015B9175                 call    sub_983EC0
+  .text:00000000015B917A                 test    al, al
+  .text:00000000015B917C                 jz      short loc_15B917F
+  .text:00000000015B917E                 ; Trap to Debugger
+  .text:00000000015B917E                 int     3; Trap to Debugger
+  .text:00000000015B917F                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B918B                 jnz     short loc_15B91B8
+  .text:00000000015B918D                 xor     eax, eax
+  .text:00000000015B918F                 movsxd  r14, r15d
+  .text:00000000015B9192                 pxor    xmm0, xmm0
+  .text:00000000015B9196                 mov     rsi, r13
+  .text:00000000015B9199                 imul    r14, 28h ; '('
+  .text:00000000015B919D                 movups  xmmword ptr [rax+r14+18h], xmm0
+  .text:00000000015B91A3                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000015B91AA                 mov     rdi, [rax]
+  .text:00000000015B91AD                 mov     rax, [rdi]
+  .text:00000000015B91B0                 call    qword ptr [rax+20h]
+  .text:00000000015B91B3                 jmp     loc_15B940E
+  .text:00000000015B91B8                 mov     rax, [r12+20B8h]
+  .text:00000000015B91C0                 jmp     short loc_15B918F
+  .text:00000000015B91D0                 push    rbp
+  .text:00000000015B91D1                 mov     rbp, rsp
+  .text:00000000015B91D4                 push    r15
+  .text:00000000015B91D6                 push    r14
+  .text:00000000015B91D8                 ; 0x20A8 = 8360 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+  .text:00000000015B91D8                 lea     r14, [rdi+20A8h]; 0x20A8 = 8360 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+  .text:00000000015B91DF                 push    r13
+  .text:00000000015B91E1                 mov     r13, rsi
+  .text:00000000015B91E4                 push    r12
+  .text:00000000015B91E6                 mov     r12, rdi
+  .text:00000000015B91E9                 push    rbx
+  .text:00000000015B91EA                 mov     ebx, ecx
+  .text:00000000015B91EC                 sub     rsp, 98h
+  .text:00000000015B91F3                 mov     [rbp+var_98], rdx
+  .text:00000000015B91FA                 mov     qword ptr [rbp+var_70], rsi
+  .text:00000000015B91FE                 test    rsi, rsi
+  .text:00000000015B9201                 jz      loc_15B92C0
+  .text:00000000015B9207                 lea     rax, [rdi+20B0h]
+  .text:00000000015B920E                 mov     qword ptr [rbp+var_50], r14
+  .text:00000000015B9212                 lea     rsi, [rbp+var_50]
+  .text:00000000015B9216                 mov     rdi, rax
+  .text:00000000015B9219                 mov     [rbp+var_40], r14
+  .text:00000000015B921D                 lea     r15, [rbp+var_70]
+  .text:00000000015B9221                 mov     [rbp+var_A8], rsi
+  .text:00000000015B9228                 mov     qword ptr [rbp+var_50+8], r15
+  .text:00000000015B922C                 mov     [rbp+var_A0], rax
+  .text:00000000015B9233                 call    sub_15A7DC0
+  .text:00000000015B9238                 mov     rcx, rax
+  .text:00000000015B923B                 mov     rsi, rdx
+  .text:00000000015B923E                 mov     [rbp+var_88], rax
+  .text:00000000015B9245                 shr     rcx, 20h
+  .text:00000000015B9249                 mov     [rbp+var_80], esi
+  .text:00000000015B924C                 movsxd  rdx, ecx
+  .text:00000000015B924F                 cmp     edx, 0FFFFFFFFh
+  .text:00000000015B9252                 jz      loc_15B92E0
+  .text:00000000015B9258                 lea     r14, [rdx+rdx*4]
+  .text:00000000015B925C                 shl     r14, 3
+  .text:00000000015B9260                 mov     rax, r14
+  .text:00000000015B9263                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B926F                 jz      loc_15B9430
+  .text:00000000015B9275                 add     rax, [r12+20B8h]
+  .text:00000000015B927D                 cmp     [rax+20h], ebx
+  .text:00000000015B9280                 jge     short loc_15B92AA
+  .text:00000000015B9282                 mov     rdi, [rbp+var_98]
+  .text:00000000015B9289                 mov     [rax+18h], rdi
+  .text:00000000015B928D                 xor     eax, eax
+  .text:00000000015B928F                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B929B                 jz      short loc_15B92A5
+  .text:00000000015B929D                 mov     rax, [r12+20B8h]
+  .text:00000000015B92A5                 mov     [rax+r14+20h], ebx
+  .text:00000000015B92AA                 add     rsp, 98h
+  .text:00000000015B92B1                 pop     rbx
+  .text:00000000015B92B2                 pop     r12
+  .text:00000000015B92B4                 pop     r13
+  .text:00000000015B92B6                 pop     r14
+  .text:00000000015B92B8                 pop     r15
+  .text:00000000015B92BA                 pop     rbp
+  .text:00000000015B92BB                 retn
+  .text:00000000015B92C0                 lea     rax, [rbp+var_50]
+  .text:00000000015B92C4                 mov     [rbp+var_A8], rax
+  .text:00000000015B92CB                 lea     rax, [rdi+20B0h]
+  .text:00000000015B92D2                 lea     r15, [rbp+var_70]
+  .text:00000000015B92D6                 mov     [rbp+var_A0], rax
+  .text:00000000015B92DD                 nop     dword ptr [rax]
+  .text:00000000015B92E0                 mov     rdi, r13
+  .text:00000000015B92E3                 call    sub_983610
+  .text:00000000015B92E8                 mov     rsi, [rbp+var_A8]
+  .text:00000000015B92EF                 mov     [rbp+var_40], r15
+  .text:00000000015B92F3                 pxor    xmm0, xmm0
+  .text:00000000015B92F7                 mov     rdi, [rbp+var_A0]
+  .text:00000000015B92FE                 mov     r13, rax
+  .text:00000000015B9301                 mov     qword ptr [rbp+var_70], rax
+  .text:00000000015B9305                 movups  [rbp+var_70+8], xmm0
+  .text:00000000015B9309                 mov     qword ptr [rbp+var_50], r14
+  .text:00000000015B930D                 mov     byte ptr [rbp+var_50+8], 1
+  .text:00000000015B9311                 call    sub_159E8A0
+  .text:00000000015B9316                 mov     rcx, rax
+  .text:00000000015B9319                 mov     [rbp+var_7C], rax
+  .text:00000000015B931D                 shr     rcx, 20h
+  .text:00000000015B9321                 mov     [rbp+var_74], edx
+  .text:00000000015B9324                 mov     r15d, ecx
+  .text:00000000015B9327                 cmp     ecx, 0FFFFFFFFh
+  .text:00000000015B932A                 jnz     loc_15B912C
+  .text:00000000015B9330                 mov     esi, [r12+20B4h]
+  .text:00000000015B9338                 mov     r15d, [r12+20C8h]
+  .text:00000000015B9340                 movsxd  rcx, dword ptr [rbp+var_7C]
+  .text:00000000015B9344                 movzx   r9d, byte ptr [rbp+var_74]
+  .text:00000000015B9349                 mov     eax, esi
+  .text:00000000015B934B                 and     eax, 7FFFFFFFh
+  .text:00000000015B9350                 cmp     r15d, 0FFFFFFFFh
+  .text:00000000015B9354                 jz      loc_15B9460
+  .text:00000000015B935A                 test    eax, eax
+  .text:00000000015B935C                 movsxd  rax, r15d
+  .text:00000000015B935F                 lea     r14, [rax+rax*4]
+  .text:00000000015B9363                 jz      loc_15B943F
+  .text:00000000015B9369                 mov     rax, [r12+20B8h]
+  .text:00000000015B9371                 shl     r14, 3
+  .text:00000000015B9375                 mov     edx, [rax+r14+4]
+  .text:00000000015B937A                 mov     [r12+20C8h], edx
+  .text:00000000015B9382                 movdqa  xmm0, [rbp+var_70]
+  .text:00000000015B9387                 movups  xmmword ptr [rax+r14+10h], xmm0
+  .text:00000000015B938D                 mov     rdx, [rbp+var_60]
+  .text:00000000015B9391                 mov     [rax+r14+20h], rdx
+  .text:00000000015B9396                 xor     eax, eax
+  .text:00000000015B9398                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B93A4                 jz      short loc_15B93AE
+  .text:00000000015B93A6                 mov     rax, [r12+20B8h]
+  .text:00000000015B93AE                 lea     rdx, [rax+r14]
+  .text:00000000015B93B2                 mov     qword ptr [rax+r14], 0FFFFFFFFFFFFFFFFh
+  .text:00000000015B93BA                 mov     byte ptr [rdx+0Ch], 0
+  .text:00000000015B93BE                 mov     [rdx+8], ecx
+  .text:00000000015B93C1                 cmp     ecx, 0FFFFFFFFh
+  .text:00000000015B93C4                 jz      loc_15B95C3
+  .text:00000000015B93CA                 mov     eax, [r12+20B4h]
+  .text:00000000015B93D2                 xor     edx, edx
+  .text:00000000015B93D4                 and     eax, 7FFFFFFFh
+  .text:00000000015B93D9                 test    r9b, r9b
+  .text:00000000015B93DC                 jz      loc_15B95D9
+  .text:00000000015B93E2                 test    eax, eax
+  .text:00000000015B93E4                 jz      short loc_15B93EE
+  .text:00000000015B93E6                 mov     rdx, [r12+20B8h]
+  .text:00000000015B93EE                 lea     rax, [rcx+rcx*4]
+  .text:00000000015B93F2                 mov     [rdx+rax*8], r15d
+  .text:00000000015B93F6                 mov     rdi, [rbp+var_A0]
+  .text:00000000015B93FD                 mov     esi, r15d
+  .text:00000000015B9400                 call    sub_15B8D90
+  .text:00000000015B9405                 add     dword ptr [r12+20C4h], 1
+  .text:00000000015B940E                 mov     rax, r14
+  .text:00000000015B9411                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B941D                 jz      loc_15B9282
+  .text:00000000015B9423                 add     rax, [r12+20B8h]
+  .text:00000000015B942B                 jmp     loc_15B9282
+  .text:00000000015B9430                 cmp     ebx, [r14+20h]
+  .text:00000000015B9434                 jle     loc_15B92AA
+  .text:00000000015B943A                 jmp     loc_15B9282
+  .text:00000000015B943F                 shl     r14, 3
+  .text:00000000015B9443                 mov     eax, [r14+4]
+  .text:00000000015B9447                 mov     [r12+20C8h], eax
+  .text:00000000015B944F                 xor     eax, eax
+  .text:00000000015B9451                 jmp     loc_15B9382
+  .text:00000000015B9460                 mov     r15d, [r12+20B0h]
+  .text:00000000015B9468                 mov     edx, eax
+  .text:00000000015B946A                 lea     edi, [r15+1]
+  .text:00000000015B946E                 cmp     edi, eax
+  .text:00000000015B9470                 jg      short loc_15B949C
+  .text:00000000015B9472                 jmp     loc_15B95F3
+  .text:00000000015B9480                 test    edx, edx
+  .text:00000000015B9482                 jnz     short loc_15B9492
+  .text:00000000015B9484                 mov     edx, 1
+  .text:00000000015B9489                 cmp     edi, 1
+  .text:00000000015B948C                 jz      loc_15B960B
+  .text:00000000015B9492                 add     edx, edx
+  .text:00000000015B9494                 cmp     edi, edx
+  .text:00000000015B9496                 jle     loc_15B960B
+  .text:00000000015B949C                 cmp     edx, 3FFFFFFEh
+  .text:00000000015B94A2                 jle     short loc_15B9480
+  .text:00000000015B94A4                 mov     r14, 13FFFFFFD8h
+  .text:00000000015B94AE                 mov     edx, 7FFFFFFFh
+  .text:00000000015B94B3                 mov     r13, cs:g_pMemAlloc_ptr
+  .text:00000000015B94BA                 mov     dword ptr [rbp+var_A8], edx
+  .text:00000000015B94C0                 mov     rdi, [r13+0]
+  .text:00000000015B94C4                 mov     rax, [rdi]
+  .text:00000000015B94C7                 test    esi, esi
+  .text:00000000015B94C9                 js      loc_15B961F
+  .text:00000000015B94CF                 mov     byte ptr [rbp+var_B4], r9b
+  .text:00000000015B94D6                 mov     rdx, r14
+  .text:00000000015B94D9                 mov     rsi, [r12+20B8h]
+  .text:00000000015B94E1                 mov     dword ptr [rbp+var_B0], ecx
+  .text:00000000015B94E7                 call    qword ptr [rax+18h]
+  .text:00000000015B94EA                 mov     rdi, [r13+0]
+  .text:00000000015B94EE                 mov     r10, rax
+  .text:00000000015B94F1                 mov     rsi, r10
+  .text:00000000015B94F4                 mov     [rbp+var_A8], r10
+  .text:00000000015B94FB                 mov     rax, [rdi]
+  .text:00000000015B94FE                 call    qword ptr [rax+90h]
+  .text:00000000015B9504                 movzx   r9d, byte ptr [rbp+var_B4]
+  .text:00000000015B950C                 movsxd  rcx, dword ptr [rbp+var_B0]
+  .text:00000000015B9513                 cmp     rax, r14
+  .text:00000000015B9516                 cmovnb  r14, rax
+  .text:00000000015B951A                 mov     r10, [rbp+var_A8]
+  .text:00000000015B9521                 mov     rax, 0CCCCCCCCCCCCCCCDh
+  .text:00000000015B952B                 mov     [r12+20B8h], r10
+  .text:00000000015B9533                 mul     r14
+  .text:00000000015B9536                 mov     eax, 7FFFFFFFh
+  .text:00000000015B953B                 shr     rdx, 5
+  .text:00000000015B953F                 cmp     rdx, rax
+  .text:00000000015B9542                 cmova   rdx, rax
+  .text:00000000015B9546                 mov     [r12+20B4h], edx
+  .text:00000000015B954E                 movsxd  rax, r15d
+  .text:00000000015B9551                 lea     rdx, [rax+rax*4+5]
+  .text:00000000015B9556                 shl     rdx, 3
+  .text:00000000015B955A                 lea     r14, [rdx-28h]
+  .text:00000000015B955E                 lea     rax, [r10+r14]
+  .text:00000000015B9562                 add     r10, rdx
+  .text:00000000015B9565                 cmp     rax, r10
+  .text:00000000015B9568                 jnb     short loc_15B956E
+  .text:00000000015B956A                 test    al, 7
+  .text:00000000015B956C                 jnz     short loc_15B95A0
+  .text:00000000015B956E                 add     dword ptr [r12+20B0h], 1
+  .text:00000000015B9577                 xor     eax, eax
+  .text:00000000015B9579                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B9585                 jz      loc_15B9382
+  .text:00000000015B958B                 mov     rax, [r12+20B8h]
+  .text:00000000015B9593                 jmp     loc_15B9382
+  .text:00000000015B95A0                 mov     byte ptr [rbp+var_B0], r9b
+  .text:00000000015B95A7                 mov     dword ptr [rbp+var_A8], ecx
+  .text:00000000015B95AD                 call    sub_1B25C20
+  .text:00000000015B95B2                 movzx   r9d, byte ptr [rbp+var_B0]
+  .text:00000000015B95BA                 movsxd  rcx, dword ptr [rbp+var_A8]
+  .text:00000000015B95C1                 jmp     short loc_15B956E
+  .text:00000000015B95C3                 test    r9b, r9b
+  .text:00000000015B95C6                 jz      loc_15B93F6
+  .text:00000000015B95CC                 mov     [r12+20C0h], r15d
+  .text:00000000015B95D4                 jmp     loc_15B93F6
+  .text:00000000015B95D9                 test    eax, eax
+  .text:00000000015B95DB                 jz      short loc_15B95E5
+  .text:00000000015B95DD                 mov     rdx, [r12+20B8h]
+  .text:00000000015B95E5                 lea     rax, [rcx+rcx*4]
+  .text:00000000015B95E9                 mov     [rdx+rax*8+4], r15d
+  .text:00000000015B95EE                 jmp     loc_15B93F6
+  .text:00000000015B95F3                 xor     r10d, r10d
+  .text:00000000015B95F6                 test    eax, eax
+  .text:00000000015B95F8                 jz      loc_15B954E
+  .text:00000000015B95FE                 mov     r10, [r12+20B8h]
+  .text:00000000015B9606                 jmp     loc_15B954E
+  .text:00000000015B960B                 movsxd  rax, edx
+  .text:00000000015B960E                 lea     r11, [rax+rax*4]
+  .text:00000000015B9612                 lea     r14, ds:0[r11*8]
+  .text:00000000015B961A                 jmp     loc_15B94B3
+  .text:00000000015B961F                 mov     [rbp+var_B5], r9b
+  .text:00000000015B9626                 mov     rsi, r14
+  .text:00000000015B9629                 mov     [rbp+var_B4], ecx
+  .text:00000000015B962F                 call    qword ptr [rax+10h]
+  .text:00000000015B9632                 mov     rdi, [r13+0]
+  .text:00000000015B9636                 mov     r10, rax
+  .text:00000000015B9639                 mov     rsi, r10
+  .text:00000000015B963C                 mov     [rbp+var_B0], r10
+  .text:00000000015B9643                 mov     rax, [rdi]
+  .text:00000000015B9646                 call    qword ptr [rax+90h]
+  .text:00000000015B964C                 mov     r10, [rbp+var_B0]
+  .text:00000000015B9653                 cmp     rax, r14
+  .text:00000000015B9656                 movsxd  rcx, [rbp+var_B4]
+  .text:00000000015B965D                 cmovnb  r14, rax
+  .text:00000000015B9661                 xor     esi, esi
+  .text:00000000015B9663                 test    dword ptr [r12+20B4h], 7FFFFFFFh
+  .text:00000000015B966F                 movzx   r9d, [rbp+var_B5]
+  .text:00000000015B9677                 movsxd  rdx, dword ptr [rbp+var_A8]
+  .text:00000000015B967E                 jz      short loc_15B9688
+  .text:00000000015B9680                 mov     rsi, [r12+20B8h]
+  .text:00000000015B9688                 movsxd  rax, dword ptr [r12+20B0h]
+  .text:00000000015B9690                 cmp     edx, eax
+  .text:00000000015B9692                 cmovle  rax, rdx
+  .text:00000000015B9696                 lea     rdx, [rax+rax*4]
+  .text:00000000015B969A                 shl     rdx, 3
+  .text:00000000015B969E                 lea     rax, [rsi+rdx]
+  .text:00000000015B96A2                 cmp     rsi, rax
+  .text:00000000015B96A5                 jnb     loc_15B9521
+  .text:00000000015B96AB                 mov     rdi, r10
+  .text:00000000015B96AE                 mov     byte ptr [rbp+var_B0], r9b
+  .text:00000000015B96B5                 mov     dword ptr [rbp+var_A8], ecx
+  .text:00000000015B96BB                 call    sub_985D80
+  .text:00000000015B96C0                 movsxd  rcx, dword ptr [rbp+var_A8]
+  .text:00000000015B96C7                 movzx   r9d, byte ptr [rbp+var_B0]
+  .text:00000000015B96CF                 mov     r10, rax
+  .text:00000000015B96D2                 jmp     loc_15B9521
+procedure: |-
+  __int64 __fastcall sub_15B91D0(__int64 a1, __int64 a2, __int64 a3, int a4)
+  {
+    __int64 v4; // rax
+    int v7; // rax^4
+    __int64 v8; // rdx
+    __int64 v9; // r14
+    __int64 result; // rax
+    __int64 v11; // rax
+    __int64 v12; // r13
+    char v13; // dl
+    unsigned __int64 v14; // rsi
+    unsigned int v15; // r15d
+    __int64 v16; // rcx
+    char v17; // r9
+    int v18; // eax
+    __int64 v19; // rax
+    __int64 v20; // rax
+    __int64 v21; // rdx
+    __int64 v22; // rdx
+    int v23; // eax
+    int v24; // edx
+    unsigned __int64 v25; // rdi
+    unsigned __int64 v26; // r14
+    __int64 v27; // rax
+    __int64 v28; // rax
+    unsigned __int64 v29; // rax
+    __int64 v30; // r10
+    unsigned __int64 v31; // rdx
+    __int64 v32; // rdx
+    unsigned __int64 v33; // rax
+    __int64 v34; // rax
+    unsigned __int64 v35; // rax
+    __int64 v36; // rax
+    __int64 v37; // rax
+    char v38; // [rsp+10h] [rbp-B0h]
+    _QWORD *v39; // [rsp+10h] [rbp-B0h]
+    int v40; // [rsp+18h] [rbp-A8h]
+    __int64 v41; // [rsp+18h] [rbp-A8h]
+    int v42; // [rsp+18h] [rbp-A8h]
+    __int64 v43; // [rsp+20h] [rbp-A0h]
+    __int64 v45; // [rsp+44h] [rbp-7Ch]
+    char v46; // [rsp+4Ch] [rbp-74h]
+    __int64 v47; // [rsp+50h] [rbp-70h] BYREF
+    __int128 v48; // [rsp+58h] [rbp-68h]
+    __m128i inserted; // [rsp+70h] [rbp-50h] BYREF
+    const char *v50; // [rsp+80h] [rbp-40h]
+    int v51; // [rsp+88h] [rbp-38h]
+    char v52; // [rsp+8Ch] [rbp-34h]
+
+    v47 = a2;
+    if ( !a2 )
+    {
+      v43 = a1 + 8368;
+      goto LABEL_10;
+    }
+    inserted.m128i_i64[0] = a1 + 8360;            // 0x20A8 = 8360 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+    v50 = (const char *)(a1 + 8360);
+    inserted.m128i_i64[1] = (__int64)&v47;
+    v43 = a1 + 8368;
+    v7 = (unsigned __int64)sub_15A7DC0(a1 + 8368, &inserted) >> 32;
+    v8 = v7;
+    if ( v7 == -1 )
+    {
+  LABEL_10:
+      v11 = sub_983610(a2);
+      v50 = (const char *)&v47;
+      v12 = v11;
+      v47 = v11;
+      v48 = 0;
+      inserted.m128i_i64[0] = a1 + 8360;
+      inserted.m128i_i8[8] = 1;
+      v45 = sub_159E8A0(v43, &inserted);
+      v46 = v13;
+      if ( HIDWORD(v45) == -1 )
+      {
+        v14 = *(unsigned int *)(a1 + 8372);
+        v15 = *(_DWORD *)(a1 + 8392);
+        v16 = (int)v45;
+        v17 = v13;
+        v18 = *(_DWORD *)(a1 + 8372) & 0x7FFFFFFF;
+        if ( v15 == -1 )
+        {
+          v15 = *(_DWORD *)(a1 + 8368);
+          v24 = *(_DWORD *)(a1 + 8372) & 0x7FFFFFFF;
+          v25 = v15 + 1;
+          if ( (int)v25 > v18 )
+          {
+            do
+            {
+              if ( v24 > 1073741822 )
+              {
+                v26 = 0x13FFFFFFD8LL;
+                v24 = 0x7FFFFFFF;
+                goto LABEL_34;
+              }
+              if ( !v24 )
+              {
+                v24 = 1;
+                if ( !v15 )
+                  break;
+              }
+              v24 *= 2;
+            }
+            while ( (int)v25 > v24 );
+            v26 = 40LL * v24;
+  LABEL_34:
+            v40 = v24;
+            v27 = *g_pMemAlloc;
+            if ( (v14 & 0x80000000) != 0LL )
+            {
+              v34 = (*(__int64 (__fastcall **)(_QWORD *, unsigned __int64))(v27 + 16))(g_pMemAlloc, v26);
+              v25 = (unsigned __int64)g_pMemAlloc;
+              v39 = (_QWORD *)v34;
+              v35 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 144LL))(g_pMemAlloc, v34);
+              v30 = (__int64)v39;
+              v16 = (int)v45;
+              if ( v35 >= v26 )
+                v26 = v35;
+              v14 = 0;
+              v17 = v46;
+              if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+                v14 = *(_QWORD *)(a1 + 8376);
+              v36 = *(int *)(a1 + 8368);
+              if ( v40 <= (int)v36 )
+                v36 = v40;
+              if ( v14 < v14 + 40 * v36 )
+              {
+                v25 = (unsigned __int64)v39;
+                v37 = sub_985D80(v39, v14, 40 * v36);
+                v16 = (int)v45;
+                v17 = v46;
+                v30 = v37;
+              }
+            }
+            else
+            {
+              v28 = (*(__int64 (__fastcall **)(_QWORD *, _QWORD, unsigned __int64))(v27 + 24))(
+                      g_pMemAlloc,
+                      *(_QWORD *)(a1 + 8376),
+                      v26);
+              v25 = (unsigned __int64)g_pMemAlloc;
+              v14 = v28;
+              v41 = v28;
+              v29 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 144LL))(g_pMemAlloc, v28);
+              v17 = v46;
+              v16 = (int)v45;
+              if ( v29 >= v26 )
+                v26 = v29;
+              v30 = v41;
+            }
+            *(_QWORD *)(a1 + 8376) = v30;
+            v31 = v26 / 0x28;
+            if ( v26 / 0x28 > 0x7FFFFFFF )
+              LODWORD(v31) = 0x7FFFFFFF;
+            *(_DWORD *)(a1 + 8372) = v31;
+          }
+          else
+          {
+            v30 = 0;
+            if ( v18 )
+              v30 = *(_QWORD *)(a1 + 8376);
+          }
+          v32 = 8 * (5LL * (int)v15 + 5);
+          v9 = v32 - 40;
+          v33 = v30 + v32 - 40;
+          if ( v33 < v32 + v30 && (v33 & 7) != 0 )
+          {
+            v38 = v17;
+            v42 = v16;
+            sub_1B25C20(v25, v14);
+            v17 = v38;
+            v16 = v42;
+          }
+          ++*(_DWORD *)(a1 + 8368);
+          v19 = 0;
+          if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+            v19 = *(_QWORD *)(a1 + 8376);
+        }
+        else if ( v18 )
+        {
+          v19 = *(_QWORD *)(a1 + 8376);
+          v9 = 40LL * (int)v15;
+          *(_DWORD *)(a1 + 8392) = *(_DWORD *)(v19 + v9 + 4);
+        }
+        else
+        {
+          v9 = 40LL * (int)v15;
+          *(_DWORD *)(a1 + 8392) = *(_DWORD *)&byte_4[v9];
+          v19 = 0;
+        }
+        *(__m128i *)(v19 + v9 + 16) = _mm_load_si128((const __m128i *)&v47);
+        *(_QWORD *)(v19 + v9 + 32) = *((_QWORD *)&v48 + 1);
+        v20 = 0;
+        if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+          v20 = *(_QWORD *)(a1 + 8376);
+        v21 = v20 + v9;
+        *(_QWORD *)(v20 + v9) = -1;
+        *(_BYTE *)(v21 + 12) = 0;
+        *(_DWORD *)(v21 + 8) = v16;
+        if ( (_DWORD)v16 == -1 )
+        {
+          if ( v17 )
+            *(_DWORD *)(a1 + 8384) = v15;
+        }
+        else
+        {
+          v22 = 0;
+          v23 = *(_DWORD *)(a1 + 8372) & 0x7FFFFFFF;
+          if ( v17 )
+          {
+            if ( v23 )
+              v22 = *(_QWORD *)(a1 + 8376);
+            *(_DWORD *)(v22 + 40 * v16) = v15;
+          }
+          else
+          {
+            if ( v23 )
+              v22 = *(_QWORD *)(a1 + 8376);
+            *(_DWORD *)(v22 + 40 * v16 + 4) = v15;
+          }
+        }
+        sub_15B8D90(v43, v15);
+        ++*(_DWORD *)(a1 + 8388);
+      }
+      else
+      {
+        v51 = 230;
+        inserted = _mm_insert_epi64(_mm_loadl_epi64((const __m128i *)off_2363610), (signed __int64)"Insert", 1);
+        v50 = "false";
+        v52 = v52 & 0x80 | 0x14;
+        if ( (unsigned __int8)sub_983EC0(
+                                &inserted,
+                                "Found existing value when inserting into dict - replacing existing value with new value. I"
+                                "f this is intended behavior, use InsertOrReplace. If leaving existing values alone is inte"
+                                "nded, use InsertIfNotFound.") )
+          __debugbreak();
+        if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+          v4 = *(_QWORD *)(a1 + 8376);
+        else
+          v4 = 0;
+        v9 = 40LL * SHIDWORD(v45);
+        *(_OWORD *)(v4 + v9 + 24) = 0;
+        (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v12);
+      }
+      result = v9;
+      if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+        result = *(_QWORD *)(a1 + 8376) + v9;
+      goto LABEL_5;
+    }
+    v9 = 40LL * v7;
+    result = v9;
+    if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+    {
+      result = *(_QWORD *)(a1 + 8376) + v9;
+      if ( *(_DWORD *)(result + 32) >= a4 )
+        return result;
+    }
+    else if ( a4 <= SLODWORD(qword_20[5 * v8]) )
+    {
+      return result;
+    }
+  LABEL_5:
+    *(_QWORD *)(result + 24) = a3;
+    result = 0;
+    if ( (*(_DWORD *)(a1 + 8372) & 0x7FFFFFFF) != 0 )
+      result = *(_QWORD *)(a1 + 8376);
+    *(_DWORD *)(result + v9 + 32) = a4;
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.windows.yaml
@@ -1,0 +1,238 @@
+func_name: CGameEntitySystem_RegisterSpawnGroupEntityFilter
+func_va: '0x180b7b020'
+disasm_code: |-
+  .text:0000000180B7B020                 mov     rax, rsp
+  .text:0000000180B7B023                 push    rbp
+  .text:0000000180B7B024                 push    rdi
+  .text:0000000180B7B025                 lea     rbp, [rax-5Fh]
+  .text:0000000180B7B029                 sub     rsp, 0B8h
+  .text:0000000180B7B030                 mov     rdi, cs:qword_181F64488
+  .text:0000000180B7B037                 test    rdi, rdi
+  .text:0000000180B7B03A                 jz      loc_180B7B23F
+  .text:0000000180B7B040                 mov     [rax+18h], rbx
+  .text:0000000180B7B044                 mov     [rax-18h], rsi
+  .text:0000000180B7B048                 mov     [rax-28h], r13
+  .text:0000000180B7B04C                 mov     [rax-30h], r14
+  .text:0000000180B7B050                 mov     [rax-38h], r15
+  .text:0000000180B7B054                 mov     [rax-20h], r12
+  .text:0000000180B7B058                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000180B7B060                 mov     r14, [rdi+8]
+  .text:0000000180B7B064                 mov     rbx, cs:g_pGameEntitySystem
+  .text:0000000180B7B06B                 mov     rax, [rdi]
+  .text:0000000180B7B06E                 mov     r13d, [rdi+10h]
+  .text:0000000180B7B072                 mov     [rbp+57h+arg_8], rax
+  .text:0000000180B7B076                 mov     [rbp+57h+arg_0], r14
+  .text:0000000180B7B07A                 ; 0x2098 = 8344 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+  .text:0000000180B7B07A                 lea     r15, [rbx+2098h]; 0x2098 = 8344 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+  .text:0000000180B7B081                 test    r14, r14
+  .text:0000000180B7B084                 jz      short loc_180B7B0DC
+  .text:0000000180B7B086                 lea     rax, [rbp+57h+arg_0]
+  .text:0000000180B7B08A                 mov     [rbp+57h+var_70], r15
+  .text:0000000180B7B08E                 lea     r8, [rbp+57h+var_70]
+  .text:0000000180B7B092                 mov     [rbp+57h+var_68], rax
+  .text:0000000180B7B096                 lea     rdx, [rbp+57h+var_80]
+  .text:0000000180B7B09A                 mov     [rbp+57h+var_60], r15
+  .text:0000000180B7B09E                 lea     rcx, [r15+8]
+  .text:0000000180B7B0A2                 call    sub_180B2E1D0
+  .text:0000000180B7B0A7                 movsxd  r12, dword ptr [rax+4]
+  .text:0000000180B7B0AB                 cmp     r12d, 0FFFFFFFFh
+  .text:0000000180B7B0AF                 jz      short loc_180B7B0DC
+  .text:0000000180B7B0B1                 test    dword ptr [rbx+20A4h], 7FFFFFFFh
+  .text:0000000180B7B0BB                 jnz     short loc_180B7B0C1
+  .text:0000000180B7B0BD                 xor     edx, edx
+  .text:0000000180B7B0BF                 jmp     short loc_180B7B0C8
+  .text:0000000180B7B0C1                 mov     rdx, [rbx+20A8h]
+  .text:0000000180B7B0C8                 lea     rcx, [r12+r12*4]
+  .text:0000000180B7B0CC                 cmp     [rdx+rcx*8+20h], r13d
+  .text:0000000180B7B0D1                 jge     loc_180B7B202
+  .text:0000000180B7B0D7                 jmp     loc_180B7B1BF
+  .text:0000000180B7B0DC                 mov     rcx, r14
+  .text:0000000180B7B0DF                 call    cs:MemAlloc_StrDupFunc
+  .text:0000000180B7B0E5                 xorps   xmm0, xmm0
+  .text:0000000180B7B0E8                 mov     [rbp+57h+var_70], r15
+  .text:0000000180B7B0EC                 mov     r14, rax
+  .text:0000000180B7B0EF                 mov     [rbp+57h+var_58], rax
+  .text:0000000180B7B0F3                 lea     rax, [rbp+57h+var_58]
+  .text:0000000180B7B0F7                 mov     byte ptr [rbp+57h+var_68], 1
+  .text:0000000180B7B0FB                 lea     r8, [rbp+57h+var_70]
+  .text:0000000180B7B0FF                 mov     [rbp+57h+var_60], rax
+  .text:0000000180B7B103                 lea     rdx, [rbp+57h+var_A0]
+  .text:0000000180B7B107                 lea     rcx, [r15+8]
+  .text:0000000180B7B10B                 movups  [rbp+57h+var_50], xmm0
+  .text:0000000180B7B10F                 call    sub_180B2F900
+  .text:0000000180B7B114                 movsxd  r12, dword ptr [rbp+57h+var_A0+4]
+  .text:0000000180B7B118                 cmp     r12d, 0FFFFFFFFh
+  .text:0000000180B7B11C                 jz      short loc_180B7B19B
+  .text:0000000180B7B11E                 lea     rax, aCBuildworkerCs_0; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B7B125                 mov     [rbp+57h+var_40], 0E6h
+  .text:0000000180B7B12C                 mov     [rbp+57h+var_58], rax
+  .text:0000000180B7B130                 lea     rdx, aFoundExistingV; "Found existing value when inserting int"...
+  .text:0000000180B7B137                 lea     rax, aCutldictStruct_3; "CUtlDict<struct CGameEntitySystem::Spaw"...
+  .text:0000000180B7B13E                 mov     [rbp+57h+var_3C], 14h
+  .text:0000000180B7B145                 mov     qword ptr [rbp+57h+var_50], rax
+  .text:0000000180B7B149                 lea     rcx, [rbp+57h+var_58]
+  .text:0000000180B7B14D                 lea     rax, aFalse; "false"
+  .text:0000000180B7B154                 mov     qword ptr [rbp+57h+var_50+8], rax
+  .text:0000000180B7B158                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@PEBDZZ; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &,char const *,...)
+  .text:0000000180B7B15E                 test    al, al
+  .text:0000000180B7B160                 jz      short loc_180B7B163
+  .text:0000000180B7B162                 ; Trap to Debugger
+  .text:0000000180B7B162                 int     3; Trap to Debugger
+  .text:0000000180B7B163                 test    dword ptr [rbx+20A4h], 7FFFFFFFh
+  .text:0000000180B7B16D                 jnz     short loc_180B7B173
+  .text:0000000180B7B16F                 xor     edx, edx
+  .text:0000000180B7B171                 jmp     short loc_180B7B17A
+  .text:0000000180B7B173                 mov     rdx, [rbx+20A8h]
+  .text:0000000180B7B17A                 lea     rcx, [r12+r12*4]
+  .text:0000000180B7B17E                 xorps   xmm0, xmm0
+  .text:0000000180B7B181                 movups  xmmword ptr [rdx+rcx*8+18h], xmm0
+  .text:0000000180B7B186                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180B7B18D                 mov     rdx, r14
+  .text:0000000180B7B190                 mov     rcx, [rax]
+  .text:0000000180B7B193                 mov     rax, [rcx]
+  .text:0000000180B7B196                 call    qword ptr [rax+18h]
+  .text:0000000180B7B199                 jmp     short loc_180B7B1BF
+  .text:0000000180B7B19B                 movsd   xmm0, [rbp+57h+var_A0]
+  .text:0000000180B7B1A0                 lea     r8, [rbp+57h+var_58]
+  .text:0000000180B7B1A4                 mov     eax, [rbp+57h+var_98]
+  .text:0000000180B7B1A7                 lea     rdx, [rbp+57h+var_90]
+  .text:0000000180B7B1AB                 lea     rcx, [r15+8]
+  .text:0000000180B7B1AF                 movsd   [rbp+57h+var_90], xmm0
+  .text:0000000180B7B1B4                 mov     [rbp+57h+var_88], eax
+  .text:0000000180B7B1B7                 call    sub_180B2A9D0
+  .text:0000000180B7B1BC                 mov     r12d, eax
+  .text:0000000180B7B1BF                 test    dword ptr [rbx+20A4h], 7FFFFFFFh
+  .text:0000000180B7B1C9                 jnz     short loc_180B7B1CF
+  .text:0000000180B7B1CB                 xor     edx, edx
+  .text:0000000180B7B1CD                 jmp     short loc_180B7B1D6
+  .text:0000000180B7B1CF                 mov     rdx, [rbx+20A8h]
+  .text:0000000180B7B1D6                 movsxd  rax, r12d
+  .text:0000000180B7B1D9                 lea     rcx, [rax+rax*4]
+  .text:0000000180B7B1DD                 mov     rax, [rbp+57h+arg_8]
+  .text:0000000180B7B1E1                 mov     [rdx+rcx*8+18h], rax
+  .text:0000000180B7B1E6                 test    dword ptr [rbx+20A4h], 7FFFFFFFh
+  .text:0000000180B7B1F0                 jnz     short loc_180B7B1F6
+  .text:0000000180B7B1F2                 xor     eax, eax
+  .text:0000000180B7B1F4                 jmp     short loc_180B7B1FD
+  .text:0000000180B7B1F6                 mov     rax, [rbx+20A8h]
+  .text:0000000180B7B1FD                 mov     [rax+rcx*8+20h], r13d
+  .text:0000000180B7B202                 mov     rdi, [rdi+18h]
+  .text:0000000180B7B206                 test    rdi, rdi
+  .text:0000000180B7B209                 jnz     loc_180B7B060
+  .text:0000000180B7B20F                 mov     r15, [rsp+0C0h+var_30]
+  .text:0000000180B7B217                 mov     r14, [rsp+0C0h+var_28]
+  .text:0000000180B7B21F                 mov     r13, [rsp+0C0h+var_20]
+  .text:0000000180B7B227                 mov     r12, [rsp+0C0h+var_18]
+  .text:0000000180B7B22F                 mov     rsi, [rsp+0B0h]
+  .text:0000000180B7B237                 mov     rbx, [rsp+0C0h+arg_10]
+  .text:0000000180B7B23F                 add     rsp, 0B8h
+  .text:0000000180B7B246                 pop     rdi
+  .text:0000000180B7B247                 pop     rbp
+  .text:0000000180B7B248                 retn
+procedure: |-
+  _UNKNOWN **sub_180B7B020()
+  {
+    _UNKNOWN **result; // rax
+    __int64 i; // rdi
+    __int64 v2; // r14
+    __int64 v3; // rbx
+    int v4; // r13d
+    __int64 v5; // r15
+    __int64 v6; // r12
+    __int64 v7; // rdx
+    __int64 v8; // rax
+    __int64 v9; // r14
+    __int64 v10; // rdx
+    __int64 v11; // rdx
+    __int64 v12; // [rsp+28h] [rbp-49h] BYREF
+    int v13; // [rsp+30h] [rbp-41h]
+    __int64 v14; // [rsp+38h] [rbp-39h] BYREF
+    int v15; // [rsp+40h] [rbp-31h]
+    _BYTE v16[16]; // [rsp+48h] [rbp-29h] BYREF
+    __int64 v17; // [rsp+58h] [rbp-19h] BYREF
+    __int64 *v18; // [rsp+60h] [rbp-11h]
+    const char **v19; // [rsp+68h] [rbp-9h]
+    const char *v20; // [rsp+70h] [rbp-1h] BYREF
+    __int128 v21; // [rsp+78h] [rbp+7h]
+    int v22; // [rsp+88h] [rbp+17h]
+    int v23; // [rsp+8Ch] [rbp+1Bh]
+    _UNKNOWN *retaddr; // [rsp+D0h] [rbp+5Fh] BYREF
+    __int64 v25; // [rsp+D8h] [rbp+67h] BYREF
+    __int64 v26; // [rsp+E0h] [rbp+6Fh]
+
+    result = &retaddr;
+    for ( i = qword_181F64488; i; i = *(_QWORD *)(i + 24) )
+    {
+      v2 = *(_QWORD *)(i + 8);
+      v3 = g_pGameEntitySystem;
+      v4 = *(_DWORD *)(i + 16);
+      v26 = *(_QWORD *)i;
+      v25 = v2;
+      v5 = g_pGameEntitySystem + 8344;            // 0x2098 = 8344 = CGameEntitySystem::m_spawnGroupEntityFilters(structmember,struct=CGameEntitySystem,member=m_spawnGroupEntityFilters)
+      if ( !v2
+        || (v17 = g_pGameEntitySystem + 8344,
+            v18 = &v25,
+            v19 = (const char **)(g_pGameEntitySystem + 8344),
+            result = (_UNKNOWN **)sub_180B2E1D0(g_pGameEntitySystem + 8352, v16, &v17),
+            v6 = *((int *)result + 1),
+            (_DWORD)v6 == -1) )
+      {
+        v8 = MemAlloc_StrDupFunc(v2);
+        v17 = v5;
+        v9 = v8;
+        v20 = (const char *)v8;
+        LOBYTE(v18) = 1;
+        v19 = &v20;
+        v21 = 0;
+        sub_180B2F900(v5 + 8, &v12, &v17);
+        v6 = SHIDWORD(v12);
+        if ( HIDWORD(v12) == -1 )
+        {
+          v14 = v12;
+          v15 = v13;
+          LODWORD(v6) = sub_180B2A9D0(v5 + 8, &v14, &v20);
+        }
+        else
+        {
+          v22 = 230;
+          v20 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\public\\tier0\\utldict.h";
+          v23 = 20;
+          *(_QWORD *)&v21 = "CUtlDict<struct CGameEntitySystem::SpawnGroupEntityFilterInfo_t,class CDefFastCaselessStringLess>::Insert";
+          *((_QWORD *)&v21 + 1) = "false";
+          if ( Assert_ConditionFailed(
+                 (const struct _AssertCompileTimeConstantStruct_t *)&v20,
+                 "Found existing value when inserting into dict - replacing existing value with new value. If this is inten"
+                 "ded behavior, use InsertOrReplace. If leaving existing values alone is intended, use InsertIfNotFound.") )
+          {
+            __debugbreak();
+          }
+          if ( (*(_DWORD *)(v3 + 8356) & 0x7FFFFFFF) != 0 )
+            v10 = *(_QWORD *)(v3 + 8360);
+          else
+            v10 = 0;
+          *(_OWORD *)(v10 + 40 * v6 + 24) = 0;
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v9);
+        }
+      }
+      else
+      {
+        if ( (*(_DWORD *)(v3 + 8356) & 0x7FFFFFFF) != 0 )
+          v7 = *(_QWORD *)(v3 + 8360);
+        else
+          v7 = 0;
+        if ( *(_DWORD *)(v7 + 40 * v6 + 32) >= v4 )
+          continue;
+      }
+      if ( (*(_DWORD *)(v3 + 8356) & 0x7FFFFFFF) != 0 )
+        v11 = *(_QWORD *)(v3 + 8360);
+      else
+        v11 = 0;
+      *(_QWORD *)(v11 + 40LL * (int)v6 + 24) = v26;
+      if ( (*(_DWORD *)(v3 + 8356) & 0x7FFFFFFF) != 0 )
+        result = *(_UNKNOWN ***)(v3 + 8360);
+      else
+        result = nullptr;
+      LODWORD(result[5 * (int)v6 + 4]) = v4;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
@@ -1,238 +1,236 @@
 func_name: CSource2EntitySystem_StaticInit
-func_va: '0x15bc690'
+func_va: '0x15bc750'
 disasm_code: |-
-  .text:00000000015BC690                 push    rbp
-  .text:00000000015BC691                 mov     rbp, rsp
-  .text:00000000015BC694                 push    r15
-  .text:00000000015BC696                 push    r14
-  .text:00000000015BC698                 push    r13
-  .text:00000000015BC69A                 push    r12
-  .text:00000000015BC69C                 push    rbx
-  .text:00000000015BC69D                 sub     rsp, 28h
-  .text:00000000015BC6A1                 lea     rdx, dword_27C4720
-  .text:00000000015BC6A8                 mov     eax, [rdx]
-  .text:00000000015BC6AA                 lea     ecx, [rax+1]
-  .text:00000000015BC6AD                 mov     [rdx], ecx
-  .text:00000000015BC6AF                 test    eax, eax
-  .text:00000000015BC6B1                 jg      short loc_15BC6DE
-  .text:00000000015BC6B3                 ; _QWORD
-  .text:00000000015BC6B3                 mov     edi, 2100h; _QWORD
-  .text:00000000015BC6B8                 call    __Znwm; operator new(ulong)
-  .text:00000000015BC6BD                 mov     rbx, rax
-  .text:00000000015BC6C0                 mov     rdi, rax
-  .text:00000000015BC6C3                 call    CGameEntitySystem_ctor
-  .text:00000000015BC6C8                 xor     r8d, r8d
-  .text:00000000015BC6CB                 xor     ecx, ecx
-  .text:00000000015BC6CD                 xor     edx, edx
-  .text:00000000015BC6CF                 lea     rsi, aServerEntities; "server_entities"
-  .text:00000000015BC6D6                 mov     rdi, rbx
-  .text:00000000015BC6D9                 call    CEntitySystem_PostCreateEntitySystem
-  .text:00000000015BC6DE                 lea     r13, g_pEntitySystem
-  .text:00000000015BC6E5                 mov     rbx, [r13+0]
-  .text:00000000015BC6E9                 movsxd  r12, dword ptr [rbx+0B90h]  ; 0B90h = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
-  .text:00000000015BC6F0                 mov     cs:g_pGameEntitySystem, rbx
-  .text:00000000015BC6F7                 mov     eax, r12d
-  .text:00000000015BC6FA                 cmp     r12d, [rbx+0BA0h]
-  .text:00000000015BC701                 jz      loc_15BCA30
-  .text:00000000015BC707                 add     eax, 1
-  .text:00000000015BC70A                 ; _QWORD
-  .text:00000000015BC70A                 mov     edi, 1340h; _QWORD
-  .text:00000000015BC70F                 mov     [rbx+0B90h], eax
-  .text:00000000015BC715                 mov     rax, [rbx+0B98h]
-  .text:00000000015BC71C                 lea     rcx, off_24C9FE0
-  .text:00000000015BC723                 mov     [rax+r12*8], rcx
-  .text:00000000015BC727                 call    __Znwm; operator new(ulong)
-  .text:00000000015BC72C                 mov     rdi, rax
-  .text:00000000015BC72F                 mov     rbx, rax
-  .text:00000000015BC732                 call    sub_1569780
-  .text:00000000015BC737                 mov     rax, cs:g_pGameEntitySystem
-  .text:00000000015BC73E                 lea     rdx, aMod_0; "MOD"
-  .text:00000000015BC745                 lea     rsi, aSave; "save/"
-  .text:00000000015BC74C                 mov     [rax+20E8h], rbx
-  .text:00000000015BC753                 lea     rax, qword_274C230
-  .text:00000000015BC75A                 mov     rdi, [rax]
-  .text:00000000015BC75D                 mov     rax, [rdi]
-  .text:00000000015BC760                 call    qword ptr [rax+180h]
-  .text:00000000015BC766                 lea     r14, g_pVApplication_0
-  .text:00000000015BC76D                 mov     rdi, [r14]
-  .text:00000000015BC770                 test    rdi, rdi
-  .text:00000000015BC773                 jz      short loc_15BC787
-  .text:00000000015BC775                 mov     rax, [rdi]
-  .text:00000000015BC778                 call    qword ptr [rax+120h]
-  .text:00000000015BC77E                 cmp     eax, 2
-  .text:00000000015BC781                 jz      loc_15BCA20
-  .text:00000000015BC787                 movdqa  xmm0, cs:xmmword_86C670
-  .text:00000000015BC78F                 mov     byte ptr [rbp+var_50+14h], 0
-  .text:00000000015BC793                 lea     r12, [rbp+var_50]
-  .text:00000000015BC797                 mov     dword ptr [rbp+var_50+10h], 40000h
-  .text:00000000015BC79E                 movaps  xmmword ptr [rbp+var_50], xmm0
-  .text:00000000015BC7A2                 call    _CreateNewThreadPool
-  .text:00000000015BC7A7                 lea     rdx, aSavejob; "SaveJob"
-  .text:00000000015BC7AE                 mov     rsi, r12
-  .text:00000000015BC7B1                 mov     rdi, rax
-  .text:00000000015BC7B4                 mov     [rbx+0E0h], rax
-  .text:00000000015BC7BB                 mov     rax, [rax]
-  .text:00000000015BC7BE                 call    qword ptr [rax+20h]
-  .text:00000000015BC7C1                 mov     rax, [rbx+0E0h]
-  .text:00000000015BC7C8                 mov     [rbx+0E8h], rax
-  .text:00000000015BC7CF                 call    _CommandLine
-  .text:00000000015BC7D4                 xor     edx, edx
-  .text:00000000015BC7D6                 mov     esi, 6FEFF596h
-  .text:00000000015BC7DB                 mov     rdi, rax
-  .text:00000000015BC7DE                 mov     rax, [rax]
-  .text:00000000015BC7E1                 call    qword ptr [rax+30h]
-  .text:00000000015BC7E4                 test    eax, eax
-  .text:00000000015BC7E6                 jnz     short loc_15BC7F0
-  .text:00000000015BC7E8                 mov     rdi, rbx
-  .text:00000000015BC7EB                 call    sub_1555CE0
-  .text:00000000015BC7F0                 mov     rdi, cs:qword_26E2FE0
-  .text:00000000015BC7F7                 mov     rax, [rdi]
-  .text:00000000015BC7FA                 call    qword ptr [rax+70h]
-  .text:00000000015BC7FD                 mov     [rbx+128h], rax
-  .text:00000000015BC804                 test    rax, rax
-  .text:00000000015BC807                 jz      loc_15BCA70
-  .text:00000000015BC80D                 mov     rax, [rbx]
-  .text:00000000015BC810                 lea     rdx, sub_152DD00
-  .text:00000000015BC817                 mov     rdi, cs:qword_26E0870
-  .text:00000000015BC81E                 mov     r15, [rax+88h]
-  .text:00000000015BC825                 mov     rax, [rdi]
-  .text:00000000015BC828                 mov     rax, [rax+0C0h]
-  .text:00000000015BC82F                 cmp     rax, rdx
-  .text:00000000015BC832                 jnz     loc_15BCA60
-  .text:00000000015BC838                 mov     rdi, [r14]
-  .text:00000000015BC83B                 mov     rax, [rdi]
-  .text:00000000015BC83E                 call    qword ptr [rax+0E0h]
-  .text:00000000015BC844                 ; char *
-  .text:00000000015BC844                 mov     rsi, rax; char *
-  .text:00000000015BC847                 lea     rax, sub_1530150
-  .text:00000000015BC84E                 cmp     r15, rax
-  .text:00000000015BC851                 jnz     loc_15BCA50
-  .text:00000000015BC857                 ; this
-  .text:00000000015BC857                 lea     rdi, [rbx+108h]; this
-  .text:00000000015BC85E                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
-  .text:00000000015BC863                 mov     rbx, cs:qword_26E0828
-  .text:00000000015BC86A                 test    rbx, rbx
-  .text:00000000015BC86D                 jz      short loc_15BC88F
-  .text:00000000015BC86F                 nop
-  .text:00000000015BC870                 mov     ecx, [rbx+10h]
-  .text:00000000015BC873                 mov     rdx, [rbx]
-  .text:00000000015BC876                 mov     rsi, [rbx+8]
-  .text:00000000015BC87A                 mov     rdi, cs:g_pGameEntitySystem
-  .text:00000000015BC881                 call    sub_15B9110
-  .text:00000000015BC886                 mov     rbx, [rbx+18h]
-  .text:00000000015BC88A                 test    rbx, rbx
-  .text:00000000015BC88D                 jnz     short loc_15BC870
-  .text:00000000015BC88F                 mov     rdi, cs:g_pGameEntitySystem
-  .text:00000000015BC896                 mov     esi, 1
-  .text:00000000015BC89B                 call    CEntitySystem_EnableAutoDeletionExecution
-  .text:00000000015BC8A0                 mov     rax, cs:qword_26E0870
-  .text:00000000015BC8A7                 lea     rdx, sub_1535520
-  .text:00000000015BC8AE                 lea     rdi, [rax+8]
-  .text:00000000015BC8B2                 mov     rax, [rax+8]
-  .text:00000000015BC8B6                 mov     rax, [rax+0A8h]
-  .text:00000000015BC8BD                 cmp     rax, rdx
-  .text:00000000015BC8C0                 jnz     loc_15BC9E0
-  .text:00000000015BC8C6                 mov     rdi, [r14]
-  .text:00000000015BC8C9                 mov     rax, [rdi]
-  .text:00000000015BC8CC                 call    qword ptr [rax+0B8h]
-  .text:00000000015BC8D2                 test    al, al
-  .text:00000000015BC8D4                 jnz     loc_15BC9EA
-  .text:00000000015BC8DA                 lea     rax, g_pGameResourceService
-  .text:00000000015BC8E1                 mov     rdi, [rax]
-  .text:00000000015BC8E4                 test    rdi, rdi
-  .text:00000000015BC8E7                 jz      short loc_15BC8F9
-  .text:00000000015BC8E9                 mov     rax, [rdi]
-  .text:00000000015BC8EC                 mov     rsi, cs:g_pGameEntitySystem
-  .text:00000000015BC8F3                 call    qword ptr [rax+110h]
-  .text:00000000015BC8F9                 mov     rax, [r13+0]
-  .text:00000000015BC8FD                 lea     rbx, sub_152EFF0
-  .text:00000000015BC904                 mov     rdi, cs:g_pGameEntitySystem
-  .text:00000000015BC90B                 mov     esi, [rax+278h]
-  .text:00000000015BC911                 call    sub_15BC5D0
-  .text:00000000015BC916                 mov     rdi, [r13+0]
-  .text:00000000015BC91A                 mov     rdx, r12
-  .text:00000000015BC91D                 mov     [rbp+var_50+8], rbx
-  .text:00000000015BC921                 lea     rax, sub_156AEA0
-  .text:00000000015BC928                 mov     esi, 28h ; '('
-  .text:00000000015BC92D                 mov     [rbp+var_50+10h], 0
-  .text:00000000015BC935                 mov     [rbp+var_50], rax
-  .text:00000000015BC939                 call    sub_1E67E40
-  .text:00000000015BC93E                 mov     rdi, [r13+0]
-  .text:00000000015BC942                 mov     rdx, r12
-  .text:00000000015BC945                 mov     [rbp+var_50+8], rbx
-  .text:00000000015BC949                 lea     rax, sub_156AF70
-  .text:00000000015BC950                 mov     esi, 36h ; '6'
-  .text:00000000015BC955                 mov     [rbp+var_50+10h], 0
-  .text:00000000015BC95D                 mov     [rbp+var_50], rax
-  .text:00000000015BC961                 call    sub_1E67E40
-  .text:00000000015BC966                 mov     rdi, [r13+0]
-  .text:00000000015BC96A                 mov     rdx, r12
-  .text:00000000015BC96D                 mov     [rbp+var_50+8], rbx
-  .text:00000000015BC971                 lea     rax, sub_1530BE0
-  .text:00000000015BC978                 mov     esi, 43h ; 'C'
-  .text:00000000015BC97D                 mov     [rbp+var_50+10h], 0
-  .text:00000000015BC985                 mov     [rbp+var_50], rax
-  .text:00000000015BC989                 call    sub_1E67E40
-  .text:00000000015BC98E                 lea     rax, g_pFlattenedSerializers
-  .text:00000000015BC995                 lea     rcx, sub_152F010
-  .text:00000000015BC99C                 mov     rsi, r12
-  .text:00000000015BC99F                 mov     rdi, [rax]
-  .text:00000000015BC9A2                 mov     rax, [rdi]
-  .text:00000000015BC9A5                 mov     rax, [rax+108h]
-  .text:00000000015BC9AC                 mov     [rbp+var_50+8], rcx
-  .text:00000000015BC9B0                 lea     rcx, sub_152DF60
-  .text:00000000015BC9B7                 mov     [rbp+var_50+10h], 0
-  .text:00000000015BC9BF                 mov     [rbp+var_50], rcx
-  .text:00000000015BC9C3                 call    rax
-  .text:00000000015BC9C5                 add     rsp, 28h
-  .text:00000000015BC9C9                 mov     eax, 1
-  .text:00000000015BC9CE                 pop     rbx
-  .text:00000000015BC9CF                 pop     r12
-  .text:00000000015BC9D1                 pop     r13
-  .text:00000000015BC9D3                 pop     r14
-  .text:00000000015BC9D5                 pop     r15
-  .text:00000000015BC9D7                 pop     rbp
-  .text:00000000015BC9D8                 retn
-  .text:00000000015BC9E0                 call    rax
-  .text:00000000015BC9E2                 test    al, al
-  .text:00000000015BC9E4                 jz      loc_15BC8C6
-  .text:00000000015BC9EA                 mov     rdi, cs:g_pGameEntitySystem
-  .text:00000000015BC9F1                 lea     rax, sub_152EFE0
-  .text:00000000015BC9F8                 mov     rsi, r12
-  .text:00000000015BC9FB                 mov     [rbp+var_50+10h], 0
-  .text:00000000015BCA03                 mov     [rbp+var_50+8], rax
-  .text:00000000015BCA07                 lea     rax, sub_15420E0
-  .text:00000000015BCA0E                 mov     [rbp+var_50], rax
-  .text:00000000015BCA12                 call    CEntitySystem_InstallPostSpawnCallback
-  .text:00000000015BCA17                 jmp     loc_15BC8DA
-  .text:00000000015BCA20                 lea     r12, [rbp+var_50]
-  .text:00000000015BCA24                 jmp     loc_15BC7C1
-  .text:00000000015BCA30                 lea     rdi, [rbx+0B98h]
-  .text:00000000015BCA37                 mov     esi, 1
-  .text:00000000015BCA3C                 call    sub_11A8EC0
-  .text:00000000015BCA41                 mov     eax, [rbx+0B90h]
-  .text:00000000015BCA47                 jmp     loc_15BC707
-  .text:00000000015BCA50                 mov     rdi, rbx
-  .text:00000000015BCA53                 call    r15
-  .text:00000000015BCA56                 jmp     loc_15BC863
-  .text:00000000015BCA60                 call    rax
-  .text:00000000015BCA62                 mov     rsi, rax
-  .text:00000000015BCA65                 jmp     loc_15BC847
-  .text:00000000015BCA70                 ; _QWORD
-  .text:00000000015BCA70                 mov     edi, 350h; _QWORD
-  .text:00000000015BCA75                 call    __Znwm; operator new(ulong)
-  .text:00000000015BCA7A                 mov     rdi, rax
-  .text:00000000015BCA7D                 mov     r15, rax
-  .text:00000000015BCA80                 call    sub_1553330
-  .text:00000000015BCA85                 mov     rdi, cs:qword_26E2FE0
-  .text:00000000015BCA8C                 mov     [rbx+128h], r15
-  .text:00000000015BCA93                 mov     rsi, r15
-  .text:00000000015BCA96                 mov     byte ptr [rbx+130h], 1
-  .text:00000000015BCA9D                 mov     rax, [rdi]
-  .text:00000000015BCAA0                 call    qword ptr [rax+68h]
-  .text:00000000015BCAA3                 jmp     loc_15BC80D
+  .text:00000000015BC750                 push    rbp
+  .text:00000000015BC751                 mov     rbp, rsp
+  .text:00000000015BC754                 push    r15
+  .text:00000000015BC756                 push    r14
+  .text:00000000015BC758                 push    r13
+  .text:00000000015BC75A                 push    r12
+  .text:00000000015BC75C                 push    rbx
+  .text:00000000015BC75D                 sub     rsp, 28h
+  .text:00000000015BC761                 lea     rdx, dword_27C44A0
+  .text:00000000015BC768                 mov     eax, [rdx]
+  .text:00000000015BC76A                 lea     ecx, [rax+1]
+  .text:00000000015BC76D                 mov     [rdx], ecx
+  .text:00000000015BC76F                 test    eax, eax
+  .text:00000000015BC771                 jg      short loc_15BC79E
+  .text:00000000015BC773                 mov     edi, 2100h
+  .text:00000000015BC778                 call    sub_97A1D0
+  .text:00000000015BC77D                 mov     rbx, rax
+  .text:00000000015BC780                 mov     rdi, rax
+  .text:00000000015BC783                 call    CGameEntitySystem_ctor
+  .text:00000000015BC788                 xor     r8d, r8d
+  .text:00000000015BC78B                 xor     ecx, ecx
+  .text:00000000015BC78D                 xor     edx, edx
+  .text:00000000015BC78F                 lea     rsi, aServerEntities; "server_entities"
+  .text:00000000015BC796                 mov     rdi, rbx
+  .text:00000000015BC799                 call    CEntitySystem_PostCreateEntitySystem
+  .text:00000000015BC79E                 lea     r13, g_pEntitySystem
+  .text:00000000015BC7A5                 mov     rbx, [r13+0]
+  .text:00000000015BC7A9                 ; 0xB90 = 2960LL = CEntitySystem::m_entityIONotifiers
+  .text:00000000015BC7A9                 movsxd  r12, dword ptr [rbx+0B90h]; 0xB90 = 2960LL = CEntitySystem::m_entityIONotifiers
+  .text:00000000015BC7B0                 mov     cs:g_pGameEntitySystem, rbx
+  .text:00000000015BC7B7                 mov     eax, r12d
+  .text:00000000015BC7BA                 cmp     r12d, [rbx+0BA0h]
+  .text:00000000015BC7C1                 jz      loc_15BCAF0
+  .text:00000000015BC7C7                 add     eax, 1
+  .text:00000000015BC7CA                 mov     edi, 1340h
+  .text:00000000015BC7CF                 mov     [rbx+0B90h], eax
+  .text:00000000015BC7D5                 mov     rax, [rbx+0B98h]
+  .text:00000000015BC7DC                 lea     rcx, off_24C9D60
+  .text:00000000015BC7E3                 mov     [rax+r12*8], rcx
+  .text:00000000015BC7E7                 call    sub_97A1D0
+  .text:00000000015BC7EC                 mov     rdi, rax
+  .text:00000000015BC7EF                 mov     rbx, rax
+  .text:00000000015BC7F2                 call    sub_1569840
+  .text:00000000015BC7F7                 mov     rax, cs:g_pGameEntitySystem
+  .text:00000000015BC7FE                 lea     rdx, aMod_0; "MOD"
+  .text:00000000015BC805                 lea     rsi, aSave; "save/"
+  .text:00000000015BC80C                 mov     [rax+20E8h], rbx
+  .text:00000000015BC813                 lea     rax, g_pFileSystem
+  .text:00000000015BC81A                 mov     rdi, [rax]
+  .text:00000000015BC81D                 mov     rax, [rdi]
+  .text:00000000015BC820                 call    qword ptr [rax+180h]
+  .text:00000000015BC826                 lea     r14, g_pVApplication
+  .text:00000000015BC82D                 mov     rdi, [r14]
+  .text:00000000015BC830                 test    rdi, rdi
+  .text:00000000015BC833                 jz      short loc_15BC847
+  .text:00000000015BC835                 mov     rax, [rdi]
+  .text:00000000015BC838                 call    qword ptr [rax+120h]
+  .text:00000000015BC83E                 cmp     eax, 2
+  .text:00000000015BC841                 jz      loc_15BCAE0
+  .text:00000000015BC847                 movdqa  xmm0, cs:xmmword_86C670
+  .text:00000000015BC84F                 mov     byte ptr [rbp+var_40+4], 0
+  .text:00000000015BC853                 lea     r12, [rbp+var_50]
+  .text:00000000015BC857                 mov     dword ptr [rbp+var_40], 40000h
+  .text:00000000015BC85E                 movaps  [rbp+var_50], xmm0
+  .text:00000000015BC862                 call    sub_9835C0
+  .text:00000000015BC867                 lea     rdx, aSavejob; "SaveJob"
+  .text:00000000015BC86E                 mov     rsi, r12
+  .text:00000000015BC871                 mov     rdi, rax
+  .text:00000000015BC874                 mov     [rbx+0E0h], rax
+  .text:00000000015BC87B                 mov     rax, [rax]
+  .text:00000000015BC87E                 call    qword ptr [rax+20h]
+  .text:00000000015BC881                 mov     rax, [rbx+0E0h]
+  .text:00000000015BC888                 mov     [rbx+0E8h], rax
+  .text:00000000015BC88F                 call    sub_984890
+  .text:00000000015BC894                 xor     edx, edx
+  .text:00000000015BC896                 mov     esi, 6FEFF596h
+  .text:00000000015BC89B                 mov     rdi, rax
+  .text:00000000015BC89E                 mov     rax, [rax]
+  .text:00000000015BC8A1                 call    qword ptr [rax+30h]
+  .text:00000000015BC8A4                 test    eax, eax
+  .text:00000000015BC8A6                 jnz     short loc_15BC8B0
+  .text:00000000015BC8A8                 mov     rdi, rbx
+  .text:00000000015BC8AB                 call    sub_1555DA0
+  .text:00000000015BC8B0                 mov     rdi, cs:qword_26E2D60
+  .text:00000000015BC8B7                 mov     rax, [rdi]
+  .text:00000000015BC8BA                 call    qword ptr [rax+70h]
+  .text:00000000015BC8BD                 mov     [rbx+128h], rax
+  .text:00000000015BC8C4                 test    rax, rax
+  .text:00000000015BC8C7                 jz      loc_15BCB30
+  .text:00000000015BC8CD                 mov     rax, [rbx]
+  .text:00000000015BC8D0                 lea     rdx, sub_152DDC0
+  .text:00000000015BC8D7                 mov     rdi, cs:qword_26E05F0
+  .text:00000000015BC8DE                 mov     r15, [rax+88h]
+  .text:00000000015BC8E5                 mov     rax, [rdi]
+  .text:00000000015BC8E8                 mov     rax, [rax+0C0h]
+  .text:00000000015BC8EF                 cmp     rax, rdx
+  .text:00000000015BC8F2                 jnz     loc_15BCB20
+  .text:00000000015BC8F8                 mov     rdi, [r14]
+  .text:00000000015BC8FB                 mov     rax, [rdi]
+  .text:00000000015BC8FE                 call    qword ptr [rax+0E0h]
+  .text:00000000015BC904                 mov     rsi, rax
+  .text:00000000015BC907                 lea     rax, sub_1530210
+  .text:00000000015BC90E                 cmp     r15, rax
+  .text:00000000015BC911                 jnz     loc_15BCB10
+  .text:00000000015BC917                 lea     rdi, [rbx+108h]
+  .text:00000000015BC91E                 call    sub_9849D0
+  .text:00000000015BC923                 mov     rbx, cs:qword_26E05A8
+  .text:00000000015BC92A                 test    rbx, rbx
+  .text:00000000015BC92D                 jz      short loc_15BC94F
+  .text:00000000015BC92F                 nop
+  .text:00000000015BC930                 ; CGameEntitySystem_RegisterSpawnGroupEntityFilter
+  .text:00000000015BC930                 mov     ecx, [rbx+10h]; CGameEntitySystem_RegisterSpawnGroupEntityFilter
+  .text:00000000015BC933                 mov     rdx, [rbx]
+  .text:00000000015BC936                 mov     rsi, [rbx+8]
+  .text:00000000015BC93A                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC941                 call    CGameEntitySystem_RegisterSpawnGroupEntityFilter
+  .text:00000000015BC946                 mov     rbx, [rbx+18h]
+  .text:00000000015BC94A                 test    rbx, rbx
+  .text:00000000015BC94D                 jnz     short loc_15BC930
+  .text:00000000015BC94F                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC956                 mov     esi, 1
+  .text:00000000015BC95B                 call    CEntitySystem_EnableAutoDeletionExecution
+  .text:00000000015BC960                 mov     rax, cs:qword_26E05F0
+  .text:00000000015BC967                 lea     rdx, sub_15355E0
+  .text:00000000015BC96E                 lea     rdi, [rax+8]
+  .text:00000000015BC972                 mov     rax, [rax+8]
+  .text:00000000015BC976                 mov     rax, [rax+0A8h]
+  .text:00000000015BC97D                 cmp     rax, rdx
+  .text:00000000015BC980                 jnz     loc_15BCAA0
+  .text:00000000015BC986                 mov     rdi, [r14]
+  .text:00000000015BC989                 mov     rax, [rdi]
+  .text:00000000015BC98C                 call    qword ptr [rax+0B8h]
+  .text:00000000015BC992                 test    al, al
+  .text:00000000015BC994                 jnz     loc_15BCAAA
+  .text:00000000015BC99A                 lea     rax, g_pGameResourceService
+  .text:00000000015BC9A1                 mov     rdi, [rax]
+  .text:00000000015BC9A4                 test    rdi, rdi
+  .text:00000000015BC9A7                 jz      short loc_15BC9B9
+  .text:00000000015BC9A9                 mov     rax, [rdi]
+  .text:00000000015BC9AC                 mov     rsi, cs:g_pGameEntitySystem
+  .text:00000000015BC9B3                 ; 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+  .text:00000000015BC9B3                 call    qword ptr [rax+110h]; 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+  .text:00000000015BC9B9                 mov     rax, [r13+0]
+  .text:00000000015BC9BD                 lea     rbx, sub_152F0B0
+  .text:00000000015BC9C4                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BC9CB                 mov     esi, [rax+278h]
+  .text:00000000015BC9D1                 call    CEntitySystem_InstallCreationWrapperCallbacks
+  .text:00000000015BC9D6                 mov     rdi, [r13+0]
+  .text:00000000015BC9DA                 mov     rdx, r12
+  .text:00000000015BC9DD                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BC9E1                 lea     rax, sub_156AF60
+  .text:00000000015BC9E8                 mov     esi, 28h ; '('
+  .text:00000000015BC9ED                 mov     [rbp+var_40], 0
+  .text:00000000015BC9F5                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BC9F9                 call    sub_1E67F00
+  .text:00000000015BC9FE                 mov     rdi, [r13+0]
+  .text:00000000015BCA02                 mov     rdx, r12
+  .text:00000000015BCA05                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BCA09                 lea     rax, sub_156B030
+  .text:00000000015BCA10                 mov     esi, 36h ; '6'
+  .text:00000000015BCA15                 mov     [rbp+var_40], 0
+  .text:00000000015BCA1D                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BCA21                 call    sub_1E67F00
+  .text:00000000015BCA26                 mov     rdi, [r13+0]
+  .text:00000000015BCA2A                 mov     rdx, r12
+  .text:00000000015BCA2D                 mov     qword ptr [rbp+var_50+8], rbx
+  .text:00000000015BCA31                 lea     rax, sub_1530CA0
+  .text:00000000015BCA38                 mov     esi, 43h ; 'C'
+  .text:00000000015BCA3D                 mov     [rbp+var_40], 0
+  .text:00000000015BCA45                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BCA49                 call    sub_1E67F00
+  .text:00000000015BCA4E                 lea     rax, g_pFlattenedSerializers
+  .text:00000000015BCA55                 lea     rcx, sub_152F0D0
+  .text:00000000015BCA5C                 mov     rsi, r12
+  .text:00000000015BCA5F                 mov     rdi, [rax]
+  .text:00000000015BCA62                 mov     rax, [rdi]
+  .text:00000000015BCA65                 mov     rax, [rax+108h]
+  .text:00000000015BCA6C                 mov     qword ptr [rbp+var_50+8], rcx
+  .text:00000000015BCA70                 lea     rcx, sub_152E020
+  .text:00000000015BCA77                 mov     [rbp+var_40], 0
+  .text:00000000015BCA7F                 mov     qword ptr [rbp+var_50], rcx
+  .text:00000000015BCA83                 call    rax
+  .text:00000000015BCA85                 add     rsp, 28h
+  .text:00000000015BCA89                 mov     eax, 1
+  .text:00000000015BCA8E                 pop     rbx
+  .text:00000000015BCA8F                 pop     r12
+  .text:00000000015BCA91                 pop     r13
+  .text:00000000015BCA93                 pop     r14
+  .text:00000000015BCA95                 pop     r15
+  .text:00000000015BCA97                 pop     rbp
+  .text:00000000015BCA98                 retn
+  .text:00000000015BCAA0                 call    rax
+  .text:00000000015BCAA2                 test    al, al
+  .text:00000000015BCAA4                 jz      loc_15BC986
+  .text:00000000015BCAAA                 mov     rdi, cs:g_pGameEntitySystem
+  .text:00000000015BCAB1                 lea     rax, sub_152F0A0
+  .text:00000000015BCAB8                 mov     rsi, r12
+  .text:00000000015BCABB                 mov     [rbp+var_40], 0
+  .text:00000000015BCAC3                 mov     qword ptr [rbp+var_50+8], rax
+  .text:00000000015BCAC7                 lea     rax, sub_15421A0
+  .text:00000000015BCACE                 mov     qword ptr [rbp+var_50], rax
+  .text:00000000015BCAD2                 call    CEntitySystem_InstallPostSpawnCallback
+  .text:00000000015BCAD7                 jmp     loc_15BC99A
+  .text:00000000015BCAE0                 lea     r12, [rbp+var_50]
+  .text:00000000015BCAE4                 jmp     loc_15BC881
+  .text:00000000015BCAF0                 lea     rdi, [rbx+0B98h]
+  .text:00000000015BCAF7                 mov     esi, 1
+  .text:00000000015BCAFC                 call    sub_11A8EC0
+  .text:00000000015BCB01                 mov     eax, [rbx+0B90h]
+  .text:00000000015BCB07                 jmp     loc_15BC7C7
+  .text:00000000015BCB10                 mov     rdi, rbx
+  .text:00000000015BCB13                 call    r15
+  .text:00000000015BCB16                 jmp     loc_15BC923
+  .text:00000000015BCB20                 call    rax
+  .text:00000000015BCB22                 mov     rsi, rax
+  .text:00000000015BCB25                 jmp     loc_15BC907
+  .text:00000000015BCB30                 mov     edi, 350h
+  .text:00000000015BCB35                 call    sub_97A1D0
+  .text:00000000015BCB3A                 mov     rdi, rax
+  .text:00000000015BCB3D                 mov     r15, rax
+  .text:00000000015BCB40                 call    sub_15533F0
+  .text:00000000015BCB45                 mov     rdi, cs:qword_26E2D60
+  .text:00000000015BCB4C                 mov     [rbx+128h], r15
+  .text:00000000015BCB53                 mov     rsi, r15
+  .text:00000000015BCB56                 mov     byte ptr [rbx+130h], 1
+  .text:00000000015BCB5D                 mov     rax, [rdi]
+  .text:00000000015BCB60                 call    qword ptr [rax+68h]
+  .text:00000000015BCB63                 jmp     loc_15BC8CD
 procedure: |-
-  __int64 CSource2EntitySystem_StaticInit()
+  __int64 sub_15BC750()
   {
     int v0; // eax
     __int64 v1; // rbx
@@ -242,114 +240,128 @@ procedure: |-
     __int64 v5; // rbx
     __int64 v6; // rdx
     _QWORD *v7; // rdi
-    __int64 NewThreadPool; // rax
+    __int64 v8; // rax
     __int64 v9; // rax
     __int64 v10; // rax
     __int64 (__fastcall *v11)(); // r15
     __int64 (*v12)(void); // rax
-    const char *v13; // rsi
+    __int64 v13; // rsi
     __int64 i; // rbx
     __int64 (__fastcall *v15)(); // rax
-    void (__fastcall *v16)(_QWORD *, __int64 *); // rax
-    __int64 v18; // r15
-    __int64 v19; // rdi
-    __int64 v20[3]; // [rsp+0h] [rbp-50h] BYREF
+    __int64 v16; // rcx
+    __int64 v17; // r8
+    __int64 v18; // r9
+    __int64 v19; // rcx
+    __int64 v20; // r8
+    __int64 v21; // r9
+    void (__fastcall *v22)(_QWORD *, __m128i *); // rax
+    __int64 v24; // r15
+    __int64 v25; // rdi
+    __m128i si128; // [rsp+0h] [rbp-50h] BYREF
+    __int64 v27; // [rsp+10h] [rbp-40h]
 
-    v0 = dword_27C4720++;
+    v0 = dword_27C44A0++;
     if ( v0 <= 0 )
     {
-      v1 = operator new(8448);
+      v1 = sub_97A1D0(8448);
       CGameEntitySystem_ctor(v1);
       CEntitySystem_PostCreateEntitySystem(v1, "server_entities", 0, 0, 0);
     }
     v2 = g_pEntitySystem;
-    v3 = *(int *)(g_pEntitySystem + 2960LL);  // 2960 = 0xB90 = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
+    v3 = *(int *)(g_pEntitySystem + 2960);        // 0xB90 = 2960LL = CEntitySystem::m_entityIONotifiers
     g_pGameEntitySystem = g_pEntitySystem;
     v4 = v3;
-    if ( (_DWORD)v3 == *(_DWORD *)(g_pEntitySystem + 2976LL) )
+    if ( (_DWORD)v3 == *(_DWORD *)(g_pEntitySystem + 2976) )
     {
-      sub_11A8EC0(g_pEntitySystem + 2968LL, 1);
+      sub_11A8EC0(g_pEntitySystem + 2968, 1);
       v4 = *(_DWORD *)(v2 + 2960);
     }
     *(_DWORD *)(v2 + 2960) = v4 + 1;
-    *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_24C9FE0;
-    v5 = operator new(4928);
-    sub_1569780(v5);
+    *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_24C9D60;
+    v5 = sub_97A1D0(4928);
+    sub_1569840(v5);
     *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;
-    (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*qword_274C230 + 384LL))(qword_274C230, "save/", "MOD");
-    v7 = g_pVApplication_0;
-    if ( !g_pVApplication_0
-      || (*(unsigned int (__fastcall **)(_QWORD *))(*g_pVApplication_0 + 288LL))(g_pVApplication_0) != 2 )
+    (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*g_pFileSystem + 384LL))(g_pFileSystem, "save/", "MOD");
+    v7 = g_pVApplication;
+    if ( !g_pVApplication || (*(unsigned int (__fastcall **)(_QWORD *))(*g_pVApplication + 288LL))(g_pVApplication) != 2 )
     {
-      BYTE4(v20[2]) = 0;
-      LODWORD(v20[2]) = 0x40000;
-      *(__m128i *)v20 = _mm_load_si128((const __m128i *)&xmmword_86C670);
-      NewThreadPool = CreateNewThreadPool(v7, "save/", v6);
-      *(_QWORD *)(v5 + 224) = NewThreadPool;
-      (*(void (__fastcall **)(__int64, __int64 *, const char *))(*(_QWORD *)NewThreadPool + 32LL))(
-        NewThreadPool,
-        v20,
-        "SaveJob");
+      BYTE4(v27) = 0;
+      LODWORD(v27) = 0x40000;
+      si128 = _mm_load_si128((const __m128i *)&xmmword_86C670);
+      v8 = sub_9835C0(v7, "save/", v6);
+      *(_QWORD *)(v5 + 224) = v8;
+      (*(void (__fastcall **)(__int64, __m128i *, const char *))(*(_QWORD *)v8 + 32LL))(v8, &si128, "SaveJob");
     }
     *(_QWORD *)(v5 + 232) = *(_QWORD *)(v5 + 224);
-    v9 = CommandLine();
+    v9 = sub_984890();
     if ( !(*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v9 + 48LL))(v9, 1877996950, 0) )
-      sub_1555CE0(v5);
-    v10 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_26E2FE0 + 112LL))(qword_26E2FE0);
+      sub_1555DA0(v5);
+    v10 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_26E2D60 + 112LL))(qword_26E2D60);
     *(_QWORD *)(v5 + 296) = v10;
     if ( !v10 )
     {
-      v18 = operator new(848);
-      sub_1553330(v18);
-      v19 = qword_26E2FE0;
-      *(_QWORD *)(v5 + 296) = v18;
+      v24 = sub_97A1D0(848);
+      sub_15533F0(v24);
+      v25 = qword_26E2D60;
+      *(_QWORD *)(v5 + 296) = v24;
       *(_BYTE *)(v5 + 304) = 1;
-      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v19 + 104LL))(v19, v18);
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v25 + 104LL))(v25, v24);
     }
     v11 = *(__int64 (__fastcall **)())(*(_QWORD *)v5 + 136LL);
-    v12 = *(__int64 (**)(void))(*(_QWORD *)qword_26E0870 + 192LL);
-    if ( v12 == sub_152DD00 )
-      v13 = (const char *)(*(__int64 (__fastcall **)(_QWORD *))(*g_pVApplication_0 + 224LL))(g_pVApplication_0);
+    v12 = *(__int64 (**)(void))(*(_QWORD *)qword_26E05F0 + 192LL);
+    if ( v12 == sub_152DDC0 )
+      v13 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pVApplication + 224LL))(g_pVApplication);
     else
-      v13 = (const char *)v12();
-    if ( v11 == sub_1530150 )
-      CUtlString::Set((CUtlString *)(v5 + 264), v13);
+      v13 = v12();
+    if ( v11 == sub_1530210 )
+      sub_9849D0(v5 + 264);
     else
-      ((void (__fastcall *)(__int64, const char *))v11)(v5, v13);
-    for ( i = qword_26E0828; i; i = *(_QWORD *)(i + 24) )
-      sub_15B9110(g_pGameEntitySystem, *(_QWORD *)(i + 8), *(_QWORD *)i, *(_DWORD *)(i + 16));
+      ((void (__fastcall *)(__int64, __int64))v11)(v5, v13);
+    for ( i = qword_26E05A8; i; i = *(_QWORD *)(i + 24) )
+      sub_15B91D0(g_pGameEntitySystem, *(_QWORD *)(i + 8), *(_QWORD *)i, *(unsigned int *)(i + 16));// CGameEntitySystem_RegisterSpawnGroupEntityFilter
     CEntitySystem_EnableAutoDeletionExecution(g_pGameEntitySystem, 1);
-    v15 = *(__int64 (__fastcall **)())(*(_QWORD *)(qword_26E0870 + 8) + 168LL);
-    if ( v15 != sub_1535520 && ((unsigned __int8 (__fastcall *)(__int64))v15)(qword_26E0870 + 8)
-      || (*(unsigned __int8 (__fastcall **)(_QWORD *))(*g_pVApplication_0 + 184LL))(g_pVApplication_0) )
+    v15 = *(__int64 (__fastcall **)())(*(_QWORD *)(qword_26E05F0 + 8) + 168LL);
+    if ( v15 != sub_15355E0 && ((unsigned __int8 (__fastcall *)(__int64))v15)(qword_26E05F0 + 8)
+      || (*(unsigned __int8 (__fastcall **)(_QWORD *))(*g_pVApplication + 184LL))(g_pVApplication) )
     {
-      v20[2] = 0;
-      v20[1] = (__int64)sub_152EFE0;
-      v20[0] = (__int64)sub_15420E0;
-      CEntitySystem_InstallPostSpawnCallback(g_pGameEntitySystem, v20);
+      v27 = 0;
+      si128.m128i_i64[1] = (__int64)sub_152F0A0;
+      si128.m128i_i64[0] = (__int64)sub_15421A0;
+      ((void (__fastcall *)(__int64, __m128i *))CEntitySystem_InstallPostSpawnCallback)(g_pGameEntitySystem, &si128);
     }
     if ( g_pGameResourceService )
-      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService
-                                               + 272LL))(// IGameResourceService_SetEntityResourceManifestHandler
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService + 272LL))(
         g_pGameResourceService,
-        g_pGameEntitySystem);
-    sub_15BC5D0(g_pGameEntitySystem, *(_DWORD *)(g_pEntitySystem + 632LL));
-    v20[1] = (__int64)sub_152EFF0;
-    v20[2] = 0;
-    v20[0] = (__int64)sub_156AEA0;
-    sub_1E67E40(g_pEntitySystem, 40, v20);
-    v20[1] = (__int64)sub_152EFF0;
-    v20[2] = 0;
-    v20[0] = (__int64)sub_156AF70;
-    sub_1E67E40(g_pEntitySystem, 54, v20);
-    v20[1] = (__int64)sub_152EFF0;
-    v20[2] = 0;
-    v20[0] = (__int64)sub_1530BE0;
-    sub_1E67E40(g_pEntitySystem, 67, v20);
-    v16 = *(void (__fastcall **)(_QWORD *, __int64 *))(*g_pFlattenedSerializers + 264LL);
-    v20[1] = (__int64)sub_152F010;
-    v20[2] = 0;
-    v20[0] = (__int64)sub_152DF60;
-    v16(g_pFlattenedSerializers, v20);
+        g_pGameEntitySystem);                     // 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+    CEntitySystem_InstallCreationWrapperCallbacks(g_pGameEntitySystem, *(unsigned int *)(g_pEntitySystem + 632));
+    si128.m128i_i64[1] = (__int64)sub_152F0B0;
+    v27 = 0;
+    si128.m128i_i64[0] = (__int64)sub_156AF60;
+    ((void (__fastcall *)(__int64, __int64, __m128i *))sub_1E67F00)(g_pEntitySystem, 40, &si128);
+    si128.m128i_i64[1] = (__int64)sub_152F0B0;
+    v27 = 0;
+    si128.m128i_i64[0] = (__int64)sub_156B030;
+    ((void (__fastcall *)(__int64, __int64, __m128i *, __int64, __int64, __int64))sub_1E67F00)(
+      g_pEntitySystem,
+      54,
+      &si128,
+      v16,
+      v17,
+      v18);
+    si128.m128i_i64[1] = (__int64)sub_152F0B0;
+    v27 = 0;
+    si128.m128i_i64[0] = (__int64)sub_1530CA0;
+    ((void (__fastcall *)(__int64, __int64, __m128i *, __int64, __int64, __int64))sub_1E67F00)(
+      g_pEntitySystem,
+      67,
+      &si128,
+      v19,
+      v20,
+      v21);
+    v22 = *(void (__fastcall **)(_QWORD *, __m128i *))(*g_pFlattenedSerializers + 264LL);
+    si128.m128i_i64[1] = (__int64)sub_152F0D0;
+    v27 = 0;
+    si128.m128i_i64[0] = (__int64)sub_152E020;
+    v22(g_pFlattenedSerializers, &si128);
     return 1;
   }

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
@@ -1,223 +1,226 @@
 func_name: CSource2EntitySystem_StaticInit
-func_va: '0x180b8d740'
+func_va: '0x180b8d780'
 disasm_code: |-
-  .text:0000000180B8D740                 mov     [rsp-18h+arg_0], rbx
-  .text:0000000180B8D745                 mov     [rsp-18h+arg_8], rsi
-  .text:0000000180B8D74A                 mov     [rsp-18h+arg_10], rdi
-  .text:0000000180B8D74F                 push    rbp
-  .text:0000000180B8D750                 push    r14
-  .text:0000000180B8D752                 push    r15
-  .text:0000000180B8D754                 mov     rbp, rsp
-  .text:0000000180B8D757                 sub     rsp, 50h
-  .text:0000000180B8D75B                 mov     eax, cs:dword_1820B9400
-  .text:0000000180B8D761                 xor     r15d, r15d
-  .text:0000000180B8D764                 mov     ecx, eax
-  .text:0000000180B8D766                 inc     eax
-  .text:0000000180B8D768                 mov     cs:dword_1820B9400, eax
-  .text:0000000180B8D76E                 test    ecx, ecx
-  .text:0000000180B8D770                 jg      short loc_180B8D7A8
-  .text:0000000180B8D772                 mov     ecx, 20F0h
-  .text:0000000180B8D777                 call    operator_new
-  .text:0000000180B8D77C                 test    rax, rax
-  .text:0000000180B8D77F                 jz      short loc_180B8D78B
-  .text:0000000180B8D781                 mov     rcx, rax
-  .text:0000000180B8D784                 call    CGameEntitySystem_ctor
-  .text:0000000180B8D789                 jmp     short loc_180B8D78E
-  .text:0000000180B8D78B                 mov     rax, r15
-  .text:0000000180B8D78E                 xor     r9d, r9d
-  .text:0000000180B8D791                 mov     [rsp+50h+var_30], r15b
-  .text:0000000180B8D796                 xor     r8d, r8d
-  .text:0000000180B8D799                 lea     rdx, aServerEntities; "server_entities"
-  .text:0000000180B8D7A0                 mov     rcx, rax
-  .text:0000000180B8D7A3                 call    CEntitySystem_PostCreateEntitySystem
-  .text:0000000180B8D7A8                 mov     rbx, cs:g_pEntitySystem
-  .text:0000000180B8D7AF                 mov     cs:g_pGameEntitySystem, rbx
-  .text:0000000180B8D7B6                 movsxd  r14, dword ptr [rbx+0B90h]  ; 0B90h = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
-  .text:0000000180B8D7BD                 cmp     r14d, [rbx+0BA0h]
-  .text:0000000180B8D7C4                 jnz     loc_180B8D88F
-  .text:0000000180B8D7CA                 test    dword ptr [rbx+0BA4h], 40000000h
-  .text:0000000180B8D7D4                 jnz     loc_180B8D88F
-  .text:0000000180B8D7DA                 mov     ecx, [rbx+0BA0h]
-  .text:0000000180B8D7E0                 cmp     ecx, 7FFFFFFEh
-  .text:0000000180B8D7E6                 jle     short loc_180B8D7F3
-  .text:0000000180B8D7E8                 mov     edx, 1
-  .text:0000000180B8D7ED                 call    cs:UtlVectorMemory_FailedAllocation
-  .text:0000000180B8D7F3                 mov     ecx, [rbx+0BA0h]
-  .text:0000000180B8D7F9                 mov     r9d, 8
-  .text:0000000180B8D7FF                 mov     edx, [rbx+0BA4h]
-  .text:0000000180B8D805                 and     edx, 3FFFFFFFh
-  .text:0000000180B8D80B                 lea     esi, [rcx+1]
-  .text:0000000180B8D80E                 mov     r8d, esi
-  .text:0000000180B8D811                 call    cs:UtlVectorMemory_CalcNewAllocationCount
-  .text:0000000180B8D817                 mov     edi, eax
-  .text:0000000180B8D819                 cmp     eax, esi
-  .text:0000000180B8D81B                 jge     short loc_180B8D83E
-  .text:0000000180B8D81D                 test    eax, eax
-  .text:0000000180B8D81F                 jnz     short loc_180B8D830
-  .text:0000000180B8D821                 cmp     esi, 0FFFFFFFFh
-  .text:0000000180B8D824                 jg      short loc_180B8D830
-  .text:0000000180B8D826                 mov     edi, 0FFFFFFFFh
-  .text:0000000180B8D82B                 jmp     short loc_180B8D83E
-  .text:0000000180B8D830                 lea     eax, [rdi+rsi]
-  .text:0000000180B8D833                 cdq
-  .text:0000000180B8D834                 sub     eax, edx
-  .text:0000000180B8D836                 sar     eax, 1
-  .text:0000000180B8D838                 mov     edi, eax
-  .text:0000000180B8D83A                 cmp     eax, esi
-  .text:0000000180B8D83C                 jl      short loc_180B8D830
-  .text:0000000180B8D83E                 movsxd  r9, dword ptr [rbx+0BA0h]
-  .text:0000000180B8D845                 mov     rcx, [rbx+0B98h]
-  .text:0000000180B8D84C                 shl     r9, 3
-  .text:0000000180B8D850                 movsxd  r8, edi
-  .text:0000000180B8D853                 shl     r8, 3
-  .text:0000000180B8D857                 test    dword ptr [rbx+0BA4h], 0C0000000h
-  .text:0000000180B8D861                 setz    dl
-  .text:0000000180B8D864                 call    cs:UtlVectorMemory_Alloc
-  .text:0000000180B8D86A                 mov     [rbx+0B98h], rax
-  .text:0000000180B8D871                 mov     eax, [rbx+0BA4h]
-  .text:0000000180B8D877                 test    eax, 0C0000000h
-  .text:0000000180B8D87C                 jz      short loc_180B8D889
-  .text:0000000180B8D87E                 and     eax, 3FFFFFFFh
-  .text:0000000180B8D883                 mov     [rbx+0BA4h], eax
-  .text:0000000180B8D889                 mov     [rbx+0BA0h], edi
-  .text:0000000180B8D88F                 inc     dword ptr [rbx+0B90h]
-  .text:0000000180B8D895                 lea     rdx, off_181C16478
-  .text:0000000180B8D89C                 mov     rax, [rbx+0B98h]
-  .text:0000000180B8D8A3                 mov     ecx, 1340h
-  .text:0000000180B8D8A8                 mov     [rax+r14*8], rdx
-  .text:0000000180B8D8AC                 call    operator_new
-  .text:0000000180B8D8B1                 test    rax, rax
-  .text:0000000180B8D8B4                 jz      short loc_180B8D8C3
-  .text:0000000180B8D8B6                 mov     rcx, rax
-  .text:0000000180B8D8B9                 call    sub_180B38C50
-  .text:0000000180B8D8BE                 mov     rdi, rax
-  .text:0000000180B8D8C1                 jmp     short loc_180B8D8C6
-  .text:0000000180B8D8C3                 mov     rdi, r15
-  .text:0000000180B8D8C6                 mov     rax, cs:g_pGameEntitySystem
-  .text:0000000180B8D8CD                 mov     rcx, rdi
-  .text:0000000180B8D8D0                 mov     [rax+20D8h], rdi
-  .text:0000000180B8D8D7                 mov     rax, [rdi]
-  .text:0000000180B8D8DA                 call    qword ptr [rax]
-  .text:0000000180B8D8DC                 mov     rax, [rdi]
-  .text:0000000180B8D8DF                 mov     rcx, cs:qword_181F65210
-  .text:0000000180B8D8E6                 mov     rbx, [rax+88h]
-  .text:0000000180B8D8ED                 mov     rax, [rcx]
-  .text:0000000180B8D8F0                 call    qword ptr [rax+0C0h]
-  .text:0000000180B8D8F6                 mov     rdx, rax
-  .text:0000000180B8D8F9                 mov     rcx, rdi
-  .text:0000000180B8D8FC                 call    rbx
-  .text:0000000180B8D8FE                 call    CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters
-  .text:0000000180B8D903                 mov     rcx, cs:g_pGameEntitySystem
-  .text:0000000180B8D90A                 mov     dl, 1
-  .text:0000000180B8D90C                 call    CEntitySystem_EnableAutoDeletionExecution
-  .text:0000000180B8D911                 mov     rcx, cs:qword_181F65210
-  .text:0000000180B8D918                 add     rcx, 8
-  .text:0000000180B8D91C                 mov     rax, [rcx]
-  .text:0000000180B8D91F                 call    qword ptr [rax+0A8h]
-  .text:0000000180B8D925                 test    al, al
-  .text:0000000180B8D927                 jnz     short loc_180B8D93D
-  .text:0000000180B8D929                 mov     rcx, cs:g_pVApplication
-  .text:0000000180B8D930                 mov     rax, [rcx]
-  .text:0000000180B8D933                 call    qword ptr [rax+0B0h]
-  .text:0000000180B8D939                 test    al, al
-  .text:0000000180B8D93B                 jz      short loc_180B8D963
-  .text:0000000180B8D93D                 mov     rcx, cs:g_pGameEntitySystem
-  .text:0000000180B8D944                 lea     rax, sub_180B68B10
-  .text:0000000180B8D94B                 mov     [rbp+var_18], rax
-  .text:0000000180B8D94F                 lea     rdx, [rbp+var_20]
-  .text:0000000180B8D953                 lea     rax, sub_180B56140
-  .text:0000000180B8D95A                 mov     [rbp+var_20], rax
-  .text:0000000180B8D95E                 call    CEntitySystem_InstallPostSpawnCallback
-  .text:0000000180B8D963                 mov     rcx, cs:g_pGameResourceService
-  .text:0000000180B8D96A                 test    rcx, rcx
-  .text:0000000180B8D96D                 jz      short loc_180B8D97F
-  .text:0000000180B8D96F                 mov     rax, [rcx]
-  .text:0000000180B8D972                 mov     rdx, cs:g_pGameEntitySystem
-  .text:0000000180B8D979                 call    qword ptr [rax+110h]
-  .text:0000000180B8D97F                 mov     rax, cs:g_pEntitySystem
-  .text:0000000180B8D986                 lea     rcx, [rbp+var_20]
-  .text:0000000180B8D98A                 mov     r14, cs:g_pGameEntitySystem
-  .text:0000000180B8D991                 mov     [rbp+var_18], 1388h
-  .text:0000000180B8D999                 mov     [rbp+var_10], r15b
-  .text:0000000180B8D99D                 mov     esi, [rax+278h]
-  .text:0000000180B8D9A3                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
-  .text:0000000180B8D9AA                 mov     [rbp+var_20], rax
-  .text:0000000180B8D9AE                 call    cs:ToolsStallMonitorInternal_BeginScope
-  .text:0000000180B8D9B4                 mov     ecx, 48h ; 'H'
-  .text:0000000180B8D9B9                 call    operator_new
-  .text:0000000180B8D9BE                 mov     rdi, rax
-  .text:0000000180B8D9C1                 test    rax, rax
-  .text:0000000180B8D9C4                 jz      short loc_180B8DA1C
-  .text:0000000180B8D9C6                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
-  .text:0000000180B8D9CD                 xor     edx, edx
-  .text:0000000180B8D9CF                 mov     [rdi], rax
-  .text:0000000180B8D9D2                 lea     rcx, [rdi+30h]
-  .text:0000000180B8D9D6                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
-  .text:0000000180B8D9DD                 mov     r8d, 1
-  .text:0000000180B8D9E3                 mov     [rdi+8], rax
-  .text:0000000180B8D9E7                 mov     [rdi+18h], r15
-  .text:0000000180B8D9EB                 mov     [rdi+20h], r15
-  .text:0000000180B8D9EF                 mov     [rdi+10h], r15d
-  .text:0000000180B8D9F3                 mov     [rdi+28h], r15b
-  .text:0000000180B8D9F7                 mov     [rdi+30h], r15d
-  .text:0000000180B8D9FB                 mov     [rdi+38h], r15
-  .text:0000000180B8D9FF                 call    sub_180B52ED0
-  .text:0000000180B8DA04                 mov     eax, 0FFFFh
-  .text:0000000180B8DA09                 mov     edx, esi
-  .text:0000000180B8DA0B                 mov     rcx, rdi
-  .text:0000000180B8DA0E                 mov     [rdi+40h], eax
-  .text:0000000180B8DA11                 mov     [rdi+44h], ax
-  .text:0000000180B8DA15                 call    sub_180B62730
-  .text:0000000180B8DA1A                 jmp     short loc_180B8DA1F
-  .text:0000000180B8DA1C                 mov     rdi, r15
-  .text:0000000180B8DA1F                 lea     rcx, [rbp+var_20]
-  .text:0000000180B8DA23                 mov     [r14+20E0h], rdi
-  .text:0000000180B8DA2A                 call    cs:ToolsStallMonitorInternal_EndScope
-  .text:0000000180B8DA30                 mov     rcx, cs:g_pEntitySystem
-  .text:0000000180B8DA37                 lea     rax, sub_180B4E030
-  .text:0000000180B8DA3E                 lea     rbx, sub_180B68B50
-  .text:0000000180B8DA45                 mov     [rbp+var_20], rax
-  .text:0000000180B8DA49                 lea     r8, [rbp+var_20]
-  .text:0000000180B8DA4D                 mov     [rbp+var_18], rbx
-  .text:0000000180B8DA51                 mov     dl, 28h ; '('
-  .text:0000000180B8DA53                 call    sub_1811FA820
-  .text:0000000180B8DA58                 mov     rcx, cs:g_pEntitySystem
-  .text:0000000180B8DA5F                 lea     rax, sub_180B4DFA0
-  .text:0000000180B8DA66                 lea     r8, [rbp+var_20]
-  .text:0000000180B8DA6A                 mov     [rbp+var_20], rax
-  .text:0000000180B8DA6E                 mov     dl, 36h ; '6'
-  .text:0000000180B8DA70                 mov     [rbp+var_18], rbx
-  .text:0000000180B8DA74                 call    sub_1811FA820
-  .text:0000000180B8DA79                 mov     rcx, cs:g_pEntitySystem
-  .text:0000000180B8DA80                 lea     rax, sub_180B4DF50
-  .text:0000000180B8DA87                 lea     r8, [rbp+var_20]
-  .text:0000000180B8DA8B                 mov     [rbp+var_20], rax
-  .text:0000000180B8DA8F                 mov     dl, 43h ; 'C'
-  .text:0000000180B8DA91                 mov     [rbp+var_18], rbx
-  .text:0000000180B8DA95                 call    sub_1811FA820
-  .text:0000000180B8DA9A                 mov     rcx, cs:g_pFlattenedSerializers
-  .text:0000000180B8DAA1                 lea     rdx, sub_180B68B20
-  .text:0000000180B8DAA8                 mov     rax, [rcx]
-  .text:0000000180B8DAAB                 mov     [rbp+var_18], rdx
-  .text:0000000180B8DAAF                 lea     rdx, unknown_libname_200; Microsoft VisualC v7/14 64bit runtime
-  .text:0000000180B8DAB6                 mov     [rbp+var_20], rdx
-  .text:0000000180B8DABA                 lea     rdx, [rbp+var_20]
-  .text:0000000180B8DABE                 call    qword ptr [rax+108h]
-  .text:0000000180B8DAC4                 mov     rbx, [rsp+50h+arg_0]
-  .text:0000000180B8DAC9                 mov     al, 1
-  .text:0000000180B8DACB                 mov     rsi, [rsp+50h+arg_8]
-  .text:0000000180B8DAD0                 mov     rdi, [rsp+50h+arg_10]
-  .text:0000000180B8DAD8                 add     rsp, 50h
-  .text:0000000180B8DADC                 pop     r15
-  .text:0000000180B8DADE                 pop     r14
-  .text:0000000180B8DAE0                 pop     rbp
-  .text:0000000180B8DAE1                 retn
+  .text:0000000180B8D780                 mov     [rsp-18h+arg_0], rbx
+  .text:0000000180B8D785                 mov     [rsp-18h+arg_8], rsi
+  .text:0000000180B8D78A                 mov     [rsp-18h+arg_10], rdi
+  .text:0000000180B8D78F                 push    rbp
+  .text:0000000180B8D790                 push    r14
+  .text:0000000180B8D792                 push    r15
+  .text:0000000180B8D794                 mov     rbp, rsp
+  .text:0000000180B8D797                 sub     rsp, 50h
+  .text:0000000180B8D79B                 mov     eax, cs:dword_1820B94A0
+  .text:0000000180B8D7A1                 xor     r15d, r15d
+  .text:0000000180B8D7A4                 mov     ecx, eax
+  .text:0000000180B8D7A6                 inc     eax
+  .text:0000000180B8D7A8                 mov     cs:dword_1820B94A0, eax
+  .text:0000000180B8D7AE                 test    ecx, ecx
+  .text:0000000180B8D7B0                 jg      short loc_180B8D7E8
+  .text:0000000180B8D7B2                 mov     ecx, 20F0h
+  .text:0000000180B8D7B7                 call    sub_180E7C960
+  .text:0000000180B8D7BC                 test    rax, rax
+  .text:0000000180B8D7BF                 jz      short loc_180B8D7CB
+  .text:0000000180B8D7C1                 mov     rcx, rax
+  .text:0000000180B8D7C4                 call    CGameEntitySystem_ctor
+  .text:0000000180B8D7C9                 jmp     short loc_180B8D7CE
+  .text:0000000180B8D7CB                 mov     rax, r15
+  .text:0000000180B8D7CE                 xor     r9d, r9d
+  .text:0000000180B8D7D1                 mov     [rsp+50h+var_30], r15b
+  .text:0000000180B8D7D6                 xor     r8d, r8d
+  .text:0000000180B8D7D9                 lea     rdx, aServerEntities; "server_entities"
+  .text:0000000180B8D7E0                 mov     rcx, rax
+  .text:0000000180B8D7E3                 call    CEntitySystem_PostCreateEntitySystem
+  .text:0000000180B8D7E8                 mov     rbx, cs:g_pEntitySystem
+  .text:0000000180B8D7EF                 mov     cs:g_pGameEntitySystem, rbx
+  .text:0000000180B8D7F6                 movsxd  r14, dword ptr [rbx+0B90h]
+  .text:0000000180B8D7FD                 cmp     r14d, [rbx+0BA0h]
+  .text:0000000180B8D804                 jnz     loc_180B8D8CF
+  .text:0000000180B8D80A                 test    dword ptr [rbx+0BA4h], 40000000h
+  .text:0000000180B8D814                 jnz     loc_180B8D8CF
+  .text:0000000180B8D81A                 mov     ecx, [rbx+0BA0h]
+  .text:0000000180B8D820                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180B8D826                 jle     short loc_180B8D833
+  .text:0000000180B8D828                 mov     edx, 1
+  .text:0000000180B8D82D                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180B8D833                 mov     ecx, [rbx+0BA0h]
+  .text:0000000180B8D839                 mov     r9d, 8
+  .text:0000000180B8D83F                 mov     edx, [rbx+0BA4h]
+  .text:0000000180B8D845                 and     edx, 3FFFFFFFh
+  .text:0000000180B8D84B                 lea     esi, [rcx+1]
+  .text:0000000180B8D84E                 mov     r8d, esi
+  .text:0000000180B8D851                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180B8D857                 mov     edi, eax
+  .text:0000000180B8D859                 cmp     eax, esi
+  .text:0000000180B8D85B                 jge     short loc_180B8D87E
+  .text:0000000180B8D85D                 test    eax, eax
+  .text:0000000180B8D85F                 jnz     short loc_180B8D870
+  .text:0000000180B8D861                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180B8D864                 jg      short loc_180B8D870
+  .text:0000000180B8D866                 mov     edi, 0FFFFFFFFh
+  .text:0000000180B8D86B                 jmp     short loc_180B8D87E
+  .text:0000000180B8D870                 lea     eax, [rdi+rsi]
+  .text:0000000180B8D873                 cdq
+  .text:0000000180B8D874                 sub     eax, edx
+  .text:0000000180B8D876                 sar     eax, 1
+  .text:0000000180B8D878                 mov     edi, eax
+  .text:0000000180B8D87A                 cmp     eax, esi
+  .text:0000000180B8D87C                 jl      short loc_180B8D870
+  .text:0000000180B8D87E                 movsxd  r9, dword ptr [rbx+0BA0h]
+  .text:0000000180B8D885                 ; 0xB98 = 2968LL = CEntitySystem::m_entityIONotifiers
+  .text:0000000180B8D885                 mov     rcx, [rbx+0B98h]; 0xB98 = 2968LL = CEntitySystem::m_entityIONotifiers
+  .text:0000000180B8D88C                 shl     r9, 3
+  .text:0000000180B8D890                 movsxd  r8, edi
+  .text:0000000180B8D893                 shl     r8, 3
+  .text:0000000180B8D897                 test    dword ptr [rbx+0BA4h], 0C0000000h
+  .text:0000000180B8D8A1                 setz    dl
+  .text:0000000180B8D8A4                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180B8D8AA                 mov     [rbx+0B98h], rax
+  .text:0000000180B8D8B1                 mov     eax, [rbx+0BA4h]
+  .text:0000000180B8D8B7                 test    eax, 0C0000000h
+  .text:0000000180B8D8BC                 jz      short loc_180B8D8C9
+  .text:0000000180B8D8BE                 and     eax, 3FFFFFFFh
+  .text:0000000180B8D8C3                 mov     [rbx+0BA4h], eax
+  .text:0000000180B8D8C9                 mov     [rbx+0BA0h], edi
+  .text:0000000180B8D8CF                 inc     dword ptr [rbx+0B90h]
+  .text:0000000180B8D8D5                 lea     rdx, off_181C16478
+  .text:0000000180B8D8DC                 mov     rax, [rbx+0B98h]
+  .text:0000000180B8D8E3                 mov     ecx, 1340h
+  .text:0000000180B8D8E8                 mov     [rax+r14*8], rdx
+  .text:0000000180B8D8EC                 call    sub_180E7C960
+  .text:0000000180B8D8F1                 test    rax, rax
+  .text:0000000180B8D8F4                 jz      short loc_180B8D903
+  .text:0000000180B8D8F6                 mov     rcx, rax
+  .text:0000000180B8D8F9                 call    sub_180B38C90
+  .text:0000000180B8D8FE                 mov     rdi, rax
+  .text:0000000180B8D901                 jmp     short loc_180B8D906
+  .text:0000000180B8D903                 mov     rdi, r15
+  .text:0000000180B8D906                 mov     rax, cs:g_pGameEntitySystem
+  .text:0000000180B8D90D                 mov     rcx, rdi
+  .text:0000000180B8D910                 mov     [rax+20D8h], rdi
+  .text:0000000180B8D917                 mov     rax, [rdi]
+  .text:0000000180B8D91A                 call    qword ptr [rax]
+  .text:0000000180B8D91C                 mov     rax, [rdi]
+  .text:0000000180B8D91F                 mov     rcx, cs:qword_181F65290
+  .text:0000000180B8D926                 mov     rbx, [rax+88h]
+  .text:0000000180B8D92D                 mov     rax, [rcx]
+  .text:0000000180B8D930                 call    qword ptr [rax+0C0h]
+  .text:0000000180B8D936                 mov     rdx, rax
+  .text:0000000180B8D939                 mov     rcx, rdi
+  .text:0000000180B8D93C                 call    rbx
+  .text:0000000180B8D93E                 ; CGameEntitySystem_RegisterSpawnGroupEntityFilter
+  .text:0000000180B8D93E                 call    CGameEntitySystem_RegisterSpawnGroupEntityFilter; CGameEntitySystem_RegisterSpawnGroupEntityFilter
+  .text:0000000180B8D943                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180B8D94A                 mov     dl, 1
+  .text:0000000180B8D94C                 call    CEntitySystem_EnableAutoDeletionExecution
+  .text:0000000180B8D951                 mov     rcx, cs:qword_181F65290
+  .text:0000000180B8D958                 add     rcx, 8
+  .text:0000000180B8D95C                 mov     rax, [rcx]
+  .text:0000000180B8D95F                 call    qword ptr [rax+0A8h]
+  .text:0000000180B8D965                 test    al, al
+  .text:0000000180B8D967                 jnz     short loc_180B8D97D
+  .text:0000000180B8D969                 mov     rcx, cs:g_pVApplication
+  .text:0000000180B8D970                 mov     rax, [rcx]
+  .text:0000000180B8D973                 call    qword ptr [rax+0B0h]
+  .text:0000000180B8D979                 test    al, al
+  .text:0000000180B8D97B                 jz      short loc_180B8D9A3
+  .text:0000000180B8D97D                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180B8D984                 lea     rax, sub_180B68B50
+  .text:0000000180B8D98B                 mov     [rbp+var_18], rax
+  .text:0000000180B8D98F                 lea     rdx, [rbp+var_20]
+  .text:0000000180B8D993                 lea     rax, sub_180B56180
+  .text:0000000180B8D99A                 mov     [rbp+var_20], rax
+  .text:0000000180B8D99E                 call    CEntitySystem_InstallPostSpawnCallback
+  .text:0000000180B8D9A3                 mov     rcx, cs:g_pGameResourceService
+  .text:0000000180B8D9AA                 test    rcx, rcx
+  .text:0000000180B8D9AD                 jz      short loc_180B8D9BF
+  .text:0000000180B8D9AF                 mov     rax, [rcx]
+  .text:0000000180B8D9B2                 mov     rdx, cs:g_pGameEntitySystem
+  .text:0000000180B8D9B9                 ; 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+  .text:0000000180B8D9B9                 call    qword ptr [rax+110h]; 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+  .text:0000000180B8D9BF                 mov     rax, cs:g_pEntitySystem
+  .text:0000000180B8D9C6                 lea     rcx, [rbp+var_20]
+  .text:0000000180B8D9CA                 mov     r14, cs:g_pGameEntitySystem
+  .text:0000000180B8D9D1                 mov     [rbp+var_18], 1388h
+  .text:0000000180B8D9D9                 mov     [rbp+var_10], r15b
+  .text:0000000180B8D9DD                 mov     esi, [rax+278h]
+  .text:0000000180B8D9E3                 lea     rax, aCgameentitysys_0; "CGameEntitySystem::InitEntity2NetworkCl"...
+  .text:0000000180B8D9EA                 mov     [rbp+var_20], rax
+  .text:0000000180B8D9EE                 call    cs:ToolsStallMonitorInternal_BeginScope
+  .text:0000000180B8D9F4                 mov     ecx, 48h ; 'H'
+  .text:0000000180B8D9F9                 call    sub_180E7C960
+  .text:0000000180B8D9FE                 mov     rdi, rax
+  .text:0000000180B8DA01                 test    rax, rax
+  .text:0000000180B8DA04                 jz      short loc_180B8DA5C
+  .text:0000000180B8DA06                 lea     rax, ??_7CEntity2NetworkClasses@@6B@; const CEntity2NetworkClasses::`vftable'
+  .text:0000000180B8DA0D                 xor     edx, edx
+  .text:0000000180B8DA0F                 mov     [rdi], rax
+  .text:0000000180B8DA12                 lea     rcx, [rdi+30h]
+  .text:0000000180B8DA16                 lea     rax, ??_7CEntity2NetworkClasses@@6B@_0; const CEntity2NetworkClasses::`vftable'
+  .text:0000000180B8DA1D                 mov     r8d, 1
+  .text:0000000180B8DA23                 mov     [rdi+8], rax
+  .text:0000000180B8DA27                 mov     [rdi+18h], r15
+  .text:0000000180B8DA2B                 mov     [rdi+20h], r15
+  .text:0000000180B8DA2F                 mov     [rdi+10h], r15d
+  .text:0000000180B8DA33                 mov     [rdi+28h], r15b
+  .text:0000000180B8DA37                 mov     [rdi+30h], r15d
+  .text:0000000180B8DA3B                 mov     [rdi+38h], r15
+  .text:0000000180B8DA3F                 call    sub_180B52F10
+  .text:0000000180B8DA44                 mov     eax, 0FFFFh
+  .text:0000000180B8DA49                 mov     edx, esi
+  .text:0000000180B8DA4B                 mov     rcx, rdi
+  .text:0000000180B8DA4E                 mov     [rdi+40h], eax
+  .text:0000000180B8DA51                 mov     [rdi+44h], ax
+  .text:0000000180B8DA55                 call    sub_180B62770
+  .text:0000000180B8DA5A                 jmp     short loc_180B8DA5F
+  .text:0000000180B8DA5C                 mov     rdi, r15
+  .text:0000000180B8DA5F                 lea     rcx, [rbp+var_20]
+  .text:0000000180B8DA63                 mov     [r14+20E0h], rdi
+  .text:0000000180B8DA6A                 call    cs:ToolsStallMonitorInternal_EndScope
+  .text:0000000180B8DA70                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DA77                 lea     rax, sub_180B4E070
+  .text:0000000180B8DA7E                 lea     rbx, sub_180B68B90
+  .text:0000000180B8DA85                 mov     [rbp+var_20], rax
+  .text:0000000180B8DA89                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DA8D                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DA91                 mov     dl, 28h ; '('
+  .text:0000000180B8DA93                 call    CEntitySystem_InstallCreationWrapperCallbacks
+  .text:0000000180B8DA98                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DA9F                 lea     rax, sub_180B4DFE0
+  .text:0000000180B8DAA6                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DAAA                 mov     [rbp+var_20], rax
+  .text:0000000180B8DAAE                 mov     dl, 36h ; '6'
+  .text:0000000180B8DAB0                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DAB4                 call    CEntitySystem_InstallCreationWrapperCallbacks
+  .text:0000000180B8DAB9                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B8DAC0                 lea     rax, sub_180B4DF90
+  .text:0000000180B8DAC7                 lea     r8, [rbp+var_20]
+  .text:0000000180B8DACB                 mov     [rbp+var_20], rax
+  .text:0000000180B8DACF                 mov     dl, 43h ; 'C'
+  .text:0000000180B8DAD1                 mov     [rbp+var_18], rbx
+  .text:0000000180B8DAD5                 call    CEntitySystem_InstallCreationWrapperCallbacks
+  .text:0000000180B8DADA                 mov     rcx, cs:g_pFlattenedSerializers
+  .text:0000000180B8DAE1                 lea     rdx, sub_180B68B60
+  .text:0000000180B8DAE8                 mov     rax, [rcx]
+  .text:0000000180B8DAEB                 mov     [rbp+var_18], rdx
+  .text:0000000180B8DAEF                 lea     rdx, unknown_libname_200; Microsoft VisualC v7/14 64bit runtime
+  .text:0000000180B8DAF6                 mov     [rbp+var_20], rdx
+  .text:0000000180B8DAFA                 lea     rdx, [rbp+var_20]
+  .text:0000000180B8DAFE                 call    qword ptr [rax+108h]
+  .text:0000000180B8DB04                 mov     rbx, [rsp+50h+arg_0]
+  .text:0000000180B8DB09                 mov     al, 1
+  .text:0000000180B8DB0B                 mov     rsi, [rsp+50h+arg_8]
+  .text:0000000180B8DB10                 mov     rdi, [rsp+50h+arg_10]
+  .text:0000000180B8DB18                 add     rsp, 50h
+  .text:0000000180B8DB1C                 pop     r15
+  .text:0000000180B8DB1E                 pop     r14
+  .text:0000000180B8DB20                 pop     rbp
+  .text:0000000180B8DB21                 retn
 procedure: |-
   char CSource2EntitySystem_StaticInit()
   {
     int v0; // ecx
     __int64 v1; // rax
-    __int64 v2; // rax
+    int v2; // eax
     __int64 v3; // rbx
     __int64 v4; // r14
     __int64 v5; // rcx
@@ -231,31 +234,32 @@ procedure: |-
     __int64 v13; // rdi
     void (__fastcall *v14)(__int64, __int64); // rbx
     __int64 v15; // rax
-    __int64 v16; // r14
-    unsigned int v17; // esi
-    __int64 v18; // rax
-    __int64 v19; // rdi
-    __int64 v20; // rdx
+    __int64 v16; // rdx
+    __int64 v17; // r14
+    unsigned int v18; // esi
+    __int64 v19; // rax
+    __int64 v20; // rdi
     __int64 v21; // rdx
     __int64 v22; // rdx
-    __int64 v23; // rax
-    __int64 (__fastcall *v25)(unsigned int, __int64); // [rsp+30h] [rbp-20h] BYREF
-    __int64 v26; // [rsp+38h] [rbp-18h]
-    char v27; // [rsp+40h] [rbp-10h]
+    __int64 v23; // rdx
+    __int64 v24; // rax
+    const char *v26; // [rsp+30h] [rbp-20h] BYREF
+    __int64 v27; // [rsp+38h] [rbp-18h]
+    char v28; // [rsp+40h] [rbp-10h]
 
-    v0 = dword_1820B9400++;
+    v0 = dword_1820B94A0++;
     if ( v0 <= 0 )
     {
-      v1 = operator_new(8432);
+      v1 = sub_180E7C960(8432);
       if ( v1 )
         v2 = CGameEntitySystem_ctor(v1);
       else
         v2 = 0;
-      CEntitySystem_PostCreateEntitySystem(v2, "server_entities", 0, 0, 0);
+      CEntitySystem_PostCreateEntitySystem(v2, (unsigned int)"server_entities", 0, 0, 0);
     }
     v3 = g_pEntitySystem;
     g_pGameEntitySystem = g_pEntitySystem;
-    v4 = *(int *)(g_pEntitySystem + 2960);  // 2960 = 0xB90 = CEntitySystem_m_entityIONotifiers (structmember, struct=CEntitySystem, member=m_entityIONotifiers)
+    v4 = *(int *)(g_pEntitySystem + 2960);
     if ( (_DWORD)v4 == *(_DWORD *)(g_pEntitySystem + 2976) && (*(_DWORD *)(g_pEntitySystem + 2980) & 0x40000000) == 0 )
     {
       v5 = *(unsigned int *)(g_pEntitySystem + 2976);
@@ -282,7 +286,7 @@ procedure: |-
         }
       }
       LOBYTE(v9) = (*(_DWORD *)(v3 + 2980) & 0xC0000000) == 0;
-      *(_QWORD *)(v3 + 2968) = UtlVectorMemory_Alloc(*(_QWORD *)(v3 + 2968), v9, 8LL * v10, 8LL * *(int *)(v3 + 2976));
+      *(_QWORD *)(v3 + 2968) = UtlVectorMemory_Alloc(*(_QWORD *)(v3 + 2968), v9, 8LL * v10, 8LL * *(int *)(v3 + 2976));// 0xB98 = 2968LL = CEntitySystem::m_entityIONotifiers
       v11 = *(_DWORD *)(v3 + 2980);
       if ( (v11 & 0xC0000000) != 0 )
         *(_DWORD *)(v3 + 2980) = v11 & 0x3FFFFFFF;
@@ -290,76 +294,74 @@ procedure: |-
     }
     ++*(_DWORD *)(v3 + 2960);
     *(_QWORD *)(*(_QWORD *)(v3 + 2968) + 8 * v4) = &off_181C16478;
-    v12 = operator_new(4928);
+    v12 = sub_180E7C960(4928);
     if ( v12 )
-      v13 = sub_180B38C50(v12);
+      v13 = sub_180B38C90(v12);
     else
       v13 = 0;
     *(_QWORD *)(g_pGameEntitySystem + 8408) = v13;
     (**(void (__fastcall ***)(__int64))v13)(v13);
     v14 = *(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v13 + 136LL);
-    v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_181F65210 + 192LL))(qword_181F65210);
+    v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_181F65290 + 192LL))(qword_181F65290);
     v14(v13, v15);
-    CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters();
-    CEntitySystem_EnableAutoDeletionExecution(g_pGameEntitySystem, 1);
-    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_181F65210 + 8) + 168LL))(qword_181F65210 + 8)
+    sub_180B7B020();                              // CGameEntitySystem_RegisterSpawnGroupEntityFilter
+    LOBYTE(v16) = 1;
+    CEntitySystem_EnableAutoDeletionExecution(g_pGameEntitySystem, v16);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)(qword_181F65290 + 8) + 168LL))(qword_181F65290 + 8)
       || (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 176LL))(g_pVApplication) )
     {
-      v26 = (__int64)sub_180B68B10;
-      v25 = sub_180B56140;
-      CEntitySystem_InstallPostSpawnCallback(g_pGameEntitySystem, (__int64 *)&v25);
+      v27 = (__int64)sub_180B68B50;
+      v26 = (const char *)sub_180B56180;
+      CEntitySystem_InstallPostSpawnCallback(g_pGameEntitySystem, &v26);
     }
     if ( g_pGameResourceService )
-      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService
-                                               + 272LL))(// IGameResourceService_SetEntityResourceManifestHandler
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameResourceService + 272LL))(
         g_pGameResourceService,
-        g_pGameEntitySystem);
-    v16 = g_pGameEntitySystem;
-    v26 = 5000;
-    v27 = 0;
-    v17 = *(_DWORD *)(g_pEntitySystem + 632);
-    v25 = (__int64 (__fastcall *)(unsigned int, __int64))"CGameEntitySystem::InitEntity2NetworkClasses";
-    ToolsStallMonitorInternal_BeginScope(&v25);
-    v18 = operator_new(72);
-    v19 = v18;
-    if ( v18 )
+        g_pGameEntitySystem);                     // 0x110 = 272LL = IGameResourceService_SetEntityResourceManifestHandler
+    v17 = g_pGameEntitySystem;
+    v27 = 5000;
+    v28 = 0;
+    v18 = *(_DWORD *)(g_pEntitySystem + 632);
+    v26 = "CGameEntitySystem::InitEntity2NetworkClasses";
+    ToolsStallMonitorInternal_BeginScope(&v26);
+    v19 = sub_180E7C960(72);
+    v20 = v19;
+    if ( v19 )
     {
-      *(_QWORD *)v18 = &CEntity2NetworkClasses::`vftable';
-      *(_QWORD *)(v18 + 8) = &CEntity2NetworkClasses::`vftable';
-      *(_QWORD *)(v18 + 24) = 0;
-      *(_QWORD *)(v18 + 32) = 0;
-      *(_DWORD *)(v18 + 16) = 0;
-      *(_BYTE *)(v18 + 40) = 0;
-      *(_DWORD *)(v18 + 48) = 0;
-      *(_QWORD *)(v18 + 56) = 0;
-      sub_180B52ED0(v18 + 48, 0, 1);
-      *(_DWORD *)(v19 + 64) = 0xFFFF;
-      *(_WORD *)(v19 + 68) = -1;
-      sub_180B62730(v19, v17);
+      *(_QWORD *)v19 = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v19 + 8) = &CEntity2NetworkClasses::`vftable';
+      *(_QWORD *)(v19 + 24) = 0;
+      *(_QWORD *)(v19 + 32) = 0;
+      *(_DWORD *)(v19 + 16) = 0;
+      *(_BYTE *)(v19 + 40) = 0;
+      *(_DWORD *)(v19 + 48) = 0;
+      *(_QWORD *)(v19 + 56) = 0;
+      sub_180B52F10(v19 + 48, 0, 1);
+      *(_DWORD *)(v20 + 64) = 0xFFFF;
+      *(_WORD *)(v20 + 68) = -1;
+      sub_180B62770(v20, v18);
     }
     else
     {
-      v19 = 0;
+      v20 = 0;
     }
-    *(_QWORD *)(v16 + 8416) = v19;
-    ToolsStallMonitorInternal_EndScope(&v25);
-    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4E030;
-    v26 = (__int64)sub_180B68B50;
-    LOBYTE(v20) = 40;
-    sub_1811FA820(g_pEntitySystem, v20, &v25);
-    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4DFA0;
-    LOBYTE(v21) = 54;
-    v26 = (__int64)sub_180B68B50;
-    sub_1811FA820(g_pEntitySystem, v21, &v25);
-    v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4DF50;
-    LOBYTE(v22) = 67;
-    v26 = (__int64)sub_180B68B50;
-    sub_1811FA820(g_pEntitySystem, v22, &v25);
-    v23 = *(_QWORD *)g_pFlattenedSerializers;
-    v26 = (__int64)sub_180B68B20;
-    v25 = (__int64 (__fastcall *)(unsigned int, __int64))unknown_libname_200;
-    (*(void (__fastcall **)(__int64, __int64 (__fastcall **)(unsigned int, __int64)))(v23 + 264))(
-      g_pFlattenedSerializers,
-      &v25);
+    *(_QWORD *)(v17 + 8416) = v20;
+    ToolsStallMonitorInternal_EndScope(&v26);
+    v26 = (const char *)sub_180B4E070;
+    v27 = (__int64)sub_180B68B90;
+    LOBYTE(v21) = 40;
+    CEntitySystem_InstallCreationWrapperCallbacks(g_pEntitySystem, v21, &v26);
+    v26 = (const char *)sub_180B4DFE0;
+    LOBYTE(v22) = 54;
+    v27 = (__int64)sub_180B68B90;
+    CEntitySystem_InstallCreationWrapperCallbacks(g_pEntitySystem, v22, &v26);
+    v26 = (const char *)sub_180B4DF90;
+    LOBYTE(v23) = 67;
+    v27 = (__int64)sub_180B68B90;
+    CEntitySystem_InstallCreationWrapperCallbacks(g_pEntitySystem, v23, &v26);
+    v24 = *(_QWORD *)g_pFlattenedSerializers;
+    v27 = (__int64)sub_180B68B60;
+    v26 = (const char *)unknown_libname_200;
+    (*(void (__fastcall **)(__int64, const char **))(v24 + 264))(g_pFlattenedSerializers, &v26);
     return 1;
   }


### PR DESCRIPTION
## Summary

- Added `CGameEntitySystem_RegisterSpawnGroupEntityFilter` as a new expected output of `find-CSource2EntitySystem_StaticInit-decompiles`; regenerated its reference YAMLs (server win/linux, client win) to include the call site
- New preprocessor script `find-CGameEntitySystem_m_spawnGroupEntityFilters` using **Pattern E** (struct member offset via LLM_DECOMPILE of `CGameEntitySystem_RegisterSpawnGroupEntityFilter`)
- `config.yaml`: new skill entry with dependency chain, symbol entries for both `CGameEntitySystem_RegisterSpawnGroupEntityFilter` (func) and `CGameEntitySystem_m_spawnGroupEntityFilters` (structmember)
- Generated reference YAMLs for `CGameEntitySystem_RegisterSpawnGroupEntityFilter` on both platforms, with corrected struct annotation (`CGameEntitySystem`, not `CEntitySystem` as IDA had it)
- **Offsets differ by platform**: Windows `0x2098` (8344), Linux `0x20A8` (8360)

## Test plan

- [ ] `ida_analyze_bin.py -debug` reports 0 failures
- [ ] `bin/14165/server/CGameEntitySystem_RegisterSpawnGroupEntityFilter.{windows,linux}.yaml` exist
- [ ] `bin/14165/server/CGameEntitySystem_m_spawnGroupEntityFilters.{windows,linux}.yaml` exist with correct offsets