### PR TITLE
feat(server): add CEntityKeyValues_LoadFromContext, CEntityKeyValues_Initialized, and CEntitySystem_m_nEntityKeyValuesAllocatorRefCount preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5451,6 +5451,12 @@ modules:
         expected_input:
           - CEntityKeyValues_LoadFromContext.{platform}.yaml
 
+      - name: find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+        expected_output:
+          - CEntitySystem_m_nEntityKeyValuesAllocatorRefCount.{platform}.yaml
+        expected_input:
+          - CEntityKeyValues_Initialized.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8786,6 +8792,11 @@ modules:
         category: func
         alias:
           - CEntityKeyValues::Initialized
+
+      - name: CEntitySystem_m_nEntityKeyValuesAllocatorRefCount
+        category: structmember
+        alias:
+          - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5445,6 +5445,12 @@ modules:
         expected_output:
           - CEntityKeyValues_LoadFromContext.{platform}.yaml
 
+      - name: find-CEntityKeyValues_Initialized
+        expected_output:
+          - CEntityKeyValues_Initialized.{platform}.yaml
+        expected_input:
+          - CEntityKeyValues_LoadFromContext.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8775,6 +8781,11 @@ modules:
         category: func
         alias:
           - CEntityKeyValues::LoadFromContext
+
+      - name: CEntityKeyValues_Initialized
+        category: func
+        alias:
+          - CEntityKeyValues::Initialized
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5441,6 +5441,10 @@ modules:
         expected_input:
           - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
 
+      - name: find-CEntityKeyValues_LoadFromContext
+        expected_output:
+          - CEntityKeyValues_LoadFromContext.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8766,6 +8770,11 @@ modules:
         category: structmember
         struct: CEntitySystem
         member: m_EntityKeyValuesAllocator
+
+      - name: CEntityKeyValues_LoadFromContext
+        category: func
+        alias:
+          - CEntityKeyValues::LoadFromContext
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/ida_preprocessor_scripts/find-CEntityKeyValues_Initialized.py
+++ b/ida_preprocessor_scripts/find-CEntityKeyValues_Initialized.py
@@ -1,32 +1,25 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CEntityKeyValues_LoadFromContext skill."""
+"""Preprocess script for find-CEntityKeyValues_Initialized skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CEntityKeyValues_LoadFromContext",
+    "CEntityKeyValues_Initialized",
 ]
 
-FUNC_XREFS = [
-    {
-        "func_name": "CEntityKeyValues_LoadFromContext",
-        "xref_strings": [
-            "CEntityKeyValues::LoadFromContext: Invalid version! Expected %d, encountered %d!\n",
-        ],
-        "xref_gvs": [],
-        "xref_signatures": [],
-        "xref_funcs": [],
-        "exclude_funcs": [],
-        "exclude_strings": [],
-        "exclude_gvs": [],
-        "exclude_signatures": [],
-    },
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityKeyValues_Initialized",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityKeyValues_LoadFromContext.{platform}.yaml",
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CEntityKeyValues_LoadFromContext",
+        "CEntityKeyValues_Initialized",
         [
             "func_name",
             "func_sig",
@@ -39,7 +32,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
 
 async def preprocess_skill(
     session, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, image_base, debug=False,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
 ):
     """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
     return await preprocess_common_skill(
@@ -50,7 +43,8 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
-        func_xrefs=FUNC_XREFS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-CEntityKeyValues_LoadFromContext.py
+++ b/ida_preprocessor_scripts/find-CEntityKeyValues_LoadFromContext.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityKeyValues_LoadFromContext skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityKeyValues_LoadFromContext",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntityKeyValues_LoadFromContext",
+        "xref_strings": [
+            "Field %s::%s cannot have sub-keyfields since it is an atomic type!\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityKeyValues_LoadFromContext",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_nEntityKeyValuesAllocatorRefCount",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_nEntityKeyValuesAllocatorRefCount",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityKeyValues_Initialized.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_nEntityKeyValuesAllocatorRefCount",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValues_Initialized.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValues_Initialized.linux.yaml
@@ -1,0 +1,84 @@
+func_name: CEntityKeyValues_Initialized
+func_va: '0x1e57920'
+disasm_code: |-
+  .text:0000000001E57920                 mov     rax, [rdi]
+  .text:0000000001E57923                 test    rax, rax
+  .text:0000000001E57926                 jz      short loc_1E57930
+  .text:0000000001E57928                 retn
+  .text:0000000001E57930                 push    rbp
+  .text:0000000001E57931                 mov     rbp, rsp
+  .text:0000000001E57934                 push    r12
+  .text:0000000001E57936                 push    rbx
+  .text:0000000001E57937                 movzx   eax, byte ptr [rdi+25h]
+  .text:0000000001E5793B                 mov     rbx, rdi
+  .text:0000000001E5793E                 sub     eax, 1
+  .text:0000000001E57941                 cmp     al, 1
+  .text:0000000001E57943                 ja      short loc_1E579B0
+  .text:0000000001E57945                 lea     rax, g_pEntitySystem
+  .text:0000000001E5794C                 mov     rcx, [rax]
+  .text:0000000001E5794F                 lea     r12, [rcx+0CD0h]
+  .text:0000000001E57956                 mov     [rdi], r12
+  .text:0000000001E57959                 mov     rax, [rax]
+  .text:0000000001E5795C                 lea     rdx, [rax+0CD0h]
+  .text:0000000001E57963                 cmp     r12, rdx
+  .text:0000000001E57966                 jnz     short loc_1E57972
+  .text:0000000001E57968                 add     dword ptr [rax+0BD0h], 1 ; 0xBD0 = 3024 = CEntitySystem::m_nEntityKeyValuesAllocatorRefCount (structmember, struct=CEntitySystem, member=m_nEntityKeyValuesAllocatorRefCount)
+  .text:0000000001E5796F                 mov     r12, [rdi]
+  .text:0000000001E57972                 mov     rdi, r12
+  .text:0000000001E57975                 mov     edx, 8
+  .text:0000000001E5797A                 mov     esi, 9
+  .text:0000000001E5797F                 call    sub_1B1A850
+  .text:0000000001E57984                 mov     rdi, [rbx]
+  .text:0000000001E57987                 mov     edx, 8
+  .text:0000000001E5798C                 mov     esi, 9
+  .text:0000000001E57991                 mov     [rbx+10h], rax
+  .text:0000000001E57995                 call    sub_1B1A850
+  .text:0000000001E5799A                 mov     [rbx+18h], rax
+  .text:0000000001E5799E                 mov     rax, [rbx]
+  .text:0000000001E579A1                 pop     rbx
+  .text:0000000001E579A2                 pop     r12
+  .text:0000000001E579A4                 pop     rbp
+  .text:0000000001E579A5                 retn
+  .text:0000000001E579B0                 mov     edi, 1200h
+  .text:0000000001E579B5                 call    sub_97A1D0
+  .text:0000000001E579BA                 mov     esi, 1
+  .text:0000000001E579BF                 mov     r12, rax
+  .text:0000000001E579C2                 mov     rdi, rax
+  .text:0000000001E579C5                 call    sub_1B1CF50
+  .text:0000000001E579CA                 mov     [rbx], r12
+  .text:0000000001E579CD                 jmp     short loc_1E57972
+procedure: |-
+  __int64 __fastcall CEntityKeyValues_Initialized(__int64 a1)
+  {
+    __int64 result; // rax
+    __int64 v3; // r12
+    __int64 v4; // rax
+    __int64 v5; // rdi
+
+    result = *(_QWORD *)a1;
+    if ( !*(_QWORD *)a1 )
+    {
+      if ( (unsigned __int8)(*(_BYTE *)(a1 + 37) - 1) > 1u )
+      {
+        v3 = sub_97A1D0();
+        sub_1B1CF50(v3, 1);
+        *(_QWORD *)a1 = v3;
+      }
+      else
+      {
+        v3 = g_pEntitySystem + 3280;
+        *(_QWORD *)a1 = g_pEntitySystem + 3280;
+        if ( v3 == g_pEntitySystem + 3280 )
+        {
+          ++*(_DWORD *)(g_pEntitySystem + 3024); // 0xBD0 = 3024 = CEntitySystem::m_nEntityKeyValuesAllocatorRefCount (structmember, struct=CEntitySystem, member=m_nEntityKeyValuesAllocatorRefCount)
+          v3 = *(_QWORD *)a1;
+        }
+      }
+      v4 = sub_1B1A850(v3, 9, 8);
+      v5 = *(_QWORD *)a1;
+      *(_QWORD *)(a1 + 16) = v4;
+      *(_QWORD *)(a1 + 24) = sub_1B1A850(v5, 9, 8);
+      return *(_QWORD *)a1;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValues_Initialized.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValues_Initialized.windows.yaml
@@ -1,0 +1,82 @@
+func_name: CEntityKeyValues_Initialized
+func_va: '0x181207a90'
+disasm_code: |-
+  .text:0000000181207A90                 push    rbx
+  .text:0000000181207A92                 sub     rsp, 20h
+  .text:0000000181207A96                 cmp     qword ptr [rcx], 0
+  .text:0000000181207A9A                 mov     rbx, rcx
+  .text:0000000181207A9D                 jnz     loc_181207B29
+  .text:0000000181207AA3                 movzx   eax, byte ptr [rcx+25h]
+  .text:0000000181207AA7                 dec     al
+  .text:0000000181207AA9                 cmp     al, 1
+  .text:0000000181207AAB                 ja      short loc_181207AE8
+  .text:0000000181207AAD                 mov     rdx, cs:1820B9498h
+  .text:0000000181207AB4                 add     rdx, 0CC8h
+  .text:0000000181207ABB                 mov     [rcx], rdx
+  .text:0000000181207ABE                 mov     rcx, cs:1820B9498h
+  .text:0000000181207AC5                 lea     rax, [rcx+0CC8h]
+  .text:0000000181207ACC                 cmp     rdx, rax
+  .text:0000000181207ACF                 jnz     short loc_181207B18
+  .text:0000000181207AD1                 inc     dword ptr [rcx+0BD0h] ; 0xBD0 = 3024 = CEntitySystem::m_nEntityKeyValuesAllocatorRefCount (structmember, struct=CEntitySystem, member=m_nEntityKeyValuesAllocatorRefCount)
+  .text:0000000181207AD7                 mov     rcx, rbx
+  .text:0000000181207ADA                 call    sub_181207B40
+  .text:0000000181207ADF                 mov     rax, [rbx]
+  .text:0000000181207AE2                 add     rsp, 20h
+  .text:0000000181207AE6                 pop     rbx
+  .text:0000000181207AE7                 retn
+  .text:0000000181207AE8                 mov     ecx, 1200h
+  .text:0000000181207AED                 mov     [rsp+28h+arg_0], rdi
+  .text:0000000181207AF2                 call    sub_180E7C960
+  .text:0000000181207AF7                 mov     rdi, rax
+  .text:0000000181207AFA                 test    rax, rax
+  .text:0000000181207AFD                 jz      short loc_181207B0E
+  .text:0000000181207AFF                 mov     edx, 1
+  .text:0000000181207B04                 mov     rcx, rax
+  .text:0000000181207B07                 call    sub_1814D6420
+  .text:0000000181207B0C                 jmp     short loc_181207B10
+  .text:0000000181207B0E                 xor     edi, edi
+  .text:0000000181207B10                 mov     [rbx], rdi
+  .text:0000000181207B13                 mov     rdi, [rsp+28h+arg_0]
+  .text:0000000181207B18                 mov     rcx, rbx
+  .text:0000000181207B1B                 call    sub_181207B40
+  .text:0000000181207B20                 mov     rax, [rbx]
+  .text:0000000181207B23                 add     rsp, 20h
+  .text:0000000181207B27                 pop     rbx
+  .text:0000000181207B28                 retn
+  .text:0000000181207B29                 mov     rax, [rcx]
+  .text:0000000181207B2C                 add     rsp, 20h
+  .text:0000000181207B30                 pop     rbx
+  .text:0000000181207B31                 retn
+procedure: |-
+  __int64 __fastcall CEntityKeyValues_Initialized(_BYTE *a1)
+  {
+    __int64 v2; // rdx
+    __int64 v4; // rax
+    __int64 v5; // rdi
+
+    if ( *(_QWORD *)a1 )
+      return *(_QWORD *)a1;
+    if ( (unsigned __int8)(a1[37] - 1) > 1u )
+    {
+      v4 = sub_180E7C960(4608);
+      v5 = v4;
+      if ( v4 )
+        sub_1814D6420(v4, 1);
+      else
+        v5 = 0;
+      *(_QWORD *)a1 = v5;
+    }
+    else
+    {
+      v2 = MEMORY[0x1820B9498] + 3272;
+      *(_QWORD *)a1 = MEMORY[0x1820B9498] + 3272;
+      if ( v2 == MEMORY[0x1820B9498] + 3272 )
+      {
+        ++*(_DWORD *)(MEMORY[0x1820B9498] + 3024); // 0xBD0 = 3024 = CEntitySystem::m_nEntityKeyValuesAllocatorRefCount (structmember, struct=CEntitySystem, member=m_nEntityKeyValuesAllocatorRefCount)
+        sub_181207B40(a1);
+        return *(_QWORD *)a1;
+      }
+    }
+    sub_181207B40(a1);
+    return *(_QWORD *)a1;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValues_LoadFromContext.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValues_LoadFromContext.linux.yaml
@@ -1,0 +1,161 @@
+func_name: CEntityKeyValues_LoadFromContext
+func_va: '0x1e58750'
+disasm_code: |-
+  .text:0000000001E58750                 test    rsi, rsi
+  .text:0000000001E58753                 jz      loc_1E588E0
+  .text:0000000001E58759                 push    rbp
+  .text:0000000001E5875A                 lea     rax, aVersion; "version"
+  .text:0000000001E58761                 mov     edx, 0FFFFFFFFh
+  .text:0000000001E58766                 mov     rbp, rsp
+  .text:0000000001E58769                 push    r14
+  .text:0000000001E5876B                 lea     r14, [rbp-60h]
+  .text:0000000001E5876F                 push    r13
+  .text:0000000001E58771                 mov     r13, rdi
+  .text:0000000001E58774                 push    r12
+  .text:0000000001E58776                 push    rbx
+  .text:0000000001E58777                 mov     rbx, rsi
+  .text:0000000001E5877A                 mov     rsi, r14
+  .text:0000000001E5877D                 sub     rsp, 50h
+  .text:0000000001E58781                 mov     rdi, rbx
+  .text:0000000001E58784                 mov     qword ptr [rbp-60h], 0FFFFFFFFCA0850D5h
+  .text:0000000001E5878C                 mov     [rbp-58h], rax
+  .text:0000000001E58790                 call    sub_1B1DE40
+  .text:0000000001E58795                 mov     r12d, eax
+  .text:0000000001E58798                 cmp     eax, 1
+  .text:0000000001E5879B                 jz      short loc_1E587D0
+  .text:0000000001E5879D                 lea     rbx, dword_27C455C
+  .text:0000000001E587A4                 mov     esi, 5
+  .text:0000000001E587A9                 mov     edi, [rbx]
+  .text:0000000001E587AB                 call    sub_983F70
+  .text:0000000001E587B0                 test    al, al
+  .text:0000000001E587B2                 jnz     loc_1E58870
+  .text:0000000001E587B8                 add     rsp, 50h
+  .text:0000000001E587BC                 xor     eax, eax
+  .text:0000000001E587BE                 pop     rbx
+  .text:0000000001E587BF                 pop     r12
+  .text:0000000001E587C1                 pop     r13
+  .text:0000000001E587C3                 pop     r14
+  .text:0000000001E587C5                 pop     rbp
+  .text:0000000001E587C6                 retn
+  .text:0000000001E587D0                 lea     r12, [rbp-64h]
+  .text:0000000001E587D4                 mov     rdi, r13
+  .text:0000000001E587D7                 call    sub_1E57920; CEntityKeyValues_Initialized
+  .text:0000000001E587DC                 xor     ecx, ecx
+  .text:0000000001E587DE                 mov     rdx, r12
+  .text:0000000001E587E1                 mov     rsi, r14
+  .text:0000000001E587E4                 lea     rax, aValues; "values"
+  .text:0000000001E587EB                 mov     rdi, rbx
+  .text:0000000001E587EE                 mov     dword ptr [rbp-64h], 0FFFFFFFFh
+  .text:0000000001E587F5                 mov     qword ptr [rbp-60h], 0FFFFFFFFDACDDCE8h
+  .text:0000000001E587FD                 mov     [rbp-58h], rax
+  .text:0000000001E58801                 call    sub_1B1E770
+  .text:0000000001E58806                 test    rax, rax
+  .text:0000000001E58809                 jz      short loc_1E58817
+  .text:0000000001E5880B                 mov     rdi, [r13+10h]
+  .text:0000000001E5880F                 mov     rsi, rax
+  .text:0000000001E58812                 call    sub_1B22970
+  .text:0000000001E58817                 xor     ecx, ecx
+  .text:0000000001E58819                 mov     rdx, r12
+  .text:0000000001E5881C                 mov     rsi, r14
+  .text:0000000001E5881F                 mov     dword ptr [rbp-64h], 0FFFFFFFFh
+  .text:0000000001E58826                 mov     rax, 0FFFFFFFF1D9B29BBh
+  .text:0000000001E58830                 mov     rdi, rbx
+  .text:0000000001E58833                 mov     [rbp-60h], rax
+  .text:0000000001E58837                 lea     rax, aAttributes; "attributes"
+  .text:0000000001E5883E                 mov     [rbp-58h], rax
+  .text:0000000001E58842                 call    sub_1B1E770
+  .text:0000000001E58847                 test    rax, rax
+  .text:0000000001E5884A                 jz      short loc_1E58858
+  .text:0000000001E5884C                 mov     rdi, [r13+18h]
+  .text:0000000001E58850                 mov     rsi, rax
+  .text:0000000001E58853                 call    sub_1B22970
+  .text:0000000001E58858                 add     rsp, 50h
+  .text:0000000001E5885C                 mov     eax, 1
+  .text:0000000001E58861                 pop     rbx
+  .text:0000000001E58862                 pop     r12
+  .text:0000000001E58864                 pop     r13
+  .text:0000000001E58866                 pop     r14
+  .text:0000000001E58868                 pop     rbp
+  .text:0000000001E58869                 retn
+  .text:0000000001E58870                 mov     edi, [rbx]
+  .text:0000000001E58872                 lea     rax, aEntitykeyvalue; "entitykeyvalues.cpp"
+  .text:0000000001E58879                 mov     r9d, r12d
+  .text:0000000001E5887C                 mov     rdx, r14
+  .text:0000000001E5887F                 mov     [rbp-60h], rax
+  .text:0000000001E58883                 mov     r8d, 1
+  .text:0000000001E58889                 mov     esi, 5
+  .text:0000000001E5888E                 lea     rax, aLoadfromkv3; "LoadFromKV3"
+  .text:0000000001E58895                 mov     dword ptr [rbp-58h], 2D2h
+  .text:0000000001E5889C                 mov     [rbp-50h], rax
+  .text:0000000001E588A0                 lea     rcx, aCentitykeyvalu; "CEntityKeyValues::LoadFromContext: Inva"...
+  .text:0000000001E588A7                 xor     eax, eax
+  .text:0000000001E588A9                 mov     qword ptr [rbp-48h], 0
+  .text:0000000001E588B1                 mov     qword ptr [rbp-40h], 0
+  .text:0000000001E588B9                 mov     qword ptr [rbp-38h], 0
+  .text:0000000001E588C1                 mov     qword ptr [rbp-30h], 0
+  .text:0000000001E588C9                 mov     dword ptr [rbp-28h], 0
+  .text:0000000001E588D0                 call    sub_983DB0
+  .text:0000000001E588D5                 jmp     loc_1E587B8
+  .text:0000000001E588E0                 xor     eax, eax
+  .text:0000000001E588E2                 retn
+procedure: |-
+  __int64 __fastcall CEntityKeyValues_LoadFromContext(__int64 a1, __int64 a2)
+  {
+    int v2; // r12d
+    __int64 v4; // rax
+    __int64 v5; // rax
+    int v6; // [rsp-6Ch] [rbp-6Ch] BYREF
+    __int64 v7; // [rsp-68h] [rbp-68h] BYREF
+    const char *v8; // [rsp-60h] [rbp-60h]
+    const char *v9; // [rsp-58h] [rbp-58h]
+    __int64 v10; // [rsp-50h] [rbp-50h]
+    __int64 v11; // [rsp-48h] [rbp-48h]
+    __int64 v12; // [rsp-40h] [rbp-40h]
+    __int64 v13; // [rsp-38h] [rbp-38h]
+    int v14; // [rsp-30h] [rbp-30h]
+
+    if ( !a2 )
+      return 0;
+    v7 = -905424683;
+    v8 = "version";
+    v2 = sub_1B1DE40(a2, &v7, 0xFFFFFFFFLL);
+    if ( v2 == 1 )
+    {
+      sub_1E57920(a1); // CEntityKeyValues_Initialized
+      v6 = -1;
+      v7 = -624042776;
+      v8 = "values";
+      v4 = sub_1B1E770(a2, &v7, &v6, 0);
+      if ( v4 )
+        sub_1B22970(*(_QWORD *)(a1 + 16), v4);
+      v6 = -1;
+      v7 = -3798259269LL;
+      v8 = "attributes";
+      v5 = sub_1B1E770(a2, &v7, &v6, 0);
+      if ( v5 )
+        sub_1B22970(*(_QWORD *)(a1 + 24), v5);
+      return 1;
+    }
+    else
+    {
+      if ( (unsigned __int8)sub_983F70((unsigned int)dword_27C455C, 5) )
+      {
+        v7 = (__int64)"entitykeyvalues.cpp";
+        LODWORD(v8) = 722;
+        v9 = "LoadFromKV3";
+        v10 = 0;
+        v11 = 0;
+        v12 = 0;
+        v13 = 0;
+        v14 = 0;
+        sub_983DB0(
+          (unsigned int)dword_27C455C,
+          5,
+          &v7,
+          "CEntityKeyValues::LoadFromContext: Invalid version! Expected %d, encountered %d!\n",
+          1,
+          v2);
+      }
+      return 0;
+    }
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValues_LoadFromContext.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValues_LoadFromContext.windows.yaml
@@ -1,0 +1,139 @@
+func_name: CEntityKeyValues_LoadFromContext
+func_va: '0x181207bc0'
+disasm_code: |-
+  .text:0000000181207BC0                 mov     [rsp+arg_0], rbx
+  .text:0000000181207BC5                 mov     [rsp+arg_10], rsi
+  .text:0000000181207BCA                 push    rdi
+  .text:0000000181207BCB                 sub     rsp, 80h
+  .text:0000000181207BD2                 mov     rbx, rdx
+  .text:0000000181207BD5                 mov     rdi, rcx
+  .text:0000000181207BD8                 test    rdx, rdx
+  .text:0000000181207BDB                 jz      loc_181207C8C
+  .text:0000000181207BE1                 lea     rax, aVersion; "version"
+  .text:0000000181207BE8                 mov     [rsp+88h+var_58], 0FFFFFFFFCA0850D5h
+  .text:0000000181207BF1                 mov     r8d, 0FFFFFFFFh
+  .text:0000000181207BF7                 mov     [rsp+88h+var_50], rax
+  .text:0000000181207BFC                 lea     rdx, [rsp+88h+var_58]
+  .text:0000000181207C01                 mov     rcx, rbx
+  .text:0000000181207C04                 call    sub_1814DC050
+  .text:0000000181207C09                 mov     esi, eax
+  .text:0000000181207C0B                 cmp     eax, 1
+  .text:0000000181207C0E                 jz      loc_181207CA3
+  .text:0000000181207C14                 mov     ecx, dword ptr cs:unk_1820B98C8
+  .text:0000000181207C1A                 mov     edx, 5
+  .text:0000000181207C1F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000181207C25                 test    al, al
+  .text:0000000181207C27                 jz      short loc_181207C8C
+  .text:0000000181207C29                 mov     ecx, dword ptr cs:unk_1820B98C8
+  .text:0000000181207C2F                 lea     rax, aCBuildworkerCs_63; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000181207C36                 mov     [rsp+88h+var_48], rax
+  .text:0000000181207C3B                 lea     r9, aCentitykeyvalu_0; "CEntityKeyValues::LoadFromContext: Inva"...
+  .text:0000000181207C42                 lea     rax, aCentitykeyvalu_1; "CEntityKeyValues::LoadFromKV3"
+  .text:0000000181207C49                 mov     [rsp+88h+var_60], esi
+  .text:0000000181207C4D                 xorps   xmm0, xmm0
+  .text:0000000181207C50                 mov     [rsp+88h+var_38], rax
+  .text:0000000181207C55                 xorps   xmm1, xmm1
+  .text:0000000181207C58                 mov     [rsp+88h+var_40], 2D3h
+  .text:0000000181207C60                 lea     r8, [rsp+88h+var_48]
+  .text:0000000181207C65                 mov     [rsp+88h+var_10], 0
+  .text:0000000181207C6D                 mov     edx, 5
+  .text:0000000181207C72                 mov     [rsp+88h+var_68], 1
+  .text:0000000181207C7A                 movdqu  [rsp+88h+var_30], xmm0
+  .text:0000000181207C80                 movdqu  [rsp+88h+var_20], xmm1
+  .text:0000000181207C86                 call    cs:LoggingSystem_Log
+  .text:0000000181207C8C                 xor     al, al
+  .text:0000000181207C8E                 lea     r11, [rsp+88h+var_8]
+  .text:0000000181207C96                 mov     rbx, [r11+10h]
+  .text:0000000181207C9A                 mov     rsi, [r11+20h]
+  .text:0000000181207C9E                 mov     rsp, r11
+  .text:0000000181207CA1                 pop     rdi
+  .text:0000000181207CA2                 retn
+  .text:0000000181207CA3                 mov     rcx, rdi
+  .text:0000000181207CA6                 call    sub_181207A90; CEntityKeyValues_Initialized
+  .text:0000000181207CAB                 lea     rax, aValues; "values"
+  .text:0000000181207CB2                 mov     [rsp+88h+arg_8], 0FFFFFFFFh
+  .text:0000000181207CBD                 xor     r9d, r9d
+  .text:0000000181207CC0                 mov     [rsp+88h+var_50], rax
+  .text:0000000181207CC5                 lea     r8, [rsp+88h+arg_8]
+  .text:0000000181207CCD                 mov     [rsp+88h+var_58], 0FFFFFFFFDACDDCE8h
+  .text:0000000181207CD6                 lea     rdx, [rsp+88h+var_58]
+  .text:0000000181207CDB                 mov     rcx, rbx
+  .text:0000000181207CDE                 call    sub_1814DA7F0
+  .text:0000000181207CE3                 test    rax, rax
+  .text:0000000181207CE6                 jz      short loc_181207CF4
+  .text:0000000181207CE8                 mov     rcx, [rdi+10h]
+  .text:0000000181207CEC                 mov     rdx, rax
+  .text:0000000181207CEF                 call    sub_1814D9460
+  .text:0000000181207CF4                 lea     rax, aAttributes; "attributes"
+  .text:0000000181207CFB                 mov     [rsp+88h+arg_8], 0FFFFFFFFh
+  .text:0000000181207D06                 xor     r9d, r9d
+  .text:0000000181207D09                 mov     [rsp+88h+var_50], rax
+  .text:0000000181207D0E                 lea     r8, [rsp+88h+arg_8]
+  .text:0000000181207D16                 mov     dword ptr [rsp+88h+var_58], 1D9B29BBh
+  .text:0000000181207D1E                 lea     rdx, [rsp+88h+var_58]
+  .text:0000000181207D23                 mov     dword ptr [rsp+88h+var_58+4], 0FFFFFFFFh
+  .text:0000000181207D2B                 mov     rcx, rbx
+  .text:0000000181207D2E                 call    sub_1814DA7F0
+  .text:0000000181207D33                 test    rax, rax
+  .text:0000000181207D36                 jz      short loc_181207D44
+  .text:0000000181207D38                 mov     rcx, [rdi+18h]
+  .text:0000000181207D3C                 mov     rdx, rax
+  .text:0000000181207D3F                 call    sub_1814D9460
+  .text:0000000181207D44                 mov     al, 1
+  .text:0000000181207D46                 jmp     loc_181207C8E
+procedure: |-
+  char __fastcall CEntityKeyValues_LoadFromContext(__int64 a1, __int64 a2)
+  {
+    int v4; // esi
+    __int64 v6; // rax
+    __int64 v7; // rax
+    __int64 v8; // [rsp+30h] [rbp-58h] BYREF
+    const char *v9; // [rsp+38h] [rbp-50h]
+    const char *v10; // [rsp+40h] [rbp-48h] BYREF
+    int v11; // [rsp+48h] [rbp-40h]
+    const char *v12; // [rsp+50h] [rbp-38h]
+    __int128 v13; // [rsp+58h] [rbp-30h]
+    __int128 v14; // [rsp+68h] [rbp-20h]
+    int v15; // [rsp+78h] [rbp-10h]
+    int v16; // [rsp+98h] [rbp+10h] BYREF
+
+    if ( !a2 )
+      return 0;
+    v8 = -905424683;
+    v9 = "version";
+    v4 = sub_1814DC050(a2, &v8, 0xFFFFFFFFLL);
+    if ( v4 != 1 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)unk_1820B98C8, 5) )
+      {
+        v10 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\entity2\\entitykeyvalues.cpp";
+        v12 = "CEntityKeyValues::LoadFromKV3";
+        v11 = 723;
+        v15 = 0;
+        v13 = 0;
+        v14 = 0;
+        LoggingSystem_Log(
+          (unsigned int)unk_1820B98C8,
+          5,
+          &v10,
+          "CEntityKeyValues::LoadFromContext: Invalid version! Expected %d, encountered %d!\n",
+          1,
+          v4);
+      }
+      return 0;
+    }
+    sub_181207A90((_BYTE *)a1); // CEntityKeyValues_Initialized
+    v16 = -1;
+    v9 = "values";
+    v8 = -624042776;
+    v6 = sub_1814DA7F0(a2, &v8, &v16, 0);
+    if ( v6 )
+      sub_1814D9460(*(_QWORD *)(a1 + 16), v6);
+    v16 = -1;
+    v9 = "attributes";
+    v8 = -3798259269LL;
+    v7 = sub_1814DA7F0(a2, &v8, &v16, 0);
+    if ( v7 )
+      sub_1814D9460(*(_QWORD *)(a1 + 24), v7);
+    return 1;
+  }


### PR DESCRIPTION
## Summary

- Add `find-CEntityKeyValues_LoadFromContext` (Pattern A) — locates function via `CEntityKeyValues::LoadFromContext: Invalid version!` xref string
- Add `find-CEntityKeyValues_Initialized` (Pattern D) — locates function via LLM_DECOMPILE of `CEntityKeyValues_LoadFromContext`
- Add `find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount` (Pattern E) — locates struct member offset `CEntitySystem::m_nEntityKeyValuesAllocatorRefCount` (offset `0xBD0` = 3024) via LLM_DECOMPILE of `CEntityKeyValues_Initialized`

## Test plan

- [ ] Verify `find-CEntityKeyValues_LoadFromContext` resolves to `0x181207bc0` (Windows) / `0x1e58750` (Linux)
- [ ] Verify `find-CEntityKeyValues_Initialized` resolves to `0x181207a90` (Windows) / `0x1e57920` (Linux)
- [ ] Verify `find-CEntitySystem_m_nEntityKeyValuesAllocatorRefCount` resolves to offset `0xBD0` on both platforms