### PR TITLE
Add find-PerformKick and find-CEngineServer_KickClient preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -983,6 +983,15 @@ modules:
         expected_input:
           - CLog_Print.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-PerformKick
+        expected_output:
+          - PerformKick.{platform}.yaml
+      - name: find-CEngineServer_KickClient
+        expected_output:
+          - CEngineServer_KickClient.{platform}.yaml
+        expected_input:
+          - PerformKick.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
           - CLoopTypeClientServerService_vtable.{platform}.yaml
@@ -1765,6 +1774,12 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::LogPrint
+      - name: PerformKick
+        category: func
+      - name: CEngineServer_KickClient
+        category: vfunc
+        alias:
+          - CEngineServer::KickClient
       - name: CLoopTypeClientServerService_vtable
         category: vtable
       - name: CLoopTypeClientServerService_vtable2
@@ -4791,9 +4806,6 @@ modules:
       - name: find-BotKill_CommandHandler
         expected_output:
           - BotKill_CommandHandler.{platform}.yaml
-      - name: find-PerformKick
-        expected_output:
-          - PerformKick.{platform}.yaml
       - name: find-EntInfo_CommandHandler
         expected_output:
           - EntInfo_CommandHandler.{platform}.yaml
@@ -8485,8 +8497,6 @@ modules:
         category: func
         alias:
           - CCSBotManager::BotKillCommand
-      - name: PerformKick
-        category: func
       - name: EntInfo_CommandHandler
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -4791,6 +4791,9 @@ modules:
       - name: find-BotKill_CommandHandler
         expected_output:
           - BotKill_CommandHandler.{platform}.yaml
+      - name: find-PerformKick
+        expected_output:
+          - PerformKick.{platform}.yaml
       - name: find-EntInfo_CommandHandler
         expected_output:
           - EntInfo_CommandHandler.{platform}.yaml
@@ -8482,6 +8485,8 @@ modules:
         category: func
         alias:
           - CCSBotManager::BotKillCommand
+      - name: PerformKick
+        category: func
       - name: EntInfo_CommandHandler
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_KickClient.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_KickClient.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_KickClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_KickClient",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_KickClient",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["PerformKick"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_KickClient", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_KickClient",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-PerformKick.py
+++ b/ida_preprocessor_scripts/find-PerformKick.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-PerformKick skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "PerformKick",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "PerformKick",
+        "xref_strings": [
+            "%s kicked by %s (%s)\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "PerformKick",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

- Adds `find-PerformKick`: Pattern A script that finds `PerformKick` via xref string `"%s kicked by %s (%s)\n"` in `engine2.dll`
- Adds `find-CEngineServer_KickClient`: Pattern B script that finds the `CEngineServer::KickClient` vfunc via `xref_funcs: ["PerformKick"]`
- Corrects module placement: `PerformKick` was initially placed in the server module then moved to engine where it belongs (same binary as `CEngineServer`)

## Test plan

- [ ] `uv run ida_analyze_bin.py -debug` passes for `find-PerformKick` and `find-CEngineServer_KickClient` skills
- [ ] `uv run python format_repo_files.py --check` reports no formatting issues
- [ ] `uv run python -m unittest discover -s tests -b` passes with 0 failures