### PR TITLE
feat(engine): add CEngineServer_GetClientConVarValue preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -930,6 +930,11 @@ modules:
           - CEngineServer_ClientCommand.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_GetClientConVarValue
+        expected_output:
+          - CEngineServer_GetClientConVarValue.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1668,6 +1673,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientCommand
+      - name: CEngineServer_GetClientConVarValue
+        category: vfunc
+        alias:
+          - CEngineServer::GetClientConVarValue
       - name: CLoopTypeClientServerService_vtable
         category: vtable
       - name: CLoopTypeClientServerService_vtable2

--- a/ida_preprocessor_scripts/find-CEngineServer_GetClientConVarValue.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetClientConVarValue.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetClientConVarValue skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetClientConVarValue",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetClientConVarValue",
+        "xref_strings": [
+            "GetClientConVarValue: player invalid index %i",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetClientConVarValue", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetClientConVarValue",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CEngineServer_GetClientConVarValue` preprocessor script that locates the `CEngineServer::GetClientConVarValue` virtual function via the `CEngineServer_vtable` and the xref string `GetClientConVarValue: player invalid index %i`, then writes its YAML (func va/rva/size/sig + vtable offset/index).
- Register the new script and its expected input/output (`CEngineServer_GetClientConVarValue.{platform}.yaml`, `CEngineServer_vtable.{platform}.yaml`) in `config.yaml`.
- Add the `CEngineServer_GetClientConVarValue` vfunc entry (alias `CEngineServer::GetClientConVarValue`) to `config.yaml`.

## Test Plan
- [ ] Run `uv run ida_analyze_bin.py -debug` and confirm the new script produces `CEngineServer_GetClientConVarValue.{platform}.yaml` with valid vfunc offset/index.