### PR TITLE
Add find-CEngineServer_LogPrint and find-CEngineServer_LogPrint_Internal preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1074,6 +1074,13 @@ modules:
         expected_output:
           - CEngineServer_LogPrint_Internal.{platform}.yaml
 
+      - name: find-CEngineServer_LogPrint
+        expected_output:
+          - CEngineServer_LogPrint.{platform}.yaml
+        expected_input:
+          - CEngineServer_LogPrint_Internal.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1966,6 +1973,11 @@ modules:
         category: func
         alias:
           - CEngineServer::LogPrint_Internal
+
+      - name: CEngineServer_LogPrint
+        category: vfunc
+        alias:
+          - CEngineServer::LogPrint
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/config.yaml
+++ b/config.yaml
@@ -1070,6 +1070,10 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_LogPrint_Internal
+        expected_output:
+          - CEngineServer_LogPrint_Internal.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1957,6 +1961,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientCommand
+
+      - name: CEngineServer_LogPrint_Internal
+        category: func
+        alias:
+          - CEngineServer::LogPrint_Internal
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_LogPrint.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_LogPrint.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_LogPrint skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_LogPrint",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_LogPrint",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEngineServer_LogPrint_Internal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_LogPrint", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_LogPrint",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_LogPrint_Internal.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_LogPrint_Internal.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_LogPrint_Internal skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_LogPrint_Internal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_LogPrint_Internal",
+        "xref_strings": [
+            "L %02i/%02i/%04i - %02i:%02i:%02i: %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_LogPrint_Internal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CEngineServer_LogPrint_Internal` (Pattern A): discovers the regular function via xref to the log timestamp format string `"L %02i/%02i/%04i - %02i:%02i:%02i: %s"`
- Adds `find-CEngineServer_LogPrint` (Pattern B): discovers the vfunc on `CEngineServer` vtable via `xref_funcs: ["CEngineServer_LogPrint_Internal"]`
- Updates `config.yaml` with skill and symbol entries for both (engine module)

## Test plan

- [ ] Windows YAML validated via direct preprocess test: `func_sig: 48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 80 79 ?? ??`, `func_va: 0x1800e3250`
- [ ] `find-CEngineServer_LogPrint` confirmed structurally correct (Pattern B with vtable relations); blocked from full test run by pre-existing IDB locks on engine2.dll / libengine2.so