### PR TITLE
Add CEngineServer::GetSteamUniverse preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1001,6 +1001,14 @@ modules:
         expected_output:
           - CEngineServer_GetSteamUniverse_Impl.{platform}.yaml
 
+      - name: find-CEngineServer_GetSteamUniverse-linux
+        platform: linux
+        expected_output:
+          - CEngineServer_GetSteamUniverse.{platform}.yaml
+        expected_input:
+          - CEngineServer_GetSteamUniverse_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -996,6 +996,11 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetSteamUniverse_Impl-linux
+        platform: linux
+        expected_output:
+          - CEngineServer_GetSteamUniverse_Impl.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1820,6 +1825,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::GetSteamUniverse
+
+      - name: CEngineServer_GetSteamUniverse_Impl
+        category: func
+        alias:
+          - CEngineServer::GetSteamUniverse_Impl
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,13 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetSteamUniverse-windows
+        platform: windows
+        expected_output:
+          - CEngineServer_GetSteamUniverse.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1815,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_GetSteamUniverse
+        category: vfunc
+        alias:
+          - CEngineServer::GetSteamUniverse
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse-linux.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse-linux.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetSteamUniverse-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetSteamUniverse",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetSteamUniverse",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_GetSteamUniverse_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetSteamUniverse", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetSteamUniverse",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse-windows.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse-windows.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetSteamUniverse-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetSteamUniverse",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetSteamUniverse",
+        "xref_strings": [
+            "Steam Universe is invalid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetSteamUniverse", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetSteamUniverse",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse_Impl-linux.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetSteamUniverse_Impl-linux.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetSteamUniverse_Impl-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetSteamUniverse_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetSteamUniverse_Impl",
+        "xref_strings": [
+            "Steam Universe is invalid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetSteamUniverse_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CEngineServer_GetSteamUniverse-windows` (Pattern B): discovers the vfunc via xref string `"Steam Universe is invalid"`, resolves vtable index from `CEngineServer_vtable`
- Add `find-CEngineServer_GetSteamUniverse_Impl-linux` (Pattern A): finds the real implementation function via the same xref string on Linux
- Add `find-CEngineServer_GetSteamUniverse-linux` (Pattern B): finds the thin thunk vfunc via `xref_funcs: ["CEngineServer_GetSteamUniverse_Impl"]`; `func_sig` omitted because the Linux vfunc is a 5-byte `jmp` thunk with no unique signature

## Notes

- Linux uses a two-step approach: the Impl script runs first (same IDA session), renames the function, then the vfunc script finds callers of it via `xref_funcs`
- `CEngineServer_GetSteamUniverse_Impl` is listed in `expected_input` of the vfunc skill to enforce ordering

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` passes with `Failed: 0`
- [x] Windows YAML: `CEngineServer_GetSteamUniverse.windows.yaml` generated (vtable index 18, offset `0x90`)
- [x] Linux Impl YAML: `CEngineServer_GetSteamUniverse_Impl.linux.yaml` generated (`0x5056c0`, size `0xc0`)
- [x] Linux vfunc YAML: `CEngineServer_GetSteamUniverse.linux.yaml` generated (thunk at `0x670be0`, size `0x5`, vtable index 18)