### PR TITLE
feat(engine): add CLog_Print and CEngineServer_LogPrint preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -940,6 +940,15 @@ modules:
           - CEngineServer_GetPlayerInfo.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CLog_Print
+        expected_output:
+          - CLog_Print.{platform}.yaml
+      - name: find-CEngineServer_LogPrint
+        expected_output:
+          - CEngineServer_LogPrint.{platform}.yaml
+        expected_input:
+          - CLog_Print.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1686,6 +1695,14 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::GetPlayerInfo
+      - name: CLog_Print
+        category: func
+        alias:
+          - CLog::Print
+      - name: CEngineServer_LogPrint
+        category: vfunc
+        alias:
+          - CEngineServer::LogPrint
       - name: CLoopTypeClientServerService_vtable
         category: vtable
       - name: CLoopTypeClientServerService_vtable2

--- a/ida_preprocessor_scripts/find-CEngineServer_LogPrint.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_LogPrint.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_LogPrint skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_LogPrint",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_LogPrint",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CLog_Print"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_LogPrint", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_LogPrint",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLog_Print.py
+++ b/ida_preprocessor_scripts/find-CLog_Print.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLog_Print skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLog_Print",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLog_Print",
+        "xref_strings": ["L %02i/%02i/%04i - %02i:%02i:%02i: %s"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLog_Print",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Adds `find-CLog_Print.py` (Pattern A — regular function via xref string `"L %02i/%02i/%04i - %02i:%02i:%02i: %s"`). Outputs `func_name, func_sig, func_va, func_rva, func_size`.
- Adds `find-CEngineServer_LogPrint.py` (Pattern B — vfunc via `xref_funcs: ["CLog_Print"]`). Outputs `func_name, func_va, func_rva, func_size, func_sig, vtable_name, vfunc_offset, vfunc_index`. `FUNC_VTABLE_RELATIONS` uses the `CEngineServer_vtable` artifact stem, matching the recent CEngineServer_* scripts.
- Updates `config.yaml` with skill entries (dependency chain: `find-CLog_Print` → `find-CEngineServer_LogPrint` which needs both `CLog_Print.{platform}.yaml` and `CEngineServer_vtable.{platform}.yaml`) and symbol entries (`CLog_Print` / `category: func` / alias `CLog::Print`; `CEngineServer_LogPrint` / `category: vfunc` / alias `CEngineServer::LogPrint`).

## Test plan
- [x] `uv run ida_analyze_bin.py -modules engine -debug` — 6 successful, 0 failed (both skills OK on Windows + Linux; `CEngineServer_LogPrint` matched `CEngineServer_vtable` slot 55 / offset 0x1b8)
- [x] `uv run python format_repo_files.py --check` — clean (0 fixed)
- [x] `uv run python -m unittest discover -s tests -b` — 575 tests, 0 failures
