### PR TITLE
Add find-CEngineServer_PrecacheGeneric preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1052,6 +1052,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_PrecacheGeneric
+        expected_output:
+          - CEngineServer_PrecacheGeneric.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1924,6 +1930,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ChangeLevel
+
+      - name: CEngineServer_PrecacheGeneric
+        category: vfunc
+        alias:
+          - CEngineServer::PrecacheGeneric
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_PrecacheGeneric.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_PrecacheGeneric.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_PrecacheGeneric skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_PrecacheGeneric",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_PrecacheGeneric",
+        "xref_strings": [
+            "CEngineServer::PrecacheGeneric: '%s' overflow, too many decals",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_PrecacheGeneric", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_PrecacheGeneric",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds Pattern B preprocessor script for `CEngineServer_PrecacheGeneric` (virtual function of `CEngineServer`)
- Discovery via xref string `"CEngineServer::PrecacheGeneric: '%s' overflow, too many decals"` (present in both Windows and Linux binaries)
- Found at vtable index 37, offset `0x128` on both platforms

## Test plan

- [x] `uv run ida_analyze_bin.py -debug -module engine` passes with 0 failures
- [x] `CEngineServer_PrecacheGeneric.windows.yaml` generated (vtable index 37, offset 0x128)
- [x] `CEngineServer_PrecacheGeneric.linux.yaml` generated (vtable index 37, offset 0x128)