### PR TITLE
feat(engine): add net stats preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -780,6 +780,15 @@ modules:
           - CNetworkGameClient_RecordEntityBandwidth.{platform}.yaml
         expected_input:
           - CNetworkServerService_Init.{platform}.yaml
+      - name: find-CNetworkGameClient_PrintNetStats
+        expected_output:
+          - CNetworkGameClient_PrintNetStats.{platform}.yaml
+      - name: find-CL_NET_PrintSummary_CommandHandler
+        expected_output:
+          - CL_NET_PrintSummary_CommandHandler.{platform}.yaml
+      - name: find-CMsgSource2NetworkFlowQuality_PrintStats
+        expected_output:
+          - CMsgSource2NetworkFlowQuality_PrintStats.{platform}.yaml
       - name: find-CNetworkGameClient_vtable
         expected_output:
           - CNetworkGameClient_vtable.{platform}.yaml
@@ -796,8 +805,22 @@ modules:
       - name: find-CEngineClient_vtable
         expected_output:
           - CEngineClient_vtable.{platform}.yaml
+      - name: find-CEngineClient_DumpNetStats
+        expected_output:
+          - CEngineClient_DumpNetStats.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_PrintNetStats.{platform}.yaml
+          - CL_NET_PrintSummary_CommandHandler.{platform}.yaml
+          - CEngineClient_vtable.{platform}.yaml
       - name: find-CEngineServer_vtable
         expected_output:
+          - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_DumpNetStats
+        expected_output:
+          - CEngineServer_DumpNetStats.{platform}.yaml
+        expected_input:
+          - CMsgSource2NetworkFlowQuality_PrintStats.{platform}.yaml
+          - CNetworkGameClient_PrintNetStats.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_ClientPrintf
         expected_output:
@@ -1341,6 +1364,16 @@ modules:
         alias:
           - CNetworkGameClient::RecordEntityBandwidth
           - RecordEntityBandwidth
+      - name: CNetworkGameClient_PrintNetStats
+        category: func
+        alias:
+          - CNetworkGameClient::PrintNetStats
+      - name: CL_NET_PrintSummary_CommandHandler
+        category: func
+      - name: CMsgSource2NetworkFlowQuality_PrintStats
+        category: func
+        alias:
+          - CMsgSource2NetworkFlowQuality::PrintStats
       - name: CNetworkGameClient_vtable
         category: vtable
       - name: CNetworkGameClient_DisconnectGame
@@ -1518,8 +1551,16 @@ modules:
         shared: true
       - name: CEngineClient_vtable
         category: vtable
+      - name: CEngineClient_DumpNetStats
+        category: vfunc
+        alias:
+          - CEngineClient::DumpNetStats
       - name: CEngineServer_vtable
         category: vtable
+      - name: CEngineServer_DumpNetStats
+        category: vfunc
+        alias:
+          - CEngineServer::DumpNetStats
       - name: CEngineServer_ClientPrintf
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CEngineClient_DumpNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_DumpNetStats.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_DumpNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineClient_DumpNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineClient_DumpNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameClient_PrintNetStats"],
+        "exclude_funcs": ["CL_NET_PrintSummary_CommandHandler"],
+        "exclude_strings": [
+            "For packet-level statistics, see net_connections_stats.",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineClient_DumpNetStats", "CEngineClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineClient_DumpNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_DumpNetStats.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_DumpNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_DumpNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_DumpNetStats",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CMsgSource2NetworkFlowQuality_PrintStats"],
+        "exclude_funcs": ["CNetworkGameClient_PrintNetStats"],
+        "exclude_strings": [
+            "Source2 engine networking summary.  %u seconds.",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_DumpNetStats", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_DumpNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CL_NET_PrintSummary_CommandHandler.py
+++ b/ida_preprocessor_scripts/find-CL_NET_PrintSummary_CommandHandler.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CL_NET_PrintSummary_CommandHandler skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CL_NET_PrintSummary_CommandHandler",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CL_NET_PrintSummary_CommandHandler",
+        "xref_strings": [
+            "For packet-level statistics, see net_connections_stats.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CL_NET_PrintSummary_CommandHandler",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CMsgSource2NetworkFlowQuality_PrintStats.py
+++ b/ida_preprocessor_scripts/find-CMsgSource2NetworkFlowQuality_PrintStats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CMsgSource2NetworkFlowQuality_PrintStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CMsgSource2NetworkFlowQuality_PrintStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CMsgSource2NetworkFlowQuality_PrintStats",
+        "xref_strings": [
+            "Bandwidth . . . . . . . : Total:%.1fkb",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CMsgSource2NetworkFlowQuality_PrintStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_PrintNetStats.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_PrintNetStats.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_PrintNetStats skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_PrintNetStats",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_PrintNetStats",
+        "xref_strings": [
+            "Source2 engine networking summary.  %u seconds.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_PrintNetStats",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add xref-based engine preprocessor scripts for client/server net stats printing paths.
- Wire new skills and symbols into `config.yaml` with vtable dependencies for `CEngineClient` and `CEngineServer` DumpNetStats.

## Test Plan
- `uv run python format_repo_files.py --check`
- `uv run python -m unittest discover -s tests -b`
- `uv run ida_analyze_bin.py -debug -platform windows -modules engine`
- `uv run ida_analyze_bin.py -debug -platform linux -modules engine`