### PR TITLE
Add find-CEngineServer_ClientCommand preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1058,6 +1058,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_ClientCommand
+        expected_output:
+          - CEngineServer_ClientCommand.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1935,6 +1941,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::PrecacheGeneric
+
+      - name: CEngineServer_ClientCommand
+        category: vfunc
+        alias:
+          - CEngineServer::ClientCommand
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -1851,6 +1851,36 @@ def wait_for_port(host, port, timeout=60):
     return False
 
 
+def wait_for_port_released(host, port, timeout=30):
+    """
+    Wait for a port to stop listening (released by a previous process).
+
+    Prevents WinError 10048 / EADDRINUSE when starting a new idalib-mcp
+    session immediately after the previous one exits.
+
+    Args:
+        host: Host address
+        port: Port number
+        timeout: Maximum time to wait in seconds
+
+    Returns:
+        True if port is free within timeout, False otherwise
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            result = sock.connect_ex((host, port))
+            sock.close()
+            if result != 0:
+                return True  # connection refused — port is free
+        except socket.error:
+            return True
+        time.sleep(1)
+    return False
+
+
 def start_idalib_mcp(binary_path, host=DEFAULT_HOST, port=DEFAULT_PORT, ida_args="", debug=False):
     """
     Start idalib-mcp as a background process.
@@ -1865,6 +1895,9 @@ def start_idalib_mcp(binary_path, host=DEFAULT_HOST, port=DEFAULT_PORT, ida_args
     Returns:
         subprocess.Popen object if successful, None if failed
     """
+    if not wait_for_port_released(host, port, timeout=30):
+        print(f"  Warning: port {port} still in use after 30s, proceeding anyway")
+
     cmd = ["uv", "run", "idalib-mcp", "--unsafe", "--host", host, "--port", str(port)]
 
     if ida_args:

--- a/ida_preprocessor_scripts/find-CEngineServer_ClientCommand.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ClientCommand.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ClientCommand skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ClientCommand",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ClientCommand",
+        "xref_strings": [
+            "ClientCommand, 0 length string supplied.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ClientCommand", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ClientCommand",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CEngineServer_ClientCommand.py` preprocessor script (Pattern B: vfunc via xref string)
- Xref string: `"ClientCommand, 0 length string supplied."`
- Vtable: `CEngineServer_vtable` — found at index 46, offset `0x170` (Windows validated)
- Updates `config.yaml` with skill entry and symbol entry (`category: vfunc`, alias `CEngineServer::ClientCommand`)
- Fixes `WinError 10048` port conflict between back-to-back IDA sessions: adds `wait_for_port_released()` in `ida_analyze_bin.py` so each new session waits for the OS to fully release port 13337 before binding again

## Test plan

- [x] Windows: matched `CEngineServer_vtable` vtable index 46 (offset `0x170`), generated YAML successfully
- [x] Linux: previously failed with `WinError 10048` (port not yet released after Windows session); fixed by `wait_for_port_released()` in `start_idalib_mcp()`