### PR TITLE
Add CNetworkGameServer preprocessor scripts and rename symbols

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -459,6 +459,11 @@ modules:
           - CNetworkGameServer_ActivateServer.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_DirectUpdate
+        expected_output:
+          - CNetworkGameServer_DirectUpdate.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -1396,6 +1401,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::ActivateServer
+      - name: CNetworkGameServer_DirectUpdate
+        category: vfunc
+        alias:
+          - CNetworkGameServer::DirectUpdate
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -767,22 +767,22 @@ modules:
           - CNetworkServerService_OnSimpleLoopFrameUpdate.{platform}.yaml
         expected_input:
           - CNetworkServerService_RegisterEventMapInternal.{platform}.yaml
-      - name: find-INetworkGameServer_ClientUpdate
+      - name: find-INetworkGameServer_PreWorldUpdate
         expected_output:
-          - INetworkGameServer_ClientUpdate.{platform}.yaml
+          - INetworkGameServer_PreWorldUpdate.{platform}.yaml
         expected_input:
           - CNetworkServerService_OnServerPostAdvanceTick.{platform}.yaml
-      - name: find-CNetworkGameServer_ClientUpdate
+      - name: find-CNetworkGameServer_PreWorldUpdate
         expected_output:
-          - CNetworkGameServer_ClientUpdate.{platform}.yaml
+          - CNetworkGameServer_PreWorldUpdate.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
-          - INetworkGameServer_ClientUpdate.{platform}.yaml
+          - INetworkGameServer_PreWorldUpdate.{platform}.yaml
       - name: find-ISource2Server_PreWorldUpdate
         expected_output:
           - ISource2Server_PreWorldUpdate.{platform}.yaml
         expected_input:
-          - CNetworkGameServer_ClientUpdate.{platform}.yaml
+          - CNetworkGameServer_PreWorldUpdate.{platform}.yaml
       - name: find-INetworkMessages_SetIsForServer
         expected_output:
           - INetworkMessages_SetIsForServer.{platform}.yaml
@@ -1621,14 +1621,14 @@ modules:
         category: func
         alias:
           - CNetworkServerService::OnSimpleLoopFrameUpdate
-      - name: INetworkGameServer_ClientUpdate
+      - name: INetworkGameServer_PreWorldUpdate
         category: vfunc
         alias:
-          - INetworkGameServer::ClientUpdate
-      - name: CNetworkGameServer_ClientUpdate
+          - INetworkGameServer::PreWorldUpdate
+      - name: CNetworkGameServer_PreWorldUpdate
         category: vfunc
         alias:
-          - CNetworkGameServer::ClientUpdate
+          - CNetworkGameServer::PreWorldUpdate
       - name: ISource2Server_PreWorldUpdate
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -565,9 +565,9 @@ modules:
       - name: find-CNetworkGameServer_GetFreeClient
         expected_output:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
-      - name: find-CNetworkGameServer_CreateFakeClient_Impl
+      - name: find-CNetworkGameServerBase_CreateFakeClient
         expected_output:
-          - CNetworkGameServer_CreateFakeClient_Impl.{platform}.yaml
+          - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
           - g_pGameServer.{platform}.yaml
@@ -947,7 +947,7 @@ modules:
         expected_output:
           - CEngineServer_CreateFakeClient.{platform}.yaml
         expected_input:
-          - CNetworkGameServer_CreateFakeClient_Impl.{platform}.yaml
+          - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_GetPlayerInfo
         expected_output:
@@ -1374,10 +1374,10 @@ modules:
         alias:
           - CNetworkGameServer::GetFreeClient
           - GetFreeClient
-      - name: CNetworkGameServer_CreateFakeClient_Impl
+      - name: CNetworkGameServerBase_CreateFakeClient
         category: func
         alias:
-          - CNetworkGameServer::CreateFakeClient_Impl
+          - CNetworkGameServerBase::CreateFakeClient
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -454,6 +454,11 @@ modules:
       - name: find-CNetworkGameServer_vtable
         expected_output:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_ActivateServer
+        expected_output:
+          - CNetworkGameServer_ActivateServer.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -567,6 +572,11 @@ modules:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
       - name: find-CNetworkGameServerBase_CreateFakeClient
         expected_output:
+          - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
+      - name: find-CNetworkGameServerBase_StartHLTVMaster
+        expected_output:
+          - CNetworkGameServerBase_StartHLTVMaster.{platform}.yaml
+        expected_input:
           - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
@@ -1378,6 +1388,14 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::CreateFakeClient
+      - name: CNetworkGameServerBase_StartHLTVMaster
+        category: func
+        alias:
+          - CNetworkGameServerBase::StartHLTVMaster
+      - name: CNetworkGameServer_ActivateServer
+        category: vfunc
+        alias:
+          - CNetworkGameServer::ActivateServer
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_CreateFakeClient.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_CreateFakeClient.py
@@ -13,7 +13,7 @@ FUNC_XREFS = [
         "xref_strings": [],
         "xref_gvs": [],
         "xref_signatures": [],
-        "xref_funcs": ["CNetworkGameServer_CreateFakeClient_Impl"],
+        "xref_funcs": ["CNetworkGameServerBase_CreateFakeClient"],
         "exclude_funcs": [],
         "exclude_strings": [],
         "exclude_gvs": [],

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_CreateFakeClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_CreateFakeClient.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServer_CreateFakeClient_Impl skill."""
+"""Preprocess script for find-CNetworkGameServerBase_CreateFakeClient skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServer_CreateFakeClient_Impl",
+    "CNetworkGameServerBase_CreateFakeClient",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServer_CreateFakeClient_Impl",
+        "func_name": "CNetworkGameServerBase_CreateFakeClient",
         "xref_strings": [
-            "30000",
-            "rate",
+            "FULLMATCH:30000",
+            "FULLMATCH:rate",
         ],
         "xref_gvs": [],
         "xref_signatures": [],
@@ -27,7 +27,7 @@ FUNC_XREFS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServer_CreateFakeClient_Impl",
+        "CNetworkGameServerBase_CreateFakeClient",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_StartHLTVMaster.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_StartHLTVMaster.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_StartHLTVMaster skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_StartHLTVMaster",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_StartHLTVMaster",
+        "xref_strings": [
+            "FULLMATCH:SourceTV",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameServerBase_CreateFakeClient"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_StartHLTVMaster",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_ActivateServer.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_ActivateServer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_ActivateServer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_ActivateServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_ActivateServer",
+        "xref_strings": [
+            "CNetworkGameServer::ActivateServer",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServer_ActivateServer", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_ActivateServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_DirectUpdate.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_DirectUpdate.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_DirectUpdate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_DirectUpdate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_DirectUpdate",
+        "xref_strings": [
+            "FULLMATCH:CNetworkStringTableContainer::DirectUpdate",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServer_DirectUpdate", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_DirectUpdate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_PreWorldUpdate.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_PreWorldUpdate.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServer_ClientUpdate skill."""
+"""Preprocess script for find-CNetworkGameServer_PreWorldUpdate skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
-    ("CNetworkGameServer_ClientUpdate", "CNetworkGameServer", "INetworkGameServer_ClientUpdate", True),
+    ("CNetworkGameServer_PreWorldUpdate", "CNetworkGameServer", "INetworkGameServer_PreWorldUpdate", True),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServer_ClientUpdate",
+        "CNetworkGameServer_PreWorldUpdate",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-INetworkGameServer_PreWorldUpdate.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_PreWorldUpdate.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-INetworkGameServer_ClientUpdate skill."""
+"""Preprocess script for find-INetworkGameServer_PreWorldUpdate skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "INetworkGameServer_ClientUpdate",
+    "INetworkGameServer_PreWorldUpdate",
 ]
 
 LLM_DECOMPILE = [
     # (symbol_name, path_to_prompt, path_to_reference)
     (
-        "INetworkGameServer_ClientUpdate",
+        "INetworkGameServer_PreWorldUpdate",
         "prompt/call_llm_decompile.md",
         "references/engine/CNetworkServerService_OnServerPostAdvanceTick.{platform}.yaml",
     ),
@@ -19,13 +19,13 @@ LLM_DECOMPILE = [
 # INetworkGameServer is an abstract interface -- no vtable YAML needed; vtable_name is metadata only
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("INetworkGameServer_ClientUpdate", "INetworkGameServer"),
+    ("INetworkGameServer_PreWorldUpdate", "INetworkGameServer"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "INetworkGameServer_ClientUpdate",
+        "INetworkGameServer_PreWorldUpdate",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/find-ISource2Server_PreWorldUpdate.py
+++ b/ida_preprocessor_scripts/find-ISource2Server_PreWorldUpdate.py
@@ -12,7 +12,7 @@ LLM_DECOMPILE = [
     (
         "ISource2Server_PreWorldUpdate",
         "prompt/call_llm_decompile.md",
-        "references/engine/CNetworkGameServer_ClientUpdate.{platform}.yaml",
+        "references/engine/CNetworkGameServer_PreWorldUpdate.{platform}.yaml",
     ),
 ]
 

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_PreWorldUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_PreWorldUpdate.linux.yaml
@@ -1,4 +1,4 @@
-func_name: CNetworkGameServer_ClientUpdate
+func_name: CNetworkGameServer_PreWorldUpdate
 func_va: '0x6aeb90'
 disasm_code: |-
   .text:00000000006AEB90                 cmp     dword ptr [rdi+38h], 3
@@ -12,7 +12,7 @@ disasm_code: |-
   .text:00000000006AEBB4                 mov     rax, [rax+78h]; 0x78 = 120 = ISource2Server_PreWorldUpdate
   .text:00000000006AEBB8                 jmp     rax
 procedure: |-
-  __int64 __fastcall CNetworkGameServer_ClientUpdate(__int64 a1)
+  __int64 __fastcall CNetworkGameServer_PreWorldUpdate(__int64 a1)
   {
     __int64 result; // rax
 

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_PreWorldUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_PreWorldUpdate.windows.yaml
@@ -1,4 +1,4 @@
-func_name: CNetworkGameServer_ClientUpdate
+func_name: CNetworkGameServer_PreWorldUpdate
 func_va: '0x1800aba40'
 disasm_code: |-
   .text:00000001800ABA40                 cmp     dword ptr [rcx+38h], 3
@@ -12,7 +12,7 @@ disasm_code: |-
   .text:00000001800ABA57                 jmp     qword ptr [rax+78h]; 0x78 = 120LL = ISource2Server_PreWorldUpdate
   .text:00000001800ABA5B                 retn
 procedure: |-
-  __int64 __fastcall CNetworkGameServer_ClientUpdate(__int64 a1, __int64 a2)
+  __int64 __fastcall CNetworkGameServer_PreWorldUpdate(__int64 a1, __int64 a2)
   {
     __int64 result; // rax
 

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostAdvanceTick.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostAdvanceTick.linux.yaml
@@ -99,7 +99,7 @@ disasm_code: |-
   .text:00000000005A68DF                 jmp     sub_5A5740
   .text:00000000005A68E8                 mov     rdi, cs:qword_9779A8
   .text:00000000005A68EF                 mov     rax, [rdi]
-  .text:00000000005A68F2                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+  .text:00000000005A68F2                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
   .text:00000000005A68F8                 jmp     loc_5A6746
   .text:00000000005A68FD                 mov     cs:byte_9BCF34, 0
   .text:00000000005A6904                 mov     rax, cs:g_pThreadPool_ptr
@@ -150,7 +150,7 @@ disasm_code: |-
   .text:00000000005A69C8                 mov     rdi, rdx
   .text:00000000005A69CB                 xor     ebx, ebx
   .text:00000000005A69CD                 mov     rax, [rdi]
-  .text:00000000005A69D0                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+  .text:00000000005A69D0                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
   .text:00000000005A69D6                 lea     eax, [rbx+1]
   .text:00000000005A69D9                 mov     rdi, cs:qword_9779A0
   .text:00000000005A69E0                 mov     rdx, cs:g_pGameServer
@@ -218,7 +218,7 @@ procedure: |-
       {
         v19 = 1;
   LABEL_31:
-        (*(void (__fastcall **)(__int64))(*(_QWORD *)v18 + 456LL))(v18);// 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)v18 + 456LL))(v18);// 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
         v20 = v19 + 1;
         v18 = qword_9779A0;
         v17 = g_pGameServer;
@@ -244,7 +244,7 @@ procedure: |-
     }
   LABEL_3:
     if ( qword_9779A8 )
-      (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_9779A8 + 456LL))(qword_9779A8);// 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_9779A8 + 456LL))(qword_9779A8);// 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
     if ( *(_BYTE *)(a1 + 400) && *(_QWORD *)(a1 + 336) )
       sub_5C6800(a1);
     if ( *(_BYTE *)(a2 + 60) || *(_BYTE *)(a2 + 41) )

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostAdvanceTick.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostAdvanceTick.windows.yaml
@@ -57,8 +57,8 @@ disasm_code: |-
   .text:00000001801EB386                 jmp     short loc_1801EB38E
   .text:00000001801EB388                 mov     rax, [r8]
   .text:00000001801EB38B                 mov     rcx, r8
-  .text:00000001801EB38E                 ; 0x1C8 = 456 = INetworkGameServer_ClientUpdate
-  .text:00000001801EB38E                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+  .text:00000001801EB38E                 ; 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
+  .text:00000001801EB38E                 call    qword ptr [rax+1C8h]; 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
   .text:00000001801EB394                 inc     ebx
   .text:00000001801EB396                 mov     r9, cs:qword_1806874B8
   .text:00000001801EB39D                 mov     rcx, cs:qword_1806874B0
@@ -245,7 +245,7 @@ procedure: |-
       }
       v10 = *v4;
   LABEL_20:
-      (*(void (__fastcall **)(__int64 *, __int64, __int64 *, __int64))(v10 + 456))(v4, v9, v6, v2);// 0x1C8 = 456 = INetworkGameServer_ClientUpdate
+      (*(void (__fastcall **)(__int64 *, __int64, __int64 *, __int64))(v10 + 456))(v4, v9, v6, v2);// 0x1C8 = 456 = INetworkGameServer_PreWorldUpdate
       ++i;
   LABEL_21:
       v2 = qword_1806874B8;


### PR DESCRIPTION
Add CNetworkGameServer preprocessor scripts and rename symbols

- Add find-CNetworkGameServer_DirectUpdate preprocessor script
- Add find-CNetworkGameServerBase_StartHLTVMaster preprocessor script
- Add find-CNetworkGameServer_ActivateServer preprocessor script
- Rename CNetworkGameServer_ClientUpdate to CNetworkGameServer_PreWorldUpdate
- Rename INetworkGameServer_ClientUpdate to INetworkGameServer_PreWorldUpdate
- Rename CNetworkGameServer_CreateFakeClient_Impl to CNetworkGameServerBase_CreateFakeClient