### PR TITLE
Add find-CEngineServer_ShowFrameTimeReport

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,10 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_ShowFrameTimeReport_Impl
+        expected_output:
+          - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1812,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_ShowFrameTimeReport_Impl
+        category: func
+        alias:
+          - CEngineServer::ShowFrameTimeReport
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -993,6 +993,13 @@ modules:
         expected_output:
           - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
 
+      - name: find-CEngineServer_ShowFrameTimeReport
+        expected_output:
+          - CEngineServer_ShowFrameTimeReport.{platform}.yaml
+        expected_input:
+          - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1815,6 +1822,11 @@ modules:
 
       - name: CEngineServer_ShowFrameTimeReport_Impl
         category: func
+        alias:
+          - CEngineServer::ShowFrameTimeReport
+
+      - name: CEngineServer_ShowFrameTimeReport
+        category: vfunc
         alias:
           - CEngineServer::ShowFrameTimeReport
 

--- a/ida_preprocessor_scripts/find-CEngineServer_ShowFrameTimeReport.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ShowFrameTimeReport.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ShowFrameTimeReport skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ShowFrameTimeReport",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ShowFrameTimeReport",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_ShowFrameTimeReport_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ShowFrameTimeReport", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ShowFrameTimeReport",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_ShowFrameTimeReport_Impl.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ShowFrameTimeReport_Impl.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ShowFrameTimeReport_Impl skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ShowFrameTimeReport_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ShowFrameTimeReport_Impl",
+        "xref_strings": [
+            "Summary of %d frames.  (%d frames excluded from analysis.)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ShowFrameTimeReport_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CEngineServer_ShowFrameTimeReport_Impl` (Pattern A): finds the real implementation function via xref to debug string `"Summary of %d frames.  (%d frames excluded from analysis.)"`
- Adds `find-CEngineServer_ShowFrameTimeReport` (Pattern B): finds the thin vtable wrapper (vfunc at `CEngineServer_vtable` index 28, offset `0xe0`) by intersecting callers of the impl with the vtable

## Test plan

- [ ] Windows: preprocessor locates `0x180075b30`, vtable index 28 confirmed, YAML generated
- [ ] Linux: preprocessor locates `0x6740f0`, vtable index 28 confirmed, YAML generated
- [ ] `ida_analyze_bin.py -gamever 14165c -modules engine`: Failed: 0