### PR TITLE
fix: harden IDA preprocessing and cpp test vtable parsing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "hl2sdk_cs2"]
 	path = hl2sdk_cs2
-	url = https://github.com/alliedmodders/hl2sdk
-	branch = cs2
+	url = https://github.com/HLND2T/hl2sdk
+	branch = cs2_vibe

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, all signatures/offsets from **CounterStrikeSharp** and **CS2Fixes** c
 
 1. [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-2. [depotdownloader](https://github.com/steamre/depotdownloader)
+2. [depotdownloader](https://github.com/steamre/depotdownloader) (`depotdownloader.exe` must be available in PATH)
 
 3. claude / codex
 
@@ -22,7 +22,7 @@ Currently, all signatures/offsets from **CounterStrikeSharp** and **CS2Fixes** c
 
 6. [idalib](https://docs.hex-rays.com/user-guide/idalib) (mandatory for `ida_analyze_bin.py`)
 
-7. Clang-LLVM (mandatory for `run_cpp_tests.py`)
+7. Clang-LLVM (mandatory for `run_cpp_tests.py`, `clang.exe` must be available in PATH)
 
 ## Overall workflow
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -12,7 +12,7 @@
 
 1. 安装 [uv](https://docs.astral.sh/uv/getting-started/installation/)
 
-2. [depotdownloader](https://github.com/steamre/depotdownloader)
+2. [depotdownloader](https://github.com/steamre/depotdownloader) (需要将depotdownloader.exe所在目录添加到PATH中)
 
 3. `uv sync`
 
@@ -24,7 +24,7 @@
 
 7. [idalib](https://docs.hex-rays.com/user-guide/idalib)（运行 `ida_analyze_bin.py` 的必需项）
 
-8. Clang-LLVM（运行 `run_cpp_tests.py` 的必需项）
+8. Clang-LLVM（运行 `run_cpp_tests.py` 的必需项，需要将clang.exe所在目录添加到PATH中）
 
 ## 整体工作流
 

--- a/cpp_tests_util.py
+++ b/cpp_tests_util.py
@@ -16,6 +16,10 @@ except ImportError:
 VFTABLE_HEADER_RE = re.compile(
     r"^\s*(?:VFTable|VTable) indices for '([^']+)' \((\d+) (?:entry|entries)\)\.\s*$"
 )
+VFTABLE_LAYOUT_HEADER_RE = re.compile(
+    r"^\s*(?:VFTable|VTable) for '([^']+)'(?: in '([^']+)')? "
+    r"\((\d+) (?:entry|entries)\)\.\s*$"
+)
 VFTABLE_ENTRY_RE = re.compile(r"^\s*(\d+)\s+\|\s+(.+?)\s*$")
 # Group 2 captures the run of spaces between `|` and the declaration so the
 # parser can derive nesting depth from clang's 2-space-per-level indentation.
@@ -75,17 +79,52 @@ def parse_vftable_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
     parsed: Dict[str, Dict[str, Any]] = {}
     current_class: Optional[str] = None
     current_declared_entries = 0
+    current_raw_declared_entries = 0
+    current_raw_entries = 0
+    current_metadata_entries = 0
+    current_section_kind = ""
 
     for raw_line in compiler_output.splitlines():
         header = VFTABLE_HEADER_RE.match(raw_line)
         if header:
-            current_class = header.group(1)
+            class_name = header.group(1)
             declared_entries = int(header.group(2))
+            if parsed.get(class_name, {}).get("source_kind") == "complete":
+                current_class = None
+                current_declared_entries = 0
+                current_raw_declared_entries = 0
+                current_raw_entries = 0
+                current_metadata_entries = 0
+                current_section_kind = ""
+                continue
+
+            current_class = class_name
             current_declared_entries = declared_entries
+            current_raw_declared_entries = declared_entries
+            current_raw_entries = 0
+            current_metadata_entries = 0
+            current_section_kind = "indices"
             parsed[current_class] = {
                 "declared_entries": declared_entries,
                 "methods_by_index": {},
                 "entry_count": 0,
+                "source_kind": "indices",
+            }
+            continue
+
+        layout_header = VFTABLE_LAYOUT_HEADER_RE.match(raw_line)
+        if layout_header:
+            current_class = layout_header.group(2) or layout_header.group(1)
+            current_declared_entries = 0
+            current_raw_declared_entries = int(layout_header.group(3))
+            current_raw_entries = 0
+            current_metadata_entries = 0
+            current_section_kind = "complete"
+            parsed[current_class] = {
+                "declared_entries": 0,
+                "methods_by_index": {},
+                "entry_count": 0,
+                "source_kind": "complete",
             }
             continue
 
@@ -96,14 +135,19 @@ def parse_vftable_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
         if not entry:
             if (
                 current_class is not None
-                and parsed[current_class]["methods_by_index"]
+                and current_raw_entries
                 and not raw_line.strip()
             ):
                 current_class = None
                 current_declared_entries = 0
+                current_raw_declared_entries = 0
+                current_raw_entries = 0
+                current_metadata_entries = 0
+                current_section_kind = ""
             continue
 
         index = int(entry.group(1))
+        current_raw_entries += 1
         # Sections are already bounded by the next ``VFTable …`` header, a blank
         # line, or by reaching the declared entry count post-insertion (below).
         # Don't reject indices that exceed ``declared``: clang reports the count
@@ -112,32 +156,90 @@ def parse_vftable_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
         # base lists its own 14 entries at indices 10..23 — well past 14.
 
         signature = entry.group(2).strip()
+        if current_section_kind == "complete" and _is_vftable_metadata_entry(signature):
+            if not parsed[current_class]["methods_by_index"]:
+                current_metadata_entries += 1
+            if current_raw_entries >= current_raw_declared_entries:
+                current_class = None
+                current_declared_entries = 0
+                current_raw_declared_entries = 0
+                current_raw_entries = 0
+                current_metadata_entries = 0
+                current_section_kind = ""
+            continue
+
+        if current_section_kind == "complete":
+            index -= current_metadata_entries
+            if index < 0:
+                continue
+
         member_name = _extract_member_name(signature, current_class)
         parsed[current_class]["methods_by_index"][index] = {
             "signature": signature,
             "member_name": member_name,
         }
 
-        if len(parsed[current_class]["methods_by_index"]) >= current_declared_entries:
+        if current_section_kind == "complete":
+            section_done = current_raw_entries >= current_raw_declared_entries
+        else:
+            section_done = (
+                len(parsed[current_class]["methods_by_index"])
+                >= current_declared_entries
+            )
+        if section_done:
             current_class = None
             current_declared_entries = 0
+            current_raw_declared_entries = 0
+            current_raw_entries = 0
+            current_metadata_entries = 0
+            current_section_kind = ""
 
     for class_name, section in parsed.items():
         section["entry_count"] = len(section["methods_by_index"])
+        if section.get("source_kind") == "complete":
+            section["declared_entries"] = section["entry_count"]
 
     return parsed
+
+
+def _is_vftable_metadata_entry(signature: str) -> bool:
+    text = signature.strip()
+    if not text:
+        return True
+    if "::" not in text and text.endswith(" RTTI"):
+        return True
+    return text.startswith("offset_to_top")
 
 
 def _extract_member_name(signature: str, class_name: str) -> str:
     marker = f"{class_name}::"
     pos = signature.find(marker)
-    if pos < 0:
+    if pos >= 0:
+        tail = signature[pos + len(marker) :]
+        end = tail.find("(")
+        if end < 0:
+            end = len(tail)
+        return tail[:end].strip()
+
+    match = re.search(
+        r"(?:[A-Za-z_][A-Za-z0-9_]*::)+(~?[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+        signature,
+    )
+    if not match:
         return ""
-    tail = signature[pos + len(marker) :]
-    end = tail.find("(")
-    if end < 0:
-        end = len(tail)
-    return tail[:end].strip()
+    return match.group(1).strip()
+
+
+def _reference_member_matches(expected_member: str, actual_member: str) -> bool:
+    expected = expected_member.strip()
+    actual = actual_member.strip()
+    if not expected or not actual:
+        return True
+    if expected == actual:
+        return True
+    if expected in {"dtor", "vdtor"} and actual.startswith("~"):
+        return True
+    return expected.startswith(f"{actual}_")
 
 
 def parse_record_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
@@ -1076,10 +1178,11 @@ def compare_compiler_vtable_with_yaml(
 
         expected_member = ref_item.get("member_name", "")
         actual_member = compiled.get("member_name", "")
-        if expected_member and actual_member and expected_member != actual_member:
-            # "dtor"/"vdtor" in YAML matches any destructor "~ClassName" from compiler
-            if expected_member in {"dtor", "vdtor"} and actual_member.startswith("~"):
-                continue
+        if (
+            expected_member
+            and actual_member
+            and not _reference_member_matches(expected_member, actual_member)
+        ):
             report["differences"].append(
                 {
                     "type": "vfunc_name_mismatch",

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -59,6 +59,7 @@ except ImportError as e:
 from ida_skill_preprocessor import (
     PREPROCESS_STATUS_ABSENT_OK,
     PREPROCESS_STATUS_FAILED,
+    PREPROCESS_STATUS_NO_SCRIPT,
     PREPROCESS_STATUS_SUCCESS,
     preprocess_single_skill_via_mcp,
 )
@@ -2363,6 +2364,7 @@ def process_binary(
 
     try:
         # Process each skill: try preprocess first, then run_skill if needed
+        abort_binary_processing = False
         for skill_index, (
             skill_name,
             required_outputs,
@@ -2399,6 +2401,7 @@ def process_binary(
                 remaining = len(skills_to_process) - skill_index
                 fail_count += remaining
                 print(f"  Failed to restore MCP connection, aborting remaining {remaining} skill(s)")
+                abort_binary_processing = True
                 break
 
             # Check if all expected_input files are available before running the skill
@@ -2477,6 +2480,8 @@ def process_binary(
                 preprocess_status = PREPROCESS_STATUS_SUCCESS
             elif preprocess_status == PREPROCESS_STATUS_ABSENT_OK:
                 preprocess_status = PREPROCESS_STATUS_ABSENT_OK
+            elif preprocess_status == PREPROCESS_STATUS_NO_SCRIPT:
+                preprocess_status = PREPROCESS_STATUS_NO_SCRIPT
             else:
                 preprocess_status = PREPROCESS_STATUS_FAILED
 
@@ -2496,6 +2501,9 @@ def process_binary(
                         f"  Pre-processed but missing expected_output: {skill_name} "
                         f"({', '.join(missing_names)})"
                     )
+                    print("  Aborting remaining skills after preprocess output validation failure")
+                    abort_binary_processing = True
+                    break
                 elif (
                     not required_outputs
                     and optional_outputs
@@ -2514,6 +2522,12 @@ def process_binary(
                 skip_count += 1
                 print(f"  Skipping skill: {skill_name} (preprocess reported absent_ok)")
                 continue
+            if preprocess_status == PREPROCESS_STATUS_FAILED:
+                fail_count += 1
+                print(f"  Failed: {skill_name} (preprocess failed)")
+                print("  Aborting remaining skills after preprocess failure")
+                abort_binary_processing = True
+                break
 
             if should_skip_skill_for_existing_outputs(required_outputs, optional_outputs):
                 print(f"  Skipping skill: {skill_name} (all outputs exist)")
@@ -2542,6 +2556,12 @@ def process_binary(
             else:
                 fail_count += 1
                 print(f"    Failed")
+                print("  Aborting remaining skills after fallback skill failure")
+                abort_binary_processing = True
+                break
+
+        if abort_binary_processing:
+            return success_count, fail_count, skip_count
 
         for object_index, object_name in enumerate(vcall_targets):
             process, mcp_ok = ensure_mcp_available(
@@ -2687,6 +2707,7 @@ def main():
     total_fail = 0
     total_skip = 0
     all_vcall_objects = set()
+    abort_processing = False
 
     for module in modules:
         module_name = module["name"]
@@ -2763,8 +2784,15 @@ def main():
             total_success += success
             total_fail += fail
             total_skip += skip
+            if fail > 0:
+                abort_processing = True
+                print("  Aborting remaining modules after binary processing failure")
+                break
 
-    if args.vcall_finder_filter and all_vcall_objects:
+        if abort_processing:
+            break
+
+    if args.vcall_finder_filter and all_vcall_objects and not abort_processing:
         print("\nRunning vcall_finder LLM aggregation")
         for object_name in sorted(all_vcall_objects):
             print(f"  Aggregating vcall_finder: {object_name}")

--- a/ida_skill_preprocessor.py
+++ b/ida_skill_preprocessor.py
@@ -40,6 +40,7 @@ class PreprocessStatus(str):
 PREPROCESS_STATUS_SUCCESS = PreprocessStatus("success", True)
 PREPROCESS_STATUS_FAILED = PreprocessStatus("failed", False)
 PREPROCESS_STATUS_ABSENT_OK = PreprocessStatus("absent_ok", True)
+PREPROCESS_STATUS_NO_SCRIPT = PreprocessStatus("no_script", False)
 
 
 def _normalize_preprocess_status(result):
@@ -47,6 +48,8 @@ def _normalize_preprocess_status(result):
         return PREPROCESS_STATUS_SUCCESS
     if result == PREPROCESS_STATUS_ABSENT_OK:
         return PREPROCESS_STATUS_ABSENT_OK
+    if result == PREPROCESS_STATUS_NO_SCRIPT:
+        return PREPROCESS_STATUS_NO_SCRIPT
     return PREPROCESS_STATUS_FAILED
 
 
@@ -125,8 +128,15 @@ async def preprocess_single_skill_via_mcp(
         debug: enable debug output
 
     Returns:
-        One of: "success", "absent_ok", or "failed"
+        One of: "success", "absent_ok", "no_script", or "failed"
     """
+    script_path = _SCRIPT_DIR / f"{skill_name}.py"
+    if not script_path.exists():
+        if debug:
+            print(f"    Preprocess: no script for skill {skill_name}: {script_path}")
+        _SCRIPT_ENTRY_CACHE[skill_name] = None
+        return PREPROCESS_STATUS_NO_SCRIPT
+
     preprocess_func = _get_preprocess_entry(skill_name, debug=debug)
     if preprocess_func is None:
         return PREPROCESS_STATUS_FAILED

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -1273,7 +1273,7 @@ class TestProcessBinary(unittest.TestCase):
                 patch.object(
                     ida_analyze_bin,
                     "_run_preprocess_single_skill_via_mcp",
-                    return_value="failed",
+                    return_value="no_script",
                 ) as mock_preprocess,
                 patch.object(ida_analyze_bin, "run_skill", return_value=False) as mock_run_skill,
                 patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
@@ -1370,7 +1370,233 @@ class TestProcessBinary(unittest.TestCase):
         self.assertEqual(1, mock_preprocess.call_count)
         mock_run_skill.assert_not_called()
 
-    def test_process_binary_skips_optional_only_skill_when_preprocess_fails_without_output(
+    def test_process_binary_aborts_when_preprocess_script_fails_without_fallback(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    return_value="failed",
+                ) as mock_preprocess,
+                patch.object(ida_analyze_bin, "run_skill", return_value=True) as mock_run_skill,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                success, fail, skip = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "a_preprocess_fails",
+                            "expected_output": ["A.{platform}.yaml"],
+                            "expected_input": [],
+                        },
+                        {
+                            "name": "b_should_not_run",
+                            "expected_output": ["B.{platform}.yaml"],
+                            "expected_input": [],
+                        },
+                    ],
+                    old_binary_dir=None,
+                    platform="windows",
+                    agent="codex",
+                    max_retries=1,
+                    debug=True,
+                    host="127.0.0.1",
+                    port=39091,
+                    ida_args=None,
+                )
+
+        self.assertEqual((0, 1, 0), (success, fail, skip))
+        self.assertEqual(1, mock_preprocess.call_count)
+        self.assertEqual(
+            "a_preprocess_fails",
+            mock_preprocess.call_args.kwargs["skill_name"],
+        )
+        mock_run_skill.assert_not_called()
+
+    def test_process_binary_skips_vcall_targets_after_preprocess_failure(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    return_value="failed",
+                ),
+                patch.object(ida_analyze_bin, "run_skill") as mock_run_skill,
+                patch.object(
+                    ida_analyze_bin,
+                    "preprocess_single_vcall_object_via_mcp",
+                    new_callable=AsyncMock,
+                    return_value={
+                        "status": "success",
+                        "exported_functions": 1,
+                        "failed_functions": 0,
+                        "skipped_functions": 0,
+                    },
+                ) as mock_vcall,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                success, fail, skip = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "a_preprocess_fails",
+                            "expected_output": ["A.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    old_binary_dir=None,
+                    platform="windows",
+                    agent="codex",
+                    max_retries=1,
+                    debug=True,
+                    host="127.0.0.1",
+                    port=39091,
+                    ida_args=None,
+                    vcall_targets=["g_pShouldNotRun"],
+                )
+
+        self.assertEqual((0, 1, 0), (success, fail, skip))
+        mock_run_skill.assert_not_called()
+        mock_vcall.assert_not_called()
+
+    def test_process_binary_runs_fallback_skill_only_when_preprocess_has_no_script(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    return_value="no_script",
+                ) as mock_preprocess,
+                patch.object(ida_analyze_bin, "run_skill", return_value=True) as mock_run_skill,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                success, fail, skip = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "find-fallback-only",
+                            "expected_output": ["FallbackOnly.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    old_binary_dir=None,
+                    platform="windows",
+                    agent="codex",
+                    max_retries=1,
+                    debug=True,
+                    host="127.0.0.1",
+                    port=39091,
+                    ida_args=None,
+                )
+
+        self.assertEqual((1, 0, 0), (success, fail, skip))
+        mock_preprocess.assert_called_once()
+        mock_run_skill.assert_called_once()
+
+    def test_process_binary_aborts_when_fallback_skill_fails(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    return_value="no_script",
+                ) as mock_preprocess,
+                patch.object(ida_analyze_bin, "run_skill", return_value=False) as mock_run_skill,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                success, fail, skip = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "a_fallback_fails",
+                            "expected_output": ["A.{platform}.yaml"],
+                            "expected_input": [],
+                        },
+                        {
+                            "name": "b_should_not_run",
+                            "expected_output": ["B.{platform}.yaml"],
+                            "expected_input": [],
+                        },
+                    ],
+                    old_binary_dir=None,
+                    platform="windows",
+                    agent="codex",
+                    max_retries=1,
+                    debug=True,
+                    host="127.0.0.1",
+                    port=39091,
+                    ida_args=None,
+                )
+
+        self.assertEqual((0, 1, 0), (success, fail, skip))
+        self.assertEqual(1, mock_preprocess.call_count)
+        self.assertEqual(1, mock_run_skill.call_count)
+
+    def test_process_binary_skips_optional_only_skill_when_no_preprocess_script_and_no_output(
         self,
     ) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -1398,7 +1624,7 @@ class TestProcessBinary(unittest.TestCase):
                 patch.object(
                     ida_analyze_bin,
                     "_run_preprocess_single_skill_via_mcp",
-                    return_value="failed",
+                    return_value="no_script",
                 ) as mock_preprocess,
                 patch.object(ida_analyze_bin, "run_skill", return_value=False) as mock_run_skill,
                 patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
@@ -1608,7 +1834,7 @@ class TestProcessBinary(unittest.TestCase):
                 patch.object(
                     ida_analyze_bin,
                     "_run_preprocess_single_skill_via_mcp",
-                    return_value="failed",
+                    return_value="no_script",
                 ),
                 patch.object(ida_analyze_bin, "run_skill", return_value=True) as mock_run_skill,
                 patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
@@ -3099,6 +3325,74 @@ class TestMainLlmWiring(unittest.TestCase):
             },
             captured["kwargs"],
         )
+
+    @patch.object(ida_analyze_bin, "parse_config")
+    @patch("ida_analyze_bin.os.path.exists", return_value=True)
+    @patch.object(ida_analyze_bin, "parse_args")
+    def test_main_aborts_after_process_binary_failure_and_skips_later_work(
+        self,
+        mock_parse_args,
+        _mock_exists,
+        mock_parse_config,
+    ) -> None:
+        mock_parse_args.return_value = SimpleNamespace(
+            configyaml="config.yaml",
+            bindir="bin",
+            gamever="14141",
+            oldgamever=None,
+            platforms=["windows"],
+            module_filter=None,
+            modules="*",
+            agent="codex",
+            ida_args="",
+            debug=False,
+            maxretry=3,
+            vcall_finder_filter={"all": True},
+            llm_model="gpt-4.1-mini",
+            llm_apikey=None,
+            llm_baseurl=None,
+            llm_temperature=None,
+            llm_effort="high",
+            llm_fake_as="codex",
+            rename=False,
+        )
+        mock_parse_config.return_value = [
+            {
+                "name": "engine",
+                "skills": [
+                    {
+                        "name": "find-first",
+                        "expected_output": ["First.{platform}.yaml"],
+                        "expected_input": [],
+                    }
+                ],
+                "vcall_finder_objects": ["g_pFirst"],
+                "path_windows": "game/bin/win64/engine2.dll",
+            },
+            {
+                "name": "server",
+                "skills": [
+                    {
+                        "name": "find-second",
+                        "expected_output": ["Second.{platform}.yaml"],
+                        "expected_input": [],
+                    }
+                ],
+                "vcall_finder_objects": ["g_pSecond"],
+                "path_windows": "game/bin/win64/server.dll",
+            },
+        ]
+
+        with (
+            patch.object(ida_analyze_bin, "process_binary", return_value=(0, 1, 0)) as mock_process,
+            patch.object(ida_analyze_bin, "aggregate_vcall_results_for_object") as mock_aggregate,
+            self.assertRaises(SystemExit) as exit_context,
+        ):
+            ida_analyze_bin.main()
+
+        self.assertEqual(1, exit_context.exception.code)
+        self.assertEqual(1, mock_process.call_count)
+        mock_aggregate.assert_not_called()
 
 
 class TestMainPostProcessWiring(unittest.TestCase):

--- a/tests/test_ida_preprocessor_scripts.py
+++ b/tests/test_ida_preprocessor_scripts.py
@@ -1698,6 +1698,25 @@ class TestFindCSpawnGroupMgrGameSystemDoesGameSystemReallocate(
 
 
 class TestPreprocessSingleSkillViaMcp(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_no_script_when_skill_has_no_preprocessor_script(self) -> None:
+        with patch.object(
+            ida_skill_preprocessor,
+            "_get_preprocess_entry",
+            return_value=None,
+        ):
+            result = await ida_skill_preprocessor.preprocess_single_skill_via_mcp(
+                host="127.0.0.1",
+                port=13337,
+                skill_name="find-NoPreprocessorScript",
+                expected_outputs=["out.yaml"],
+                old_yaml_map={},
+                new_binary_dir="bin_dir",
+                platform="windows",
+                debug=True,
+            )
+
+        self.assertEqual("no_script", result)
+
     async def test_forwards_llm_config_when_script_accepts_it(self) -> None:
         received = {}
 

--- a/tests/test_run_cpp_tests.py
+++ b/tests/test_run_cpp_tests.py
@@ -25,6 +25,88 @@ class TestParseVftableLayouts(unittest.TestCase):
             parsed["ILoopType"]["methods_by_index"][0]["member_name"],
         )
 
+    def test_prefers_complete_vftable_for_derived_class(self) -> None:
+        compiler_output = (
+            "VFTable indices for 'IParent' (2 entries).\n"
+            "   0 | void IParent::ParentVirtual() [pure]\n"
+            "   1 | void IParent::ParentOverload(int) [pure]\n"
+            "\n"
+            "VFTable for 'IParent' in 'CDerived' (5 entries).\n"
+            "   0 | CDerived RTTI\n"
+            "   1 | void IParent::ParentVirtual() [pure]\n"
+            "   2 | void IParent::ParentOverload(int) [pure]\n"
+            "   3 | CDerived::~CDerived() [scalar deleting] [pure]\n"
+            "   4 | void CDerived::ChildVirtual() [pure]\n"
+            "\n"
+            "VFTable indices for 'CDerived' (2 entries).\n"
+            "   2 | CDerived::~CDerived() [scalar deleting]\n"
+            "   3 | void CDerived::ChildVirtual()\n"
+        )
+
+        parsed = cpp_tests_util.parse_vftable_layouts(compiler_output)
+
+        self.assertIn("CDerived", parsed)
+        self.assertEqual(4, parsed["CDerived"]["declared_entries"])
+        self.assertEqual(4, parsed["CDerived"]["entry_count"])
+        self.assertEqual(
+            "ParentVirtual",
+            parsed["CDerived"]["methods_by_index"][0]["member_name"],
+        )
+        self.assertEqual(
+            "ParentOverload",
+            parsed["CDerived"]["methods_by_index"][1]["member_name"],
+        )
+        self.assertEqual(
+            "~CDerived",
+            parsed["CDerived"]["methods_by_index"][2]["member_name"],
+        )
+        self.assertEqual(
+            "ChildVirtual",
+            parsed["CDerived"]["methods_by_index"][3]["member_name"],
+        )
+
+
+class TestCompareVtableWithYaml(unittest.TestCase):
+    def test_complete_derived_vftable_matches_inherited_overload_reference(self) -> None:
+        compiler_output = (
+            "VFTable for 'IParent' in 'CDerived' (4 entries).\n"
+            "   0 | CDerived RTTI\n"
+            "   1 | void IParent::ParentVirtual() [pure]\n"
+            "   2 | void IParent::ParentOverload(int) [pure]\n"
+            "   3 | void CDerived::ChildVirtual() [pure]\n"
+            "\n"
+            "VFTable indices for 'CDerived' (1 entry).\n"
+            "   2 | void CDerived::ChildVirtual()\n"
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_dir = Path(temp_dir) / "14167" / "server"
+            module_dir.mkdir(parents=True)
+            (module_dir / "CDerived_vtable.windows.yaml").write_text(
+                "vtable_class: CDerived\n"
+                "vtable_size: '0x18'\n"
+                "vtable_numvfunc: 3\n",
+                encoding="utf-8",
+            )
+            (module_dir / "CDerived_ParentOverload_Int.windows.yaml").write_text(
+                "func_name: CDerived_ParentOverload_Int\n"
+                "vtable_name: CDerived\n"
+                "vfunc_index: 1\n",
+                encoding="utf-8",
+            )
+
+            report = cpp_tests_util.compare_compiler_vtable_with_yaml(
+                class_name="CDerived",
+                compiler_output=compiler_output,
+                bindir=Path(temp_dir),
+                gamever="14167",
+                platform="windows",
+                reference_modules=["server"],
+                pointer_size=8,
+            )
+
+        self.assertEqual([], report["differences"])
+
 
 class TestParseRecordLayouts(unittest.TestCase):
     def test_parses_struct_member_offsets_from_record_layout(self) -> None:


### PR DESCRIPTION
## Summary
- stop IDA analysis when preprocessors or skill fallbacks fail instead of continuing with incomplete results
- parse inherited C++ vtable entries in cpp test utilities and cover the behavior with unit tests
- update hl2sdk submodule/docs references for the `cs2_vibe` switch

## Test Plan
- [x] `uv run python -m unittest discover -s tests -b` (560 tests)