### PR TITLE
Add find-CNetworkGameServerBase_OnKickByName preprocessor script

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -997,14 +997,14 @@ modules:
         expected_input:
           - CLog_Print.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
-      - name: find-PerformKick
+      - name: find-CNetworkGameServerBase_KickClient
         expected_output:
-          - PerformKick.{platform}.yaml
+          - CNetworkGameServerBase_KickClient.{platform}.yaml
       - name: find-CEngineServer_KickClient
         expected_output:
           - CEngineServer_KickClient.{platform}.yaml
         expected_input:
-          - PerformKick.{platform}.yaml
+          - CNetworkGameServerBase_KickClient.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
       - name: find-CLoopTypeClientServerService_vtable
         expected_output:
@@ -1816,7 +1816,7 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::LogPrint
-      - name: PerformKick
+      - name: CNetworkGameServerBase_KickClient
         category: func
       - name: CEngineServer_KickClient
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -475,6 +475,9 @@ modules:
       - name: find-CNetworkGameServerBase_OnKickById
         expected_output:
           - CNetworkGameServerBase_OnKickById.{platform}.yaml
+      - name: find-CNetworkGameServerBase_OnKickByName
+        expected_output:
+          - CNetworkGameServerBase_OnKickByName.{platform}.yaml
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
@@ -1452,6 +1455,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::OnKickById
+      - name: CNetworkGameServerBase_OnKickByName
+        category: func
+        alias:
+          - CNetworkGameServerBase::OnKickByName
       - name: CNetworkGameClient_SendMovePacket
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_KickClient.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_KickClient.py
@@ -13,7 +13,7 @@ FUNC_XREFS = [
         "xref_strings": [],
         "xref_gvs": [],
         "xref_signatures": [],
-        "xref_funcs": ["PerformKick"],
+        "xref_funcs": ["CNetworkGameServerBase_KickClient"],
         "exclude_funcs": [],
         "exclude_strings": [],
         "exclude_gvs": [],

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_KickClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_KickClient.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-PerformKick skill."""
+"""Preprocess script for find-CNetworkGameServerBase_KickClient skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "PerformKick",
+    "CNetworkGameServerBase_KickClient",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "PerformKick",
+        "func_name": "CNetworkGameServerBase_KickClient",
         "xref_strings": [
             "%s kicked by %s (%s)\n",
         ],
@@ -26,7 +26,7 @@ FUNC_XREFS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "PerformKick",
+        "CNetworkGameServerBase_KickClient",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_OnKickByName.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_OnKickByName.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_OnKickByName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_OnKickByName",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_OnKickByName",
+        "xref_strings": [
+            'Can\'t kick "%s", name not found',
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_OnKickByName",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

Add a new preprocessor script to locate `CNetworkGameServerBase_OnKickByName`, a regular function in the engine module, via the debug string xref `Can't kick "%s", name not found`.

## Changes

- **New script:** `ida_preprocessor_scripts/find-CNetworkGameServerBase_OnKickByName.py` (Pattern A — regular function via xref string, no dependencies)
- **config.yaml:**
  - Added skill entry `find-CNetworkGameServerBase_OnKickByName` after `find-CNetworkGameServerBase_OnKickById`
  - Added symbol entry `CNetworkGameServerBase_OnKickByName` (category: `func`, alias: `CNetworkGameServerBase::OnKickByName`)

## Validation

- `uv run ida_analyze_bin.py -debug` — 0 failures
  - Windows: found at `0x1801e22d0`
  - Linux: found at `0x5aa380`
- `uv run python format_repo_files.py --check` — clean
- `uv run python -m unittest discover -s tests -b` — 576 tests OK

## Commits included

- `8b5bb28` Add find-CNetworkGameServerBase_OnKickByName preprocessor script
- `a1b8ee1` rename PerformKick to CNetworkGameServerBase_KickClient across preprocessor scripts
