### PR TITLE
Add CEngineServer_CreateFakeClient and CNetworkGameServer_CreateFakeClient_Impl preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -565,6 +565,9 @@ modules:
       - name: find-CNetworkGameServer_GetFreeClient
         expected_output:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
+      - name: find-CNetworkGameServer_CreateFakeClient_Impl
+        expected_output:
+          - CNetworkGameServer_CreateFakeClient_Impl.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
           - g_pGameServer.{platform}.yaml
@@ -1365,6 +1368,10 @@ modules:
         alias:
           - CNetworkGameServer::GetFreeClient
           - GetFreeClient
+      - name: CNetworkGameServer_CreateFakeClient_Impl
+        category: func
+        alias:
+          - CNetworkGameServer::CreateFakeClient_Impl
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -943,6 +943,12 @@ modules:
           - CEngineServer_SetFakeClientConVarValue.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_CreateFakeClient
+        expected_output:
+          - CEngineServer_CreateFakeClient.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_CreateFakeClient_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_GetPlayerInfo
         expected_output:
           - CEngineServer_GetPlayerInfo.{platform}.yaml
@@ -1712,6 +1718,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::SetFakeClientConVarValue
+      - name: CEngineServer_CreateFakeClient
+        category: vfunc
+        alias:
+          - CEngineServer::CreateFakeClient
       - name: CEngineServer_GetPlayerInfo
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_CreateFakeClient.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_CreateFakeClient.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_CreateFakeClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_CreateFakeClient",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_CreateFakeClient",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameServer_CreateFakeClient_Impl"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_CreateFakeClient", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_CreateFakeClient",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_CreateFakeClient_Impl.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_CreateFakeClient_Impl.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_CreateFakeClient_Impl skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_CreateFakeClient_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_CreateFakeClient_Impl",
+        "xref_strings": [
+            "30000",
+            "rate",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_CreateFakeClient_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Add `find-CNetworkGameServer_CreateFakeClient_Impl` (Pattern A): regular function found via xref strings `"30000"` and `"rate"`
- Add `find-CEngineServer_CreateFakeClient` (Pattern B): vfunc of `CEngineServer` found via `xref_funcs: [CNetworkGameServer_CreateFakeClient_Impl]`

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes with 0 failures
- [ ] `uv run python format_repo_files.py --check` clean
- [ ] `uv run python -m unittest discover -s tests -b` — 0 failures (2 pre-existing unrelated failures excluded)