### PR TITLE
Add CEntityInstance_GetChangeAccessorPathInfo_2 (vfunc, LLM_DECOMPILE)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6577,6 +6577,13 @@ modules:
         expected_input:
           - CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.{platform}.yaml
 
+      - name: find-CEntityInstance_GetChangeAccessorPathInfo_2
+        expected_output:
+          - CEntityInstance_GetChangeAccessorPathInfo_2.{platform}.yaml
+        expected_input:
+          - PolymorphicHelper_t__GetChangeAccessorPathInfo_2.{platform}.yaml
+          - CEntityInstance_vtable.{platform}.yaml
+
       - name: find-CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
         expected_output:
           - CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats.{platform}.yaml
@@ -7683,6 +7690,11 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::GetChangeAccessorPathInfo_1
+
+      - name: CEntityInstance_GetChangeAccessorPathInfo_2
+        category: vfunc
+        alias:
+          - CEntityInstance::GetChangeAccessorPathInfo_2
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -6571,6 +6571,12 @@ modules:
         expected_output:
           - CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.{platform}.yaml
 
+      - name: find-PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+        expected_output:
+          - PolymorphicHelper_t__GetChangeAccessorPathInfo_2.{platform}.yaml
+        expected_input:
+          - CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.{platform}.yaml
+
       - name: find-CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
         expected_output:
           - CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats.{platform}.yaml
@@ -10306,6 +10312,11 @@ modules:
         category: func
         alias:
           - CNetworkUtlVectorEmbedded<CRenderAttribute>::NetworkStateChanged_m_vecRenderAttributes
+
+      - name: PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+        category: func
+        alias:
+          - PolymorphicHelper_t::GetChangeAccessorPathInfo_2
 
       - name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_perRoundStats
         category: func

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -2083,6 +2083,26 @@ def run_skill(skill_name, agent="claude", debug=False, expected_yaml_paths=None,
     return False
 
 
+def _is_idb_file_locked(path):
+    """Return True if *path* is currently held open (OS-level) by another process.
+
+    Uses an exclusive-open attempt rather than mere file existence so that stale
+    .id0 files left by a previous idalib-mcp session that exited cleanly do not
+    trigger a false-positive lock warning.
+
+    IDA Pro opens database files with no share mode (exclusive access), so any
+    open() attempt while IDA has the file open raises PermissionError/OSError.
+    """
+    if not os.path.exists(path):
+        return False
+    try:
+        with open(path, "r+b"):
+            pass
+        return False
+    except (IOError, OSError):
+        return True
+
+
 def process_binary(
     binary_path,
     skills,
@@ -2219,11 +2239,12 @@ def process_binary(
             print("  All skills already have yaml files and no vcall_finder/post_process targets remain, skipping IDA startup")
         return success_count, fail_count, skip_count
 
-    # Refuse to start IDA if an `.id0` lock file exists next to the binary —
-    # that means another IDA instance currently has this IDB open, and starting
-    # idalib-mcp on top of it would corrupt the database.
+    # Refuse to start IDA if an `.id0` file is held open by another process —
+    # starting idalib-mcp on top of an already-open IDB would corrupt the database.
+    # Use OS-level lock detection (not mere existence) so stale files left by a
+    # previous idalib-mcp session that exited cleanly do not block the next run.
     lock_file = f"{binary_path}.id0"
-    if os.path.exists(lock_file):
+    if _is_idb_file_locked(lock_file):
         print(
             f"  Failed: IDB lock file detected ({lock_file}); another IDA instance "
             f"has this database open. Close it and retry."

--- a/ida_preprocessor_scripts/find-CEntityInstance_GetChangeAccessorPathInfo_2.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_GetChangeAccessorPathInfo_2.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_GetChangeAccessorPathInfo_2 skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_GetChangeAccessorPathInfo_2",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntityInstance_GetChangeAccessorPathInfo_2",
+        "prompt/call_llm_decompile.md",
+        "references/server/PolymorphicHelper_t__GetChangeAccessorPathInfo_2.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntityInstance_GetChangeAccessorPathInfo_2", "CEntityInstance"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_GetChangeAccessorPathInfo_2",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-PolymorphicHelper_t__GetChangeAccessorPathInfo_2.py
+++ b/ida_preprocessor_scripts/find-PolymorphicHelper_t__GetChangeAccessorPathInfo_2.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-PolymorphicHelper_t__GetChangeAccessorPathInfo_2 skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "PolymorphicHelper_t__GetChangeAccessorPathInfo_2",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "PolymorphicHelper_t__GetChangeAccessorPathInfo_2",
+        "prompt/call_llm_decompile.md",
+        "references/server/CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "PolymorphicHelper_t__GetChangeAccessorPathInfo_2",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.linux.yaml
@@ -450,7 +450,7 @@ disasm_code: |-
   .text:0000000000ED620C                 or      eax, 8
   .text:0000000000ED620F                 mov     [r14+61h], al
   .text:0000000000ED6213                 lea     rsi, [r14+28h]
-  .text:0000000000ED6217                 call    sub_1D877B0
+  .text:0000000000ED6217                 call    PolymorphicHelper_t__GetChangeAccessorPathInfo_2
   .text:0000000000ED621C                 movzx   edx, byte ptr [r14+61h]
   .text:0000000000ED6221                 mov     ecx, eax
   .text:0000000000ED6223                 and     ecx, 1
@@ -1105,7 +1105,7 @@ procedure: |-
       || ((v15 & 8) == 0
         ? (*((_BYTE *)a1 + 97) = v15 | 8,
            v10 = (unsigned __int64)(a1 + 10),
-           v16 = sub_1D877B0(v14, a1 + 10, a1 + 18),
+           v16 = PolymorphicHelper_t__GetChangeAccessorPathInfo_2(v14, a1 + 10, a1 + 18),
            LODWORD(a4) = 16 * (v16 & 1),
            *((_BYTE *)a1 + 97) = (16 * (v16 & 1)) | *((_BYTE *)a1 + 97) & 0xEF)
         : (v16 = (v15 & 0x10) != 0),

--- a/ida_preprocessor_scripts/references/server/CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes.windows.yaml
@@ -1,323 +1,327 @@
 func_name: CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
-func_va: '0x1805ed250'
+func_va: '0x1806058e0'
 disasm_code: |-
-  .text:00000001805ED250                 push    rbp
-  .text:00000001805ED252                 push    rsi
-  .text:00000001805ED253                 push    r12
-  .text:00000001805ED255                 push    r14
-  .text:00000001805ED257                 push    r15
-  .text:00000001805ED259                 lea     rbp, [rsp-70h]
-  .text:00000001805ED25E                 sub     rsp, 170h
-  .text:00000001805ED265                 mov     r12, r8
-  .text:00000001805ED268                 movzx   r15d, dl
-  .text:00000001805ED26C                 mov     r14, rcx
-  .text:00000001805ED26F                 test    dl, 1
-  .text:00000001805ED272                 jz      short loc_1805ED2CA
-  .text:00000001805ED274                 test    byte ptr [rcx+61h], 1
-  .text:00000001805ED278                 jnz     short loc_1805ED2CA
-  .text:00000001805ED27A                 call    CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
-  .text:00000001805ED27F                 test    al, al
-  .text:00000001805ED281                 jz      short loc_1805ED2CA
-  .text:00000001805ED283                 mov     eax, [r14]
-  .text:00000001805ED286                 test    eax, eax
-  .text:00000001805ED288                 jle     short loc_1805ED2CA
-  .text:00000001805ED28A                 cmp     byte ptr [r14+60h], 0
-  .text:00000001805ED28F                 jnz     short loc_1805ED2CA
-  .text:00000001805ED291                 and     r15b, 0FEh
-  .text:00000001805ED295                 mov     [rbp+90h+arg_1C], eax
-  .text:00000001805ED29B                 or      r15b, 0Ah
-  .text:00000001805ED29F                 lea     r8, [rbp+90h+arg_18]
-  .text:00000001805ED2A6                 xor     esi, esi
-  .text:00000001805ED2A8                 movzx   edx, r15b
-  .text:00000001805ED2AC                 mov     rcx, r14
-  .text:00000001805ED2AF                 mov     [rbp+90h+arg_18], esi
-  .text:00000001805ED2B5                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
-  .text:00000001805ED2BA                 add     rsp, 170h
-  .text:00000001805ED2C1                 pop     r15
-  .text:00000001805ED2C3                 pop     r14
-  .text:00000001805ED2C5                 pop     r12
-  .text:00000001805ED2C7                 pop     rsi
-  .text:00000001805ED2C8                 pop     rbp
-  .text:00000001805ED2C9                 retn
-  .text:00000001805ED2CA                 mov     [rsp+190h+arg_0], rbx
-  .text:00000001805ED2D2                 xor     esi, esi
-  .text:00000001805ED2D4                 test    byte ptr [r14+61h], 1
-  .text:00000001805ED2D9                 mov     [rsp+190h+arg_8], rdi
-  .text:00000001805ED2E1                 mov     [rsp+190h+arg_10], r13
-  .text:00000001805ED2E9                 mov     r13d, [r12]
-  .text:00000001805ED2ED                 jz      short loc_1805ED340
-  .text:00000001805ED2EF                 cmp     [r14+60h], sil
-  .text:00000001805ED2F3                 jnz     short loc_1805ED340
-  .text:00000001805ED2F5                 test    r15b, 2
-  .text:00000001805ED2F9                 jz      short loc_1805ED340
-  .text:00000001805ED2FB                 cmp     r13d, 0FFFFFFFFh
-  .text:00000001805ED2FF                 jnz     short loc_1805ED322
-  .text:00000001805ED301                 mov     edi, [r14]
-  .text:00000001805ED304                 mov     ebx, esi
-  .text:00000001805ED306                 test    edi, edi
-  .text:00000001805ED308                 jz      short loc_1805ED340
-  .text:00000001805ED30A                 nop     word ptr [rax+rax+00h]
-  .text:00000001805ED310                 mov     edx, ebx
-  .text:00000001805ED312                 mov     rcx, r14
-  .text:00000001805ED315                 call    sub_1805D9240
-  .text:00000001805ED31A                 inc     ebx
-  .text:00000001805ED31C                 cmp     ebx, edi
-  .text:00000001805ED31E                 jnz     short loc_1805ED310
-  .text:00000001805ED320                 jmp     short loc_1805ED340
-  .text:00000001805ED322                 mov     edi, [r12+4]
-  .text:00000001805ED327                 mov     ebx, r13d
-  .text:00000001805ED32A                 cmp     r13d, edi
-  .text:00000001805ED32D                 jz      short loc_1805ED340
-  .text:00000001805ED32F                 nop
-  .text:00000001805ED330                 mov     edx, ebx
-  .text:00000001805ED332                 mov     rcx, r14
-  .text:00000001805ED335                 call    sub_1805D9240
-  .text:00000001805ED33A                 inc     ebx
-  .text:00000001805ED33C                 cmp     ebx, edi
-  .text:00000001805ED33E                 jnz     short loc_1805ED330
-  .text:00000001805ED340                 test    r15b, 4
-  .text:00000001805ED344                 jz      loc_1805ED47C
-  .text:00000001805ED34A                 mov     rcx, [r14+20h]
-  .text:00000001805ED34E                 test    rcx, rcx
-  .text:00000001805ED351                 jz      short loc_1805ED35C
-  .text:00000001805ED353                 mov     rax, [rcx+8]
-  .text:00000001805ED357                 mov     rcx, [rcx]
-  .text:00000001805ED35A                 call    rax
-  .text:00000001805ED35C                 xorps   xmm0, xmm0
-  .text:00000001805ED35F                 mov     [rsp+190h+var_170], 1
-  .text:00000001805ED367                 xor     edx, edx
-  .text:00000001805ED369                 movdqa  [rsp+190h+var_150], xmm0
-  .text:00000001805ED36F                 xor     ecx, ecx
-  .text:00000001805ED371                 mov     [rsp+190h+var_160], rsi
-  .text:00000001805ED376                 mov     r9d, 4
-  .text:00000001805ED37C                 mov     [rsp+190h+var_158], rsi
-  .text:00000001805ED381                 mov     r8d, 1
-  .text:00000001805ED387                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED38B                 mov     [rsp+190h+var_140], 0FFFFFFFFFFFFFFFFh
-  .text:00000001805ED394                 mov     [rsp+190h+var_138], 0FFFFFFFFh
-  .text:00000001805ED39C                 mov     [rsp+190h+var_134], si
-  .text:00000001805ED3A1                 call    cs:UtlVectorMemory_CalcNewAllocationCount
-  .text:00000001805ED3A7                 mov     ebx, eax
-  .text:00000001805ED3A9                 cmp     eax, 1
-  .text:00000001805ED3AC                 jge     short loc_1805ED3BF
-  .text:00000001805ED3AE                 xchg    ax, ax
-  .text:00000001805ED3B0                 lea     eax, [rbx+1]
-  .text:00000001805ED3B3                 cdq
-  .text:00000001805ED3B4                 sub     eax, edx
-  .text:00000001805ED3B6                 sar     eax, 1
-  .text:00000001805ED3B8                 mov     ebx, eax
-  .text:00000001805ED3BA                 cmp     eax, 1
-  .text:00000001805ED3BD                 jl      short loc_1805ED3B0
-  .text:00000001805ED3BF                 movsxd  r9, dword ptr [rsp+190h+var_158]
-  .text:00000001805ED3C4                 mov     rcx, [rsp+190h+var_160]
-  .text:00000001805ED3C9                 shl     r9, 2
-  .text:00000001805ED3CD                 test    dword ptr [rsp+190h+var_158+4], 0C0000000h
-  .text:00000001805ED3D5                 mov     r8d, ebx
-  .text:00000001805ED3D8                 setz    dl
-  .text:00000001805ED3DB                 shl     r8, 2
-  .text:00000001805ED3DF                 call    cs:UtlVectorMemory_Alloc
-  .text:00000001805ED3E5                 mov     edx, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED3E9                 mov     [rsp+190h+var_160], rax
-  .text:00000001805ED3EE                 test    edx, 0C0000000h
-  .text:00000001805ED3F4                 jz      short loc_1805ED400
-  .text:00000001805ED3F6                 and     edx, 3FFFFFFFh
-  .text:00000001805ED3FC                 mov     dword ptr [rsp+190h+var_158+4], edx
-  .text:00000001805ED400                 inc     [rsp+190h+var_168]
-  .text:00000001805ED404                 lea     rdx, [rsp+190h+var_170]
-  .text:00000001805ED409                 mov     dword ptr [rsp+190h+var_158], ebx
-  .text:00000001805ED40D                 lea     rcx, [r14-540h]
-  .text:00000001805ED414                 mov     dword ptr [rax], 540h
-  .text:00000001805ED41A                 mov     rax, [r14-540h]
-  .text:00000001805ED421                 call    qword ptr [rax+0D8h]
-  .text:00000001805ED427                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED42B                 mov     rdx, [rsp+190h+var_160]
-  .text:00000001805ED430                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED434                 test    eax, 0C0000000h
-  .text:00000001805ED439                 jnz     short loc_1805ED47C
-  .text:00000001805ED43B                 test    rdx, rdx
-  .text:00000001805ED43E                 jz      short loc_1805ED45C
-  .text:00000001805ED440                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED447                 mov     rcx, [rax]
-  .text:00000001805ED44A                 mov     rax, [rcx]
-  .text:00000001805ED44D                 call    qword ptr [rax+18h]
-  .text:00000001805ED450                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED454                 mov     rdx, rsi
-  .text:00000001805ED457                 mov     [rsp+190h+var_160], rdx
-  .text:00000001805ED45C                 mov     dword ptr [rsp+190h+var_158], esi
-  .text:00000001805ED460                 test    eax, 0C0000000h
-  .text:00000001805ED465                 jnz     short loc_1805ED47C
-  .text:00000001805ED467                 test    rdx, rdx
-  .text:00000001805ED46A                 jz      short loc_1805ED47C
-  .text:00000001805ED46C                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED473                 mov     rcx, [rax]
-  .text:00000001805ED476                 mov     rax, [rcx]
-  .text:00000001805ED479                 call    qword ptr [rax+18h]
-  .text:00000001805ED47C                 test    r15b, 8
-  .text:00000001805ED480                 jz      loc_1805ED70A
-  .text:00000001805ED486                 mov     rcx, [r14+18h]
-  .text:00000001805ED48A                 test    rcx, rcx
-  .text:00000001805ED48D                 jz      loc_1805ED70A
-  .text:00000001805ED493                 cmp     r13d, 0FFFFFFFFh
-  .text:00000001805ED497                 jz      loc_1805ED606
-  .text:00000001805ED49D                 movzx   edx, byte ptr [r14+61h]
-  .text:00000001805ED4A2                 test    dl, 1
-  .text:00000001805ED4A5                 jz      loc_1805ED606
-  .text:00000001805ED4AB                 lea     rdi, [r14+48h]
-  .text:00000001805ED4AF                 test    dl, 8
-  .text:00000001805ED4B2                 jnz     short loc_1805ED4D8
-  .text:00000001805ED4B4                 or      dl, 8
-  .text:00000001805ED4B7                 mov     r8, rdi
-  .text:00000001805ED4BA                 mov     [r14+61h], dl
-  .text:00000001805ED4BE                 lea     rdx, [r14+28h]
-  .text:00000001805ED4C2                 call    sub_1811A5E80
-  .text:00000001805ED4C7                 movzx   edx, byte ptr [r14+61h]
-  .text:00000001805ED4CC                 and     dl, 0EFh
-  .text:00000001805ED4CF                 shl     al, 4
-  .text:00000001805ED4D2                 or      dl, al
-  .text:00000001805ED4D4                 mov     [r14+61h], dl
-  .text:00000001805ED4D8                 test    dl, 10h
-  .text:00000001805ED4DB                 jz      loc_1805ED606
-  .text:00000001805ED4E1                 movsxd  rcx, dword ptr [r12]
-  .text:00000001805ED4E5                 mov     eax, [r12+4]
-  .text:00000001805ED4EA                 cmp     ecx, eax
-  .text:00000001805ED4EC                 jz      loc_1805ED70A
-  .text:00000001805ED4F2                 lea     r15, [rcx+rcx*8]
-  .text:00000001805ED4F6                 shl     r15, 3
-  .text:00000001805ED4FA                 sub     eax, ecx
-  .text:00000001805ED4FC                 mov     r12d, eax
-  .text:00000001805ED4FF                 nop
-  .text:00000001805ED500                 movsxd  rbx, dword ptr [rdi]
-  .text:00000001805ED503                 mov     rcx, rsi
-  .text:00000001805ED506                 mov     rax, [r14+8]
-  .text:00000001805ED50A                 xorps   xmm0, xmm0
-  .text:00000001805ED50D                 mov     rdi, [rdi+8]
-  .text:00000001805ED511                 mov     [rsp+190h+var_170], 1
-  .text:00000001805ED519                 mov     [rsp+190h+var_160], rcx
-  .text:00000001805ED51E                 mov     eax, [r15+rax+28h]
-  .text:00000001805ED523                 mov     [rsp+190h+var_138], eax
-  .text:00000001805ED527                 mov     [rsp+190h+var_158], rsi
-  .text:00000001805ED52C                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED530                 movdqa  [rsp+190h+var_150], xmm0
-  .text:00000001805ED536                 mov     [rsp+190h+var_140], 0FFFFFFFFFFFFFFFFh
-  .text:00000001805ED53F                 mov     [rsp+190h+var_134], 1
-  .text:00000001805ED546                 test    ebx, ebx
-  .text:00000001805ED548                 jle     short loc_1805ED55D
-  .text:00000001805ED54A                 mov     edx, ebx
-  .text:00000001805ED54C                 lea     rcx, [rsp+190h+var_168]
-  .text:00000001805ED551                 call    sub_180165C40
-  .text:00000001805ED556                 mov     rcx, [rsp+190h+var_160]
-  .text:00000001805ED55B                 jmp     short loc_1805ED55F
-  .text:00000001805ED55D                 jns     short loc_1805ED563
-  .text:00000001805ED55F                 mov     [rsp+190h+var_168], ebx
-  .text:00000001805ED563                 test    rdi, rdi
-  .text:00000001805ED566                 jz      short loc_1805ED581
-  .text:00000001805ED568                 lea     r8, ds:0[rbx*4]
-  .text:00000001805ED570                 lea     rax, [r8+rdi]
-  .text:00000001805ED574                 cmp     rax, rdi
-  .text:00000001805ED577                 jbe     short loc_1805ED581
-  .text:00000001805ED579                 mov     rdx, rdi
-  .text:00000001805ED57C                 call    sub_1814DA740
-  .text:00000001805ED581                 mov     rax, [r14-540h]
-  .text:00000001805ED588                 lea     rdx, [rsp+190h+var_170]
-  .text:00000001805ED58D                 lea     rcx, [r14-540h]
-  .text:00000001805ED594                 call    qword ptr [rax+0D8h]
-  .text:00000001805ED59A                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED59E                 mov     rdx, [rsp+190h+var_160]
-  .text:00000001805ED5A3                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED5A7                 test    eax, 0C0000000h
-  .text:00000001805ED5AC                 jnz     short loc_1805ED5EF
-  .text:00000001805ED5AE                 test    rdx, rdx
-  .text:00000001805ED5B1                 jz      short loc_1805ED5CF
-  .text:00000001805ED5B3                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED5BA                 mov     rcx, [rax]
-  .text:00000001805ED5BD                 mov     rax, [rcx]
-  .text:00000001805ED5C0                 call    qword ptr [rax+18h]
-  .text:00000001805ED5C3                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED5C7                 mov     rdx, rsi
-  .text:00000001805ED5CA                 mov     [rsp+190h+var_160], rdx
-  .text:00000001805ED5CF                 mov     dword ptr [rsp+190h+var_158], esi
-  .text:00000001805ED5D3                 test    eax, 0C0000000h
-  .text:00000001805ED5D8                 jnz     short loc_1805ED5EF
-  .text:00000001805ED5DA                 test    rdx, rdx
-  .text:00000001805ED5DD                 jz      short loc_1805ED5EF
-  .text:00000001805ED5DF                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED5E6                 mov     rcx, [rax]
-  .text:00000001805ED5E9                 mov     rax, [rcx]
-  .text:00000001805ED5EC                 call    qword ptr [rax+18h]
-  .text:00000001805ED5EF                 add     r15, 48h ; 'H'
-  .text:00000001805ED5F3                 lea     rdi, [r14+48h]
-  .text:00000001805ED5F7                 sub     r12, 1
-  .text:00000001805ED5FB                 jnz     loc_1805ED500
-  .text:00000001805ED601                 jmp     loc_1805ED70A
-  .text:00000001805ED606                 lea     rax, aSWasNotCompose; "%s was not composed of trivial POD-type"...
-  .text:00000001805ED60D                 mov     [rsp+190h+var_130], esi
-  .text:00000001805ED611                 cmp     r13d, 0FFFFFFFFh
-  .text:00000001805ED615                 mov     [rsp+190h+var_128], rsi
-  .text:00000001805ED61A                 lea     rdx, aSWithoutPathIn; "%s without path index range"
-  .text:00000001805ED621                 mov     [rsp+190h+var_12C], 0C0000100h
-  .text:00000001805ED629                 cmovnz  rdx, rax
-  .text:00000001805ED62D                 lea     r8, aMVecrenderattr; "m_vecRenderAttributes"
-  .text:00000001805ED634                 lea     rcx, [rsp+190h+var_130]
-  .text:00000001805ED639                 call    sub_1801D0E70
-  .text:00000001805ED63E                 mov     eax, [rsp+190h+var_12C]
-  .text:00000001805ED642                 bt      eax, 1Eh
-  .text:00000001805ED646                 jnb     short loc_1805ED64F
-  .text:00000001805ED648                 lea     rax, [rsp+190h+var_128]
-  .text:00000001805ED64D                 jmp     short loc_1805ED661
-  .text:00000001805ED64F                 test    eax, 3FFFFFFFh
-  .text:00000001805ED654                 lea     rax, byte_18152DF88
-  .text:00000001805ED65B                 cmova   rax, [rsp+190h+var_128]
-  .text:00000001805ED661                 mov     rcx, [r14+18h]
-  .text:00000001805ED665                 lea     rdx, [rsp+190h+var_170]
-  .text:00000001805ED66A                 mov     qword ptr [rsp+190h+var_150], rax
-  .text:00000001805ED66F                 lea     rax, aCBuildworkerCs_2; "C:\\buildworker\\csgo_rel_win64\\build"...
-  .text:00000001805ED676                 mov     qword ptr [rsp+190h+var_150+8], rax
-  .text:00000001805ED67B                 mov     [rsp+190h+var_170], esi
-  .text:00000001805ED67F                 mov     [rsp+190h+var_160], rsi
-  .text:00000001805ED684                 mov     [rsp+190h+var_158], rsi
-  .text:00000001805ED689                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED68D                 mov     dword ptr [rsp+190h+var_140], 0CDBh
-  .text:00000001805ED695                 mov     [rsp+190h+var_140+4], 0FFFFFFFFFFFFFFFFh
-  .text:00000001805ED69E                 mov     [rsp+190h+var_134], si
-  .text:00000001805ED6A3                 call    sub_1811A5F10
-  .text:00000001805ED6A8                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED6AC                 mov     rdx, [rsp+190h+var_160]
-  .text:00000001805ED6B1                 mov     [rsp+190h+var_168], esi
-  .text:00000001805ED6B5                 test    eax, 0C0000000h
-  .text:00000001805ED6BA                 jnz     short loc_1805ED6FD
-  .text:00000001805ED6BC                 test    rdx, rdx
-  .text:00000001805ED6BF                 jz      short loc_1805ED6DD
-  .text:00000001805ED6C1                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED6C8                 mov     rcx, [rax]
-  .text:00000001805ED6CB                 mov     rax, [rcx]
-  .text:00000001805ED6CE                 call    qword ptr [rax+18h]
-  .text:00000001805ED6D1                 mov     eax, dword ptr [rsp+190h+var_158+4]
-  .text:00000001805ED6D5                 mov     rdx, rsi
-  .text:00000001805ED6D8                 mov     [rsp+190h+var_160], rdx
-  .text:00000001805ED6DD                 mov     dword ptr [rsp+190h+var_158], esi
-  .text:00000001805ED6E1                 test    eax, 0C0000000h
-  .text:00000001805ED6E6                 jnz     short loc_1805ED6FD
-  .text:00000001805ED6E8                 test    rdx, rdx
-  .text:00000001805ED6EB                 jz      short loc_1805ED6FD
-  .text:00000001805ED6ED                 mov     rax, cs:g_pMemAlloc
-  .text:00000001805ED6F4                 mov     rcx, [rax]
-  .text:00000001805ED6F7                 mov     rax, [rcx]
-  .text:00000001805ED6FA                 call    qword ptr [rax+18h]
-  .text:00000001805ED6FD                 xor     edx, edx
-  .text:00000001805ED6FF                 lea     rcx, [rsp+190h+var_130]
-  .text:00000001805ED704                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
-  .text:00000001805ED70A                 mov     rdi, [rsp+190h+arg_8]
-  .text:00000001805ED712                 mov     rbx, [rsp+190h+arg_0]
-  .text:00000001805ED71A                 mov     r13, [rsp+190h+arg_10]
-  .text:00000001805ED722                 add     rsp, 170h
-  .text:00000001805ED729                 pop     r15
-  .text:00000001805ED72B                 pop     r14
-  .text:00000001805ED72D                 pop     r12
-  .text:00000001805ED72F                 pop     rsi
-  .text:00000001805ED730                 pop     rbp
-  .text:00000001805ED731                 retn
+  .text:00000001806058E0                 push    rbp
+  .text:00000001806058E2                 push    rsi
+  .text:00000001806058E3                 push    r12
+  .text:00000001806058E5                 push    r14
+  .text:00000001806058E7                 push    r15
+  .text:00000001806058E9                 lea     rbp, [rsp-70h]
+  .text:00000001806058EE                 sub     rsp, 170h
+  .text:00000001806058F5                 mov     r12, r8
+  .text:00000001806058F8                 movzx   r15d, dl
+  .text:00000001806058FC                 mov     r14, rcx
+  .text:00000001806058FF                 test    dl, 1
+  .text:0000000180605902                 jz      short loc_18060595A
+  .text:0000000180605904                 test    byte ptr [rcx+61h], 1
+  .text:0000000180605908                 jnz     short loc_18060595A
+  .text:000000018060590A                 call    CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes
+  .text:000000018060590F                 test    al, al
+  .text:0000000180605911                 jz      short loc_18060595A
+  .text:0000000180605913                 mov     eax, [r14]
+  .text:0000000180605916                 test    eax, eax
+  .text:0000000180605918                 jle     short loc_18060595A
+  .text:000000018060591A                 cmp     byte ptr [r14+60h], 0
+  .text:000000018060591F                 jnz     short loc_18060595A
+  .text:0000000180605921                 and     r15b, 0FEh
+  .text:0000000180605925                 mov     [rbp+90h+arg_1C], eax
+  .text:000000018060592B                 or      r15b, 0Ah
+  .text:000000018060592F                 lea     r8, [rbp+90h+arg_18]
+  .text:0000000180605936                 xor     esi, esi
+  .text:0000000180605938                 movzx   edx, r15b
+  .text:000000018060593C                 mov     rcx, r14
+  .text:000000018060593F                 mov     [rbp+90h+arg_18], esi
+  .text:0000000180605945                 call    CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes
+  .text:000000018060594A                 add     rsp, 170h
+  .text:0000000180605951                 pop     r15
+  .text:0000000180605953                 pop     r14
+  .text:0000000180605955                 pop     r12
+  .text:0000000180605957                 pop     rsi
+  .text:0000000180605958                 pop     rbp
+  .text:0000000180605959                 retn
+  .text:000000018060595A                 mov     [rsp+190h+arg_0], rbx
+  .text:0000000180605962                 xor     esi, esi
+  .text:0000000180605964                 test    byte ptr [r14+61h], 1
+  .text:0000000180605969                 mov     [rsp+190h+arg_8], rdi
+  .text:0000000180605971                 mov     [rsp+190h+arg_10], r13
+  .text:0000000180605979                 mov     r13d, [r12]
+  .text:000000018060597D                 jz      short loc_1806059D0
+  .text:000000018060597F                 cmp     [r14+60h], sil
+  .text:0000000180605983                 jnz     short loc_1806059D0
+  .text:0000000180605985                 test    r15b, 2
+  .text:0000000180605989                 jz      short loc_1806059D0
+  .text:000000018060598B                 cmp     r13d, 0FFFFFFFFh
+  .text:000000018060598F                 jnz     short loc_1806059B2
+  .text:0000000180605991                 mov     edi, [r14]
+  .text:0000000180605994                 mov     ebx, esi
+  .text:0000000180605996                 test    edi, edi
+  .text:0000000180605998                 jz      short loc_1806059D0
+  .text:000000018060599A                 nop     word ptr [rax+rax+00h]
+  .text:00000001806059A0                 mov     edx, ebx
+  .text:00000001806059A2                 mov     rcx, r14
+  .text:00000001806059A5                 call    sub_1805E2980
+  .text:00000001806059AA                 inc     ebx
+  .text:00000001806059AC                 cmp     ebx, edi
+  .text:00000001806059AE                 jnz     short loc_1806059A0
+  .text:00000001806059B0                 jmp     short loc_1806059D0
+  .text:00000001806059B2                 mov     edi, [r12+4]
+  .text:00000001806059B7                 mov     ebx, r13d
+  .text:00000001806059BA                 cmp     r13d, edi
+  .text:00000001806059BD                 jz      short loc_1806059D0
+  .text:00000001806059BF                 nop
+  .text:00000001806059C0                 mov     edx, ebx
+  .text:00000001806059C2                 mov     rcx, r14
+  .text:00000001806059C5                 call    sub_1805E2980
+  .text:00000001806059CA                 inc     ebx
+  .text:00000001806059CC                 cmp     ebx, edi
+  .text:00000001806059CE                 jnz     short loc_1806059C0
+  .text:00000001806059D0                 test    r15b, 4
+  .text:00000001806059D4                 jz      loc_180605B0C
+  .text:00000001806059DA                 mov     rcx, [r14+20h]
+  .text:00000001806059DE                 test    rcx, rcx
+  .text:00000001806059E1                 jz      short loc_1806059EC
+  .text:00000001806059E3                 mov     rax, [rcx+8]
+  .text:00000001806059E7                 mov     rcx, [rcx]
+  .text:00000001806059EA                 call    rax
+  .text:00000001806059EC                 xorps   xmm0, xmm0
+  .text:00000001806059EF                 mov     [rsp+190h+var_170], 1
+  .text:00000001806059F7                 xor     edx, edx
+  .text:00000001806059F9                 movdqa  [rsp+190h+var_150], xmm0
+  .text:00000001806059FF                 xor     ecx, ecx
+  .text:0000000180605A01                 mov     [rsp+190h+var_160], rsi
+  .text:0000000180605A06                 mov     r9d, 4
+  .text:0000000180605A0C                 mov     [rsp+190h+var_158], rsi
+  .text:0000000180605A11                 mov     r8d, 1
+  .text:0000000180605A17                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605A1B                 mov     [rsp+190h+var_140], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180605A24                 mov     [rsp+190h+var_138], 0FFFFFFFFh
+  .text:0000000180605A2C                 mov     [rsp+190h+var_134], si
+  .text:0000000180605A31                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180605A37                 mov     ebx, eax
+  .text:0000000180605A39                 cmp     eax, 1
+  .text:0000000180605A3C                 jge     short loc_180605A4F
+  .text:0000000180605A3E                 xchg    ax, ax
+  .text:0000000180605A40                 lea     eax, [rbx+1]
+  .text:0000000180605A43                 cdq
+  .text:0000000180605A44                 sub     eax, edx
+  .text:0000000180605A46                 sar     eax, 1
+  .text:0000000180605A48                 mov     ebx, eax
+  .text:0000000180605A4A                 cmp     eax, 1
+  .text:0000000180605A4D                 jl      short loc_180605A40
+  .text:0000000180605A4F                 movsxd  r9, dword ptr [rsp+190h+var_158]
+  .text:0000000180605A54                 mov     rcx, [rsp+190h+var_160]
+  .text:0000000180605A59                 shl     r9, 2
+  .text:0000000180605A5D                 test    dword ptr [rsp+190h+var_158+4], 0C0000000h
+  .text:0000000180605A65                 mov     r8d, ebx
+  .text:0000000180605A68                 setz    dl
+  .text:0000000180605A6B                 shl     r8, 2
+  .text:0000000180605A6F                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180605A75                 mov     edx, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605A79                 mov     [rsp+190h+var_160], rax
+  .text:0000000180605A7E                 test    edx, 0C0000000h
+  .text:0000000180605A84                 jz      short loc_180605A90
+  .text:0000000180605A86                 and     edx, 3FFFFFFFh
+  .text:0000000180605A8C                 mov     dword ptr [rsp+190h+var_158+4], edx
+  .text:0000000180605A90                 inc     [rsp+190h+var_168]
+  .text:0000000180605A94                 lea     rdx, [rsp+190h+var_170]
+  .text:0000000180605A99                 mov     dword ptr [rsp+190h+var_158], ebx
+  .text:0000000180605A9D                 lea     rcx, [r14-578h]
+  .text:0000000180605AA4                 mov     dword ptr [rax], 578h
+  .text:0000000180605AAA                 mov     rax, [r14-578h]
+  .text:0000000180605AB1                 call    qword ptr [rax+0E0h]
+  .text:0000000180605AB7                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605ABB                 mov     rdx, [rsp+190h+var_160]
+  .text:0000000180605AC0                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605AC4                 test    eax, 0C0000000h
+  .text:0000000180605AC9                 jnz     short loc_180605B0C
+  .text:0000000180605ACB                 test    rdx, rdx
+  .text:0000000180605ACE                 jz      short loc_180605AEC
+  .text:0000000180605AD0                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605AD7                 mov     rcx, [rax]
+  .text:0000000180605ADA                 mov     rax, [rcx]
+  .text:0000000180605ADD                 call    qword ptr [rax+18h]
+  .text:0000000180605AE0                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605AE4                 mov     rdx, rsi
+  .text:0000000180605AE7                 mov     [rsp+190h+var_160], rdx
+  .text:0000000180605AEC                 mov     dword ptr [rsp+190h+var_158], esi
+  .text:0000000180605AF0                 test    eax, 0C0000000h
+  .text:0000000180605AF5                 jnz     short loc_180605B0C
+  .text:0000000180605AF7                 test    rdx, rdx
+  .text:0000000180605AFA                 jz      short loc_180605B0C
+  .text:0000000180605AFC                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605B03                 mov     rcx, [rax]
+  .text:0000000180605B06                 mov     rax, [rcx]
+  .text:0000000180605B09                 call    qword ptr [rax+18h]
+  .text:0000000180605B0C                 test    r15b, 8
+  .text:0000000180605B10                 jz      loc_180605D9A
+  .text:0000000180605B16                 mov     rcx, [r14+18h]
+  .text:0000000180605B1A                 test    rcx, rcx
+  .text:0000000180605B1D                 jz      loc_180605D9A
+  .text:0000000180605B23                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000180605B27                 jz      loc_180605C96
+  .text:0000000180605B2D                 movzx   edx, byte ptr [r14+61h]
+  .text:0000000180605B32                 test    dl, 1
+  .text:0000000180605B35                 jz      loc_180605C96
+  .text:0000000180605B3B                 lea     rdi, [r14+48h]
+  .text:0000000180605B3F                 test    dl, 8
+  .text:0000000180605B42                 jnz     short loc_180605B68
+  .text:0000000180605B44                 or      dl, 8
+  .text:0000000180605B47                 mov     r8, rdi
+  .text:0000000180605B4A                 mov     [r14+61h], dl
+  .text:0000000180605B4E                 lea     rdx, [r14+28h]
+  .text:0000000180605B52                 ; PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+  .text:0000000180605B52                 call    PolymorphicHelper_t__GetChangeAccessorPathInfo_2; PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+  .text:0000000180605B57                 movzx   edx, byte ptr [r14+61h]
+  .text:0000000180605B5C                 and     dl, 0EFh
+  .text:0000000180605B5F                 shl     al, 4
+  .text:0000000180605B62                 or      dl, al
+  .text:0000000180605B64                 mov     [r14+61h], dl
+  .text:0000000180605B68                 test    dl, 10h
+  .text:0000000180605B6B                 jz      loc_180605C96
+  .text:0000000180605B71                 movsxd  rcx, dword ptr [r12]
+  .text:0000000180605B75                 mov     eax, [r12+4]
+  .text:0000000180605B7A                 cmp     ecx, eax
+  .text:0000000180605B7C                 jz      loc_180605D9A
+  .text:0000000180605B82                 lea     r15, [rcx+rcx*8]
+  .text:0000000180605B86                 shl     r15, 3
+  .text:0000000180605B8A                 sub     eax, ecx
+  .text:0000000180605B8C                 mov     r12d, eax
+  .text:0000000180605B8F                 nop
+  .text:0000000180605B90                 movsxd  rbx, dword ptr [rdi]
+  .text:0000000180605B93                 mov     rcx, rsi
+  .text:0000000180605B96                 mov     rax, [r14+8]
+  .text:0000000180605B9A                 xorps   xmm0, xmm0
+  .text:0000000180605B9D                 mov     rdi, [rdi+8]
+  .text:0000000180605BA1                 mov     [rsp+190h+var_170], 1
+  .text:0000000180605BA9                 mov     [rsp+190h+var_160], rcx
+  .text:0000000180605BAE                 mov     eax, [r15+rax+28h]
+  .text:0000000180605BB3                 mov     [rsp+190h+var_138], eax
+  .text:0000000180605BB7                 mov     [rsp+190h+var_158], rsi
+  .text:0000000180605BBC                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605BC0                 movdqa  [rsp+190h+var_150], xmm0
+  .text:0000000180605BC6                 mov     [rsp+190h+var_140], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180605BCF                 mov     [rsp+190h+var_134], 1
+  .text:0000000180605BD6                 test    ebx, ebx
+  .text:0000000180605BD8                 jle     short loc_180605BED
+  .text:0000000180605BDA                 mov     edx, ebx
+  .text:0000000180605BDC                 lea     rcx, [rsp+190h+var_168]
+  .text:0000000180605BE1                 call    sub_1801856B0
+  .text:0000000180605BE6                 mov     rcx, [rsp+190h+var_160]
+  .text:0000000180605BEB                 jmp     short loc_180605BEF
+  .text:0000000180605BED                 jns     short loc_180605BF3
+  .text:0000000180605BEF                 mov     [rsp+190h+var_168], ebx
+  .text:0000000180605BF3                 test    rdi, rdi
+  .text:0000000180605BF6                 jz      short loc_180605C11
+  .text:0000000180605BF8                 lea     r8, ds:0[rbx*4]
+  .text:0000000180605C00                 lea     rax, [r8+rdi]
+  .text:0000000180605C04                 cmp     rax, rdi
+  .text:0000000180605C07                 jbe     short loc_180605C11
+  .text:0000000180605C09                 mov     rdx, rdi
+  .text:0000000180605C0C                 call    sub_1815514F0
+  .text:0000000180605C11                 mov     rax, [r14-578h]
+  .text:0000000180605C18                 lea     rdx, [rsp+190h+var_170]
+  .text:0000000180605C1D                 lea     rcx, [r14-578h]
+  .text:0000000180605C24                 call    qword ptr [rax+0E0h]
+  .text:0000000180605C2A                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605C2E                 mov     rdx, [rsp+190h+var_160]
+  .text:0000000180605C33                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605C37                 test    eax, 0C0000000h
+  .text:0000000180605C3C                 jnz     short loc_180605C7F
+  .text:0000000180605C3E                 test    rdx, rdx
+  .text:0000000180605C41                 jz      short loc_180605C5F
+  .text:0000000180605C43                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605C4A                 mov     rcx, [rax]
+  .text:0000000180605C4D                 mov     rax, [rcx]
+  .text:0000000180605C50                 call    qword ptr [rax+18h]
+  .text:0000000180605C53                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605C57                 mov     rdx, rsi
+  .text:0000000180605C5A                 mov     [rsp+190h+var_160], rdx
+  .text:0000000180605C5F                 mov     dword ptr [rsp+190h+var_158], esi
+  .text:0000000180605C63                 test    eax, 0C0000000h
+  .text:0000000180605C68                 jnz     short loc_180605C7F
+  .text:0000000180605C6A                 test    rdx, rdx
+  .text:0000000180605C6D                 jz      short loc_180605C7F
+  .text:0000000180605C6F                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605C76                 mov     rcx, [rax]
+  .text:0000000180605C79                 mov     rax, [rcx]
+  .text:0000000180605C7C                 call    qword ptr [rax+18h]
+  .text:0000000180605C7F                 add     r15, 48h ; 'H'
+  .text:0000000180605C83                 lea     rdi, [r14+48h]
+  .text:0000000180605C87                 sub     r12, 1
+  .text:0000000180605C8B                 jnz     loc_180605B90
+  .text:0000000180605C91                 jmp     loc_180605D9A
+  .text:0000000180605C96                 lea     rax, aSWasNotCompose; "%s was not composed of trivial POD-type"...
+  .text:0000000180605C9D                 mov     [rsp+190h+var_130], esi
+  .text:0000000180605CA1                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000180605CA5                 mov     [rsp+190h+var_128], rsi
+  .text:0000000180605CAA                 lea     rdx, aSWithoutPathIn; "%s without path index range"
+  .text:0000000180605CB1                 mov     [rsp+190h+var_12C], 0C0000100h
+  .text:0000000180605CB9                 cmovnz  rdx, rax
+  .text:0000000180605CBD                 lea     r8, aMVecrenderattr; "m_vecRenderAttributes"
+  .text:0000000180605CC4                 lea     rcx, [rsp+190h+var_130]
+  .text:0000000180605CC9                 call    sub_1801F1DA0
+  .text:0000000180605CCE                 mov     eax, [rsp+190h+var_12C]
+  .text:0000000180605CD2                 bt      eax, 1Eh
+  .text:0000000180605CD6                 jnb     short loc_180605CDF
+  .text:0000000180605CD8                 lea     rax, [rsp+190h+var_128]
+  .text:0000000180605CDD                 jmp     short loc_180605CF1
+  .text:0000000180605CDF                 test    eax, 3FFFFFFFh
+  .text:0000000180605CE4                 lea     rax, byte_1815A2980
+  .text:0000000180605CEB                 cmova   rax, [rsp+190h+var_128]
+  .text:0000000180605CF1                 mov     rcx, [r14+18h]
+  .text:0000000180605CF5                 lea     rdx, [rsp+190h+var_170]
+  .text:0000000180605CFA                 mov     qword ptr [rsp+190h+var_150], rax
+  .text:0000000180605CFF                 lea     rax, aCBuildworkerCs_4; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180605D06                 mov     qword ptr [rsp+190h+var_150+8], rax
+  .text:0000000180605D0B                 mov     [rsp+190h+var_170], esi
+  .text:0000000180605D0F                 mov     [rsp+190h+var_160], rsi
+  .text:0000000180605D14                 mov     [rsp+190h+var_158], rsi
+  .text:0000000180605D19                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605D1D                 mov     dword ptr [rsp+190h+var_140], 0CDFh
+  .text:0000000180605D25                 mov     [rsp+190h+var_140+4], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180605D2E                 mov     [rsp+190h+var_134], si
+  .text:0000000180605D33                 call    sub_181218460
+  .text:0000000180605D38                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605D3C                 mov     rdx, [rsp+190h+var_160]
+  .text:0000000180605D41                 mov     [rsp+190h+var_168], esi
+  .text:0000000180605D45                 test    eax, 0C0000000h
+  .text:0000000180605D4A                 jnz     short loc_180605D8D
+  .text:0000000180605D4C                 test    rdx, rdx
+  .text:0000000180605D4F                 jz      short loc_180605D6D
+  .text:0000000180605D51                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605D58                 mov     rcx, [rax]
+  .text:0000000180605D5B                 mov     rax, [rcx]
+  .text:0000000180605D5E                 call    qword ptr [rax+18h]
+  .text:0000000180605D61                 mov     eax, dword ptr [rsp+190h+var_158+4]
+  .text:0000000180605D65                 mov     rdx, rsi
+  .text:0000000180605D68                 mov     [rsp+190h+var_160], rdx
+  .text:0000000180605D6D                 mov     dword ptr [rsp+190h+var_158], esi
+  .text:0000000180605D71                 test    eax, 0C0000000h
+  .text:0000000180605D76                 jnz     short loc_180605D8D
+  .text:0000000180605D78                 test    rdx, rdx
+  .text:0000000180605D7B                 jz      short loc_180605D8D
+  .text:0000000180605D7D                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180605D84                 mov     rcx, [rax]
+  .text:0000000180605D87                 mov     rax, [rcx]
+  .text:0000000180605D8A                 call    qword ptr [rax+18h]
+  .text:0000000180605D8D                 xor     edx, edx
+  .text:0000000180605D8F                 lea     rcx, [rsp+190h+var_130]
+  .text:0000000180605D94                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:0000000180605D9A                 mov     rdi, [rsp+190h+arg_8]
+  .text:0000000180605DA2                 mov     rbx, [rsp+190h+arg_0]
+  .text:0000000180605DAA                 mov     r13, [rsp+190h+arg_10]
+  .text:0000000180605DB2                 add     rsp, 170h
+  .text:0000000180605DB9                 pop     r15
+  .text:0000000180605DBB                 pop     r14
+  .text:0000000180605DBD                 pop     r12
+  .text:0000000180605DBF                 pop     rsi
+  .text:0000000180605DC0                 pop     rbp
+  .text:0000000180605DC1                 retn
 procedure: |-
-  void __fastcall CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(__int64 a1, char a2, unsigned int *a3)
+  void __fastcall CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(
+          __int64 a1,
+          char a2,
+          unsigned int *a3)
   {
     unsigned int v6; // r13d
     int v7; // edi
@@ -362,13 +366,13 @@ procedure: |-
 
     if ( (a2 & 1) != 0
       && (*(_BYTE *)(a1 + 97) & 1) == 0
-      && CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes(a1) // Note that this can sometimes be decompiled as sub_180XXXXXX() due to IDA decompiler's mistakes
+      && (unsigned __int8)CNetworkUtlVectorEmbedded_TryLateResolve_m_vecRenderAttributes()
       && *(int *)a1 > 0
       && !*(_BYTE *)(a1 + 96) )
     {
       v45 = *(_DWORD *)a1;
       v44 = 0;
-      CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(a1, a2 & 0xF4 | 0xAu, &v44); //self-recursive
+      CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes(a1, a2 & 0xF4 | 0xAu, &v44);
       return;
     }
     v6 = *a3;
@@ -381,7 +385,7 @@ procedure: |-
         if ( *(_DWORD *)a1 )
         {
           do
-            sub_1805D9240(a1, v8++);
+            sub_1805E2980(a1, v8++);
           while ( v8 != v7 );
         }
       }
@@ -392,7 +396,7 @@ procedure: |-
         if ( v6 != v9 )
         {
           do
-            sub_1805D9240(a1, v10++);
+            sub_1805E2980(a1, v10++);
           while ( v10 != v9 );
         }
       }
@@ -415,8 +419,8 @@ procedure: |-
       v36 = (_DWORD *)UtlVectorMemory_Alloc(v36, v12, 4LL * (unsigned int)i, 4LL * (int)v37);
       ++v35;
       LODWORD(v37) = i;
-      *v36 = 1344;
-      (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)(a1 - 1344) + 216LL))(a1 - 1344, &v34);
+      *v36 = 1400;
+      (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)(a1 - 1400) + 224LL))(a1 - 1400, &v34);
       v14 = HIDWORD(v37);
       v15 = v36;
       v35 = 0;
@@ -448,7 +452,7 @@ procedure: |-
         if ( (v17 & 8) == 0 )
         {
           *(_BYTE *)(a1 + 97) = v17 | 8;
-          v17 = (16 * sub_1811A5E80(v16, a1 + 40, a1 + 72)) | *(_BYTE *)(a1 + 97) & 0xEF;
+          v17 = (16 * PolymorphicHelper_t__GetChangeAccessorPathInfo_2(v16, a1 + 40, a1 + 72)) | *(_BYTE *)(a1 + 97) & 0xEF;// PolymorphicHelper_t__GetChangeAccessorPathInfo_2
           *(_BYTE *)(a1 + 97) = v17;
         }
         if ( (v17 & 0x10) != 0 )
@@ -479,14 +483,14 @@ procedure: |-
               }
               else
               {
-                sub_180165C40(&v35, (unsigned int)v23);
+                sub_1801856B0(&v35, (unsigned int)v23);
                 v24 = v36;
               }
               v35 = v23;
   LABEL_40:
               if ( v26 && 4 * v23 + v26 > v26 )
-                sub_1814DA740(v24, v26, 4 * v23);
-              (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)(a1 - 1344) + 216LL))(a1 - 1344, &v34);
+                sub_1815514F0(v24, v26, 4 * v23);
+              (*(void (__fastcall **)(__int64, int *))(*(_QWORD *)(a1 - 1400) + 224LL))(a1 - 1400, &v34);
               v27 = HIDWORD(v37);
               v28 = v36;
               v35 = 0;
@@ -520,14 +524,14 @@ procedure: |-
           v42 = -1073741568;
           if ( v6 != -1 )
             v29 = "%s was not composed of trivial POD-type fields";
-          sub_1801D0E70(&v41, v29, "m_vecRenderAttributes");
+          sub_1801F1DA0(&v41, v29, "m_vecRenderAttributes");
           if ( (v42 & 0x40000000) != 0 )
           {
             v30 = (char *)&v43;
           }
           else
           {
-            v30 = byte_18152DF88;
+            v30 = byte_1815A2980;
             if ( (v42 & 0x3FFFFFFF) != 0 )
               v30 = v43;
           }
@@ -538,10 +542,10 @@ procedure: |-
           v36 = nullptr;
           v37 = 0;
           v35 = 0;
-          *(_DWORD *)v39 = 3291;
+          *(_DWORD *)v39 = 3295;
           *(_QWORD *)&v39[4] = -1;
           v40 = 0;
-          sub_1811A5F10(v31, &v34);
+          sub_181218460(v31, &v34);
           v32 = HIDWORD(v37);
           v33 = v36;
           v35 = 0;

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__GetChangeAccessorPathInfo_2.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__GetChangeAccessorPathInfo_2.linux.yaml
@@ -1,0 +1,23 @@
+func_name: PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+func_va: '0x1e7e410'
+disasm_code: |-
+  .text:0000000001E7E410                 mov     rax, [rdi]
+  .text:0000000001E7E413                 lea     rcx, sub_1E4F2C0
+  .text:0000000001E7E41A                 ; 0x148 = 328LL = CEntityInstance::GetChangeAccessorPathInfo_2
+  .text:0000000001E7E41A                 mov     rax, [rax+148h]; 0x148 = 328LL = CEntityInstance::GetChangeAccessorPathInfo_2
+  .text:0000000001E7E421                 cmp     rax, rcx
+  .text:0000000001E7E424                 jnz     short loc_1E7E430
+  .text:0000000001E7E426                 xor     eax, eax
+  .text:0000000001E7E428                 retn
+  .text:0000000001E7E430                 jmp     rax
+procedure: |-
+  __int64 __fastcall sub_1E7E410(__int64 a1)
+  {
+    __int64 (*v1)(void); // rax
+
+    v1 = *(__int64 (**)(void))(*(_QWORD *)a1 + 328LL);// 0x148 = 328LL = CEntityInstance::GetChangeAccessorPathInfo_2
+    if ( v1 == sub_1E4F2C0 )
+      return 0;
+    else
+      return v1();
+  }

--- a/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__GetChangeAccessorPathInfo_2.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/PolymorphicHelper_t__GetChangeAccessorPathInfo_2.windows.yaml
@@ -1,0 +1,10 @@
+func_name: PolymorphicHelper_t__GetChangeAccessorPathInfo_2
+func_va: '0x1812183d0'
+disasm_code: |-
+  .text:00000001812183D0                 mov     rax, [rcx]
+  .text:00000001812183D3                 jmp     qword ptr [rax+140h]; 0x140 = 320LL = CEntityInstance::GetChangeAccessorPathInfo_2
+procedure: |-
+  __int64 __fastcall sub_1812183D0(__int64 a1)
+  {
+    return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 320LL))(a1);// 0x140 = 320LL = CEntityInstance::GetChangeAccessorPathInfo_2
+  }


### PR DESCRIPTION
## Summary

- Adds `find-PolymorphicHelper_t__GetChangeAccessorPathInfo_2` preprocessor script (Pattern D / LLM_DECOMPILE, finds the function via `CNetworkUtlVectorEmbedded_NetworkStateChanged_m_vecRenderAttributes` decompile)
- Adds `find-CEntityInstance_GetChangeAccessorPathInfo_2` preprocessor script (Pattern C / LLM_DECOMPILE, discovers the vfunc by decompiling `PolymorphicHelper_t__GetChangeAccessorPathInfo_2` and reading the vtable call offset)
- Adds reference YAMLs for `PolymorphicHelper_t__GetChangeAccessorPathInfo_2` on both platforms, showing the vtable dispatch with annotated offsets (`0x140` Windows / `0x148` Linux)
- Adds `_is_idb_file_locked()` guard in `ida_analyze_bin.py` to skip gracefully when another IDA instance holds the IDB open
- Updates `config.yaml`: skill entries for both new preprocessors and symbol entries for both new symbols

## Vtable details

| Platform | Offset | Index |
|----------|--------|-------|
| Windows  | `0x140` (320 dec) | 40 |
| Linux    | `0x148` (328 dec) | 41 |

## Test plan

- [ ] Run `uv run ida_analyze_bin.py -gamever 14165 -modules server -platform linux -debug` and verify `Successful: 1, Failed: 0` for `find-CEntityInstance_GetChangeAccessorPathInfo_2`
- [ ] Run same for `-platform windows` once IDB lock from lingering idalib-mcp session is cleared