### PR TITLE
Add find-CEngineServer_GetClientConVarValue preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1070,6 +1070,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_GetClientConVarValue
+        expected_output:
+          - CEngineServer_GetClientConVarValue.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1957,6 +1963,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientCommand
+
+      - name: CEngineServer_GetClientConVarValue
+        category: vfunc
+        alias:
+          - CEngineServer::GetClientConVarValue
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_GetClientConVarValue.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetClientConVarValue.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetClientConVarValue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetClientConVarValue",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetClientConVarValue",
+        "xref_strings": [
+            "GetClientConVarValue: player invalid index %i",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetClientConVarValue", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetClientConVarValue",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CEngineServer_GetClientConVarValue.py` (Pattern B: vfunc via xref string)
- Discovers `CEngineServer::GetClientConVarValue` via the debug string `"GetClientConVarValue: player invalid index %i"`
- Resolves vtable slot in `CEngineServer_vtable`
- Updates `config.yaml` with skill entry and symbol entry (`category: vfunc`)

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures (IDB lock errors are pre-existing/unrelated)
- [ ] Output YAML `CEngineServer_GetClientConVarValue.{platform}.yaml` contains correct `func_va`, `vfunc_offset`, `vfunc_index`, and `func_sig`