### PR TITLE
Add CEngineServer::GetSteamUniverse

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetSteamUniverse
+        expected_output:
+          - CEngineServer_GetSteamUniverse.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1814,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_GetSteamUniverse
+        category: vfunc
+        alias:
+          - CEngineServer::GetSteamUniverse
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetSteamUniverse skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetSteamUniverse",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetSteamUniverse",
+        "xref_strings": [
+            "Steam Universe is invalid, possibly asking before Steam was successfully initialized",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        # 6 functions reference both Universe strings; exclude the other 5 by prologue bytes.
+        # sub_1800626F0 (0x176): 48 83 EC 48 ...  (sub esp,48h vs our sub esp,28h)
+        # sub_1800848D0 (0x24c): 40 55 41 54 ...  (push r12/r13/r14/r15 prologue)
+        # sub_18006C280 (0x8fd), sub_1800B3170 (0xd69),
+        # CServerSideClientBase_ProcessClientInfo: all start 48 89 5C 24 ??
+        "exclude_signatures": ["48 83 EC 48", "40 55 41 54", "48 89 5C 24 ??"],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetSteamUniverse", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetSteamUniverse",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vfunc_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CEngineServer_GetSteamUniverse` preprocessor script (Pattern B — vfunc via xref string)
- Adds skill and symbol entries in `config.yaml` under the engine module

## Discovery method
`CEngineServer::GetSteamUniverse` is found via xref to `"Steam Universe is invalid, possibly asking before Steam was successfully initialized"`. Six functions share this string; the other five are eliminated using `exclude_signatures` on their function prologues.

The function is at vtable index 18 (offset `0x90`) in `CEngineServer`.

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` reports 0 new failures (pre-existing Linux IDB lock excluded)
- [ ] `CEngineServer_GetSteamUniverse.windows.yaml` is correctly skipped (all outputs exist)