### PR TITLE
feat(server): add CEntityInstance_GetChangeAccessorPathInfo_1 preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7022,6 +7022,13 @@ modules:
           - EntityInstanceAssignChangeAccessorPathIds.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CEntityInstance_GetChangeAccessorPathInfo_1
+        expected_output:
+          - CEntityInstance_GetChangeAccessorPathInfo_1.{platform}.yaml
+        expected_input:
+          - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CEntityInstance_Schema_DynamicBinding
         expected_output:
           - CEntityInstance_Schema_DynamicBinding.{platform}.yaml
@@ -7651,6 +7658,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::AssignChangeAccessorPathIds
+
+      - name: CEntityInstance_GetChangeAccessorPathInfo_1
+        category: vfunc
+        alias:
+          - CEntityInstance::GetChangeAccessorPathInfo_1
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEntityInstance_GetChangeAccessorPathInfo_1.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_GetChangeAccessorPathInfo_1.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_GetChangeAccessorPathInfo_1 skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_GetChangeAccessorPathInfo_1",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_GetChangeAccessorPathInfo_1",
+        "prompt/call_llm_decompile.md",
+        "references/server/PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_GetChangeAccessorPathInfo_1", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: CEntityInstance_GetChangeAccessorPathInfo_1 is not a downstream predecessor.
+    (
+        "CEntityInstance_GetChangeAccessorPathInfo_1",
+        [
+            "func_name",
+            "vfunc_sig",    # REQUIRED for Pattern C
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+            "vfunc_sig_allow_across_function_boundary:true",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Locate CEntityInstance_GetChangeAccessorPathInfo_1 vfunc via LLM decompile of PolymorphicHelper_t__SetPolymorphicPointer."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.linux.yaml
@@ -139,7 +139,8 @@ disasm_code: |-
   .text:00000000011DE51D                 mov     rdi, rbx
   .text:00000000011DE520                 mov     r13, [rax]
   .text:00000000011DE523                 mov     rax, [rbx]
-  .text:00000000011DE526                 call    qword ptr [rax+138h]
+  .text:00000000011DE526                 ; 0x138 = 312LL = CEntityInstance_GetChangeAccessorPathInfo_1
+  .text:00000000011DE526                 call    qword ptr [rax+138h]  ; 0x138 = 312LL = CEntityInstance_GetChangeAccessorPathInfo_1
   .text:00000000011DE52C                 mov     edx, [rax+4]
   .text:00000000011DE52F                 and     edx, 7FFFFFFFh
   .text:00000000011DE535                 jz      loc_11DE830
@@ -501,7 +502,7 @@ procedure: |-
     if ( (int)a4 >= 0 )
     {
       a3 = (__int64 *)qword_26F8388;
-      v14 = (*(__int64 (__fastcall **)(_QWORD *))(*a1 + 312LL))(a1);
+      v14 = (*(__int64 (__fastcall **)(_QWORD *))(*a1 + 312LL))(a1);  // 312LL = 0x138 = CEntityInstance_GetChangeAccessorPathInfo_1
       if ( (*(_DWORD *)(v14 + 4) & 0x7FFFFFFF) == 0 )
       {
         v15 = 0;

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__SetPolymorphicPointer.windows.yaml
@@ -215,7 +215,8 @@ disasm_code: |-
   .text:0000000180885841                 js      loc_180885A60
   .text:0000000180885847                 mov     rax, [r14]
   .text:000000018088584A                 mov     rcx, r14
-  .text:000000018088584D                 call    qword ptr [rax+138h]
+  .text:000000018088584D                 ; 0x138 = 312LL = CEntityInstance_GetChangeAccessorPathInfo_1
+  .text:000000018088584D                 call    qword ptr [rax+138h]  ; 0x138 = 312LL = CEntityInstance_GetChangeAccessorPathInfo_1
   .text:0000000180885853                 mov     ecx, [rax+4]
   .text:0000000180885856                 and     ecx, 7FFFFFFFh
   .text:000000018088585C                 jnz     short loc_180885884
@@ -598,7 +599,7 @@ procedure: |-
       v24 = *((int *)*a4 + 10);
       if ( (int)v24 >= 0 )
       {
-        v25 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*a1 + 312LL))(a1, v13);
+        v25 = (*(__int64 (__fastcall **)(_QWORD *, __int64))(*a1 + 312LL))(a1, v13);  // 312LL = 0x138 = CEntityInstance_GetChangeAccessorPathInfo_1
         if ( (*(_DWORD *)(v25 + 4) & 0x7FFFFFFF) != 0 )
         {
           v26 = (_QWORD *)(v25 + 8);


### PR DESCRIPTION
## Summary

- Adds `find-CEntityInstance_GetChangeAccessorPathInfo_1.py` (Pattern C — vfunc via LLM_DECOMPILE)
- Annotates `PolymorphicHelper_t__SetPolymorphicPointer` reference YAMLs (both platforms) with the `CEntityInstance_GetChangeAccessorPathInfo_1` vtable call at offset `0x138` (312LL)
- Adds config.yaml skill and symbol entries for `CEntityInstance_GetChangeAccessorPathInfo_1` (vfunc of `CEntityInstance_vtable`)

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with `Successful: 1, Failed: 0`
- [x] `CEntityInstance_GetChangeAccessorPathInfo_1.windows.yaml` and `.linux.yaml` generated correctly