### PR TITLE
Add find-CEngineServer_DumpNetStats preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1068,6 +1068,13 @@ modules:
         expected_output:
           - CEngineServer_DumpNetStats_Internal.{platform}.yaml
 
+      - name: find-CEngineServer_DumpNetStats
+        expected_output:
+          - CEngineServer_DumpNetStats.{platform}.yaml
+        expected_input:
+          - CEngineServer_DumpNetStats_Internal.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1955,6 +1962,11 @@ modules:
         category: func
         alias:
           - CEngineServer::DumpNetStats_Internal
+
+      - name: CEngineServer_DumpNetStats
+        category: vfunc
+        alias:
+          - CEngineServer::DumpNetStats
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -1064,6 +1064,10 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_DumpNetStats_Internal
+        expected_output:
+          - CEngineServer_DumpNetStats_Internal.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1946,6 +1950,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::LightStyle
+
+      - name: CEngineServer_DumpNetStats_Internal
+        category: func
+        alias:
+          - CEngineServer::DumpNetStats_Internal
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_DumpNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_DumpNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_DumpNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_DumpNetStats_Internal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_DumpNetStats", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_DumpNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats_Internal.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats_Internal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_DumpNetStats_Internal skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_DumpNetStats_Internal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_DumpNetStats_Internal",
+        "xref_strings": [
+            "Bandwidth . . . . . . . : Total:%.1fkb",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_DumpNetStats_Internal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CEngineServer_DumpNetStats_Internal` (Pattern A): regular function found via xref string `"Bandwidth . . . . . . . : Total:%.1fkb"`
- Add `find-CEngineServer_DumpNetStats` (Pattern B): vfunc of `CEngineServer` found via `xref_funcs: [CEngineServer_DumpNetStats_Internal]`
- Update `config.yaml` with skill entries, dependency chain, and symbol definitions

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes with no new failures (pre-existing `Failed: 9` from server IDB locks remain unchanged)
- [ ] `CEngineServer_DumpNetStats_Internal.{platform}.yaml` generated for both platforms with `func_sig`, `func_va`, `func_rva`, `func_size`
- [ ] `CEngineServer_DumpNetStats.{platform}.yaml` generated for both platforms with `func_sig`, `vtable_name`, `vfunc_offset`, `vfunc_index`