### PR TITLE
Add CEntitySystem_m_Accessors[ MAX_ACCESSORS ] (structmember, offset 0x1F70/0x1F80)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6367,6 +6367,12 @@ modules:
           - CGameEntitySystem_vtable.{platform}.yaml
           - CEntitySystem_ctor.{platform}.yaml
 
+      - name: find-CEntitySystem_RegisterAccessor
+        expected_output:
+          - CEntitySystem_RegisterAccessor.{platform}.yaml
+        expected_input:
+          - CGameEntitySystem_ctor.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntitySystem
         expected_output:
           - CEntitySystem_CreateEntitySystem.{platform}.yaml
@@ -10029,6 +10035,11 @@ modules:
         category: func
         alias:
           - CGameEntitySystem::CGameEntitySystem
+
+      - name: CEntitySystem_RegisterAccessor
+        category: func
+        alias:
+          - CEntitySystem::RegisterAccessor
 
       - name: CEntitySystem_CreateEntitySystem
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -6373,6 +6373,12 @@ modules:
         expected_input:
           - CGameEntitySystem_ctor.{platform}.yaml
 
+      - name: find-CEntitySystem_m_Accessors
+        expected_output:
+          - CEntitySystem_m_Accessors.{platform}.yaml
+        expected_input:
+          - CEntitySystem_RegisterAccessor.{platform}.yaml
+
       - name: find-CEntitySystem_CreateEntitySystem
         expected_output:
           - CEntitySystem_CreateEntitySystem.{platform}.yaml
@@ -10040,6 +10046,11 @@ modules:
         category: func
         alias:
           - CEntitySystem::RegisterAccessor
+
+      - name: CEntitySystem_m_Accessors
+        category: structmember
+        struct: CEntitySystem
+        member: m_Accessors
 
       - name: CEntitySystem_CreateEntitySystem
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_RegisterAccessor.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_RegisterAccessor.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_RegisterAccessor skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_RegisterAccessor",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_RegisterAccessor",
+        "prompt/call_llm_decompile.md",
+        "references/server/CGameEntitySystem_ctor.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_RegisterAccessor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_m_Accessors.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_m_Accessors.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_m_Accessors skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CEntitySystem_m_Accessors",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_m_Accessors",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_RegisterAccessor.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_m_Accessors",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate target struct offset and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterAccessor.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterAccessor.linux.yaml
@@ -1,0 +1,18 @@
+func_name: CEntitySystem_RegisterAccessor
+func_va: '0x1e62220'
+disasm_code: |-
+  .text:0000000001E62220                 cmp     esi, 1Fh
+  .text:0000000001E62223                 ja      short locret_1E6223A
+  .text:0000000001E62225                 movsxd  rsi, esi
+  .text:0000000001E62228                 cmp     qword ptr [rdi+rsi*8+1F80h], 0 ; 0x1F80 = 8064 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+  .text:0000000001E62231                 lea     rax, [rsi+3F0h]
+  .text:0000000001E62238                 jz      short loc_1E62240
+  .text:0000000001E6223A                 retn
+  .text:0000000001E62240                 mov     [rdi+rax*8], rdx               ; rax = rsi+0x3F0 => effective offset = rsi*8+0x1F80 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+  .text:0000000001E62244                 retn
+procedure: |-
+  void __fastcall CEntitySystem_RegisterAccessor(__int64 a1, signed int a2, __int64 a3)
+  {
+    if ( (unsigned int)a2 <= 0x1F && !*(_QWORD *)(a1 + 8LL * a2 + 8064) )  // 8064 = 0x1F80 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+      *(_QWORD *)(a1 + 8 * (a2 + 1008LL)) = a3;                             // 8 * 1008 = 8064 = 0x1F80 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterAccessor.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_RegisterAccessor.windows.yaml
@@ -1,0 +1,23 @@
+func_name: CEntitySystem_RegisterAccessor
+func_va: '0x1811ec950'
+disasm_code: |-
+  .text:00000001811EC950                 cmp     edx, 1Fh
+  .text:00000001811EC953                 ja      short locret_1811EC96B
+  .text:00000001811EC955                 movsxd  rax, edx
+  .text:00000001811EC958                 cmp     qword ptr [rcx+rax*8+1F70h], 0 ; 0x1F70 = 8048 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+  .text:00000001811EC961                 jnz     short locret_1811EC96B
+  .text:00000001811EC963                 mov     [rcx+rax*8+1F70h], r8          ; 0x1F70 = 8048 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+  .text:00000001811EC96B                 retn
+procedure: |-
+  __int64 __fastcall CEntitySystem_RegisterAccessor(__int64 a1, signed int a2, __int64 a3)
+  {
+    __int64 result; // rax
+
+    if ( (unsigned int)a2 <= 0x1F )
+    {
+      result = a2;
+      if ( !*(_QWORD *)(a1 + 8LL * a2 + 8048) )   // 8048 = 0x1F70 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+        *(_QWORD *)(a1 + 8LL * a2 + 8048) = a3;   // 8048 = 0x1F70 = CEntitySystem::m_Accessors (structmember, struct=CEntitySystem, member=m_Accessors)
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_ctor.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_ctor.linux.yaml
@@ -1,0 +1,155 @@
+func_name: CGameEntitySystem_ctor
+func_va: '0x155add0'
+disasm_code: |-
+  .text:000000000155ADD0                 push    rbp
+  .text:000000000155ADD1                 mov     rbp, rsp
+  .text:000000000155ADD4                 push    r12
+  .text:000000000155ADD6                 push    rbx
+  .text:000000000155ADD7                 lea     r12, off_235FF28
+  .text:000000000155ADDE                 mov     rbx, rdi
+  .text:000000000155ADE1                 call    CEntitySystem_ctor
+  .text:000000000155ADE6                 lea     rax, CGameEntitySystem_vtable
+  .text:000000000155ADED                 pxor    xmm0, xmm0
+  .text:000000000155ADF1                 mov     qword ptr [rbx+20A0h], 0
+  .text:000000000155ADFC                 mov     [rbx], rax
+  .text:000000000155ADFF                 mov     edi, 28h ; '('
+  .text:000000000155AE04                 mov     rax, qword ptr cs:xmmword_86C540
+  .text:000000000155AE0B                 movups  xmmword ptr [rbx+20E8h], xmm0
+  .text:000000000155AE12                 mov     qword ptr [rbx+20B0h], 0
+  .text:000000000155AE1D                 mov     qword ptr [rbx+20B8h], 0
+  .text:000000000155AE28                 mov     [rbx+20C0h], rax
+  .text:000000000155AE2F                 mov     eax, 0FFFFFFFFh
+  .text:000000000155AE34                 mov     [rbx+20C8h], rax
+  .text:000000000155AE3B                 mov     qword ptr [rbx+20D0h], 0
+  .text:000000000155AE46                 mov     qword ptr [rbx+20D8h], 0
+  .text:000000000155AE51                 mov     qword ptr [rbx+20E0h], 0
+  .text:000000000155AE5C                 call    sub_97A1D0
+  .text:000000000155AE61                 xor     esi, esi
+  .text:000000000155AE63                 mov     rdi, rbx
+  .text:000000000155AE66                 mov     rdx, rax
+  .text:000000000155AE69                 lea     rax, off_235FEF0
+  .text:000000000155AE70                 mov     qword ptr [rdx+8], 0
+  .text:000000000155AE78                 mov     [rdx], rax
+  .text:000000000155AE7B                 xor     eax, eax
+  .text:000000000155AE7D                 mov     qword ptr [rdx+10h], 0
+  .text:000000000155AE85                 mov     qword ptr [rdx+18h], 0
+  .text:000000000155AE8D                 mov     dword ptr [rdx+20h], 40h ; '@'
+  .text:000000000155AE94                 mov     [rdx+24h], ax
+  .text:000000000155AE98                 call    CEntitySystem_RegisterAccessor
+  .text:000000000155AE9D                 mov     edi, 28h ; '('
+  .text:000000000155AEA2                 call    sub_97A1D0
+  .text:000000000155AEA7                 xor     ecx, ecx
+  .text:000000000155AEA9                 mov     esi, 2
+  .text:000000000155AEAE                 mov     rdi, rbx
+  .text:000000000155AEB1                 mov     [rax+24h], cx
+  .text:000000000155AEB5                 mov     rdx, rax
+  .text:000000000155AEB8                 mov     [rax], r12
+  .text:000000000155AEBB                 mov     qword ptr [rax+8], 0
+  .text:000000000155AEC3                 mov     qword ptr [rax+10h], 0
+  .text:000000000155AECB                 mov     qword ptr [rax+18h], 0
+  .text:000000000155AED3                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:000000000155AEDA                 call    CEntitySystem_RegisterAccessor
+  .text:000000000155AEDF                 mov     edi, 28h ; '('
+  .text:000000000155AEE4                 call    sub_97A1D0
+  .text:000000000155AEE9                 xor     esi, esi
+  .text:000000000155AEEB                 mov     rdi, rbx
+  .text:000000000155AEEE                 mov     rdx, rax
+  .text:000000000155AEF1                 lea     rax, off_235FF60
+  .text:000000000155AEF8                 mov     [rdx+24h], si
+  .text:000000000155AEFC                 mov     esi, 3
+  .text:000000000155AF01                 mov     [rdx], rax
+  .text:000000000155AF04                 mov     qword ptr [rdx+8], 0
+  .text:000000000155AF0C                 mov     qword ptr [rdx+10h], 0
+  .text:000000000155AF14                 mov     qword ptr [rdx+18h], 0
+  .text:000000000155AF1C                 mov     dword ptr [rdx+20h], 40h ; '@'
+  .text:000000000155AF23                 call    CEntitySystem_RegisterAccessor
+  .text:000000000155AF28                 mov     edi, 28h ; '('
+  .text:000000000155AF2D                 call    sub_97A1D0
+  .text:000000000155AF32                 xor     edi, edi
+  .text:000000000155AF34                 mov     esi, 4
+  .text:000000000155AF39                 mov     rdx, rax
+  .text:000000000155AF3C                 mov     [rax], r12
+  .text:000000000155AF3F                 mov     [rax+24h], di
+  .text:000000000155AF43                 mov     rdi, rbx
+  .text:000000000155AF46                 mov     qword ptr [rax+8], 0
+  .text:000000000155AF4E                 mov     qword ptr [rax+10h], 0
+  .text:000000000155AF56                 mov     qword ptr [rax+18h], 0
+  .text:000000000155AF5E                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:000000000155AF65                 call    CEntitySystem_RegisterAccessor
+  .text:000000000155AF6A                 mov     edi, 28h ; '('
+  .text:000000000155AF6F                 call    sub_97A1D0
+  .text:000000000155AF74                 xor     r8d, r8d
+  .text:000000000155AF77                 mov     rdi, rbx
+  .text:000000000155AF7A                 mov     esi, 5
+  .text:000000000155AF7F                 mov     [rax], r12
+  .text:000000000155AF82                 mov     rdx, rax
+  .text:000000000155AF85                 mov     qword ptr [rax+8], 0
+  .text:000000000155AF8D                 mov     qword ptr [rax+10h], 0
+  .text:000000000155AF95                 mov     qword ptr [rax+18h], 0
+  .text:000000000155AF9D                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:000000000155AFA4                 mov     [rax+24h], r8w
+  .text:000000000155AFA9                 pop     rbx
+  .text:000000000155AFAA                 pop     r12
+  .text:000000000155AFAC                 pop     rbp
+  .text:000000000155AFAD                 jmp     CEntitySystem_RegisterAccessor
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_ctor(__int64 a1)
+  {
+    __int64 v1; // rax
+    __int64 v2; // rax
+    __int64 v3; // rax
+    __int64 v4; // rax
+    __int64 v5; // rax
+
+    CEntitySystem_ctor(a1);
+    *(_QWORD *)(a1 + 8352) = 0;
+    *(_QWORD *)a1 = &CGameEntitySystem_vtable;
+    *(_OWORD *)(a1 + 8424) = 0;
+    *(_QWORD *)(a1 + 8368) = 0;
+    *(_QWORD *)(a1 + 8376) = 0;
+    *(_QWORD *)(a1 + 8384) = 0xFFFFFFFFLL;
+    *(_QWORD *)(a1 + 8392) = 0xFFFFFFFFLL;
+    *(_QWORD *)(a1 + 8400) = 0;
+    *(_QWORD *)(a1 + 8408) = 0;
+    *(_QWORD *)(a1 + 8416) = 0;
+    v1 = sub_97A1D0(40);
+    *(_QWORD *)(v1 + 8) = 0;
+    *(_QWORD *)v1 = off_235FEF0;
+    *(_QWORD *)(v1 + 16) = 0;
+    *(_QWORD *)(v1 + 24) = 0;
+    *(_DWORD *)(v1 + 32) = 64;
+    *(_WORD *)(v1 + 36) = 0;
+    CEntitySystem_RegisterAccessor(a1, 0);
+    v2 = sub_97A1D0(40);
+    *(_WORD *)(v2 + 36) = 0;
+    *(_QWORD *)v2 = off_235FF28;
+    *(_QWORD *)(v2 + 8) = 0;
+    *(_QWORD *)(v2 + 16) = 0;
+    *(_QWORD *)(v2 + 24) = 0;
+    *(_DWORD *)(v2 + 32) = 64;
+    CEntitySystem_RegisterAccessor(a1, 2);
+    v3 = sub_97A1D0(40);
+    *(_WORD *)(v3 + 36) = 0;
+    *(_QWORD *)v3 = off_235FF60;
+    *(_QWORD *)(v3 + 8) = 0;
+    *(_QWORD *)(v3 + 16) = 0;
+    *(_QWORD *)(v3 + 24) = 0;
+    *(_DWORD *)(v3 + 32) = 64;
+    CEntitySystem_RegisterAccessor(a1, 3);
+    v4 = sub_97A1D0(40);
+    *(_QWORD *)v4 = off_235FF28;
+    *(_WORD *)(v4 + 36) = 0;
+    *(_QWORD *)(v4 + 8) = 0;
+    *(_QWORD *)(v4 + 16) = 0;
+    *(_QWORD *)(v4 + 24) = 0;
+    *(_DWORD *)(v4 + 32) = 64;
+    CEntitySystem_RegisterAccessor(a1, 4);
+    v5 = sub_97A1D0(40);
+    *(_QWORD *)v5 = off_235FF28;
+    *(_QWORD *)(v5 + 8) = 0;
+    *(_QWORD *)(v5 + 16) = 0;
+    *(_QWORD *)(v5 + 24) = 0;
+    *(_DWORD *)(v5 + 32) = 64;
+    *(_WORD *)(v5 + 36) = 0;
+    return CEntitySystem_RegisterAccessor(a1, 5);
+  }

--- a/ida_preprocessor_scripts/references/server/CGameEntitySystem_ctor.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CGameEntitySystem_ctor.windows.yaml
@@ -1,0 +1,229 @@
+func_name: CGameEntitySystem_ctor
+func_va: '0x180b38f20'
+disasm_code: |-
+  .text:0000000180B38F20                 mov     [rsp+arg_0], rbx
+  .text:0000000180B38F25                 mov     [rsp+arg_8], rsi
+  .text:0000000180B38F2A                 push    rdi
+  .text:0000000180B38F2B                 sub     rsp, 20h
+  .text:0000000180B38F2F                 mov     rdi, rcx
+  .text:0000000180B38F32                 call    CEntitySystem_ctor
+  .text:0000000180B38F37                 xor     esi, esi
+  .text:0000000180B38F39                 lea     rbx, [rdi+20A0h]
+  .text:0000000180B38F40                 mov     [rdi+2090h], rsi
+  .text:0000000180B38F47                 lea     rax, CGameEntitySystem_vtable
+  .text:0000000180B38F4E                 mov     [rdi], rax
+  .text:0000000180B38F51                 xor     edx, edx
+  .text:0000000180B38F53                 mov     [rdi+2098h], sil
+  .text:0000000180B38F5A                 mov     r8d, 1
+  .text:0000000180B38F60                 mov     rcx, rbx
+  .text:0000000180B38F63                 mov     [rbx], rsi
+  .text:0000000180B38F66                 mov     [rbx+8], rsi
+  .text:0000000180B38F6A                 call    sub_180B53920
+  .text:0000000180B38F6F                 mov     dword ptr [rbx+10h], 0FFFFFFFFh
+  .text:0000000180B38F76                 mov     ecx, 28h ; '('
+  .text:0000000180B38F7B                 mov     [rbx+14h], esi
+  .text:0000000180B38F7E                 mov     dword ptr [rbx+18h], 0FFFFFFFFh
+  .text:0000000180B38F85                 mov     [rdi+20C8h], rsi
+  .text:0000000180B38F8C                 mov     [rdi+20D0h], rsi
+  .text:0000000180B38F93                 mov     [rdi+20C0h], esi
+  .text:0000000180B38F99                 mov     [rdi+20D8h], rsi
+  .text:0000000180B38FA0                 mov     [rdi+20E0h], rsi
+  .text:0000000180B38FA7                 call    sub_180E7C960
+  .text:0000000180B38FAC                 test    rax, rax
+  .text:0000000180B38FAF                 jz      short loc_180B38FD4
+  .text:0000000180B38FB1                 mov     [rax+8], rsi
+  .text:0000000180B38FB5                 lea     rcx, ??_7?$CEntityDataInstantiator@Ugroundlink_t@@@@6B@; const CEntityDataInstantiator<groundlink_t>::`vftable'
+  .text:0000000180B38FBC                 mov     [rax], rcx
+  .text:0000000180B38FBF                 mov     [rax+10h], rsi
+  .text:0000000180B38FC3                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:0000000180B38FCA                 mov     [rax+24h], sil
+  .text:0000000180B38FCE                 mov     [rax+18h], rsi
+  .text:0000000180B38FD2                 jmp     short loc_180B38FD7
+  .text:0000000180B38FD4 loc_180B38FD4:
+  .text:0000000180B38FD4                 mov     rax, rsi
+  .text:0000000180B38FD7 loc_180B38FD7:
+  .text:0000000180B38FD7                 mov     r8, rax
+  .text:0000000180B38FDA                 xor     edx, edx
+  .text:0000000180B38FDC                 mov     rcx, rdi
+  .text:0000000180B38FDF                 call    CEntitySystem_RegisterAccessor
+  .text:0000000180B38FE4                 mov     ecx, 28h ; '('
+  .text:0000000180B38FE9                 call    sub_180E7C960
+  .text:0000000180B38FEE                 lea     rbx, ??_7?$CEntityDataInstantiator@VCWatcherList@@@@6B@; const CEntityDataInstantiator<CWatcherList>::`vftable'
+  .text:0000000180B38FF5                 test    rax, rax
+  .text:0000000180B38FF8                 jz      short loc_180B39016
+  .text:0000000180B38FFA                 mov     [rax], rbx
+  .text:0000000180B38FFD                 mov     [rax+8], rsi
+  .text:0000000180B39001                 mov     [rax+10h], rsi
+  .text:0000000180B39005                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:0000000180B3900C                 mov     [rax+24h], sil
+  .text:0000000180B39010                 mov     [rax+18h], rsi
+  .text:0000000180B39014                 jmp     short loc_180B39019
+  .text:0000000180B39016 loc_180B39016:
+  .text:0000000180B39016                 mov     rax, rsi
+  .text:0000000180B39019 loc_180B39019:
+  .text:0000000180B39019                 mov     r8, rax
+  .text:0000000180B3901C                 mov     edx, 2
+  .text:0000000180B39021                 mov     rcx, rdi
+  .text:0000000180B39024                 call    CEntitySystem_RegisterAccessor
+  .text:0000000180B39029                 mov     ecx, 28h ; '('
+  .text:0000000180B3902E                 call    sub_180E7C960
+  .text:0000000180B39033                 test    rax, rax
+  .text:0000000180B39036                 jz      short loc_180B3905B
+  .text:0000000180B39038                 mov     [rax+8], rsi
+  .text:0000000180B3903C                 lea     rcx, ??_7?$CEntityDataInstantiator@Uphysicspushlist_t@@@@6B@; const CEntityDataInstantiator<physicspushlist_t>::`vftable'
+  .text:0000000180B39043                 mov     [rax], rcx
+  .text:0000000180B39046                 mov     [rax+10h], rsi
+  .text:0000000180B3904A                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:0000000180B39051                 mov     [rax+24h], sil
+  .text:0000000180B39055                 mov     [rax+18h], rsi
+  .text:0000000180B39059                 jmp     short loc_180B3905E
+  .text:0000000180B3905B loc_180B3905B:
+  .text:0000000180B3905B                 mov     rax, rsi
+  .text:0000000180B3905E loc_180B3905E:
+  .text:0000000180B3905E                 mov     r8, rax
+  .text:0000000180B39061                 mov     edx, 3
+  .text:0000000180B39066                 mov     rcx, rdi
+  .text:0000000180B39069                 call    CEntitySystem_RegisterAccessor
+  .text:0000000180B3906E                 mov     ecx, 28h ; '('
+  .text:0000000180B39073                 call    sub_180E7C960
+  .text:0000000180B39078                 test    rax, rax
+  .text:0000000180B3907B                 jz      short loc_180B39099
+  .text:0000000180B3907D                 mov     [rax], rbx
+  .text:0000000180B39080                 mov     [rax+8], rsi
+  .text:0000000180B39084                 mov     [rax+10h], rsi
+  .text:0000000180B39088                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:0000000180B3908F                 mov     [rax+24h], sil
+  .text:0000000180B39093                 mov     [rax+18h], rsi
+  .text:0000000180B39097                 jmp     short loc_180B3909C
+  .text:0000000180B39099 loc_180B39099:
+  .text:0000000180B39099                 mov     rax, rsi
+  .text:0000000180B3909C loc_180B3909C:
+  .text:0000000180B3909C                 mov     r8, rax
+  .text:0000000180B3909F                 mov     edx, 4
+  .text:0000000180B390A4                 mov     rcx, rdi
+  .text:0000000180B390A7                 call    CEntitySystem_RegisterAccessor
+  .text:0000000180B390AC                 mov     ecx, 28h ; '('
+  .text:0000000180B390B1                 call    sub_180E7C960
+  .text:0000000180B390B6                 test    rax, rax
+  .text:0000000180B390B9                 jz      short loc_180B390D7
+  .text:0000000180B390BB                 mov     [rax], rbx
+  .text:0000000180B390BE                 mov     [rax+8], rsi
+  .text:0000000180B390C2                 mov     [rax+10h], rsi
+  .text:0000000180B390C6                 mov     dword ptr [rax+20h], 40h ; '@'
+  .text:0000000180B390CD                 mov     [rax+24h], sil
+  .text:0000000180B390D1                 mov     [rax+18h], rsi
+  .text:0000000180B390D5                 jmp     short loc_180B390DA
+  .text:0000000180B390D7 loc_180B390D7:
+  .text:0000000180B390D7                 mov     rax, rsi
+  .text:0000000180B390DA loc_180B390DA:
+  .text:0000000180B390DA                 mov     r8, rax
+  .text:0000000180B390DD                 mov     edx, 5
+  .text:0000000180B390E2                 mov     rcx, rdi
+  .text:0000000180B390E5                 call    CEntitySystem_RegisterAccessor
+  .text:0000000180B390EA                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180B390EF                 mov     rax, rdi
+  .text:0000000180B390F2                 mov     rsi, [rsp+28h+arg_8]
+  .text:0000000180B390F7                 add     rsp, 20h
+  .text:0000000180B390FB                 pop     rdi
+  .text:0000000180B390FC                 retn
+procedure: |-
+  __int64 __fastcall CGameEntitySystem_ctor(__int64 a1)
+  {
+    __int64 v2; // rax
+    __int64 v3; // rax
+    __int64 v4; // rax
+    __int64 v5; // rax
+    __int64 v6; // rax
+
+    CEntitySystem_ctor(a1);
+    *(_QWORD *)(a1 + 8336) = 0;
+    *(_QWORD *)a1 = &CGameEntitySystem_vtable;
+    *(_BYTE *)(a1 + 8344) = 0;
+    *(_QWORD *)(a1 + 8352) = 0;
+    *(_QWORD *)(a1 + 8360) = 0;
+    sub_180B53920(a1 + 8352, 0, 1);
+    *(_DWORD *)(a1 + 8368) = -1;
+    *(_DWORD *)(a1 + 8372) = 0;
+    *(_DWORD *)(a1 + 8376) = -1;
+    *(_QWORD *)(a1 + 8392) = 0;
+    *(_QWORD *)(a1 + 8400) = 0;
+    *(_DWORD *)(a1 + 8384) = 0;
+    *(_QWORD *)(a1 + 8408) = 0;
+    *(_QWORD *)(a1 + 8416) = 0;
+    v2 = sub_180E7C960(40);
+    if ( v2 )
+    {
+      *(_QWORD *)(v2 + 8) = 0;
+      *(_QWORD *)v2 = &CEntityDataInstantiator<groundlink_t>::`vftable';
+      *(_QWORD *)(v2 + 16) = 0;
+      *(_DWORD *)(v2 + 32) = 64;
+      *(_BYTE *)(v2 + 36) = 0;
+      *(_QWORD *)(v2 + 24) = 0;
+    }
+    else
+    {
+      v2 = 0;
+    }
+    CEntitySystem_RegisterAccessor(a1, 0, v2);
+    v3 = sub_180E7C960(40);
+    if ( v3 )
+    {
+      *(_QWORD *)v3 = &CEntityDataInstantiator<CWatcherList>::`vftable';
+      *(_QWORD *)(v3 + 8) = 0;
+      *(_QWORD *)(v3 + 16) = 0;
+      *(_DWORD *)(v3 + 32) = 64;
+      *(_BYTE *)(v3 + 36) = 0;
+      *(_QWORD *)(v3 + 24) = 0;
+    }
+    else
+    {
+      v3 = 0;
+    }
+    CEntitySystem_RegisterAccessor(a1, 2, v3);
+    v4 = sub_180E7C960(40);
+    if ( v4 )
+    {
+      *(_QWORD *)(v4 + 8) = 0;
+      *(_QWORD *)v4 = &CEntityDataInstantiator<physicspushlist_t>::`vftable';
+      *(_QWORD *)(v4 + 16) = 0;
+      *(_DWORD *)(v4 + 32) = 64;
+      *(_BYTE *)(v4 + 36) = 0;
+      *(_QWORD *)(v4 + 24) = 0;
+    }
+    else
+    {
+      v4 = 0;
+    }
+    CEntitySystem_RegisterAccessor(a1, 3, v4);
+    v5 = sub_180E7C960(40);
+    if ( v5 )
+    {
+      *(_QWORD *)v5 = &CEntityDataInstantiator<CWatcherList>::`vftable';
+      *(_QWORD *)(v5 + 8) = 0;
+      *(_QWORD *)(v5 + 16) = 0;
+      *(_DWORD *)(v5 + 32) = 64;
+      *(_BYTE *)(v5 + 36) = 0;
+      *(_QWORD *)(v5 + 24) = 0;
+    }
+    else
+    {
+      v5 = 0;
+    }
+    CEntitySystem_RegisterAccessor(a1, 4, v5);
+    v6 = sub_180E7C960(40);
+    if ( v6 )
+    {
+      *(_QWORD *)v6 = &CEntityDataInstantiator<CWatcherList>::`vftable';
+      *(_QWORD *)(v6 + 8) = 0;
+      *(_QWORD *)(v6 + 16) = 0;
+      *(_DWORD *)(v6 + 32) = 64;
+      *(_BYTE *)(v6 + 36) = 0;
+      *(_QWORD *)(v6 + 24) = 0;
+    }
+    else
+    {
+      v6 = 0;
+    }
+    CEntitySystem_RegisterAccessor(a1, 5, v6);
+    return a1;
+  }


### PR DESCRIPTION
## Summary

- Add `find-CEntitySystem_m_Accessors` preprocessor script (Pattern E — struct member via LLM_DECOMPILE)
- Add `CEntitySystem_RegisterAccessor` reference YAMLs for both platforms (predecessor function used for decompile context)
- Register `CEntitySystem_m_Accessors` in `config.yaml` as `structmember` of `CEntitySystem`

## Offsets

| Platform | Offset | Signature |
|----------|--------|-----------|
| Windows | `0x1F70` | `48 83 BC C1 ?? ?? ?? ?? ??` |
| Linux | `0x1F80` | `48 83 BC F7 ?? ?? ?? ?? ??` |

## Test plan

- [x] `ida_analyze_bin.py -module server` — Successful: 1, Failed: 0