### PR TITLE
Fix PR self-runner workspace finalization and SortEntities script

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -2,7 +2,7 @@ name: PR Self Runner Validation
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, closed]
 
 permissions:
   contents: read
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   validate:
     if: >-
+      github.event.action != 'closed' &&
       (github.repository == 'HLND2T/CS2_VibeSignatures' ||
        github.repository == 'hzqst/CS2_VibeSignatures') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -289,58 +290,137 @@ jobs:
             throw "run_cpp_tests.py failed with exit code $LASTEXITCODE"
           }
 
-      - name: Clean PR bin copy
-        if: always()
+  finalize-pr-workspace:
+    if: >-
+      github.event.action == 'closed' &&
+      (github.repository == 'HLND2T/CS2_VibeSignatures' ||
+       github.repository == 'hzqst/CS2_VibeSignatures') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !(github.event.pull_request.user.login == 'github-actions[bot]' &&
+        startsWith(github.event.pull_request.head.ref, 'bump-download/') &&
+        startsWith(github.event.pull_request.title, 'chore(download): Update manifest for '))
+    environment: win64
+    runs-on: [self-hosted, windows, x64]
+    env:
+      PERSISTED_WORKSPACE: ${{ secrets.PERSISTED_WORKSPACE }}
+
+    steps:
+      - name: Finalize PR workspace
         shell: pwsh
         run: |
-          if ([string]::IsNullOrWhiteSpace($env:WORKSPACE)) {
-            Write-Host "WORKSPACE is not configured; skipping PR bin cleanup."
-            exit 0
+          $prNumber = "${{ github.event.pull_request.number }}"
+          $prWasMerged = "${{ github.event.pull_request.merged }}"
+
+          if ([string]::IsNullOrWhiteSpace($prNumber)) {
+            throw "Unable to determine pull request number."
           }
 
-          if ([string]::IsNullOrWhiteSpace($env:GAMEVER)) {
-            Write-Host "GAMEVER is not configured; skipping PR bin cleanup."
-            exit 0
+          if ([string]::IsNullOrWhiteSpace($env:RUNNER_WORKSPACE)) {
+            throw "RUNNER_WORKSPACE is not configured."
           }
 
-          $workspaceRoot = [IO.Path]::GetFullPath($env:WORKSPACE)
-          $binRoot = [IO.Path]::GetFullPath((Join-Path $workspaceRoot "bin"))
-          $targetBinGamever = [IO.Path]::GetFullPath((Join-Path $binRoot $env:GAMEVER))
+          $workspaceRoot = [IO.Path]::GetFullPath($env:RUNNER_WORKSPACE)
+          $workspaceName = "CS2_VibeSignatures-pr-$prNumber"
+          $prWorkspace = [IO.Path]::GetFullPath((Join-Path $workspaceRoot $workspaceName))
           $workspaceRootWithSeparator = $workspaceRoot.TrimEnd('\') + '\'
-          $binRootWithSeparator = $binRoot.TrimEnd('\') + '\'
 
-          if (-not $binRoot.StartsWith($workspaceRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Resolved bin root is outside WORKSPACE: $binRoot"
+          if ((Split-Path -Leaf $prWorkspace) -ne $workspaceName) {
+            throw "Resolved PR workspace leaf mismatch: $prWorkspace"
           }
 
-          if (Test-Path -LiteralPath $binRoot) {
-            $binItem = Get-Item -LiteralPath $binRoot -Force
-            if ($binItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
-              throw "Refusing to clean PR bin copy because workspace bin is a reparse point: $binRoot"
+          if (-not $prWorkspace.StartsWith($workspaceRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+            throw "Resolved PR workspace is outside RUNNER_WORKSPACE: $prWorkspace"
+          }
+
+          if (-not (Test-Path -LiteralPath $prWorkspace)) {
+            if ($prWasMerged -eq "true") {
+              throw "PR workspace does not exist for merged PR: $prWorkspace"
             }
-          }
 
-          if ((Split-Path -Leaf $targetBinGamever) -ne $env:GAMEVER) {
-            throw "Resolved PR bin cleanup leaf mismatch: $targetBinGamever"
-          }
-
-          if (-not $targetBinGamever.StartsWith($binRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
-            throw "Resolved PR bin cleanup target is outside workspace bin root: $targetBinGamever"
-          }
-
-          if (-not (Test-Path -LiteralPath $targetBinGamever)) {
-            Write-Host "PR bin cleanup target does not exist: $targetBinGamever"
+            Write-Host "PR workspace does not exist; nothing to delete: $prWorkspace"
             exit 0
           }
 
-          if (-not (Test-Path -LiteralPath $targetBinGamever -PathType Container)) {
-            throw "PR bin cleanup target exists but is not a directory: $targetBinGamever"
+          if (-not (Test-Path -LiteralPath $prWorkspace -PathType Container)) {
+            throw "PR workspace exists but is not a directory: $prWorkspace"
           }
 
-          $targetItem = Get-Item -LiteralPath $targetBinGamever -Force
-          if ($targetItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
-            throw "Refusing to remove PR bin cleanup target because it is a reparse point: $targetBinGamever"
+          $workspaceItem = Get-Item -LiteralPath $prWorkspace -Force
+          if ($workspaceItem.Attributes -band [IO.FileAttributes]::ReparsePoint) {
+            throw "Refusing to remove PR workspace because it is a reparse point: $prWorkspace"
           }
 
-          Remove-Item -LiteralPath $targetBinGamever -Recurse -Force
-          Write-Host "Removed PR bin copy: $targetBinGamever"
+          if ($prWasMerged -eq "true") {
+            if ([string]::IsNullOrWhiteSpace($env:PERSISTED_WORKSPACE)) {
+              throw "PERSISTED_WORKSPACE secret is not configured for the win64 environment."
+            }
+
+            Set-Location $prWorkspace
+            $gamever = uv run python -c "import yaml; d=yaml.safe_load(open('download.yaml', encoding='utf-8')); print(d['downloads'][-1]['tag'])"
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to read latest game version from PR download.yaml."
+            }
+
+            $gamever = $gamever.Trim()
+            if ([string]::IsNullOrWhiteSpace($gamever)) {
+              throw "Latest game version from PR download.yaml is empty."
+            }
+
+            $sourceBinGamever = [IO.Path]::GetFullPath((Join-Path $prWorkspace "bin\$gamever"))
+            $sourceRootWithSeparator = $prWorkspace.TrimEnd('\') + '\'
+            if (-not $sourceBinGamever.StartsWith($sourceRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+              throw "Resolved PR bin source is outside PR workspace: $sourceBinGamever"
+            }
+
+            if (-not (Test-Path -LiteralPath $sourceBinGamever -PathType Container)) {
+              throw "PR bin source for GAMEVER=$gamever does not exist: $sourceBinGamever"
+            }
+
+            $persistedRoot = [IO.Path]::GetFullPath($env:PERSISTED_WORKSPACE)
+            $persistedBinRoot = [IO.Path]::GetFullPath((Join-Path $persistedRoot "bin"))
+            $targetBinGamever = [IO.Path]::GetFullPath((Join-Path $persistedBinRoot $gamever))
+            $persistedRootWithSeparator = $persistedRoot.TrimEnd('\') + '\'
+            $persistedBinRootWithSeparator = $persistedBinRoot.TrimEnd('\') + '\'
+
+            if (-not $persistedBinRoot.StartsWith($persistedRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+              throw "Resolved persisted bin root is outside PERSISTED_WORKSPACE: $persistedBinRoot"
+            }
+
+            if ((Split-Path -Leaf $targetBinGamever) -ne $gamever) {
+              throw "Resolved persisted bin target leaf mismatch: $targetBinGamever"
+            }
+
+            if (-not $targetBinGamever.StartsWith($persistedBinRootWithSeparator, [StringComparison]::OrdinalIgnoreCase)) {
+              throw "Resolved persisted bin target is outside persisted bin root: $targetBinGamever"
+            }
+
+            New-Item -ItemType Directory -Path $targetBinGamever -Force | Out-Null
+
+            $robocopyArgs = @(
+              $sourceBinGamever
+              $targetBinGamever
+              "*.yaml"
+              "/S"
+              "/COPY:DAT"
+              "/DCOPY:DAT"
+              "/R:2"
+              "/W:5"
+              "/XC"
+              "/XN"
+              "/XO"
+            )
+
+            robocopy @robocopyArgs
+            $robocopyExitCode = $LASTEXITCODE
+            if ($robocopyExitCode -ge 8) {
+              throw "Failed to copy PR bin/$gamever YAML files into persisted workspace; robocopy exit code $robocopyExitCode"
+            }
+
+            Write-Host "Copied PR bin/$gamever YAML files into persisted workspace; robocopy exit code $robocopyExitCode"
+            $global:LASTEXITCODE = 0
+          } else {
+            Write-Host "PR was closed without merge; skipping persisted YAML copy."
+          }
+
+          Remove-Item -LiteralPath $prWorkspace -Recurse -Force
+          Write-Host "Removed PR workspace: $prWorkspace"

--- a/config.yaml
+++ b/config.yaml
@@ -4284,6 +4284,18 @@ modules:
         expected_input:
           - CEntityIdentity_SetEntityName.{platform}.yaml
           - CEntityIdentity_FreeAttributes.{platform}.yaml
+      - name: find-CEntitySystem_SortEntities
+        expected_output:
+          - CEntitySystem_SortEntities.{platform}.yaml
+        expected_input:
+          - CEntitySystem_HelperExecuteQueuedSpawn.{platform}.yaml
+          - CEntitySystem_vtable.{platform}.yaml
+      - name: find-CGameEntitySystem_SortEntities
+        expected_output:
+          - CGameEntitySystem_SortEntities.{platform}.yaml
+        expected_input:
+          - CEntitySystem_SortEntities.{platform}.yaml
+          - CGameEntitySystem_vtable.{platform}.yaml
       - name: find-CEntitySystem_ExecuteQueuedActivates-AND-CEntitySystem_ExecuteQueuedPostDataUpdateAndActivates
         expected_output:
           - CEntitySystem_ExecuteQueuedActivates.{platform}.yaml
@@ -7172,6 +7184,14 @@ modules:
         category: func
         alias:
           - CEntitySystem::HelperExecuteQueuedSpawn
+      - name: CEntitySystem_SortEntities
+        category: vfunc
+        alias:
+          - CEntitySystem::SortEntities
+      - name: CGameEntitySystem_SortEntities
+        category: vfunc
+        alias:
+          - CGameEntitySystem::SortEntities
       - name: CEntitySystem_InstallCreationWrapperCallbacks
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEntitySystem_SortEntities.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_SortEntities.py
@@ -40,8 +40,15 @@ GENERATE_YAML_DESIRED_FIELDS = [
 
 
 async def preprocess_skill(
-    session, skill_name, expected_outputs, old_yaml_map,
-    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
 ):
     """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
     return await preprocess_common_skill(

--- a/ida_preprocessor_scripts/find-CEntitySystem_SortEntities.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_SortEntities.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntitySystem_SortEntities skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntitySystem_SortEntities",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "CEntitySystem_SortEntities",
+        "prompt/call_llm_decompile.md",
+        "references/server/CEntitySystem_HelperExecuteQueuedSpawn.{platform}.yaml",
+    ),
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEntitySystem_SortEntities", "CEntitySystem"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: CEntitySystem_SortEntities is an empty stub that just returns 0
+    # and is not used as a downstream LLM_DECOMPILE predecessor, so func_va/func_sig
+    # are omitted. vfunc_sig is still mandatory for Pattern C.
+    (
+        "CEntitySystem_SortEntities",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map,
+    new_binary_dir, platform, image_base, llm_config=None, debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_SortEntities.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_SortEntities.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_SortEntities skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CGameEntitySystem_SortEntities", "CGameEntitySystem", "CEntitySystem_SortEntities", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEntitySystem_SortEntities",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.linux.yaml
@@ -307,7 +307,7 @@ disasm_code: |-
   .text:0000000001E61973                 mov     rax, [rbx]
   .text:0000000001E61976                 cmp     r15d, 1
   .text:0000000001E6197A                 jz      short loc_1E61993
-  .text:0000000001E6197C                 mov     rcx, [rax+98h]; 0x98 = CEntitySystem_SortEntities
+  .text:0000000001E6197C                 mov     rcx, [rax+98h]; 152LL = 0x98 = CEntitySystem_SortEntities
   .text:0000000001E61983                 lea     rdx, nullsub_1672
   .text:0000000001E6198A                 cmp     rcx, rdx
   .text:0000000001E6198D                 jnz     loc_1E61B90
@@ -728,7 +728,7 @@ procedure: |-
           v44 = *a1;
           if ( v20 != 1 )
           {
-            v45 = *(__int64 (__fastcall **)())(v44 + 152);// 152LL = CEntitySystem_SortEntities
+            v45 = *(__int64 (__fastcall **)())(v44 + 152);// 152LL = 0x98 = CEntitySystem_SortEntities
             if ( v45 != nullsub_1672 )
             {
               ((void (__fastcall *)(__int64 *, _QWORD, _QWORD *))v45)(a1, v20, dest);

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.linux.yaml
@@ -1,0 +1,751 @@
+func_name: CEntitySystem_HelperExecuteQueuedSpawn
+func_va: '0x1e61480'
+disasm_code: |-
+  .text:0000000001E61480                 mov     rax, 3200000000h
+  .text:0000000001E6148A                 push    rbp
+  .text:0000000001E6148B                 mov     rbp, rsp
+  .text:0000000001E6148E                 push    r15
+  .text:0000000001E61490                 push    r14
+  .text:0000000001E61492                 push    r13
+  .text:0000000001E61494                 mov     r13, rsi
+  .text:0000000001E61497                 push    r12
+  .text:0000000001E61499                 push    rbx
+  .text:0000000001E6149A                 mov     rbx, rdi
+  .text:0000000001E6149D                 sub     rsp, 4F8h
+  .text:0000000001E614A4                 movsxd  r12, dword ptr [rdi+0BE0h]
+  .text:0000000001E614AB                 mov     [rbp+var_4F0], rax
+  .text:0000000001E614B2                 cmp     r12d, 32h ; '2'
+  .text:0000000001E614B6                 jle     loc_1E61AF8
+  .text:0000000001E614BC                 mov     r14, cs:g_pMemAlloc_ptr
+  .text:0000000001E614C3                 lea     r15, [r12+r12*2]
+  .text:0000000001E614C7                 shl     r15, 3
+  .text:0000000001E614CB                 mov     rsi, r15
+  .text:0000000001E614CE                 mov     rdi, [r14]
+  .text:0000000001E614D1                 mov     rax, [rdi]
+  .text:0000000001E614D4                 call    qword ptr [rax+10h]
+  .text:0000000001E614D7                 mov     rdi, [r14]
+  .text:0000000001E614DA                 mov     rsi, rax
+  .text:0000000001E614DD                 mov     [rbp+dest], rax
+  .text:0000000001E614E4                 mov     rax, [rdi]
+  .text:0000000001E614E7                 call    qword ptr [rax+90h]
+  .text:0000000001E614ED                 cmp     r15, rax
+  .text:0000000001E614F0                 cmovb   r15, rax
+  .text:0000000001E614F4                 mov     eax, dword ptr [rbp+var_4F0+4]
+  .text:0000000001E614FA                 and     eax, 7FFFFFFFh
+  .text:0000000001E614FF                 jz      loc_1E61B30
+  .text:0000000001E61505                 ; src
+  .text:0000000001E61505                 lea     rsi, [rbp+src]; src
+  .text:0000000001E6150C                 cmp     eax, 32h ; '2'
+  .text:0000000001E6150F                 ja      loc_1E61B21
+  .text:0000000001E61515                 movsxd  rax, dword ptr [rbp+var_4F0]
+  .text:0000000001E6151C                 lea     rdx, [rax+rax*2]
+  .text:0000000001E61520                 ; n
+  .text:0000000001E61520                 shl     rdx, 3; n
+  .text:0000000001E61524                 lea     rax, [rsi+rdx]
+  .text:0000000001E61528                 cmp     rsi, rax
+  .text:0000000001E6152B                 jb      loc_1E61B10
+  .text:0000000001E61531                 mov     rax, [rbp+dest]
+  .text:0000000001E61538                 mov     [rbp+src], rax
+  .text:0000000001E6153F                 mov     rax, 0AAAAAAAAAAAAAAABh
+  .text:0000000001E61549                 mul     r15
+  .text:0000000001E6154C                 mov     eax, 7FFFFFFFh
+  .text:0000000001E61551                 shr     rdx, 4
+  .text:0000000001E61555                 cmp     rdx, rax
+  .text:0000000001E61558                 cmova   rdx, rax
+  .text:0000000001E6155C                 mov     dword ptr [rbp+var_4F0+4], edx
+  .text:0000000001E61562                 lea     rax, [rbp+var_500]
+  .text:0000000001E61569                 mov     rdx, [rbx+0BE8h]
+  .text:0000000001E61570                 shl     r12, 5
+  .text:0000000001E61574                 xor     r14d, r14d
+  .text:0000000001E61577                 mov     [rbp+var_510], rax
+  .text:0000000001E6157E                 jmp     short loc_1E615D7
+  .text:0000000001E61580                 mov     rsi, [rbp+var_510]
+  .text:0000000001E61587                 xor     edx, edx
+  .text:0000000001E61589                 mov     rax, 0FFFFFFFF4137AF6Bh
+  .text:0000000001E61593                 mov     [rbp+var_500], rax
+  .text:0000000001E6159A                 lea     rax, aTargetname_0; "targetname"
+  .text:0000000001E615A1                 mov     [rbp+var_4F8], rax
+  .text:0000000001E615A8                 call    sub_1E57DC0
+  .text:0000000001E615AD                 mov     rdi, rax
+  .text:0000000001E615B0                 test    rax, rax
+  .text:0000000001E615B3                 jz      short loc_1E615C7
+  .text:0000000001E615B5                 movzx   eax, word ptr [rax]
+  .text:0000000001E615B8                 shr     ax, 2
+  .text:0000000001E615BC                 and     eax, 0Fh
+  .text:0000000001E615BF                 cmp     al, 6
+  .text:0000000001E615C1                 jz      loc_1E61A00
+  .text:0000000001E615C7                 mov     rdx, [rbx+0BE8h]
+  .text:0000000001E615CE                 add     r14, 20h ; ' '
+  .text:0000000001E615D2                 cmp     r14, r12
+  .text:0000000001E615D5                 jz      short loc_1E61650
+  .text:0000000001E615D7                 lea     rax, [rdx+r14]
+  .text:0000000001E615DB                 mov     rdi, [rax+10h]
+  .text:0000000001E615DF                 test    rdi, rdi
+  .text:0000000001E615E2                 jz      short loc_1E615CE
+  .text:0000000001E615E4                 cmp     byte ptr [rax+18h], 0
+  .text:0000000001E615E8                 jz      short loc_1E615CE
+  .text:0000000001E615EA                 mov     r15, [rax+8]
+  .text:0000000001E615EE                 test    r15, r15
+  .text:0000000001E615F1                 jnz     short loc_1E61580
+  .text:0000000001E615F3                 mov     esi, [rax]
+  .text:0000000001E615F5                 cmp     esi, 0FFFFFFFFh
+  .text:0000000001E615F8                 jz      short loc_1E615CE
+  .text:0000000001E615FA                 mov     r10, cs:qword_256F1A0
+  .text:0000000001E61601                 test    r10, r10
+  .text:0000000001E61604                 jz      short loc_1E615CE
+  .text:0000000001E61606                 cmp     esi, 0FFFFFFFEh
+  .text:0000000001E61609                 jz      short loc_1E615CE
+  .text:0000000001E6160B                 movzx   eax, word ptr [rax]
+  .text:0000000001E6160E                 mov     r8, rax
+  .text:0000000001E61611                 shr     r8, 9
+  .text:0000000001E61615                 and     r8d, 3Fh
+  .text:0000000001E61619                 mov     r8, [r10+r8*8]
+  .text:0000000001E6161D                 test    r8, r8
+  .text:0000000001E61620                 jz      short loc_1E615CE
+  .text:0000000001E61622                 and     eax, 1FFh
+  .text:0000000001E61627                 imul    rax, 70h ; 'p'
+  .text:0000000001E6162B                 add     rax, r8
+  .text:0000000001E6162E                 cmp     esi, [rax+10h]
+  .text:0000000001E61631                 jnz     short loc_1E615CE
+  .text:0000000001E61633                 mov     r15, [rax]
+  .text:0000000001E61636                 test    r15, r15
+  .text:0000000001E61639                 jnz     loc_1E61580
+  .text:0000000001E6163F                 add     r14, 20h ; ' '
+  .text:0000000001E61643                 cmp     r14, r12
+  .text:0000000001E61646                 jnz     short loc_1E615D7
+  .text:0000000001E61648                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000001E61650                 xor     r10d, r10d
+  .text:0000000001E61653                 xor     r15d, r15d
+  .text:0000000001E61656                 jmp     short loc_1E616D1
+  .text:0000000001E61660                 mov     rcx, [rax+10h]
+  .text:0000000001E61664                 test    rcx, rcx
+  .text:0000000001E61667                 jz      loc_1E61723
+  .text:0000000001E6166D                 mov     rdx, [r14+10h]
+  .text:0000000001E61671                 test    rdx, rdx
+  .text:0000000001E61674                 jz      short loc_1E61681
+  .text:0000000001E61676                 cmp     byte ptr [r14+18h], 0
+  .text:0000000001E6167B                 jnz     loc_1E61900
+  .text:0000000001E61681                 mov     rsi, [rbp+dest]
+  .text:0000000001E61688                 movsxd  rax, r15d
+  .text:0000000001E6168B                 lea     rax, [rax+rax*2]
+  .text:0000000001E6168F                 lea     rax, [rsi+rax*8]
+  .text:0000000001E61693                 mov     [rax], rcx
+  .text:0000000001E61696                 mov     rdx, [r14+10h]
+  .text:0000000001E6169A                 mov     [rax+14h], r15w
+  .text:0000000001E6169F                 add     r15d, 1
+  .text:0000000001E616A3                 mov     [rax+8], rdx
+  .text:0000000001E616A7                 mov     rdx, [rcx+8]
+  .text:0000000001E616AB                 mov     edx, [rdx+6Ch]
+  .text:0000000001E616AE                 mov     [rax+17h], dl
+  .text:0000000001E616B1                 mov     eax, [rcx+30h]
+  .text:0000000001E616B4                 and     ah, 0FEh
+  .text:0000000001E616B7                 or      eax, 2
+  .text:0000000001E616BA                 mov     [rcx+30h], eax
+  .text:0000000001E616BD                 add     r10, 20h ; ' '
+  .text:0000000001E616C1                 cmp     r10, r12
+  .text:0000000001E616C4                 jz      loc_1E61790
+  .text:0000000001E616CA                 mov     rdx, [rbx+0BE8h]
+  .text:0000000001E616D1                 lea     r14, [rdx+r10]
+  .text:0000000001E616D5                 mov     rax, [r14+8]
+  .text:0000000001E616D9                 test    rax, rax
+  .text:0000000001E616DC                 jnz     short loc_1E61660
+  .text:0000000001E616DE                 mov     edx, [r14]
+  .text:0000000001E616E1                 cmp     edx, 0FFFFFFFFh
+  .text:0000000001E616E4                 jz      short loc_1E61723
+  .text:0000000001E616E6                 mov     rsi, cs:qword_256F1A0
+  .text:0000000001E616ED                 test    rsi, rsi
+  .text:0000000001E616F0                 jz      short loc_1E61723
+  .text:0000000001E616F2                 cmp     edx, 0FFFFFFFEh
+  .text:0000000001E616F5                 jz      short loc_1E61723
+  .text:0000000001E616F7                 movzx   eax, word ptr [r14]
+  .text:0000000001E616FB                 mov     rcx, rax
+  .text:0000000001E616FE                 shr     rcx, 9
+  .text:0000000001E61702                 and     ecx, 3Fh
+  .text:0000000001E61705                 mov     rcx, [rsi+rcx*8]
+  .text:0000000001E61709                 test    rcx, rcx
+  .text:0000000001E6170C                 jz      short loc_1E61723
+  .text:0000000001E6170E                 and     eax, 1FFh
+  .text:0000000001E61713                 imul    rax, 70h ; 'p'
+  .text:0000000001E61717                 add     rcx, rax
+  .text:0000000001E6171A                 cmp     edx, [rcx+10h]
+  .text:0000000001E6171D                 jz      loc_1E6166D
+  .text:0000000001E61723                 mov     rax, [r14+10h]
+  .text:0000000001E61727                 test    rax, rax
+  .text:0000000001E6172A                 jz      short loc_1E616BD
+  .text:0000000001E6172C                 sub     word ptr [rax+22h], 1
+  .text:0000000001E61731                 mov     r14, [r14+10h]
+  .text:0000000001E61735                 cmp     byte ptr [r14+24h], 0
+  .text:0000000001E6173A                 jnz     loc_1E61A96
+  .text:0000000001E61740                 movzx   eax, word ptr [r14+20h]
+  .text:0000000001E61745                 sub     eax, 1
+  .text:0000000001E61748                 mov     [r14+20h], ax
+  .text:0000000001E6174D                 test    ax, ax
+  .text:0000000001E61750                 jg      loc_1E616BD
+  .text:0000000001E61756                 mov     rdi, r14
+  .text:0000000001E61759                 mov     [rbp+var_510], r10
+  .text:0000000001E61760                 call    sub_1E57790
+  .text:0000000001E61765                 ; _QWORD
+  .text:0000000001E61765                 mov     esi, 38h ; '8'; _QWORD
+  .text:0000000001E6176A                 ; _QWORD
+  .text:0000000001E6176A                 mov     rdi, r14; _QWORD
+  .text:0000000001E6176D                 call    __ZdlPvm; operator delete(void *,ulong)
+  .text:0000000001E61772                 mov     r10, [rbp+var_510]
+  .text:0000000001E61779                 add     r10, 20h ; ' '
+  .text:0000000001E6177D                 cmp     r10, r12
+  .text:0000000001E61780                 jnz     loc_1E616CA
+  .text:0000000001E61786                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001E61790                 mov     r14, [rbx+218h]
+  .text:0000000001E61797                 mov     dword ptr [rbx+0BE0h], 0
+  .text:0000000001E617A1                 mov     rax, [rbx+210h]
+  .text:0000000001E617A8                 cmp     r14, rax
+  .text:0000000001E617AB                 jz      loc_1E61967
+  .text:0000000001E617B1                 xor     eax, eax
+  .text:0000000001E617B3                 test    r14, r14
+  .text:0000000001E617B6                 jnz     short loc_1E617EF
+  .text:0000000001E617B8                 jmp     loc_1E61967
+  .text:0000000001E617C0                 mov     rax, [r13+8]
+  .text:0000000001E617C4                 mov     edx, r8d
+  .text:0000000001E617C7                 add     edx, 1
+  .text:0000000001E617CA                 mov     [r13+0], edx
+  .text:0000000001E617CE                 ; _QWORD
+  .text:0000000001E617CE                 movsxd  rdx, r8d; _QWORD
+  .text:0000000001E617D1                 mov     [rax+rdx*4], r12d
+  .text:0000000001E617D5                 mov     r14, [r14+58h]
+  .text:0000000001E617D9                 cmp     r14, [rbx+210h]
+  .text:0000000001E617E0                 jz      loc_1E61960
+  .text:0000000001E617E6                 test    r14, r14
+  .text:0000000001E617E9                 jz      loc_1E61960
+  .text:0000000001E617EF                 mov     r12d, [r14+10h]
+  .text:0000000001E617F3                 mov     eax, [r14+30h]
+  .text:0000000001E617F7                 shr     r12d, 0Fh
+  .text:0000000001E617FB                 and     eax, 1
+  .text:0000000001E617FE                 sub     r12d, eax
+  .text:0000000001E61801                 cmp     dword ptr [r14+10h], 0FFFFFFFFh
+  .text:0000000001E61806                 jz      loc_1E619F0
+  .text:0000000001E6180C                 movzx   eax, word ptr [r14+10h]
+  .text:0000000001E61811                 and     ax, 7FFFh
+  .text:0000000001E61815                 mov     r8d, [r13+0]
+  .text:0000000001E61819                 shl     r12d, 0Fh
+  .text:0000000001E6181D                 movzx   eax, ax
+  .text:0000000001E61820                 ; _QWORD
+  .text:0000000001E61820                 mov     edi, [r13+10h]; _QWORD
+  .text:0000000001E61824                 or      r12d, eax
+  .text:0000000001E61827                 cmp     r8d, edi
+  .text:0000000001E6182A                 jnz     short loc_1E617C0
+  .text:0000000001E6182C                 mov     esi, [r13+14h]
+  .text:0000000001E61830                 cmp     esi, 3FFFFFFFh
+  .text:0000000001E61836                 jbe     short loc_1E6184A
+  .text:0000000001E61838                 mov     eax, esi
+  .text:0000000001E6183A                 and     eax, 0C0000000h
+  .text:0000000001E6183F                 cmp     eax, 80000000h
+  .text:0000000001E61844                 jnz     loc_1E617C0
+  .text:0000000001E6184A                 cmp     edi, 7FFFFFFFh
+  .text:0000000001E61850                 jz      loc_1E61A30
+  .text:0000000001E61856                 ; _QWORD
+  .text:0000000001E61856                 lea     edx, [rdi+1]; _QWORD
+  .text:0000000001E61859                 ; _QWORD
+  .text:0000000001E61859                 and     esi, 3FFFFFFFh; _QWORD
+  .text:0000000001E6185F                 ; _QWORD
+  .text:0000000001E6185F                 mov     ecx, 4; _QWORD
+  .text:0000000001E61864                 mov     dword ptr [rbp+var_518], r8d
+  .text:0000000001E6186B                 mov     dword ptr [rbp+var_510], edx
+  .text:0000000001E61871                 call    _UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000001E61876                 mov     edx, dword ptr [rbp+var_510]
+  .text:0000000001E6187C                 mov     r8d, dword ptr [rbp+var_518]
+  .text:0000000001E61883                 mov     r10d, eax
+  .text:0000000001E61886                 cmp     edx, eax
+  .text:0000000001E61888                 jg      loc_1E61940
+  .text:0000000001E6188E                 movsxd  rcx, dword ptr [r13+10h]
+  .text:0000000001E61892                 movsxd  rdx, r10d
+  .text:0000000001E61895                 xor     esi, esi
+  .text:0000000001E61897                 mov     dword ptr [rbp+var_518], r8d
+  .text:0000000001E6189E                 ; _QWORD
+  .text:0000000001E6189E                 shl     rdx, 2; _QWORD
+  .text:0000000001E618A2                 ; _QWORD
+  .text:0000000001E618A2                 mov     rdi, [r13+8]; _QWORD
+  .text:0000000001E618A6                 mov     dword ptr [rbp+var_510], r10d
+  .text:0000000001E618AD                 ; _QWORD
+  .text:0000000001E618AD                 shl     rcx, 2; _QWORD
+  .text:0000000001E618B1                 cmp     dword ptr [r13+14h], 3FFFFFFFh
+  .text:0000000001E618B9                 ; _QWORD
+  .text:0000000001E618B9                 setbe   sil; _QWORD
+  .text:0000000001E618BD                 call    _UtlVectorMemory_Alloc
+  .text:0000000001E618C2                 mov     edx, [r13+14h]
+  .text:0000000001E618C6                 mov     r10d, dword ptr [rbp+var_510]
+  .text:0000000001E618CD                 mov     [r13+8], rax
+  .text:0000000001E618D1                 mov     r8d, dword ptr [rbp+var_518]
+  .text:0000000001E618D8                 cmp     edx, 3FFFFFFFh
+  .text:0000000001E618DE                 jbe     short loc_1E618EA
+  .text:0000000001E618E0                 and     edx, 3FFFFFFFh
+  .text:0000000001E618E6                 mov     [r13+14h], edx
+  .text:0000000001E618EA                 mov     edx, [r13+0]
+  .text:0000000001E618EE                 mov     [r13+10h], r10d
+  .text:0000000001E618F2                 jmp     loc_1E617C7
+  .text:0000000001E61900                 mov     rsi, [rcx]
+  .text:0000000001E61903                 mov     [rbp+var_518], r10
+  .text:0000000001E6190A                 mov     rdi, [rcx+8]
+  .text:0000000001E6190E                 mov     [rbp+var_510], rcx
+  .text:0000000001E61915                 call    sub_1E49C20
+  .text:0000000001E6191A                 mov     rcx, [rbp+var_510]
+  .text:0000000001E61921                 test    al, al
+  .text:0000000001E61923                 mov     r10, [rbp+var_518]
+  .text:0000000001E6192A                 jz      loc_1E61A58
+  .text:0000000001E61930                 or      dword ptr [rcx+30h], 1000h
+  .text:0000000001E61937                 jmp     loc_1E61681
+  .text:0000000001E61940                 lea     eax, [rdx+r10]
+  .text:0000000001E61944                 mov     r10d, eax
+  .text:0000000001E61947                 shr     r10d, 1Fh
+  .text:0000000001E6194B                 add     r10d, eax
+  .text:0000000001E6194E                 sar     r10d, 1
+  .text:0000000001E61951                 cmp     edx, r10d
+  .text:0000000001E61954                 jg      short loc_1E61940
+  .text:0000000001E61956                 jmp     loc_1E6188E
+  .text:0000000001E61960                 mov     rax, [rbx+218h]
+  .text:0000000001E61967                 mov     [rbx+210h], rax
+  .text:0000000001E6196E                 test    r15d, r15d
+  .text:0000000001E61971                 jz      short loc_1E619A6
+  .text:0000000001E61973                 mov     rax, [rbx]
+  .text:0000000001E61976                 cmp     r15d, 1
+  .text:0000000001E6197A                 jz      short loc_1E61993
+  .text:0000000001E6197C                 mov     rcx, [rax+98h]; 0x98 = CEntitySystem_SortEntities
+  .text:0000000001E61983                 lea     rdx, nullsub_1672
+  .text:0000000001E6198A                 cmp     rcx, rdx
+  .text:0000000001E6198D                 jnz     loc_1E61B90
+  .text:0000000001E61993                 mov     rdx, [rbp+dest]
+  .text:0000000001E6199A                 mov     esi, r15d
+  .text:0000000001E6199D                 mov     rdi, rbx
+  .text:0000000001E619A0                 call    qword ptr [rax+0A0h]
+  .text:0000000001E619A6                 mov     dword ptr [rbp+var_4F0], 0
+  .text:0000000001E619B0                 mov     eax, dword ptr [rbp+var_4F0+4]
+  .text:0000000001E619B6                 and     eax, 7FFFFFFFh
+  .text:0000000001E619BB                 cmp     eax, 32h ; '2'
+  .text:0000000001E619BE                 jbe     short loc_1E619D7
+  .text:0000000001E619C0                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001E619C7                 mov     rsi, [rbp+src]
+  .text:0000000001E619CE                 mov     rdi, [rax]
+  .text:0000000001E619D1                 mov     rax, [rdi]
+  .text:0000000001E619D4                 call    qword ptr [rax+20h]
+  .text:0000000001E619D7                 add     rsp, 4F8h
+  .text:0000000001E619DE                 pop     rbx
+  .text:0000000001E619DF                 pop     r12
+  .text:0000000001E619E1                 pop     r13
+  .text:0000000001E619E3                 pop     r14
+  .text:0000000001E619E5                 pop     r15
+  .text:0000000001E619E7                 pop     rbp
+  .text:0000000001E619E8                 retn
+  .text:0000000001E619F0                 mov     eax, 7FFFh
+  .text:0000000001E619F5                 jmp     loc_1E61815
+  .text:0000000001E61A00                 lea     rsi, haystack
+  .text:0000000001E61A07                 call    sub_1B13050
+  .text:0000000001E61A0C                 mov     rsi, rax
+  .text:0000000001E61A0F                 test    rax, rax
+  .text:0000000001E61A12                 jz      loc_1E615C7
+  .text:0000000001E61A18                 mov     rdi, [r15+10h]
+  .text:0000000001E61A1C                 call    CEntityIdentity_SetEntityName
+  .text:0000000001E61A21                 jmp     loc_1E615C7
+  .text:0000000001E61A30                 ; _QWORD
+  .text:0000000001E61A30                 mov     esi, 1; _QWORD
+  .text:0000000001E61A35                 mov     dword ptr [rbp+var_510], r8d
+  .text:0000000001E61A3C                 call    _UtlVectorMemory_FailedAllocation
+  .text:0000000001E61A41                 mov     edi, [r13+10h]
+  .text:0000000001E61A45                 mov     esi, [r13+14h]
+  .text:0000000001E61A49                 mov     r8d, dword ptr [rbp+var_510]
+  .text:0000000001E61A50                 jmp     loc_1E61856
+  .text:0000000001E61A58                 xor     esi, esi
+  .text:0000000001E61A5A                 mov     rdi, rcx
+  .text:0000000001E61A5D                 call    CEntityIdentity_FreeAttributes
+  .text:0000000001E61A62                 mov     rsi, [rbp+var_510]
+  .text:0000000001E61A69                 lea     rdi, [rbx+10h]
+  .text:0000000001E61A6D                 mov     edx, 1
+  .text:0000000001E61A72                 call    CConcreteEntityList_FreeEntity
+  .text:0000000001E61A77                 mov     rax, [r14+10h]
+  .text:0000000001E61A7B                 mov     r10, [rbp+var_518]
+  .text:0000000001E61A82                 sub     word ptr [rax+22h], 1
+  .text:0000000001E61A87                 mov     r14, [r14+10h]
+  .text:0000000001E61A8B                 cmp     byte ptr [r14+24h], 0
+  .text:0000000001E61A90                 jz      loc_1E61740
+  .text:0000000001E61A96                 mov     rax, cs:LOG_GENERAL_ptr
+  .text:0000000001E61A9D                 ; _QWORD
+  .text:0000000001E61A9D                 mov     esi, 2; _QWORD
+  .text:0000000001E61AA2                 mov     [rbp+var_510], r10
+  .text:0000000001E61AA9                 ; _QWORD
+  .text:0000000001E61AA9                 mov     edi, [rax]; _QWORD
+  .text:0000000001E61AAB                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000001E61AB0                 mov     r10, [rbp+var_510]
+  .text:0000000001E61AB7                 test    al, al
+  .text:0000000001E61AB9                 jz      loc_1E61740
+  .text:0000000001E61ABF                 movsx   eax, word ptr [r14+20h]
+  .text:0000000001E61AC4                 mov     rcx, r14
+  .text:0000000001E61AC7                 mov     rsi, cs:LOG_GENERAL_ptr
+  .text:0000000001E61ACE                 lea     rdx, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:0000000001E61AD5                 lea     r8d, [rax-1]
+  .text:0000000001E61AD9                 xor     eax, eax
+  .text:0000000001E61ADB                 ; _QWORD
+  .text:0000000001E61ADB                 mov     edi, [rsi]; _QWORD
+  .text:0000000001E61ADD                 ; _QWORD
+  .text:0000000001E61ADD                 mov     esi, 2; _QWORD
+  .text:0000000001E61AE2                 call    _LoggingSystem_Log
+  .text:0000000001E61AE7                 mov     r10, [rbp+var_510]
+  .text:0000000001E61AEE                 jmp     loc_1E61740
+  .text:0000000001E61AF8                 test    r12d, r12d
+  .text:0000000001E61AFB                 jle     short loc_1E61B40
+  .text:0000000001E61AFD                 lea     rax, [rbp+src]
+  .text:0000000001E61B04                 mov     [rbp+dest], rax
+  .text:0000000001E61B0B                 jmp     loc_1E61562
+  .text:0000000001E61B10                 ; dest
+  .text:0000000001E61B10                 mov     rdi, [rbp+dest]; dest
+  .text:0000000001E61B17                 call    _memcpy
+  .text:0000000001E61B1C                 jmp     loc_1E61531
+  .text:0000000001E61B21                 mov     rsi, [rbp+src]
+  .text:0000000001E61B28                 jmp     loc_1E61515
+  .text:0000000001E61B30                 xor     esi, esi
+  .text:0000000001E61B32                 jmp     loc_1E61515
+  .text:0000000001E61B40                 mov     r14, [rdi+218h]
+  .text:0000000001E61B47                 mov     dword ptr [rdi+0BE0h], 0
+  .text:0000000001E61B51                 cmp     r14, [rdi+210h]
+  .text:0000000001E61B58                 jz      loc_1E619A6
+  .text:0000000001E61B5E                 xor     r15d, r15d
+  .text:0000000001E61B61                 lea     rax, [rbp+src]
+  .text:0000000001E61B68                 mov     [rbp+dest], rax
+  .text:0000000001E61B6F                 test    r14, r14
+  .text:0000000001E61B72                 jnz     loc_1E617EF
+  .text:0000000001E61B78                 mov     qword ptr [rdi+210h], 0
+  .text:0000000001E61B83                 jmp     loc_1E619A6
+  .text:0000000001E61B90                 mov     rdx, [rbp+dest]
+  .text:0000000001E61B97                 mov     esi, r15d
+  .text:0000000001E61B9A                 mov     rdi, rbx
+  .text:0000000001E61B9D                 call    rcx
+  .text:0000000001E61B9F                 mov     rax, [rbx]
+  .text:0000000001E61BA2                 jmp     loc_1E61993
+procedure: |-
+  __int64 __fastcall CEntitySystem_HelperExecuteQueuedSpawn(__int64 *a1, unsigned __int64 a2, __int64 a3)
+  {
+    unsigned __int64 v3; // r13
+    __int64 v5; // r12
+    unsigned __int64 v6; // r15
+    unsigned __int64 v7; // rax
+    size_t v8; // rdx
+    unsigned __int64 v9; // rdx
+    __int64 v10; // r12
+    __int64 v11; // r14
+    _WORD *v12; // rax
+    unsigned int *v13; // rax
+    __int64 v14; // rdi
+    __int64 v15; // r15
+    unsigned __int64 v16; // rax
+    __int64 v17; // r8
+    __int64 *v18; // rax
+    __int64 v19; // r10
+    unsigned int v20; // r15d
+    unsigned __int64 v21; // rcx
+    unsigned __int64 *v22; // rax
+    unsigned __int64 v23; // rdx
+    unsigned int *v24; // r14
+    __int64 v25; // rax
+    __int64 v26; // rcx
+    __int64 v27; // rax
+    __int64 v28; // r14
+    __int16 v29; // ax
+    __int64 v30; // r14
+    __int64 v31; // rax
+    __int64 v32; // rax
+    int v33; // edx
+    unsigned __int16 v34; // ax
+    int v35; // r8d
+    __int64 v36; // rdi
+    int v37; // r12d
+    unsigned int v38; // esi
+    int v39; // eax
+    int v40; // edx
+    int i; // r10d
+    unsigned int v42; // edx
+    char v43; // al
+    __int64 v44; // rax
+    __int64 (__fastcall *v45)(); // rcx
+    __int64 result; // rax
+    char IsChannelEnabled; // al
+    int v48; // [rsp+8h] [rbp-518h]
+    __int64 v49; // [rsp+8h] [rbp-518h]
+    __int64 v50; // [rsp+10h] [rbp-510h]
+    int v51; // [rsp+10h] [rbp-510h]
+    unsigned __int64 v52; // [rsp+10h] [rbp-510h]
+    int v53; // [rsp+10h] [rbp-510h]
+    __int64 v54; // [rsp+10h] [rbp-510h]
+    _QWORD *dest; // [rsp+18h] [rbp-508h]
+    _QWORD v56[2]; // [rsp+20h] [rbp-500h] BYREF
+    __int64 v57; // [rsp+30h] [rbp-4F0h]
+    _QWORD src[157]; // [rsp+38h] [rbp-4E8h] BYREF
+
+    v3 = a2;
+    v5 = *((int *)a1 + 760);
+    v57 = 0x3200000000LL;
+    if ( (int)v5 > 50 )
+    {
+      v6 = 24 * v5;
+      dest = (_QWORD *)(*(__int64 (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 16LL))(g_pMemAlloc, 24 * v5);
+      v7 = (*(__int64 (__fastcall **)(_QWORD *, _QWORD *))(*g_pMemAlloc + 144LL))(g_pMemAlloc, dest);
+      if ( 24 * v5 < v7 )
+        v6 = v7;
+      a2 = (unsigned __int64)src;
+      v8 = 24LL * (int)v57;
+      if ( a2 < a2 + v8 )
+        memcpy(dest, src, v8);
+      src[0] = dest;
+      v9 = v6 / 0x18;
+      if ( v6 / 0x18 > 0x7FFFFFFF )
+        LODWORD(v9) = 0x7FFFFFFF;
+      HIDWORD(v57) = v9;
+      goto LABEL_9;
+    }
+    if ( (int)v5 > 0 )
+    {
+      dest = src;
+  LABEL_9:
+      a3 = a1[381];
+      v10 = 32 * v5;
+      v11 = 0;
+      while ( 1 )
+      {
+        v13 = (unsigned int *)(a3 + v11);
+        v14 = *(_QWORD *)(a3 + v11 + 16);
+        if ( !v14 || !*((_BYTE *)v13 + 24) )
+          goto LABEL_13;
+        v15 = *((_QWORD *)v13 + 1);
+        if ( v15 )
+          goto LABEL_10;
+        a2 = *v13;
+        if ( (_DWORD)a2 != -1
+          && qword_256F1A0
+          && (_DWORD)a2 != -2
+          && (v16 = *(unsigned __int16 *)v13, (v17 = *(_QWORD *)(qword_256F1A0 + 8 * ((v16 >> 9) & 0x3F))) != 0)
+          && (v18 = (__int64 *)(v17 + 112 * (v16 & 0x1FF)), (_DWORD)a2 == *((_DWORD *)v18 + 4)) )
+        {
+          v15 = *v18;
+          if ( *v18 )
+          {
+  LABEL_10:
+            a2 = (unsigned __int64)v56;
+            v56[0] = -3200798869LL;
+            v56[1] = "targetname";
+            v12 = (_WORD *)sub_1E57DC0(v14, v56, 0);
+            if ( v12 )
+            {
+              if ( ((*v12 >> 2) & 0xF) == 6 )
+              {
+                a2 = sub_1B13050(v12, &haystack);
+                if ( a2 )
+                  CEntityIdentity_SetEntityName(*(_QWORD *)(v15 + 16), a2);
+              }
+            }
+            a3 = a1[381];
+            goto LABEL_13;
+          }
+          v11 += 32;
+          if ( v11 == v10 )
+          {
+  LABEL_24:
+            v19 = 0;
+            v20 = 0;
+            while ( 1 )
+            {
+              v24 = (unsigned int *)(a3 + v19);
+              v25 = *(_QWORD *)(a3 + v19 + 8);
+              if ( v25 )
+              {
+                v21 = *(_QWORD *)(v25 + 16);
+                if ( !v21 )
+                  goto LABEL_37;
+              }
+              else
+              {
+                a3 = *v24;
+                if ( (_DWORD)a3 == -1
+                  || (a2 = qword_256F1A0) == 0
+                  || (_DWORD)a3 == -2
+                  || (v26 = *(_QWORD *)(qword_256F1A0 + 8 * (((unsigned __int64)*(unsigned __int16 *)v24 >> 9) & 0x3F))) == 0
+                  || (v21 = 112LL * (*(_WORD *)v24 & 0x1FF) + v26, (_DWORD)a3 != *(_DWORD *)(v21 + 16)) )
+                {
+  LABEL_37:
+                  v27 = *((_QWORD *)v24 + 2);
+                  if ( !v27 )
+                    goto LABEL_29;
+                  --*(_WORD *)(v27 + 34);
+                  v28 = *((_QWORD *)v24 + 2);
+                  if ( *(_BYTE *)(v28 + 36) )
+                    goto LABEL_75;
+                  goto LABEL_39;
+                }
+              }
+              if ( !*((_QWORD *)v24 + 2) || !*((_BYTE *)v24 + 24) )
+                goto LABEL_28;
+              v49 = v19;
+              v52 = v21;
+              v43 = sub_1E49C20(*(_QWORD *)(v21 + 8), *(_QWORD *)v21);
+              v21 = v52;
+              v19 = v49;
+              if ( v43 )
+              {
+                *(_DWORD *)(v52 + 48) |= 0x1000u;
+  LABEL_28:
+                a2 = (unsigned __int64)dest;
+                v22 = &dest[3 * (int)v20];
+                *v22 = v21;
+                v23 = *((_QWORD *)v24 + 2);
+                *((_WORD *)v22 + 10) = v20++;
+                v22[1] = v23;
+                a3 = *(unsigned int *)(*(_QWORD *)(v21 + 8) + 108LL);
+                *((_BYTE *)v22 + 23) = a3;
+                LODWORD(v22) = *(_DWORD *)(v21 + 48);
+                BYTE1(v22) &= ~1u;
+                *(_DWORD *)(v21 + 48) = (unsigned int)v22 | 2;
+  LABEL_29:
+                v19 += 32;
+                if ( v19 == v10 )
+                  goto LABEL_41;
+                goto LABEL_30;
+              }
+              CEntityIdentity_FreeAttributes(v52);
+              a2 = v52;
+              CConcreteEntityList_FreeEntity((__int64)(a1 + 2), v52, 1);
+              v19 = v49;
+              --*(_WORD *)(*((_QWORD *)v24 + 2) + 34LL);
+              v28 = *((_QWORD *)v24 + 2);
+              if ( *(_BYTE *)(v28 + 36) )
+              {
+  LABEL_75:
+                a2 = 2;
+                v54 = v19;
+                IsChannelEnabled = LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2);
+                v19 = v54;
+                if ( IsChannelEnabled )
+                {
+                  a2 = 2;
+                  LoggingSystem_Log(LOG_GENERAL, 2, "kv 0x%p Release refcount == %d\n");
+                  v19 = v54;
+                }
+              }
+  LABEL_39:
+              v29 = *(_WORD *)(v28 + 32) - 1;
+              *(_WORD *)(v28 + 32) = v29;
+              if ( v29 > 0 )
+                goto LABEL_29;
+              v50 = v19;
+              sub_1E57790(v28, a2, a3);
+              a2 = 56;
+              operator delete(v28, 56);
+              v19 = v50 + 32;
+              if ( v50 + 32 == v10 )
+              {
+  LABEL_41:
+                v30 = a1[67];
+                *((_DWORD *)a1 + 760) = 0;
+                v31 = a1[66];
+                if ( v30 == v31 )
+                  goto LABEL_63;
+                v31 = 0;
+                if ( !v30 )
+                  goto LABEL_63;
+                goto LABEL_47;
+              }
+  LABEL_30:
+              a3 = a1[381];
+            }
+          }
+        }
+        else
+        {
+  LABEL_13:
+          v11 += 32;
+          if ( v11 == v10 )
+            goto LABEL_24;
+        }
+      }
+    }
+    v30 = a1[67];
+    *((_DWORD *)a1 + 760) = 0;
+    if ( v30 != a1[66] )
+    {
+      v20 = 0;
+      dest = src;
+      if ( v30 )
+      {
+        do
+        {
+  LABEL_47:
+          if ( *(_DWORD *)(v30 + 16) == -1 )
+            v34 = 0x7FFF;
+          else
+            v34 = *(_WORD *)(v30 + 16) & 0x7FFF;
+          v35 = *(_DWORD *)v3;
+          v36 = *(unsigned int *)(v3 + 16);
+          v37 = v34 | (((*(_DWORD *)(v30 + 16) >> 15) - (*(_DWORD *)(v30 + 48) & 1)) << 15);
+          if ( *(_DWORD *)v3 == (_DWORD)v36
+            && ((v38 = *(_DWORD *)(v3 + 20), v38 <= 0x3FFFFFFF) || (v38 & 0xC0000000) == 0x80000000) )
+          {
+            if ( (_DWORD)v36 == 0x7FFFFFFF )
+            {
+              v53 = *(_DWORD *)v3;
+              UtlVectorMemory_FailedAllocation(v36, 1, a3);
+              v36 = *(unsigned int *)(v3 + 16);
+              v38 = *(_DWORD *)(v3 + 20);
+              v35 = v53;
+            }
+            v48 = v35;
+            v39 = UtlVectorMemory_CalcNewAllocationCount(v36, v38 & 0x3FFFFFFF, (unsigned int)(v36 + 1), 4);
+            v40 = v36 + 1;
+            for ( i = v39; v40 > i; i = (v40 + i) / 2 )
+              ;
+            v51 = i;
+            v32 = UtlVectorMemory_Alloc(
+                    *(_QWORD *)(v3 + 8),
+                    *(_DWORD *)(v3 + 20) <= 0x3FFFFFFFu,
+                    4LL * i,
+                    4LL * *(int *)(v3 + 16));
+            v42 = *(_DWORD *)(v3 + 20);
+            *(_QWORD *)(v3 + 8) = v32;
+            v35 = v48;
+            if ( v42 > 0x3FFFFFFF )
+              *(_DWORD *)(v3 + 20) = v42 & 0x3FFFFFFF;
+            v33 = *(_DWORD *)v3;
+            *(_DWORD *)(v3 + 16) = v51;
+          }
+          else
+          {
+            v32 = *(_QWORD *)(v3 + 8);
+            v33 = *(_DWORD *)v3;
+          }
+          *(_DWORD *)v3 = v33 + 1;
+          a3 = v35;
+          *(_DWORD *)(v32 + 4LL * v35) = v37;
+          v30 = *(_QWORD *)(v30 + 88);
+        }
+        while ( v30 != a1[66] && v30 );
+        v31 = a1[67];
+  LABEL_63:
+        a1[66] = v31;
+        if ( v20 )
+        {
+          v44 = *a1;
+          if ( v20 != 1 )
+          {
+            v45 = *(__int64 (__fastcall **)())(v44 + 152);// 152LL = CEntitySystem_SortEntities
+            if ( v45 != nullsub_1672 )
+            {
+              ((void (__fastcall *)(__int64 *, _QWORD, _QWORD *))v45)(a1, v20, dest);
+              v44 = *a1;
+            }
+          }
+          (*(void (__fastcall **)(__int64 *, _QWORD, _QWORD *))(v44 + 160))(a1, v20, dest);
+        }
+      }
+      else
+      {
+        a1[66] = 0;
+      }
+    }
+    LODWORD(v57) = 0;
+    result = HIDWORD(v57) & 0x7FFFFFFF;
+    if ( (unsigned int)result > 0x32 )
+      return (*(__int64 (__fastcall **)(_QWORD *, _QWORD))(*g_pMemAlloc + 32LL))(g_pMemAlloc, src[0]);
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.windows.yaml
@@ -340,7 +340,7 @@ disasm_code: |-
   .text:00000001811F81DB                 mov     r8, rdi
   .text:00000001811F81DE                 mov     edx, ebx
   .text:00000001811F81E0                 mov     rcx, r12
-  .text:00000001811F81E3                 call    qword ptr [rax+90h]; 0x90 = CEntitySystem_SortEntities
+  .text:00000001811F81E3                 call    qword ptr [rax+90h]; 144LL = 0x90 = CEntitySystem_SortEntities
   .text:00000001811F81E9                 mov     rax, [r12]
   .text:00000001811F81ED                 mov     r8, rdi
   .text:00000001811F81F0                 mov     edx, ebx
@@ -642,8 +642,8 @@ procedure: |-
     if ( v51 > 0 )
     {
       if ( v51 > 1 )
-        (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 144LL))(v4, (unsigned int)v51, v52);// 144LL = CEntitySystem_SortEntities
-      (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 152LL))(v4, (unsigned int)v51, v52);// CEntitySystem_Spawn
+        (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 144LL))(v4, (unsigned int)v51, v52);// 144LL = 0x90 = CEntitySystem_SortEntities
+      (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 152LL))(v4, (unsigned int)v51, v52);// 152LL = 0x98 = CEntitySystem_Spawn
     }
     v42 = v47;
     LODWORD(v42) = v47 & 0x7FFFFFFF;

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_HelperExecuteQueuedSpawn.windows.yaml
@@ -1,0 +1,662 @@
+func_name: CEntitySystem_HelperExecuteQueuedSpawn
+func_va: '0x1811f7c80'
+disasm_code: |-
+  .text:00000001811F7C80                 mov     rax, rsp
+  .text:00000001811F7C83                 mov     [rax+10h], rdx
+  .text:00000001811F7C87                 mov     [rax+8], rcx
+  .text:00000001811F7C8B                 push    rbp
+  .text:00000001811F7C8C                 sub     rsp, 540h
+  .text:00000001811F7C93                 mov     [rax-10h], rbx
+  .text:00000001811F7C97                 xor     ebp, ebp
+  .text:00000001811F7C99                 movsxd  rbx, dword ptr [rcx+0BE0h]
+  .text:00000001811F7CA0                 mov     r8d, 1
+  .text:00000001811F7CA6                 mov     [rax-28h], r12
+  .text:00000001811F7CAA                 mov     r12, rcx
+  .text:00000001811F7CAD                 mov     [rax-30h], r13
+  .text:00000001811F7CB1                 lea     rcx, [rsp+548h+var_508]
+  .text:00000001811F7CB6                 mov     r13, rdx
+  .text:00000001811F7CB9                 mov     [rax-38h], r14
+  .text:00000001811F7CBD                 mov     edx, ebx
+  .text:00000001811F7CBF                 mov     [rax-40h], r15
+  .text:00000001811F7CC3                 mov     [rsp+548h+nSpawnCount], ebp
+  .text:00000001811F7CCA                 mov     [rsp+548h+var_508], ebp
+  .text:00000001811F7CCE                 mov     [rsp+548h+var_504], 32h ; '2'
+  .text:00000001811F7CD6                 call    sub_1811F4850
+  .text:00000001811F7CDB                 mov     eax, [rsp+548h+var_504]
+  .text:00000001811F7CDF                 and     eax, 7FFFFFFFh
+  .text:00000001811F7CE4                 jnz     short loc_1811F7CF0
+  .text:00000001811F7CE6                 mov     [rsp+548h+entities], rbp
+  .text:00000001811F7CEE                 jmp     short loc_1811F7D06
+  .text:00000001811F7CF0                 cmp     eax, 32h ; '2'
+  .text:00000001811F7CF3                 lea     rcx, [rsp+548h+var_500]
+  .text:00000001811F7CF8                 cmova   rcx, [rsp+548h+var_500]
+  .text:00000001811F7CFE                 mov     [rsp+548h+entities], rcx
+  .text:00000001811F7D06                 mov     [rsp+548h+var_18], rsi
+  .text:00000001811F7D0E                 mov     r14, rbx
+  .text:00000001811F7D11                 mov     [rsp+548h+var_20], rdi
+  .text:00000001811F7D19                 test    ebx, ebx
+  .text:00000001811F7D1B                 jle     loc_1811F8050
+  .text:00000001811F7D21                 mov     rdi, rbp
+  .text:00000001811F7D24                 lea     r15, aTargetname; "targetname"
+  .text:00000001811F7D2B                 mov     rsi, rbx
+  .text:00000001811F7D2E                 xchg    ax, ax
+  .text:00000001811F7D30                 mov     rax, [r12+0BE8h]
+  .text:00000001811F7D38                 mov     r10, [rdi+rax+10h]
+  .text:00000001811F7D3D                 test    r10, r10
+  .text:00000001811F7D40                 jz      loc_1811F7E11
+  .text:00000001811F7D46                 cmp     [rdi+rax+18h], bpl
+  .text:00000001811F7D4B                 jz      loc_1811F7E11
+  .text:00000001811F7D51                 mov     rbx, [rdi+rax+8]
+  .text:00000001811F7D56                 test    rbx, rbx
+  .text:00000001811F7D59                 jnz     short loc_1811F7DB9
+  .text:00000001811F7D5B                 mov     edx, [rdi+rax]
+  .text:00000001811F7D5E                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811F7D61                 jz      short loc_1811F7DB1
+  .text:00000001811F7D63                 mov     r8, cs:qword_181D9D980
+  .text:00000001811F7D6A                 test    r8, r8
+  .text:00000001811F7D6D                 jz      short loc_1811F7DB1
+  .text:00000001811F7D6F                 cmp     edx, 0FFFFFFFEh
+  .text:00000001811F7D72                 jz      short loc_1811F7DA4
+  .text:00000001811F7D74                 mov     ecx, edx
+  .text:00000001811F7D76                 and     ecx, 7FFFh
+  .text:00000001811F7D7C                 mov     eax, ecx
+  .text:00000001811F7D7E                 shr     rax, 9
+  .text:00000001811F7D82                 mov     r9, [r8+rax*8]
+  .text:00000001811F7D86                 test    r9, r9
+  .text:00000001811F7D89                 jz      short loc_1811F7DA4
+  .text:00000001811F7D8B                 mov     eax, ecx
+  .text:00000001811F7D8D                 and     eax, 1FFh
+  .text:00000001811F7D92                 imul    rcx, rax, 70h ; 'p'
+  .text:00000001811F7D96                 add     rcx, r9
+  .text:00000001811F7D99                 jz      short loc_1811F7DA4
+  .text:00000001811F7D9B                 cmp     [rcx+10h], edx
+  .text:00000001811F7D9E                 cmovnz  rcx, rbp
+  .text:00000001811F7DA2                 jmp     short loc_1811F7DA7
+  .text:00000001811F7DA4                 mov     rcx, rbp
+  .text:00000001811F7DA7                 test    rcx, rcx
+  .text:00000001811F7DAA                 jz      short loc_1811F7DB1
+  .text:00000001811F7DAC                 mov     rbx, [rcx]
+  .text:00000001811F7DAF                 jmp     short loc_1811F7DB4
+  .text:00000001811F7DB1                 mov     rbx, rbp
+  .text:00000001811F7DB4                 test    rbx, rbx
+  .text:00000001811F7DB7                 jz      short loc_1811F7E11
+  .text:00000001811F7DB9                 xor     r8d, r8d
+  .text:00000001811F7DBC                 mov     [rsp+548h+var_518], 4137AF6Bh
+  .text:00000001811F7DC4                 lea     rdx, [rsp+548h+var_518]
+  .text:00000001811F7DC9                 mov     [rsp+548h+var_514], 0FFFFFFFFh
+  .text:00000001811F7DD1                 mov     rcx, r10
+  .text:00000001811F7DD4                 mov     [rsp+548h+var_510], r15
+  .text:00000001811F7DD9                 call    sub_181207640
+  .text:00000001811F7DDE                 test    rax, rax
+  .text:00000001811F7DE1                 jz      short loc_1811F7E11
+  .text:00000001811F7DE3                 movzx   edx, byte ptr [rax]
+  .text:00000001811F7DE6                 shr     dl, 2
+  .text:00000001811F7DE9                 and     dl, 0Fh
+  .text:00000001811F7DEC                 cmp     dl, 6
+  .text:00000001811F7DEF                 jnz     short loc_1811F7E11
+  .text:00000001811F7DF1                 lea     rdx, byte_1815A2980
+  .text:00000001811F7DF8                 mov     rcx, rax
+  .text:00000001811F7DFB                 call    sub_1814DD810
+  .text:00000001811F7E00                 test    rax, rax
+  .text:00000001811F7E03                 jz      short loc_1811F7E11
+  .text:00000001811F7E05                 mov     rcx, [rbx+10h]
+  .text:00000001811F7E09                 mov     rdx, rax
+  .text:00000001811F7E0C                 call    CEntityIdentity_SetEntityName
+  .text:00000001811F7E11                 add     rdi, 20h ; ' '
+  .text:00000001811F7E15                 sub     rsi, 1
+  .text:00000001811F7E19                 jnz     loc_1811F7D30
+  .text:00000001811F7E1F                 mov     r15d, [rsp+548h+nSpawnCount]
+  .text:00000001811F7E27                 mov     rsi, rbp
+  .text:00000001811F7E2A                 mov     r13, [rsp+548h+entities]
+  .text:00000001811F7E32                 nop     dword ptr [rax+00h]
+  .text:00000001811F7E36                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001811F7E40                 mov     rdi, [r12+0BE8h]
+  .text:00000001811F7E48                 add     rdi, rsi
+  .text:00000001811F7E4B                 mov     rbx, [rdi+8]
+  .text:00000001811F7E4F                 test    rbx, rbx
+  .text:00000001811F7E52                 jz      short loc_1811F7E5A
+  .text:00000001811F7E54                 mov     rbx, [rbx+10h]
+  .text:00000001811F7E58                 jmp     short loc_1811F7EAD
+  .text:00000001811F7E5A                 mov     edx, [rdi]
+  .text:00000001811F7E5C                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811F7E5F                 jz      short loc_1811F7EAA
+  .text:00000001811F7E61                 cmp     cs:qword_181D9D980, rbp
+  .text:00000001811F7E68                 jz      short loc_1811F7EAA
+  .text:00000001811F7E6A                 cmp     edx, 0FFFFFFFEh
+  .text:00000001811F7E6D                 jz      short loc_1811F7EAA
+  .text:00000001811F7E6F                 mov     rax, cs:qword_181D9D980
+  .text:00000001811F7E76                 mov     r8d, edx
+  .text:00000001811F7E79                 and     r8d, 7FFFh
+  .text:00000001811F7E80                 mov     ecx, r8d
+  .text:00000001811F7E83                 shr     rcx, 9
+  .text:00000001811F7E87                 mov     r9, [rax+rcx*8]
+  .text:00000001811F7E8B                 test    r9, r9
+  .text:00000001811F7E8E                 jz      short loc_1811F7EAA
+  .text:00000001811F7E90                 mov     eax, r8d
+  .text:00000001811F7E93                 and     eax, 1FFh
+  .text:00000001811F7E98                 imul    rbx, rax, 70h ; 'p'
+  .text:00000001811F7E9C                 add     rbx, r9
+  .text:00000001811F7E9F                 jz      short loc_1811F7EAA
+  .text:00000001811F7EA1                 cmp     [rbx+10h], edx
+  .text:00000001811F7EA4                 cmovnz  rbx, rbp
+  .text:00000001811F7EA8                 jmp     short loc_1811F7EAD
+  .text:00000001811F7EAA                 mov     rbx, rbp
+  .text:00000001811F7EAD                 mov     r8, [rdi+10h]
+  .text:00000001811F7EB1                 test    rbx, rbx
+  .text:00000001811F7EB4                 jnz     loc_1811F7F3A
+  .text:00000001811F7EBA                 test    r8, r8
+  .text:00000001811F7EBD                 jz      loc_1811F8032
+  .text:00000001811F7EC3                 dec     word ptr [r8+22h]
+  .text:00000001811F7EC8                 mov     rbx, [rdi+10h]
+  .text:00000001811F7ECC                 cmp     [rbx+24h], bpl
+  .text:00000001811F7ED0                 jz      short loc_1811F7F12
+  .text:00000001811F7ED2                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001811F7ED9                 mov     edx, 2
+  .text:00000001811F7EDE                 mov     ecx, [rcx]
+  .text:00000001811F7EE0                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F7EE6                 test    al, al
+  .text:00000001811F7EE8                 jz      short loc_1811F7F12
+  .text:00000001811F7EEA                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001811F7EF1                 lea     r8, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:00000001811F7EF8                 movsx   eax, word ptr [rbx+20h]
+  .text:00000001811F7EFC                 mov     r9, rbx
+  .text:00000001811F7EFF                 dec     eax
+  .text:00000001811F7F01                 mov     edx, 2
+  .text:00000001811F7F06                 mov     [rsp+548h+var_528], eax
+  .text:00000001811F7F0A                 mov     ecx, [rcx]
+  .text:00000001811F7F0C                 call    cs:LoggingSystem_Log
+  .text:00000001811F7F12                 dec     word ptr [rbx+20h]
+  .text:00000001811F7F16                 cmp     [rbx+20h], bp
+  .text:00000001811F7F1A                 jg      loc_1811F8032
+  .text:00000001811F7F20                 mov     rcx, rbx
+  .text:00000001811F7F23                 call    sub_181206B10
+  .text:00000001811F7F28                 mov     edx, 38h ; '8'
+  .text:00000001811F7F2D                 mov     rcx, rbx
+  .text:00000001811F7F30                 call    sub_180E7C9C0
+  .text:00000001811F7F35                 jmp     loc_1811F8032
+  .text:00000001811F7F3A                 test    r8, r8
+  .text:00000001811F7F3D                 jz      loc_1811F7FF5
+  .text:00000001811F7F43                 cmp     [rdi+18h], bpl
+  .text:00000001811F7F47                 jz      loc_1811F7FF5
+  .text:00000001811F7F4D                 mov     rdx, [rbx]
+  .text:00000001811F7F50                 mov     rcx, [rbx+8]
+  .text:00000001811F7F54                 call    sub_1811E7E90
+  .text:00000001811F7F59                 test    al, al
+  .text:00000001811F7F5B                 jnz     loc_1811F7FEE
+  .text:00000001811F7F61                 xor     edx, edx
+  .text:00000001811F7F63                 mov     rcx, rbx
+  .text:00000001811F7F66                 call    CEntityIdentity_FreeAttributes
+  .text:00000001811F7F6B                 lea     rcx, [r12+10h]
+  .text:00000001811F7F70                 mov     r8b, 1
+  .text:00000001811F7F73                 mov     rdx, rbx
+  .text:00000001811F7F76                 call    CConcreteEntityList_FreeEntity
+  .text:00000001811F7F7B                 mov     rax, [rdi+10h]
+  .text:00000001811F7F7F                 dec     word ptr [rax+22h]
+  .text:00000001811F7F83                 mov     rbx, [rdi+10h]
+  .text:00000001811F7F87                 cmp     [rbx+24h], bpl
+  .text:00000001811F7F8B                 jz      short loc_1811F7FCD
+  .text:00000001811F7F8D                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001811F7F94                 mov     edx, 2
+  .text:00000001811F7F99                 mov     ecx, [rcx]
+  .text:00000001811F7F9B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001811F7FA1                 test    al, al
+  .text:00000001811F7FA3                 jz      short loc_1811F7FCD
+  .text:00000001811F7FA5                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001811F7FAC                 lea     r8, aKv0xPReleaseRe; "kv 0x%p Release refcount == %d\n"
+  .text:00000001811F7FB3                 movsx   eax, word ptr [rbx+20h]
+  .text:00000001811F7FB7                 mov     r9, rbx
+  .text:00000001811F7FBA                 dec     eax
+  .text:00000001811F7FBC                 mov     edx, 2
+  .text:00000001811F7FC1                 mov     [rsp+548h+var_528], eax
+  .text:00000001811F7FC5                 mov     ecx, [rcx]
+  .text:00000001811F7FC7                 call    cs:LoggingSystem_Log
+  .text:00000001811F7FCD                 dec     word ptr [rbx+20h]
+  .text:00000001811F7FD1                 cmp     [rbx+20h], bp
+  .text:00000001811F7FD5                 jg      short loc_1811F8032
+  .text:00000001811F7FD7                 mov     rcx, rbx
+  .text:00000001811F7FDA                 call    sub_181206B10
+  .text:00000001811F7FDF                 mov     edx, 38h ; '8'
+  .text:00000001811F7FE4                 mov     rcx, rbx
+  .text:00000001811F7FE7                 call    sub_180E7C9C0
+  .text:00000001811F7FEC                 jmp     short loc_1811F8032
+  .text:00000001811F7FEE                 or      dword ptr [rbx+30h], 1000h
+  .text:00000001811F7FF5                 movsxd  rax, r15d
+  .text:00000001811F7FF8                 lea     rcx, [rax+rax*2]
+  .text:00000001811F7FFC                 lea     rdx, ds:0[rcx*8]
+  .text:00000001811F8004                 add     rdx, r13
+  .text:00000001811F8007                 mov     [rdx], rbx
+  .text:00000001811F800A                 mov     rax, [rdi+10h]
+  .text:00000001811F800E                 mov     [rdx+8], rax
+  .text:00000001811F8012                 mov     [rdx+14h], r15w
+  .text:00000001811F8017                 mov     rax, [rbx+8]
+  .text:00000001811F801B                 movzx   ecx, byte ptr [rax+6Ch]
+  .text:00000001811F801F                 mov     [rdx+17h], cl
+  .text:00000001811F8022                 mov     eax, [rbx+30h]
+  .text:00000001811F8025                 btr     eax, 8
+  .text:00000001811F8029                 or      eax, 2
+  .text:00000001811F802C                 mov     [rbx+30h], eax
+  .text:00000001811F802F                 inc     r15d
+  .text:00000001811F8032                 add     rsi, 20h ; ' '
+  .text:00000001811F8036                 sub     r14, 1
+  .text:00000001811F803A                 jnz     loc_1811F7E40
+  .text:00000001811F8040                 mov     r13, [rsp+548h+arg_8]
+  .text:00000001811F8048                 mov     [rsp+548h+nSpawnCount], r15d
+  .text:00000001811F8050                 mov     [r12+0BE0h], ebp
+  .text:00000001811F8058                 lea     rcx, [r12+218h]
+  .text:00000001811F8060                 mov     rax, [rcx]
+  .text:00000001811F8063                 lea     r15, [r12+210h]
+  .text:00000001811F806B                 cmp     rax, [r15]
+  .text:00000001811F806E                 mov     r14, rbp
+  .text:00000001811F8071                 cmovnz  r14, rax
+  .text:00000001811F8075                 test    r14, r14
+  .text:00000001811F8078                 jz      loc_1811F8199
+  .text:00000001811F807E                 xchg    ax, ax
+  .text:00000001811F8080                 mov     edx, [r14+10h]
+  .text:00000001811F8084                 mov     ecx, 7FFFh
+  .text:00000001811F8089                 mov     eax, [r14+30h]
+  .text:00000001811F808D                 mov     ebx, edx
+  .text:00000001811F808F                 movsxd  r12, dword ptr [r13+0]
+  .text:00000001811F8093                 and     eax, 1
+  .text:00000001811F8096                 shr     ebx, 0Fh
+  .text:00000001811F8099                 sub     ebx, eax
+  .text:00000001811F809B                 mov     eax, edx
+  .text:00000001811F809D                 and     eax, 7FFFh
+  .text:00000001811F80A2                 shl     ebx, 0Fh
+  .text:00000001811F80A5                 cmp     edx, 0FFFFFFFFh
+  .text:00000001811F80A8                 cmovnz  ecx, eax
+  .text:00000001811F80AB                 or      ebx, ecx
+  .text:00000001811F80AD                 cmp     r12d, [r13+10h]
+  .text:00000001811F80B1                 jnz     loc_1811F8160
+  .text:00000001811F80B7                 test    dword ptr [r13+14h], 40000000h
+  .text:00000001811F80BF                 jnz     loc_1811F8160
+  .text:00000001811F80C5                 mov     ecx, [r13+10h]
+  .text:00000001811F80C9                 cmp     ecx, 7FFFFFFEh
+  .text:00000001811F80CF                 jle     short loc_1811F80DC
+  .text:00000001811F80D1                 mov     edx, 1
+  .text:00000001811F80D6                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:00000001811F80DC                 mov     ecx, [r13+10h]
+  .text:00000001811F80E0                 mov     r9d, 4
+  .text:00000001811F80E6                 mov     edx, [r13+14h]
+  .text:00000001811F80EA                 and     edx, 3FFFFFFFh
+  .text:00000001811F80F0                 lea     esi, [rcx+1]
+  .text:00000001811F80F3                 mov     r8d, esi
+  .text:00000001811F80F6                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:00000001811F80FC                 mov     edi, eax
+  .text:00000001811F80FE                 cmp     eax, esi
+  .text:00000001811F8100                 jge     short loc_1811F8120
+  .text:00000001811F8102                 test    eax, eax
+  .text:00000001811F8104                 jnz     short loc_1811F8112
+  .text:00000001811F8106                 cmp     esi, 0FFFFFFFFh
+  .text:00000001811F8109                 jg      short loc_1811F8112
+  .text:00000001811F810B                 mov     edi, 0FFFFFFFFh
+  .text:00000001811F8110                 jmp     short loc_1811F8120
+  .text:00000001811F8112                 lea     eax, [rdi+rsi]
+  .text:00000001811F8115                 cdq
+  .text:00000001811F8116                 sub     eax, edx
+  .text:00000001811F8118                 sar     eax, 1
+  .text:00000001811F811A                 mov     edi, eax
+  .text:00000001811F811C                 cmp     eax, esi
+  .text:00000001811F811E                 jl      short loc_1811F8112
+  .text:00000001811F8120                 movsxd  r9, dword ptr [r13+10h]
+  .text:00000001811F8124                 mov     rcx, [r13+8]
+  .text:00000001811F8128                 shl     r9, 2
+  .text:00000001811F812C                 test    dword ptr [r13+14h], 0C0000000h
+  .text:00000001811F8134                 movsxd  r8, edi
+  .text:00000001811F8137                 setz    dl
+  .text:00000001811F813A                 shl     r8, 2
+  .text:00000001811F813E                 call    cs:UtlVectorMemory_Alloc
+  .text:00000001811F8144                 mov     [r13+8], rax
+  .text:00000001811F8148                 mov     eax, [r13+14h]
+  .text:00000001811F814C                 test    eax, 0C0000000h
+  .text:00000001811F8151                 jz      short loc_1811F815C
+  .text:00000001811F8153                 and     eax, 3FFFFFFFh
+  .text:00000001811F8158                 mov     [r13+14h], eax
+  .text:00000001811F815C                 mov     [r13+10h], edi
+  .text:00000001811F8160                 inc     dword ptr [r13+0]
+  .text:00000001811F8164                 mov     rax, [r13+8]
+  .text:00000001811F8168                 mov     [rax+r12*4], ebx
+  .text:00000001811F816C                 mov     rax, [r14+58h]
+  .text:00000001811F8170                 mov     r14, rax
+  .text:00000001811F8173                 cmp     rax, [r15]
+  .text:00000001811F8176                 jz      short loc_1811F8181
+  .text:00000001811F8178                 test    rax, rax
+  .text:00000001811F817B                 jnz     loc_1811F8080
+  .text:00000001811F8181                 mov     r12, [rsp+548h+arg_0]
+  .text:00000001811F8189                 lea     rcx, [r12+218h]
+  .text:00000001811F8191                 lea     r15, [r12+210h]
+  .text:00000001811F8199                 mov     rax, [rcx]
+  .text:00000001811F819C                 mov     ebx, [rsp+548h+nSpawnCount]
+  .text:00000001811F81A3                 mov     r14, [rsp+548h+var_38]
+  .text:00000001811F81AB                 mov     r13, [rsp+548h+var_30]
+  .text:00000001811F81B3                 mov     rsi, [rsp+548h+var_18]
+  .text:00000001811F81BB                 mov     [r15], rax
+  .text:00000001811F81BE                 mov     r15, [rsp+548h+var_40]
+  .text:00000001811F81C6                 test    ebx, ebx
+  .text:00000001811F81C8                 jle     short loc_1811F81FB
+  .text:00000001811F81CA                 mov     rdi, [rsp+548h+entities]
+  .text:00000001811F81D2                 cmp     ebx, 1
+  .text:00000001811F81D5                 jle     short loc_1811F81E9
+  .text:00000001811F81D7                 mov     rax, [r12]
+  .text:00000001811F81DB                 mov     r8, rdi
+  .text:00000001811F81DE                 mov     edx, ebx
+  .text:00000001811F81E0                 mov     rcx, r12
+  .text:00000001811F81E3                 call    qword ptr [rax+90h]; 0x90 = CEntitySystem_SortEntities
+  .text:00000001811F81E9                 mov     rax, [r12]
+  .text:00000001811F81ED                 mov     r8, rdi
+  .text:00000001811F81F0                 mov     edx, ebx
+  .text:00000001811F81F2                 mov     rcx, r12
+  .text:00000001811F81F5                 call    qword ptr [rax+98h]
+  .text:00000001811F81FB                 mov     ecx, [rsp+548h+var_504]
+  .text:00000001811F81FF                 mov     eax, ecx
+  .text:00000001811F8201                 mov     r12, [rsp+548h+var_28]
+  .text:00000001811F8209                 btr     eax, 1Fh
+  .text:00000001811F820D                 mov     rdi, [rsp+548h+var_20]
+  .text:00000001811F8215                 mov     rbx, [rsp+548h+var_10]
+  .text:00000001811F821D                 mov     [rsp+548h+var_508], ebp
+  .text:00000001811F8221                 cmp     rax, 32h ; '2'
+  .text:00000001811F8225                 jbe     short loc_1811F8250
+  .text:00000001811F8227                 and     ecx, 7FFFFFFFh
+  .text:00000001811F822D                 jz      short loc_1811F823D
+  .text:00000001811F822F                 cmp     ecx, 32h ; '2'
+  .text:00000001811F8232                 lea     rbp, [rsp+548h+var_500]
+  .text:00000001811F8237                 cmova   rbp, [rsp+548h+var_500]
+  .text:00000001811F823D                 mov     rax, cs:g_pMemAlloc
+  .text:00000001811F8244                 mov     rdx, rbp
+  .text:00000001811F8247                 mov     rcx, [rax]
+  .text:00000001811F824A                 mov     rax, [rcx]
+  .text:00000001811F824D                 call    qword ptr [rax+18h]
+  .text:00000001811F8250                 add     rsp, 540h
+  .text:00000001811F8257                 pop     rbp
+  .text:00000001811F8258                 retn
+procedure: |-
+  int __fastcall CEntitySystem_HelperExecuteQueuedSpawn(__int64 a1, int *a2)
+  {
+    _QWORD *v2; // rbp
+    __int64 v3; // rbx
+    __int64 v4; // r12
+    int *v5; // r13
+    _QWORD *v6; // rcx
+    __int64 v7; // r14
+    __int64 v8; // rdi
+    __int64 v9; // rsi
+    __int64 v10; // rax
+    __int64 v11; // r10
+    __int64 v12; // rbx
+    int v13; // edx
+    __int64 v14; // r9
+    __int64 *v15; // rcx
+    _QWORD *v16; // rax
+    char *v17; // rax
+    int v18; // r15d
+    __int64 v19; // rsi
+    int *v20; // rdi
+    __int64 v21; // rbx
+    unsigned __int64 v22; // rbx
+    int v23; // edx
+    __int64 v24; // r9
+    __int64 v25; // r8
+    __int64 v26; // rbx
+    unsigned __int64 *v27; // rdx
+    _QWORD *v28; // rcx
+    _QWORD *v29; // r15
+    __int64 v30; // r14
+    int v31; // ecx
+    __int64 v32; // r12
+    int v33; // ebx
+    __int64 v34; // rcx
+    __int64 v35; // rcx
+    int v36; // esi
+    int v37; // eax
+    __int64 v38; // rdx
+    int v39; // edi
+    int v40; // eax
+    __int64 v41; // rax
+    unsigned __int64 v42; // rax
+    _DWORD v44[2]; // [rsp+30h] [rbp-518h] BYREF
+    const char *v45; // [rsp+38h] [rbp-510h]
+    int v46; // [rsp+40h] [rbp-508h] BYREF
+    unsigned int v47; // [rsp+44h] [rbp-504h]
+    _QWORD v48[152]; // [rsp+48h] [rbp-500h] BYREF
+    int v51; // [rsp+560h] [rbp+18h]
+    _QWORD *v52; // [rsp+568h] [rbp+20h]
+
+    v2 = nullptr;
+    v3 = *(int *)(a1 + 3040);
+    v4 = a1;
+    v5 = a2;
+    v51 = 0;
+    v46 = 0;
+    v47 = 50;
+    sub_1811F4850(&v46, (unsigned int)v3, 1);
+    if ( (v47 & 0x7FFFFFFF) != 0 )
+    {
+      v6 = v48;
+      if ( (v47 & 0x7FFFFFFF) > 0x32 )
+        v6 = (_QWORD *)v48[0];
+      v52 = v6;
+    }
+    else
+    {
+      v52 = nullptr;
+    }
+    v7 = v3;
+    if ( (int)v3 > 0 )
+    {
+      v8 = 0;
+      v9 = v3;
+      do
+      {
+        v10 = *(_QWORD *)(v4 + 3048);
+        v11 = *(_QWORD *)(v8 + v10 + 16);
+        if ( v11 && *(_BYTE *)(v8 + v10 + 24) )
+        {
+          v12 = *(_QWORD *)(v8 + v10 + 8);
+          if ( v12 )
+            goto LABEL_24;
+          v13 = *(_DWORD *)(v8 + v10);
+          if ( v13 == -1 || !qword_181D9D980 )
+            goto LABEL_22;
+          if ( v13 != -2
+            && (v14 = *(_QWORD *)(qword_181D9D980 + 8 * ((unsigned __int64)(v13 & 0x7FFF) >> 9))) != 0
+            && (v15 = (__int64 *)(v14 + 112LL * (v13 & 0x1FF))) != nullptr )
+          {
+            if ( *((_DWORD *)v15 + 4) != v13 )
+              v15 = nullptr;
+          }
+          else
+          {
+            v15 = nullptr;
+          }
+          if ( v15 )
+            v12 = *v15;
+          else
+  LABEL_22:
+            v12 = 0;
+          if ( v12 )
+          {
+  LABEL_24:
+            v44[0] = 1094168427;
+            v44[1] = -1;
+            v45 = "targetname";
+            v16 = (_QWORD *)sub_181207640(v11, v44, 0);
+            if ( v16 )
+            {
+              if ( ((*(_BYTE *)v16 >> 2) & 0xF) == 6 )
+              {
+                v17 = sub_1814DD810(v16, (__int64)byte_1815A2980);
+                if ( v17 )
+                  CEntityIdentity_SetEntityName(*(_QWORD *)(v12 + 16), (__int64)v17);
+              }
+            }
+          }
+        }
+        v8 += 32;
+        --v9;
+      }
+      while ( v9 );
+      v18 = 0;
+      v19 = 0;
+      while ( 1 )
+      {
+        v20 = (int *)(v19 + *(_QWORD *)(v4 + 3048));
+        v21 = *((_QWORD *)v20 + 1);
+        if ( v21 )
+        {
+          v22 = *(_QWORD *)(v21 + 16);
+        }
+        else
+        {
+          v23 = *v20;
+          if ( *v20 != -1
+            && qword_181D9D980
+            && v23 != -2
+            && (v24 = *(_QWORD *)(qword_181D9D980 + 8 * ((unsigned __int64)(v23 & 0x7FFF) >> 9))) != 0
+            && (v22 = v24 + 112LL * (v23 & 0x1FF)) != 0 )
+          {
+            if ( *(_DWORD *)(v22 + 16) != v23 )
+              v22 = 0;
+          }
+          else
+          {
+            v22 = 0;
+          }
+        }
+        v25 = *((_QWORD *)v20 + 2);
+        if ( v22 )
+        {
+          if ( !v25 || !*((_BYTE *)v20 + 24) )
+            goto LABEL_57;
+          if ( (unsigned __int8)sub_1811E7E90(*(_QWORD *)(v22 + 8), *(_QWORD *)v22) )
+          {
+            *(_DWORD *)(v22 + 48) |= 0x1000u;
+  LABEL_57:
+            v27 = &v52[3 * v18];
+            *v27 = v22;
+            v27[1] = *((_QWORD *)v20 + 2);
+            *((_WORD *)v27 + 10) = v18;
+            *((_BYTE *)v27 + 23) = *(_BYTE *)(*(_QWORD *)(v22 + 8) + 108LL);
+            *(_DWORD *)(v22 + 48) = *(_DWORD *)(v22 + 48) & 0xFFFFFEFD | 2;
+            ++v18;
+            goto LABEL_58;
+          }
+          CEntityIdentity_FreeAttributes(v22);
+          CConcreteEntityList_FreeEntity(v4 + 16, v22, 1);
+          --*(_WORD *)(*((_QWORD *)v20 + 2) + 34LL);
+          v26 = *((_QWORD *)v20 + 2);
+          if ( *(_BYTE *)(v26 + 36) && (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+            LoggingSystem_Log(
+              LOG_GENERAL,
+              2,
+              "kv 0x%p Release refcount == %d\n",
+              (const void *)v26,
+              *(__int16 *)(v26 + 32) - 1);
+          if ( (__int16)--*(_WORD *)(v26 + 32) > 0 )
+            goto LABEL_58;
+        }
+        else
+        {
+          if ( !v25 )
+            goto LABEL_58;
+          --*(_WORD *)(v25 + 34);
+          v26 = *((_QWORD *)v20 + 2);
+          if ( *(_BYTE *)(v26 + 36) && (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+            LoggingSystem_Log(
+              LOG_GENERAL,
+              2,
+              "kv 0x%p Release refcount == %d\n",
+              (const void *)v26,
+              *(__int16 *)(v26 + 32) - 1);
+          if ( (__int16)--*(_WORD *)(v26 + 32) > 0 )
+            goto LABEL_58;
+        }
+        sub_181206B10(v26);
+        sub_180E7C9C0(v26, 56);
+  LABEL_58:
+        v19 += 32;
+        if ( !--v7 )
+        {
+          v5 = a2;
+          v51 = v18;
+          break;
+        }
+      }
+    }
+    *(_DWORD *)(v4 + 3040) = 0;
+    v28 = (_QWORD *)(v4 + 536);
+    v29 = (_QWORD *)(v4 + 528);
+    v30 = 0;
+    if ( *(_QWORD *)(v4 + 536) != *(_QWORD *)(v4 + 528) )
+      v30 = *(_QWORD *)(v4 + 536);
+    if ( v30 )
+    {
+      do
+      {
+        v31 = 0x7FFF;
+        v32 = *v5;
+        if ( *(_DWORD *)(v30 + 16) != -1 )
+          v31 = *(_DWORD *)(v30 + 16) & 0x7FFF;
+        v33 = v31 | (((*(_DWORD *)(v30 + 16) >> 15) - (*(_DWORD *)(v30 + 48) & 1)) << 15);
+        if ( (_DWORD)v32 == v5[4] && (v5[5] & 0x40000000) == 0 )
+        {
+          v34 = (unsigned int)v5[4];
+          if ( (_DWORD)v34 == 0x7FFFFFFF )
+            UtlVectorMemory_FailedAllocation(v34, 1);
+          v35 = (unsigned int)v5[4];
+          v36 = v35 + 1;
+          v37 = UtlVectorMemory_CalcNewAllocationCount(v35, v5[5] & 0x3FFFFFFF, (unsigned int)(v35 + 1), 4);
+          v39 = v37;
+          if ( v37 < v36 )
+          {
+            if ( v37 || v36 > -1 )
+            {
+              do
+              {
+                v38 = (unsigned int)((v39 + v36) >> 31);
+                v39 = (v39 + v36) / 2;
+              }
+              while ( v39 < v36 );
+            }
+            else
+            {
+              v39 = -1;
+            }
+          }
+          LOBYTE(v38) = (v5[5] & 0xC0000000) == 0;
+          *((_QWORD *)v5 + 1) = UtlVectorMemory_Alloc(*((_QWORD *)v5 + 1), v38, 4LL * v39, 4LL * v5[4]);
+          v40 = v5[5];
+          if ( (v40 & 0xC0000000) != 0 )
+            v5[5] = v40 & 0x3FFFFFFF;
+          v5[4] = v39;
+        }
+        ++*v5;
+        *(_DWORD *)(*((_QWORD *)v5 + 1) + 4 * v32) = v33;
+        v41 = *(_QWORD *)(v30 + 88);
+        v30 = v41;
+      }
+      while ( v41 != *v29 && v41 );
+      v4 = a1;
+      v28 = (_QWORD *)(a1 + 536);
+      v29 = (_QWORD *)(a1 + 528);
+    }
+    *v29 = *v28;
+    if ( v51 > 0 )
+    {
+      if ( v51 > 1 )
+        (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 144LL))(v4, (unsigned int)v51, v52);// 144LL = CEntitySystem_SortEntities
+      (*(void (__fastcall **)(__int64, _QWORD, _QWORD *))(*(_QWORD *)v4 + 152LL))(v4, (unsigned int)v51, v52);// CEntitySystem_Spawn
+    }
+    v42 = v47;
+    LODWORD(v42) = v47 & 0x7FFFFFFF;
+    v46 = 0;
+    if ( v42 > 0x32 )
+    {
+      if ( (v47 & 0x7FFFFFFF) != 0 )
+      {
+        v2 = v48;
+        if ( (v47 & 0x7FFFFFFF) > 0x32 )
+          v2 = (_QWORD *)v48[0];
+      }
+      LODWORD(v42) = (*(__int64 (__fastcall **)(_QWORD, _QWORD *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v2);
+    }
+    return v42;
+  }

--- a/tests/test_pr_self_runner_workflow.py
+++ b/tests/test_pr_self_runner_workflow.py
@@ -3,6 +3,16 @@ import unittest
 
 
 class TestPrSelfRunnerWorkflow(unittest.TestCase):
+    def test_listens_for_pull_request_closed_events(self) -> None:
+        workflow = Path(".github/workflows/pr-self-runner.yml").read_text(encoding="utf-8")
+
+        self.assertIn("types: [opened, synchronize, reopened, ready_for_review, closed]", workflow)
+
+    def test_validation_job_does_not_run_for_closed_events(self) -> None:
+        workflow = Path(".github/workflows/pr-self-runner.yml").read_text(encoding="utf-8")
+
+        self.assertIn("github.event.action != 'closed' &&", workflow)
+
     def test_skips_automated_bump_download_pull_requests(self) -> None:
         workflow = Path(".github/workflows/pr-self-runner.yml").read_text(encoding="utf-8")
 
@@ -36,6 +46,22 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
                     'throw "run_cpp_tests.py failed with exit code $LASTEXITCODE"',
                     workflow,
                 )
+
+    def test_closed_event_finalizes_pr_workspace_instead_of_cleaning_bin_copy(self) -> None:
+        workflow = Path(".github/workflows/pr-self-runner.yml").read_text(encoding="utf-8")
+
+        self.assertNotIn("- name: Clean PR bin copy", workflow)
+        self.assertIn("finalize-pr-workspace:", workflow)
+        self.assertIn("- name: Finalize PR workspace", workflow)
+        self.assertIn('$prWasMerged = "${{ github.event.pull_request.merged }}"', workflow)
+        self.assertIn("robocopy @robocopyArgs", workflow)
+        self.assertIn('"*.yaml"', workflow)
+        self.assertIn('"/XC"', workflow)
+        self.assertIn('"/XN"', workflow)
+        self.assertIn('"/XO"', workflow)
+        self.assertIn("if ($robocopyExitCode -ge 8)", workflow)
+        self.assertIn("Remove-Item -LiteralPath $prWorkspace -Recurse -Force", workflow)
+        self.assertIn('Write-Host "Removed PR workspace: $prWorkspace"', workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `find-CEntitySystem_SortEntities` and `find-CGameEntitySystem_SortEntities` preprocessor scripts
- Fix `#495`: replace the PR self-runner's bin cleanup step with a `finalize-pr-workspace` job that copies merged PR YAML results into the persisted workspace before removing the per-PR workspace, and skips validation on `closed` events
- Fix reference YAML for `CEntitySystem_HelperExecuteQueuedSpawn`

## Test plan
- [x] `uv run python -m unittest discover -s tests -b` passes (573 tests)
- [x] `uv run python format_repo_files.py --check` reports no formatting issues