### PR TITLE
feat(server): add CGameEntitySystem_m_pEntity2SaveRestore struct offset to CSource2EntitySystem_StaticInit decompile script

### DIFF
--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -21,6 +21,7 @@ TARGET_GLOBALVAR_NAMES = [
 
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_entityIONotifiers",
+    "CGameEntitySystem_m_pEntity2SaveRestore",
 ]
 
 FUNC_VTABLE_RELATIONS = [
@@ -68,6 +69,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_entityIONotifiers",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CGameEntitySystem_m_pEntity2SaveRestore",
         [
             "struct_name",
             "member_name",
@@ -142,6 +154,11 @@ async def preprocess_skill(
         ),
         (
             "CEntitySystem_m_entityIONotifiers",
+            "prompt/call_llm_decompile.md",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
+        ),
+        (
+            "CGameEntitySystem_m_pEntity2SaveRestore",
             "prompt/call_llm_decompile.md",
             "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),


### PR DESCRIPTION
## Summary
- Adds `CGameEntitySystem_m_pEntity2SaveRestore` to the target struct member names list in the `find-CSource2EntitySystem_StaticInit-decompiles.py` preprocessor script
- Adds the corresponding YAML output field configuration (struct_name, member_name, offset, size, offset_sig, offset_sig_disp)
- Adds the decompile task entry linking it to the `call_llm_decompile.md` prompt and `CSource2EntitySystem_StaticInit` reference YAML

## Test plan
- [ ] Run the preprocessor script and verify `CGameEntitySystem_m_pEntity2SaveRestore` is resolved and written to YAML output