### PR TITLE
Add CMapListService/CEngineServer IsMapValid preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1470,6 +1470,14 @@ modules:
         expected_output:
           - CMapListService_IsMapValid_Impl.{platform}.yaml
 
+      - name: find-CEngineServer_IsMapValid-linux
+        platform: linux
+        expected_output:
+          - CEngineServer_IsMapValid.{platform}.yaml
+        expected_input:
+          - CMapListService_IsMapValid_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -1457,6 +1457,14 @@ modules:
         expected_input:
           - CMapListService_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_IsMapValid-windows
+        platform: windows
+        expected_output:
+          - CEngineServer_IsMapValid.{platform}.yaml
+        expected_input:
+          - CMapListService_IsMapValid.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -1957,6 +1965,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::LightStyle
+
+      - name: CEngineServer_IsMapValid
+        category: vfunc
+        alias:
+          - CEngineServer::IsMapValid
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -1450,6 +1450,13 @@ modules:
         expected_output:
           - CMapListService_vtable.{platform}.yaml
 
+      - name: find-CMapListService_IsMapValid-windows
+        platform: windows
+        expected_output:
+          - CMapListService_IsMapValid.{platform}.yaml
+        expected_input:
+          - CMapListService_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -4208,6 +4215,11 @@ modules:
 
       - name: CMapListService_vtable
         category: vtable
+
+      - name: CMapListService_IsMapValid
+        category: vfunc
+        alias:
+          - CMapListService::IsMapValid
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/config.yaml
+++ b/config.yaml
@@ -1465,6 +1465,11 @@ modules:
           - CMapListService_IsMapValid.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CMapListService_IsMapValid_Impl-linux
+        platform: linux
+        expected_output:
+          - CMapListService_IsMapValid_Impl.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -4233,6 +4238,11 @@ modules:
         category: vfunc
         alias:
           - CMapListService::IsMapValid
+
+      - name: CMapListService_IsMapValid_Impl
+        category: func
+        alias:
+          - CMapListService::IsMapValid_Impl
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/config.yaml
+++ b/config.yaml
@@ -1446,6 +1446,10 @@ modules:
         expected_input:
           - CNetworkGameClientBase_vtable.{platform}.yaml
 
+      - name: find-CMapListService_vtable
+        expected_output:
+          - CMapListService_vtable.{platform}.yaml
+
     symbols:
       - name: CNetworkGameServer_vtable
         category: vtable
@@ -4201,6 +4205,9 @@ modules:
         category: vfunc
         alias:
           - CNetworkSerializerBindingBuildFilter::GetFieldPriority
+
+      - name: CMapListService_vtable
+        category: vtable
 
   - name: server
     path_windows: game/csgo/bin/win64/server.dll

--- a/ida_preprocessor_scripts/find-CEngineServer_IsMapValid-linux.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsMapValid-linux.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsMapValid-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_IsMapValid",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_IsMapValid",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CMapListService_IsMapValid_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": ["Changelevel %s %s"],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_IsMapValid", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_IsMapValid",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_IsMapValid-windows.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsMapValid-windows.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsMapValid-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_IsMapValid",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_IsMapValid",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CMapListService_IsMapValid"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_IsMapValid", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_IsMapValid",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CMapListService_IsMapValid-windows.py
+++ b/ida_preprocessor_scripts/find-CMapListService_IsMapValid-windows.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CMapListService_IsMapValid-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CMapListService_IsMapValid",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CMapListService_IsMapValid",
+        "xref_strings": [
+            "FULLMATCH:maps/%s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CMapListService_IsMapValid", "CMapListService_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CMapListService_IsMapValid",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CMapListService_IsMapValid_Impl-linux.py
+++ b/ida_preprocessor_scripts/find-CMapListService_IsMapValid_Impl-linux.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CMapListService_IsMapValid_Impl-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CMapListService_IsMapValid_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CMapListService_IsMapValid_Impl",
+        "xref_strings": [
+            "FULLMATCH:maps/%s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CMapListService_IsMapValid_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CMapListService_vtable.py
+++ b/ida_preprocessor_scripts/find-CMapListService_vtable.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CMapListService_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CMapListService"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CMapListService",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Generate CMapListService vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CMapListService_vtable` — vtable lookup for `CMapListService` in the engine module
- Add `find-CMapListService_IsMapValid-windows` — Windows vfunc discovery via `FULLMATCH:maps/%s` xref string
- Add `find-CMapListService_IsMapValid_Impl-linux` — Linux regular function discovery via `FULLMATCH:maps/%s` xref string
- Add `find-CEngineServer_IsMapValid-windows` — Windows vfunc discovery via `xref_funcs: CMapListService_IsMapValid`
- Add `find-CEngineServer_IsMapValid-linux` — Linux vfunc discovery via `xref_funcs: CMapListService_IsMapValid_Impl` with `exclude_strings: Changelevel %s %s`

## Test plan

- [ ] Run `uv run ida_analyze_bin.py -debug` on Windows binary — `find-CMapListService_vtable`, `find-CMapListService_IsMapValid-windows`, and `find-CEngineServer_IsMapValid-windows` all pass with 0 failures
- [ ] Run `uv run ida_analyze_bin.py -debug` on Linux binary — `find-CMapListService_vtable`, `find-CMapListService_IsMapValid_Impl-linux`, and `find-CEngineServer_IsMapValid-linux` all pass with 0 failures