### PR TITLE
test(cpp): add IVEngineServer2 vtable test

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9566,6 +9566,33 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - engine  # bin/{gamever}/engine/CLoopTypeClientServer_*.{platform}.yaml
+  - name: IVEngineServer2_MSVC
+    symbol: IVEngineServer2
+    alias_symbols:
+      - CEngineServer
+    cpp: cpp_tests/ivengineserver2.cpp
+    headers:
+      - hl2sdk_cs2/public/eiface.h  # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - engine  # bin/{gamever}/engine/CEngineServer_*.{platform}.yaml
   - name: IGameSystemFactory_MSVC
     symbol: IGameSystemFactory
     cpp: cpp_tests/igamesystemfactory.cpp

--- a/cpp_tests/ivengineserver2.cpp
+++ b/cpp_tests/ivengineserver2.cpp
@@ -1,0 +1,25 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+// Avoid pulling edict.h's heavier transitive include chain; eiface.h only needs
+// these as pointer/reference types for the IVEngineServer2 layout test.
+#define EDICT_H
+#define ISERVERENTITY_H
+class CGlobalVars;
+class CCheckTransmitInfo;
+class CSharedEdictChangeInfo;
+class IServerEntity;
+struct edict_t;
+
+#include <entity2/entityidentity.h>
+#include <eiface.h>
+
+IVEngineServer2 *engineserver();
+
+int main()
+{
+	engineserver()->GetSteamUniverse();
+
+	return 0;
+}

--- a/cpp_tests_util.py
+++ b/cpp_tests_util.py
@@ -15,9 +15,10 @@ except ImportError:
 
 VFTABLE_HEADER_RE = re.compile(r"^\s*(?:VFTable|VTable) indices for '([^']+)' \((\d+) (?:entry|entries)\)\.\s*$")
 VFTABLE_LAYOUT_HEADER_RE = re.compile(
-    r"^\s*(?:VFTable|VTable) for '([^']+)'(?: in '([^']+)')? "
+    r"^\s*(?:VFTable|VTable) for '([^']+)'((?: in '[^']+')*) "
     r"\((\d+) (?:entry|entries)\)\.\s*$"
 )
+VFTABLE_LAYOUT_IN_CLASS_RE = re.compile(r" in '([^']+)'")
 VFTABLE_ENTRY_RE = re.compile(r"^\s*(\d+)\s+\|\s+(.+?)\s*$")
 # Group 2 captures the run of spaces between `|` and the declaration so the
 # parser can derive nesting depth from clang's 2-space-per-level indentation.
@@ -112,7 +113,8 @@ def parse_vftable_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
 
         layout_header = VFTABLE_LAYOUT_HEADER_RE.match(raw_line)
         if layout_header:
-            current_class = layout_header.group(2) or layout_header.group(1)
+            in_classes = VFTABLE_LAYOUT_IN_CLASS_RE.findall(layout_header.group(2) or "")
+            current_class = in_classes[-1] if in_classes else layout_header.group(1)
             current_declared_entries = 0
             current_raw_declared_entries = int(layout_header.group(3))
             current_raw_entries = 0

--- a/tests/test_run_cpp_tests.py
+++ b/tests/test_run_cpp_tests.py
@@ -65,6 +65,38 @@ class TestParseVftableLayouts(unittest.TestCase):
             parsed["CDerived"]["methods_by_index"][3]["member_name"],
         )
 
+    def test_prefers_complete_vftable_for_multi_level_derived_class(self) -> None:
+        compiler_output = (
+            "VFTable for 'IGrandParent' in 'IParent' in 'CDerived' (5 entries).\n"
+            "   0 | CDerived RTTI\n"
+            "   1 | void IGrandParent::GrandParentVirtual() [pure]\n"
+            "   2 | void IParent::ParentVirtual() [pure]\n"
+            "   3 | void CDerived::ChildVirtual() [pure]\n"
+            "   4 | void CDerived::ChildTailVirtual() [pure]\n"
+            "\n"
+            "VFTable indices for 'CDerived' (2 entries).\n"
+            "   2 | void CDerived::ChildVirtual()\n"
+            "   3 | void CDerived::ChildTailVirtual()\n"
+        )
+
+        parsed = cpp_tests_util.parse_vftable_layouts(compiler_output)
+
+        self.assertIn("CDerived", parsed)
+        self.assertEqual(4, parsed["CDerived"]["declared_entries"])
+        self.assertEqual(4, parsed["CDerived"]["entry_count"])
+        self.assertEqual(
+            "GrandParentVirtual",
+            parsed["CDerived"]["methods_by_index"][0]["member_name"],
+        )
+        self.assertEqual(
+            "ParentVirtual",
+            parsed["CDerived"]["methods_by_index"][1]["member_name"],
+        )
+        self.assertEqual(
+            "ChildTailVirtual",
+            parsed["CDerived"]["methods_by_index"][3]["member_name"],
+        )
+
 
 class TestCompareVtableWithYaml(unittest.TestCase):
     def test_complete_derived_vftable_matches_inherited_overload_reference(self) -> None:


### PR DESCRIPTION
## Summary
- Add cpp_tests/ivengineserver2.cpp for IVEngineServer2, mapped to CEngineServer reference YAML via alias_symbols.
- Add the IVEngineServer2_MSVC cpp_tests config entry for the engine module.
- Fix multi-level clang vtable layout parsing and cover it with a unittest.
- Update the hl2sdk_cs2 submodule to include the IVEngineServer2 vtable-size fix.

## Related
- Depends on HLND2T/hl2sdk#1 for the submodule commit.

## Test Plan
- uv run run_cpp_tests.py -gamever 14167 -debug
- PYTHONPATH=.; uv run python -m unittest tests.test_run_cpp_tests -v
- git diff --check