### PR TITLE
Add CServerSideClientBase/CNetworkGameServerBase preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1254,6 +1254,9 @@ modules:
       - name: find-CServerSideClientBase_GetUserIDString
         expected_output:
           - CServerSideClientBase_GetUserIDString.{platform}.yaml
+      - name: find-CServerSideClientBase_GetNetworkIDString
+        expected_output:
+          - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
       - name: find-CNetworkGameClientBase_vtable
         expected_output:
           - CNetworkGameClientBase_vtable.{platform}.yaml
@@ -2001,6 +2004,10 @@ modules:
         category: func
         alias:
           - CServerSideClientBase::GetUserIDString
+      - name: CServerSideClientBase_GetNetworkIDString
+        category: func
+        alias:
+          - CServerSideClientBase::GetNetworkIDString
       - name: CNetworkGameClientBase_vtable
         category: vtable
       - name: CNetworkGameClientBase_ProcessSetConVar

--- a/config.yaml
+++ b/config.yaml
@@ -472,6 +472,9 @@ modules:
       - name: find-CNetworkGameServerBase_CheckTimeouts
         expected_output:
           - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
+      - name: find-CNetworkGameServerBase_OnKickById
+        expected_output:
+          - CNetworkGameServerBase_OnKickById.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -767,6 +770,9 @@ modules:
       - name: find-CNetworkServerService_RegisterEventMapInternal
         expected_output:
           - CNetworkServerService_RegisterEventMapInternal.{platform}.yaml
+      - name: find-CNetworkServerService_OnKickByIdHLTV
+        expected_output:
+          - CNetworkServerService_OnKickByIdHLTV.{platform}.yaml
       - name: find-CNetworkServerService_OnEventMapCallbacks-engine
         expected_output:
           - CNetworkServerService_OnServerAdvanceTick.{platform}.yaml
@@ -1427,6 +1433,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::CheckTimeouts
+      - name: CNetworkGameServerBase_OnKickById
+        category: func
+        alias:
+          - CNetworkGameServerBase::OnKickById
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:
@@ -1652,6 +1662,10 @@ modules:
         category: func
         alias:
           - CNetworkServerService::OnSimpleLoopFrameUpdate
+      - name: CNetworkServerService_OnKickByIdHLTV
+        category: func
+        alias:
+          - CNetworkServerService::OnKickByIdHLTV
       - name: INetworkGameServer_PreWorldUpdate
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -2039,6 +2039,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::GetPlayerNetworkIDString
+      - name: CNetworkGameServerBase_RemoveClientFromGame
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::RemoveClientFromGame
       - name: CEngineServer_GetPlayerNetworkIDString
         category: vfunc
         alias:
@@ -9449,6 +9453,17 @@ modules:
           - CNetworkGameServer_vtable.{platform}.yaml
           - g_pSource2GameClients.{platform}.yaml
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
+      # Same late-pass placement/reason as the skill above: depends on g_pSource2GameClients.
+      # Discovered as the CNetworkGameServer_vtable entry that BOTH calls
+      # CServerSideClientBase_GetNetworkIDString and references g_pSource2GameClients (the
+      # xref_funcs + xref_gvs + vtable intersection uniquely selects it, no excludes needed).
+      - name: find-CNetworkGameServerBase_RemoveClientFromGame
+        expected_output:
+          - CNetworkGameServerBase_RemoveClientFromGame.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - g_pSource2GameClients.{platform}.yaml
   - name: client  # Execute Shutdown-dependent client skills after engine2.dll generates ILoopModeFactory_Shutdown
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so

--- a/config.yaml
+++ b/config.yaml
@@ -9439,10 +9439,8 @@ modules:
       # Placed in the late engine pass because it depends on g_pSource2GameClients,
       # which is only produced for engine2.dll here (via find-g_pInterfaceGlobals_ppGlobal).
       # The script also excludes CNetworkGameServerBase_ConnectClient (an extra xref
-      # collider on Linux) via exclude_funcs. ConnectClient is produced earlier in the
-      # primary engine pass, so its YAML already exists when this runs; it is intentionally
-      # NOT listed in expected_input because its YAML has no func_sig (it is only an
-      # LLM_DECOMPILE predecessor), which expected_input validation would reject.
+      # collider on Linux) via exclude_funcs; it is produced in the primary engine pass and
+      # listed in expected_input below (only its func_va is consumed for the xref exclude).
       - name: find-CNetworkGameServerBase_GetPlayerNetworkIDString
         expected_output:
           - CNetworkGameServerBase_GetPlayerNetworkIDString.{platform}.yaml
@@ -9450,6 +9448,7 @@ modules:
           - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
           - CNetworkGameServer_vtable.{platform}.yaml
           - g_pSource2GameClients.{platform}.yaml
+          - CNetworkGameServerBase_ConnectClient.{platform}.yaml
   - name: client  # Execute Shutdown-dependent client skills after engine2.dll generates ILoopModeFactory_Shutdown
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so

--- a/config.yaml
+++ b/config.yaml
@@ -464,6 +464,11 @@ modules:
           - CNetworkGameServer_DirectUpdate.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_SetMaxClients
+        expected_output:
+          - CNetworkGameServerBase_SetMaxClients.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -1405,6 +1410,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::DirectUpdate
+      - name: CNetworkGameServerBase_SetMaxClients
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::SetMaxClients
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -1266,6 +1266,12 @@ modules:
       - name: find-CServerSideClientBase_GetNetworkIDString
         expected_output:
           - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
+      - name: find-CEngineServer_GetPlayerNetworkIDString
+        expected_output:
+          - CEngineServer_GetPlayerNetworkIDString.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CNetworkGameClientBase_vtable
         expected_output:
           - CNetworkGameClientBase_vtable.{platform}.yaml
@@ -2029,6 +2035,14 @@ modules:
         category: func
         alias:
           - CServerSideClientBase::GetNetworkIDString
+      - name: CNetworkGameServerBase_GetPlayerNetworkIDString
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetPlayerNetworkIDString
+      - name: CEngineServer_GetPlayerNetworkIDString
+        category: vfunc
+        alias:
+          - CEngineServer::GetPlayerNetworkIDString
       - name: CNetworkGameClientBase_vtable
         category: vtable
       - name: CNetworkGameClientBase_ProcessSetConVar
@@ -9422,6 +9436,20 @@ modules:
           - g_pNavGameTest.{platform}.yaml
         expected_input:
           - g_pInterfaceGlobals.{platform}.yaml
+      # Placed in the late engine pass because it depends on g_pSource2GameClients,
+      # which is only produced for engine2.dll here (via find-g_pInterfaceGlobals_ppGlobal).
+      # The script also excludes CNetworkGameServerBase_ConnectClient (an extra xref
+      # collider on Linux) via exclude_funcs. ConnectClient is produced earlier in the
+      # primary engine pass, so its YAML already exists when this runs; it is intentionally
+      # NOT listed in expected_input because its YAML has no func_sig (it is only an
+      # LLM_DECOMPILE predecessor), which expected_input validation would reject.
+      - name: find-CNetworkGameServerBase_GetPlayerNetworkIDString
+        expected_output:
+          - CNetworkGameServerBase_GetPlayerNetworkIDString.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - g_pSource2GameClients.{platform}.yaml
   - name: client  # Execute Shutdown-dependent client skills after engine2.dll generates ILoopModeFactory_Shutdown
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so

--- a/config.yaml
+++ b/config.yaml
@@ -1251,6 +1251,9 @@ modules:
         expected_input:
           - CServerSideClientBase_ProcessSplitPlayerConnectInternal.{platform}.yaml
           - CServerSideClientBase_vtable.{platform}.yaml
+      - name: find-CServerSideClientBase_GetUserIDString
+        expected_output:
+          - CServerSideClientBase_GetUserIDString.{platform}.yaml
       - name: find-CNetworkGameClientBase_vtable
         expected_output:
           - CNetworkGameClientBase_vtable.{platform}.yaml
@@ -1994,6 +1997,10 @@ modules:
         category: vfunc
         alias:
           - CServerSideClientBase::ProcessSplitPlayerConnect
+      - name: CServerSideClientBase_GetUserIDString
+        category: func
+        alias:
+          - CServerSideClientBase::GetUserIDString
       - name: CNetworkGameClientBase_vtable
         category: vtable
       - name: CNetworkGameClientBase_ProcessSetConVar

--- a/config.yaml
+++ b/config.yaml
@@ -469,6 +469,9 @@ modules:
           - CNetworkGameServerBase_SetMaxClients.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_CheckTimeouts
+        expected_output:
+          - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -1420,6 +1423,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::SetMaxClients
+      - name: CNetworkGameServerBase_CheckTimeouts
+        category: func
+        alias:
+          - CNetworkGameServerBase::CheckTimeouts
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -372,10 +372,9 @@ async def validate_expected_input_artifacts_via_session(
         if should_require_func_va and not func_va_text:
             issues.append("missing required field func_va")
 
-        if category == "func":
-            func_sig_text = str(artifact_payload.get("func_sig") or "").strip()
-            if not func_sig_text:
-                issues.append("missing required field func_sig")
+        # func_sig is intentionally NOT required here: a func artifact may be consumed
+        # only as an xref/exclude anchor (located by func_va for same-binary xref
+        # computation), in which case its YAML legitimately omits func_sig.
 
         if func_va_text:
             try:

--- a/ida_preprocessor_scripts/find-CEngineServer_GetPlayerNetworkIDString.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetPlayerNetworkIDString.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetPlayerNetworkIDString skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetPlayerNetworkIDString",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_GetPlayerNetworkIDString",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CServerSideClientBase_GetNetworkIDString",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_GetPlayerNetworkIDString", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetPlayerNetworkIDString",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckTimeouts.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckTimeouts.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_CheckTimeouts skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_CheckTimeouts",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_CheckTimeouts",
+        "xref_strings": [
+            "netchan timeout: %.2fs since recv",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_CheckTimeouts",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetPlayerNetworkIDString.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetPlayerNetworkIDString.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetPlayerNetworkIDString skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetPlayerNetworkIDString",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_GetPlayerNetworkIDString",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CServerSideClientBase_GetNetworkIDString",
+        ],
+        # CNetworkGameServerBase_RemoveClientFromGame and
+        # CNetworkGameServerBase_ConnectClient also call
+        # CServerSideClientBase_GetNetworkIDString and live in CNetworkGameServer_vtable,
+        # so they collide with the target in the xref intersection.
+        #   - ConnectClient (an extra collider on Linux) is dropped via exclude_funcs.
+        #   - RemoveClientFromGame references g_pSource2GameClients (which the target does
+        #     not), so it is dropped via exclude_gvs (gv_va auto-loaded from
+        #     g_pSource2GameClients.{platform}.yaml).
+        "exclude_funcs": ["CNetworkGameServerBase_ConnectClient"],
+        "exclude_strings": [],
+        "exclude_gvs": ["g_pSource2GameClients"],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetPlayerNetworkIDString", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_GetPlayerNetworkIDString",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_OnKickById.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_OnKickById.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_OnKickById skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_OnKickById",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_OnKickById",
+        "xref_strings": [
+            "Usage:  kickid < userid | uniqueid > { message }",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_OnKickById",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_RemoveClientFromGame.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_RemoveClientFromGame.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_RemoveClientFromGame skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_RemoveClientFromGame",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_RemoveClientFromGame",
+        "xref_strings": [],
+        # gv_va auto-loaded from g_pSource2GameClients.{platform}.yaml. Among the
+        # CNetworkGameServer_vtable entries that call CServerSideClientBase_GetNetworkIDString
+        # (RemoveClientFromGame, GetPlayerNetworkIDString, and ConnectClient on Linux), only
+        # RemoveClientFromGame also references g_pSource2GameClients -- so the
+        # xref_funcs + xref_gvs + vtable intersection collapses to it with no excludes.
+        "xref_gvs": [
+            "g_pSource2GameClients",
+        ],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CServerSideClientBase_GetNetworkIDString",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_RemoveClientFromGame", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_RemoveClientFromGame",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_SetMaxClients.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_SetMaxClients.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_SetMaxClients skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_SetMaxClients",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_SetMaxClients",
+        "xref_strings": [
+            "SV:  maxplayers set to %i",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_SetMaxClients", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_SetMaxClients",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerService_OnKickByIdHLTV.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_OnKickByIdHLTV.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_OnKickByIdHLTV skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkServerService_OnKickByIdHLTV",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkServerService_OnKickByIdHLTV",
+        "xref_strings": [
+            "No HLTV server running",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkServerService_OnKickByIdHLTV",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CServerSideClientBase_GetNetworkIDString.py
+++ b/ida_preprocessor_scripts/find-CServerSideClientBase_GetNetworkIDString.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClientBase_GetNetworkIDString skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClientBase_GetNetworkIDString",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CServerSideClientBase_GetNetworkIDString",
+        "xref_strings": [
+            "FULLMATCH:STEAM_ID_LAN",
+            "FULLMATCH:STEAM_ID_PENDING",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [
+            "FULLMATCH:HLTV",
+            "FULLMATCH:REPLAY",
+            "FULLMATCH:UNKNOWN",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CServerSideClientBase_GetNetworkIDString",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CServerSideClientBase_GetUserIDString.py
+++ b/ida_preprocessor_scripts/find-CServerSideClientBase_GetUserIDString.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClientBase_GetUserIDString skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClientBase_GetUserIDString",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CServerSideClientBase_GetUserIDString",
+        "xref_strings": [
+            "FULLMATCH:STEAM_ID_LAN",
+            "FULLMATCH:STEAM_ID_PENDING",
+            "FULLMATCH:HLTV",
+            "FULLMATCH:REPLAY",
+            "FULLMATCH:UNKNOWN",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [
+            "%.3f min",
+            "for %.2f minutes",
+            "removeid:  couldn't find %s",
+            "FULLMATCH:%s %s",
+            "banid 0 %s",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CServerSideClientBase_GetUserIDString",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -1915,10 +1915,7 @@ class TestProcessBinary(unittest.TestCase):
                     ida_analyze_bin,
                     "_run_validate_expected_input_artifacts_via_mcp",
                     return_value=[
-                        (
-                            f"{expected_input_path}: func_va=0x616050 resolves to segment "
-                            "'.data' instead of '.text'; missing required field func_sig"
-                        )
+                        (f"{expected_input_path}: func_va=0x616050 resolves to segment '.data' instead of '.text'")
                     ],
                 ),
                 patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp") as mock_preprocess,
@@ -1947,7 +1944,6 @@ class TestProcessBinary(unittest.TestCase):
         mock_preprocess.assert_not_called()
         mock_run_skill.assert_not_called()
         self.assertIn("invalid expected_input artifact", stdout.getvalue())
-        self.assertIn("missing required field func_sig", stdout.getvalue())
         mock_quit_ida.assert_called_once_with(fake_process, "127.0.0.1", 13337, debug=False)
 
     def test_process_binary_does_not_start_ida_for_post_process_when_rename_is_false(
@@ -2195,7 +2191,7 @@ class TestProcessBinary(unittest.TestCase):
 
 
 class TestExpectedInputArtifactValidation(unittest.IsolatedAsyncioTestCase):
-    async def test_validate_expected_input_artifacts_reports_invalid_func_va_and_missing_func_sig(self) -> None:
+    async def test_validate_expected_input_artifacts_reports_invalid_func_va_segment(self) -> None:
         with TemporaryDirectory() as temp_dir:
             artifact_path = Path(temp_dir) / "CDemoRecorder_WriteSpawnGroups.linux.yaml"
             artifact_path.write_text(
@@ -2243,7 +2239,9 @@ class TestExpectedInputArtifactValidation(unittest.IsolatedAsyncioTestCase):
             "func_va=0x616050 resolves to segment '.data' instead of '.text'",
             issues[0],
         )
-        self.assertIn("missing required field func_sig", issues[0])
+        # func_sig is no longer required for category:func artifacts, so a sig-less
+        # payload must NOT produce a "missing required field func_sig" issue.
+        self.assertNotIn("missing required field func_sig", issues[0])
 
     async def test_validate_expected_input_artifacts_skips_func_va_mapping_for_sibling_module_artifact(
         self,


### PR DESCRIPTION
Add network client/server preprocessor scripts and relax expected_input validation

- Add find-CNetworkGameServerBase_SetMaxClients preprocessor script
- Add find-CServerSideClientBase_GetUserIDString preprocessor script
- Add find-CServerSideClientBase_GetNetworkIDString preprocessor script
- Add find-CNetworkGameServerBase_CheckTimeouts preprocessor script
- Add find-CNetworkGameServerBase_OnKickById preprocessor script
- Add find-CNetworkServerService_OnKickByIdHLTV preprocessor script
- Add find-CNetworkGameServerBase_GetPlayerNetworkIDString preprocessor script
- Add find-CEngineServer_GetPlayerNetworkIDString preprocessor script
- Add find-CNetworkGameServerBase_RemoveClientFromGame preprocessor script
- Relax expected_input validation to require only func_va (not func_sig)