### PR TITLE
Add CEntitySystem_m_flChangeCallbackSpewThreshold

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6079,6 +6079,7 @@ modules:
         expected_output:
           - CEntityInstance_PostDataUpdatePreserve.{platform}.yaml
           - CEntityInstance_PostDataUpdateDelta.{platform}.yaml
+          - CEntitySystem_m_flChangeCallbackSpewThreshold.{platform}.yaml
         expected_input:
           - CEntitySystem_PostDataUpdate.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
@@ -10105,6 +10106,13 @@ modules:
         member: m_Symbols
         alias:
           - CEntitySystem::m_ComponentUnserializerInfoAllocator
+
+      - name: CEntitySystem_m_flChangeCallbackSpewThreshold
+        category: structmember
+        struct: CEntitySystem
+        member: m_flChangeCallbackSpewThreshold
+        alias:
+          - CEntitySystem::m_flChangeCallbackSpewThreshold
 
       - name: CEntitySystem_m_nSuppressDestroyImmediateCount
         category: structmember

--- a/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta.py
@@ -8,6 +8,10 @@ TARGET_FUNCTION_NAMES = [
     "CEntityInstance_PostDataUpdateDelta",
 ]
 
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_flChangeCallbackSpewThreshold",
+]
+
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
@@ -17,6 +21,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CEntityInstance_PostDataUpdateDelta",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
+    ),
+    (
+        "CEntitySystem_m_flChangeCallbackSpewThreshold",
         "prompt/call_llm_decompile.md",
         "references/server/CEntitySystem_PostDataUpdate.{platform}.yaml",
     ),
@@ -54,6 +63,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vtable_name",
         ],
     ),
+    (
+        "CEntitySystem_m_flChangeCallbackSpewThreshold",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
 ]
 
 async def preprocess_skill(
@@ -69,6 +89,7 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
         llm_decompile_specs=LLM_DECOMPILE,
         llm_config=llm_config,

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.linux.yaml
@@ -1,50 +1,51 @@
 func_name: CEntitySystem_PostDataUpdate
-func_va: '0x1e502e0'
+func_va: '0x1e59620'
 disasm_code: |-
-  .text:0000000001E502E0                 push    rbp
-  .text:0000000001E502E1                 mov     rbp, rsp
-  .text:0000000001E502E4                 push    r13
-  .text:0000000001E502E6                 push    r12
-  .text:0000000001E502E8                 movsxd  r12, esi
-  .text:0000000001E502EB                 mov     esi, 80000001h
-  .text:0000000001E502F0                 push    rbx
-  .text:0000000001E502F1                 mov     rbx, rdx
-  .text:0000000001E502F4                 sub     rsp, 8
-  .text:0000000001E502F8                 mov     rax, [rdi+0C88h]
-  .text:0000000001E502FF                 movss   xmm0, dword ptr [rdi+0BD4h]
-  .text:0000000001E50307                 mov     rdx, [rax]
-  .text:0000000001E5030A                 mov     rdi, rax
-  .text:0000000001E5030D                 call    qword ptr [rdx+20h]
-  .text:0000000001E50310                 test    r12d, r12d
-  .text:0000000001E50313                 jle     short loc_1E5035B
-  .text:0000000001E50315                 shl     r12, 4
-  .text:0000000001E50319                 lea     r13, byte_27BB16B
-  .text:0000000001E50320                 add     r12, rbx
-  .text:0000000001E50323                 jmp     short loc_1E50334
-  .text:0000000001E50328                 ; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
-  .text:0000000001E50328                 call    qword ptr [rax+68h]; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
-  .text:0000000001E5032B                 add     rbx, 10h
-  .text:0000000001E5032F                 cmp     r12, rbx
-  .text:0000000001E50332                 jz      short loc_1E5035B
-  .text:0000000001E50334                 mov     rax, [rbx]
-  .text:0000000001E50337                 mov     byte ptr [r13+0], 0
-  .text:0000000001E5033C                 and     dword ptr [rax+30h], 0FFFFFFF7h
-  .text:0000000001E50340                 mov     rdi, [rax]
-  .text:0000000001E50343                 mov     esi, [rbx+8]
-  .text:0000000001E50346                 mov     rax, [rdi]
-  .text:0000000001E50349                 test    sil, 4
-  .text:0000000001E5034D                 jnz     short loc_1E50328
-  .text:0000000001E5034F                 ; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
-  .text:0000000001E5034F                 call    qword ptr [rax+58h]; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
-  .text:0000000001E50352                 add     rbx, 10h
-  .text:0000000001E50356                 cmp     r12, rbx
-  .text:0000000001E50359                 jnz     short loc_1E50334
-  .text:0000000001E5035B                 add     rsp, 8
-  .text:0000000001E5035F                 pop     rbx
-  .text:0000000001E50360                 pop     r12
-  .text:0000000001E50362                 pop     r13
-  .text:0000000001E50364                 pop     rbp
-  .text:0000000001E50365                 retn
+  .text:0000000001E59620                 push    rbp
+  .text:0000000001E59621                 mov     rbp, rsp
+  .text:0000000001E59624                 push    r13
+  .text:0000000001E59626                 push    r12
+  .text:0000000001E59628                 movsxd  r12, esi
+  .text:0000000001E5962B                 mov     esi, 80000001h
+  .text:0000000001E59630                 push    rbx
+  .text:0000000001E59631                 mov     rbx, rdx
+  .text:0000000001E59634                 sub     rsp, 8
+  .text:0000000001E59638                 mov     rax, [rdi+0C88h]
+  .text:0000000001E5963F                 ; 0xBD4 = 3028LL = CEntitySystem::m_flChangeCallbackSpewThreshold(structmember,struct=CEntitySystem,member=m_flChangeCallbackSpewThreshold)
+  .text:0000000001E5963F                 movss   xmm0, dword ptr [rdi+0BD4h]; 0xBD4 = 3028LL = CEntitySystem::m_flChangeCallbackSpewThreshold(structmember,struct=CEntitySystem,member=m_flChangeCallbackSpewThreshold)
+  .text:0000000001E59647                 mov     rdx, [rax]
+  .text:0000000001E5964A                 mov     rdi, rax
+  .text:0000000001E5964D                 call    qword ptr [rdx+20h]
+  .text:0000000001E59650                 test    r12d, r12d
+  .text:0000000001E59653                 jle     short loc_1E5969B
+  .text:0000000001E59655                 shl     r12, 4
+  .text:0000000001E59659                 lea     r13, byte_27C426B
+  .text:0000000001E59660                 add     r12, rbx
+  .text:0000000001E59663                 jmp     short loc_1E59674
+  .text:0000000001E59668                 ; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
+  .text:0000000001E59668                 call    qword ptr [rax+68h]; 0x68 = 104LL = CEntityInstance_PostDataUpdatePreserve
+  .text:0000000001E5966B                 add     rbx, 10h
+  .text:0000000001E5966F                 cmp     r12, rbx
+  .text:0000000001E59672                 jz      short loc_1E5969B
+  .text:0000000001E59674                 mov     rax, [rbx]
+  .text:0000000001E59677                 mov     byte ptr [r13+0], 0
+  .text:0000000001E5967C                 and     dword ptr [rax+30h], 0FFFFFFF7h
+  .text:0000000001E59680                 mov     rdi, [rax]
+  .text:0000000001E59683                 mov     esi, [rbx+8]
+  .text:0000000001E59686                 mov     rax, [rdi]
+  .text:0000000001E59689                 test    sil, 4
+  .text:0000000001E5968D                 jnz     short loc_1E59668
+  .text:0000000001E5968F                 ; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
+  .text:0000000001E5968F                 call    qword ptr [rax+58h]; 0x58 = 88LL = CEntityInstance_PostDataUpdateDelta
+  .text:0000000001E59692                 add     rbx, 10h
+  .text:0000000001E59696                 cmp     r12, rbx
+  .text:0000000001E59699                 jnz     short loc_1E59674
+  .text:0000000001E5969B                 add     rsp, 8
+  .text:0000000001E5969F                 pop     rbx
+  .text:0000000001E596A0                 pop     r12
+  .text:0000000001E596A2                 pop     r13
+  .text:0000000001E596A4                 pop     rbp
+  .text:0000000001E596A5                 retn
 procedure: |-
   __int64 __fastcall CEntitySystem_PostDataUpdate(__int64 a1, int a2, __int64 ***a3)
   {
@@ -56,7 +57,7 @@ procedure: |-
     result = (*(__int64 (__fastcall **)(_QWORD, __int64, float))(**(_QWORD **)(a1 + 3208) + 32LL))(
                *(_QWORD *)(a1 + 3208),
                2147483649LL,
-               *(float *)(a1 + 3028));
+               *(float *)(a1 + 3028));            // 0xBD4 = 3028LL = CEntitySystem::m_flChangeCallbackSpewThreshold(structmember,struct=CEntitySystem,member=m_flChangeCallbackSpewThreshold)
     if ( a2 > 0 )
     {
       v5 = &a3[2 * a2];
@@ -65,7 +66,7 @@ procedure: |-
         while ( 1 )
         {
           v6 = *a3;
-          byte_27BB16B = 0;
+          byte_27C426B = 0;
           *((_DWORD *)v6 + 12) &= ~8u;
           v7 = **v6;
           if ( ((_DWORD)a3[1] & 4) == 0 )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_PostDataUpdate.windows.yaml
@@ -1,71 +1,72 @@
 func_name: CEntitySystem_PostDataUpdate
-func_va: '0x1811f4700'
+func_va: '0x1811fbef0'
 disasm_code: |-
-  .text:00000001811F4700                 mov     [rsp+arg_0], rbx
-  .text:00000001811F4705                 push    rdi
-  .text:00000001811F4706                 sub     rsp, 20h
-  .text:00000001811F470A                 mov     rax, [rcx+0C80h]
-  .text:00000001811F4711                 mov     rdi, r8
-  .text:00000001811F4714                 movss   xmm2, dword ptr [rcx+0BD4h]
-  .text:00000001811F471C                 mov     rcx, rax
-  .text:00000001811F471F                 movsxd  rbx, edx
-  .text:00000001811F4722                 mov     edx, 80000001h
-  .text:00000001811F4727                 mov     r9, [rax]
-  .text:00000001811F472A                 call    qword ptr [r9+18h]
-  .text:00000001811F472E                 test    rbx, rbx
-  .text:00000001811F4731                 jle     short loc_1811F4774
-  .text:00000001811F4733                 nop     dword ptr [rax+00h]
-  .text:00000001811F4737                 nop     word ptr [rax+rax+00000000h]
-  .text:00000001811F4740                 mov     rax, [rdi]
-  .text:00000001811F4743                 and     dword ptr [rax+30h], 0FFFFFFF7h
-  .text:00000001811F4747                 mov     cs:g_bReceivedChainedPostDataUpdate, 0
-  .text:00000001811F474E                 mov     rcx, [rax]
-  .text:00000001811F4751                 mov     edx, [rdi+8]
-  .text:00000001811F4754                 mov     eax, edx
-  .text:00000001811F4756                 shr     eax, 2
-  .text:00000001811F4759                 mov     r8, [rcx]
-  .text:00000001811F475C                 test    al, 1
-  .text:00000001811F475E                 jz      short loc_1811F4766
-  .text:00000001811F4760                 ; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
-  .text:00000001811F4760                 call    qword ptr [r8+60h]; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
-  .text:00000001811F4764                 jmp     short loc_1811F476A
-  .text:00000001811F4766                 ; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
-  .text:00000001811F4766                 call    qword ptr [r8+50h]; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
-  .text:00000001811F476A                 add     rdi, 10h
-  .text:00000001811F476E                 sub     rbx, 1
-  .text:00000001811F4772                 jnz     short loc_1811F4740
-  .text:00000001811F4774                 mov     rbx, [rsp+28h+arg_0]
-  .text:00000001811F4779                 add     rsp, 20h
-  .text:00000001811F477D                 pop     rdi
-  .text:00000001811F477E                 retn
+  .text:00000001811FBEF0                 mov     [rsp+arg_0], rbx
+  .text:00000001811FBEF5                 push    rdi
+  .text:00000001811FBEF6                 sub     rsp, 20h
+  .text:00000001811FBEFA                 mov     rax, [rcx+0C80h]
+  .text:00000001811FBF01                 mov     rdi, r8
+  .text:00000001811FBF04                 ; 0xBD4 = 3028LL = CEntitySystem::m_flChangeCallbackSpewThreshold(structmember,struct=CEntitySystem,member=m_flChangeCallbackSpewThreshold)
+  .text:00000001811FBF04                 movss   xmm2, dword ptr [rcx+0BD4h]; 0xBD4 = 3028LL = CEntitySystem::m_flChangeCallbackSpewThreshold(structmember,struct=CEntitySystem,member=m_flChangeCallbackSpewThreshold)
+  .text:00000001811FBF0C                 mov     rcx, rax
+  .text:00000001811FBF0F                 movsxd  rbx, edx
+  .text:00000001811FBF12                 mov     edx, 80000001h
+  .text:00000001811FBF17                 mov     r9, [rax]
+  .text:00000001811FBF1A                 call    qword ptr [r9+18h]
+  .text:00000001811FBF1E                 test    rbx, rbx
+  .text:00000001811FBF21                 jle     short loc_1811FBF64
+  .text:00000001811FBF23                 nop     dword ptr [rax+00h]
+  .text:00000001811FBF27                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811FBF30                 mov     rax, [rdi]
+  .text:00000001811FBF33                 and     dword ptr [rax+30h], 0FFFFFFF7h
+  .text:00000001811FBF37                 mov     byte ptr cs:unk_1820B9646, 0
+  .text:00000001811FBF3E                 mov     rcx, [rax]
+  .text:00000001811FBF41                 mov     edx, [rdi+8]
+  .text:00000001811FBF44                 mov     eax, edx
+  .text:00000001811FBF46                 shr     eax, 2
+  .text:00000001811FBF49                 mov     r8, [rcx]
+  .text:00000001811FBF4C                 test    al, 1
+  .text:00000001811FBF4E                 jz      short loc_1811FBF56
+  .text:00000001811FBF50                 ; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
+  .text:00000001811FBF50                 call    qword ptr [r8+60h]; 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
+  .text:00000001811FBF54                 jmp     short loc_1811FBF5A
+  .text:00000001811FBF56                 ; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+  .text:00000001811FBF56                 call    qword ptr [r8+50h]; 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+  .text:00000001811FBF5A                 add     rdi, 10h
+  .text:00000001811FBF5E                 sub     rbx, 1
+  .text:00000001811FBF62                 jnz     short loc_1811FBF30
+  .text:00000001811FBF64                 mov     rbx, [rsp+28h+arg_0]
+  .text:00000001811FBF69                 add     rsp, 20h
+  .text:00000001811FBF6D                 pop     rdi
+  .text:00000001811FBF6E                 retn
 procedure: |-
-  void __fastcall CEntitySystem_PostDataUpdate(__int64 a1, int a2, __int64 a3)
+  __int64 __fastcall CEntitySystem_PostDataUpdate(__int64 a1, int a2, __int64 ***a3)
   {
     __int64 v4; // rbx
-    __int64 **v5; // rax
-    __int64 *pEntity; // rcx
-    int updateType; // edx
-    __int64 v8; // r8
+    __int64 result; // rax
+    __int64 **v6; // rax
+    __int64 v7; // r8
 
     v4 = a2;
-    (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)(a1 + 3200) + 24LL))(*(_QWORD *)(a1 + 3200), 2147483649LL);
+    result = (*(__int64 (__fastcall **)(_QWORD, __int64))(**(_QWORD **)(a1 + 3200) + 24LL))(
+               *(_QWORD *)(a1 + 3200),
+               2147483649LL);
     if ( v4 > 0 )
     {
       do
       {
-        v5 = *(__int64 ***)a3;
-        *((_DWORD *)v5 + 12) &= ~8u;
-        g_bReceivedChainedPostDataUpdate = 0;
-        pEntity = *v5;
-        updateType = *(_DWORD *)(a3 + 8);
-        v8 = **v5;
-        if ( (updateType & 4) != 0 )
-          (*(void (__thiscall **)(__int64, int))(v8 + 96))((__int64)pEntity, updateType);// 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
+        v6 = *a3;
+        *((_DWORD *)v6 + 12) &= ~8u;
+        unk_1820B9646 = 0;
+        v7 = **v6;
+        if ( ((_DWORD)a3[1] & 4) != 0 )
+          result = (*(__int64 (**)(void))(v7 + 96))();// 0x60 = 96LL = CEntityInstance_PostDataUpdatePreserve
         else
-          (*(void (__thiscall **)(__int64, int))(v8 + 80))((__int64)pEntity, updateType);// 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
-        a3 += 16;
+          result = (*(__int64 (**)(void))(v7 + 80))();// 0x50 = 80LL = CEntityInstance_PostDataUpdateDelta
+        a3 += 2;
         --v4;
       }
       while ( v4 );
     }
+    return result;
   }


### PR DESCRIPTION
## Summary
- Add `CEntitySystem_m_flChangeCallbackSpewThreshold` struct member offset (offset `0xBD4` = 3028, `float`) found in `CEntitySystem_PostDataUpdate`
- Update `find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta` preprocessor script to include the new struct member with `offset_sig` / `offset_sig_disp` fields
- Add symbol entry in `config.yaml` (`category: structmember`, `struct: CEntitySystem`, `member: m_flChangeCallbackSpewThreshold`)
- Regenerate `CEntitySystem_PostDataUpdate` reference YAMLs (windows/linux) against gamever 14165 with the `m_flChangeCallbackSpewThreshold` annotation at `0xBD4`

## Test plan
- [ ] Run `find-CEntityInstance_PostDataUpdatePreserve-AND-CEntityInstance_PostDataUpdateDelta` skill on a new game binary and verify `CEntitySystem_m_flChangeCallbackSpewThreshold.{platform}.yaml` is produced with correct offset `0xBD4`