### PR TITLE
Refactor find-CGameEntitySystem_OnAddEntity to INHERIT_VFUNCS (Pattern F)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5138,7 +5138,7 @@ modules:
         expected_output:
           - CGameEntitySystem_OnAddEntity.{platform}.yaml
         expected_input:
-          - CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml
+          - CEntitySystem_OnAddEntity.{platform}.yaml
           - CGameEntitySystem_vtable.{platform}.yaml
 
       - name: find-CGameEntitySystem_m_iNetworkedEntCount-AND-CGameEntitySystem_m_iNonNetworkedSavedEntCount-AND-CGameEntitySystem_m_entityListeners

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_OnAddEntity.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_OnAddEntity.py
@@ -3,22 +3,9 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CGameEntitySystem_OnAddEntity",
-]
-
-LLM_DECOMPILE = [
-    # (symbol_name, path_to_prompt, path_to_reference)
-    (
-        "CGameEntitySystem_OnAddEntity",
-        "prompt/call_llm_decompile.md",
-        "references/server/CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml",
-    ),
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
-    ("CGameEntitySystem_OnAddEntity", "CGameEntitySystem"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CGameEntitySystem_OnAddEntity", "CGameEntitySystem", "CEntitySystem_OnAddEntity", True),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -30,20 +17,21 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_va",
             "func_rva",
             "func_size",
-            "vfunc_sig",    # REQUIRED -- never omit for Pattern C
+            "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+    new_binary_dir, platform, image_base, debug=False,
 ):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
 
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -51,10 +39,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )


### PR DESCRIPTION
## Summary
- Switch `find-CGameEntitySystem_OnAddEntity` from LLM_DECOMPILE (Pattern C) to INHERIT_VFUNCS (Pattern F standard)
- `CGameEntitySystem` inherits from `CEntitySystem`, so `OnAddEntity` occupies the same vtable slot as `CEntitySystem_OnAddEntity` — no decompilation needed
- Update `config.yaml` `expected_input` to reference `CEntitySystem_OnAddEntity.{platform}.yaml` instead of `CEntitySystem_AddEntityToEntityDataBase.{platform}.yaml`

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)