### PR TITLE
Check ida-pro-mcp before agent fallback

### DIFF
--- a/.claude/skills/find-CBaseEntity_GetChangeAccessorPathInfo_1/SKILL.md
+++ b/.claude/skills/find-CBaseEntity_GetChangeAccessorPathInfo_1/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: find-CBaseEntity_GetChangeAccessorPathInfo_1
+description: |
+  Find and identify the CBaseEntity_GetChangeAccessorPathInfo_1 virtual function in CS2 binary using IDA Pro MCP.
+  Use this skill when reverse engineering CS2 server.dll or libserver.so to locate the second
+  GetChangeAccessorPathInfo override by scanning CBaseEntity vtable slots near the known
+  CBaseEntity_GetChangeAccessorPathInfo_2 slot for an implementation identical to CBaseEntity_GetChangeAccessorPathInfo_2.
+  Trigger: CBaseEntity_GetChangeAccessorPathInfo_1
+disable-model-invocation: true
+---
+
+# Find CBaseEntity_GetChangeAccessorPathInfo_1
+
+Locate `CBaseEntity_GetChangeAccessorPathInfo_1` vfunc in CS2 `server.dll` or `libserver.so` using IDA Pro MCP tools.
+
+## Background
+
+`CBaseEntity` overrides two separate `CEntityInstance` interface methods, `GetChangeAccessorPathInfo_1` and
+`GetChangeAccessorPathInfo_2`, with **byte-for-byte identical implementations** (both simply forward to the same
+internal lazy-init helper at the same member offset). Because the source bodies are identical, the compiler may
+fold both vtable slots onto the exact same function address, or it may still emit two separate but structurally
+identical functions. `CBaseEntity_GetChangeAccessorPathInfo_2` is already resolved (it inherits its vtable slot
+from `CEntityInstance_GetChangeAccessorPathInfo_2`); `CBaseEntity_GetChangeAccessorPathInfo_1` occupies a
+**different** slot within +/-2 entries of it in the same `CBaseEntity` vtable.
+
+## Method
+
+### 1. Load CBaseEntity_GetChangeAccessorPathInfo_2 from YAML
+
+**ALWAYS** Use SKILL `/get-func-from-yaml` with `func_name=CBaseEntity_GetChangeAccessorPathInfo_2`.
+
+If the skill returns an error, **STOP** and report to user.
+
+Otherwise, extract:
+- `func_va` (the reference implementation address)
+- `vfunc_index`
+- `vfunc_offset`
+- `vtable_name` (should be `CBaseEntity`)
+
+### 2. Load CBaseEntity VTable from YAML
+
+**ALWAYS** Use SKILL `/get-vtable-from-yaml` with `class_name=CBaseEntity`.
+
+If the skill returns an error, **STOP** and report to user.
+
+Otherwise, extract:
+- `vtable_numvfunc`
+- `vtable_entries`
+
+### 3. Enumerate Candidate Slots
+
+Compute the scan window around the known slot:
+
+- `window_start = max(0, CBaseEntity_GetChangeAccessorPathInfo_2.vfunc_index - 2)`
+- `window_end = min(vtable_numvfunc - 1, CBaseEntity_GetChangeAccessorPathInfo_2.vfunc_index + 2)`
+
+For every index `i` in `[window_start, window_end]` **except** `CBaseEntity_GetChangeAccessorPathInfo_2.vfunc_index`
+itself, read the candidate function address `vtable_entries[i]`.
+
+### 4. Check for Identical-Address Folding First
+
+Compilers (MSVC `/OPT:ICF`, GCC/Clang identical code folding) commonly merge functions with byte-identical bodies
+into a single implementation, so multiple vtable slots end up pointing at the **same address**.
+
+For each candidate index `i`:
+- If `vtable_entries[i] == CBaseEntity_GetChangeAccessorPathInfo_2.func_va`, this slot is folded onto the same
+  implementation and is an immediate match. Record `i` as `target_vfunc_index` and stop scanning further.
+
+### 5. Otherwise, Decompile and Compare Candidates
+
+If no candidate address matched directly, decompile the reference function and every remaining candidate:
+
+```text
+mcp__ida-pro-mcp__decompile addr="<CBaseEntity_GetChangeAccessorPathInfo_2_func_va>"
+mcp__ida-pro-mcp__decompile addr="<candidate_func_addr>"
+```
+
+#### Windows (`server.dll`)
+
+The reference implementation is a one-line forwarder:
+
+```c
+__int64 __fastcall CBaseEntity_GetChangeAccessorPathInfo_2(__int64 a1)
+{
+  return sub_180184630(a1 + 56);
+}
+```
+
+A matching candidate must be **structurally identical**:
+1. Takes a single `(__int64 a1)` argument (this only)
+2. Directly tail-calls the exact same helper address as the reference (e.g. `sub_180184630`)
+3. Passes the exact same constant offset argument (`a1 + 56`)
+4. Returns the helper's result unchanged
+
+#### Linux (`libserver.so`)
+
+The reference implementation is a lazy-init pattern:
+
+```c
+__int64 __fastcall CBaseEntity_GetChangeAccessorPathInfo_2(__int64 a1)
+{
+  __int64 result;
+  ...
+  result = *(_QWORD *)(a1 + 64);
+  if ( !result )
+  {
+    result = operator new(384);
+    ...
+    *(_QWORD *)(a1 + 64) = result;
+  }
+  return result;
+}
+```
+
+A matching candidate must:
+1. Read/write the exact same member offset as the reference (`a1 + 64`)
+2. Allocate the exact same size via `operator new` (`384`)
+3. Initialize the same set of fixed fields at the same relative offsets (`+56`, `+24`, `+40`, `+48`, `+96` .. `+352`, etc.)
+4. Return the same lazily-initialized pointer
+
+### 6. Confirm the Match
+
+Among the scanned candidates (excluding the known `_2` slot), exactly one should match either by identical address
+(Step 4) or by identical decompiled structure (Step 5). That candidate is `CBaseEntity_GetChangeAccessorPathInfo_1`.
+
+If zero or more than one candidate match, **STOP** and report to user.
+
+### 7. Write IDA Analysis Output as YAML
+
+**ALWAYS** Use SKILL `/write-vfunc-as-yaml` to write the analysis results.
+
+Required parameters:
+- `func_name`: `CBaseEntity_GetChangeAccessorPathInfo_1`
+- `func_addr`: `<matched_func_addr>`
+- `func_sig`: `None`
+- `vfunc_sig`: `None`
+
+VTable parameters:
+- `vtable_name`: `CBaseEntity`
+- `vfunc_offset`: `<target_vfunc_index * 8>` in hex
+- `vfunc_index`: `<target_vfunc_index>`
+
+## Function Characteristics
+
+- **Purpose**: Lazily creates/returns the change-accessor path-info object for this entity; implementation is
+  identical to `CBaseEntity_GetChangeAccessorPathInfo_2`, distinguished only by its vtable slot
+- **Binary**: `server.dll` / `libserver.so`
+- **Parameters**: `(this)` only
+- **Return value**: Pointer to the lazily-allocated path accessor object stored at a fixed member offset
+
+## Discovery Strategy
+
+1. Reuse the existing `CBaseEntity_GetChangeAccessorPathInfo_2` YAML to obtain the reference address and known slot
+2. Reuse the existing `CBaseEntity_vtable` YAML to scan the +/-2 neighboring slots
+3. Prefer an identical-address (ICF-folded) match; fall back to structural decompile comparison
+4. Generate a stable `func_sig` from the resolved candidate body
+
+This is robust because:
+- The two overrides are guaranteed byte-identical in source, so either the compiler folds them to one address or
+  their decompiled structure will be indistinguishable except for the vtable slot
+- Scanning a narrow +/-2 window avoids false positives from unrelated vtable entries
+- The final YAML stores both the resolved function signature and the precise vtable metadata
+
+## Output YAML Format
+
+The output YAML filename depends on the platform:
+- `server.dll` -> `CBaseEntity_GetChangeAccessorPathInfo_1.windows.yaml`
+- `libserver.so` -> `CBaseEntity_GetChangeAccessorPathInfo_1.linux.yaml`

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -127,7 +127,7 @@ jobs:
           "GAMEVER=$gamever" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "PR validation GAMEVER=$gamever"
 
-      - name: Create persisted workspace links
+      - name: Prepare persisted depot link and PR bin copy
         shell: pwsh
         run: |
           function Ensure-DirectoryLink {
@@ -158,46 +158,109 @@ jobs:
             }
           }
 
+          function Get-BinCopyExcludes {
+            param(
+              [Parameter(Mandatory=$true)][string]$IgnoreFile
+            )
+
+            if (-not (Test-Path -LiteralPath $IgnoreFile -PathType Leaf)) {
+              throw "Missing bin ignore file: $IgnoreFile"
+            }
+
+            $filePatterns = @()
+            $dirPatterns = @()
+            $slashChars = [char[]]@("/", "\")
+
+            foreach ($line in Get-Content -LiteralPath $IgnoreFile) {
+              $pattern = $line.Trim()
+              if ([string]::IsNullOrWhiteSpace($pattern) -or $pattern.StartsWith("#") -or $pattern.StartsWith("!")) {
+                continue
+              }
+
+              $isDirectoryPattern = $pattern.EndsWith("/") -or $pattern.EndsWith("\")
+              $pattern = $pattern.TrimStart($slashChars)
+              if ($isDirectoryPattern) {
+                $pattern = $pattern.TrimEnd($slashChars)
+              }
+
+              if ($pattern.Contains("/") -or $pattern.Contains("\")) {
+                throw "Unsupported nested bin ignore pattern for robocopy: $pattern"
+              }
+
+              if ($isDirectoryPattern -or $pattern -eq ".git") {
+                $dirPatterns += $pattern
+              } else {
+                $filePatterns += $pattern
+              }
+            }
+
+            [pscustomobject]@{
+              Files = $filePatterns
+              Dirs = $dirPatterns
+            }
+          }
+
           Set-Location $env:WORKSPACE
           $depotTarget = Join-Path $env:PERSISTED_WORKSPACE "cs2_depot"
-          $binTarget = Join-Path $env:PERSISTED_WORKSPACE "bin-pr\$env:PR_NUMBER"
+          $persistedBinRoot = Join-Path $env:PERSISTED_WORKSPACE "bin"
+          $sourceBinGamever = Join-Path $persistedBinRoot $env:GAMEVER
+          $workspaceBinRoot = Join-Path $env:WORKSPACE "bin"
+          $targetBinGamever = Join-Path $workspaceBinRoot $env:GAMEVER
 
           Ensure-DirectoryLink `
             -LinkPath (Join-Path $env:WORKSPACE "cs2_depot") `
             -TargetPath $depotTarget
 
-          Ensure-DirectoryLink `
-            -LinkPath (Join-Path $env:WORKSPACE "bin") `
-            -TargetPath $binTarget
+          if (-not (Test-Path -LiteralPath $sourceBinGamever -PathType Container)) {
+            throw "Persisted bin source for GAMEVER=$env:GAMEVER does not exist: $sourceBinGamever"
+          }
+
+          if (Test-Path -LiteralPath $workspaceBinRoot) {
+            $binItem = Get-Item -LiteralPath $workspaceBinRoot -Force
+            if ($binItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+              throw "Workspace bin must be a real directory for PR validation, not a link: $workspaceBinRoot"
+            }
+          } else {
+            New-Item -ItemType Directory -Path $workspaceBinRoot -Force | Out-Null
+          }
+
+          New-Item -ItemType Directory -Path $targetBinGamever -Force | Out-Null
+
+          $excludes = Get-BinCopyExcludes -IgnoreFile (Join-Path $persistedBinRoot ".stignore")
+          $robocopyArgs = @(
+            $sourceBinGamever
+            $targetBinGamever
+            "/E"
+            "/COPY:DAT"
+            "/DCOPY:DAT"
+            "/R:2"
+            "/W:5"
+          )
+
+          if ($excludes.Files.Count -gt 0) {
+            $robocopyArgs += "/XF"
+            $robocopyArgs += $excludes.Files
+          }
+
+          if ($excludes.Dirs.Count -gt 0) {
+            $robocopyArgs += "/XD"
+            $robocopyArgs += $excludes.Dirs
+          }
+
+          robocopy @robocopyArgs
+          $robocopyExitCode = $LASTEXITCODE
+          if ($robocopyExitCode -ge 8) {
+            throw "Failed to copy persisted bin/$env:GAMEVER into PR workspace; robocopy exit code $robocopyExitCode"
+          }
+
+          Write-Host "Copied persisted bin/$env:GAMEVER into PR workspace; robocopy exit code $robocopyExitCode"
+          $global:LASTEXITCODE = 0
 
       - name: Run Python unit tests
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
           uv run python -m unittest discover -s tests
-
-      - name: Check cached binaries
-        id: check_cached_binaries
-        shell: pwsh
-        run: |
-          Set-Location $env:WORKSPACE
-          $PSNativeCommandUseErrorActionPreference = $false
-          uv run copy_depot_bin.py -gamever "$env:GAMEVER" -platform all-platform -checkonly
-          $exitCode = $LASTEXITCODE
-
-          if ($exitCode -eq 0) {
-            "bin_ready=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "All expected binaries already exist; skipping depot download."
-            exit 0
-          }
-
-          if ($exitCode -eq 1) {
-            "bin_ready=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-            Write-Host "At least one expected binary is missing; depot download is required."
-            exit 0
-          }
-
-          throw "copy_depot_bin.py -checkonly failed with exit code $exitCode"
 
       - name: Analyze binaries
         shell: pwsh
@@ -216,3 +279,59 @@ jobs:
         run: |
           Set-Location $env:WORKSPACE
           uv run run_cpp_tests.py -gamever "$env:GAMEVER" -debug
+
+      - name: Clean PR bin copy
+        if: always()
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WORKSPACE)) {
+            Write-Host "WORKSPACE is not configured; skipping PR bin cleanup."
+            exit 0
+          }
+
+          if ([string]::IsNullOrWhiteSpace($env:GAMEVER)) {
+            Write-Host "GAMEVER is not configured; skipping PR bin cleanup."
+            exit 0
+          }
+
+          $workspaceRoot = [IO.Path]::GetFullPath($env:WORKSPACE)
+          $binRoot = [IO.Path]::GetFullPath((Join-Path $workspaceRoot "bin"))
+          $targetBinGamever = [IO.Path]::GetFullPath((Join-Path $binRoot $env:GAMEVER))
+          $workspaceRootWithSeparator = $workspaceRoot.TrimEnd('\') + '\'
+          $binRootWithSeparator = $binRoot.TrimEnd('\') + '\'
+
+          if (-not $binRoot.StartsWith($workspaceRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Resolved bin root is outside WORKSPACE: $binRoot"
+          }
+
+          if (Test-Path -LiteralPath $binRoot) {
+            $binItem = Get-Item -LiteralPath $binRoot -Force
+            if ($binItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+              throw "Refusing to clean PR bin copy because workspace bin is a reparse point: $binRoot"
+            }
+          }
+
+          if ((Split-Path -Leaf $targetBinGamever) -ne $env:GAMEVER) {
+            throw "Resolved PR bin cleanup leaf mismatch: $targetBinGamever"
+          }
+
+          if (-not $targetBinGamever.StartsWith($binRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Resolved PR bin cleanup target is outside workspace bin root: $targetBinGamever"
+          }
+
+          if (-not (Test-Path -LiteralPath $targetBinGamever)) {
+            Write-Host "PR bin cleanup target does not exist: $targetBinGamever"
+            exit 0
+          }
+
+          if (-not (Test-Path -LiteralPath $targetBinGamever -PathType Container)) {
+            throw "PR bin cleanup target exists but is not a directory: $targetBinGamever"
+          }
+
+          $targetItem = Get-Item -LiteralPath $targetBinGamever -Force
+          if ($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+            throw "Refusing to remove PR bin cleanup target because it is a reparse point: $targetBinGamever"
+          }
+
+          Remove-Item -LiteralPath $targetBinGamever -Recurse -Force
+          Write-Host "Removed PR bin copy: $targetBinGamever"

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -199,43 +199,6 @@ jobs:
 
           throw "copy_depot_bin.py -checkonly failed with exit code $exitCode"
 
-      - name: Update CS2 depot
-        if: steps.check_cached_binaries.outputs.bin_ready != 'true'
-        shell: pwsh
-        run: |
-          Set-Location $env:WORKSPACE
-          $depotDir = Join-Path $env:WORKSPACE "cs2_depot"
-          uv run download_depot.py -tag "$env:GAMEVER" -depotdir "$depotDir" -config download.yaml -username "$env:STEAM_USERNAME" -password "$env:STEAM_PASSWORD" -remember-password
-
-      - name: Copy depot binaries
-        if: steps.check_cached_binaries.outputs.bin_ready != 'true'
-        shell: pwsh
-        run: |
-          Set-Location $env:WORKSPACE
-          uv run copy_depot_bin.py -gamever "$env:GAMEVER" -platform all-platform
-
-      - name: Clean stale PR analysis artifacts
-        shell: pwsh
-        run: |
-          $binRoot = [IO.Path]::GetFullPath((Join-Path $env:WORKSPACE "bin"))
-          $gameverDir = [IO.Path]::GetFullPath((Join-Path $binRoot $env:GAMEVER))
-          $binRootWithSeparator = $binRoot.TrimEnd('\') + '\'
-
-          if (-not $gameverDir.StartsWith($binRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Refusing to clean path outside PR bin root: $gameverDir"
-          }
-
-          if (-not (Test-Path -LiteralPath $gameverDir -PathType Container)) {
-            Write-Host "PR bin gamever directory does not exist yet: $gameverDir"
-            exit 0
-          }
-
-          $patterns = @("*.yaml", "*.id0", "*.id1", "*.id2", "*.nam", "*.til")
-          foreach ($pattern in $patterns) {
-            Get-ChildItem -LiteralPath $gameverDir -Recurse -File -Filter $pattern -Force -ErrorAction SilentlyContinue |
-              ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
-          }
-
       - name: Analyze binaries
         shell: pwsh
         run: |
@@ -253,26 +216,3 @@ jobs:
         run: |
           Set-Location $env:WORKSPACE
           uv run run_cpp_tests.py -gamever "$env:GAMEVER" -debug
-
-      - name: Clean temporary IDA database files
-        if: always()
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:PERSISTED_WORKSPACE) -or
-              [string]::IsNullOrWhiteSpace($env:PR_NUMBER) -or
-              [string]::IsNullOrWhiteSpace($env:GAMEVER)) {
-            Write-Host "Required cleanup variables are missing; skipping temporary IDA database cleanup."
-            exit 0
-          }
-
-          $targetDir = Join-Path $env:PERSISTED_WORKSPACE "bin-pr\$env:PR_NUMBER\$env:GAMEVER"
-          if (-not (Test-Path -LiteralPath $targetDir -PathType Container)) {
-            Write-Host "Temporary IDA database cleanup target does not exist: $targetDir"
-            exit 0
-          }
-
-          $extensions = @("*.id0", "*.id1", "*.id2", "*.nam", "*.til")
-          foreach ($extension in $extensions) {
-            Get-ChildItem -LiteralPath $targetDir -Recurse -File -Filter $extension -Force -ErrorAction SilentlyContinue |
-              ForEach-Object { Remove-Item -LiteralPath $_.FullName -Force }
-          }

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -260,7 +260,7 @@ jobs:
         shell: pwsh
         run: |
           Set-Location $env:WORKSPACE
-          uv run python -m unittest discover -s tests
+          uv run python -m unittest discover -s tests -b
 
       - name: Analyze binaries
         shell: pwsh

--- a/config.yaml
+++ b/config.yaml
@@ -7208,6 +7208,20 @@ modules:
           - PolymorphicHelper_t__SetPolymorphicPointer.{platform}.yaml
           - CEntityInstance_vtable.{platform}.yaml
 
+      - name: find-CBaseEntity_GetChangeAccessorPathInfo_2
+        expected_output:
+          - CBaseEntity_GetChangeAccessorPathInfo_2.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
+          - CEntityInstance_GetChangeAccessorPathInfo_2.{platform}.yaml
+
+      - name: find-CBaseEntity_GetChangeAccessorPathInfo_1
+        expected_output:
+          - CBaseEntity_GetChangeAccessorPathInfo_1.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
+          - CBaseEntity_GetChangeAccessorPathInfo_2.{platform}.yaml
+
       - name: find-CEntityInstance_AddChangeAccessorPath
         expected_output:
           - CEntityInstance_AddChangeAccessorPath.{platform}.yaml
@@ -7856,6 +7870,16 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::GetChangeAccessorPathInfo_2
+
+      - name: CBaseEntity_GetChangeAccessorPathInfo_2
+        category: vfunc
+        alias:
+          - CBaseEntity::GetChangeAccessorPathInfo_2
+
+      - name: CBaseEntity_GetChangeAccessorPathInfo_1
+        category: vfunc
+        alias:
+          - CBaseEntity::GetChangeAccessorPathInfo_1
 
       - name: CGameSceneNode_vtable
         category: vtable

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -86,6 +86,13 @@ ERROR_MARKER_RE = re.compile(
 _MCP_PREFLIGHT_DONE = False
 _MCP_PREFLIGHT_FAILED = False
 _ARTIFACT_SYMBOL_CATEGORY_CACHE = {}
+
+
+def _absolute_path_preserve_spelling(path):
+    """Make a local path absolute without resolving 8.3 names or junction targets."""
+    return os.path.abspath(os.path.normpath(os.fspath(path)))
+
+
 SURVEY_CURRENT_IDB_PATH_PY_EVAL = (
     "import json\n"
     "path = ''\n"
@@ -1406,14 +1413,19 @@ def resolve_artifact_path(binary_dir, artifact_path, platform):
         raise ValueError("artifact path is empty")
 
     expanded = artifact_path.replace("{platform}", platform)
-    module_dir = Path(binary_dir).resolve()
-    gamever_dir = module_dir.parent.resolve()
-    candidate = (module_dir / expanded).resolve()
+    module_dir = _absolute_path_preserve_spelling(binary_dir)
+    candidate = _absolute_path_preserve_spelling(os.path.join(module_dir, expanded))
+    real_module_dir = Path(binary_dir).resolve()
+    real_gamever_dir = real_module_dir.parent.resolve()
+    real_candidate = (real_module_dir / expanded).resolve()
 
-    if os.path.commonpath([str(candidate), str(gamever_dir)]) != str(gamever_dir):
+    if (
+        os.path.commonpath([str(real_candidate), str(real_gamever_dir)])
+        != str(real_gamever_dir)
+    ):
         raise ValueError(f"artifact path escapes gamever root: {artifact_path}")
 
-    return str(candidate)
+    return candidate
 
 
 def expand_expected_paths(binary_dir, paths, platform):
@@ -1502,23 +1514,24 @@ def _collect_post_process_yaml_mappings(
             continue
 
         for output_path in expected_outputs:
-            resolved_path = str(Path(output_path).resolve())
-            if not _is_current_module_artifact_path(resolved_path, binary_dir):
+            artifact_path = _absolute_path_preserve_spelling(output_path)
+            if not _is_current_module_artifact_path(artifact_path, binary_dir):
                 if debug:
                     print(
                         "  Post-process: skipping YAML outside current module dir "
-                        f"{resolved_path}"
+                        f"{artifact_path}"
                     )
                 continue
-            if resolved_path in seen_paths:
+            seen_key = os.path.normcase(artifact_path)
+            if seen_key in seen_paths:
                 continue
-            seen_paths.add(resolved_path)
-            if not os.path.exists(resolved_path):
+            seen_paths.add(seen_key)
+            if not os.path.exists(artifact_path):
                 continue
-            payload = _load_post_process_yaml_mapping(resolved_path, debug=debug)
+            payload = _load_post_process_yaml_mapping(artifact_path, debug=debug)
             if payload is None:
                 continue
-            yaml_items.append((resolved_path, payload))
+            yaml_items.append((artifact_path, payload))
 
     return yaml_items
 

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -78,10 +78,13 @@ DEFAULT_PORT = 13337
 POST_PROCESS_FUNC_RENAME_BATCH_SIZE = 50
 MCP_STARTUP_TIMEOUT = 1200  # seconds to wait for MCP server
 SKILL_TIMEOUT = 1200  # 10 minutes per skill
+MCP_LIST_TIMEOUT = 30
 ERROR_MARKER_RE = re.compile(
     r"(?<![A-Za-z0-9])error(?![A-Za-z0-9])",
     re.IGNORECASE,
 )
+_MCP_PREFLIGHT_DONE = False
+_MCP_PREFLIGHT_FAILED = False
 _ARTIFACT_SYMBOL_CATEGORY_CACHE = {}
 SURVEY_CURRENT_IDB_PATH_PY_EVAL = (
     "import json\n"
@@ -104,6 +107,66 @@ SURVEY_CURRENT_IDB_PATH_PY_EVAL = (
 def _output_contains_error_marker(*texts: str) -> bool:
     merged_output = "\n".join(text for text in texts if text)
     return bool(ERROR_MARKER_RE.search(merged_output))
+
+
+def _mcp_list_contains_server(output, server_name="ida-pro-mcp"):
+    if not output:
+        return False
+    pattern = re.compile(rf"(?m)^\s*(?:[-*]\s*)?{re.escape(server_name)}(?:\s|:|$)")
+    return bool(pattern.search(output))
+
+
+def _format_mcp_list_output(output, limit=1200):
+    text = (output or "").strip()
+    if not text:
+        return "<empty>"
+    if len(text) > limit:
+        text = text[:limit] + "... <truncated>"
+    return "\n".join(f"      {line}" for line in text.splitlines())
+
+
+def _ensure_agent_mcp_preflight(agent, debug=False, server_name="ida-pro-mcp"):
+    global _MCP_PREFLIGHT_DONE, _MCP_PREFLIGHT_FAILED
+
+    if _MCP_PREFLIGHT_DONE:
+        return True
+    if _MCP_PREFLIGHT_FAILED:
+        print("    Error: MCP preflight previously failed; refusing to start agent.")
+        return False
+
+    cmd = [agent, "mcp", "list"]
+    print(f"    Checking MCP server list: {' '.join(cmd)}")
+
+    try:
+        result = _run_process_with_stream_capture(
+            cmd,
+            debug=debug,
+            timeout=MCP_LIST_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        _MCP_PREFLIGHT_FAILED = True
+        print(f"    Error: MCP list preflight timeout ({MCP_LIST_TIMEOUT} seconds): {' '.join(cmd)}")
+        return False
+    except FileNotFoundError:
+        _MCP_PREFLIGHT_FAILED = True
+        print(f"    Error: Agent '{agent}' not found while running MCP list preflight.")
+        return False
+    except Exception as e:
+        _MCP_PREFLIGHT_FAILED = True
+        print(f"    Error executing MCP list preflight: {e}")
+        return False
+
+    output = "\n".join(text for text in (result.stdout, result.stderr) if text)
+    if _mcp_list_contains_server(output, server_name):
+        _MCP_PREFLIGHT_DONE = True
+        return True
+
+    _MCP_PREFLIGHT_FAILED = True
+    print(f"    Error: Required MCP server '{server_name}' is not listed by '{agent} mcp list'.")
+    if result.returncode != 0:
+        print(f"    mcp list return code: {result.returncode}")
+    print(f"    mcp list output:\n{_format_mcp_list_output(output)}")
+    return False
 
 
 def _parse_tool_json_content(result):
@@ -1978,8 +2041,25 @@ def run_skill(skill_name, agent="claude", debug=False, expected_yaml_paths=None,
     """
     claude_session_id = str(uuid.uuid4())
     codex_developer_instructions = None
+    agent_lower = agent.lower()
+    is_claude_agent = "claude" in agent_lower
+    is_codex_agent = "codex" in agent_lower
 
-    if "codex" in agent.lower():
+    if not is_claude_agent and not is_codex_agent:
+        print(f"    Error: Unknown agent type '{agent}'. Agent name must contain 'claude' or 'codex'.")
+        return False
+
+    # Verify SKILL.md exists before launching agent
+    skill_md_path = os.path.join(".claude", "skills", skill_name, "SKILL.md")
+    print(f"    Falling back to: {skill_md_path}")
+    if not os.path.exists(skill_md_path):
+        print(f"    Error: Skill file not found: {skill_md_path}")
+        return False
+
+    if not _ensure_agent_mcp_preflight(agent, debug=debug):
+        return False
+
+    if is_codex_agent:
         system_prompt_path = Path(".claude/agents/sig-finder.md")
         try:
             system_prompt_raw = system_prompt_path.read_text(encoding="utf-8")
@@ -2009,20 +2089,9 @@ def run_skill(skill_name, agent="claude", debug=False, expected_yaml_paths=None,
 
         codex_developer_instructions = f"developer_instructions={json.dumps(codex_system_prompt)}"
 
-    # Verify SKILL.md exists before launching agent
-    skill_md_path = os.path.join(".claude", "skills", skill_name, "SKILL.md")
-    print(f"    Falling back to: {skill_md_path}")
-    if not os.path.exists(skill_md_path):
-        print(f"    Error: Skill file not found: {skill_md_path}")
-        return False
-
     for attempt in range(max_retries):
         is_retry = attempt > 0
         agent_input = None
-
-        # Determine agent type based on executable name
-        is_claude_agent = "claude" in agent.lower()
-        is_codex_agent = "codex" in agent.lower()
 
         if is_claude_agent:
             cmd = [agent,
@@ -2046,9 +2115,6 @@ def run_skill(skill_name, agent="claude", debug=False, expected_yaml_paths=None,
             else:
                 cmd = [agent, "-c", codex_developer_instructions, "-c", "model_reasoning_effort=high", "-c", "model_reasoning_summary=none", "-c", "model_verbosity=low", "exec", "-"]
             retry_target_desc = "the latest codex session (--last)"
-        else:
-            print(f"    Error: Unknown agent type '{agent}'. Agent name must contain 'claude' or 'codex'.")
-            return False
 
         attempt_str = f"(attempt {attempt + 1}/{max_retries})" if max_retries > 1 else ""
         retry_str = "[RETRY] " if is_retry else ""

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -4,7 +4,9 @@
 import asyncio
 import json
 import math
+import ntpath
 import os
+import posixpath
 import re
 import tempfile
 import textwrap
@@ -25,6 +27,21 @@ except Exception:
     call_llm_text = None
     normalize_optional_effort = None
     normalize_optional_temperature = None
+
+
+def _is_remote_absolute_path(path):
+    """Return True for absolute paths in either host, POSIX, or Windows form."""
+    path_str = os.fspath(path)
+    return (
+        os.path.isabs(path_str)
+        or posixpath.isabs(path_str)
+        or ntpath.isabs(path_str)
+    )
+
+
+def _absolute_path_preserve_spelling(path):
+    """Make a local path absolute without resolving 8.3 names or junction targets."""
+    return Path(os.path.abspath(os.path.normpath(os.fspath(path))))
 
 
 # Combined vtable lookup + entry reading script for IDA py_eval.
@@ -704,7 +721,7 @@ def build_remote_text_export_py_eval(
 ):
     """Build a py_eval script that writes large text to disk and returns a small ack."""
     output_path_str = os.fspath(output_path)
-    if not os.path.isabs(output_path_str):
+    if not _is_remote_absolute_path(output_path_str):
         raise ValueError(f"output_path must be absolute, got {output_path_str!r}")
     if not str(producer_code).strip():
         raise ValueError("producer_code cannot be empty")
@@ -713,15 +730,21 @@ def build_remote_text_export_py_eval(
 
     producer_block = textwrap.indent(str(producer_code).rstrip(), "    ")
     return (
-        "import json, os, traceback\n"
+        "import json, ntpath, os, posixpath, traceback\n"
         f"output_path = {output_path_str!r}\n"
         f"format_name = {str(format_name)!r}\n"
         "tmp_path = output_path + '.tmp'\n"
+        "def _is_remote_absolute_path(output_path):\n"
+        "    return (\n"
+        "        os.path.isabs(output_path)\n"
+        "        or posixpath.isabs(output_path)\n"
+        "        or ntpath.isabs(output_path)\n"
+        "    )\n"
         "def _truncate_text(value, limit=800):\n"
         "    text = '' if value is None else str(value)\n"
         "    return text if len(text) <= limit else text[:limit] + ' [truncated]'\n"
         "try:\n"
-        "    if not os.path.isabs(output_path):\n"
+        "    if not _is_remote_absolute_path(output_path):\n"
         "        raise ValueError(f'output_path must be absolute: {output_path}')\n"
         f"{producer_block}\n"
         f"    payload_text = str({content_var})\n"
@@ -2583,7 +2606,7 @@ def _prepare_llm_decompile_request(
     )
     if not prompt_path.is_absolute():
         prompt_path = scripts_dir / prompt_path
-    prompt_path = prompt_path.resolve()
+    prompt_path = _absolute_path_preserve_spelling(prompt_path)
 
     if not prompt_path.is_file():
         if debug:
@@ -2624,7 +2647,7 @@ def _prepare_llm_decompile_request(
         )
         if not reference_yaml_path.is_absolute():
             reference_yaml_path = scripts_dir / reference_yaml_path
-        reference_yaml_path = reference_yaml_path.resolve()
+        reference_yaml_path = _absolute_path_preserve_spelling(reference_yaml_path)
 
         if not reference_yaml_path.is_file():
             if debug:
@@ -5608,10 +5631,15 @@ async def preprocess_index_based_vfunc_via_mcp(
 
     def _resolve_related_yaml_path(binary_dir, artifact_stem, platform_name):
         expanded = f"{artifact_stem}.{platform_name}.yaml"
-        module_dir = Path(binary_dir).resolve()
-        gamever_dir = module_dir.parent.resolve()
-        candidate = (module_dir / expanded).resolve()
-        if os.path.commonpath([str(candidate), str(gamever_dir)]) != str(gamever_dir):
+        module_dir = _absolute_path_preserve_spelling(binary_dir)
+        candidate = _absolute_path_preserve_spelling(module_dir / expanded)
+        real_module_dir = Path(binary_dir).resolve()
+        real_gamever_dir = real_module_dir.parent.resolve()
+        real_candidate = (real_module_dir / expanded).resolve()
+        if (
+            os.path.commonpath([str(real_candidate), str(real_gamever_dir)])
+            != str(real_gamever_dir)
+        ):
             raise ValueError(f"artifact path escapes gamever root: {artifact_stem}")
         return str(candidate)
 

--- a/ida_preprocessor_scripts/find-CBaseEntity_GetChangeAccessorPathInfo_2.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_GetChangeAccessorPathInfo_2.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_GetChangeAccessorPathInfo_2 skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CBaseEntity_GetChangeAccessorPathInfo_2", "CBaseEntity", "CEntityInstance_GetChangeAccessorPathInfo_2", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_GetChangeAccessorPathInfo_2",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            #"func_sig",// unable to generate unique sig because there is CBaseEntity_GetChangeAccessorPathInfo_1
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -2177,6 +2177,10 @@ class _FakePopen:
 
 
 class TestRunSkillOutputDetection(unittest.TestCase):
+    def setUp(self) -> None:
+        ida_analyze_bin._MCP_PREFLIGHT_DONE = False
+        ida_analyze_bin._MCP_PREFLIGHT_FAILED = False
+
     def test_output_contains_error_marker_only_matches_standalone_tokens(self) -> None:
         self.assertTrue(ida_analyze_bin._output_contains_error_marker("Error"))
         self.assertTrue(ida_analyze_bin._output_contains_error_marker("prefix [ERROR] suffix"))
@@ -2190,6 +2194,10 @@ class TestRunSkillOutputDetection(unittest.TestCase):
 
 
 class TestRunSkillCodexPromptTransport(unittest.TestCase):
+    def setUp(self) -> None:
+        ida_analyze_bin._MCP_PREFLIGHT_DONE = False
+        ida_analyze_bin._MCP_PREFLIGHT_FAILED = False
+
     @patch.object(Path, 'read_text', return_value='sig finder prompt')
     @patch('ida_analyze_bin.os.path.exists', return_value=True)
     @patch('ida_analyze_bin._run_process_with_stream_capture')
@@ -2200,6 +2208,12 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         _mock_read_text,
     ) -> None:
         mock_run_process.side_effect = [
+            ida_analyze_bin.subprocess.CompletedProcess(
+                args=['codex', 'mcp', 'list'],
+                returncode=1,
+                stdout='Name\nida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n',
+                stderr='',
+            ),
             ida_analyze_bin.subprocess.CompletedProcess(
                 args=['codex'],
                 returncode=1,
@@ -2222,11 +2236,13 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         )
 
         self.assertTrue(result)
-        self.assertEqual(2, mock_run_process.call_count)
+        self.assertEqual(3, mock_run_process.call_count)
 
-        first_call = mock_run_process.call_args_list[0]
-        second_call = mock_run_process.call_args_list[1]
+        preflight_call = mock_run_process.call_args_list[0]
+        first_call = mock_run_process.call_args_list[1]
+        second_call = mock_run_process.call_args_list[2]
 
+        self.assertEqual(['codex', 'mcp', 'list'], preflight_call.args[0])
         self.assertEqual(['exec', '-'], first_call.args[0][-2:])
         self.assertEqual(['exec', 'resume', '--last', '-'], second_call.args[0][-4:])
         expected_prompt = 'Run SKILL: .claude/skills/find-IGameSystem_vtable/SKILL.md'
@@ -2244,11 +2260,17 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         mock_popen,
         _mock_exists,
     ) -> None:
-        mock_popen.return_value = _FakePopen(
+        preflight_process = _FakePopen(
+            stdout_chunks=['ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Failed\n'],
+            stderr_chunks=[],
+            returncode=0,
+        )
+        agent_process = _FakePopen(
             stdout_chunks=['agent stdout line\n'],
             stderr_chunks=['agent stderr line\n'],
             returncode=0,
         )
+        mock_popen.side_effect = [preflight_process, agent_process]
 
         with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout, patch(
             'sys.stderr', new_callable=io.StringIO
@@ -2261,6 +2283,7 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
             )
 
         self.assertTrue(result)
+        self.assertEqual(['claude', 'mcp', 'list'], mock_popen.call_args_list[0].args[0])
         self.assertIn('agent stdout line\n', fake_stdout.getvalue())
         self.assertIn('agent stderr line\n', fake_stderr.getvalue())
 
@@ -2273,6 +2296,11 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
         _mock_exists,
         _mock_read_text,
     ) -> None:
+        preflight_process = _FakePopen(
+            stdout_chunks=['ida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n'],
+            stderr_chunks=[],
+            returncode=0,
+        )
         first_process = _FakePopen(
             stdout_chunks=['starting\n', '[ERROR] lookup failed\n'],
             stderr_chunks=[],
@@ -2283,7 +2311,7 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
             stderr_chunks=[],
             returncode=0,
         )
-        mock_popen.side_effect = [first_process, second_process]
+        mock_popen.side_effect = [preflight_process, first_process, second_process]
 
         with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout, patch(
             'sys.stderr', new_callable=io.StringIO
@@ -2296,12 +2324,268 @@ class TestRunSkillCodexPromptTransport(unittest.TestCase):
             )
 
         self.assertTrue(result)
-        self.assertEqual(2, mock_popen.call_count)
+        self.assertEqual(3, mock_popen.call_count)
+        self.assertEqual(['codex', 'mcp', 'list'], mock_popen.call_args_list[0].args[0])
         self.assertNotIn('[ERROR] lookup failed\n', fake_stdout.getvalue())
         self.assertEqual('', fake_stderr.getvalue())
         expected_prompt = 'Run SKILL: .claude/skills/find-IGameSystem_vtable/SKILL.md'
         self.assertEqual(expected_prompt, ''.join(first_process.stdin.writes))
         self.assertEqual(expected_prompt, ''.join(second_process.stdin.writes))
+
+
+class TestRunSkillMcpListPreflight(unittest.TestCase):
+    def setUp(self) -> None:
+        ida_analyze_bin._MCP_PREFLIGHT_DONE = False
+        ida_analyze_bin._MCP_PREFLIGHT_FAILED = False
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_claude_mcp_list_accepts_failed_connection_when_server_is_listed(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        preflight_process = _FakePopen(
+            stdout_chunks=[
+                'ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Failed to connect\n'
+            ],
+            stderr_chunks=[],
+            returncode=0,
+        )
+        agent_process = _FakePopen(stdout_chunks=['done\n'], stderr_chunks=[], returncode=0)
+        mock_popen.side_effect = [preflight_process, agent_process]
+
+        result = ida_analyze_bin.run_skill(
+            skill_name='find-IGameSystem_vtable',
+            agent='claude',
+            debug=False,
+            max_retries=1,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(['claude', 'mcp', 'list'], mock_popen.call_args_list[0].args[0])
+        self.assertEqual(2, mock_popen.call_count)
+
+    @patch.object(Path, 'read_text', return_value='sig finder prompt')
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin._run_process_with_stream_capture')
+    def test_codex_mcp_list_accepts_table_row_when_server_is_listed(
+        self,
+        mock_run_process,
+        _mock_exists,
+        _mock_read_text,
+    ) -> None:
+        mock_run_process.side_effect = [
+            ida_analyze_bin.subprocess.CompletedProcess(
+                args=['codex', 'mcp', 'list'],
+                returncode=0,
+                stdout=(
+                    'Name         Url                         Status\n'
+                    'ida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n'
+                ),
+                stderr='',
+            ),
+            ida_analyze_bin.subprocess.CompletedProcess(
+                args=['codex'],
+                returncode=0,
+                stdout='',
+                stderr='',
+            ),
+        ]
+
+        result = ida_analyze_bin.run_skill(
+            skill_name='find-IGameSystem_vtable',
+            agent='codex',
+            debug=False,
+            max_retries=1,
+        )
+
+        self.assertTrue(result)
+        self.assertEqual(['codex', 'mcp', 'list'], mock_run_process.call_args_list[0].args[0])
+        self.assertEqual(2, mock_run_process.call_count)
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_missing_ida_pro_mcp_blocks_agent_start(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        preflight_process = _FakePopen(
+            stdout_chunks=['serena: http://127.0.0.1:9131/mcp (HTTP) - Connected\n'],
+            stderr_chunks=[],
+            returncode=0,
+        )
+        mock_popen.return_value = preflight_process
+
+        with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout:
+            result = ida_analyze_bin.run_skill(
+                skill_name='find-IGameSystem_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(1, mock_popen.call_count)
+        self.assertEqual(['claude', 'mcp', 'list'], mock_popen.call_args.args[0])
+        self.assertIn("Required MCP server 'ida-pro-mcp' is not listed", fake_stdout.getvalue())
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_mcp_list_timeout_blocks_agent_start(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        timeout_process = _FakePopen(stdout_chunks=[], stderr_chunks=[], returncode=0)
+        timeout_process.wait = MagicMock(
+            side_effect=ida_analyze_bin.subprocess.TimeoutExpired(
+                ['claude', 'mcp', 'list'],
+                30,
+            )
+        )
+        mock_popen.return_value = timeout_process
+
+        with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout:
+            result = ida_analyze_bin.run_skill(
+                skill_name='find-IGameSystem_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(1, mock_popen.call_count)
+        self.assertIn('MCP list preflight timeout', fake_stdout.getvalue())
+        self.assertTrue(timeout_process.killed)
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen', side_effect=FileNotFoundError)
+    def test_mcp_list_missing_agent_blocks_agent_start(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout:
+            result = ida_analyze_bin.run_skill(
+                skill_name='find-IGameSystem_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(1, mock_popen.call_count)
+        self.assertIn(
+            "Agent 'claude' not found while running MCP list preflight",
+            fake_stdout.getvalue(),
+        )
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_empty_mcp_list_output_blocks_agent_start(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        mock_popen.return_value = _FakePopen(stdout_chunks=[], stderr_chunks=[], returncode=0)
+
+        with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout:
+            result = ida_analyze_bin.run_skill(
+                skill_name='find-IGameSystem_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+
+        self.assertFalse(result)
+        self.assertEqual(1, mock_popen.call_count)
+        self.assertIn("Required MCP server 'ida-pro-mcp' is not listed", fake_stdout.getvalue())
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_preflight_runs_only_once_for_multiple_skills(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        preflight_process = _FakePopen(
+            stdout_chunks=['ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Failed\n'],
+            stderr_chunks=[],
+            returncode=0,
+        )
+        first_agent = _FakePopen(stdout_chunks=['first\n'], stderr_chunks=[], returncode=0)
+        second_agent = _FakePopen(stdout_chunks=['second\n'], stderr_chunks=[], returncode=0)
+        mock_popen.side_effect = [preflight_process, first_agent, second_agent]
+
+        first_result = ida_analyze_bin.run_skill(
+            skill_name='find-IGameSystem_vtable',
+            agent='claude',
+            debug=False,
+            max_retries=1,
+        )
+        second_result = ida_analyze_bin.run_skill(
+            skill_name='find-CBaseEntity_vtable',
+            agent='claude',
+            debug=False,
+            max_retries=1,
+        )
+
+        self.assertTrue(first_result)
+        self.assertTrue(second_result)
+        commands = [call_args.args[0] for call_args in mock_popen.call_args_list]
+        self.assertEqual(1, commands.count(['claude', 'mcp', 'list']))
+        self.assertEqual(3, mock_popen.call_count)
+
+    @patch('ida_analyze_bin.os.path.exists', return_value=True)
+    @patch('ida_analyze_bin.subprocess.Popen')
+    def test_failed_preflight_is_not_retried_for_later_skills(
+        self,
+        mock_popen,
+        _mock_exists,
+    ) -> None:
+        mock_popen.return_value = _FakePopen(
+            stdout_chunks=['serena: http://127.0.0.1:9131/mcp (HTTP) - Connected\n'],
+            stderr_chunks=[],
+            returncode=0,
+        )
+
+        with patch('sys.stdout', new_callable=io.StringIO) as fake_stdout:
+            first_result = ida_analyze_bin.run_skill(
+                skill_name='find-IGameSystem_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+            second_result = ida_analyze_bin.run_skill(
+                skill_name='find-CBaseEntity_vtable',
+                agent='claude',
+                debug=False,
+                max_retries=1,
+            )
+
+        self.assertFalse(first_result)
+        self.assertFalse(second_result)
+        self.assertEqual(1, mock_popen.call_count)
+        self.assertIn('MCP preflight previously failed', fake_stdout.getvalue())
+
+    def test_mcp_list_server_matching_requires_list_item_name(self) -> None:
+        self.assertTrue(
+            ida_analyze_bin._mcp_list_contains_server(
+                'ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Failed\n'
+            )
+        )
+        self.assertTrue(
+            ida_analyze_bin._mcp_list_contains_server(
+                'ida-pro-mcp  http://127.0.0.1:13337/mcp  enabled\n'
+            )
+        )
+        self.assertFalse(
+            ida_analyze_bin._mcp_list_contains_server(
+                'not-ida-pro-mcp: http://127.0.0.1:13337/mcp (HTTP) - Failed\n'
+            )
+        )
 
 
 @patch.dict(

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -580,7 +580,11 @@ class TestPostProcessActionCollection(unittest.TestCase):
                 debug=False,
             )
 
-        self.assertEqual([(str(valid_path.resolve()), {"func_name": "Valid", "func_va": "0x180100000"})], result)
+        expected_path = ida_analyze_bin._absolute_path_preserve_spelling(valid_path)
+        self.assertEqual(
+            [(expected_path, {"func_name": "Valid", "func_va": "0x180100000"})],
+            result,
+        )
 
     def test_collect_post_process_yaml_mappings_skips_paths_outside_current_binary_dir(
         self,

--- a/tests/test_ida_remote_export.py
+++ b/tests/test_ida_remote_export.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from ida_analyze_util import build_remote_text_export_py_eval
 
@@ -24,6 +25,16 @@ class TestBuildRemoteTextExportPyEval(unittest.TestCase):
         self.assertIn("os.replace(tmp_path, output_path)", script)
         self.assertIn("'bytes_written'", script)
         self.assertIn("'format': format_name", script)
+
+    def test_build_remote_text_export_py_eval_accepts_posix_absolute_path(self) -> None:
+        with patch("ida_analyze_util.os.path.isabs", return_value=False):
+            script = build_remote_text_export_py_eval(
+                output_path="/tmp/vcall-detail.yaml",
+                producer_code="payload_text = 'ok'",
+                content_var="payload_text",
+            )
+
+        self.assertIn("posixpath.isabs(output_path)", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a program-level one-time MCP list preflight before the first Claude/Codex agent fallback.
- Require `ida-pro-mcp` to be listed without requiring it to be connected.
- Cache preflight success/failure for later `run_skill()` calls and cover the behavior with unit tests.

## Test Plan
- `uv run python -m unittest tests.test_ida_analyze_bin.TestRunSkillOutputDetection tests.test_ida_analyze_bin.TestRunSkillCodexPromptTransport tests.test_ida_analyze_bin.TestRunSkillMcpListPreflight -v`
- `uv run python -m unittest tests.test_ida_analyze_bin -v`