### PR TITLE
Add CGameEntitySystem_m_pEntity2SaveRestore (structmember, offset 0x20D8/0x20E8)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6417,6 +6417,7 @@ modules:
           - g_pGameResourceService.{platform}.yaml
           - g_pGameEntitySystem.{platform}.yaml
           - CEntitySystem_m_entityIONotifiers.{platform}.yaml
+          - CGameEntitySystem_m_pEntity2SaveRestore.{platform}.yaml
           - CEntitySystem_EnableAutoDeletionExecution.{platform}.yaml
           - CEntitySystem_InstallPostSpawnCallback.{platform}.yaml
           - CEntitySystem_InstallCreationWrapperCallbacks.{platform}.yaml

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -21,6 +21,7 @@ TARGET_GLOBALVAR_NAMES = [
 
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_entityIONotifiers",
+    "CGameEntitySystem_m_pEntity2SaveRestore",
 ]
 
 FUNC_VTABLE_RELATIONS = [
@@ -68,6 +69,17 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CEntitySystem_m_entityIONotifiers",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+    (
+        "CGameEntitySystem_m_pEntity2SaveRestore",
         [
             "struct_name",
             "member_name",
@@ -142,6 +154,11 @@ async def preprocess_skill(
         ),
         (
             "CEntitySystem_m_entityIONotifiers",
+            "prompt/call_llm_decompile.md",
+            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
+        ),
+        (
+            "CGameEntitySystem_m_pEntity2SaveRestore",
             "prompt/call_llm_decompile.md",
             "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),

--- a/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.linux.yaml
@@ -46,7 +46,7 @@ disasm_code: |-
   .text:00000000015C0AF9                 mov     rax, cs:g_pGameEntitySystem
   .text:00000000015C0B00                 lea     rdx, aMod; "MOD"
   .text:00000000015C0B07                 lea     rsi, aSave; "save/"
-  .text:00000000015C0B0E                 mov     [rax+20E8h], rbx
+  .text:00000000015C0B0E                 mov     [rax+20E8h], rbx  ; 20E8h = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
   .text:00000000015C0B15                 lea     rax, g_pFileSystem
   .text:00000000015C0B1C                 mov     rdi, [rax]
   .text:00000000015C0B1F                 mov     rax, [rdi]
@@ -269,7 +269,7 @@ procedure: |-
     *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_4404C60;
     v5 = operator new(4920);
     sub_1556BF0(v5);
-    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;
+    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;  // 8424 = 0x20E8 = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
     (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*g_pFileSystem + 384LL))(g_pFileSystem, "save/", "MOD");
     v6 = CommandLine();
     if ( !(*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v6 + 48LL))(v6, 1877996950, 0) )

--- a/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2EntitySystem_StaticInit.windows.yaml
@@ -152,7 +152,7 @@ disasm_code: |-
   .text:000000018098F707                 mov     rbx, r15
   .text:000000018098F70A                 mov     rax, cs:g_pGameEntitySystem
   .text:000000018098F711                 mov     rcx, rbx
-  .text:000000018098F714                 mov     [rax+20D8h], rbx
+  .text:000000018098F714                 mov     [rax+20D8h], rbx  ; 20D8h = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
   .text:000000018098F71B                 mov     rax, [rbx]
   .text:000000018098F71E                 mov     rdx, [rax]
   .text:000000018098F721                 lea     rax, sub_18095E160
@@ -420,7 +420,7 @@ procedure: |-
     {
       v12 = 0;
     }
-    *(_QWORD *)(g_pGameEntitySystem + 8408) = v12;
+    *(_QWORD *)(g_pGameEntitySystem + 8408) = v12;  // 8408 = 0x20D8 = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
     v14 = **(void (__fastcall ***)(__int64))v12;
     if ( (char *)v14 == (char *)sub_18095E160 )
       sub_18095E160(v12);

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
@@ -48,7 +48,7 @@ disasm_code: |-
   .text:00000000015BC737                 mov     rax, cs:g_pGameEntitySystem
   .text:00000000015BC73E                 lea     rdx, aMod_0; "MOD"
   .text:00000000015BC745                 lea     rsi, aSave; "save/"
-  .text:00000000015BC74C                 mov     [rax+20E8h], rbx
+  .text:00000000015BC74C                 mov     [rax+20E8h], rbx  ; 20E8h = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
   .text:00000000015BC753                 lea     rax, qword_274C230
   .text:00000000015BC75A                 mov     rdi, [rax]
   .text:00000000015BC75D                 mov     rax, [rdi]
@@ -275,7 +275,7 @@ procedure: |-
     *(_QWORD *)(*(_QWORD *)(v2 + 2968) + 8 * v3) = &off_24C9FE0;
     v5 = operator new(4928);
     sub_1569780(v5);
-    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;
+    *(_QWORD *)(g_pGameEntitySystem + 8424) = v5;  // 8424 = 0x20E8 = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
     (*(void (__fastcall **)(_QWORD *, const char *, const char *))(*qword_274C230 + 384LL))(qword_274C230, "save/", "MOD");
     v7 = g_pVApplication_0;
     if ( !g_pVApplication_0

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
@@ -95,7 +95,7 @@ disasm_code: |-
   .text:0000000180B8D8C3                 mov     rdi, r15
   .text:0000000180B8D8C6                 mov     rax, cs:g_pGameEntitySystem
   .text:0000000180B8D8CD                 mov     rcx, rdi
-  .text:0000000180B8D8D0                 mov     [rax+20D8h], rdi
+  .text:0000000180B8D8D0                 mov     [rax+20D8h], rdi  ; 20D8h = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
   .text:0000000180B8D8D7                 mov     rax, [rdi]
   .text:0000000180B8D8DA                 call    qword ptr [rax]
   .text:0000000180B8D8DC                 mov     rax, [rdi]
@@ -295,7 +295,7 @@ procedure: |-
       v13 = sub_180B38C50(v12);
     else
       v13 = 0;
-    *(_QWORD *)(g_pGameEntitySystem + 8408) = v13;
+    *(_QWORD *)(g_pGameEntitySystem + 8408) = v13;  // 8408 = 0x20D8 = CGameEntitySystem_m_pEntity2SaveRestore (structmember, struct=CGameEntitySystem, member=m_pEntity2SaveRestore)
     (**(void (__fastcall ***)(__int64))v13)(v13);
     v14 = *(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v13 + 136LL);
     v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_181F65210 + 192LL))(qword_181F65210);


### PR DESCRIPTION
## Summary
- Adds `CGameEntitySystem_m_pEntity2SaveRestore` struct member of `CGameEntitySystem` (Windows: offset `0x20D8`, Linux: `0x20E8`)
- Updates `find-CSource2EntitySystem_StaticInit-decompiles.py` to include the new struct member in target lists, YAML fields, and LLM decompile specs
- Adds `CGameEntitySystem_m_pEntity2SaveRestore.{platform}.yaml` to `expected_output` in `config.yaml`
- Annotates all 4 reference YAMLs (`client`/`server` × `windows`/`linux`) with struct member comments in both `disasm_code` and `procedure` sections

## Test plan
- [ ] Run `find-CSource2EntitySystem_StaticInit-decompiles` skill and verify `CGameEntitySystem_m_pEntity2SaveRestore.{platform}.yaml` is generated with correct offset, sig, and struct fields