### PR TITLE
Add find-CEntitySystem_HelperExecuteQueuedSpawn preprocessor script and pre-commit checks

### DIFF
--- a/.claude/skills/create-preprocessor-scripts/SKILL.md
+++ b/.claude/skills/create-preprocessor-scripts/SKILL.md
@@ -456,7 +456,39 @@ This step is mandatory -- do not report completion without running and passing t
 
 ---
 
-## Step 6: Commit Changes
+## Step 6: Verify Formatting and Regression Tests
+
+Before committing, verify code formatting for tracked Python/YAML files and run the regression test suite.
+
+### 6a. Formatting
+
+Check formatting for all tracked Python/YAML files:
+
+```bash
+uv run python format_repo_files.py --check
+```
+
+If the check reports files that need formatting, apply it:
+
+```bash
+uv run python format_repo_files.py
+```
+
+### 6b. Regression Tests
+
+Run the unittest suite:
+
+```bash
+uv run python -m unittest discover -s tests -b
+```
+
+**Keep 0 unittest failures before committing.** If any test fails, investigate and fix it before proceeding to the commit step.
+
+This step is mandatory -- do not commit until formatting passes (`--check` is clean) and the unittest suite reports 0 failures.
+
+---
+
+## Step 7: Commit Changes
 
 After validation passes, commit all changes to git.
 
@@ -495,6 +527,8 @@ Before finishing, verify:
 - [ ] config.yaml `symbols` section has entries for all targets (no duplicates)
 - [ ] Pattern-specific checks pass (see the Checklist section in the chosen pattern reference file)
 - [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures
+- [ ] `uv run python format_repo_files.py --check` reports no formatting issues (run `uv run python format_repo_files.py` to fix)
+- [ ] `uv run python -m unittest discover -s tests -b` passes with 0 failures
 - [ ] All changes committed to git (on `dev` branch, NOT `main`)
 
 ## Real-World Examples

--- a/.serena/memories/completion_checklist.md
+++ b/.serena/memories/completion_checklist.md
@@ -2,5 +2,6 @@
 
 - If changing scripts/config, ensure CLI usage in README and docstrings stays accurate.
 - Before completion, run `uv run python format_repo_files.py --check` to verify formatting for tracked Python/YAML files. Use `uv run python format_repo_files.py` to apply formatting when needed.
+- Before completion, run `uv run python -m unittest discover -s tests -b` to verify the regression tests. We should keep 0 unittest failure before committing.
 - Formatting uses Ruff for `*.py` and yamlfix for tracked `*.yaml`; generated YAML under `ida_preprocessor_scripts/references/` is intentionally skipped.
 - If outputs are expected, verify YAML in bin/<gamever>/... and gamedata outputs in dist/...

--- a/config.yaml
+++ b/config.yaml
@@ -4278,6 +4278,12 @@ modules:
           - CEntitySystem_ExecuteQueuedCreation.{platform}.yaml
         expected_input:
           - CBaseEntity_DispatchSpawn.{platform}.yaml
+      - name: find-CEntitySystem_HelperExecuteQueuedSpawn
+        expected_output:
+          - CEntitySystem_HelperExecuteQueuedSpawn.{platform}.yaml
+        expected_input:
+          - CEntityIdentity_SetEntityName.{platform}.yaml
+          - CEntityIdentity_FreeAttributes.{platform}.yaml
       - name: find-CEntitySystem_ExecuteQueuedActivates-AND-CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
         expected_output:
           - CEntitySystem_ExecuteQueuedActivates.{platform}.yaml
@@ -7162,6 +7168,10 @@ modules:
         category: func
         alias:
           - CEntitySystem::QueueSpawnEntity
+      - name: CEntitySystem_HelperExecuteQueuedSpawn
+        category: func
+        alias:
+          - CEntitySystem::HelperExecuteQueuedSpawn
       - name: CEntitySystem_InstallCreationWrapperCallbacks
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEntitySystem_HelperExecuteQueuedSpawn.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_HelperExecuteQueuedSpawn.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_HelperExecuteQueuedSpawn skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_HelperExecuteQueuedSpawn",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEntitySystem_HelperExecuteQueuedSpawn",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEntityIdentity_SetEntityName", "CEntityIdentity_FreeAttributes"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntitySystem_HelperExecuteQueuedSpawn",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CEntitySystem_HelperExecuteQueuedSpawn` preprocessor script and corresponding `config.yaml` entries
- Require formatting checks (`format_repo_files.py --check`) and the regression test suite (`unittest discover -s tests`) to pass before committing, documented in the `create-preprocessor-scripts` skill and completion checklist memory

## Test plan
- [x] `uv run ida_analyze_bin.py -debug` passes with 0 failures
- [x] `uv run python format_repo_files.py --check` reports no formatting issues
- [x] `uv run python -m unittest discover -s tests -b` passes with 0 failures