### PR TITLE
feat(server): add find-CEntitySystem_AddEntityIOEventToQueue and find-CEntitySystem_m_EventQueue preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5796,6 +5796,20 @@ modules:
         expected_input:
           - CEntitySystem_AddEntityIOEvent.{platform}.yaml
 
+      - name: find-CEntitySystem_AddEntityIOEventToQueue
+        expected_output:
+          - CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml
+        expected_input_windows:
+          - CEntitySystem_AddEntityIOEvent.{platform}.yaml
+        expected_input_linux:
+          - CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml
+
+      - name: find-CEntitySystem_m_EventQueue
+        expected_output:
+          - CEntitySystem_m_EventQueue.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml
+
       - name: find-CGameEntitySystem_FindEntityByClassName
         expected_output:
           - CGameEntitySystem_FindEntityByClassName.{platform}.yaml
@@ -9403,6 +9417,18 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddEntityIOEventBuildStruct
+
+      - name: CEntitySystem_AddEntityIOEventToQueue
+        category: func
+        alias:
+          - CEntitySystem::AddEntityIOEventToQueue
+
+      - name: CEntitySystem_m_EventQueue
+        category: structmember
+        struct: CEntitySystem
+        member: m_EventQueue
+        alias:
+          - CEntitySystem::m_EventQueue
 
       - name: CGameEntitySystem_FindEntityByClassName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5789,6 +5789,13 @@ modules:
         expected_input:
           - CMomentaryRotButton_Use.{platform}.yaml
 
+      - name: find-CEntitySystem_AddEntityIOEventBuildStruct-linux
+        platform: linux
+        expected_output:
+          - CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEvent.{platform}.yaml
+
       - name: find-CGameEntitySystem_FindEntityByClassName
         expected_output:
           - CGameEntitySystem_FindEntityByClassName.{platform}.yaml
@@ -9391,6 +9398,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddEntityIOEvent2
+
+      - name: CEntitySystem_AddEntityIOEventBuildStruct
+        category: func
+        alias:
+          - CEntitySystem::AddEntityIOEventBuildStruct
 
       - name: CGameEntitySystem_FindEntityByClassName
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventBuildStruct-linux.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventBuildStruct-linux.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddEntityIOEventBuildStruct-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddEntityIOEventBuildStruct",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_AddEntityIOEventBuildStruct",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEvent.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddEntityIOEventBuildStruct",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddEntityIOEventToQueue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddEntityIOEventToQueue",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddEntityIOEventToQueue",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    if platform == "windows":
+        llm_decompile_specs = [
+            (
+                "CEntitySystem_AddEntityIOEventToQueue",
+                "prompt/call_llm_decompile.md",
+                "references/server/CEntitySystem_AddEntityIOEvent.windows.yaml",
+            ),
+        ]
+    else:
+        llm_decompile_specs = [
+            (
+                "CEntitySystem_AddEntityIOEventToQueue",
+                "prompt/call_llm_decompile.md",
+                "references/server/CEntitySystem_AddEntityIOEventBuildStruct.linux.yaml",
+            ),
+        ]
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=llm_decompile_specs,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_EventQueue.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_EventQueue.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_EventQueue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_EventQueue",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CEntitySystem_m_EventQueue",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEntitySystem_m_EventQueue",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.linux.yaml
@@ -1,0 +1,113 @@
+func_name: CEntitySystem_AddEntityIOEvent
+func_va: '0x1e744c0'
+disasm_code: |-
+  .text:0000000001E744C0                 push    rbp
+  .text:0000000001E744C1                 mov     rbp, rsp
+  .text:0000000001E744C4                 push    r13
+  .text:0000000001E744C6                 mov     r13, rcx
+  .text:0000000001E744C9                 push    r12
+  .text:0000000001E744CB                 mov     r12, rdi
+  .text:0000000001E744CE                 push    rbx
+  .text:0000000001E744CF                 mov     ebx, 0FFFFFFFFh
+  .text:0000000001E744D4                 sub     rsp, 38h
+  .text:0000000001E744D8                 test    rsi, rsi
+  .text:0000000001E744DB                 jz      short loc_1E7450E
+  .text:0000000001E744DD                 mov     rax, [rsi+10h]
+  .text:0000000001E744E1                 test    rax, rax
+  .text:0000000001E744E4                 jz      short loc_1E7450E
+  .text:0000000001E744E6                 mov     ebx, [rax+10h]
+  .text:0000000001E744E9                 mov     ecx, [rax+30h]
+  .text:0000000001E744EC                 shr     ebx, 0Fh
+  .text:0000000001E744EF                 and     ecx, 1
+  .text:0000000001E744F2                 sub     ebx, ecx
+  .text:0000000001E744F4                 cmp     dword ptr [rax+10h], 0FFFFFFFFh
+  .text:0000000001E744F8                 jz      loc_1E74588
+  .text:0000000001E744FE                 movzx   eax, word ptr [rax+10h]
+  .text:0000000001E74502                 and     ax, 7FFFh
+  .text:0000000001E74506                 shl     ebx, 0Fh
+  .text:0000000001E74509                 movzx   eax, ax
+  .text:0000000001E7450C                 or      ebx, eax
+  .text:0000000001E7450E                 test    rdx, rdx
+  .text:0000000001E74511                 jz      short loc_1E74550
+  .text:0000000001E74513                 xor     eax, eax
+  .text:0000000001E74515                 cmp     byte ptr [rdx], 0
+  .text:0000000001E74518                 jnz     short loc_1E74550
+  .text:0000000001E7451A                 mov     [rbp+var_28], rax
+  .text:0000000001E7451E                 sub     rsp, 8
+  .text:0000000001E74522                 mov     rcx, r13
+  .text:0000000001E74525                 mov     esi, ebx
+  .text:0000000001E74527                 push    [rbp+arg_10]
+  .text:0000000001E7452A                 lea     rdx, [rbp+var_28]
+  .text:0000000001E7452E                 mov     rdi, r12
+  .text:0000000001E74531                 push    [rbp+arg_8]
+  .text:0000000001E74534                 mov     eax, [rbp+arg_0]
+  .text:0000000001E74537                 push    rax
+  .text:0000000001E74538                 call    CEntitySystem_AddEntityIOEventBuildStruct
+  .text:0000000001E7453D                 add     rsp, 20h
+  .text:0000000001E74541                 lea     rsp, [rbp-18h]
+  .text:0000000001E74545                 pop     rbx
+  .text:0000000001E74546                 pop     r12
+  .text:0000000001E74548                 pop     r13
+  .text:0000000001E7454A                 pop     rbp
+  .text:0000000001E7454B                 retn
+  .text:0000000001E74550                 lea     rdi, [rbp+var_30]
+  .text:0000000001E74554                 movss   [rbp+var_44], xmm0
+  .text:0000000001E74559                 lea     rsi, [r12+1ED0h]
+  .text:0000000001E74561                 mov     [rbp+var_40], r9
+  .text:0000000001E74565                 mov     [rbp+var_38], r8
+  .text:0000000001E74569                 call    sub_1E71540
+  .text:0000000001E7456E                 mov     rax, [rbp+var_30]
+  .text:0000000001E74572                 mov     r9, [rbp+var_40]
+  .text:0000000001E74576                 mov     r8, [rbp+var_38]
+  .text:0000000001E7457A                 movss   xmm0, [rbp+var_44]
+  .text:0000000001E7457F                 jmp     short loc_1E7451A
+  .text:0000000001E74588                 mov     eax, 7FFFh
+  .text:0000000001E7458D                 jmp     loc_1E74506
+procedure: |-
+  __int64 __fastcall CEntitySystem_AddEntityIOEvent(
+          __int64 a1,
+          __int64 a2,
+          _BYTE *a3,
+          int a4,
+          int a5,
+          int a6,
+          int a7,
+          __int64 a8,
+          __int64 a9)
+  {
+    int v10; // ebx
+    __int64 v11; // rax
+    int v12; // ebx
+    unsigned __int16 v13; // ax
+    __int64 v14; // rax
+    int v16; // [rsp+10h] [rbp-40h]
+    int v17; // [rsp+18h] [rbp-38h]
+    __int64 v18; // [rsp+20h] [rbp-30h] BYREF
+    __int64 v19; // [rsp+28h] [rbp-28h] BYREF
+
+    v10 = -1;
+    if ( a2 )
+    {
+      v11 = *(_QWORD *)(a2 + 16);
+      if ( v11 )
+      {
+        v12 = (*(_DWORD *)(v11 + 16) >> 15) - (*(_DWORD *)(v11 + 48) & 1);
+        if ( *(_DWORD *)(v11 + 16) == -1 )
+          v13 = 0x7FFF;
+        else
+          v13 = *(_WORD *)(v11 + 16) & 0x7FFF;
+        v10 = v13 | (v12 << 15);
+      }
+    }
+    if ( !a3 || (v14 = 0, *a3) )
+    {
+      v16 = a6;
+      v17 = a5;
+      sub_1E71540(&v18, a1 + 7888);
+      v14 = v18;
+      a6 = v16;
+      a5 = v17;
+    }
+    v19 = v14;
+    return CEntitySystem_AddEntityIOEventBuildStruct(a1, v10, (unsigned int)&v19, a4, a5, a6, a7, a8, a9);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.windows.yaml
@@ -1,0 +1,354 @@
+func_name: CEntitySystem_AddEntityIOEvent
+func_va: '0x1811ecb70'
+disasm_code: |-
+  .text:00000001811ECB70                 mov     [rsp+arg_10], rbx
+  .text:00000001811ECB75                 mov     [rsp+arg_18], r9
+  .text:00000001811ECB7A                 mov     [rsp+arg_0], rcx
+  .text:00000001811ECB7F                 push    rbp
+  .text:00000001811ECB80                 push    rsi
+  .text:00000001811ECB81                 push    rdi
+  .text:00000001811ECB82                 push    r12
+  .text:00000001811ECB84                 push    r13
+  .text:00000001811ECB86                 push    r14
+  .text:00000001811ECB88                 push    r15
+  .text:00000001811ECB8A                 sub     rsp, 20h
+  .text:00000001811ECB8E                 mov     rdi, r9
+  .text:00000001811ECB91                 mov     r9, rcx
+  .text:00000001811ECB94                 mov     r13d, 7FFFh
+  .text:00000001811ECB9A                 test    rdx, rdx
+  .text:00000001811ECB9D                 jz      short loc_1811ECBD2
+  .text:00000001811ECB9F                 mov     rax, [rdx+10h]
+  .text:00000001811ECBA3                 test    rax, rax
+  .text:00000001811ECBA6                 jz      short loc_1811ECBD2
+  .text:00000001811ECBA8                 mov     edx, [rax+10h]
+  .text:00000001811ECBAB                 mov     ecx, r13d
+  .text:00000001811ECBAE                 mov     eax, [rax+30h]
+  .text:00000001811ECBB1                 mov     r14d, edx
+  .text:00000001811ECBB4                 and     eax, 1
+  .text:00000001811ECBB7                 shr     r14d, 0Fh
+  .text:00000001811ECBBB                 sub     r14d, eax
+  .text:00000001811ECBBE                 mov     eax, edx
+  .text:00000001811ECBC0                 and     eax, r13d
+  .text:00000001811ECBC3                 shl     r14d, 0Fh
+  .text:00000001811ECBC7                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811ECBCA                 cmovnz  ecx, eax
+  .text:00000001811ECBCD                 or      r14d, ecx
+  .text:00000001811ECBD0                 jmp     short loc_1811ECBD8
+  .text:00000001811ECBD2                 mov     r14d, 0FFFFFFFFh
+  .text:00000001811ECBD8                 test    r8, r8
+  .text:00000001811ECBDB                 jz      short loc_1811ECBE9
+  .text:00000001811ECBDD                 cmp     byte ptr [r8], 0
+  .text:00000001811ECBE1                 jnz     short loc_1811ECBE9
+  .text:00000001811ECBE3                 xor     ebp, ebp
+  .text:00000001811ECBE5                 mov     ebx, ebp
+  .text:00000001811ECBE7                 jmp     short loc_1811ECC22
+  .text:00000001811ECBE9                 xor     ebp, ebp
+  .text:00000001811ECBEB                 lea     rcx, [r9+1EC8h]
+  .text:00000001811ECBF2                 test    r8, r8
+  .text:00000001811ECBF5                 jz      short loc_1811ECC0B
+  .text:00000001811ECBF7                 mov     r9, 0FFFFFFFFFFFFFFFFh
+  .text:00000001811ECBFE                 xchg    ax, ax
+  .text:00000001811ECC00                 inc     r9
+  .text:00000001811ECC03                 cmp     [r8+r9], bpl
+  .text:00000001811ECC07                 jnz     short loc_1811ECC00
+  .text:00000001811ECC09                 jmp     short loc_1811ECC0E
+  .text:00000001811ECC0B                 mov     r9d, ebp
+  .text:00000001811ECC0E                 lea     rdx, [rsp+58h+arg_8]
+  .text:00000001811ECC13                 call    sub_18050F990
+  .text:00000001811ECC18                 mov     r9, [rsp+58h+arg_0]
+  .text:00000001811ECC1D                 mov     rbx, [rsp+58h+arg_8]
+  .text:00000001811ECC22                 mov     r15, [rsp+58h+arg_20]
+  .text:00000001811ECC2A                 test    r15, r15
+  .text:00000001811ECC2D                 jz      short loc_1811ECC39
+  .text:00000001811ECC2F                 mov     rax, [r15+10h]
+  .text:00000001811ECC33                 mov     r12d, [rax+38h]
+  .text:00000001811ECC37                 jmp     short loc_1811ECC3C
+  .text:00000001811ECC39                 mov     r12d, ebp
+  .text:00000001811ECC3C                 mov     rax, [r9]
+  .text:00000001811ECC3F                 lea     rdx, [rsp+58h+arg_20]
+  .text:00000001811ECC47                 mov     r8d, r12d
+  .text:00000001811ECC4A                 mov     rcx, r9
+  .text:00000001811ECC4D                 call    qword ptr [rax+58h]
+  .text:00000001811ECC50                 mov     ecx, 70h ; 'p'
+  .text:00000001811ECC55                 call    sub_180E7C960
+  .text:00000001811ECC5A                 mov     rsi, rax
+  .text:00000001811ECC5D                 test    rax, rax
+  .text:00000001811ECC60                 jz      short loc_1811ECCAD
+  .text:00000001811ECC62                 lea     rcx, [rax+4]
+  .text:00000001811ECC66                 mov     [rax], ebp
+  .text:00000001811ECC68                 call    unknown_libname_33; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001811ECC6D                 mov     r8b, 8
+  .text:00000001811ECC70                 mov     [rsi+10h], rbp
+  .text:00000001811ECC74                 mov     dl, 1
+  .text:00000001811ECC76                 mov     [rsi+18h], rbp
+  .text:00000001811ECC7A                 lea     rcx, [rsi+48h]
+  .text:00000001811ECC7E                 mov     qword ptr [rsi+20h], 0FFFFFFFFFFFFFFFFh
+  .text:00000001811ECC86                 mov     dword ptr [rsi+2Ch], 0FFFFFFFFh
+  .text:00000001811ECC8D                 mov     byte ptr [rsi+38h], 0
+  .text:00000001811ECC91                 mov     [rsi+3Ah], bp
+  .text:00000001811ECC95                 mov     [rsi+30h], rbp
+  .text:00000001811ECC99                 mov     [rsi+40h], rbp
+  .text:00000001811ECC9D                 call    sub_1814D69E0
+  .text:00000001811ECCA2                 mov     rdi, [rsp+58h+arg_18]
+  .text:00000001811ECCA7                 mov     byte ptr [rsi+58h], 0
+  .text:00000001811ECCAB                 jmp     short loc_1811ECCB0
+  .text:00000001811ECCAD                 mov     rsi, rbp
+  .text:00000001811ECCB0                 movss   xmm2, dword ptr [rsp+58h+arg_30]
+  .text:00000001811ECCB9                 lea     rdx, [rsp+58h+arg_20]
+  .text:00000001811ECCC1                 lea     rcx, [rsp+58h+arg_18]
+  .text:00000001811ECCC6                 mov     [rsi], r12d
+  .text:00000001811ECCC9                 call    sub_1801B3530
+  .text:00000001811ECCCE                 movss   xmm0, dword ptr [rax]
+  .text:00000001811ECCD2                 movss   dword ptr [rsi+4], xmm0
+  .text:00000001811ECCD7                 mov     [rsi+10h], rbp
+  .text:00000001811ECCDB                 mov     [rsi+2Ch], r14d
+  .text:00000001811ECCDF                 mov     dword ptr [rsi+8], 6
+  .text:00000001811ECCE6                 mov     [rsi+18h], rbx
+  .text:00000001811ECCEA                 test    rdi, rdi
+  .text:00000001811ECCED                 jz      short loc_1811ECD22
+  .text:00000001811ECCEF                 mov     rax, [rdi+10h]
+  .text:00000001811ECCF3                 test    rax, rax
+  .text:00000001811ECCF6                 jz      short loc_1811ECD22
+  .text:00000001811ECCF8                 mov     edx, [rax+10h]
+  .text:00000001811ECCFB                 mov     ecx, r13d
+  .text:00000001811ECCFE                 mov     eax, [rax+30h]
+  .text:00000001811ECD01                 mov     r8d, edx
+  .text:00000001811ECD04                 and     eax, 1
+  .text:00000001811ECD07                 shr     r8d, 0Fh
+  .text:00000001811ECD0B                 sub     r8d, eax
+  .text:00000001811ECD0E                 mov     eax, edx
+  .text:00000001811ECD10                 and     eax, r13d
+  .text:00000001811ECD13                 shl     r8d, 0Fh
+  .text:00000001811ECD17                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811ECD1A                 cmovnz  ecx, eax
+  .text:00000001811ECD1D                 or      r8d, ecx
+  .text:00000001811ECD20                 jmp     short loc_1811ECD28
+  .text:00000001811ECD22                 mov     r8d, 0FFFFFFFFh
+  .text:00000001811ECD28                 mov     [rsi+20h], r8d
+  .text:00000001811ECD2C                 test    r15, r15
+  .text:00000001811ECD2F                 jz      short loc_1811ECD5E
+  .text:00000001811ECD31                 mov     rax, [r15+10h]
+  .text:00000001811ECD35                 test    rax, rax
+  .text:00000001811ECD38                 jz      short loc_1811ECD5E
+  .text:00000001811ECD3A                 mov     ecx, [rax+10h]
+  .text:00000001811ECD3D                 mov     edx, ecx
+  .text:00000001811ECD3F                 mov     eax, [rax+30h]
+  .text:00000001811ECD42                 and     eax, 1
+  .text:00000001811ECD45                 shr     edx, 0Fh
+  .text:00000001811ECD48                 sub     edx, eax
+  .text:00000001811ECD4A                 mov     eax, ecx
+  .text:00000001811ECD4C                 and     eax, r13d
+  .text:00000001811ECD4F                 shl     edx, 0Fh
+  .text:00000001811ECD52                 cmp     ecx, 0FFFFFFFFh
+  .text:00000001811ECD55                 cmovnz  r13d, eax
+  .text:00000001811ECD59                 or      edx, r13d
+  .text:00000001811ECD5C                 jmp     short loc_1811ECD63
+  .text:00000001811ECD5E                 mov     edx, 0FFFFFFFFh
+  .text:00000001811ECD63                 mov     rcx, [rsp+58h+arg_28]
+  .text:00000001811ECD6B                 mov     [rsi+24h], edx
+  .text:00000001811ECD6E                 lea     rdx, [rsi+30h]
+  .text:00000001811ECD72                 call    sub_1801799F0
+  .text:00000001811ECD77                 mov     rbx, [rsp+58h+arg_40]
+  .text:00000001811ECD7F                 mov     eax, dword ptr [rsp+58h+arg_38]
+  .text:00000001811ECD86                 mov     [rsi+28h], eax
+  .text:00000001811ECD89                 test    rbx, rbx
+  .text:00000001811ECD8C                 jz      short loc_1811ECDAB
+  .text:00000001811ECD8E                 mov     ecx, 90h
+  .text:00000001811ECD93                 call    sub_180E7C960
+  .text:00000001811ECD98                 test    rax, rax
+  .text:00000001811ECD9B                 jz      short loc_1811ECDAB
+  .text:00000001811ECD9D                 mov     rdx, rbx
+  .text:00000001811ECDA0                 mov     rcx, rax
+  .text:00000001811ECDA3                 call    sub_1813F9340
+  .text:00000001811ECDA8                 mov     rbp, rax
+  .text:00000001811ECDAB                 mov     rdi, [rsp+58h+arg_48]
+  .text:00000001811ECDB3                 mov     [rsi+40h], rbp
+  .text:00000001811ECDB7                 test    rdi, rdi
+  .text:00000001811ECDBA                 jz      short loc_1811ECDCF
+  .text:00000001811ECDBC                 mov     rdx, rdi
+  .text:00000001811ECDBF                 lea     rcx, [rsi+48h]
+  .text:00000001811ECDC3                 call    sub_1814D6AC0
+  .text:00000001811ECDC8                 movzx   eax, byte ptr [rdi+10h]
+  .text:00000001811ECDCC                 mov     [rsi+58h], al
+  .text:00000001811ECDCF                 mov     rcx, [rsp+58h+arg_0]
+  .text:00000001811ECDD4                 mov     rdx, rsi
+  .text:00000001811ECDD7                 call    CEntitySystem_AddEntityIOEventToQueue
+  .text:00000001811ECDDC                 mov     rbx, [rsp+58h+arg_10]
+  .text:00000001811ECDE1                 add     rsp, 20h
+  .text:00000001811ECDE5                 pop     r15
+  .text:00000001811ECDE7                 pop     r14
+  .text:00000001811ECDE9                 pop     r13
+  .text:00000001811ECDEB                 pop     r12
+  .text:00000001811ECDED                 pop     rdi
+  .text:00000001811ECDEE                 pop     rsi
+  .text:00000001811ECDEF                 pop     rbp
+  .text:00000001811ECDF0                 retn
+procedure: |-
+  __int64 CEntitySystem_AddEntityIOEvent(__int64 a1, __int64 a2, _BYTE *a3, ...)
+  {
+    __int64 v3; // rdi
+    __int64 v4; // r9
+    int v5; // r13d
+    __int64 v6; // rax
+    unsigned int v7; // edx
+    int v8; // ecx
+    int v9; // r14d
+    __int64 v10; // rbp
+    __int64 v11; // rbx
+    __int64 v12; // rcx
+    __int64 v13; // r9
+    __int64 v14; // r15
+    unsigned int v15; // r12d
+    unsigned int *v16; // rax
+    unsigned int *v17; // rsi
+    __int64 v18; // r8
+    __int64 v19; // rdx
+    __int64 v20; // rax
+    unsigned int v21; // edx
+    int v22; // ecx
+    int v23; // r8d
+    __int64 v24; // rax
+    unsigned int v25; // ecx
+    int v26; // edx
+    __int64 v27; // rcx
+    __int64 v28; // rbx
+    __int64 v29; // rax
+    __int64 v30; // rdi
+    __int64 v33; // [rsp+68h] [rbp+10h] BYREF
+    __int64 v34; // [rsp+78h] [rbp+20h] BYREF
+    va_list va; // [rsp+78h] [rbp+20h]
+    __int64 v36; // [rsp+80h] [rbp+28h] BYREF
+    va_list va1; // [rsp+80h] [rbp+28h]
+    __int64 v38; // [rsp+88h] [rbp+30h]
+    __int64 v39; // [rsp+90h] [rbp+38h]
+    __int64 v40; // [rsp+98h] [rbp+40h]
+    __int64 v41; // [rsp+A0h] [rbp+48h]
+    __int64 v42; // [rsp+A8h] [rbp+50h]
+    va_list va2; // [rsp+B0h] [rbp+58h] BYREF
+
+    va_start(va2, a3);
+    va_start(va1, a3);
+    va_start(va, a3);
+    v34 = va_arg(va1, _QWORD);
+    va_copy(va2, va1);
+    v36 = va_arg(va2, _QWORD);
+    v38 = va_arg(va2, _QWORD);
+    v39 = va_arg(va2, _QWORD);
+    v40 = va_arg(va2, _QWORD);
+    v41 = va_arg(va2, _QWORD);
+    v42 = va_arg(va2, _QWORD);
+    v3 = v34;
+    v4 = a1;
+    v5 = 0x7FFF;
+    if ( a2 && (v6 = *(_QWORD *)(a2 + 16)) != 0 )
+    {
+      v7 = *(_DWORD *)(v6 + 16);
+      v8 = 0x7FFF;
+      if ( v7 != -1 )
+        v8 = v7 & 0x7FFF;
+      v9 = v8 | (((v7 >> 15) - (*(_DWORD *)(v6 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v9 = -1;
+    }
+    if ( !a3 || *a3 )
+    {
+      v10 = 0;
+      v12 = v4 + 7880;
+      if ( a3 )
+      {
+        v13 = -1;
+        do
+          ++v13;
+        while ( a3[v13] );
+      }
+      sub_18050F990(v12, &v33, a3);
+      v4 = a1;
+      v11 = v33;
+    }
+    else
+    {
+      v10 = 0;
+      v11 = 0;
+    }
+    v14 = v36;
+    if ( v36 )
+      v15 = *(_DWORD *)(*(_QWORD *)(v36 + 16) + 56LL);
+    else
+      v15 = 0;
+    (*(void (__fastcall **)(__int64, __int64 *, _QWORD))(*(_QWORD *)v4 + 88LL))(v4, (__int64 *)va1, v15);
+    v16 = (unsigned int *)sub_180E7C960(112);
+    v17 = v16;
+    if ( v16 )
+    {
+      *v16 = 0;
+      unknown_libname_33(v16 + 1);
+      LOBYTE(v18) = 8;
+      *((_QWORD *)v17 + 2) = 0;
+      LOBYTE(v19) = 1;
+      *((_QWORD *)v17 + 3) = 0;
+      *((_QWORD *)v17 + 4) = -1;
+      v17[11] = -1;
+      *((_BYTE *)v17 + 56) = 0;
+      *((_WORD *)v17 + 29) = 0;
+      *((_QWORD *)v17 + 6) = 0;
+      *((_QWORD *)v17 + 8) = 0;
+      sub_1814D69E0(v17 + 18, v19, v18);
+      v3 = v34;
+      *((_BYTE *)v17 + 88) = 0;
+    }
+    else
+    {
+      v17 = nullptr;
+    }
+    *v17 = v15;
+    v17[1] = *(_DWORD *)sub_1801B3530((__int64 *)va, (__int64 *)va1);
+    *((_QWORD *)v17 + 2) = 0;
+    v17[11] = v9;
+    v17[2] = 6;
+    *((_QWORD *)v17 + 3) = v11;
+    if ( v3 && (v20 = *(_QWORD *)(v3 + 16)) != 0 )
+    {
+      v21 = *(_DWORD *)(v20 + 16);
+      v22 = 0x7FFF;
+      if ( v21 != -1 )
+        v22 = v21 & 0x7FFF;
+      v23 = v22 | (((v21 >> 15) - (*(_DWORD *)(v20 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v23 = -1;
+    }
+    v17[8] = v23;
+    if ( v14 && (v24 = *(_QWORD *)(v14 + 16)) != 0 )
+    {
+      v25 = *(_DWORD *)(v24 + 16);
+      if ( v25 != -1 )
+        v5 = v25 & 0x7FFF;
+      v26 = v5 | (((v25 >> 15) - (*(_DWORD *)(v24 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v26 = -1;
+    }
+    v27 = v38;
+    v17[9] = v26;
+    sub_1801799F0(v27, v17 + 12);
+    v28 = v41;
+    v17[10] = v40;
+    if ( v28 )
+    {
+      v29 = sub_180E7C960(144);
+      if ( v29 )
+        v10 = sub_1813F9340(v29, v28);
+    }
+    v30 = v42;
+    *((_QWORD *)v17 + 8) = v10;
+    if ( v30 )
+    {
+      sub_1814D6AC0(v17 + 18, v30);
+      *((_BYTE *)v17 + 88) = *(_BYTE *)(v30 + 16);
+    }
+    return CEntitySystem_AddEntityIOEventToQueue(a1, v17);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventBuildStruct.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventBuildStruct.linux.yaml
@@ -1,0 +1,247 @@
+func_name: CEntitySystem_AddEntityIOEventBuildStruct
+func_va: '0x1e630d0'
+disasm_code: |-
+  .text:0000000001E630D0                 push    rbp
+  .text:0000000001E630D1                 mov     rbp, rsp
+  .text:0000000001E630D4                 push    r15
+  .text:0000000001E630D6                 push    r14
+  .text:0000000001E630D8                 xor     r14d, r14d
+  .text:0000000001E630DB                 push    r13
+  .text:0000000001E630DD                 push    r12
+  .text:0000000001E630DF                 mov     r12, r8
+  .text:0000000001E630E2                 push    rbx
+  .text:0000000001E630E3                 mov     rbx, rdi
+  .text:0000000001E630E6                 sub     rsp, 48h
+  .text:0000000001E630EA                 mov     eax, [rbp+arg_0]
+  .text:0000000001E630ED                 mov     [rbp+var_38], esi
+  .text:0000000001E630F0                 mov     r13, [rbp+arg_10]
+  .text:0000000001E630F4                 mov     [rbp+var_40], rdx
+  .text:0000000001E630F8                 mov     [rbp+var_48], rcx
+  .text:0000000001E630FC                 mov     [rbp+var_50], r9
+  .text:0000000001E63100                 mov     [rbp+var_58], eax
+  .text:0000000001E63103                 mov     rax, [rbp+arg_8]
+  .text:0000000001E63107                 movss   [rbp+var_54], xmm0
+  .text:0000000001E6310C                 mov     [rbp+var_60], rax
+  .text:0000000001E63110                 test    r8, r8
+  .text:0000000001E63113                 jz      short loc_1E6311D
+  .text:0000000001E63115                 mov     rax, [r8+10h]
+  .text:0000000001E63119                 mov     r14d, [rax+38h]
+  .text:0000000001E6311D                 mov     rax, [rbx]
+  .text:0000000001E63120                 lea     rdx, sub_1E59480
+  .text:0000000001E63127                 mov     rax, [rax+60h]
+  .text:0000000001E6312B                 cmp     rax, rdx
+  .text:0000000001E6312E                 jnz     loc_1E632D0
+  .text:0000000001E63134                 call    cs:qword_27C42A0
+  .text:0000000001E6313A                 movss   [rbp+var_34], xmm0
+  .text:0000000001E6313F                 mov     edi, 70h ; 'p'
+  .text:0000000001E63144                 call    sub_97A1D0
+  .text:0000000001E63149                 pxor    xmm0, xmm0
+  .text:0000000001E6314D                 mov     edx, 8
+  .text:0000000001E63152                 mov     esi, 1
+  .text:0000000001E63157                 mov     r15, rax
+  .text:0000000001E6315A                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000001E6315E                 mov     qword ptr [rax], 0
+  .text:0000000001E63165                 mov     qword ptr [rax+20h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000001E6316D                 mov     rax, 0FFFFFFFF00000000h
+  .text:0000000001E63177                 mov     [r15+28h], rax
+  .text:0000000001E6317B                 lea     rax, [r15+48h]
+  .text:0000000001E6317F                 mov     rdi, rax
+  .text:0000000001E63182                 mov     qword ptr [r15+30h], 0
+  .text:0000000001E6318A                 mov     qword ptr [r15+38h], 0
+  .text:0000000001E63192                 mov     qword ptr [r15+40h], 0
+  .text:0000000001E6319A                 mov     [rbp+var_68], rax
+  .text:0000000001E6319E                 call    sub_1B15700
+  .text:0000000001E631A3                 mov     eax, [rbp+var_38]
+  .text:0000000001E631A6                 mov     byte ptr [r15+58h], 0
+  .text:0000000001E631AB                 mov     rcx, [rbp+var_48]
+  .text:0000000001E631AF                 mov     [r15], r14d
+  .text:0000000001E631B2                 movss   xmm0, [rbp+var_54]
+  .text:0000000001E631B7                 mov     dword ptr [r15+8], 6
+  .text:0000000001E631BF                 addss   xmm0, [rbp+var_34]
+  .text:0000000001E631C4                 mov     qword ptr [r15+10h], 0
+  .text:0000000001E631CC                 mov     [r15+2Ch], eax
+  .text:0000000001E631D0                 mov     rax, [rbp+var_40]
+  .text:0000000001E631D4                 movss   dword ptr [r15+4], xmm0
+  .text:0000000001E631DA                 mov     rax, [rax]
+  .text:0000000001E631DD                 mov     [r15+18h], rax
+  .text:0000000001E631E1                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E631E6                 test    rcx, rcx
+  .text:0000000001E631E9                 jz      short loc_1E6321D
+  .text:0000000001E631EB                 mov     rdx, [rcx+10h]
+  .text:0000000001E631EF                 test    rdx, rdx
+  .text:0000000001E631F2                 jz      short loc_1E6321D
+  .text:0000000001E631F4                 mov     eax, [rdx+10h]
+  .text:0000000001E631F7                 mov     esi, [rdx+30h]
+  .text:0000000001E631FA                 shr     eax, 0Fh
+  .text:0000000001E631FD                 and     esi, 1
+  .text:0000000001E63200                 sub     eax, esi
+  .text:0000000001E63202                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001E63206                 jz      loc_1E632F0
+  .text:0000000001E6320C                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000001E63210                 and     dx, 7FFFh
+  .text:0000000001E63215                 shl     eax, 0Fh
+  .text:0000000001E63218                 movzx   edx, dx
+  .text:0000000001E6321B                 or      eax, edx
+  .text:0000000001E6321D                 mov     [r15+20h], eax
+  .text:0000000001E63221                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E63226                 test    r12, r12
+  .text:0000000001E63229                 jz      short loc_1E6325E
+  .text:0000000001E6322B                 mov     rdx, [r12+10h]
+  .text:0000000001E63230                 test    rdx, rdx
+  .text:0000000001E63233                 jz      short loc_1E6325E
+  .text:0000000001E63235                 mov     eax, [rdx+10h]
+  .text:0000000001E63238                 mov     esi, [rdx+30h]
+  .text:0000000001E6323B                 shr     eax, 0Fh
+  .text:0000000001E6323E                 and     esi, 1
+  .text:0000000001E63241                 sub     eax, esi
+  .text:0000000001E63243                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001E63247                 jz      loc_1E63300
+  .text:0000000001E6324D                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000001E63251                 and     dx, 7FFFh
+  .text:0000000001E63256                 shl     eax, 0Fh
+  .text:0000000001E63259                 movzx   edx, dx
+  .text:0000000001E6325C                 or      eax, edx
+  .text:0000000001E6325E                 mov     rdi, [rbp+var_50]
+  .text:0000000001E63262                 mov     [r15+24h], eax
+  .text:0000000001E63266                 lea     rsi, [r15+30h]
+  .text:0000000001E6326A                 call    sub_1E5B1F0
+  .text:0000000001E6326F                 mov     eax, [rbp+var_58]
+  .text:0000000001E63272                 mov     r14, [rbp+var_60]
+  .text:0000000001E63276                 mov     [r15+28h], eax
+  .text:0000000001E6327A                 test    r14, r14
+  .text:0000000001E6327D                 jz      short loc_1E632E8
+  .text:0000000001E6327F                 mov     edi, 90h
+  .text:0000000001E63284                 call    sub_97A1D0
+  .text:0000000001E63289                 mov     rsi, r14
+  .text:0000000001E6328C                 mov     rdi, rax
+  .text:0000000001E6328F                 mov     r12, rax
+  .text:0000000001E63292                 call    sub_1D8E230
+  .text:0000000001E63297                 mov     [r15+40h], r12
+  .text:0000000001E6329B                 test    r13, r13
+  .text:0000000001E6329E                 jz      short loc_1E632B5
+  .text:0000000001E632A0                 mov     rdi, [rbp+var_68]
+  .text:0000000001E632A4                 mov     rsi, r13
+  .text:0000000001E632A7                 call    sub_1B22D60
+  .text:0000000001E632AC                 movzx   eax, byte ptr [r13+10h]
+  .text:0000000001E632B1                 mov     [r15+58h], al
+  .text:0000000001E632B5                 add     rsp, 48h
+  .text:0000000001E632B9                 mov     rsi, r15
+  .text:0000000001E632BC                 mov     rdi, rbx
+  .text:0000000001E632BF                 pop     rbx
+  .text:0000000001E632C0                 pop     r12
+  .text:0000000001E632C2                 pop     r13
+  .text:0000000001E632C4                 pop     r14
+  .text:0000000001E632C6                 pop     r15
+  .text:0000000001E632C8                 pop     rbp
+  .text:0000000001E632C9                 jmp     CEntitySystem_AddEntityIOEventToQueue
+  .text:0000000001E632D0                 mov     esi, r14d
+  .text:0000000001E632D3                 mov     rdi, rbx
+  .text:0000000001E632D6                 call    rax
+  .text:0000000001E632D8                 movss   [rbp+var_34], xmm0
+  .text:0000000001E632DD                 jmp     loc_1E6313F
+  .text:0000000001E632E8                 xor     r12d, r12d
+  .text:0000000001E632EB                 jmp     short loc_1E63297
+  .text:0000000001E632F0                 mov     edx, 7FFFh
+  .text:0000000001E632F5                 jmp     loc_1E63215
+  .text:0000000001E63300                 mov     edx, 7FFFh
+  .text:0000000001E63305                 jmp     loc_1E63256
+procedure: |-
+  __int64 __fastcall CEntitySystem_AddEntityIOEventBuildStruct(
+          __int64 a1,
+          int a2,
+          _QWORD *a3,
+          __int64 a4,
+          __int64 a5,
+          __int64 a6,
+          float a7,
+          int a8,
+          __int64 a9,
+          __int64 a10)
+  {
+    unsigned int v10; // r14d
+    __int64 (__fastcall *v12)(); // rax
+    __int64 v13; // r15
+    int v14; // eax
+    __int64 v15; // rdx
+    int v16; // eax
+    unsigned __int16 v17; // dx
+    int v18; // eax
+    __int64 v19; // rdx
+    int v20; // eax
+    unsigned __int16 v21; // dx
+    __int64 v22; // r12
+    float v28; // [rsp+3Ch] [rbp-34h]
+
+    v10 = 0;
+    if ( a5 )
+      v10 = *(_DWORD *)(*(_QWORD *)(a5 + 16) + 56LL);
+    v12 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 96LL);
+    if ( v12 == sub_1E59480 )
+      v28 = qword_27C42A0();
+    else
+      v28 = ((float (__fastcall *)(__int64, _QWORD))v12)(a1, v10);
+    v13 = sub_97A1D0();
+    *(_OWORD *)(v13 + 16) = 0;
+    *(_QWORD *)v13 = 0;
+    *(_QWORD *)(v13 + 32) = -1;
+    *(_QWORD *)(v13 + 40) = 0xFFFFFFFF00000000LL;
+    *(_QWORD *)(v13 + 48) = 0;
+    *(_QWORD *)(v13 + 56) = 0;
+    *(_QWORD *)(v13 + 64) = 0;
+    sub_1B15700(v13 + 72, 1, 8);
+    *(_BYTE *)(v13 + 88) = 0;
+    *(_DWORD *)v13 = v10;
+    *(_DWORD *)(v13 + 8) = 6;
+    *(_QWORD *)(v13 + 16) = 0;
+    *(_DWORD *)(v13 + 44) = a2;
+    *(float *)(v13 + 4) = a7 + v28;
+    *(_QWORD *)(v13 + 24) = *a3;
+    v14 = -1;
+    if ( a4 )
+    {
+      v15 = *(_QWORD *)(a4 + 16);
+      if ( v15 )
+      {
+        v16 = (*(_DWORD *)(v15 + 16) >> 15) - (*(_DWORD *)(v15 + 48) & 1);
+        if ( *(_DWORD *)(v15 + 16) == -1 )
+          v17 = 0x7FFF;
+        else
+          v17 = *(_WORD *)(v15 + 16) & 0x7FFF;
+        v14 = v17 | (v16 << 15);
+      }
+    }
+    *(_DWORD *)(v13 + 32) = v14;
+    v18 = -1;
+    if ( a5 )
+    {
+      v19 = *(_QWORD *)(a5 + 16);
+      if ( v19 )
+      {
+        v20 = (*(_DWORD *)(v19 + 16) >> 15) - (*(_DWORD *)(v19 + 48) & 1);
+        if ( *(_DWORD *)(v19 + 16) == -1 )
+          v21 = 0x7FFF;
+        else
+          v21 = *(_WORD *)(v19 + 16) & 0x7FFF;
+        v18 = v21 | (v20 << 15);
+      }
+    }
+    *(_DWORD *)(v13 + 36) = v18;
+    sub_1E5B1F0(a6, v13 + 48);
+    *(_DWORD *)(v13 + 40) = a8;
+    if ( a9 )
+    {
+      v22 = sub_97A1D0();
+      sub_1D8E230(v22, a9);
+    }
+    else
+    {
+      v22 = 0;
+    }
+    *(_QWORD *)(v13 + 64) = v22;
+    if ( a10 )
+    {
+      sub_1B22D60(v13 + 72, a10);
+      *(_BYTE *)(v13 + 88) = *(_BYTE *)(a10 + 16);
+    }
+    return CEntitySystem_AddEntityIOEventToQueue(a1, v13);
+  }


### PR DESCRIPTION
## Summary

- find-CEntitySystem_AddEntityIOEventBuildStruct-linux (Pattern D): Linux-only function, found via LLM_DECOMPILE with CEntitySystem_AddEntityIOEvent as predecessor
- find-CEntitySystem_AddEntityIOEventToQueue (Pattern D): regular function on both platforms, uses CEntitySystem_AddEntityIOEvent predecessor on Windows and CEntitySystem_AddEntityIOEventBuildStruct on Linux (platform-split predecessor)
- find-CEntitySystem_m_EventQueue (Pattern E): finds CEntitySystem::m_EventQueue struct member offset via LLM_DECOMPILE with CEntitySystem_AddEntityIOEventToQueue as predecessor
- Reference YAMLs for CEntitySystem_AddEntityIOEvent (Windows) and CEntitySystem_AddEntityIOEventBuildStruct (Linux) annotated with call targets
- config.yaml skill and symbol entries for all new targets

## Test plan

- [ ] find-CEntitySystem_AddEntityIOEventBuildStruct-linux: Linux output YAML generated
- [ ] find-CEntitySystem_AddEntityIOEventToQueue: Windows output YAML generated; Linux pending (reference YAMLs for CEntitySystem_AddEntityIOEventToQueue to be added as follow-up commit)
- [ ] find-CEntitySystem_m_EventQueue: pending reference YAML generation for CEntitySystem_AddEntityIOEventToQueue on both platforms
- [ ] Run uv run ida_analyze_bin.py -debug after adding reference YAMLs and verify 0 failures