### PR TITLE
Add CGameEntitySystem_m_pEntity2Networkables

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6472,8 +6472,11 @@ modules:
           - CEntitySystem_EnableAutoDeletionExecution.{platform}.yaml
           - CEntitySystem_InstallPostSpawnCallback.{platform}.yaml
           - CEntitySystem_InstallCreationWrapperCallbacks.{platform}.yaml
+        expected_output_linux:
+          - CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses.{platform}.yaml
         expected_output_windows:
           - CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters.{platform}.yaml
+          - CGameEntitySystem_m_pEntity2Networkables.{platform}.yaml
         expected_input:
           - CSource2EntitySystem_StaticInit.{platform}.yaml
 
@@ -6483,6 +6486,13 @@ modules:
         expected_input:
           - CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters.{platform}.yaml
         platform: windows
+
+      - name: find-CGameEntitySystem_m_pEntity2Networkables-linux
+        expected_output:
+          - CGameEntitySystem_m_pEntity2Networkables.{platform}.yaml
+        expected_input:
+          - CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses.{platform}.yaml
+        platform: linux
 
       - name: find-CEntitySystem_m_EntityPostSpawnCallback
         expected_output:
@@ -10168,6 +10178,18 @@ modules:
         member: m_spawnGroupEntityFilters
         alias:
           - CGameEntitySystem::m_spawnGroupEntityFilters
+
+      - name: CGameEntitySystem_m_pEntity2Networkables
+        category: structmember
+        struct: CGameEntitySystem
+        member: m_pEntity2Networkables
+        alias:
+          - CGameEntitySystem::m_pEntity2Networkables
+
+      - name: CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+        category: func
+        alias:
+          - CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses
 
       - name: CEntitySystem_m_sEntSystemName
         category: structmember

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_m_pEntity2Networkables-linux.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_m_pEntity2Networkables-linux.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_m_pEntity2Networkables-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CGameEntitySystem_m_pEntity2Networkables",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CGameEntitySystem_m_pEntity2Networkables",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever offset_sig to locate struct member and write YAML."""
+    llm_decompile = [
+        (
+            "CGameEntitySystem_m_pEntity2Networkables",
+            "prompt/call_llm_decompile.md",
+            "references/{module_name}/CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses.{platform}.yaml",
+        ),
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=llm_decompile,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -14,6 +14,10 @@ TARGET_FUNCTION_NAMES_WINDOWS = [
     "CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters",
 ]
 
+TARGET_FUNCTION_NAMES_LINUX = [
+    "CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses",
+]
+
 TARGET_GLOBALVAR_NAMES = [
     "g_pGameResourceService",
     "g_pGameEntitySystem",
@@ -22,6 +26,10 @@ TARGET_GLOBALVAR_NAMES = [
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_entityIONotifiers",
     "CGameEntitySystem_m_pEntity2SaveRestore",
+]
+
+TARGET_STRUCT_MEMBER_NAMES_WINDOWS = [
+    "CGameEntitySystem_m_pEntity2Networkables",
 ]
 
 FUNC_VTABLE_RELATIONS = [
@@ -121,6 +129,19 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
 ]
 
+GENERATE_YAML_DESIRED_FIELDS_LINUX = [
+    (
+        "CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
 GENERATE_YAML_DESIRED_FIELDS_WINDOWS = [
     (
         "CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters",
@@ -130,6 +151,17 @@ GENERATE_YAML_DESIRED_FIELDS_WINDOWS = [
             "func_va",
             "func_rva",
             "func_size",
+        ],
+    ),
+    (
+        "CGameEntitySystem_m_pEntity2Networkables",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
         ],
     ),
 ]
@@ -175,22 +207,30 @@ async def preprocess_skill(
             "prompt/call_llm_decompile.md",
             "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
         ),
-        (
-            "CEntitySystem_InstallCreationWrapperCallbacks",
-            "prompt/call_llm_decompile.md",
-            "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
-        ),
     ]
 
     func_names = list(TARGET_FUNCTION_NAMES)
+    struct_member_names = list(TARGET_STRUCT_MEMBER_NAMES)
     generate_yaml_desired_fields = list(GENERATE_YAML_DESIRED_FIELDS)
+
+    if platform == "linux":
+        func_names += TARGET_FUNCTION_NAMES_LINUX
+        generate_yaml_desired_fields += GENERATE_YAML_DESIRED_FIELDS_LINUX
 
     if platform == "windows":
         func_names += TARGET_FUNCTION_NAMES_WINDOWS
+        struct_member_names += TARGET_STRUCT_MEMBER_NAMES_WINDOWS
         generate_yaml_desired_fields += GENERATE_YAML_DESIRED_FIELDS_WINDOWS
         llm_decompile.append(
             (
                 "CSpawnGroupEntityFilterRegistrar_RegisterSpawnGroupEntityFilters",
+                "prompt/call_llm_decompile.md",
+                "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
+            ),
+        )
+        llm_decompile.append(
+            (
+                "CGameEntitySystem_m_pEntity2Networkables",
                 "prompt/call_llm_decompile.md",
                 "references/{module_name}/CSource2EntitySystem_StaticInit.{platform}.yaml",
             ),
@@ -205,7 +245,7 @@ async def preprocess_skill(
         image_base=image_base,
         func_names=func_names,
         gv_names=TARGET_GLOBALVAR_NAMES,
-        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        struct_member_names=struct_member_names,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
         llm_decompile_specs=llm_decompile,
         llm_config=llm_config,

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.linux.yaml
@@ -1,5 +1,6 @@
 func_name: CEntitySystem_InstallCreationWrapperCallbacks
-func_va: '0x1e5f3c0'
+func_va: '0x1e67e40'
+func_sig: 55 48 8D 05 ?? ?? ?? ?? 48 89 E5 41 56 4C 8D 75 ??
 disasm_code: |-
   .text:0000000001E5F3C0                 push    rbp
   .text:0000000001E5F3C1                 xor     ecx, ecx

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.linux.yaml
@@ -1,6 +1,5 @@
 func_name: CEntitySystem_InstallCreationWrapperCallbacks
 func_va: '0x1e67e40'
-func_sig: 55 48 8D 05 ?? ?? ?? ?? 48 89 E5 41 56 4C 8D 75 ??
 disasm_code: |-
   .text:0000000001E5F3C0                 push    rbp
   .text:0000000001E5F3C1                 xor     ecx, ecx

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.windows.yaml
@@ -1,5 +1,8 @@
 func_name: CEntitySystem_InstallCreationWrapperCallbacks
-func_va: '0x1811f30d0'
+func_va: '0x1811fa860'
+func_rva: '0x11fa860'
+func_size: '0xc7'
+func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 88 54 24 ??
 disasm_code: |-
   .text:00000001811F30D0                 mov     [rsp+arg_0], rbx
   .text:00000001811F30D5                 mov     [rsp+arg_10], rsi

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_InstallCreationWrapperCallbacks.windows.yaml
@@ -1,8 +1,5 @@
 func_name: CEntitySystem_InstallCreationWrapperCallbacks
 func_va: '0x1811fa860'
-func_rva: '0x11fa860'
-func_size: '0xc7'
-func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 88 54 24 ??
 disasm_code: |-
   .text:00000001811F30D0                 mov     [rsp+arg_0], rbx
   .text:00000001811F30D5                 mov     [rsp+arg_10], rsi

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
@@ -148,7 +148,7 @@ disasm_code: |-
   .text:00000000015BC8FD                 lea     rbx, sub_152EFF0
   .text:00000000015BC904                 mov     rdi, cs:g_pGameEntitySystem
   .text:00000000015BC90B                 mov     esi, [rax+278h]
-  .text:00000000015BC911                 call    sub_15BC5D0  ; CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
+  .text:00000000015BC911                 call    CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
   .text:00000000015BC916                 mov     rdi, [r13+0]
   .text:00000000015BC91A                 mov     rdx, r12
   .text:00000000015BC91D                 mov     [rbp+var_50+8], rbx

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.linux.yaml
@@ -148,7 +148,7 @@ disasm_code: |-
   .text:00000000015BC8FD                 lea     rbx, sub_152EFF0
   .text:00000000015BC904                 mov     rdi, cs:g_pGameEntitySystem
   .text:00000000015BC90B                 mov     esi, [rax+278h]
-  .text:00000000015BC911                 call    sub_15BC5D0
+  .text:00000000015BC911                 call    sub_15BC5D0  ; CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses
   .text:00000000015BC916                 mov     rdi, [r13+0]
   .text:00000000015BC91A                 mov     rdx, r12
   .text:00000000015BC91D                 mov     [rbp+var_50+8], rbx
@@ -333,7 +333,7 @@ procedure: |-
                                                + 272LL))(// IGameResourceService_SetEntityResourceManifestHandler
         g_pGameResourceService,
         g_pGameEntitySystem);
-    sub_15BC5D0(g_pGameEntitySystem, *(_DWORD *)(g_pEntitySystem + 632LL));
+    CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses(g_pGameEntitySystem, *(_DWORD *)(g_pEntitySystem + 632LL));
     v20[1] = (__int64)sub_152EFF0;
     v20[2] = 0;
     v20[0] = (__int64)sub_156AEA0;

--- a/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2EntitySystem_StaticInit.windows.yaml
@@ -171,7 +171,7 @@ disasm_code: |-
   .text:0000000180B8DA1A                 jmp     short loc_180B8DA1F
   .text:0000000180B8DA1C                 mov     rdi, r15
   .text:0000000180B8DA1F                 lea     rcx, [rbp+var_20]
-  .text:0000000180B8DA23                 mov     [r14+20E0h], rdi
+  .text:0000000180B8DA23                 mov     [r14+20E0h], rdi  ; 20E0h = CGameEntitySystem::m_pEntity2Networkables (structmember, struct=CGameEntitySystem, member=m_pEntity2Networkables)
   .text:0000000180B8DA2A                 call    cs:ToolsStallMonitorInternal_EndScope
   .text:0000000180B8DA30                 mov     rcx, cs:g_pEntitySystem
   .text:0000000180B8DA37                 lea     rax, sub_180B4E030
@@ -341,7 +341,7 @@ procedure: |-
     {
       v19 = 0;
     }
-    *(_QWORD *)(v16 + 8416) = v19;
+    *(_QWORD *)(v16 + 8416) = v19;  // 8416 = 0x20E0 = CGameEntitySystem::m_pEntity2Networkables (structmember, struct=CGameEntitySystem, member=m_pEntity2Networkables)
     ToolsStallMonitorInternal_EndScope(&v25);
     v25 = (__int64 (__fastcall *)(unsigned int, __int64))sub_180B4E030;
     v26 = (__int64)sub_180B68B50;


### PR DESCRIPTION
## Summary

- **Windows**: `CGameEntitySystem_m_pEntity2Networkables` (struct member, offset `0x20E0`) found via LLM_DECOMPILE from `CSource2EntitySystem_StaticInit`; reference YAML annotated with `(structmember, struct=CGameEntitySystem, member=m_pEntity2Networkables)` tag
- **Linux**: `CGameEntitySystem_m_pEntity2Networkables` found via new `find-CGameEntitySystem_m_pEntity2Networkables-linux.py` script (Pattern E), using `CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses` as the LLM_DECOMPILE predecessor
- **Linux**: `CEntity2NetworkClasses<ServerClass>::InitEntity2NetworkClasses` tracked as a regular method via `find-CSource2EntitySystem_StaticInit-decompiles`; `CSource2EntitySystem_StaticInit.linux.yaml` annotated with function call identification
- `CEntitySystem_InstallCreationWrapperCallbacks` promoted to regular method (removed from `llm_decompile_specs`); reference YAMLs updated with bin/14165 signature and correct Windows `func_va`

## Pending (IDA required)

- Regenerate `CEntitySystem_InstallCreationWrapperCallbacks` reference YAMLs for both platforms (disasm/procedure are from old binary)
- Generate `CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses.linux.yaml` reference YAML and annotate with the `m_pEntity2Networkables` struct member access

## Test plan

- [ ] Run `uv run ida_analyze_bin.py -debug` on Windows after IDA reference YAMLs are updated — confirm `CGameEntitySystem_m_pEntity2Networkables.windows.yaml` generated with offset `0x20E0`
- [ ] Run `uv run ida_analyze_bin.py -debug` on Linux (multi-phase: first pass creates `CEntity2NetworkClasses_ServerClass_InitEntity2NetworkClasses.linux.yaml`, second pass after reference YAML creation finds `CGameEntitySystem_m_pEntity2Networkables.linux.yaml`)
- [ ] Confirm 0 failures in summary