### PR TITLE
feat(server): add CEntitySystem_m_ComponentUnserializerInfoAllocator preprocessor script

### DIFF
--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -14,6 +14,7 @@ TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_Symbols",
     "CEntitySystem_m_pNetworkFieldChangedEventQueue",
     "CEntitySystem_m_pNetworkFieldScratchData",
+    "CEntitySystem_m_ComponentUnserializerInfoAllocator",
 ]
 
 LLM_DECOMPILE = [
@@ -50,6 +51,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntitySystem_m_pNetworkFieldScratchData",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_Init.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_Init.{platform}.yaml",
     ),
@@ -140,6 +146,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "offset_sig_disp",
             #"offset_sig_max_match:2",
             "offset_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "CEntitySystem_m_ComponentUnserializerInfoAllocator",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            #"size",
+            "offset_sig",
+            "offset_sig_disp",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -31,8 +31,8 @@ disasm_code: |-
   .text:0000000001E7C416                 xor     ecx, ecx; void *
   .text:0000000001E7C418                 ; unsigned int
   .text:0000000001E7C418                 xor     edx, edx; unsigned int
-  .text:0000000001E7C41A                 ; this
-  .text:0000000001E7C41A                 lea     rdi, [rbx+0CC0h]; this
+  .text:0000000001E7C41A                 ; 0xCC0 = 3264LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
+  .text:0000000001E7C41A                 lea     rdi, [rbx+0CC0h]; 0xCC0 = 3264LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
   .text:0000000001E7C421                 ; unsigned int
   .text:0000000001E7C421                 mov     esi, 400h; unsigned int
   .text:0000000001E7C426                 call    __ZN21CUtlScratchMemoryPool4InitEjjPvb; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -24,7 +24,8 @@ disasm_code: |-
   .text:00000001811F82AD                 movzx   eax, dil
   .text:00000001811F82B1                 jmp     short loc_1811F82B5
   .text:00000001811F82B3                 xor     al, al
-  .text:00000001811F82B5                 lea     rcx, [rsi+0CB8h]
+  .text:00000001811F82B5                 ; 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
+  .text:00000001811F82B5                 lea     rcx, [rsi+0CB8h]; 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
   .text:00000001811F82BC                 ; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
   .text:00000001811F82BC                 mov     [rsi+0BDAh], al; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
   .text:00000001811F82C2                 xor     r9d, r9d
@@ -508,7 +509,7 @@ procedure: |-
     *(_DWORD *)(a1 + 3004) = a4;
     v8 = a3 == 1 && g_pNetworkMessages;
     *(_BYTE *)(a1 + 3034) = v8;                   // 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
-    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);
+    CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);// 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
     v11 = qword_1820B9438;
     v12 = a1 + 16;
     qword_181E1C888 = a1;


### PR DESCRIPTION
## Summary
- Adds `CEntitySystem_m_ComponentUnserializerInfoAllocator` to the `find-CEntitySystem_Init-decompiles.py` preprocessor script (struct member names, LLM decompile list, and YAML desired fields)
- Updates Linux and Windows reference YAML files to annotate the `0xCC0`/`0xCB8` offsets as `CEntitySystem::m_ComponentUnserializerInfoAllocator`

## Test plan
- [ ] Run the preprocessor script against a current binary and verify the new struct offset is resolved correctly
- [ ] Confirm generated YAML includes `CEntitySystem_m_ComponentUnserializerInfoAllocator` with expected offset and signature fields