### PR TITLE
Add find-CEngineServer_ClientCommandKeyValues preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -940,6 +940,11 @@ modules:
           - CEngineServer_GetPlayerInfo.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_ClientCommandKeyValues
+        expected_output:
+          - CEngineServer_ClientCommandKeyValues.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CLog_Print
         expected_output:
           - CLog_Print.{platform}.yaml
@@ -1695,6 +1700,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::GetPlayerInfo
+      - name: CEngineServer_ClientCommandKeyValues
+        category: vfunc
+        alias:
+          - CEngineServer::ClientCommandKeyValues
       - name: CLog_Print
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_ClientCommandKeyValues.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ClientCommandKeyValues.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ClientCommandKeyValues skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ClientCommandKeyValues",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ClientCommandKeyValues",
+        "xref_strings": [
+            "ClientCommandKeyValues:  Some entity tried to stuff '%s' to console buffer of entity %i when maxclients was set",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ClientCommandKeyValues", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ClientCommandKeyValues",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
Add Pattern B preprocessor script for `CEngineServer_ClientCommandKeyValues` (vfunc of `CEngineServer_vtable`), discovered via the xref string `"ClientCommandKeyValues:  Some entity tried to stuff '%s' to console buffer of entity %i when maxclients was set"`.

## Changes
- New script: `ida_preprocessor_scripts/find-CEngineServer_ClientCommandKeyValues.py`
- `config.yaml`: skill entry with `expected_input: CEngineServer_vtable.{platform}.yaml`
- `config.yaml`: `CEngineServer_ClientCommandKeyValues` symbol (`category: vfunc`, alias `CEngineServer::ClientCommandKeyValues`)

## Validation
- `uv run ida_analyze_bin.py -debug`: Successful on Windows (vtable idx 73 / offset 0x248) and Linux; 0 failures
- `uv run python format_repo_files.py --check`: clean
- `uv run python -m unittest discover -s tests -b`: 575 tests pass