### PR TITLE
feat(engine): add CEngineServer_GetPlayerInfo preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -935,6 +935,11 @@ modules:
           - CEngineServer_GetClientConVarValue.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_GetPlayerInfo
+        expected_output:
+          - CEngineServer_GetPlayerInfo.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1677,6 +1682,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::GetClientConVarValue
+      - name: CEngineServer_GetPlayerInfo
+        category: vfunc
+        alias:
+          - CEngineServer::GetPlayerInfo
       - name: CLoopTypeClientServerService_vtable
         category: vtable
       - name: CLoopTypeClientServerService_vtable2

--- a/ida_preprocessor_scripts/find-CEngineServer_GetPlayerInfo.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetPlayerInfo.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetPlayerInfo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetPlayerInfo",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetPlayerInfo",
+        "xref_strings": [
+            "userinfo",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetPlayerInfo", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetPlayerInfo",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CEngineServer_GetPlayerInfo.py` (Pattern B — vfunc via xref string `"userinfo"`)
- `CEngineServer_GetPlayerInfo` is a vfunc of `CEngineServer_vtable`; outputs `func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index`
- Updates `config.yaml` with the skill entry (`expected_input: CEngineServer_vtable`) and symbol entry (`category: vfunc`, alias `CEngineServer::GetPlayerInfo`)

## Test plan
- [ ] `uv run ida_analyze_bin.py -debug` passes (blocked by open IDA lock during dev; script/config structure validated via formatting + 574 unit tests)
- [ ] `uv run python format_repo_files.py --check` — clean
- [ ] `uv run python -m unittest discover -s tests -b` — 574 tests OK