### PR TITLE
Add CEntitySystem_m_vSpawnOriginOffset (structmember, offset 0x1F40/0x1F50)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5441,6 +5441,12 @@ modules:
         expected_input:
           - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
 
+      - name: find-CEntityKeyValuesAllocator_GetTempBuffer
+        expected_output:
+          - CEntityKeyValuesAllocator_GetTempBuffer.{platform}.yaml
+        expected_input:
+          - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
+
       - name: find-CEntityKeyValues_LoadFromContext
         expected_output:
           - CEntityKeyValues_LoadFromContext.{platform}.yaml
@@ -8792,6 +8798,11 @@ modules:
         category: structmember
         struct: CEntitySystem
         member: m_EntityKeyValuesAllocator
+
+      - name: CEntityKeyValuesAllocator_GetTempBuffer
+        category: func
+        alias:
+          - CEntityKeyValuesAllocator::GetTempBuffer
 
       - name: CEntityKeyValues_LoadFromContext
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -5447,6 +5447,12 @@ modules:
         expected_input:
           - CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml
 
+      - name: find-CEntitySystem_m_vSpawnOriginOffset
+        expected_output:
+          - CEntitySystem_m_vSpawnOriginOffset.{platform}.yaml
+        expected_input:
+          - CEntityKeyValuesAllocator_GetTempBuffer.{platform}.yaml
+
       - name: find-CEntityKeyValues_LoadFromContext
         expected_output:
           - CEntityKeyValues_LoadFromContext.{platform}.yaml
@@ -8803,6 +8809,11 @@ modules:
         category: func
         alias:
           - CEntityKeyValuesAllocator::GetTempBuffer
+
+      - name: CEntitySystem_m_vSpawnOriginOffset
+        category: structmember
+        struct: CEntitySystem
+        member: m_vSpawnOriginOffset
 
       - name: CEntityKeyValues_LoadFromContext
         category: func

--- a/ida_preprocessor_scripts/find-CEntityKeyValuesAllocator_GetTempBuffer.py
+++ b/ida_preprocessor_scripts/find-CEntityKeyValuesAllocator_GetTempBuffer.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityKeyValuesAllocator_GetTempBuffer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityKeyValuesAllocator_GetTempBuffer",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityKeyValuesAllocator_GetTempBuffer",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityKeyValuesAllocator_GetTempBuffer",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_vSpawnOriginOffset.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_vSpawnOriginOffset.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_vSpawnOriginOffset skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_vSpawnOriginOffset",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_vSpawnOriginOffset",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntityKeyValuesAllocator_GetTempBuffer.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_vSpawnOriginOffset",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValuesAllocator_GetTempBuffer.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValuesAllocator_GetTempBuffer.linux.yaml
@@ -1,0 +1,20 @@
+func_name: CEntityKeyValuesAllocator_GetTempBuffer
+func_va: '0x1e62200'
+disasm_code: |-
+  .text:0000000001E62200  cmp     dword ptr [rdi+0BC0h], 1
+  .text:0000000001E62207  lea     rax, xmmword_7A9FC0
+  .text:0000000001E6220E  jle     short loc_1E62218
+  .text:0000000001E62210  retn
+  .text:0000000001E62211  nop     dword ptr [rax+00000000h]
+  .text:0000000001E62218  lea     rax, [rdi+1F50h]; 0x1F50 = 8016LL = CEntitySystem::m_vSpawnOriginOffset(structmember,struct=CEntitySystem,member=m_vSpawnOriginOffset)
+  .text:0000000001E6221F  retn
+procedure: |-
+  __int128 *__fastcall CEntityKeyValuesAllocator_GetTempBuffer(__int64 a1)
+  {
+    __int128 *result; // rax
+
+    result = &xmmword_7A9FC0;
+    if ( *(int *)(a1 + 3008) <= 1 )
+      return (__int128 *)(a1 + 8016);             // 8016 = 0x1F50 = CEntitySystem::m_vSpawnOriginOffset (structmember, struct=CEntitySystem, member=m_vSpawnOriginOffset)
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntityKeyValuesAllocator_GetTempBuffer.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntityKeyValuesAllocator_GetTempBuffer.windows.yaml
@@ -1,0 +1,18 @@
+func_name: CEntityKeyValuesAllocator_GetTempBuffer
+func_va: '0x1811f7a90'
+disasm_code: |-
+  .text:00000001811F7A90  cmp     dword ptr [rcx+0BC0h], 1
+  .text:00000001811F7A97  lea     rax, [rcx+1F40h]; 0x1F40 = 8000LL = CEntitySystem::m_vSpawnOriginOffset(structmember,struct=CEntitySystem,member=m_vSpawnOriginOffset)
+  .text:00000001811F7A9E  lea     rdx, xmmword_1815EFC90
+  .text:00000001811F7AA5  cmovg   rax, rdx
+  .text:00000001811F7AA9  retn
+procedure: |-
+  __int128 *__fastcall sub_1811F7A90(__int64 a1)
+  {
+    __int128 *result; // rax
+
+    result = (__int128 *)(a1 + 8000);             // 8000 = 0x1F40 = CEntitySystem::m_vSpawnOriginOffset (structmember, struct=CEntitySystem, member=m_vSpawnOriginOffset)
+    if ( *(int *)(a1 + 3008) > 1 )
+      return &xmmword_1815EFC90;
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.linux.yaml
@@ -29,7 +29,7 @@ disasm_code: |-
   .text:0000000000B1736E                 mov     [rbp+var_1A4], eax
   .text:0000000000B17374                 lea     rax, g_pEntitySystem
   .text:0000000000B1737B                 mov     rdi, [rax]
-  .text:0000000000B1737E                 call    sub_1E62140
+  .text:0000000000B1737E                 call    CEntityKeyValuesAllocator_GetTempBuffer
   .text:0000000000B17383                 movdqa  xmm0, xmmword ptr [rax]
   .text:0000000000B17387                 mov     [rbp+var_1C8], 0
   .text:0000000000B17392                 movaps  [rbp+var_1A0], xmm0
@@ -1051,7 +1051,7 @@ procedure: |-
     v107 = -1;
     v4 = g_pEntitySystem + 3280;                  // 0xCD0 = 3280 = CEntitySystem::m_EntityKeyValuesAllocator(structmember,struct=CEntitySystem,member=m_EntityKeyValuesAllocator)
     v101 = sub_1E62130(g_pEntitySystem);
-    v5 = (const __m128i *)sub_1E62140(g_pEntitySystem);
+    v5 = (const __m128i *)CEntityKeyValuesAllocator_GetTempBuffer(g_pEntitySystem);
     v96 = 0;
     v102[0] = _mm_load_si128(v5);
     v97 = v4;

--- a/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySpawner_CPlayerSprayDecal_Spawn.windows.yaml
@@ -29,7 +29,7 @@ disasm_code: |-
   .text:00000001802A4CDD                 call    sub_1811F7750
   .text:00000001802A4CE2                 mov     rcx, cs:g_pEntitySystem
   .text:00000001802A4CE9                 mov     [rbp+0C0h+var_CC], eax
-  .text:00000001802A4CEC                 call    sub_1811F7A50
+  .text:00000001802A4CEC                 call    CEntityKeyValuesAllocator_GetTempBuffer
   .text:00000001802A4CF1                 mov     rcx, cs:g_pVApplication
   .text:00000001802A4CF8                 movaps  xmm0, xmmword ptr [rax]
   .text:00000001802A4CFB                 movaps  [rbp+0C0h+var_C0], xmm0
@@ -658,7 +658,7 @@ procedure: |-
     v80 = -1;
     v81 = 0;
     v74 = sub_1811F7750(g_pEntitySystem);
-    v5 = (_OWORD *)sub_1811F7A50(g_pEntitySystem);
+    v5 = (_OWORD *)CEntityKeyValuesAllocator_GetTempBuffer(g_pEntitySystem);
     v75[0] = *v5;
     v75[1] = v5[1];
     v6 = v5[2];


### PR DESCRIPTION
## Summary
- Adds `find-CEntityKeyValuesAllocator_GetTempBuffer` (Pattern D, LLM_DECOMPILE via `CEntitySpawner_CPlayerSprayDecal_Spawn`) as a prerequisite
- Adds `find-CEntitySystem_m_vSpawnOriginOffset` (Pattern E, LLM_DECOMPILE via `CEntityKeyValuesAllocator_GetTempBuffer`) for `CEntitySystem::m_vSpawnOriginOffset`
- Windows offset: `0x1F40` (8000), Linux offset: `0x1F50` (8016)

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures