### PR TITLE
feat(server): add CEntitySystem_m_flChangeCallbackSpewThreshold struct offset

### DIFF
--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
@@ -8,6 +8,10 @@ TARGET_FUNCTION_NAMES = [
     "CEntityInstance_PostDataUpdateDelta",
 ]
 
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_flChangeCallbackSpewThreshold",
+]
+
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
@@ -17,6 +21,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntityInstance_PostDataUpdateDelta",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_flChangeCallbackSpewThreshold",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
     ),
@@ -54,6 +63,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vtable_name",
         ],
     ),
+    (
+        "CEntitySystem_m_flChangeCallbackSpewThreshold",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
@@ -70,6 +90,7 @@ async def preprocess_skill(
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
         llm_decompile_specs=LLM_DECOMPILE,
         llm_config=llm_config,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,


### PR DESCRIPTION
## Summary
- Adds `CEntitySystem_m_flChangeCallbackSpewThreshold` (struct member of `CEntitySystem`) to the `find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta` preprocessor script
- Uses `references/server/CEntitySystem_PostDataUpdate.{platform}.yaml` as the LLM decompile reference
- Outputs `struct_name`, `member_name`, `offset`, `size`, `offset_sig`, `offset_sig_disp` fields

## Test plan
- [ ] Regenerate `references/server/CEntitySystem_PostDataUpdate.{platform}.yaml` for both windows and linux via `generate_reference_yaml.py`
- [ ] Run preprocessor against a new binary version to verify `CEntitySystem_m_flChangeCallbackSpewThreshold` YAML is produced correctly