### PR TITLE
Add CNetChan_PrintNetStats and CEngineServer_DumpNetStats preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -290,6 +290,10 @@ modules:
         expected_output:
           - CNetChan_ParseMessagesDemoInternal.{platform}.yaml
 
+      - name: find-CNetChan_PrintNetStats
+        expected_output:
+          - CNetChan_PrintNetStats.{platform}.yaml
+
       - name: find-CNetChan_ParseNetMessageShowFilter-AND-g_pLoggingChannel
         expected_output:
           - CNetChan_ParseNetMessageShowFilter.{platform}.yaml
@@ -473,6 +477,11 @@ modules:
         category: func
         alias:
           - CNetChan::ParseMessagesDemoInternal
+
+      - name: CNetChan_PrintNetStats
+        category: func
+        alias:
+          - CNetChan::PrintNetStats
 
       - name: CNetChan_ParseNetMessageShowFilter
         category: func

--- a/config.yaml
+++ b/config.yaml
@@ -998,6 +998,13 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_DumpNetStats
+        expected_output:
+          - CEngineServer_DumpNetStats.{platform}.yaml
+        expected_input:
+          - ../networksystem/CNetChan_PrintNetStats.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1817,6 +1824,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_DumpNetStats
+        category: vfunc
+        alias:
+          - CEngineServer::DumpNetStats
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_DumpNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_DumpNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_DumpNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetChan_PrintNetStats"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CEngineServer_DumpNetStats", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_DumpNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetChan_PrintNetStats.py
+++ b/ida_preprocessor_scripts/find-CNetChan_PrintNetStats.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetChan_PrintNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetChan_PrintNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetChan_PrintNetStats",
+        "xref_strings": [
+            "Bandwidth . . . . . . . : Total:%.1fkb",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetChan_PrintNetStats",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CNetChan_PrintNetStats` (Pattern A): discovers `CNetChan::PrintNetStats` in `networksystem` via xref string `"Bandwidth . . . . . . . : Total:%.1fkb"`
- Adds `find-CEngineServer_DumpNetStats` (Pattern B): discovers `CEngineServer::DumpNetStats` in `engine` as a vfunc of `CEngineServer_vtable`, found via `xref_funcs: ["CNetChan_PrintNetStats"]`

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures