### PR TITLE
feat(server): add CEntitySystem_m_pFieldChangeLimitSpew preprocessor script

### DIFF
--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -14,6 +14,7 @@ TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_Symbols",
     "CEntitySystem_m_pNetworkFieldChangedEventQueue",
     "CEntitySystem_m_pNetworkFieldScratchData",
+    "CEntitySystem_m_pFieldChangeLimitSpew",
 ]
 
 LLM_DECOMPILE = [
@@ -50,6 +51,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_pNetworkFieldScratchData",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_pFieldChangeLimitSpew",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -131,6 +137,19 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_pNetworkFieldScratchData",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
+            #"offset_sig_max_match:2",
+            "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "CEntitySystem_m_pFieldChangeLimitSpew",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -303,7 +303,8 @@ disasm_code: |-
   .text:0000000001E7C8FD                 movsxd  rdx, r14d
   .text:0000000001E7C900                 mov     [rax+rdx*8], r13
   .text:0000000001E7C904                 lea     rax, g_pFlattenedSerializers
-  .text:0000000001E7C90B                 mov     rdx, [rbx+0C98h]
+  .text:0000000001E7C90B                 ; 3224 = 0xC98 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
+  .text:0000000001E7C90B                 mov     rdx, [rbx+0C98h]; 3224 = 0xC98 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
   .text:0000000001E7C912                 ; 3216 = 0xC90 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:0000000001E7C912                 mov     rsi, [rbx+0C90h]; 3216 = 0xC90 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:0000000001E7C919                 mov     rdi, [rax]
@@ -958,7 +959,7 @@ procedure: |-
                                                                    + 280LL))(// 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
                  g_pFlattenedSerializers,
                  *(_QWORD *)(a1 + 3216),          // 3216 = 0xC90 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
-                 *(_QWORD *)(a1 + 3224));
+                 *(_QWORD *)(a1 + 3224));          // 3224 = 0xC98 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
       *(_QWORD *)(a1 + 3208) = result;            // 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
     }
     if ( byte_27C42C0 )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -312,7 +312,8 @@ disasm_code: |-
   .text:00000001811F8796                 mov     r8d, cs:dword_1820B98C8
   .text:00000001811F879D                 call    qword ptr [rax+8]
   .text:00000001811F87A0                 mov     rcx, cs:g_pFlattenedSerializers
-  .text:00000001811F87A7                 mov     r8, [rsi+0C90h]
+  .text:00000001811F87A7                 ; 3216 = 0xC90 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
+  .text:00000001811F87A7                 mov     r8, [rsi+0C90h]; 3216 = 0xC90 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
   .text:00000001811F87AE                 ; 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:00000001811F87AE                 mov     rdx, [rsi+0C88h]; 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
   .text:00000001811F87B5                 mov     rax, [rcx]
@@ -702,7 +703,7 @@ procedure: |-
                                                                   + 280LL))(// 0x118 = 280LL = IFlattenedSerializers_CreateFieldChangedEventQueue
                  g_pFlattenedSerializers,
                  *(_QWORD *)(a1 + 3208),          // 3208 = 0xC88 = CEntitySystem::m_pNetworkFieldScratchData (structmember, struct=CEntitySystem, member=m_pNetworkFieldScratchData)
-                 *(_QWORD *)(a1 + 3216));
+                 *(_QWORD *)(a1 + 3216));          // 3216 = 0xC90 = CEntitySystem::m_pFieldChangeLimitSpew (structmember, struct=CEntitySystem, member=m_pFieldChangeLimitSpew)
       *(_QWORD *)(a1 + 3200) = result;            // 3200 = 0xC80 = CEntitySystem::m_pNetworkFieldChangedEventQueue (structmember, struct=CEntitySystem, member=m_pNetworkFieldChangedEventQueue)
     }
     if ( !byte_1820B959C )


### PR DESCRIPTION
## Summary
- Add `CEntitySystem_m_pFieldChangeLimitSpew` to `find-CEntitySystem_Init-decompiles.py` (TARGET_STRUCT_MEMBER_NAMES, LLM_DECOMPILE, GENERATE_YAML_DESIRED_FIELDS)
- Annotate windows reference YAML: `mov r8, [rsi+0C90h]` at offset 0xC90 (3216) as `m_pFieldChangeLimitSpew`
- Annotate linux reference YAML: `mov rdx, [rbx+0C98h]` at offset 0xC98 (3224) as `m_pFieldChangeLimitSpew` (struct layout differs between platforms)

## Test plan
- [ ] Run the preprocessor script against a new binary to verify `CEntitySystem_m_pFieldChangeLimitSpew` is correctly extracted