### PR TITLE
Add CEntitySystem_m_EventQueue (structmember, offset 0xB10)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5826,6 +5826,12 @@ modules:
         expected_input:
           - CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml
 
+      - name: find-CEntitySystem_m_EventQueue
+        expected_output:
+          - CEntitySystem_m_EventQueue.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml
+
       - name: find-CGameEntitySystem_FindEntityByClassName
         expected_output:
           - CGameEntitySystem_FindEntityByClassName.{platform}.yaml
@@ -9462,6 +9468,13 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddEntityIOEventToQueue
+
+      - name: CEntitySystem_m_EventQueue
+        category: structmember
+        struct: CEntitySystem
+        member: m_EventQueue
+        alias:
+          - CEntitySystem::m_EventQueue
 
       - name: CGameEntitySystem_FindEntityByClassName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5812,6 +5812,20 @@ modules:
         expected_input:
           - CEntitySystem_AddEntityIOEvent.{platform}.yaml
 
+      - name: find-CEntitySystem_AddEntityIOEventToQueue-windows
+        platform: windows
+        expected_output:
+          - CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEvent.{platform}.yaml
+
+      - name: find-CEntitySystem_AddEntityIOEventToQueue-linux
+        platform: linux
+        expected_output:
+          - CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml
+
       - name: find-CGameEntitySystem_FindEntityByClassName
         expected_output:
           - CGameEntitySystem_FindEntityByClassName.{platform}.yaml
@@ -9443,6 +9457,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddEntityIOEventBuildStruct
+
+      - name: CEntitySystem_AddEntityIOEventToQueue
+        category: func
+        alias:
+          - CEntitySystem::AddEntityIOEventToQueue
 
       - name: CGameEntitySystem_FindEntityByClassName
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5805,6 +5805,13 @@ modules:
         expected_input:
           - CMomentaryRotButton_Use.{platform}.yaml
 
+      - name: find-CEntitySystem_AddEntityIOEventBuildStruct-linux
+        platform: linux
+        expected_output:
+          - CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml
+        expected_input:
+          - CEntitySystem_AddEntityIOEvent.{platform}.yaml
+
       - name: find-CGameEntitySystem_FindEntityByClassName
         expected_output:
           - CGameEntitySystem_FindEntityByClassName.{platform}.yaml
@@ -9431,6 +9438,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::AddEntityIOEvent2
+
+      - name: CEntitySystem_AddEntityIOEventBuildStruct
+        category: func
+        alias:
+          - CEntitySystem::AddEntityIOEventBuildStruct
 
       - name: CGameEntitySystem_FindEntityByClassName
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventBuildStruct-linux.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventBuildStruct-linux.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddEntityIOEventBuildStruct-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddEntityIOEventBuildStruct",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_AddEntityIOEventBuildStruct",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEvent.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddEntityIOEventBuildStruct",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue-linux.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue-linux.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddEntityIOEventToQueue-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddEntityIOEventToQueue",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_AddEntityIOEventToQueue",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEventBuildStruct.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddEntityIOEventToQueue",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue-windows.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddEntityIOEventToQueue-windows.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddEntityIOEventToQueue-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddEntityIOEventToQueue",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_AddEntityIOEventToQueue",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEvent.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddEntityIOEventToQueue",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_EventQueue.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_EventQueue.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_EventQueue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_EventQueue",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_EventQueue",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_AddEntityIOEventToQueue.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_EventQueue",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.linux.yaml
@@ -1,0 +1,113 @@
+func_name: CEntitySystem_AddEntityIOEvent
+func_va: '0x1e744c0'
+disasm_code: |-
+  .text:0000000001E744C0                 push    rbp
+  .text:0000000001E744C1                 mov     rbp, rsp
+  .text:0000000001E744C4                 push    r13
+  .text:0000000001E744C6                 mov     r13, rcx
+  .text:0000000001E744C9                 push    r12
+  .text:0000000001E744CB                 mov     r12, rdi
+  .text:0000000001E744CE                 push    rbx
+  .text:0000000001E744CF                 mov     ebx, 0FFFFFFFFh
+  .text:0000000001E744D4                 sub     rsp, 38h
+  .text:0000000001E744D8                 test    rsi, rsi
+  .text:0000000001E744DB                 jz      short loc_1E7450E
+  .text:0000000001E744DD                 mov     rax, [rsi+10h]
+  .text:0000000001E744E1                 test    rax, rax
+  .text:0000000001E744E4                 jz      short loc_1E7450E
+  .text:0000000001E744E6                 mov     ebx, [rax+10h]
+  .text:0000000001E744E9                 mov     ecx, [rax+30h]
+  .text:0000000001E744EC                 shr     ebx, 0Fh
+  .text:0000000001E744EF                 and     ecx, 1
+  .text:0000000001E744F2                 sub     ebx, ecx
+  .text:0000000001E744F4                 cmp     dword ptr [rax+10h], 0FFFFFFFFh
+  .text:0000000001E744F8                 jz      loc_1E74588
+  .text:0000000001E744FE                 movzx   eax, word ptr [rax+10h]
+  .text:0000000001E74502                 and     ax, 7FFFh
+  .text:0000000001E74506                 shl     ebx, 0Fh
+  .text:0000000001E74509                 movzx   eax, ax
+  .text:0000000001E7450C                 or      ebx, eax
+  .text:0000000001E7450E                 test    rdx, rdx
+  .text:0000000001E74511                 jz      short loc_1E74550
+  .text:0000000001E74513                 xor     eax, eax
+  .text:0000000001E74515                 cmp     byte ptr [rdx], 0
+  .text:0000000001E74518                 jnz     short loc_1E74550
+  .text:0000000001E7451A                 mov     [rbp+var_28], rax
+  .text:0000000001E7451E                 sub     rsp, 8
+  .text:0000000001E74522                 mov     rcx, r13
+  .text:0000000001E74525                 mov     esi, ebx
+  .text:0000000001E74527                 push    [rbp+arg_10]
+  .text:0000000001E7452A                 lea     rdx, [rbp+var_28]
+  .text:0000000001E7452E                 mov     rdi, r12
+  .text:0000000001E74531                 push    [rbp+arg_8]
+  .text:0000000001E74534                 mov     eax, [rbp+arg_0]
+  .text:0000000001E74537                 push    rax
+  .text:0000000001E74538                 call    CEntitySystem_AddEntityIOEventBuildStruct
+  .text:0000000001E7453D                 add     rsp, 20h
+  .text:0000000001E74541                 lea     rsp, [rbp-18h]
+  .text:0000000001E74545                 pop     rbx
+  .text:0000000001E74546                 pop     r12
+  .text:0000000001E74548                 pop     r13
+  .text:0000000001E7454A                 pop     rbp
+  .text:0000000001E7454B                 retn
+  .text:0000000001E74550                 lea     rdi, [rbp+var_30]
+  .text:0000000001E74554                 movss   [rbp+var_44], xmm0
+  .text:0000000001E74559                 lea     rsi, [r12+1ED0h]
+  .text:0000000001E74561                 mov     [rbp+var_40], r9
+  .text:0000000001E74565                 mov     [rbp+var_38], r8
+  .text:0000000001E74569                 call    sub_1E71540
+  .text:0000000001E7456E                 mov     rax, [rbp+var_30]
+  .text:0000000001E74572                 mov     r9, [rbp+var_40]
+  .text:0000000001E74576                 mov     r8, [rbp+var_38]
+  .text:0000000001E7457A                 movss   xmm0, [rbp+var_44]
+  .text:0000000001E7457F                 jmp     short loc_1E7451A
+  .text:0000000001E74588                 mov     eax, 7FFFh
+  .text:0000000001E7458D                 jmp     loc_1E74506
+procedure: |-
+  __int64 __fastcall CEntitySystem_AddEntityIOEvent(
+          __int64 a1,
+          __int64 a2,
+          _BYTE *a3,
+          int a4,
+          int a5,
+          int a6,
+          int a7,
+          __int64 a8,
+          __int64 a9)
+  {
+    int v10; // ebx
+    __int64 v11; // rax
+    int v12; // ebx
+    unsigned __int16 v13; // ax
+    __int64 v14; // rax
+    int v16; // [rsp+10h] [rbp-40h]
+    int v17; // [rsp+18h] [rbp-38h]
+    __int64 v18; // [rsp+20h] [rbp-30h] BYREF
+    __int64 v19; // [rsp+28h] [rbp-28h] BYREF
+
+    v10 = -1;
+    if ( a2 )
+    {
+      v11 = *(_QWORD *)(a2 + 16);
+      if ( v11 )
+      {
+        v12 = (*(_DWORD *)(v11 + 16) >> 15) - (*(_DWORD *)(v11 + 48) & 1);
+        if ( *(_DWORD *)(v11 + 16) == -1 )
+          v13 = 0x7FFF;
+        else
+          v13 = *(_WORD *)(v11 + 16) & 0x7FFF;
+        v10 = v13 | (v12 << 15);
+      }
+    }
+    if ( !a3 || (v14 = 0, *a3) )
+    {
+      v16 = a6;
+      v17 = a5;
+      sub_1E71540(&v18, a1 + 7888);
+      v14 = v18;
+      a6 = v16;
+      a5 = v17;
+    }
+    v19 = v14;
+    return CEntitySystem_AddEntityIOEventBuildStruct(a1, v10, (unsigned int)&v19, a4, a5, a6, a7, a8, a9);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEvent.windows.yaml
@@ -1,0 +1,355 @@
+func_name: CEntitySystem_AddEntityIOEvent
+func_va: '0x1811ecb70'
+disasm_code: |-
+  .text:00000001811ECB70                 mov     [rsp+arg_10], rbx
+  .text:00000001811ECB75                 mov     [rsp+arg_18], r9
+  .text:00000001811ECB7A                 mov     [rsp+arg_0], rcx
+  .text:00000001811ECB7F                 push    rbp
+  .text:00000001811ECB80                 push    rsi
+  .text:00000001811ECB81                 push    rdi
+  .text:00000001811ECB82                 push    r12
+  .text:00000001811ECB84                 push    r13
+  .text:00000001811ECB86                 push    r14
+  .text:00000001811ECB88                 push    r15
+  .text:00000001811ECB8A                 sub     rsp, 20h
+  .text:00000001811ECB8E                 mov     rdi, r9
+  .text:00000001811ECB91                 mov     r9, rcx
+  .text:00000001811ECB94                 mov     r13d, 7FFFh
+  .text:00000001811ECB9A                 test    rdx, rdx
+  .text:00000001811ECB9D                 jz      short loc_1811ECBD2
+  .text:00000001811ECB9F                 mov     rax, [rdx+10h]
+  .text:00000001811ECBA3                 test    rax, rax
+  .text:00000001811ECBA6                 jz      short loc_1811ECBD2
+  .text:00000001811ECBA8                 mov     edx, [rax+10h]
+  .text:00000001811ECBAB                 mov     ecx, r13d
+  .text:00000001811ECBAE                 mov     eax, [rax+30h]
+  .text:00000001811ECBB1                 mov     r14d, edx
+  .text:00000001811ECBB4                 and     eax, 1
+  .text:00000001811ECBB7                 shr     r14d, 0Fh
+  .text:00000001811ECBBB                 sub     r14d, eax
+  .text:00000001811ECBBE                 mov     eax, edx
+  .text:00000001811ECBC0                 and     eax, r13d
+  .text:00000001811ECBC3                 shl     r14d, 0Fh
+  .text:00000001811ECBC7                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811ECBCA                 cmovnz  ecx, eax
+  .text:00000001811ECBCD                 or      r14d, ecx
+  .text:00000001811ECBD0                 jmp     short loc_1811ECBD8
+  .text:00000001811ECBD2                 mov     r14d, 0FFFFFFFFh
+  .text:00000001811ECBD8                 test    r8, r8
+  .text:00000001811ECBDB                 jz      short loc_1811ECBE9
+  .text:00000001811ECBDD                 cmp     byte ptr [r8], 0
+  .text:00000001811ECBE1                 jnz     short loc_1811ECBE9
+  .text:00000001811ECBE3                 xor     ebp, ebp
+  .text:00000001811ECBE5                 mov     ebx, ebp
+  .text:00000001811ECBE7                 jmp     short loc_1811ECC22
+  .text:00000001811ECBE9                 xor     ebp, ebp
+  .text:00000001811ECBEB                 lea     rcx, [r9+1EC8h]
+  .text:00000001811ECBF2                 test    r8, r8
+  .text:00000001811ECBF5                 jz      short loc_1811ECC0B
+  .text:00000001811ECBF7                 mov     r9, 0FFFFFFFFFFFFFFFFh
+  .text:00000001811ECBFE                 xchg    ax, ax
+  .text:00000001811ECC00                 inc     r9
+  .text:00000001811ECC03                 cmp     [r8+r9], bpl
+  .text:00000001811ECC07                 jnz     short loc_1811ECC00
+  .text:00000001811ECC09                 jmp     short loc_1811ECC0E
+  .text:00000001811ECC0B                 mov     r9d, ebp
+  .text:00000001811ECC0E                 lea     rdx, [rsp+58h+arg_8]
+  .text:00000001811ECC13                 call    sub_18050F990
+  .text:00000001811ECC18                 mov     r9, [rsp+58h+arg_0]
+  .text:00000001811ECC1D                 mov     rbx, [rsp+58h+arg_8]
+  .text:00000001811ECC22                 mov     r15, [rsp+58h+arg_20]
+  .text:00000001811ECC2A                 test    r15, r15
+  .text:00000001811ECC2D                 jz      short loc_1811ECC39
+  .text:00000001811ECC2F                 mov     rax, [r15+10h]
+  .text:00000001811ECC33                 mov     r12d, [rax+38h]
+  .text:00000001811ECC37                 jmp     short loc_1811ECC3C
+  .text:00000001811ECC39                 mov     r12d, ebp
+  .text:00000001811ECC3C                 mov     rax, [r9]
+  .text:00000001811ECC3F                 lea     rdx, [rsp+58h+arg_20]
+  .text:00000001811ECC47                 mov     r8d, r12d
+  .text:00000001811ECC4A                 mov     rcx, r9
+  .text:00000001811ECC4D                 call    qword ptr [rax+58h]
+  .text:00000001811ECC50                 mov     ecx, 70h ; 'p'
+  .text:00000001811ECC55                 call    sub_180E7C960
+  .text:00000001811ECC5A                 mov     rsi, rax
+  .text:00000001811ECC5D                 test    rax, rax
+  .text:00000001811ECC60                 jz      short loc_1811ECCAD
+  .text:00000001811ECC62                 lea     rcx, [rax+4]
+  .text:00000001811ECC66                 mov     [rax], ebp
+  .text:00000001811ECC68                 call    unknown_libname_33; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001811ECC6D                 mov     r8b, 8
+  .text:00000001811ECC70                 mov     [rsi+10h], rbp
+  .text:00000001811ECC74                 mov     dl, 1
+  .text:00000001811ECC76                 mov     [rsi+18h], rbp
+  .text:00000001811ECC7A                 lea     rcx, [rsi+48h]
+  .text:00000001811ECC7E                 mov     qword ptr [rsi+20h], 0FFFFFFFFFFFFFFFFh
+  .text:00000001811ECC86                 mov     dword ptr [rsi+2Ch], 0FFFFFFFFh
+  .text:00000001811ECC8D                 mov     byte ptr [rsi+38h], 0
+  .text:00000001811ECC91                 mov     [rsi+3Ah], bp
+  .text:00000001811ECC95                 mov     [rsi+30h], rbp
+  .text:00000001811ECC99                 mov     [rsi+40h], rbp
+  .text:00000001811ECC9D                 call    sub_1814D69E0
+  .text:00000001811ECCA2                 mov     rdi, [rsp+58h+arg_18]
+  .text:00000001811ECCA7                 mov     byte ptr [rsi+58h], 0
+  .text:00000001811ECCAB                 jmp     short loc_1811ECCB0
+  .text:00000001811ECCAD                 mov     rsi, rbp
+  .text:00000001811ECCB0                 movss   xmm2, dword ptr [rsp+58h+arg_30]
+  .text:00000001811ECCB9                 lea     rdx, [rsp+58h+arg_20]
+  .text:00000001811ECCC1                 lea     rcx, [rsp+58h+arg_18]
+  .text:00000001811ECCC6                 mov     [rsi], r12d
+  .text:00000001811ECCC9                 call    sub_1801B3530
+  .text:00000001811ECCCE                 movss   xmm0, dword ptr [rax]
+  .text:00000001811ECCD2                 movss   dword ptr [rsi+4], xmm0
+  .text:00000001811ECCD7                 mov     [rsi+10h], rbp
+  .text:00000001811ECCDB                 mov     [rsi+2Ch], r14d
+  .text:00000001811ECCDF                 mov     dword ptr [rsi+8], 6
+  .text:00000001811ECCE6                 mov     [rsi+18h], rbx
+  .text:00000001811ECCEA                 test    rdi, rdi
+  .text:00000001811ECCED                 jz      short loc_1811ECD22
+  .text:00000001811ECCEF                 mov     rax, [rdi+10h]
+  .text:00000001811ECCF3                 test    rax, rax
+  .text:00000001811ECCF6                 jz      short loc_1811ECD22
+  .text:00000001811ECCF8                 mov     edx, [rax+10h]
+  .text:00000001811ECCFB                 mov     ecx, r13d
+  .text:00000001811ECCFE                 mov     eax, [rax+30h]
+  .text:00000001811ECD01                 mov     r8d, edx
+  .text:00000001811ECD04                 and     eax, 1
+  .text:00000001811ECD07                 shr     r8d, 0Fh
+  .text:00000001811ECD0B                 sub     r8d, eax
+  .text:00000001811ECD0E                 mov     eax, edx
+  .text:00000001811ECD10                 and     eax, r13d
+  .text:00000001811ECD13                 shl     r8d, 0Fh
+  .text:00000001811ECD17                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811ECD1A                 cmovnz  ecx, eax
+  .text:00000001811ECD1D                 or      r8d, ecx
+  .text:00000001811ECD20                 jmp     short loc_1811ECD28
+  .text:00000001811ECD22                 mov     r8d, 0FFFFFFFFh
+  .text:00000001811ECD28                 mov     [rsi+20h], r8d
+  .text:00000001811ECD2C                 test    r15, r15
+  .text:00000001811ECD2F                 jz      short loc_1811ECD5E
+  .text:00000001811ECD31                 mov     rax, [r15+10h]
+  .text:00000001811ECD35                 test    rax, rax
+  .text:00000001811ECD38                 jz      short loc_1811ECD5E
+  .text:00000001811ECD3A                 mov     ecx, [rax+10h]
+  .text:00000001811ECD3D                 mov     edx, ecx
+  .text:00000001811ECD3F                 mov     eax, [rax+30h]
+  .text:00000001811ECD42                 and     eax, 1
+  .text:00000001811ECD45                 shr     edx, 0Fh
+  .text:00000001811ECD48                 sub     edx, eax
+  .text:00000001811ECD4A                 mov     eax, ecx
+  .text:00000001811ECD4C                 and     eax, r13d
+  .text:00000001811ECD4F                 shl     edx, 0Fh
+  .text:00000001811ECD52                 cmp     ecx, 0FFFFFFFFh
+  .text:00000001811ECD55                 cmovnz  r13d, eax
+  .text:00000001811ECD59                 or      edx, r13d
+  .text:00000001811ECD5C                 jmp     short loc_1811ECD63
+  .text:00000001811ECD5E                 mov     edx, 0FFFFFFFFh
+  .text:00000001811ECD63                 mov     rcx, [rsp+58h+arg_28]
+  .text:00000001811ECD6B                 mov     [rsi+24h], edx
+  .text:00000001811ECD6E                 lea     rdx, [rsi+30h]
+  .text:00000001811ECD72                 call    sub_1801799F0
+  .text:00000001811ECD77                 mov     rbx, [rsp+58h+arg_40]
+  .text:00000001811ECD7F                 mov     eax, dword ptr [rsp+58h+arg_38]
+  .text:00000001811ECD86                 mov     [rsi+28h], eax
+  .text:00000001811ECD89                 test    rbx, rbx
+  .text:00000001811ECD8C                 jz      short loc_1811ECDAB
+  .text:00000001811ECD8E                 mov     ecx, 90h
+  .text:00000001811ECD93                 call    sub_180E7C960
+  .text:00000001811ECD98                 test    rax, rax
+  .text:00000001811ECD9B                 jz      short loc_1811ECDAB
+  .text:00000001811ECD9D                 mov     rdx, rbx
+  .text:00000001811ECDA0                 mov     rcx, rax
+  .text:00000001811ECDA3                 call    sub_1813F9340
+  .text:00000001811ECDA8                 mov     rbp, rax
+  .text:00000001811ECDAB                 mov     rdi, [rsp+58h+arg_48]
+  .text:00000001811ECDB3                 mov     [rsi+40h], rbp
+  .text:00000001811ECDB7                 test    rdi, rdi
+  .text:00000001811ECDBA                 jz      short loc_1811ECDCF
+  .text:00000001811ECDBC                 mov     rdx, rdi
+  .text:00000001811ECDBF                 lea     rcx, [rsi+48h]
+  .text:00000001811ECDC3                 call    sub_1814D6AC0
+  .text:00000001811ECDC8                 movzx   eax, byte ptr [rdi+10h]
+  .text:00000001811ECDCC                 mov     [rsi+58h], al
+  .text:00000001811ECDCF                 mov     rcx, [rsp+58h+arg_0]
+  .text:00000001811ECDD4                 mov     rdx, rsi
+  .text:00000001811ECDD7                 ; CEntitySystem_AddEntityIOEventToQueue
+  .text:00000001811ECDD7                 call    CEntitySystem_AddEntityIOEventToQueue; CEntitySystem_AddEntityIOEventToQueue
+  .text:00000001811ECDDC                 mov     rbx, [rsp+58h+arg_10]
+  .text:00000001811ECDE1                 add     rsp, 20h
+  .text:00000001811ECDE5                 pop     r15
+  .text:00000001811ECDE7                 pop     r14
+  .text:00000001811ECDE9                 pop     r13
+  .text:00000001811ECDEB                 pop     r12
+  .text:00000001811ECDED                 pop     rdi
+  .text:00000001811ECDEE                 pop     rsi
+  .text:00000001811ECDEF                 pop     rbp
+  .text:00000001811ECDF0                 retn
+procedure: |-
+  __int64 CEntitySystem_AddEntityIOEvent(__int64 a1, __int64 a2, _BYTE *a3, ...)
+  {
+    __int64 v3; // rdi
+    __int64 v4; // r9
+    int v5; // r13d
+    __int64 v6; // rax
+    unsigned int v7; // edx
+    int v8; // ecx
+    int v9; // r14d
+    __int64 v10; // rbp
+    __int64 v11; // rbx
+    __int64 v12; // rcx
+    __int64 v13; // r9
+    __int64 v14; // r15
+    unsigned int v15; // r12d
+    unsigned int *v16; // rax
+    unsigned int *v17; // rsi
+    __int64 v18; // r8
+    __int64 v19; // rdx
+    __int64 v20; // rax
+    unsigned int v21; // edx
+    int v22; // ecx
+    int v23; // r8d
+    __int64 v24; // rax
+    unsigned int v25; // ecx
+    int v26; // edx
+    __int64 v27; // rcx
+    __int64 v28; // rbx
+    __int64 v29; // rax
+    __int64 v30; // rdi
+    __int64 v33; // [rsp+68h] [rbp+10h] BYREF
+    __int64 v34; // [rsp+78h] [rbp+20h] BYREF
+    va_list va; // [rsp+78h] [rbp+20h]
+    __int64 v36; // [rsp+80h] [rbp+28h] BYREF
+    va_list va1; // [rsp+80h] [rbp+28h]
+    __int64 v38; // [rsp+88h] [rbp+30h]
+    __int64 v39; // [rsp+90h] [rbp+38h]
+    __int64 v40; // [rsp+98h] [rbp+40h]
+    __int64 v41; // [rsp+A0h] [rbp+48h]
+    __int64 v42; // [rsp+A8h] [rbp+50h]
+    va_list va2; // [rsp+B0h] [rbp+58h] BYREF
+
+    va_start(va2, a3);
+    va_start(va1, a3);
+    va_start(va, a3);
+    v34 = va_arg(va1, _QWORD);
+    va_copy(va2, va1);
+    v36 = va_arg(va2, _QWORD);
+    v38 = va_arg(va2, _QWORD);
+    v39 = va_arg(va2, _QWORD);
+    v40 = va_arg(va2, _QWORD);
+    v41 = va_arg(va2, _QWORD);
+    v42 = va_arg(va2, _QWORD);
+    v3 = v34;
+    v4 = a1;
+    v5 = 0x7FFF;
+    if ( a2 && (v6 = *(_QWORD *)(a2 + 16)) != 0 )
+    {
+      v7 = *(_DWORD *)(v6 + 16);
+      v8 = 0x7FFF;
+      if ( v7 != -1 )
+        v8 = v7 & 0x7FFF;
+      v9 = v8 | (((v7 >> 15) - (*(_DWORD *)(v6 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v9 = -1;
+    }
+    if ( !a3 || *a3 )
+    {
+      v10 = 0;
+      v12 = v4 + 7880;
+      if ( a3 )
+      {
+        v13 = -1;
+        do
+          ++v13;
+        while ( a3[v13] );
+      }
+      sub_18050F990(v12, &v33, a3);
+      v4 = a1;
+      v11 = v33;
+    }
+    else
+    {
+      v10 = 0;
+      v11 = 0;
+    }
+    v14 = v36;
+    if ( v36 )
+      v15 = *(_DWORD *)(*(_QWORD *)(v36 + 16) + 56LL);
+    else
+      v15 = 0;
+    (*(void (__fastcall **)(__int64, __int64 *, _QWORD))(*(_QWORD *)v4 + 88LL))(v4, (__int64 *)va1, v15);
+    v16 = (unsigned int *)sub_180E7C960(112);
+    v17 = v16;
+    if ( v16 )
+    {
+      *v16 = 0;
+      unknown_libname_33(v16 + 1);
+      LOBYTE(v18) = 8;
+      *((_QWORD *)v17 + 2) = 0;
+      LOBYTE(v19) = 1;
+      *((_QWORD *)v17 + 3) = 0;
+      *((_QWORD *)v17 + 4) = -1;
+      v17[11] = -1;
+      *((_BYTE *)v17 + 56) = 0;
+      *((_WORD *)v17 + 29) = 0;
+      *((_QWORD *)v17 + 6) = 0;
+      *((_QWORD *)v17 + 8) = 0;
+      sub_1814D69E0(v17 + 18, v19, v18);
+      v3 = v34;
+      *((_BYTE *)v17 + 88) = 0;
+    }
+    else
+    {
+      v17 = nullptr;
+    }
+    *v17 = v15;
+    v17[1] = *(_DWORD *)sub_1801B3530((__int64 *)va, (__int64 *)va1);
+    *((_QWORD *)v17 + 2) = 0;
+    v17[11] = v9;
+    v17[2] = 6;
+    *((_QWORD *)v17 + 3) = v11;
+    if ( v3 && (v20 = *(_QWORD *)(v3 + 16)) != 0 )
+    {
+      v21 = *(_DWORD *)(v20 + 16);
+      v22 = 0x7FFF;
+      if ( v21 != -1 )
+        v22 = v21 & 0x7FFF;
+      v23 = v22 | (((v21 >> 15) - (*(_DWORD *)(v20 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v23 = -1;
+    }
+    v17[8] = v23;
+    if ( v14 && (v24 = *(_QWORD *)(v14 + 16)) != 0 )
+    {
+      v25 = *(_DWORD *)(v24 + 16);
+      if ( v25 != -1 )
+        v5 = v25 & 0x7FFF;
+      v26 = v5 | (((v25 >> 15) - (*(_DWORD *)(v24 + 48) & 1)) << 15);
+    }
+    else
+    {
+      v26 = -1;
+    }
+    v27 = v38;
+    v17[9] = v26;
+    sub_1801799F0(v27, v17 + 12);
+    v28 = v41;
+    v17[10] = v40;
+    if ( v28 )
+    {
+      v29 = sub_180E7C960(144);
+      if ( v29 )
+        v10 = sub_1813F9340(v29, v28);
+    }
+    v30 = v42;
+    *((_QWORD *)v17 + 8) = v10;
+    if ( v30 )
+    {
+      sub_1814D6AC0(v17 + 18, v30);
+      *((_BYTE *)v17 + 88) = *(_BYTE *)(v30 + 16);
+    }
+    return CEntitySystem_AddEntityIOEventToQueue(a1, v17);// CEntitySystem_AddEntityIOEventToQueue
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventBuildStruct.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventBuildStruct.linux.yaml
@@ -1,0 +1,247 @@
+func_name: CEntitySystem_AddEntityIOEventBuildStruct
+func_va: '0x1e630d0'
+disasm_code: |-
+  .text:0000000001E630D0                 push    rbp
+  .text:0000000001E630D1                 mov     rbp, rsp
+  .text:0000000001E630D4                 push    r15
+  .text:0000000001E630D6                 push    r14
+  .text:0000000001E630D8                 xor     r14d, r14d
+  .text:0000000001E630DB                 push    r13
+  .text:0000000001E630DD                 push    r12
+  .text:0000000001E630DF                 mov     r12, r8
+  .text:0000000001E630E2                 push    rbx
+  .text:0000000001E630E3                 mov     rbx, rdi
+  .text:0000000001E630E6                 sub     rsp, 48h
+  .text:0000000001E630EA                 mov     eax, [rbp+arg_0]
+  .text:0000000001E630ED                 mov     [rbp+var_38], esi
+  .text:0000000001E630F0                 mov     r13, [rbp+arg_10]
+  .text:0000000001E630F4                 mov     [rbp+var_40], rdx
+  .text:0000000001E630F8                 mov     [rbp+var_48], rcx
+  .text:0000000001E630FC                 mov     [rbp+var_50], r9
+  .text:0000000001E63100                 mov     [rbp+var_58], eax
+  .text:0000000001E63103                 mov     rax, [rbp+arg_8]
+  .text:0000000001E63107                 movss   [rbp+var_54], xmm0
+  .text:0000000001E6310C                 mov     [rbp+var_60], rax
+  .text:0000000001E63110                 test    r8, r8
+  .text:0000000001E63113                 jz      short loc_1E6311D
+  .text:0000000001E63115                 mov     rax, [r8+10h]
+  .text:0000000001E63119                 mov     r14d, [rax+38h]
+  .text:0000000001E6311D                 mov     rax, [rbx]
+  .text:0000000001E63120                 lea     rdx, sub_1E59480
+  .text:0000000001E63127                 mov     rax, [rax+60h]
+  .text:0000000001E6312B                 cmp     rax, rdx
+  .text:0000000001E6312E                 jnz     loc_1E632D0
+  .text:0000000001E63134                 call    cs:qword_27C42A0
+  .text:0000000001E6313A                 movss   [rbp+var_34], xmm0
+  .text:0000000001E6313F                 mov     edi, 70h ; 'p'
+  .text:0000000001E63144                 call    sub_97A1D0
+  .text:0000000001E63149                 pxor    xmm0, xmm0
+  .text:0000000001E6314D                 mov     edx, 8
+  .text:0000000001E63152                 mov     esi, 1
+  .text:0000000001E63157                 mov     r15, rax
+  .text:0000000001E6315A                 movups  xmmword ptr [rax+10h], xmm0
+  .text:0000000001E6315E                 mov     qword ptr [rax], 0
+  .text:0000000001E63165                 mov     qword ptr [rax+20h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000001E6316D                 mov     rax, 0FFFFFFFF00000000h
+  .text:0000000001E63177                 mov     [r15+28h], rax
+  .text:0000000001E6317B                 lea     rax, [r15+48h]
+  .text:0000000001E6317F                 mov     rdi, rax
+  .text:0000000001E63182                 mov     qword ptr [r15+30h], 0
+  .text:0000000001E6318A                 mov     qword ptr [r15+38h], 0
+  .text:0000000001E63192                 mov     qword ptr [r15+40h], 0
+  .text:0000000001E6319A                 mov     [rbp+var_68], rax
+  .text:0000000001E6319E                 call    sub_1B15700
+  .text:0000000001E631A3                 mov     eax, [rbp+var_38]
+  .text:0000000001E631A6                 mov     byte ptr [r15+58h], 0
+  .text:0000000001E631AB                 mov     rcx, [rbp+var_48]
+  .text:0000000001E631AF                 mov     [r15], r14d
+  .text:0000000001E631B2                 movss   xmm0, [rbp+var_54]
+  .text:0000000001E631B7                 mov     dword ptr [r15+8], 6
+  .text:0000000001E631BF                 addss   xmm0, [rbp+var_34]
+  .text:0000000001E631C4                 mov     qword ptr [r15+10h], 0
+  .text:0000000001E631CC                 mov     [r15+2Ch], eax
+  .text:0000000001E631D0                 mov     rax, [rbp+var_40]
+  .text:0000000001E631D4                 movss   dword ptr [r15+4], xmm0
+  .text:0000000001E631DA                 mov     rax, [rax]
+  .text:0000000001E631DD                 mov     [r15+18h], rax
+  .text:0000000001E631E1                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E631E6                 test    rcx, rcx
+  .text:0000000001E631E9                 jz      short loc_1E6321D
+  .text:0000000001E631EB                 mov     rdx, [rcx+10h]
+  .text:0000000001E631EF                 test    rdx, rdx
+  .text:0000000001E631F2                 jz      short loc_1E6321D
+  .text:0000000001E631F4                 mov     eax, [rdx+10h]
+  .text:0000000001E631F7                 mov     esi, [rdx+30h]
+  .text:0000000001E631FA                 shr     eax, 0Fh
+  .text:0000000001E631FD                 and     esi, 1
+  .text:0000000001E63200                 sub     eax, esi
+  .text:0000000001E63202                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001E63206                 jz      loc_1E632F0
+  .text:0000000001E6320C                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000001E63210                 and     dx, 7FFFh
+  .text:0000000001E63215                 shl     eax, 0Fh
+  .text:0000000001E63218                 movzx   edx, dx
+  .text:0000000001E6321B                 or      eax, edx
+  .text:0000000001E6321D                 mov     [r15+20h], eax
+  .text:0000000001E63221                 mov     eax, 0FFFFFFFFh
+  .text:0000000001E63226                 test    r12, r12
+  .text:0000000001E63229                 jz      short loc_1E6325E
+  .text:0000000001E6322B                 mov     rdx, [r12+10h]
+  .text:0000000001E63230                 test    rdx, rdx
+  .text:0000000001E63233                 jz      short loc_1E6325E
+  .text:0000000001E63235                 mov     eax, [rdx+10h]
+  .text:0000000001E63238                 mov     esi, [rdx+30h]
+  .text:0000000001E6323B                 shr     eax, 0Fh
+  .text:0000000001E6323E                 and     esi, 1
+  .text:0000000001E63241                 sub     eax, esi
+  .text:0000000001E63243                 cmp     dword ptr [rdx+10h], 0FFFFFFFFh
+  .text:0000000001E63247                 jz      loc_1E63300
+  .text:0000000001E6324D                 movzx   edx, word ptr [rdx+10h]
+  .text:0000000001E63251                 and     dx, 7FFFh
+  .text:0000000001E63256                 shl     eax, 0Fh
+  .text:0000000001E63259                 movzx   edx, dx
+  .text:0000000001E6325C                 or      eax, edx
+  .text:0000000001E6325E                 mov     rdi, [rbp+var_50]
+  .text:0000000001E63262                 mov     [r15+24h], eax
+  .text:0000000001E63266                 lea     rsi, [r15+30h]
+  .text:0000000001E6326A                 call    sub_1E5B1F0
+  .text:0000000001E6326F                 mov     eax, [rbp+var_58]
+  .text:0000000001E63272                 mov     r14, [rbp+var_60]
+  .text:0000000001E63276                 mov     [r15+28h], eax
+  .text:0000000001E6327A                 test    r14, r14
+  .text:0000000001E6327D                 jz      short loc_1E632E8
+  .text:0000000001E6327F                 mov     edi, 90h
+  .text:0000000001E63284                 call    sub_97A1D0
+  .text:0000000001E63289                 mov     rsi, r14
+  .text:0000000001E6328C                 mov     rdi, rax
+  .text:0000000001E6328F                 mov     r12, rax
+  .text:0000000001E63292                 call    sub_1D8E230
+  .text:0000000001E63297                 mov     [r15+40h], r12
+  .text:0000000001E6329B                 test    r13, r13
+  .text:0000000001E6329E                 jz      short loc_1E632B5
+  .text:0000000001E632A0                 mov     rdi, [rbp+var_68]
+  .text:0000000001E632A4                 mov     rsi, r13
+  .text:0000000001E632A7                 call    sub_1B22D60
+  .text:0000000001E632AC                 movzx   eax, byte ptr [r13+10h]
+  .text:0000000001E632B1                 mov     [r15+58h], al
+  .text:0000000001E632B5                 add     rsp, 48h
+  .text:0000000001E632B9                 mov     rsi, r15
+  .text:0000000001E632BC                 mov     rdi, rbx
+  .text:0000000001E632BF                 pop     rbx
+  .text:0000000001E632C0                 pop     r12
+  .text:0000000001E632C2                 pop     r13
+  .text:0000000001E632C4                 pop     r14
+  .text:0000000001E632C6                 pop     r15
+  .text:0000000001E632C8                 pop     rbp
+  .text:0000000001E632C9                 jmp     CEntitySystem_AddEntityIOEventToQueue
+  .text:0000000001E632D0                 mov     esi, r14d
+  .text:0000000001E632D3                 mov     rdi, rbx
+  .text:0000000001E632D6                 call    rax
+  .text:0000000001E632D8                 movss   [rbp+var_34], xmm0
+  .text:0000000001E632DD                 jmp     loc_1E6313F
+  .text:0000000001E632E8                 xor     r12d, r12d
+  .text:0000000001E632EB                 jmp     short loc_1E63297
+  .text:0000000001E632F0                 mov     edx, 7FFFh
+  .text:0000000001E632F5                 jmp     loc_1E63215
+  .text:0000000001E63300                 mov     edx, 7FFFh
+  .text:0000000001E63305                 jmp     loc_1E63256
+procedure: |-
+  __int64 __fastcall sub_1E630D0(
+          __int64 a1,
+          int a2,
+          _QWORD *a3,
+          __int64 a4,
+          __int64 a5,
+          __int64 a6,
+          float a7,
+          int a8,
+          __int64 a9,
+          __int64 a10)
+  {
+    unsigned int v10; // r14d
+    __int64 (__fastcall *v12)(); // rax
+    __int64 v13; // r15
+    int v14; // eax
+    __int64 v15; // rdx
+    int v16; // eax
+    unsigned __int16 v17; // dx
+    int v18; // eax
+    __int64 v19; // rdx
+    int v20; // eax
+    unsigned __int16 v21; // dx
+    __int64 v22; // r12
+    float v28; // [rsp+3Ch] [rbp-34h]
+
+    v10 = 0;
+    if ( a5 )
+      v10 = *(_DWORD *)(*(_QWORD *)(a5 + 16) + 56LL);
+    v12 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 96LL);
+    if ( v12 == sub_1E59480 )
+      v28 = qword_27C42A0();
+    else
+      v28 = ((float (__fastcall *)(__int64, _QWORD))v12)(a1, v10);
+    v13 = sub_97A1D0();
+    *(_OWORD *)(v13 + 16) = 0;
+    *(_QWORD *)v13 = 0;
+    *(_QWORD *)(v13 + 32) = -1;
+    *(_QWORD *)(v13 + 40) = 0xFFFFFFFF00000000LL;
+    *(_QWORD *)(v13 + 48) = 0;
+    *(_QWORD *)(v13 + 56) = 0;
+    *(_QWORD *)(v13 + 64) = 0;
+    sub_1B15700(v13 + 72, 1, 8);
+    *(_BYTE *)(v13 + 88) = 0;
+    *(_DWORD *)v13 = v10;
+    *(_DWORD *)(v13 + 8) = 6;
+    *(_QWORD *)(v13 + 16) = 0;
+    *(_DWORD *)(v13 + 44) = a2;
+    *(float *)(v13 + 4) = a7 + v28;
+    *(_QWORD *)(v13 + 24) = *a3;
+    v14 = -1;
+    if ( a4 )
+    {
+      v15 = *(_QWORD *)(a4 + 16);
+      if ( v15 )
+      {
+        v16 = (*(_DWORD *)(v15 + 16) >> 15) - (*(_DWORD *)(v15 + 48) & 1);
+        if ( *(_DWORD *)(v15 + 16) == -1 )
+          v17 = 0x7FFF;
+        else
+          v17 = *(_WORD *)(v15 + 16) & 0x7FFF;
+        v14 = v17 | (v16 << 15);
+      }
+    }
+    *(_DWORD *)(v13 + 32) = v14;
+    v18 = -1;
+    if ( a5 )
+    {
+      v19 = *(_QWORD *)(a5 + 16);
+      if ( v19 )
+      {
+        v20 = (*(_DWORD *)(v19 + 16) >> 15) - (*(_DWORD *)(v19 + 48) & 1);
+        if ( *(_DWORD *)(v19 + 16) == -1 )
+          v21 = 0x7FFF;
+        else
+          v21 = *(_WORD *)(v19 + 16) & 0x7FFF;
+        v18 = v21 | (v20 << 15);
+      }
+    }
+    *(_DWORD *)(v13 + 36) = v18;
+    sub_1E5B1F0(a6, v13 + 48);
+    *(_DWORD *)(v13 + 40) = a8;
+    if ( a9 )
+    {
+      v22 = sub_97A1D0();
+      sub_1D8E230(v22, a9);
+    }
+    else
+    {
+      v22 = 0;
+    }
+    *(_QWORD *)(v13 + 64) = v22;
+    if ( a10 )
+    {
+      sub_1B22D60(v13 + 72, a10);
+      *(_BYTE *)(v13 + 88) = *(_BYTE *)(a10 + 16);
+    }
+    return CEntitySystem_AddEntityIOEventToQueue(a1, v13);
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventToQueue.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventToQueue.linux.yaml
@@ -1,0 +1,114 @@
+func_name: CEntitySystem_AddEntityIOEventToQueue
+func_va: '0x1e62fa0'
+disasm_code: |-
+  .text:0000000001E62FA0                 push    rbp
+  .text:0000000001E62FA1                 mov     rbp, rsp
+  .text:0000000001E62FA4                 push    r13
+  .text:0000000001E62FA6                 mov     r13, rdi
+  .text:0000000001E62FA9                 push    r12
+  .text:0000000001E62FAB                 ; 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+  .text:0000000001E62FAB                 lea     r12, [rdi+0B10h]; 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+  .text:0000000001E62FB2                 push    rbx
+  .text:0000000001E62FB3                 mov     rbx, rsi
+  .text:0000000001E62FB6                 sub     rsp, 8
+  .text:0000000001E62FBA                 call    sub_9846D0
+  .text:0000000001E62FBF                 cmp     rax, [r13+0B18h]
+  .text:0000000001E62FC6                 jz      loc_1E63090
+  .text:0000000001E62FCC                 mov     rsi, rax
+  .text:0000000001E62FCF                 mov     eax, [r13+0B10h]
+  .text:0000000001E62FD6                 test    eax, eax
+  .text:0000000001E62FD8                 jz      loc_1E63060
+  .text:0000000001E62FDE                 mov     rdi, r12
+  .text:0000000001E62FE1                 call    sub_9835E0
+  .text:0000000001E62FE6                 lea     rax, [r13+0B20h]
+  .text:0000000001E62FED                 jmp     short loc_1E6300B
+  .text:0000000001E63000                 movss   xmm0, dword ptr [rax+4]
+  .text:0000000001E63005                 comiss  xmm0, dword ptr [rbx+4]
+  .text:0000000001E63009                 ja      short loc_1E63017
+  .text:0000000001E6300B                 mov     rdx, rax
+  .text:0000000001E6300E                 mov     rax, [rax+60h]
+  .text:0000000001E63012                 test    rax, rax
+  .text:0000000001E63015                 jnz     short loc_1E63000
+  .text:0000000001E63017                 lea     rdi, [rbx+30h]
+  .text:0000000001E6301B                 movq    xmm0, rax
+  .text:0000000001E63020                 mov     esi, 1
+  .text:0000000001E63025                 pinsrq  xmm0, rdx, 1
+  .text:0000000001E6302C                 movups  xmmword ptr [rbx+60h], xmm0
+  .text:0000000001E63030                 mov     [rdx+60h], rbx
+  .text:0000000001E63034                 call    sub_9C0600
+  .text:0000000001E63039                 mov     rax, [rbx+60h]
+  .text:0000000001E6303D                 test    rax, rax
+  .text:0000000001E63040                 jz      short loc_1E63046
+  .text:0000000001E63042                 mov     [rax+68h], rbx
+  .text:0000000001E63046                 sub     word ptr [r13+0B14h], 1
+  .text:0000000001E6304F                 jz      short loc_1E630A0
+  .text:0000000001E63051                 add     rsp, 8
+  .text:0000000001E63055                 pop     rbx
+  .text:0000000001E63056                 pop     r12
+  .text:0000000001E63058                 pop     r13
+  .text:0000000001E6305A                 pop     rbp
+  .text:0000000001E6305B                 retn
+  .text:0000000001E63060                 mov     edx, 3
+  .text:0000000001E63065                 lock cmpxchg [r12], edx
+  .text:0000000001E6306B                 jnz     loc_1E62FDE
+  .text:0000000001E63071                 mov     eax, 1
+  .text:0000000001E63076                 mov     [r13+0B18h], rsi
+  .text:0000000001E6307D                 mov     [r13+0B14h], ax
+  .text:0000000001E63085                 jmp     loc_1E62FE6
+  .text:0000000001E63090                 add     word ptr [r13+0B14h], 1
+  .text:0000000001E63099                 jmp     loc_1E62FE6
+  .text:0000000001E630A0                 mov     qword ptr [r13+0B18h], 0
+  .text:0000000001E630AB                 lock sub dword ptr [r12], 3
+  .text:0000000001E630B1                 jz      short loc_1E63051
+  .text:0000000001E630B3                 add     rsp, 8
+  .text:0000000001E630B7                 mov     rdi, r12
+  .text:0000000001E630BA                 pop     rbx
+  .text:0000000001E630BB                 pop     r12
+  .text:0000000001E630BD                 pop     r13
+  .text:0000000001E630BF                 pop     rbp
+  .text:0000000001E630C0                 jmp     sub_983A60
+procedure: |-
+  __int64 __fastcall sub_1E62FA0(__int64 a1, __int64 a2)
+  {
+    volatile signed __int32 *v2; // r12
+    __int64 v3; // rax
+    signed __int64 v4; // rax
+    signed __int64 v5; // rdx
+    __int64 result; // rax
+
+    v2 = (volatile signed __int32 *)(a1 + 2832);  // 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+    v3 = sub_9846D0();
+    if ( v3 == *(_QWORD *)(a1 + 2840) )
+    {
+      ++*(_WORD *)(a1 + 2836);
+    }
+    else if ( *(_DWORD *)(a1 + 2832) || _InterlockedCompareExchange(v2, 3, 0) )
+    {
+      sub_9835E0(a1 + 2832, v3);
+    }
+    else
+    {
+      *(_QWORD *)(a1 + 2840) = v3;
+      *(_WORD *)(a1 + 2836) = 1;
+    }
+    v4 = a1 + 2848;
+    do
+    {
+      v5 = v4;
+      v4 = *(_QWORD *)(v4 + 96);
+    }
+    while ( v4 && *(float *)(v4 + 4) <= *(float *)(a2 + 4) );
+    *(__m128i *)(a2 + 96) = _mm_insert_epi64((__m128i)(unsigned __int64)v4, v5, 1);
+    *(_QWORD *)(v5 + 96) = a2;
+    sub_9C0600(a2 + 48, 1);
+    result = *(_QWORD *)(a2 + 96);
+    if ( result )
+      *(_QWORD *)(result + 104) = a2;
+    if ( (*(_WORD *)(a1 + 2836))-- == 1 )
+    {
+      *(_QWORD *)(a1 + 2840) = 0;
+      if ( _InterlockedSub(v2, 3u) )
+        return sub_983A60(v2);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventToQueue.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_AddEntityIOEventToQueue.windows.yaml
@@ -1,0 +1,223 @@
+func_name: CEntitySystem_AddEntityIOEventToQueue
+func_va: '0x1811ec970'
+disasm_code: |-
+  .text:00000001811EC970                 mov     [rsp+arg_8], rbx
+  .text:00000001811EC975                 mov     [rsp+arg_10], rbp
+  .text:00000001811EC97A                 push    rsi
+  .text:00000001811EC97B                 push    rdi
+  .text:00000001811EC97C                 push    r14
+  .text:00000001811EC97E                 sub     rsp, 20h
+  .text:00000001811EC982                 mov     rbp, rdx
+  .text:00000001811EC985                 ; 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+  .text:00000001811EC985                 lea     rdi, [rcx+0B10h]; 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+  .text:00000001811EC98C                 mov     rsi, rcx
+  .text:00000001811EC98F                 call    cs:GetCurrentThreadId
+  .text:00000001811EC995                 mov     edx, eax
+  .text:00000001811EC997                 cmp     [rdi+8], eax
+  .text:00000001811EC99A                 jnz     short loc_1811EC9A2
+  .text:00000001811EC99C                 inc     word ptr [rdi+4]
+  .text:00000001811EC9A0                 jmp     short loc_1811EC9C8
+  .text:00000001811EC9A2                 mov     eax, [rdi]
+  .text:00000001811EC9A4                 nop
+  .text:00000001811EC9A5                 test    eax, eax
+  .text:00000001811EC9A7                 jnz     short loc_1811EC9BF
+  .text:00000001811EC9A9                 mov     ecx, 3
+  .text:00000001811EC9AE                 lock cmpxchg [rdi], ecx
+  .text:00000001811EC9B2                 jnz     short loc_1811EC9BF
+  .text:00000001811EC9B4                 mov     word ptr [rdi+4], 1
+  .text:00000001811EC9BA                 mov     [rdi+8], edx
+  .text:00000001811EC9BD                 jmp     short loc_1811EC9C8
+  .text:00000001811EC9BF                 mov     rcx, rdi
+  .text:00000001811EC9C2                 call    cs:?AcquireLock@CAtomicMutex@@AEAAXI@Z; CAtomicMutex::AcquireLock(uint)
+  .text:00000001811EC9C8                 add     rsi, 0B20h
+  .text:00000001811EC9CF                 mov     rbx, [rsi+60h]
+  .text:00000001811EC9D3                 test    rbx, rbx
+  .text:00000001811EC9D6                 jz      short loc_1811EC9FD
+  .text:00000001811EC9D8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001811EC9E0                 lea     rcx, [rbx+4]
+  .text:00000001811EC9E4                 lea     rdx, [rbp+4]
+  .text:00000001811EC9E8                 call    sub_1801E3770
+  .text:00000001811EC9ED                 test    al, al
+  .text:00000001811EC9EF                 jnz     short loc_1811EC9FD
+  .text:00000001811EC9F1                 mov     rsi, rbx
+  .text:00000001811EC9F4                 mov     rbx, [rbx+60h]
+  .text:00000001811EC9F8                 test    rbx, rbx
+  .text:00000001811EC9FB                 jnz     short loc_1811EC9E0
+  .text:00000001811EC9FD                 mov     rax, [rsi+60h]
+  .text:00000001811ECA01                 xor     r14d, r14d
+  .text:00000001811ECA04                 mov     [rbp+60h], rax
+  .text:00000001811ECA08                 mov     [rbp+68h], rsi
+  .text:00000001811ECA0C                 mov     [rsi+60h], rbp
+  .text:00000001811ECA10                 test    byte ptr [rbp+3Ah], 1
+  .text:00000001811ECA14                 jnz     def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECA1A                 movzx   eax, byte ptr [rbp+38h]
+  .text:00000001811ECA1E                 ; switch 37 cases
+  .text:00000001811ECA1E                 add     eax, 0FFFFFFFDh; switch 37 cases
+  .text:00000001811ECA21                 cmp     eax, 24h
+  .text:00000001811ECA24                 ja      def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECA2A                 lea     rcx, cs:180000000h
+  .text:00000001811ECA31                 cdqe
+  .text:00000001811ECA33                 movzx   eax, ds:(byte_1811ECB48 - 180000000h)[rcx+rax]
+  .text:00000001811ECA3B                 mov     edx, ds:(jpt_1811ECA45 - 180000000h)[rcx+rax*4]
+  .text:00000001811ECA42                 add     rdx, rcx
+  .text:00000001811ECA45                 ; switch jump
+  .text:00000001811ECA45                 jmp     rdx; switch jump
+  .text:00000001811ECA47                 ; jumptable 00000001811ECA45 case 30
+  .text:00000001811ECA47                 mov     rdx, [rbp+30h]; jumptable 00000001811ECA45 case 30
+  .text:00000001811ECA4B                 lea     rcx, [rbp+30h]
+  .text:00000001811ECA4F                 mov     r8b, 1
+  .text:00000001811ECA52                 call    sub_1801833C0
+  .text:00000001811ECA57                 jmp     def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECA5C                 ; jumptable 00000001811ECA45 case 25
+  .text:00000001811ECA5C                 mov     rdx, [rbp+30h]; jumptable 00000001811ECA45 case 25
+  .text:00000001811ECA60                 lea     rcx, [rbp+30h]
+  .text:00000001811ECA64                 mov     r8b, 1
+  .text:00000001811ECA67                 call    sub_180179C80
+  .text:00000001811ECA6C                 jmp     short def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECA6E                 ; jumptable 00000001811ECA45 case 3
+  .text:00000001811ECA6E                 mov     byte ptr [rbp+38h], 3; jumptable 00000001811ECA45 case 3
+  .text:00000001811ECA72                 mov     rbx, [rbp+30h]
+  .text:00000001811ECA76                 mov     edx, 0Ch
+  .text:00000001811ECA7B                 mov     [rbp+30h], r14
+  .text:00000001811ECA7F                 mov     rax, cs:g_pMemAlloc
+  .text:00000001811ECA86                 mov     rcx, [rax]
+  .text:00000001811ECA89                 mov     rax, [rcx]
+  .text:00000001811ECA8C                 call    qword ptr [rax+8]
+  .text:00000001811ECA8F                 mov     [rbp+30h], rax
+  .text:00000001811ECA93                 movsd   xmm0, qword ptr [rbx]
+  .text:00000001811ECA97                 movsd   qword ptr [rax], xmm0
+  .text:00000001811ECA9B                 mov     ecx, [rbx+8]
+  .text:00000001811ECA9E                 mov     [rax+8], ecx
+  .text:00000001811ECAA1                 or      word ptr [rbp+3Ah], 1
+  .text:00000001811ECAA6                 jmp     short def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECAA8                 ; jumptable 00000001811ECA45 case 14
+  .text:00000001811ECAA8                 mov     byte ptr [rbp+38h], 0Eh; jumptable 00000001811ECA45 case 14
+  .text:00000001811ECAAC                 jmp     short loc_1811ECA72
+  .text:00000001811ECAAE                 ; jumptable 00000001811ECA45 case 27
+  .text:00000001811ECAAE                 mov     rdx, [rbp+30h]; jumptable 00000001811ECA45 case 27
+  .text:00000001811ECAB2                 lea     rcx, [rbp+30h]
+  .text:00000001811ECAB6                 mov     r8b, 1
+  .text:00000001811ECAB9                 call    sub_180179D20
+  .text:00000001811ECABE                 jmp     short def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECAC0                 ; jumptable 00000001811ECA45 case 39
+  .text:00000001811ECAC0                 mov     rdx, [rbp+30h]; jumptable 00000001811ECA45 case 39
+  .text:00000001811ECAC4                 lea     rcx, [rbp+30h]
+  .text:00000001811ECAC8                 mov     r8b, 1
+  .text:00000001811ECACB                 call    sub_180179DC0
+  .text:00000001811ECAD0                 jmp     short def_1811ECA45; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECAD2                 ; jumptable 00000001811ECA45 case 4
+  .text:00000001811ECAD2                 mov     rdx, [rbp+30h]; jumptable 00000001811ECA45 case 4
+  .text:00000001811ECAD6                 lea     rcx, [rbp+30h]
+  .text:00000001811ECADA                 mov     r8b, 1
+  .text:00000001811ECADD                 call    sub_180179E60
+  .text:00000001811ECAE2                 ; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECAE2                 mov     rax, [rbp+60h]; jumptable 00000001811ECA45 default case, cases 5-13,15-24,26,28,29,31-38
+  .text:00000001811ECAE6                 test    rax, rax
+  .text:00000001811ECAE9                 jz      short loc_1811ECAEF
+  .text:00000001811ECAEB                 mov     [rax+68h], rbp
+  .text:00000001811ECAEF                 mov     eax, 0FFFFh
+  .text:00000001811ECAF4                 add     [rdi+4], ax
+  .text:00000001811ECAF8                 jnz     short loc_1811ECB15
+  .text:00000001811ECAFA                 mov     [rdi+8], r14d
+  .text:00000001811ECAFE                 mov     eax, 0FFFFFFFDh
+  .text:00000001811ECB03                 lock xadd [rdi], eax
+  .text:00000001811ECB07                 add     eax, 0FFFFFFFDh
+  .text:00000001811ECB0A                 jz      short loc_1811ECB15
+  .text:00000001811ECB0C                 mov     rcx, rdi
+  .text:00000001811ECB0F                 call    cs:?ThreadAtomicNotifyOne@@YAXPEBI@Z; ThreadAtomicNotifyOne(uint const *)
+  .text:00000001811ECB15                 mov     rbx, [rsp+38h+arg_8]
+  .text:00000001811ECB1A                 mov     rbp, [rsp+38h+arg_10]
+  .text:00000001811ECB1F                 add     rsp, 20h
+  .text:00000001811ECB23                 pop     r14
+  .text:00000001811ECB25                 pop     rdi
+  .text:00000001811ECB26                 pop     rsi
+  .text:00000001811ECB27                 retn
+procedure: |-
+  void __fastcall sub_1811EC970(__int64 a1, __int64 a2)
+  {
+    __int64 v3; // rdi
+    DWORD CurrentThreadId; // edx
+    __int64 v6; // r8
+    __int64 v7; // rsi
+    __int64 i; // rbx
+    __int64 v9; // rbx
+    __int64 v10; // rax
+    __int64 v11; // rax
+
+    v3 = a1 + 2832;                               // 0xB10 = 2832LL = CEntitySystem::m_EventQueue(structmember,struct=CEntitySystem,member=m_EventQueue)
+    CurrentThreadId = GetCurrentThreadId();
+    if ( *(_DWORD *)(v3 + 8) == CurrentThreadId )
+    {
+      ++*(_WORD *)(v3 + 4);
+    }
+    else if ( *(_DWORD *)v3 || _InterlockedCompareExchange((volatile signed __int32 *)v3, 3, 0) )
+    {
+      CAtomicMutex::AcquireLock((CAtomicMutex *)v3, CurrentThreadId);
+    }
+    else
+    {
+      *(_WORD *)(v3 + 4) = 1;
+      *(_DWORD *)(v3 + 8) = CurrentThreadId;
+    }
+    v7 = a1 + 2848;
+    for ( i = *(_QWORD *)(v7 + 96); i; i = *(_QWORD *)(i + 96) )
+    {
+      if ( (unsigned __int8)sub_1801E3770(i + 4, a2 + 4) )
+        break;
+      v7 = i;
+    }
+    *(_QWORD *)(a2 + 96) = *(_QWORD *)(v7 + 96);
+    *(_QWORD *)(a2 + 104) = v7;
+    *(_QWORD *)(v7 + 96) = a2;
+    if ( (*(_BYTE *)(a2 + 58) & 1) == 0 )
+    {
+      switch ( *(_BYTE *)(a2 + 56) )
+      {
+        case 3:
+          *(_BYTE *)(a2 + 56) = 3;
+          goto LABEL_15;
+        case 4:
+          LOBYTE(v6) = 1;
+          sub_180179E60(a2 + 48, *(_QWORD *)(a2 + 48), v6);
+          break;
+        case 0xE:
+          *(_BYTE *)(a2 + 56) = 14;
+  LABEL_15:
+          v9 = *(_QWORD *)(a2 + 48);
+          *(_QWORD *)(a2 + 48) = 0;
+          v10 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 12);
+          *(_QWORD *)(a2 + 48) = v10;
+          *(_QWORD *)v10 = *(_QWORD *)v9;
+          *(_DWORD *)(v10 + 8) = *(_DWORD *)(v9 + 8);
+          *(_WORD *)(a2 + 58) |= 1u;
+          break;
+        case 0x19:
+          LOBYTE(v6) = 1;
+          sub_180179C80(a2 + 48, *(_QWORD *)(a2 + 48), v6);
+          break;
+        case 0x1B:
+          LOBYTE(v6) = 1;
+          sub_180179D20(a2 + 48, *(_QWORD *)(a2 + 48), v6);
+          break;
+        case 0x1E:
+          LOBYTE(v6) = 1;
+          sub_1801833C0(a2 + 48, *(_QWORD *)(a2 + 48), v6);
+          break;
+        case 0x27:
+          LOBYTE(v6) = 1;
+          sub_180179DC0(a2 + 48, *(_QWORD *)(a2 + 48), v6);
+          break;
+        default:
+          break;
+      }
+    }
+    v11 = *(_QWORD *)(a2 + 96);
+    if ( v11 )
+      *(_QWORD *)(v11 + 104) = a2;
+    if ( (*(_WORD *)(v3 + 4))-- == 1 )
+    {
+      *(_DWORD *)(v3 + 8) = 0;
+      if ( _InterlockedExchangeAdd((volatile signed __int32 *)v3, 0xFFFFFFFD) != 3 )
+        ThreadAtomicNotifyOne((const unsigned int *)v3);
+    }
+  }


### PR DESCRIPTION
## Summary
- Adds `find-CEntitySystem_AddEntityIOEventBuildStruct-linux` preprocessor script (Pattern A, linux-only)
- Adds `find-CEntitySystem_AddEntityIOEventToQueue` preprocessor scripts for windows and linux (Pattern A)
- Adds `find-CEntitySystem_m_EventQueue` preprocessor script (Pattern E, LLM_DECOMPILE via `CEntitySystem_AddEntityIOEventToQueue`)
- Adds `CEntitySystem_m_EventQueue` symbol config entry (`structmember`, `CEntitySystem::m_EventQueue`, offset `0xB10` / 2832)

## Test plan
- [ ] `uv run python ida_analyze_bin.py -debug` reports 0 failures for all new skills (verified locally)
- [ ] Output YAMLs confirmed: `offset: '0xb10'` on both windows and linux