### PR TITLE
Fix PR self-runner workspace cleanup failing when CWD is inside the removed directory

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -422,5 +422,7 @@ jobs:
             Write-Host "PR was closed without merge; skipping persisted YAML copy."
           }
 
+          Set-Location $workspaceRoot
+
           Remove-Item -LiteralPath $prWorkspace -Recurse -Force
           Write-Host "Removed PR workspace: $prWorkspace"

--- a/tests/test_pr_self_runner_workflow.py
+++ b/tests/test_pr_self_runner_workflow.py
@@ -63,6 +63,14 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
         self.assertIn("Remove-Item -LiteralPath $prWorkspace -Recurse -Force", workflow)
         self.assertIn('Write-Host "Removed PR workspace: $prWorkspace"', workflow)
 
+    def test_closed_event_leaves_pr_workspace_before_deleting_it(self) -> None:
+        workflow = Path(".github/workflows/pr-self-runner.yml").read_text(encoding="utf-8")
+
+        self.assertIn(
+            "Set-Location $workspaceRoot\n\n          Remove-Item -LiteralPath $prWorkspace -Recurse -Force",
+            workflow,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- `Remove-Item` on the PR workspace directory was failing with "Cannot remove the item ... because it is in use" when the runner's working directory was still inside that directory.
- `Set-Location $workspaceRoot` before the removal so the workspace directory is no longer in use.

## Test plan
- [x] `uv run pytest tests/test_pr_self_runner_workflow.py -q` passes