### PR TITLE
Add find-CEngineServer_LightStyle preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1052,6 +1052,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_LightStyle
+        expected_output:
+          - CEngineServer_LightStyle.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1924,6 +1930,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ChangeLevel
+
+      - name: CEngineServer_LightStyle
+        category: vfunc
+        alias:
+          - CEngineServer::LightStyle
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_LightStyle.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_LightStyle.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_LightStyle skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_LightStyle",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_LightStyle",
+        "xref_strings": [
+            "LightStyle with NULL value!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_LightStyle", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_LightStyle",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `ida_preprocessor_scripts/find-CEngineServer_LightStyle.py` (Pattern B: vfunc via xref string `"LightStyle with NULL value!"`)
- Adds `config.yaml` skill entry with `expected_input: CEngineServer_vtable.{platform}.yaml`
- Adds `config.yaml` symbol entry `CEngineServer_LightStyle` (`category: vfunc`, alias `CEngineServer::LightStyle`)

## Test plan

- [ ] Close IDA (currently holds engine2 IDB lock) and run `uv run ida_analyze_bin.py -debug`
- [ ] Verify `CEngineServer_LightStyle.windows.yaml` and `CEngineServer_LightStyle.linux.yaml` are produced with correct `vfunc_offset`/`vfunc_index`/`func_sig` fields