### PR TITLE
Add CEngineServer::SetFrameTimeAmnesty and SetFrameTimeAmnesty_Impl preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,10 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_SetFrameTimeAmnesty_Impl
+        expected_output:
+          - CEngineServer_SetFrameTimeAmnesty_Impl.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1812,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_SetFrameTimeAmnesty_Impl
+        category: func
+        alias:
+          - CEngineServer::SetFrameTimeAmnesty_Impl
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -993,6 +993,13 @@ modules:
         expected_output:
           - CEngineServer_SetFrameTimeAmnesty_Impl.{platform}.yaml
 
+      - name: find-CEngineServer_SetFrameTimeAmnesty
+        expected_output:
+          - CEngineServer_SetFrameTimeAmnesty.{platform}.yaml
+        expected_input:
+          - CEngineServer_SetFrameTimeAmnesty_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1817,6 +1824,11 @@ modules:
         category: func
         alias:
           - CEngineServer::SetFrameTimeAmnesty_Impl
+
+      - name: CEngineServer_SetFrameTimeAmnesty
+        category: vfunc
+        alias:
+          - CEngineServer::SetFrameTimeAmnesty
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_SetFrameTimeAmnesty.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_SetFrameTimeAmnesty.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_SetFrameTimeAmnesty skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_SetFrameTimeAmnesty",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_SetFrameTimeAmnesty",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_SetFrameTimeAmnesty_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CEngineServer_SetFrameTimeAmnesty", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_SetFrameTimeAmnesty",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_SetFrameTimeAmnesty_Impl.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_SetFrameTimeAmnesty_Impl.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_SetFrameTimeAmnesty_Impl skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_SetFrameTimeAmnesty_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_SetFrameTimeAmnesty_Impl",
+        "xref_strings": [
+            "Frame rate warnings DISABLED (%s).",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_SetFrameTimeAmnesty_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CEngineServer_SetFrameTimeAmnesty_Impl` (Pattern A) — regular function found via xref string `"Frame rate warnings DISABLED (%s)."`
- Adds `find-CEngineServer_SetFrameTimeAmnesty` (Pattern B) — vfunc of `CEngineServer`, found as the caller of `SetFrameTimeAmnesty_Impl` via `xref_funcs`

## Test plan

- [ ] Rebuild engine IDA databases (engine2.dll + libengine2.so) in IDA Pro with full auto-analysis — required because the databases were lost during development
- [ ] Run `uv run ida_analyze_bin.py -debug` — `find-CEngineServer_vtable`, `find-CEngineServer_SetFrameTimeAmnesty_Impl`, and `find-CEngineServer_SetFrameTimeAmnesty` should all succeed in the same IDA session
- [ ] Verify `Failed: 0` in the summary