### PR TITLE
Add CEngineServer_GetFrameTimeAmnesty and CEngineServer_GetFrameTimeAmnesty_Impl

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -997,6 +997,14 @@ modules:
         expected_input_linux:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetFrameTimeAmnesty-windows
+        platform: windows
+        expected_output:
+          - CEngineServer_GetFrameTimeAmnesty.{platform}.yaml
+        expected_input:
+          - CEngineServer_GetFrameTimeAmnesty_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1820,6 +1828,12 @@ modules:
       - name: CEngineServer_GetFrameTimeAmnesty
         category: vfunc
         platform: linux
+        alias:
+          - CEngineServer::GetFrameTimeAmnesty
+
+      - name: CEngineServer_GetFrameTimeAmnesty
+        category: vfunc
+        platform: windows
         alias:
           - CEngineServer::GetFrameTimeAmnesty
 

--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,14 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetFrameTimeAmnesty-linux-AND-CEngineServer_GetFrameTimeAmnesty_Impl-windows
+        expected_output_linux:
+          - CEngineServer_GetFrameTimeAmnesty.{platform}.yaml
+        expected_output_windows:
+          - CEngineServer_GetFrameTimeAmnesty_Impl.{platform}.yaml
+        expected_input_linux:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1816,18 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_GetFrameTimeAmnesty
+        category: vfunc
+        platform: linux
+        alias:
+          - CEngineServer::GetFrameTimeAmnesty
+
+      - name: CEngineServer_GetFrameTimeAmnesty_Impl
+        category: func
+        platform: windows
+        alias:
+          - CEngineServer::GetFrameTimeAmnesty_Impl
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_GetFrameTimeAmnesty-linux-AND-CEngineServer_GetFrameTimeAmnesty_Impl-windows.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetFrameTimeAmnesty-linux-AND-CEngineServer_GetFrameTimeAmnesty_Impl-windows.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetFrameTimeAmnesty-linux-AND-CEngineServer_GetFrameTimeAmnesty_Impl-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES_LINUX = [
+    "CEngineServer_GetFrameTimeAmnesty",
+]
+
+TARGET_FUNCTION_NAMES_WINDOWS = [
+    "CEngineServer_GetFrameTimeAmnesty_Impl",
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CEngineServer_GetFrameTimeAmnesty",
+        "xref_strings": [
+            "!engine_frametime_warnings_enable",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CEngineServer_GetFrameTimeAmnesty_Impl",
+        "xref_strings": [
+            "!engine_frametime_warnings_enable",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+# Linux only: CEngineServer_GetFrameTimeAmnesty is a vfunc of CEngineServer
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineServer_GetFrameTimeAmnesty", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS_LINUX = [
+    (
+        "CEngineServer_GetFrameTimeAmnesty",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS_WINDOWS = [
+    (
+        "CEngineServer_GetFrameTimeAmnesty_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    if platform == "linux":
+        return await preprocess_common_skill(
+            session=session,
+            expected_outputs=expected_outputs,
+            old_yaml_map=old_yaml_map,
+            new_binary_dir=new_binary_dir,
+            platform=platform,
+            image_base=image_base,
+            func_names=TARGET_FUNCTION_NAMES_LINUX,
+            func_xrefs=FUNC_XREFS_LINUX,
+            func_vtable_relations=FUNC_VTABLE_RELATIONS,
+            generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS_LINUX,
+            debug=debug,
+        )
+    else:
+        return await preprocess_common_skill(
+            session=session,
+            expected_outputs=expected_outputs,
+            old_yaml_map=old_yaml_map,
+            new_binary_dir=new_binary_dir,
+            platform=platform,
+            image_base=image_base,
+            func_names=TARGET_FUNCTION_NAMES_WINDOWS,
+            func_xrefs=FUNC_XREFS_WINDOWS,
+            generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS_WINDOWS,
+            debug=debug,
+        )

--- a/ida_preprocessor_scripts/find-CEngineServer_GetFrameTimeAmnesty-windows.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetFrameTimeAmnesty-windows.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetFrameTimeAmnesty-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetFrameTimeAmnesty",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetFrameTimeAmnesty",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_GetFrameTimeAmnesty_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+# CEngineServer_GetFrameTimeAmnesty is a vfunc of CEngineServer
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineServer_GetFrameTimeAmnesty", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineServer_GetFrameTimeAmnesty",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `CEngineServer_GetFrameTimeAmnesty` (vfunc, vtable index 26) for both Linux and Windows
- Adds `CEngineServer_GetFrameTimeAmnesty_Impl` (regular func) for Windows — the implementation called by the vtable wrapper
- Linux discovery: xref string `!engine_frametime_warnings_enable` → Pattern B
- Windows `_Impl` discovery: same xref string → Pattern A
- Windows vfunc wrapper discovery: `xref_funcs` on `CEngineServer_GetFrameTimeAmnesty_Impl` → Pattern B

## Test plan

- [x] Linux: `CEngineServer_GetFrameTimeAmnesty.linux.yaml` generated — vtable index 26, offset `0xd0`, at `0x6af710`
- [x] Windows `_Impl`: `CEngineServer_GetFrameTimeAmnesty_Impl.windows.yaml` generated — at `0x18021eaa0`, 9-byte sig
- [x] Windows vfunc: `CEngineServer_GetFrameTimeAmnesty.windows.yaml` generated — vtable index 26, offset `0xd0`, 8-byte thin wrapper at `0x180075b00`
- [x] `ida_analyze_bin.py -debug` passed with `Failed: 0` for all three