### PR TITLE
Add CEngineServer_DumpNetStats and CNetChan_PrintNetStats preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -297,6 +297,10 @@ modules:
         expected_input:
           - CNetChan_ParseMessagesDemoInternal.{platform}.yaml
 
+      - name: find-CNetChan_PrintNetStats
+        expected_output:
+          - CNetChan_PrintNetStats.{platform}.yaml
+
       - name: find-CNetworkMessages_FindNetworkMessagePartial
         expected_output:
           - CNetworkMessages_FindNetworkMessagePartial.{platform}.yaml
@@ -478,6 +482,11 @@ modules:
         category: func
         alias:
           - CNetChan::ParseNetMessageShowFilter
+
+      - name: CNetChan_PrintNetStats
+        category: func
+        alias:
+          - CNetChan::PrintNetStats
 
       - name: CNetworkMessages_FindNetworkMessagePartial
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -998,6 +998,17 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_CNetChan_PrintNetStats
+        expected_output:
+          - CEngineServer_CNetChan_PrintNetStats.{platform}.yaml
+
+      - name: find-CEngineServer_DumpNetStats
+        expected_output:
+          - CEngineServer_DumpNetStats.{platform}.yaml
+        expected_input:
+          - CEngineServer_CNetChan_PrintNetStats.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1817,6 +1828,14 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_CNetChan_PrintNetStats
+        category: func
+
+      - name: CEngineServer_DumpNetStats
+        category: vfunc
+        alias:
+          - CEngineServer::DumpNetStats
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_CNetChan_PrintNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_CNetChan_PrintNetStats.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_CNetChan_PrintNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_CNetChan_PrintNetStats",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CEngineServer_CNetChan_PrintNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [
+            "48 8B C4 55 53 56 48 8D A8 ?? ?? ?? ??",
+        ],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CEngineServer_CNetChan_PrintNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [
+            "55 B9 01 00 00 00 BA FF 00 00 00 48 89 E5",
+        ],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_CNetChan_PrintNetStats",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_DumpNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_DumpNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_DumpNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_CNetChan_PrintNetStats"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_DumpNetStats", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_DumpNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetChan_PrintNetStats.py
+++ b/ida_preprocessor_scripts/find-CNetChan_PrintNetStats.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetChan_PrintNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetChan_PrintNetStats",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CNetChan_PrintNetStats",
+        "xref_strings": [
+            "Bandwidth . . . . . . . : Total:%.1fkb",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CNetChan_PrintNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [
+            "55 31 C9 BA ?? ?? ?? ?? BE ?? ?? ?? ?? 48 89 E5",
+        ],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetChan_PrintNetStats",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CNetChan_PrintNetStats` preprocessor script with platform-specific xref discovery: Windows uses the `Bandwidth . . . . . . . : Total:%.1fkb` debug string; Linux uses `xref_signatures` (`55 31 C9 BA ?? ?? ?? ?? BE ?? ?? ?? ?? 48 89 E5`) since that string is absent from Linux binaries
- Add `find-CEngineServer_CNetChan_PrintNetStats` (Pattern A): finds the engine module's copy of `CNetChan_PrintNetStats` via platform-specific prologue signatures
- Add `find-CEngineServer_DumpNetStats` (Pattern B): discovers `CEngineServer_DumpNetStats` as the caller of `CEngineServer_CNetChan_PrintNetStats`, then confirms vtable placement (entry 29, offset `0xe8` in `CEngineServer_vtable`)

## Test plan

- [x] `uv run ida_analyze_bin.py -debug` — `Successful: 0, Failed: 0, Skipped: 1586`
- [x] Gamever 14165c Windows YAML: `func_va: 0x180075b50`, `vfunc_index: 29`
- [x] Gamever 14165c Linux YAML: `func_va: 0x672870`, `func_sig: 55 66 0F EF C0 48 89 F7`