### PR TITLE
Add find-CEngineServer_ChangeLevel

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -989,6 +989,19 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_ChangeLevel
+        expected_output:
+          - CEngineServer_ChangeLevel.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
+      - name: find-CEngineServer_IsMapValid
+        expected_output:
+          - CEngineServer_IsMapValid.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+          - CEngineServer_ChangeLevel.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1808,6 +1821,16 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+
+      - name: CEngineServer_ChangeLevel
+        category: vfunc
+        alias:
+          - CEngineServer::ChangeLevel
+
+      - name: CEngineServer_IsMapValid
+        category: vfunc
+        alias:
+          - CEngineServer::IsMapValid
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ChangeLevel",
+]
+
+# Windows: string has no trailing newline; Linux: string includes \n
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CEngineServer_ChangeLevel",
+        "xref_strings": [
+            "Changelevel %s %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CEngineServer_ChangeLevel",
+        "xref_strings": [
+            "Changelevel %s %s\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineServer_ChangeLevel", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineServer_ChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    func_xrefs = FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_IsMapValid.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsMapValid.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsMapValid skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CEngineServer_IsMapValid", "CEngineServer", "CEngineServer_ChangeLevel", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineServer_IsMapValid",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CEngineServer_ChangeLevel` preprocessor script (Pattern B: vfunc via xref strings) for `CEngineServer::ChangeLevel`
- Uses platform-specific xref strings: `"Changelevel %s %s"` on Windows, `"Changelevel %s %s\n"` on Linux (Linux binary includes trailing newline)
- Also adds `find-CEngineServer_IsMapValid` which depends on `CEngineServer_ChangeLevel`
- Updates `config.yaml` with skill entries and symbol definitions for both functions

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures (validated: Successful: 2, Failed: 0)
