### PR TITLE
Add find-CEngineServer_SetFakeClientConVarValue preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1070,6 +1070,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
 
+      - name: find-CEngineServer_SetFakeClientConVarValue
+        expected_output:
+          - CEngineServer_SetFakeClientConVarValue.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1957,6 +1963,11 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientCommand
+
+      - name: CEngineServer_SetFakeClientConVarValue
+        category: vfunc
+        alias:
+          - CEngineServer::SetFakeClientConVarValue
 
       - name: CLoopTypeClientServerService_vtable
         category: vtable

--- a/ida_preprocessor_scripts/find-CEngineServer_SetFakeClientConVarValue.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_SetFakeClientConVarValue.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_SetFakeClientConVarValue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_SetFakeClientConVarValue",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_SetFakeClientConVarValue",
+        "xref_strings": [
+            "SetFakeClientConVarValue: %d not a client",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_SetFakeClientConVarValue", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_SetFakeClientConVarValue",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds Pattern B preprocessor script to find `CEngineServer_SetFakeClientConVarValue` via xref string `"SetFakeClientConVarValue: %d not a client"`
- Updates `config.yaml` with skill entry (depends on `CEngineServer_vtable`) and symbol entry (`category: vfunc`, alias `CEngineServer::SetFakeClientConVarValue`)

## Test plan
- [ ] Close IDA engine/server databases, then run `uv run ida_analyze_bin.py -debug` and confirm `CEngineServer_SetFakeClientConVarValue.{platform}.yaml` is generated with 0 failures