### PR TITLE
Add find-CServerSideClientBase_GetNetworkIDString_Impl and find-CEngineServer_GetPlayerNetworkIDString

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -943,6 +943,12 @@ modules:
       - name: find-CServerSideClientBase_GetNetworkIDString_Impl
         expected_output:
           - CServerSideClientBase_GetNetworkIDString_Impl.{platform}.yaml
+      - name: find-CEngineServer_GetPlayerNetworkIDString
+        expected_output:
+          - CEngineServer_GetPlayerNetworkIDString.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_GetNetworkIDString_Impl.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_GetPlayerInfo
         expected_output:
           - CEngineServer_GetPlayerInfo.{platform}.yaml
@@ -1712,6 +1718,10 @@ modules:
         category: func
         alias:
           - CServerSideClientBase::GetNetworkIDString
+      - name: CEngineServer_GetPlayerNetworkIDString
+        category: vfunc
+        alias:
+          - CEngineServer::GetPlayerNetworkIDString
       - name: CEngineServer_GetPlayerInfo
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -940,6 +940,9 @@ modules:
           - CEngineServer_SetFakeClientConVarValue.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CServerSideClientBase_GetNetworkIDString_Impl
+        expected_output:
+          - CServerSideClientBase_GetNetworkIDString_Impl.{platform}.yaml
       - name: find-CEngineServer_GetPlayerInfo
         expected_output:
           - CEngineServer_GetPlayerInfo.{platform}.yaml
@@ -1705,6 +1708,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::SetFakeClientConVarValue
+      - name: CServerSideClientBase_GetNetworkIDString_Impl
+        category: func
+        alias:
+          - CServerSideClientBase::GetNetworkIDString
       - name: CEngineServer_GetPlayerInfo
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_GetPlayerNetworkIDString.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetPlayerNetworkIDString.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetPlayerNetworkIDString skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetPlayerNetworkIDString",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetPlayerNetworkIDString",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CServerSideClientBase_GetNetworkIDString_Impl",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetPlayerNetworkIDString", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetPlayerNetworkIDString",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CServerSideClientBase_GetNetworkIDString_Impl.py
+++ b/ida_preprocessor_scripts/find-CServerSideClientBase_GetNetworkIDString_Impl.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClientBase_GetNetworkIDString_Impl skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClientBase_GetNetworkIDString_Impl",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CServerSideClientBase_GetNetworkIDString_Impl",
+        "xref_strings": [
+            "STEAM_ID_LAN",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [
+            "FULLMATCH:REPLAY",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CServerSideClientBase_GetNetworkIDString_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-CServerSideClientBase_GetNetworkIDString_Impl` preprocessor script (Pattern A): discovers the function via `STEAM_ID_LAN` xref string, with `FULLMATCH:REPLAY` as an exclude string to disambiguate from 7 other STEAM_ID_LAN-referencing functions
- Adds `find-CEngineServer_GetPlayerNetworkIDString` preprocessor script (Pattern B): discovers the vfunc as a caller of `CServerSideClientBase_GetNetworkIDString_Impl`, intersected with `CEngineServer_vtable` entries for disambiguation; outputs vtable slot metadata

## Test plan

- [ ] Format check passes: `uv run python format_repo_files.py --check`
- [ ] Test suite passes (2 pre-existing failures unrelated to these changes): `uv run python -m unittest discover -s tests -b`
- [ ] Logic validated on gamever 14165c via IDA MCP: `STEAM_ID_LAN` → 8 candidates, minus `REPLAY` referencers → 1 candidate (`CServerSideClientBase_GetNetworkIDString_Impl`); that function has 6 callers, intersect with `CEngineServer_vtable` → 1 candidate (`CEngineServer_GetPlayerNetworkIDString`)