### PR TITLE
Add find-CEngineServer_ChangeLevel preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1046,6 +1046,12 @@ modules:
           - CEngineServer_GetSteamUniverse_Impl.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_ChangeLevel
+        expected_output:
+          - CEngineServer_ChangeLevel.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1913,6 +1919,11 @@ modules:
         category: func
         alias:
           - CEngineServer::GetSteamUniverse_Impl
+
+      - name: CEngineServer_ChangeLevel
+        category: vfunc
+        alias:
+          - CEngineServer::ChangeLevel
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ChangeLevel",
+        "xref_strings": [
+            "Changelevel %s %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ChangeLevel", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CEngineServer_ChangeLevel.py` (Pattern B: vfunc via xref string `"Changelevel %s %s"`) for the `engine` module
- Updates `config.yaml` with skill entry (depends on `CEngineServer_vtable`) and symbol entry (`category: vfunc`, alias `CEngineServer::ChangeLevel`)

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures (2 new YAMLs created for both platforms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)