### PR TITLE
feat(server): add CEntitySystem_UpdateOnRemove vfunc preprocessor

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5569,12 +5569,14 @@ modules:
         expected_input:
           - EntInfo_CommandHandler.{platform}.yaml
 
-      - name: find-CEntitySystem_OnRemoveEntityFromDatabase-AND-CEntitySystem_DoDestructEntity
+      - name: find-CEntitySystem_DestroyEntityImmediate-decompiles
         expected_output:
           - CEntitySystem_OnRemoveEntityFromDatabase.{platform}.yaml
           - CEntitySystem_DoDestructEntity.{platform}.yaml
+          - CEntitySystem_UpdateOnRemove.{platform}.yaml
         expected_input:
           - CEntitySystem_DestroyEntityImmediate.{platform}.yaml
+          - CEntitySystem_vtable.{platform}.yaml
 
       - name: find-CEntitySystem_m_nSuppressDestroyImmediateCount-AND-CEntitySystem_m_nSuppressAutoDeletionExecutionCount-AND-CEntitySystem_m_bEnableAutoDeletionExecution
         expected_output:
@@ -9947,6 +9949,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::DoDestructEntity
+
+      - name: CEntitySystem_UpdateOnRemove
+        category: vfunc
+        alias:
+          - CEntitySystem::UpdateOnRemove
 
       - name: ClientPrintToController
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_DestroyEntityImmediate-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_DestroyEntityImmediate-decompiles.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CEntitySystem_OnRemoveEntityFromDatabase-AND-CEntitySystem_DoDestructEntity skill."""
+"""Preprocess script for find-CEntitySystem_DestroyEntityImmediate-decompiles skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "CEntitySystem_OnRemoveEntityFromDatabase",
     "CEntitySystem_DoDestructEntity",
+    "CEntitySystem_UpdateOnRemove",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySystem_UpdateOnRemove", "CEntitySystem"),
 ]
 
 LLM_DECOMPILE = [
@@ -17,6 +23,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_DoDestructEntity",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_DestroyEntityImmediate.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_UpdateOnRemove",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_DestroyEntityImmediate.{platform}.yaml",
     ),
@@ -44,13 +55,26 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_size",
         ],
     ),
+    (
+        "CEntitySystem_UpdateOnRemove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
     new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Reuse previous gamever func_sig/vfunc_sig to locate target function(s) and write YAML."""
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -59,6 +83,7 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
         llm_decompile_specs=LLM_DECOMPILE,
         llm_config=llm_config,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_DestroyEntityImmediate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_DestroyEntityImmediate.linux.yaml
@@ -37,7 +37,7 @@ disasm_code: |-
   .text:0000000001E641BD                 mov     rax, [rdi]
   .text:0000000001E641C0                 lea     rdx, sub_1E4F560
   .text:0000000001E641C7                 mov     [rbp-38h], rsi
-  .text:0000000001E641CB                 mov     rax, [rax+0C0h]
+  .text:0000000001E641CB                 mov     rax, [rax+0C0h]  ; 0C0h = CEntitySystem_UpdateOnRemove
   .text:0000000001E641D2                 cmp     rax, rdx
   .text:0000000001E641D5                 jnz     loc_1E643B8
   .text:0000000001E641DB                 lea     r15, g_pResourceSystem
@@ -219,7 +219,7 @@ procedure: |-
             {
               v7 = *a1;
               v18 = a2;
-              v8 = *(__int64 (__fastcall **)(__int64, int, __int64 **))(v7 + 192);
+              v8 = *(__int64 (__fastcall **)(__int64, int, __int64 **))(v7 + 192);  // 192LL = 0xC0 = CEntitySystem_UpdateOnRemove
               if ( v8 == sub_1E4F560 )
               {
                 if ( g_pResourceSystem )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_DestroyEntityImmediate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_DestroyEntityImmediate.windows.yaml
@@ -92,7 +92,7 @@ disasm_code: |-
   .text:00000001811EA595                 lea     r8, [rsp+48h+arg_8]
   .text:00000001811EA59A                 mov     edx, 1
   .text:00000001811EA59F                 mov     [rsp+48h+arg_8], r14
-  .text:00000001811EA5A4                 call    qword ptr [rax+0B8h]
+  .text:00000001811EA5A4                 call    qword ptr [rax+0B8h]  ; 0B8h = CEntitySystem_UpdateOnRemove
   .text:00000001811EA5AA                 mov     rdx, r14
   .text:00000001811EA5AD                 mov     rcx, rdi
   .text:00000001811EA5B0                 call    CEntitySystem_OnRemoveEntityFromDatabase
@@ -190,7 +190,7 @@ procedure: |-
             {
               v15 = *(_QWORD *)a1;
               v17 = a2;
-              (*(void (__fastcall **)(__int64, __int64, __int64 *))(v15 + 184))(a1, 1, &v17);// (numEntities, entities)?
+              (*(void (__fastcall **)(__int64, __int64, __int64 *))(v15 + 184))(a1, 1, &v17);// 184LL = 0xB8 = CEntitySystem_UpdateOnRemove
             }
             CEntitySystem_OnRemoveEntityFromDatabase((__int64 *)a1, a2);
           }


### PR DESCRIPTION
## Summary

- Renamed `find-CEntitySystem_OnRemoveEntityFromDatabase-AND-CEntitySystem_DoDestructEntity` skill to `find-CEntitySystem_DestroyEntityImmediate-decompiles`
- Added `CEntitySystem_UpdateOnRemove` as a new LLM_DECOMPILE vfunc target (Pattern C) discovered from `CEntitySystem_DestroyEntityImmediate`
- Annotated reference YAMLs with vfunc offsets: `0xB8` (Windows) / `0xC0` (Linux)

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)