### PR TITLE
Add find-CEngineServer_LightStyle preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1058,6 +1058,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_LightStyle
+        expected_output:
+          - CEngineServer_LightStyle.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1935,6 +1941,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::PrecacheGeneric
+
+      - name: CEngineServer_LightStyle
+        category: vfunc
+        alias:
+          - CEngineServer::LightStyle
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_LightStyle.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_LightStyle.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_LightStyle skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_LightStyle",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_LightStyle",
+        "xref_strings": [
+            "LightStyle with NULL value!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_LightStyle", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_LightStyle",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add Pattern B preprocessor script `find-CEngineServer_LightStyle` that locates `CEngineServer::LightStyle` via xref to `"LightStyle with NULL value!"` string
- Add skill entry and symbol entry to `config.yaml`
- Outputs: `func_name`, `func_va`, `func_rva`, `func_size`, `func_sig`, `vtable_name`, `vfunc_offset`, `vfunc_index` (vfunc index 47 in `CEngineServer_vtable`)

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` shows `Failed: 9` (pre-existing baseline, no regression)