### PR TITLE
Add find-CEntitySystem_AddRefKeyValues (Pattern B, xref string + vtable)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5469,6 +5469,12 @@ modules:
         expected_input:
           - CEntityKeyValues_Initialized.{platform}.yaml
 
+      - name: find-CEntitySystem_AddRefKeyValues
+        expected_output:
+          - CEntitySystem_AddRefKeyValues.{platform}.yaml
+        expected_input:
+          - CEntitySystem_vtable.{platform}.yaml
+
       - name: find-CCSPlayerController_HandleCommandDrop
         expected_output:
           - CCSPlayerController_HandleCommandDrop.{platform}.yaml
@@ -8856,6 +8862,11 @@ modules:
         category: structmember
         alias:
           - CEntitySystem::m_nEntityKeyValuesAllocatorRefCount
+
+      - name: CEntitySystem_AddRefKeyValues
+        category: vfunc
+        alias:
+          - CEntitySystem::AddRefKeyValues
 
       - name: CCSPlayerController_HandleCommandDrop
         category: func

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddRefKeyValues.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddRefKeyValues.py
@@ -17,11 +17,11 @@ FUNC_XREFS = [
         "xref_signatures": [],
         "xref_funcs": [],
         "exclude_funcs": [],
-        "exclude_strings": [],
+        # The true AddRefKeyValues only references the AddRef string; a large spawn-entity
+        # function that also appears in the vtable references both AddRef and Release strings.
+        "exclude_strings": ["kv 0x%p Release refcount == %d\n"],
         "exclude_gvs": [],
-        # Linux: a large spawn-entity function also xrefs "kv 0x%p AddRef refcount == %d\n";
-        # exclude it by matching its prologue bytes (harmless on Windows).
-        "exclude_signatures": ["55 48 89 E5 41 57 49 89 D7 41 56 4D 89 C6 41 55"],
+        "exclude_signatures": [],
     },
 ]
 

--- a/ida_preprocessor_scripts/find-CEntitySystem_AddRefKeyValues.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_AddRefKeyValues.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_AddRefKeyValues skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_AddRefKeyValues",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_AddRefKeyValues",
+        "xref_strings": [
+            "kv 0x%p AddRef refcount == %d\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        # Linux: a large spawn-entity function also xrefs "kv 0x%p AddRef refcount == %d\n";
+        # exclude it by matching its prologue bytes (harmless on Windows).
+        "exclude_signatures": ["55 48 89 E5 41 57 49 89 D7 41 56 4D 89 C6 41 55"],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # use artifact stem since expected_input has CEntitySystem_vtable.{platform}.yaml
+    ("CEntitySystem_AddRefKeyValues", "CEntitySystem_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_AddRefKeyValues",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CEntitySystem_AddRefKeyValues` preprocessor script (Pattern B: virtual function via xref string + vtable intersection)
- Discovers `CEntitySystem::AddRefKeyValues` (vtable index 7, offset `0x38`) via the debug string `"kv 0x%p AddRef refcount == %d\n"` intersected with `CEntitySystem_vtable`
- On Linux, a large spawn-entity helper (`sub_1E73490`) also xrefs the AddRef string; excluded via `exclude_strings: ["kv 0x%p Release refcount == %d\n"]` since it also references the Release string while the true `AddRefKeyValues` does not
- Adds `config.yaml` entries for both the skill and the symbol

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes with `Failed: 0` on both Windows (14165) and Linux (14165)