### PR TITLE
Add find-CEngineServer_ClientCommand preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1052,12 +1052,6 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
-      - name: find-CEngineServer_IsPaused
-        expected_output:
-          - CEngineServer_IsPaused.{platform}.yaml
-        expected_input:
-          - CEngineServer_vtable.{platform}.yaml
-
       - name: find-CEngineServer_ClientCommand
         expected_output:
           - CEngineServer_ClientCommand.{platform}.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -1052,6 +1052,18 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_IsPaused
+        expected_output:
+          - CEngineServer_IsPaused.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
+      - name: find-CEngineServer_ClientCommand
+        expected_output:
+          - CEngineServer_ClientCommand.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1924,6 +1936,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ChangeLevel
+
+      - name: CEngineServer_ClientCommand
+        category: vfunc
+        alias:
+          - CEngineServer::ClientCommand
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_ClientCommand.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ClientCommand.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ClientCommand skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ClientCommand",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ClientCommand",
+        "xref_strings": [
+            "ClientCommand, 0 length string supplied.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ClientCommand", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ClientCommand",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CEngineServer_ClientCommand.py` (Pattern B) — discovers `CEngineServer::ClientCommand` via xref string `"ClientCommand, 0 length string supplied."`
- Add skill entry in `config.yaml` (engine module) with `expected_input: CEngineServer_vtable.{platform}.yaml`
- Add symbol entry in `config.yaml` (`category: vfunc`, alias `CEngineServer::ClientCommand`)

## Test plan
- [ ] Close IDA instances holding engine IDB locks, then run `uv run ida_analyze_bin.py -debug` and confirm `find-CEngineServer_ClientCommand` succeeds with 0 failures