### PR TITLE
Add CNetworkGameServer/Base lifecycle preprocessor scripts and tests

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -263,6 +263,18 @@ jobs:
           Write-Host "Copied persisted bin/$env:GAMEVER into PR workspace; robocopy exit code $robocopyExitCode"
           $global:LASTEXITCODE = 0
 
+      - name: Prune PR-added expected_output YAMLs from bin
+        shell: pwsh
+        run: |
+          Set-Location $env:WORKSPACE
+          # HEAD is the refs/pull/N/merge commit; HEAD^1 is the PR base branch tip.
+          # Delete expected_output artifacts this PR adds to config.yaml so
+          # ida_analyze_bin.py regenerates them instead of skipping on stale cache.
+          uv run python prune_pr_expected_output_bin.py -gamever "$env:GAMEVER" -baseref "HEAD^1"
+          if ($LASTEXITCODE -ne 0) {
+            throw "prune_pr_expected_output_bin.py failed with exit code $LASTEXITCODE"
+          }
+
       - name: Run Python unit tests
         shell: pwsh
         run: |

--- a/config.yaml
+++ b/config.yaml
@@ -602,6 +602,23 @@ modules:
           - CNetworkGameServerBase_StartHLTVMaster.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
+      - name: find-CNetworkGameServerBase_Shutdown-windows
+        platform: windows
+        expected_output:
+          - CNetworkGameServerBase_Shutdown.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_ShutdownInternal-linux
+        platform: linux
+        expected_output:
+          - CNetworkGameServerBase_ShutdownInternal.{platform}.yaml
+      - name: find-CNetworkGameServerBase_Shutdown-linux
+        platform: linux
+        expected_output:
+          - CNetworkGameServerBase_Shutdown.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_ShutdownInternal.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
           - g_pGameServer.{platform}.yaml
@@ -786,6 +803,11 @@ modules:
       - name: find-CNetworkServerService_OnKickByIdHLTV
         expected_output:
           - CNetworkServerService_OnKickByIdHLTV.{platform}.yaml
+      - name: find-CNetworkServerService_DisconnectGameNow
+        expected_output:
+          - CNetworkServerService_DisconnectGameNow.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
       - name: find-CNetworkServerService_OnEventMapCallbacks-engine
         expected_output:
           - CNetworkServerService_OnServerAdvanceTick.{platform}.yaml
@@ -1449,6 +1471,14 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::StartHLTVMaster
+      - name: CNetworkGameServerBase_Shutdown
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::Shutdown
+      - name: CNetworkGameServerBase_ShutdownInternal
+        category: func
+        alias:
+          - CNetworkGameServerBase::ShutdownInternal
       - name: CNetworkGameServer_ActivateServer
         category: vfunc
         alias:
@@ -1706,6 +1736,10 @@ modules:
         category: func
         alias:
           - CNetworkServerService::OnKickByIdHLTV
+      - name: CNetworkServerService_DisconnectGameNow
+        category: vfunc
+        alias:
+          - CNetworkServerService::DisconnectGameNow
       - name: INetworkGameServer_PreWorldUpdate
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -890,6 +890,17 @@ modules:
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
           - INetworkGameServer_PreWorldUpdate.{platform}.yaml
+      - name: find-INetworkGameServer_ServerEndSimulate
+        expected_output:
+          - INetworkGameServer_ServerEndSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_OnServerEndSimulate.{platform}.yaml
+      - name: find-CNetworkGameServerBase_ServerEndSimulate
+        expected_output:
+          - CNetworkGameServerBase_ServerEndSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - INetworkGameServer_ServerEndSimulate.{platform}.yaml
       - name: find-ISource2Server_PreWorldUpdate
         expected_output:
           - ISource2Server_PreWorldUpdate.{platform}.yaml
@@ -1854,6 +1865,14 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::PreWorldUpdate
+      - name: INetworkGameServer_ServerEndSimulate
+        category: vfunc
+        alias:
+          - INetworkGameServer::ServerEndSimulate
+      - name: CNetworkGameServerBase_ServerEndSimulate
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::ServerEndSimulate
       - name: ISource2Server_PreWorldUpdate
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -602,6 +602,16 @@ modules:
           - CNetworkGameServerBase_StartHLTVMaster.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
+      - name: find-CNetworkGameServerBase_RegisterLoadingSpawnGroups
+        expected_output:
+          - CNetworkGameServerBase_RegisterLoadingSpawnGroups.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_Init
+        expected_output:
+          - CNetworkGameServerBase_Init.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_Shutdown-windows
         platform: windows
         expected_output:
@@ -1471,6 +1481,14 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::StartHLTVMaster
+      - name: CNetworkGameServerBase_RegisterLoadingSpawnGroups
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+      - name: CNetworkGameServerBase_Init
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::Init
       - name: CNetworkGameServerBase_Shutdown
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -646,9 +646,9 @@ modules:
           - CNetworkGameServerBase_AsyncUnloadSpawnGroup.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
-      - name: find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal
+      - name: find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
         expected_output:
-          - CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal.{platform}.yaml
+          - CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal.{platform}.yaml
       - name: find-CNetworkGameServer_PrepareForAssetLoad
         expected_output:
           - CNetworkGameServer_PrepareForAssetLoad.{platform}.yaml
@@ -1634,10 +1634,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::AsyncUnloadSpawnGroup
-      - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal
+      - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
         category: func
         alias:
-          - CNetworkGameServerBase::AsyncUnloadSpawnGroupInterrnal
+          - CNetworkGameServerBase::AsyncUnloadSpawnGroupInternal
       - name: CNetworkGameServer_PrepareForAssetLoad
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -636,6 +636,26 @@ modules:
       - name: find-CNetworkGameServerBase_SpawnGroupThink
         expected_output:
           - CNetworkGameServerBase_SpawnGroupThink.{platform}.yaml
+      - name: find-CNetworkGameServerBase_PrintSpawnGroupStatus
+        expected_output:
+          - CNetworkGameServerBase_PrintSpawnGroupStatus.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_AsyncUnloadSpawnGroup
+        expected_output:
+          - CNetworkGameServerBase_AsyncUnloadSpawnGroup.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_PrepareForAssetLoad
+        expected_output:
+          - CNetworkGameServer_PrepareForAssetLoad.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_IsSaveRestoreAllowed
+        expected_output:
+          - CNetworkGameServerBase_IsSaveRestoreAllowed.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_Init
         expected_output:
           - CNetworkGameServerBase_Init.{platform}.yaml
@@ -1603,6 +1623,22 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::SpawnGroupThink
+      - name: CNetworkGameServerBase_PrintSpawnGroupStatus
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::PrintSpawnGroupStatus
+      - name: CNetworkGameServerBase_AsyncUnloadSpawnGroup
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+      - name: CNetworkGameServer_PrepareForAssetLoad
+        category: vfunc
+        alias:
+          - CNetworkGameServer::PrepareForAssetLoad
+      - name: CNetworkGameServerBase_IsSaveRestoreAllowed
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::IsSaveRestoreAllowed
       - name: CNetworkGameServerBase_Init
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -464,6 +464,18 @@ modules:
           - CNetworkGameServer_DirectUpdate.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_Init
+        expected_output:
+          - CNetworkGameServer_Init.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - CNetworkGameServerBase_Init.{platform}.yaml
+      - name: find-CNetworkGameServer_Shutdown
+        expected_output:
+          - CNetworkGameServer_Shutdown.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - CNetworkGameServerBase_Shutdown.{platform}.yaml
       - name: find-CNetworkGameServerBase_ServerPollNetworking
         expected_output:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
@@ -1505,6 +1517,14 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::DirectUpdate
+      - name: CNetworkGameServer_Init
+        category: vfunc
+        alias:
+          - CNetworkGameServer::Init
+      - name: CNetworkGameServer_Shutdown
+        category: vfunc
+        alias:
+          - CNetworkGameServer::Shutdown
       - name: CNetworkGameServerBase_SetMaxClients
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -901,6 +901,17 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_ServerEndSimulate.{platform}.yaml
+      - name: find-INetworkGameServer_ServerPostSimulate
+        expected_output:
+          - INetworkGameServer_ServerPostSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_OnServerPostSimulate.{platform}.yaml
+      - name: find-CNetworkGameServerBase_ServerPostSimulate
+        expected_output:
+          - CNetworkGameServerBase_ServerPostSimulate.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - INetworkGameServer_ServerPostSimulate.{platform}.yaml
       - name: find-ISource2Server_PreWorldUpdate
         expected_output:
           - ISource2Server_PreWorldUpdate.{platform}.yaml
@@ -1873,6 +1884,14 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerEndSimulate
+      - name: INetworkGameServer_ServerPostSimulate
+        category: vfunc
+        alias:
+          - INetworkGameServer::ServerPostSimulate
+      - name: CNetworkGameServerBase_ServerPostSimulate
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::ServerPostSimulate
       - name: ISource2Server_PreWorldUpdate
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -476,6 +476,11 @@ modules:
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
           - CNetworkGameServerBase_Shutdown.{platform}.yaml
+      - name: find-CNetworkGameServer_SpawnServer
+        expected_output:
+          - CNetworkGameServer_SpawnServer.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_ServerPollNetworking
         expected_output:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
@@ -664,6 +669,11 @@ modules:
       - name: find-CNetworkGameServerBase_StartChangeLevel
         expected_output:
           - CNetworkGameServerBase_StartChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_SetServerState
+        expected_output:
+          - CNetworkGameServerBase_SetServerState.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
@@ -1525,6 +1535,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::StartChangeLevel
+      - name: CNetworkGameServerBase_SetServerState
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::SetServerState
       - name: CNetworkGameServer_GetFreeClient
         category: func
         alias:
@@ -1570,6 +1584,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::Shutdown
+      - name: CNetworkGameServer_SpawnServer
+        category: vfunc
+        alias:
+          - CNetworkGameServer::SpawnServer
       - name: CNetworkGameServerBase_SetMaxClients
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -624,6 +624,18 @@ modules:
           - CNetworkGameServerBase_RegisterLoadingSpawnGroups.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkServerSpawnGroupCreatePrerequisites_Init
+        expected_output:
+          - CNetworkServerSpawnGroupCreatePrerequisites_Init.{platform}.yaml
+      - name: find-CNetworkGameServerBase_LoadSpawnGroup
+        expected_output:
+          - CNetworkGameServerBase_LoadSpawnGroup.{platform}.yaml
+        expected_input:
+          - CNetworkServerSpawnGroupCreatePrerequisites_Init.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_SpawnGroupThink
+        expected_output:
+          - CNetworkGameServerBase_SpawnGroupThink.{platform}.yaml
       - name: find-CNetworkGameServerBase_Init
         expected_output:
           - CNetworkGameServerBase_Init.{platform}.yaml
@@ -1579,6 +1591,18 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::RegisterLoadingSpawnGroups
+      - name: CNetworkServerSpawnGroupCreatePrerequisites_Init
+        category: func
+        alias:
+          - CNetworkServerSpawnGroupCreatePrerequisites::Init
+      - name: CNetworkGameServerBase_LoadSpawnGroup
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::LoadSpawnGroup
+      - name: CNetworkGameServerBase_SpawnGroupThink
+        category: func
+        alias:
+          - CNetworkGameServerBase::SpawnGroupThink
       - name: CNetworkGameServerBase_Init
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -9858,3 +9858,52 @@ cpp_tests:
       - fdump-record-layouts
     reference_modules:
       - SDL3  # bin/{gamever}/SDL3/SDL_Mouse_*.{platform}.yaml
+  - name: INetworkGameServer_MSVC
+    symbol: INetworkGameServer
+    cpp: cpp_tests/inetworkgameserver.cpp
+    headers:
+      - hl2sdk_cs2/public/iserver.h  # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - engine  # bin/{gamever}/engine/INetworkGameServer_*.{platform}.yaml
+    merge_reference_modules: false  # Avoid stale duplicate INetworkGameServer_ClientUpdate at index 58
+  - name: CNetworkGameServerBase_MSVC
+    symbol: CNetworkGameServerBase
+    cpp: cpp_tests/inetworkgameserver.cpp
+    headers:
+      - hl2sdk_cs2/public/iserver.h  # This is for LLM agent
+    claude_permission_mode: acceptEdits
+    claude_allowed_tools: Read,Edit,MultiEdit,Write
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - engine  # bin/{gamever}/engine/CNetworkGameServerBase_*.{platform}.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -651,6 +651,21 @@ modules:
           - CNetworkGameServerBase_BroadcastPrintf.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_ReserveServerForQueuedGame
+        expected_output:
+          - CNetworkGameServerBase_ReserveServerForQueuedGame.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_FinishChangeLevel
+        expected_output:
+          - CNetworkGameServerBase_FinishChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_StartChangeLevel
+        expected_output:
+          - CNetworkGameServerBase_StartChangeLevel.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
           - g_pGameServer.{platform}.yaml
@@ -1498,6 +1513,18 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::BroadcastPrintf
+      - name: CNetworkGameServerBase_ReserveServerForQueuedGame
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::ReserveServerForQueuedGame
+      - name: CNetworkGameServerBase_FinishChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::FinishChangeLevel
+      - name: CNetworkGameServerBase_StartChangeLevel
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::StartChangeLevel
       - name: CNetworkGameServer_GetFreeClient
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -871,6 +871,7 @@ modules:
           - CNetworkServerService_OnServerPollNetworking.{platform}.yaml
           - CNetworkServerService_OnServerProcessNetworking.{platform}.yaml
           - CNetworkServerService_OnServerBeginSimulate.{platform}.yaml
+          - CNetworkServerService_OnServerEndSimulate.{platform}.yaml
           - CNetworkServerService_OnServerPostSimulate.{platform}.yaml
           - CNetworkServerService_OnServerPostAdvanceTick.{platform}.yaml
           - CNetworkServerService_OnFrameBoundary.{platform}.yaml
@@ -1813,6 +1814,10 @@ modules:
         category: func
         alias:
           - CNetworkServerService::OnServerBeginSimulate
+      - name: CNetworkServerService_OnServerEndSimulate
+        category: func
+        alias:
+          - CNetworkServerService::OnServerEndSimulate
       - name: CNetworkServerService_OnServerPostSimulate
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -641,6 +641,16 @@ modules:
         expected_input:
           - CNetworkGameServerBase_ShutdownInternal.{platform}.yaml
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_BroadcastMessage
+        expected_output:
+          - CNetworkGameServerBase_BroadcastMessage.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_BroadcastPrintf
+        expected_output:
+          - CNetworkGameServerBase_BroadcastPrintf.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-g_pGameServer-AND-CServerSideClientBase_ClientPrintf-AND-CNetworkGameServer_ClientList
         expected_output:
           - g_pGameServer.{platform}.yaml
@@ -1480,6 +1490,14 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerPollNetworking
+      - name: CNetworkGameServerBase_BroadcastMessage
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::BroadcastMessage
+      - name: CNetworkGameServerBase_BroadcastPrintf
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::BroadcastPrintf
       - name: CNetworkGameServer_GetFreeClient
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -464,6 +464,11 @@ modules:
           - CNetworkGameServer_DirectUpdate.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_ServerPollNetworking
+        expected_output:
+          - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_SetMaxClients
         expected_output:
           - CNetworkGameServerBase_SetMaxClients.{platform}.yaml
@@ -768,6 +773,11 @@ modules:
       - name: find-CNetworkServerService_Init
         expected_output:
           - CNetworkServerService_Init.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+      - name: find-CNetworkServerService_StartupServer
+        expected_output:
+          - CNetworkServerService_StartupServer.{platform}.yaml
         expected_input:
           - CNetworkServerService_vtable.{platform}.yaml
       - name: find-CNetworkServerService_RegisterEventMapInternal
@@ -1422,6 +1432,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerSimulate
+      - name: CNetworkGameServerBase_ServerPollNetworking
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::ServerPollNetworking
       - name: CNetworkGameServer_GetFreeClient
         category: func
         alias:
@@ -1644,6 +1658,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkServerService::Init
+      - name: CNetworkServerService_StartupServer
+        category: vfunc
+        alias:
+          - CNetworkServerService::StartupServer
       - name: CNetworkServerService_RegisterEventMapInternal
         category: func
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -646,6 +646,9 @@ modules:
           - CNetworkGameServerBase_AsyncUnloadSpawnGroup.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal
+        expected_output:
+          - CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal.{platform}.yaml
       - name: find-CNetworkGameServer_PrepareForAssetLoad
         expected_output:
           - CNetworkGameServer_PrepareForAssetLoad.{platform}.yaml
@@ -1631,6 +1634,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::AsyncUnloadSpawnGroup
+      - name: CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal
+        category: func
+        alias:
+          - CNetworkGameServerBase::AsyncUnloadSpawnGroupInterrnal
       - name: CNetworkGameServer_PrepareForAssetLoad
         category: vfunc
         alias:

--- a/cpp_tests/inetworkgameserver.cpp
+++ b/cpp_tests/inetworkgameserver.cpp
@@ -1,0 +1,49 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+// Pre-define include guards to avoid heavy transitive include chains.
+#define EDICT_H
+#define EIFACE_H
+#define INETCHANNEL_H
+
+class CGlobalVars;
+class IRecipientFilter;
+class ServerClass;
+struct RenderDeviceInfo_t;
+typedef uint32 SpawnGroupHandle_t;
+
+class CPlayerUserId
+{
+public:
+    CPlayerUserId(int index) : m_Index(static_cast<unsigned short>(index)) {}
+
+    int Get() const { return m_Index; }
+
+private:
+    unsigned short m_Index;
+};
+
+class bf_read;
+enum NetChannelBufType_t : int8 {};
+
+// Forward declarations for types added to inetworkserializer.h in hl2sdk_cs2 update
+class CPlayerBitVec;
+typedef void *(*SchemaClassManipulatorFn_t)(int, void *);
+typedef void *(*SchemaCollectionManipulatorFn_t)(int, void *, int, int);
+
+#include <bitvec.h>
+#include <playerslot.h>
+#include <tier1/convar.h>
+#include <iserver.h>
+
+INetworkGameServer * networkgameserver();
+CNetworkGameServerBase * networkgameserverbase();
+
+int main() {
+
+    networkgameserver()->PreWorldUpdate();
+    networkgameserverbase()->SetMaxClients(64);
+
+    return 0;
+}

--- a/cpp_tests_util.py
+++ b/cpp_tests_util.py
@@ -115,8 +115,26 @@ def parse_vftable_layouts(compiler_output: str) -> Dict[str, Dict[str, Any]]:
         if layout_header:
             in_classes = VFTABLE_LAYOUT_IN_CLASS_RE.findall(layout_header.group(2) or "")
             current_class = in_classes[-1] if in_classes else layout_header.group(1)
+            raw_declared_entries = int(layout_header.group(3))
+            existing = parsed.get(current_class)
+            if existing and existing.get("source_kind") == "complete":
+                existing_count = max(
+                    int(existing.get("declared_entries") or 0),
+                    len(existing.get("methods_by_index", {})),
+                )
+                # Clang emits secondary vfptr tables as `... in 'Derived'` too.
+                # Keep the largest complete table for the owning class; smaller
+                # secondary tables are not the primary vtable compare target.
+                if existing_count >= max(raw_declared_entries - 1, 0):
+                    current_class = None
+                    current_declared_entries = 0
+                    current_raw_declared_entries = 0
+                    current_raw_entries = 0
+                    current_metadata_entries = 0
+                    current_section_kind = ""
+                    continue
             current_declared_entries = 0
-            current_raw_declared_entries = int(layout_header.group(3))
+            current_raw_declared_entries = raw_declared_entries
             current_raw_entries = 0
             current_metadata_entries = 0
             current_section_kind = "complete"

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
@@ -17,7 +17,9 @@ FUNC_XREFS = [
         "xref_signatures": [],
         "xref_funcs": [],
         "exclude_funcs": [],
-        "exclude_strings": [],
+        "exclude_strings": [
+            "SV:  AsyncUnloadSpawnGroup( %s ) -- unloading loading spawngroup"
+        ],
         "exclude_gvs": [],
         "exclude_signatures": [],
     },

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_AsyncUnloadSpawnGroup skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_AsyncUnloadSpawnGroup",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_AsyncUnloadSpawnGroup",
+        "xref_strings": [
+            "SV:  AsyncUnloadSpawnGroup( %s ) -- no such group",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_AsyncUnloadSpawnGroup", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_AsyncUnloadSpawnGroup",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroup.py
@@ -17,9 +17,7 @@ FUNC_XREFS = [
         "xref_signatures": [],
         "xref_funcs": [],
         "exclude_funcs": [],
-        "exclude_strings": [
-            "SV:  AsyncUnloadSpawnGroup( %s ) -- unloading loading spawngroup"
-        ],
+        "exclude_strings": ["SV:  AsyncUnloadSpawnGroup( %s ) -- unloading loading spawngroup"],
         "exclude_gvs": [],
         "exclude_signatures": [],
     },

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal skill."""
+"""Preprocess script for find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+    "CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+        "func_name": "CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal",
         "xref_strings": [
             "SV:  AsyncUnloadSpawnGroup( %s ) -- unloading loading spawngroup",
         ],
@@ -26,7 +26,7 @@ FUNC_XREFS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+        "CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+        "xref_strings": [
+            "SV:  AsyncUnloadSpawnGroup( %s ) -- unloading loading spawngroup",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_AsyncUnloadSpawnGroupInterrnal",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_BroadcastMessage.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_BroadcastMessage.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_BroadcastMessage skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_BroadcastMessage",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_BroadcastMessage",
+        "xref_strings": [
+            "BroadcastMessage:  Recipient Filter for message type %s (reliable: %s) with bogus client slot (%i) in list",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_BroadcastMessage", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_BroadcastMessage",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_BroadcastPrintf.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_BroadcastPrintf.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_BroadcastPrintf skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_BroadcastPrintf",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_BroadcastPrintf",
+        "xref_strings": [
+            "BroadcastMessage: Reliable broadcast message overflow for client %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_BroadcastPrintf", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_BroadcastPrintf",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_FinishChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_FinishChangeLevel.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_FinishChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_FinishChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_FinishChangeLevel",
+        "xref_strings": [
+            "SV:  CNetworkServerService::FinishChangeLevel:  reactivating previous clients",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_FinishChangeLevel", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_FinishChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_Init.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_Init.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_Init",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_Init",
+        "xref_strings": [
+            "GMS/Advertise",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_Init", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_Init",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsSaveRestoreAllowed.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsSaveRestoreAllowed.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_IsSaveRestoreAllowed skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_IsSaveRestoreAllowed",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_IsSaveRestoreAllowed",
+        "xref_strings": [
+            "Engine2/AllowSaveGamesInMultiplayer",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_IsSaveRestoreAllowed", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_IsSaveRestoreAllowed",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_LoadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_LoadSpawnGroup.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_LoadSpawnGroup skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_LoadSpawnGroup",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_LoadSpawnGroup",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkServerSpawnGroupCreatePrerequisites_Init"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_LoadSpawnGroup", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_LoadSpawnGroup",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_PrintSpawnGroupStatus.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_PrintSpawnGroupStatus.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_PrintSpawnGroupStatus skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_PrintSpawnGroupStatus",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_PrintSpawnGroupStatus",
+        "xref_strings": [
+            "------------------- groups -------------------",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_PrintSpawnGroupStatus", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_PrintSpawnGroupStatus",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_RegisterLoadingSpawnGroups.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_RegisterLoadingSpawnGroups.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_RegisterLoadingSpawnGroups skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_RegisterLoadingSpawnGroups",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_RegisterLoadingSpawnGroups",
+        "xref_strings": [
+            "%s:  RegisterLoadingSpawnGroups %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_RegisterLoadingSpawnGroups", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_RegisterLoadingSpawnGroups",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ReserveServerForQueuedGame.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ReserveServerForQueuedGame.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ReserveServerForQueuedGame skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ReserveServerForQueuedGame",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ReserveServerForQueuedGame",
+        "xref_strings": [
+            "Rejecting reservation because sv_shutdown was requested.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    (
+        "CNetworkGameServerBase_ReserveServerForQueuedGame",
+        "CNetworkGameServerBase_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ReserveServerForQueuedGame",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerEndSimulate.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerEndSimulate.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerEndSimulate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_ServerEndSimulate",
+        "CNetworkGameServerBase",
+        "INetworkGameServer_ServerEndSimulate",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerEndSimulate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerPollNetworking.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerPollNetworking.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerPollNetworking skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ServerPollNetworking",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ServerPollNetworking",
+        "xref_strings": [
+            "SIGINT received",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_ServerPollNetworking", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerPollNetworking",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerPostSimulate.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ServerPostSimulate.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ServerPostSimulate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_ServerPostSimulate",
+        "CNetworkGameServerBase",
+        "INetworkGameServer_ServerPostSimulate",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ServerPostSimulate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_SetServerState.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_SetServerState.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_SetServerState skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_SetServerState",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_SetServerState",
+        "xref_strings": [
+            "CNetworkGameServerBase::SetServerState (%s -> %s)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_SetServerState", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_SetServerState",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_Shutdown-linux.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_Shutdown-linux.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_Shutdown-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_Shutdown",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_Shutdown",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CNetworkGameServerBase_ShutdownInternal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_Shutdown", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_Shutdown-windows.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_Shutdown-windows.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_Shutdown-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_Shutdown",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_Shutdown",
+        "xref_strings": [
+            "Server shutdown",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_Shutdown", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ShutdownInternal-linux.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ShutdownInternal-linux.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ShutdownInternal-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ShutdownInternal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ShutdownInternal",
+        "xref_strings": [
+            "Server shutdown",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ShutdownInternal",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_SpawnGroupThink.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_SpawnGroupThink.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_SpawnGroupThink skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_SpawnGroupThink",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_SpawnGroupThink",
+        "xref_strings": [
+            "JustInTime Resource Spawn Group",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_SpawnGroupThink",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_StartChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_StartChangeLevel.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_StartChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_StartChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_StartChangeLevel",
+        "xref_strings": [
+            "SV:  CNetworkServerService::StartChangeLevel( %s )",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_StartChangeLevel", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_StartChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_Init.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_Init.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CNetworkGameServer_Init", "CNetworkGameServer", "CNetworkGameServerBase_Init", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_Init",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_PrepareForAssetLoad.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_PrepareForAssetLoad.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_PrepareForAssetLoad skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_PrepareForAssetLoad",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_PrepareForAssetLoad",
+        "xref_strings": [
+            "PrepareForAssetLoad(%s)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServer_PrepareForAssetLoad", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_PrepareForAssetLoad",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_Shutdown.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_Shutdown.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_Shutdown skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CNetworkGameServer_Shutdown", "CNetworkGameServer", "CNetworkGameServerBase_Shutdown", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_Shutdown",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_SpawnServer.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_SpawnServer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_SpawnServer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_SpawnServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_SpawnServer",
+        "xref_strings": [
+            "SV:  Spawn Server: %s: [%s]",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServer_SpawnServer", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_SpawnServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerService_DisconnectGameNow.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_DisconnectGameNow.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_DisconnectGameNow skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkServerService_DisconnectGameNow",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkServerService_DisconnectGameNow",
+        "xref_strings": [
+            "SV:  Server shutting down: %s (%d)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkServerService_DisconnectGameNow", "CNetworkServerService_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkServerService_DisconnectGameNow",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerService_OnEventMapCallbacks-engine.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_OnEventMapCallbacks-engine.py
@@ -8,6 +8,7 @@ TARGET_FUNCTION_NAMES = [
     "CNetworkServerService_OnServerPollNetworking",
     "CNetworkServerService_OnServerProcessNetworking",
     "CNetworkServerService_OnServerBeginSimulate",
+    "CNetworkServerService_OnServerEndSimulate",
     "CNetworkServerService_OnServerPostSimulate",
     "CNetworkServerService_OnServerPostAdvanceTick",
     "CNetworkServerService_OnFrameBoundary",
@@ -34,6 +35,11 @@ LLM_DECOMPILE = [
     ),
     (
         "CNetworkServerService_OnServerBeginSimulate",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkServerService_RegisterEventMapInternal.{platform}.yaml",
+    ),
+    (
+        "CNetworkServerService_OnServerEndSimulate",
         "prompt/call_llm_decompile.md",
         "references/engine/CNetworkServerService_RegisterEventMapInternal.{platform}.yaml",
     ),
@@ -98,6 +104,16 @@ GENERATE_YAML_DESIRED_FIELDS = [
     ),
     (
         "CNetworkServerService_OnServerBeginSimulate",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+    (
+        "CNetworkServerService_OnServerEndSimulate",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CNetworkServerService_StartupServer.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_StartupServer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_StartupServer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkServerService_StartupServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkServerService_StartupServer",
+        "xref_strings": [
+            "CNetworkServerService::StartupServer called but we still have extant instance!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkServerService_StartupServer", "CNetworkServerService_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkServerService_StartupServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerSpawnGroupCreatePrerequisites_Init.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerSpawnGroupCreatePrerequisites_Init.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerSpawnGroupCreatePrerequisites_Init skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkServerSpawnGroupCreatePrerequisites_Init",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkServerSpawnGroupCreatePrerequisites_Init",
+        "xref_strings": [
+            "FULLMATCH:SAVE/%s.hl1",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkServerSpawnGroupCreatePrerequisites_Init",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -146,7 +146,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "struct_name",
             "member_name",
             "offset",
-            #"size",
+            # "size",
             "offset_sig",
             "offset_sig_disp",
             "offset_sig_allow_across_function_boundary:true",

--- a/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2EntitySystem_StaticInit-decompiles.py
@@ -146,20 +146,10 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "struct_name",
             "member_name",
             "offset",
-            "size",
+            #"size",
             "offset_sig",
             "offset_sig_disp",
-        ],
-    ),
-    (
-        "CGameEntitySystem_m_pEntity2SaveRestore",
-        [
-            "struct_name",
-            "member_name",
-            "offset",
-            "size",
-            "offset_sig",
-            "offset_sig_disp",
+            "offset_sig_allow_across_function_boundary:true",
         ],
     ),
     (

--- a/ida_preprocessor_scripts/find-INetworkGameServer_ServerEndSimulate.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_ServerEndSimulate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkGameServer_ServerEndSimulate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkGameServer_ServerEndSimulate",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "INetworkGameServer_ServerEndSimulate",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkServerService_OnServerEndSimulate.{platform}.yaml",
+    ),
+]
+
+# INetworkGameServer is an abstract interface -- no vtable YAML needed; vtable_name is metadata only
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkGameServer_ServerEndSimulate", "INetworkGameServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "INetworkGameServer_ServerEndSimulate",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-INetworkGameServer_ServerPostSimulate.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_ServerPostSimulate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkGameServer_ServerPostSimulate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkGameServer_ServerPostSimulate",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "INetworkGameServer_ServerPostSimulate",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkServerService_OnServerPostSimulate.{platform}.yaml",
+    ),
+]
+
+# INetworkGameServer is an abstract interface -- no vtable YAML needed; vtable_name is metadata only
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkGameServer_ServerPostSimulate", "INetworkGameServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "INetworkGameServer_ServerPostSimulate",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerEndSimulate.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerEndSimulate.linux.yaml
@@ -1,0 +1,20 @@
+func_name: CNetworkServerService_OnServerEndSimulate
+func_va: '0x5a8e20'
+disasm_code: |-
+  .text:00000000005A8E20                 mov     rdi, [rdi+150h]
+  .text:00000000005A8E27                 test    rdi, rdi
+  .text:00000000005A8E2A                 jz      short locret_5A8E38
+  .text:00000000005A8E2C                 mov     rax, [rdi]
+  .text:00000000005A8E2F                 jmp     qword ptr [rax+88h]; 0x88 = 136 = INetworkGameServer_ServerEndSimulate
+  .text:00000000005A8E38                 retn
+procedure: |-
+  __int64 __fastcall CNetworkServerService_OnServerEndSimulate(__int64 a1)
+  {
+    __int64 v1; // rdi
+    __int64 result; // rax
+
+    v1 = *(_QWORD *)(a1 + 336);
+    if ( v1 )
+      return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v1 + 136LL))(v1);// 0x88 = 136 = INetworkGameServer_ServerEndSimulate
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerEndSimulate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerEndSimulate.windows.yaml
@@ -1,0 +1,20 @@
+func_name: CNetworkServerService_OnServerEndSimulate
+func_va: '0x1801df5a0'
+disasm_code: |-
+  .text:00000001801DF5A0                 mov     rcx, [rcx+150h]
+  .text:00000001801DF5A7                 test    rcx, rcx
+  .text:00000001801DF5AA                 jz      short locret_1801DF5B6
+  .text:00000001801DF5AC                 mov     rax, [rcx]
+  .text:00000001801DF5AF                 jmp     qword ptr [rax+88h]; 0x88 = 136 = INetworkGameServer_ServerEndSimulate
+  .text:00000001801DF5B6                 retn
+procedure: |-
+  __int64 __fastcall CNetworkServerService_OnServerEndSimulate(__int64 a1)
+  {
+    __int64 v1; // rcx
+    __int64 result; // rax
+
+    v1 = *(_QWORD *)(a1 + 336);
+    if ( v1 )
+      return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v1 + 136LL))(v1);// 0x88 = 136 = INetworkGameServer_ServerEndSimulate
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostSimulate.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostSimulate.linux.yaml
@@ -1,0 +1,127 @@
+func_name: CNetworkServerService_OnServerPostSimulate
+func_va: '0x5a9b70'
+disasm_code: |-
+  .text:00000000005A9B70                 movss   xmm0, cs:dword_255B70
+  .text:00000000005A9B78                 pxor    xmm1, xmm1
+  .text:00000000005A9B7C                 cvtsd2ss xmm1, cs:qword_97E610
+  .text:00000000005A9B84                 push    rbp
+  .text:00000000005A9B85                 mulss   xmm0, cs:dword_9C4B14
+  .text:00000000005A9B8D                 mov     rbp, rsp
+  .text:00000000005A9B90                 push    r12
+  .text:00000000005A9B92                 mov     r12, rsi
+  .text:00000000005A9B95                 cmp     cs:byte_9C4B10, 0
+  .text:00000000005A9B9C                 push    rbx
+  .text:00000000005A9B9D                 mov     cs:qword_97E610, 0
+  .text:00000000005A9BA8                 addss   xmm0, xmm1
+  .text:00000000005A9BAC                 movss   cs:dword_9C4B14, xmm0
+  .text:00000000005A9BB4                 jz      short loc_5A9BFA
+  .text:00000000005A9BB6                 cmp     cs:g_pGameServer, 0
+  .text:00000000005A9BBE                 jnz     short loc_5A9C01
+  .text:00000000005A9BC0                 cmp     cs:qword_97E620, 0
+  .text:00000000005A9BC8                 jnz     loc_5A9C70
+  .text:00000000005A9BCE                 xchg    ax, ax
+  .text:00000000005A9BD0                 cmp     cs:qword_97E628, 0
+  .text:00000000005A9BD8                 jnz     short loc_5A9BE0
+  .text:00000000005A9BDA                 pop     rbx
+  .text:00000000005A9BDB                 pop     r12
+  .text:00000000005A9BDD                 pop     rbp
+  .text:00000000005A9BDE                 retn
+  .text:00000000005A9BE0                 mov     rdi, cs:qword_97E628
+  .text:00000000005A9BE7                 mov     rsi, r12
+  .text:00000000005A9BEA                 pop     rbx
+  .text:00000000005A9BEB                 pop     r12
+  .text:00000000005A9BED                 pop     rbp
+  .text:00000000005A9BEE                 mov     rax, [rdi]
+  .text:00000000005A9BF1                 mov     rax, [rax+90h]; 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  .text:00000000005A9BF8                 jmp     rax
+  .text:00000000005A9BFA                 call    sub_5BE940
+  .text:00000000005A9BFF                 jmp     short loc_5A9BB6
+  .text:00000000005A9C01                 mov     rdx, cs:g_pGameServer
+  .text:00000000005A9C08                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000000005A9C10                 mov     rdi, rdx
+  .text:00000000005A9C13                 xor     ebx, ebx
+  .text:00000000005A9C15                 mov     rax, [rdi]
+  .text:00000000005A9C18                 mov     rsi, r12
+  .text:00000000005A9C1B                 call    qword ptr [rax+90h]; 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  .text:00000000005A9C21                 lea     eax, [rbx+1]
+  .text:00000000005A9C24                 mov     rdi, cs:qword_97E620
+  .text:00000000005A9C2B                 mov     rdx, cs:g_pGameServer
+  .text:00000000005A9C32                 cmp     eax, 1
+  .text:00000000005A9C35                 jz      short loc_5A9C48
+  .text:00000000005A9C37                 cmp     eax, 2
+  .text:00000000005A9C3A                 jz      short loc_5A9BD0
+  .text:00000000005A9C3C                 test    eax, eax
+  .text:00000000005A9C3E                 jz      short loc_5A9C60
+  .text:00000000005A9C40                 add     eax, 1
+  .text:00000000005A9C43                 cmp     eax, 1
+  .text:00000000005A9C46                 jnz     short loc_5A9C37
+  .text:00000000005A9C48                 test    rdi, rdi
+  .text:00000000005A9C4B                 jz      short loc_5A9BD0
+  .text:00000000005A9C4D                 nop     dword ptr [rax]
+  .text:00000000005A9C50                 mov     ebx, 1
+  .text:00000000005A9C55                 jmp     short loc_5A9C15
+  .text:00000000005A9C60                 test    rdx, rdx
+  .text:00000000005A9C63                 jnz     short loc_5A9C10
+  .text:00000000005A9C65                 test    rdi, rdi
+  .text:00000000005A9C68                 jz      loc_5A9BD0
+  .text:00000000005A9C6E                 jmp     short loc_5A9C50
+  .text:00000000005A9C70                 mov     rdi, cs:qword_97E620
+  .text:00000000005A9C77                 jmp     short loc_5A9C50
+procedure: |-
+  void __fastcall CNetworkServerService_OnServerPostSimulate(__int64 a1, __int64 a2)
+  {
+    float v2; // xmm1_4
+    __int64 v3; // rdx
+    __int64 v4; // rdi
+    int v5; // ebx
+    int v6; // eax
+
+    v2 = *(double *)&qword_97E610;
+    qword_97E610 = 0;
+    *(float *)&dword_9C4B14 = (float)(0.99900001 * *(float *)&dword_9C4B14) + v2;
+    if ( !byte_9C4B10 )
+      sub_5BE940();
+    if ( g_pGameServer )
+    {
+      v3 = g_pGameServer;
+  LABEL_8:
+      v4 = v3;
+      v5 = 0;
+      goto LABEL_9;
+    }
+    if ( qword_97E620[0] )
+    {
+      v4 = qword_97E620[0];
+  LABEL_14:
+      while ( 1 )
+      {
+        v5 = 1;
+  LABEL_9:
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v4 + 144LL))(v4, a2);// 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+        v6 = v5 + 1;
+        v4 = qword_97E620[0];
+        v3 = g_pGameServer;
+        if ( v5 )
+          break;
+  LABEL_13:
+        if ( !qword_97E620[0] )
+          goto LABEL_5;
+      }
+      while ( v6 != 2 )
+      {
+        if ( !v6 )
+        {
+          if ( g_pGameServer )
+            goto LABEL_8;
+          if ( !qword_97E620[0] )
+            break;
+          goto LABEL_14;
+        }
+        if ( ++v6 == 1 )
+          goto LABEL_13;
+      }
+    }
+  LABEL_5:
+    if ( qword_97E628 )
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_97E628 + 144LL))(qword_97E628, a2);// 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostSimulate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_OnServerPostSimulate.windows.yaml
@@ -1,0 +1,281 @@
+func_name: CNetworkServerService_OnServerPostSimulate
+func_va: '0x1801dfa70'
+disasm_code: |-
+  .text:00000001801DFA70                 mov     [rsp+arg_0], rbx
+  .text:00000001801DFA75                 mov     [rsp+arg_8], rsi
+  .text:00000001801DFA7A                 push    rdi
+  .text:00000001801DFA7B                 sub     rsp, 40h
+  .text:00000001801DFA7F                 movsd   xmm0, cs:qword_18090E658
+  .text:00000001801DFA87                 xor     ebx, ebx
+  .text:00000001801DFA89                 cmp     cs:byte_18090D4E0, bl
+  .text:00000001801DFA8F                 mov     rsi, rdx
+  .text:00000001801DFA92                 movss   xmm1, cs:dword_18090D4DC
+  .text:00000001801DFA9A                 mov     rdi, rcx
+  .text:00000001801DFA9D                 mulss   xmm1, cs:dword_180583688
+  .text:00000001801DFAA5                 cvtpd2ps xmm0, xmm0
+  .text:00000001801DFAA9                 addss   xmm1, xmm0
+  .text:00000001801DFAAD                 xorps   xmm0, xmm0
+  .text:00000001801DFAB0                 movsd   cs:qword_18090E658, xmm0
+  .text:00000001801DFAB8                 movss   cs:dword_18090D4DC, xmm1
+  .text:00000001801DFAC0                 jnz     short loc_1801DFB34
+  .text:00000001801DFAC2                 lea     rdx, [rsp+48h+var_28]
+  .text:00000001801DFAC7                 call    sub_1801DF5C0
+  .text:00000001801DFACC                 mov     rcx, rax
+  .text:00000001801DFACF                 call    sub_180246430
+  .text:00000001801DFAD4                 mov     eax, [rsp+48h+var_14]
+  .text:00000001801DFAD8                 mov     rdx, [rsp+48h+var_20]
+  .text:00000001801DFADD                 mov     [rsp+48h+var_28], ebx
+  .text:00000001801DFAE1                 test    eax, 0C0000000h
+  .text:00000001801DFAE6                 jnz     short loc_1801DFB28
+  .text:00000001801DFAE8                 test    rdx, rdx
+  .text:00000001801DFAEB                 jz      short loc_1801DFB08
+  .text:00000001801DFAED                 mov     rax, cs:g_pMemAlloc
+  .text:00000001801DFAF4                 mov     rcx, [rax]
+  .text:00000001801DFAF7                 mov     rax, [rcx]
+  .text:00000001801DFAFA                 call    qword ptr [rax+18h]
+  .text:00000001801DFAFD                 mov     eax, [rsp+48h+var_14]
+  .text:00000001801DFB01                 mov     edx, ebx
+  .text:00000001801DFB03                 mov     [rsp+48h+var_20], rbx
+  .text:00000001801DFB08                 mov     [rsp+48h+var_18], ebx
+  .text:00000001801DFB0C                 test    eax, 0C0000000h
+  .text:00000001801DFB11                 jnz     short loc_1801DFB28
+  .text:00000001801DFB13                 test    rdx, rdx
+  .text:00000001801DFB16                 jz      short loc_1801DFB28
+  .text:00000001801DFB18                 mov     rax, cs:g_pMemAlloc
+  .text:00000001801DFB1F                 mov     rcx, [rax]
+  .text:00000001801DFB22                 mov     rax, [rcx]
+  .text:00000001801DFB25                 call    qword ptr [rax+18h]
+  .text:00000001801DFB28                 mov     rax, [rdi]
+  .text:00000001801DFB2B                 mov     rcx, rdi
+  .text:00000001801DFB2E                 call    qword ptr [rax+188h]
+  .text:00000001801DFB34                 mov     r10, cs:qword_180688058
+  .text:00000001801DFB3B                 mov     r8, cs:qword_180688050
+  .text:00000001801DFB42                 mov     r9, cs:g_pGameServer
+  .text:00000001801DFB49                 nop     dword ptr [rax+00000000h]
+  .text:00000001801DFB50                 mov     ecx, ebx
+  .text:00000001801DFB52                 test    ebx, ebx
+  .text:00000001801DFB54                 jz      short loc_1801DFB6A
+  .text:00000001801DFB56                 sub     ecx, 1
+  .text:00000001801DFB59                 jz      short loc_1801DFB65
+  .text:00000001801DFB5B                 cmp     ecx, 1
+  .text:00000001801DFB5E                 jnz     short loc_1801DFB72
+  .text:00000001801DFB60                 mov     rax, r10
+  .text:00000001801DFB63                 jmp     short loc_1801DFB6D
+  .text:00000001801DFB65                 mov     rax, r8
+  .text:00000001801DFB68                 jmp     short loc_1801DFB6D
+  .text:00000001801DFB6A                 mov     rax, r9
+  .text:00000001801DFB6D                 test    rax, rax
+  .text:00000001801DFB70                 jnz     short loc_1801DFB79
+  .text:00000001801DFB72                 inc     ebx
+  .text:00000001801DFB74                 cmp     ebx, 3
+  .text:00000001801DFB77                 jl      short loc_1801DFB50
+  .text:00000001801DFB79                 cmp     ebx, 3
+  .text:00000001801DFB7C                 jz      loc_1801DFC33
+  .text:00000001801DFB82                 mov     ecx, ebx
+  .text:00000001801DFB84                 test    ebx, ebx
+  .text:00000001801DFB86                 jz      short loc_1801DFBDB
+  .text:00000001801DFB88                 sub     ecx, 1
+  .text:00000001801DFB8B                 jz      short loc_1801DFBD3
+  .text:00000001801DFB8D                 mov     rdx, rsi
+  .text:00000001801DFB90                 cmp     ecx, 1
+  .text:00000001801DFB93                 jz      short loc_1801DFBAE
+  .text:00000001801DFB95                 mov     rax, ds:0
+  .text:00000001801DFB9D                 xor     ecx, ecx
+  .text:00000001801DFB9F                 call    qword ptr [rax+90h]; 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  .text:00000001801DFBA5                 inc     ebx
+  .text:00000001801DFBA7                 cmp     ebx, 3
+  .text:00000001801DFBAA                 jl      short loc_1801DFBEC
+  .text:00000001801DFBAC                 jmp     short loc_1801DFBBC
+  .text:00000001801DFBAE                 mov     rax, [r10]
+  .text:00000001801DFBB1                 mov     rcx, r10
+  .text:00000001801DFBB4                 call    qword ptr [rax+90h]; 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  .text:00000001801DFBBA                 inc     ebx
+  .text:00000001801DFBBC                 mov     r10, cs:qword_180688058
+  .text:00000001801DFBC3                 mov     r8, cs:qword_180688050
+  .text:00000001801DFBCA                 mov     r9, cs:g_pGameServer
+  .text:00000001801DFBD1                 jmp     short loc_1801DFC2A
+  .text:00000001801DFBD3                 mov     rax, [r8]
+  .text:00000001801DFBD6                 mov     rcx, r8
+  .text:00000001801DFBD9                 jmp     short loc_1801DFBE1
+  .text:00000001801DFBDB                 mov     rax, [r9]
+  .text:00000001801DFBDE                 mov     rcx, r9
+  .text:00000001801DFBE1                 mov     rdx, rsi
+  .text:00000001801DFBE4                 call    qword ptr [rax+90h]; 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+  .text:00000001801DFBEA                 inc     ebx
+  .text:00000001801DFBEC                 mov     r10, cs:qword_180688058
+  .text:00000001801DFBF3                 mov     r8, cs:qword_180688050
+  .text:00000001801DFBFA                 mov     r9, cs:g_pGameServer
+  .text:00000001801DFC01                 mov     ecx, ebx
+  .text:00000001801DFC03                 test    ebx, ebx
+  .text:00000001801DFC05                 jz      short loc_1801DFC1B
+  .text:00000001801DFC07                 sub     ecx, 1
+  .text:00000001801DFC0A                 jz      short loc_1801DFC16
+  .text:00000001801DFC0C                 cmp     ecx, 1
+  .text:00000001801DFC0F                 jnz     short loc_1801DFC23
+  .text:00000001801DFC11                 mov     rax, r10
+  .text:00000001801DFC14                 jmp     short loc_1801DFC1E
+  .text:00000001801DFC16                 mov     rax, r8
+  .text:00000001801DFC19                 jmp     short loc_1801DFC1E
+  .text:00000001801DFC1B                 mov     rax, r9
+  .text:00000001801DFC1E                 test    rax, rax
+  .text:00000001801DFC21                 jnz     short loc_1801DFC2A
+  .text:00000001801DFC23                 inc     ebx
+  .text:00000001801DFC25                 cmp     ebx, 3
+  .text:00000001801DFC28                 jl      short loc_1801DFC01
+  .text:00000001801DFC2A                 cmp     ebx, 3
+  .text:00000001801DFC2D                 jnz     loc_1801DFB82
+  .text:00000001801DFC33                 mov     rbx, [rsp+48h+arg_0]
+  .text:00000001801DFC38                 mov     rsi, [rsp+48h+arg_8]
+  .text:00000001801DFC3D                 add     rsp, 40h
+  .text:00000001801DFC41                 pop     rdi
+  .text:00000001801DFC42                 retn
+procedure: |-
+  void __fastcall CNetworkServerService_OnServerPostSimulate(__int64 a1, __int64 a2)
+  {
+    int v2; // ebx
+    float v5; // xmm0_4
+    __int64 v6; // rax
+    int v7; // eax
+    __int64 v8; // rdx
+    __int64 v9; // r10
+    _QWORD *v10; // r8
+    _QWORD *v11; // r9
+    __int64 v12; // rax
+    __int64 v13; // rax
+    _QWORD *v14; // rcx
+    __int64 v15; // rax
+    int v16; // [rsp+20h] [rbp-28h] BYREF
+    __int64 v17; // [rsp+28h] [rbp-20h]
+    int v18; // [rsp+30h] [rbp-18h]
+    int v19; // [rsp+34h] [rbp-14h]
+
+    v2 = 0;
+    v5 = *(double *)&qword_18090E658;
+    qword_18090E658 = 0;
+    *(float *)&dword_18090D4DC = (float)(*(float *)&dword_18090D4DC * 0.99900001) + v5;
+    if ( !byte_18090D4E0 )
+    {
+      v6 = sub_1801DF5C0(a1, &v16);
+      sub_180246430(v6);
+      v7 = v19;
+      v8 = v17;
+      v16 = 0;
+      if ( (v19 & 0xC0000000) == 0 )
+      {
+        if ( v17 )
+        {
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v17);
+          v7 = v19;
+          v8 = 0;
+          v17 = 0;
+        }
+        v18 = 0;
+        if ( (v7 & 0xC0000000) == 0 )
+        {
+          if ( v8 )
+            (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+        }
+      }
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 392LL))(a1, v8);
+    }
+    v9 = qword_180688058;
+    v10 = (_QWORD *)qword_180688050[0];
+    v11 = (_QWORD *)g_pGameServer;
+    do
+    {
+      if ( v2 )
+      {
+        if ( v2 == 1 )
+        {
+          v12 = qword_180688050[0];
+        }
+        else
+        {
+          if ( v2 != 2 )
+            goto LABEL_17;
+          v12 = qword_180688058;
+        }
+      }
+      else
+      {
+        v12 = g_pGameServer;
+      }
+      if ( v12 )
+        break;
+  LABEL_17:
+      ++v2;
+    }
+    while ( v2 < 3 );
+    if ( v2 != 3 )
+    {
+      while ( 1 )
+      {
+        if ( !v2 )
+        {
+          v13 = *v11;
+          v14 = v11;
+          goto LABEL_28;
+        }
+        if ( v2 == 1 )
+          break;
+        if ( v2 == 2 )
+        {
+          (*(void (__fastcall **)(__int64, __int64, _QWORD *, _QWORD *))(*(_QWORD *)v9 + 144LL))(v9, a2, v10, v11);// 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+          v2 = 3;
+        }
+        else
+        {
+          (*(void (__fastcall **)(_QWORD, __int64, _QWORD *, _QWORD *))(MEMORY[0] + 144LL))(0, a2, v10, v11);// 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+          if ( ++v2 < 3 )
+            goto LABEL_29;
+        }
+        v9 = qword_180688058;
+        v10 = (_QWORD *)qword_180688050[0];
+        v11 = (_QWORD *)g_pGameServer;
+  LABEL_38:
+        if ( v2 == 3 )
+          return;
+      }
+      v13 = *v10;
+      v14 = v10;
+  LABEL_28:
+      (*(void (__fastcall **)(_QWORD *, __int64, _QWORD *, _QWORD *, int, __int64, int))(v13
+                                                                                       + 144))(// 0x90 = 144 = INetworkGameServer_ServerPostSimulate
+        v14,
+        a2,
+        v10,
+        v11,
+        v16,
+        v17,
+        v18);
+      ++v2;
+  LABEL_29:
+      v9 = qword_180688058;
+      v10 = (_QWORD *)qword_180688050[0];
+      v11 = (_QWORD *)g_pGameServer;
+      while ( 2 )
+      {
+        if ( !v2 )
+        {
+          v15 = g_pGameServer;
+          goto LABEL_36;
+        }
+        if ( v2 != 1 )
+        {
+          if ( v2 == 2 )
+          {
+            v15 = qword_180688058;
+  LABEL_36:
+            if ( v15 )
+              goto LABEL_38;
+          }
+          if ( ++v2 >= 3 )
+            goto LABEL_38;
+          continue;
+        }
+        break;
+      }
+      v15 = qword_180688050[0];
+      goto LABEL_36;
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_RegisterEventMapInternal.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_RegisterEventMapInternal.linux.yaml
@@ -1,532 +1,587 @@
 func_name: CNetworkServerService_RegisterEventMapInternal
-func_va: '0x8dd700'
+func_va: '0x8e8160'
 disasm_code: |-
-  .text:00000000008DD700                 push    rbp
-  .text:00000000008DD701                 mov     rbp, rsp
-  .text:00000000008DD704                 push    r15
-  .text:00000000008DD706                 push    r14
-  .text:00000000008DD708                 push    r13
-  .text:00000000008DD70A                 push    r12
-  .text:00000000008DD70C                 mov     r12, rsi
-  .text:00000000008DD70F                 push    rbx
-  .text:00000000008DD710                 mov     rbx, rdi
-  .text:00000000008DD713                 sub     rsp, 28h
-  .text:00000000008DD717                 test    edx, edx
-  .text:00000000008DD719                 jnz     loc_8DDB88
-  .text:00000000008DD71F                 movzx   eax, cs:byte_C56DA8
-  .text:00000000008DD726                 test    al, al
-  .text:00000000008DD728                 jz      loc_8DDD60
-  .text:00000000008DD72E                 mov     rdx, cs:qword_968E20
-  .text:00000000008DD735                 lea     r8, qword_C56CA8
-  .text:00000000008DD73C                 test    cs:byte_C56CA7, 40h
-  .text:00000000008DD743                 jnz     short loc_8DD75E
-  .text:00000000008DD745                 test    dword ptr cs:unk_C56CA4, 3FFFFFFFh
-  .text:00000000008DD74F                 lea     r8, byte_26801C
-  .text:00000000008DD756                 cmovnz  r8, cs:qword_C56CA8
-  .text:00000000008DD75E                 xor     ecx, ecx
-  .text:00000000008DD760                 mov     rdi, rbx
-  .text:00000000008DD763                 mov     [rbp+var_40], 0
-  .text:00000000008DD76B                 mov     [rbp+var_50], r12
-  .text:00000000008DD76F                 lea     r13, [rbp+var_50]
-  .text:00000000008DD773                 lea     rax, CNetworkServerService_OnServerAdvanceTick
-  .text:00000000008DD77A                 mov     rsi, r13
-  .text:00000000008DD77D                 mov     [rbp+var_48], rax
-  .text:00000000008DD781                 call    sub_8E15B0
-  .text:00000000008DD786                 movzx   eax, cs:byte_C56C88
-  .text:00000000008DD78D                 test    al, al
-  .text:00000000008DD78F                 jz      loc_8DE0C0
-  .text:00000000008DD795                 mov     rdx, cs:qword_9684A0
-  .text:00000000008DD79C                 lea     r8, qword_C56B88
-  .text:00000000008DD7A3                 test    cs:byte_C56B87, 40h
-  .text:00000000008DD7AA                 jnz     short loc_8DD7C5
-  .text:00000000008DD7AC                 test    dword ptr cs:unk_C56B84, 3FFFFFFFh
-  .text:00000000008DD7B6                 lea     r8, byte_26801C
-  .text:00000000008DD7BD                 cmovnz  r8, cs:qword_C56B88
-  .text:00000000008DD7C5                 xor     ecx, ecx
-  .text:00000000008DD7C7                 mov     rsi, r13
-  .text:00000000008DD7CA                 mov     [rbp+var_50], r12
-  .text:00000000008DD7CE                 mov     rdi, rbx
-  .text:00000000008DD7D1                 mov     [rbp+var_40], 0
-  .text:00000000008DD7D9                 lea     rax, CNetworkServerService_OnServerPollNetworking
-  .text:00000000008DD7E0                 mov     [rbp+var_48], rax
-  .text:00000000008DD7E4                 call    sub_8E15B0
-  .text:00000000008DD7E9                 movzx   eax, cs:byte_C56B68
-  .text:00000000008DD7F0                 test    al, al
-  .text:00000000008DD7F2                 jz      loc_8DE120
-  .text:00000000008DD7F8                 mov     rdx, cs:qword_968380
-  .text:00000000008DD7FF                 lea     r8, qword_C56A68
-  .text:00000000008DD806                 test    cs:byte_C56A67, 40h
-  .text:00000000008DD80D                 jnz     short loc_8DD828
-  .text:00000000008DD80F                 test    dword ptr cs:unk_C56A64, 3FFFFFFFh
-  .text:00000000008DD819                 lea     r8, byte_26801C
-  .text:00000000008DD820                 cmovnz  r8, cs:qword_C56A68
-  .text:00000000008DD828                 xor     ecx, ecx
-  .text:00000000008DD82A                 mov     rsi, r13
-  .text:00000000008DD82D                 mov     [rbp+var_50], r12
-  .text:00000000008DD831                 mov     rdi, rbx
-  .text:00000000008DD834                 mov     [rbp+var_40], 0
-  .text:00000000008DD83C                 lea     rax, CNetworkServerService_OnServerProcessNetworking
-  .text:00000000008DD843                 mov     [rbp+var_48], rax
-  .text:00000000008DD847                 call    sub_8E15B0
-  .text:00000000008DD84C                 movzx   eax, cs:byte_C56A48
-  .text:00000000008DD853                 test    al, al
-  .text:00000000008DD855                 jz      loc_8DDDC0
-  .text:00000000008DD85B                 mov     rdx, cs:qword_968260
-  .text:00000000008DD862                 lea     r8, qword_C56948
-  .text:00000000008DD869                 test    cs:byte_C56947, 40h
-  .text:00000000008DD870                 jnz     short loc_8DD88B
-  .text:00000000008DD872                 test    dword ptr cs:unk_C56944, 3FFFFFFFh
-  .text:00000000008DD87C                 lea     r8, byte_26801C
-  .text:00000000008DD883                 cmovnz  r8, cs:qword_C56948
-  .text:00000000008DD88B                 mov     ecx, 80000000h
-  .text:00000000008DD890                 mov     rsi, r13
-  .text:00000000008DD893                 mov     [rbp+var_50], r12
-  .text:00000000008DD897                 mov     rdi, rbx
-  .text:00000000008DD89A                 mov     [rbp+var_40], 0
-  .text:00000000008DD8A2                 lea     rax, CNetworkServerService_OnServerBeginSimulate
-  .text:00000000008DD8A9                 mov     [rbp+var_48], rax
-  .text:00000000008DD8AD                 call    sub_8E15B0
-  .text:00000000008DD8B2                 movzx   eax, cs:byte_C56928
-  .text:00000000008DD8B9                 test    al, al
-  .text:00000000008DD8BB                 jz      loc_8DDE20
-  .text:00000000008DD8C1                 mov     rdx, cs:qword_9681E0
-  .text:00000000008DD8C8                 lea     r8, qword_C56828
-  .text:00000000008DD8CF                 test    cs:byte_C56827, 40h
-  .text:00000000008DD8D6                 jnz     short loc_8DD8F1
-  .text:00000000008DD8D8                 test    dword ptr cs:unk_C56824, 3FFFFFFFh
-  .text:00000000008DD8E2                 lea     r8, byte_26801C
-  .text:00000000008DD8E9                 cmovnz  r8, cs:qword_C56828
-  .text:00000000008DD8F1                 mov     ecx, 7FFFFFFFh
-  .text:00000000008DD8F6                 mov     rsi, r13
-  .text:00000000008DD8F9                 mov     [rbp+var_50], r12
-  .text:00000000008DD8FD                 mov     rdi, rbx
-  .text:00000000008DD900                 mov     [rbp+var_40], 0
-  .text:00000000008DD908                 lea     rax, CNetworkServerService_OnServerEndSimulate
-  .text:00000000008DD90F                 mov     [rbp+var_48], rax
-  .text:00000000008DD913                 call    sub_8E15B0
-  .text:00000000008DD918                 movzx   eax, cs:byte_C56808
-  .text:00000000008DD91F                 test    al, al
-  .text:00000000008DD921                 jz      loc_8DDE80
-  .text:00000000008DD927                 mov     rdx, cs:qword_9680C0
-  .text:00000000008DD92E                 lea     r8, qword_C56708
-  .text:00000000008DD935                 test    cs:byte_C56707, 40h
-  .text:00000000008DD93C                 jnz     short loc_8DD957
-  .text:00000000008DD93E                 test    dword ptr cs:unk_C56704, 3FFFFFFFh
-  .text:00000000008DD948                 lea     r8, byte_26801C
-  .text:00000000008DD94F                 cmovnz  r8, cs:qword_C56708
-  .text:00000000008DD957                 xor     ecx, ecx
-  .text:00000000008DD959                 mov     rsi, r13
-  .text:00000000008DD95C                 mov     [rbp+var_50], r12
-  .text:00000000008DD960                 mov     rdi, rbx
-  .text:00000000008DD963                 mov     [rbp+var_40], 0
-  .text:00000000008DD96B                 lea     rax, CNetworkServerService_OnServerPostSimulate
-  .text:00000000008DD972                 mov     [rbp+var_48], rax
-  .text:00000000008DD976                 call    sub_8E15B0
-  .text:00000000008DD97B                 movzx   eax, cs:byte_C566E8
-  .text:00000000008DD982                 test    al, al
-  .text:00000000008DD984                 jz      loc_8DDEE0
-  .text:00000000008DD98A                 mov     rdx, cs:qword_968BC0
-  .text:00000000008DD991                 lea     r8, qword_C565E8
-  .text:00000000008DD998                 test    cs:byte_C565E7, 40h
-  .text:00000000008DD99F                 jnz     short loc_8DD9BA
-  .text:00000000008DD9A1                 test    dword ptr cs:unk_C565E4, 3FFFFFFFh
-  .text:00000000008DD9AB                 lea     r8, byte_26801C
-  .text:00000000008DD9B2                 cmovnz  r8, cs:qword_C565E8
-  .text:00000000008DD9BA                 mov     ecx, 80000000h
-  .text:00000000008DD9BF                 mov     rsi, r13
-  .text:00000000008DD9C2                 mov     [rbp+var_50], r12
-  .text:00000000008DD9C6                 mov     rdi, rbx
-  .text:00000000008DD9C9                 mov     [rbp+var_40], 0
-  .text:00000000008DD9D1                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
-  .text:00000000008DD9D8                 mov     [rbp+var_48], rax
-  .text:00000000008DD9DC                 call    sub_8E15B0
-  .text:00000000008DD9E1                 movzx   eax, cs:byte_C565C8
-  .text:00000000008DD9E8                 test    al, al
-  .text:00000000008DD9EA                 jz      loc_8DDF40
-  .text:00000000008DD9F0                 mov     rdx, cs:qword_968A20
-  .text:00000000008DD9F7                 lea     r8, qword_C564C8
-  .text:00000000008DD9FE                 test    cs:byte_C564C7, 40h
-  .text:00000000008DDA05                 jnz     short loc_8DDA20
-  .text:00000000008DDA07                 test    dword ptr cs:unk_C564C4, 3FFFFFFFh
-  .text:00000000008DDA11                 lea     r8, byte_26801C
-  .text:00000000008DDA18                 cmovnz  r8, cs:qword_C564C8
-  .text:00000000008DDA20                 mov     ecx, 80000000h
-  .text:00000000008DDA25                 mov     rsi, r13
-  .text:00000000008DDA28                 mov     [rbp+var_50], r12
-  .text:00000000008DDA2C                 mov     rdi, rbx
-  .text:00000000008DDA2F                 mov     [rbp+var_40], 0
-  .text:00000000008DDA37                 lea     rax, CNetworkServerService_OnServerBeginAsyncPostTickWork
-  .text:00000000008DDA3E                 mov     [rbp+var_48], rax
-  .text:00000000008DDA42                 call    sub_8E15B0
-  .text:00000000008DDA47                 movzx   eax, cs:byte_C564A8
-  .text:00000000008DDA4E                 test    al, al
-  .text:00000000008DDA50                 jz      loc_8DDFA0
-  .text:00000000008DDA56                 mov     rdx, cs:qword_969080
-  .text:00000000008DDA5D                 lea     r8, qword_C563A8
-  .text:00000000008DDA64                 test    cs:byte_C563A7, 40h
-  .text:00000000008DDA6B                 jnz     short loc_8DDA86
-  .text:00000000008DDA6D                 test    dword ptr cs:unk_C563A4, 3FFFFFFFh
-  .text:00000000008DDA77                 lea     r8, byte_26801C
-  .text:00000000008DDA7E                 cmovnz  r8, cs:qword_C563A8
-  .text:00000000008DDA86                 mov     ecx, 7FFFFFFFh
-  .text:00000000008DDA8B                 mov     rsi, r13
-  .text:00000000008DDA8E                 mov     [rbp+var_50], r12
-  .text:00000000008DDA92                 mov     rdi, rbx
-  .text:00000000008DDA95                 mov     [rbp+var_40], 0
-  .text:00000000008DDA9D                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000000008DDAA4                 mov     [rbp+var_48], rax
-  .text:00000000008DDAA8                 call    sub_8E15B0
-  .text:00000000008DDAAD                 movzx   eax, cs:byte_C56388
-  .text:00000000008DDAB4                 test    al, al
-  .text:00000000008DDAB6                 jz      loc_8DE000
-  .text:00000000008DDABC                 mov     rdx, cs:qword_968420
-  .text:00000000008DDAC3                 lea     r8, qword_C56288
-  .text:00000000008DDACA                 test    cs:byte_C56287, 40h
-  .text:00000000008DDAD1                 jnz     short loc_8DDAEC
-  .text:00000000008DDAD3                 test    dword ptr cs:unk_C56284, 3FFFFFFFh
-  .text:00000000008DDADD                 lea     r8, byte_26801C
-  .text:00000000008DDAE4                 cmovnz  r8, cs:qword_C56288
-  .text:00000000008DDAEC                 mov     ecx, 1
-  .text:00000000008DDAF1                 mov     rsi, r13
-  .text:00000000008DDAF4                 mov     [rbp+var_50], r12
-  .text:00000000008DDAF8                 mov     rdi, rbx
-  .text:00000000008DDAFB                 mov     [rbp+var_40], 0
-  .text:00000000008DDB03                 lea     rax, CNetworkServerService_OnClientPollNetworking
-  .text:00000000008DDB0A                 mov     [rbp+var_48], rax
-  .text:00000000008DDB0E                 call    sub_8E15B0
-  .text:00000000008DDB13                 movzx   eax, cs:byte_C56268
-  .text:00000000008DDB1A                 test    al, al
-  .text:00000000008DDB1C                 jz      loc_8DE060
-  .text:00000000008DDB22                 mov     rdx, cs:qword_969A40
-  .text:00000000008DDB29                 lea     r8, qword_C56168
-  .text:00000000008DDB30                 test    cs:byte_C56167, 40h
-  .text:00000000008DDB37                 jnz     short loc_8DDB52
-  .text:00000000008DDB39                 test    dword ptr cs:unk_C56164, 3FFFFFFFh
-  .text:00000000008DDB43                 lea     r8, byte_26801C
-  .text:00000000008DDB4A                 cmovnz  r8, cs:qword_C56168
-  .text:00000000008DDB52                 mov     rsi, r13
-  .text:00000000008DDB55                 mov     rdi, rbx
-  .text:00000000008DDB58                 mov     [rbp+var_50], r12
-  .text:00000000008DDB5C                 xor     ecx, ecx
-  .text:00000000008DDB5E                 mov     [rbp+var_40], 0
-  .text:00000000008DDB66                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
-  .text:00000000008DDB6D                 mov     [rbp+var_48], rax
-  .text:00000000008DDB71                 call    sub_8E15B0
-  .text:00000000008DDB76                 add     rsp, 28h
-  .text:00000000008DDB7A                 pop     rbx
-  .text:00000000008DDB7B                 pop     r12
-  .text:00000000008DDB7D                 pop     r13
-  .text:00000000008DDB7F                 pop     r14
-  .text:00000000008DDB81                 pop     r15
-  .text:00000000008DDB83                 pop     rbp
-  .text:00000000008DDB84                 retn
-  .text:00000000008DDB88                 mov     rdx, cs:qword_968E20
-  .text:00000000008DDB8F                 lea     r13, [rbp+var_50]
-  .text:00000000008DDB93                 mov     [rbp+var_50], rsi
-  .text:00000000008DDB97                 lea     rax, CNetworkServerService_OnServerAdvanceTick
-  .text:00000000008DDB9E                 mov     rsi, r13
-  .text:00000000008DDBA1                 mov     [rbp+var_40], 0
-  .text:00000000008DDBA9                 mov     [rbp+var_48], rax
-  .text:00000000008DDBAD                 call    sub_550600
-  .text:00000000008DDBB2                 mov     rsi, r13
-  .text:00000000008DDBB5                 mov     rdi, rbx
-  .text:00000000008DDBB8                 mov     [rbp+var_50], r12
-  .text:00000000008DDBBC                 mov     rdx, cs:qword_9684A0
-  .text:00000000008DDBC3                 lea     rax, CNetworkServerService_OnServerPollNetworking
-  .text:00000000008DDBCA                 mov     [rbp+var_40], 0
-  .text:00000000008DDBD2                 mov     [rbp+var_48], rax
-  .text:00000000008DDBD6                 call    sub_550600
-  .text:00000000008DDBDB                 mov     rsi, r13
-  .text:00000000008DDBDE                 mov     rdi, rbx
-  .text:00000000008DDBE1                 mov     [rbp+var_50], r12
-  .text:00000000008DDBE5                 mov     rdx, cs:qword_968380
-  .text:00000000008DDBEC                 lea     rax, CNetworkServerService_OnServerProcessNetworking
-  .text:00000000008DDBF3                 mov     [rbp+var_40], 0
-  .text:00000000008DDBFB                 mov     [rbp+var_48], rax
-  .text:00000000008DDBFF                 call    sub_550600
-  .text:00000000008DDC04                 mov     rsi, r13
-  .text:00000000008DDC07                 mov     rdi, rbx
-  .text:00000000008DDC0A                 mov     [rbp+var_50], r12
-  .text:00000000008DDC0E                 mov     rdx, cs:qword_968260
-  .text:00000000008DDC15                 lea     rax, CNetworkServerService_OnServerBeginSimulate
-  .text:00000000008DDC1C                 mov     [rbp+var_40], 0
-  .text:00000000008DDC24                 mov     [rbp+var_48], rax
-  .text:00000000008DDC28                 call    sub_550600
-  .text:00000000008DDC2D                 mov     rsi, r13
-  .text:00000000008DDC30                 mov     rdi, rbx
-  .text:00000000008DDC33                 mov     [rbp+var_50], r12
-  .text:00000000008DDC37                 mov     rdx, cs:qword_9681E0
-  .text:00000000008DDC3E                 lea     rax, CNetworkServerService_OnServerEndSimulate
-  .text:00000000008DDC45                 mov     [rbp+var_40], 0
-  .text:00000000008DDC4D                 mov     [rbp+var_48], rax
-  .text:00000000008DDC51                 call    sub_550600
-  .text:00000000008DDC56                 mov     rsi, r13
-  .text:00000000008DDC59                 mov     rdi, rbx
-  .text:00000000008DDC5C                 mov     [rbp+var_50], r12
-  .text:00000000008DDC60                 mov     rdx, cs:qword_9680C0
-  .text:00000000008DDC67                 lea     rax, CNetworkServerService_OnServerPostSimulate
-  .text:00000000008DDC6E                 mov     [rbp+var_40], 0
-  .text:00000000008DDC76                 mov     [rbp+var_48], rax
-  .text:00000000008DDC7A                 call    sub_550600
-  .text:00000000008DDC7F                 mov     rsi, r13
-  .text:00000000008DDC82                 mov     rdi, rbx
-  .text:00000000008DDC85                 mov     [rbp+var_50], r12
-  .text:00000000008DDC89                 mov     rdx, cs:qword_968BC0
-  .text:00000000008DDC90                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
-  .text:00000000008DDC97                 mov     [rbp+var_40], 0
-  .text:00000000008DDC9F                 mov     [rbp+var_48], rax
-  .text:00000000008DDCA3                 call    sub_550600
-  .text:00000000008DDCA8                 mov     rsi, r13
-  .text:00000000008DDCAB                 mov     rdi, rbx
-  .text:00000000008DDCAE                 mov     [rbp+var_50], r12
-  .text:00000000008DDCB2                 mov     rdx, cs:qword_968A20
-  .text:00000000008DDCB9                 lea     rax, CNetworkServerService_OnServerBeginAsyncPostTickWork
-  .text:00000000008DDCC0                 mov     [rbp+var_40], 0
-  .text:00000000008DDCC8                 mov     [rbp+var_48], rax
-  .text:00000000008DDCCC                 call    sub_550600
-  .text:00000000008DDCD1                 mov     rsi, r13
-  .text:00000000008DDCD4                 mov     rdi, rbx
-  .text:00000000008DDCD7                 mov     [rbp+var_50], r12
-  .text:00000000008DDCDB                 mov     rdx, cs:qword_969080
-  .text:00000000008DDCE2                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000000008DDCE9                 mov     [rbp+var_40], 0
-  .text:00000000008DDCF1                 mov     [rbp+var_48], rax
-  .text:00000000008DDCF5                 call    sub_550600
-  .text:00000000008DDCFA                 mov     rsi, r13
-  .text:00000000008DDCFD                 mov     rdi, rbx
-  .text:00000000008DDD00                 mov     [rbp+var_50], r12
-  .text:00000000008DDD04                 mov     rdx, cs:qword_968420
-  .text:00000000008DDD0B                 lea     rax, CNetworkServerService_OnClientPollNetworking
-  .text:00000000008DDD12                 mov     [rbp+var_40], 0
-  .text:00000000008DDD1A                 mov     [rbp+var_48], rax
-  .text:00000000008DDD1E                 call    sub_550600
-  .text:00000000008DDD23                 mov     rsi, r13
-  .text:00000000008DDD26                 mov     rdi, rbx
-  .text:00000000008DDD29                 mov     [rbp+var_50], r12
-  .text:00000000008DDD2D                 mov     rdx, cs:qword_969A40
-  .text:00000000008DDD34                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
-  .text:00000000008DDD3B                 mov     [rbp+var_40], 0
-  .text:00000000008DDD43                 mov     [rbp+var_48], rax
-  .text:00000000008DDD47                 call    sub_550600
-  .text:00000000008DDD4C                 add     rsp, 28h
-  .text:00000000008DDD50                 pop     rbx
-  .text:00000000008DDD51                 pop     r12
-  .text:00000000008DDD53                 pop     r13
-  .text:00000000008DDD55                 pop     r14
-  .text:00000000008DDD57                 pop     r15
-  .text:00000000008DDD59                 pop     rbp
-  .text:00000000008DDD5A                 retn
-  .text:00000000008DDD60                 lea     r13, byte_C56DA8
-  .text:00000000008DDD67                 mov     rdi, r13
-  .text:00000000008DDD6A                 call    sub_2A6DE0
-  .text:00000000008DDD6F                 test    eax, eax
-  .text:00000000008DDD71                 jz      loc_8DD72E
-  .text:00000000008DDD77                 lea     r14, unk_C56CA0
-  .text:00000000008DDD7E                 xor     eax, eax
-  .text:00000000008DDD80                 lea     rcx, aOnserveradvanc; "OnServerAdvanceTick"
-  .text:00000000008DDD87                 mov     rdi, r14
-  .text:00000000008DDD8A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDD91                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDD98                 call    sub_4886F0
-  .text:00000000008DDD9D                 lea     rdx, off_964B60
-  .text:00000000008DDDA4                 mov     rsi, r14
-  .text:00000000008DDDA7                 lea     rdi, sub_535D60
-  .text:00000000008DDDAE                 call    sub_2B41A0
-  .text:00000000008DDDB3                 mov     rdi, r13
-  .text:00000000008DDDB6                 call    sub_2A6E00
-  .text:00000000008DDDBB                 jmp     loc_8DD72E
-  .text:00000000008DDDC0                 lea     r14, byte_C56A48
-  .text:00000000008DDDC7                 mov     rdi, r14
-  .text:00000000008DDDCA                 call    sub_2A6DE0
-  .text:00000000008DDDCF                 test    eax, eax
-  .text:00000000008DDDD1                 jz      loc_8DD85B
-  .text:00000000008DDDD7                 lea     r15, unk_C56940
-  .text:00000000008DDDDE                 xor     eax, eax
-  .text:00000000008DDDE0                 lea     rcx, aOnserverbegins; "OnServerBeginSimulate"
-  .text:00000000008DDDE7                 mov     rdi, r15
-  .text:00000000008DDDEA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDDF1                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDDF8                 call    sub_4886F0
-  .text:00000000008DDDFD                 lea     rdx, off_964B60
-  .text:00000000008DDE04                 mov     rsi, r15
-  .text:00000000008DDE07                 lea     rdi, sub_535D60
-  .text:00000000008DDE0E                 call    sub_2B41A0
-  .text:00000000008DDE13                 mov     rdi, r14
-  .text:00000000008DDE16                 call    sub_2A6E00
-  .text:00000000008DDE1B                 jmp     loc_8DD85B
-  .text:00000000008DDE20                 lea     r14, byte_C56928
-  .text:00000000008DDE27                 mov     rdi, r14
-  .text:00000000008DDE2A                 call    sub_2A6DE0
-  .text:00000000008DDE2F                 test    eax, eax
-  .text:00000000008DDE31                 jz      loc_8DD8C1
-  .text:00000000008DDE37                 lea     r15, unk_C56820
-  .text:00000000008DDE3E                 xor     eax, eax
-  .text:00000000008DDE40                 lea     rcx, aOnserverendsim; "OnServerEndSimulate"
-  .text:00000000008DDE47                 mov     rdi, r15
-  .text:00000000008DDE4A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDE51                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDE58                 call    sub_4886F0
-  .text:00000000008DDE5D                 lea     rdx, off_964B60
-  .text:00000000008DDE64                 mov     rsi, r15
-  .text:00000000008DDE67                 lea     rdi, sub_535D60
-  .text:00000000008DDE6E                 call    sub_2B41A0
-  .text:00000000008DDE73                 mov     rdi, r14
-  .text:00000000008DDE76                 call    sub_2A6E00
-  .text:00000000008DDE7B                 jmp     loc_8DD8C1
-  .text:00000000008DDE80                 lea     r14, byte_C56808
-  .text:00000000008DDE87                 mov     rdi, r14
-  .text:00000000008DDE8A                 call    sub_2A6DE0
-  .text:00000000008DDE8F                 test    eax, eax
-  .text:00000000008DDE91                 jz      loc_8DD927
-  .text:00000000008DDE97                 lea     r15, unk_C56700
-  .text:00000000008DDE9E                 xor     eax, eax
-  .text:00000000008DDEA0                 lea     rcx, aOnserverpostsi; "OnServerPostSimulate"
-  .text:00000000008DDEA7                 mov     rdi, r15
-  .text:00000000008DDEAA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDEB1                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDEB8                 call    sub_4886F0
-  .text:00000000008DDEBD                 lea     rdx, off_964B60
-  .text:00000000008DDEC4                 mov     rsi, r15
-  .text:00000000008DDEC7                 lea     rdi, sub_535D60
-  .text:00000000008DDECE                 call    sub_2B41A0
-  .text:00000000008DDED3                 mov     rdi, r14
-  .text:00000000008DDED6                 call    sub_2A6E00
-  .text:00000000008DDEDB                 jmp     loc_8DD927
-  .text:00000000008DDEE0                 lea     r14, byte_C566E8
-  .text:00000000008DDEE7                 mov     rdi, r14
-  .text:00000000008DDEEA                 call    sub_2A6DE0
-  .text:00000000008DDEEF                 test    eax, eax
-  .text:00000000008DDEF1                 jz      loc_8DD98A
-  .text:00000000008DDEF7                 lea     r15, unk_C565E0
-  .text:00000000008DDEFE                 xor     eax, eax
-  .text:00000000008DDF00                 lea     rcx, aOnserverpostad; "OnServerPostAdvanceTick"
-  .text:00000000008DDF07                 mov     rdi, r15
-  .text:00000000008DDF0A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDF11                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDF18                 call    sub_4886F0
-  .text:00000000008DDF1D                 lea     rdx, off_964B60
-  .text:00000000008DDF24                 mov     rsi, r15
-  .text:00000000008DDF27                 lea     rdi, sub_535D60
-  .text:00000000008DDF2E                 call    sub_2B41A0
-  .text:00000000008DDF33                 mov     rdi, r14
-  .text:00000000008DDF36                 call    sub_2A6E00
-  .text:00000000008DDF3B                 jmp     loc_8DD98A
-  .text:00000000008DDF40                 lea     r14, byte_C565C8
-  .text:00000000008DDF47                 mov     rdi, r14
-  .text:00000000008DDF4A                 call    sub_2A6DE0
-  .text:00000000008DDF4F                 test    eax, eax
-  .text:00000000008DDF51                 jz      loc_8DD9F0
-  .text:00000000008DDF57                 lea     r15, unk_C564C0
-  .text:00000000008DDF5E                 xor     eax, eax
-  .text:00000000008DDF60                 lea     rcx, aOnserverbegina; "OnServerBeginAsyncPostTickWork"
-  .text:00000000008DDF67                 mov     rdi, r15
-  .text:00000000008DDF6A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDF71                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDF78                 call    sub_4886F0
-  .text:00000000008DDF7D                 lea     rdx, off_964B60
-  .text:00000000008DDF84                 mov     rsi, r15
-  .text:00000000008DDF87                 lea     rdi, sub_535D60
-  .text:00000000008DDF8E                 call    sub_2B41A0
-  .text:00000000008DDF93                 mov     rdi, r14
-  .text:00000000008DDF96                 call    sub_2A6E00
-  .text:00000000008DDF9B                 jmp     loc_8DD9F0
-  .text:00000000008DDFA0                 lea     r14, byte_C564A8
-  .text:00000000008DDFA7                 mov     rdi, r14
-  .text:00000000008DDFAA                 call    sub_2A6DE0
-  .text:00000000008DDFAF                 test    eax, eax
-  .text:00000000008DDFB1                 jz      loc_8DDA56
-  .text:00000000008DDFB7                 lea     r15, unk_C563A0
-  .text:00000000008DDFBE                 xor     eax, eax
-  .text:00000000008DDFC0                 lea     rcx, aOnframeboundar; "OnFrameBoundary"
-  .text:00000000008DDFC7                 mov     rdi, r15
-  .text:00000000008DDFCA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DDFD1                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DDFD8                 call    sub_4886F0
-  .text:00000000008DDFDD                 lea     rdx, off_964B60
-  .text:00000000008DDFE4                 mov     rsi, r15
-  .text:00000000008DDFE7                 lea     rdi, sub_535D60
-  .text:00000000008DDFEE                 call    sub_2B41A0
-  .text:00000000008DDFF3                 mov     rdi, r14
-  .text:00000000008DDFF6                 call    sub_2A6E00
-  .text:00000000008DDFFB                 jmp     loc_8DDA56
-  .text:00000000008DE000                 lea     r14, byte_C56388
-  .text:00000000008DE007                 mov     rdi, r14
-  .text:00000000008DE00A                 call    sub_2A6DE0
-  .text:00000000008DE00F                 test    eax, eax
-  .text:00000000008DE011                 jz      loc_8DDABC
-  .text:00000000008DE017                 lea     r15, unk_C56280
-  .text:00000000008DE01E                 xor     eax, eax
-  .text:00000000008DE020                 lea     rcx, aOnclientpollne; "OnClientPollNetworking"
-  .text:00000000008DE027                 mov     rdi, r15
-  .text:00000000008DE02A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DE031                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DE038                 call    sub_4886F0
-  .text:00000000008DE03D                 lea     rdx, off_964B60
-  .text:00000000008DE044                 mov     rsi, r15
-  .text:00000000008DE047                 lea     rdi, sub_535D60
-  .text:00000000008DE04E                 call    sub_2B41A0
-  .text:00000000008DE053                 mov     rdi, r14
-  .text:00000000008DE056                 call    sub_2A6E00
-  .text:00000000008DE05B                 jmp     loc_8DDABC
-  .text:00000000008DE060                 lea     r14, byte_C56268
-  .text:00000000008DE067                 mov     rdi, r14
-  .text:00000000008DE06A                 call    sub_2A6DE0
-  .text:00000000008DE06F                 test    eax, eax
-  .text:00000000008DE071                 jz      loc_8DDB22
-  .text:00000000008DE077                 lea     r15, unk_C56160
-  .text:00000000008DE07E                 xor     eax, eax
-  .text:00000000008DE080                 lea     rcx, aOnsimpleloopfr; "OnSimpleLoopFrameUpdate"
-  .text:00000000008DE087                 mov     rdi, r15
-  .text:00000000008DE08A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DE091                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DE098                 call    sub_4886F0
-  .text:00000000008DE09D                 lea     rdx, off_964B60
-  .text:00000000008DE0A4                 mov     rsi, r15
-  .text:00000000008DE0A7                 lea     rdi, sub_535D60
-  .text:00000000008DE0AE                 call    sub_2B41A0
-  .text:00000000008DE0B3                 mov     rdi, r14
-  .text:00000000008DE0B6                 call    sub_2A6E00
-  .text:00000000008DE0BB                 jmp     loc_8DDB22
-  .text:00000000008DE0C0                 lea     r14, byte_C56C88
-  .text:00000000008DE0C7                 mov     rdi, r14
-  .text:00000000008DE0CA                 call    sub_2A6DE0
-  .text:00000000008DE0CF                 test    eax, eax
-  .text:00000000008DE0D1                 jz      loc_8DD795
-  .text:00000000008DE0D7                 lea     r15, unk_C56B80
-  .text:00000000008DE0DE                 xor     eax, eax
-  .text:00000000008DE0E0                 lea     rcx, aOnserverpollne; "OnServerPollNetworking"
-  .text:00000000008DE0E7                 mov     rdi, r15
-  .text:00000000008DE0EA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DE0F1                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DE0F8                 call    sub_4886F0
-  .text:00000000008DE0FD                 lea     rdx, off_964B60
-  .text:00000000008DE104                 mov     rsi, r15
-  .text:00000000008DE107                 lea     rdi, sub_535D60
-  .text:00000000008DE10E                 call    sub_2B41A0
-  .text:00000000008DE113                 mov     rdi, r14
-  .text:00000000008DE116                 call    sub_2A6E00
-  .text:00000000008DE11B                 jmp     loc_8DD795
-  .text:00000000008DE120                 lea     r14, byte_C56B68
-  .text:00000000008DE127                 mov     rdi, r14
-  .text:00000000008DE12A                 call    sub_2A6DE0
-  .text:00000000008DE12F                 test    eax, eax
-  .text:00000000008DE131                 jz      loc_8DD7F8
-  .text:00000000008DE137                 lea     r15, unk_C56A60
-  .text:00000000008DE13E                 xor     eax, eax
-  .text:00000000008DE140                 lea     rcx, aOnserverproces; "OnServerProcessNetworking"
-  .text:00000000008DE147                 mov     rdi, r15
-  .text:00000000008DE14A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
-  .text:00000000008DE151                 lea     rsi, aSS_5; "%s::%s"
-  .text:00000000008DE158                 call    sub_4886F0
-  .text:00000000008DE15D                 lea     rdx, off_964B60
-  .text:00000000008DE164                 mov     rsi, r15
-  .text:00000000008DE167                 lea     rdi, sub_535D60
-  .text:00000000008DE16E                 call    sub_2B41A0
-  .text:00000000008DE173                 mov     rdi, r14
-  .text:00000000008DE176                 call    sub_2A6E00
-  .text:00000000008DE17B                 jmp     loc_8DD7F8
+  .text:00000000008E8160                 push    rbp
+  .text:00000000008E8161                 mov     rbp, rsp
+  .text:00000000008E8164                 push    r15
+  .text:00000000008E8166                 push    r14
+  .text:00000000008E8168                 push    r13
+  .text:00000000008E816A                 push    r12
+  .text:00000000008E816C                 mov     r12, rsi
+  .text:00000000008E816F                 push    rbx
+  .text:00000000008E8170                 mov     rbx, rdi
+  .text:00000000008E8173                 sub     rsp, 28h
+  .text:00000000008E8177                 test    edx, edx
+  .text:00000000008E8179                 jnz     loc_8E85E8
+  .text:00000000008E817F                 movzx   eax, cs:byte_C60F48
+  .text:00000000008E8186                 test    al, al
+  .text:00000000008E8188                 jz      loc_8E87C0
+  .text:00000000008E818E                 mov     rdx, cs:qword_970F00
+  .text:00000000008E8195                 lea     r8, qword_C60E48
+  .text:00000000008E819C                 test    cs:byte_C60E47, 40h
+  .text:00000000008E81A3                 jnz     short loc_8E81BE
+  .text:00000000008E81A5                 test    dword ptr cs:unk_C60E44, 3FFFFFFFh
+  .text:00000000008E81AF                 lea     r8, s1
+  .text:00000000008E81B6                 cmovnz  r8, cs:qword_C60E48
+  .text:00000000008E81BE                 xor     ecx, ecx
+  .text:00000000008E81C0                 mov     rdi, rbx
+  .text:00000000008E81C3                 mov     [rbp+var_40], 0
+  .text:00000000008E81CB                 mov     [rbp+var_50], r12
+  .text:00000000008E81CF                 lea     r13, [rbp+var_50]
+  .text:00000000008E81D3                 lea     rax, CNetworkServerService_OnServerAdvanceTick
+  .text:00000000008E81DA                 mov     rsi, r13
+  .text:00000000008E81DD                 mov     [rbp+var_48], rax
+  .text:00000000008E81E1                 call    RegisterEventListener_Abstract
+  .text:00000000008E81E6                 movzx   eax, cs:byte_C60E28
+  .text:00000000008E81ED                 test    al, al
+  .text:00000000008E81EF                 jz      loc_8E8B20
+  .text:00000000008E81F5                 mov     rdx, cs:qword_970580
+  .text:00000000008E81FC                 lea     r8, qword_C60D28
+  .text:00000000008E8203                 test    cs:byte_C60D27, 40h
+  .text:00000000008E820A                 jnz     short loc_8E8225
+  .text:00000000008E820C                 test    dword ptr cs:unk_C60D24, 3FFFFFFFh
+  .text:00000000008E8216                 lea     r8, s1
+  .text:00000000008E821D                 cmovnz  r8, cs:qword_C60D28
+  .text:00000000008E8225                 xor     ecx, ecx
+  .text:00000000008E8227                 mov     rsi, r13
+  .text:00000000008E822A                 mov     [rbp+var_50], r12
+  .text:00000000008E822E                 mov     rdi, rbx
+  .text:00000000008E8231                 mov     [rbp+var_40], 0
+  .text:00000000008E8239                 lea     rax, CNetworkServerService_OnServerPollNetworking
+  .text:00000000008E8240                 mov     [rbp+var_48], rax
+  .text:00000000008E8244                 call    RegisterEventListener_Abstract
+  .text:00000000008E8249                 movzx   eax, cs:byte_C60D08
+  .text:00000000008E8250                 test    al, al
+  .text:00000000008E8252                 jz      loc_8E8B80
+  .text:00000000008E8258                 mov     rdx, cs:qword_970460
+  .text:00000000008E825F                 lea     r8, qword_C60C08
+  .text:00000000008E8266                 test    cs:byte_C60C07, 40h
+  .text:00000000008E826D                 jnz     short loc_8E8288
+  .text:00000000008E826F                 test    dword ptr cs:unk_C60C04, 3FFFFFFFh
+  .text:00000000008E8279                 lea     r8, s1
+  .text:00000000008E8280                 cmovnz  r8, cs:qword_C60C08
+  .text:00000000008E8288                 xor     ecx, ecx
+  .text:00000000008E828A                 mov     rsi, r13
+  .text:00000000008E828D                 mov     [rbp+var_50], r12
+  .text:00000000008E8291                 mov     rdi, rbx
+  .text:00000000008E8294                 mov     [rbp+var_40], 0
+  .text:00000000008E829C                 lea     rax, CNetworkServerService_OnServerProcessNetworking
+  .text:00000000008E82A3                 mov     [rbp+var_48], rax
+  .text:00000000008E82A7                 call    RegisterEventListener_Abstract
+  .text:00000000008E82AC                 movzx   eax, cs:byte_C60BE8
+  .text:00000000008E82B3                 test    al, al
+  .text:00000000008E82B5                 jz      loc_8E8820
+  .text:00000000008E82BB                 mov     rdx, cs:qword_970340
+  .text:00000000008E82C2                 lea     r8, qword_C60AE8
+  .text:00000000008E82C9                 test    cs:byte_C60AE7, 40h
+  .text:00000000008E82D0                 jnz     short loc_8E82EB
+  .text:00000000008E82D2                 test    dword ptr cs:unk_C60AE4, 3FFFFFFFh
+  .text:00000000008E82DC                 lea     r8, s1
+  .text:00000000008E82E3                 cmovnz  r8, cs:qword_C60AE8
+  .text:00000000008E82EB                 mov     ecx, 80000000h
+  .text:00000000008E82F0                 mov     rsi, r13
+  .text:00000000008E82F3                 mov     [rbp+var_50], r12
+  .text:00000000008E82F7                 mov     rdi, rbx
+  .text:00000000008E82FA                 mov     [rbp+var_40], 0
+  .text:00000000008E8302                 lea     rax, CNetworkServerService_OnServerBeginSimulate
+  .text:00000000008E8309                 mov     [rbp+var_48], rax
+  .text:00000000008E830D                 call    RegisterEventListener_Abstract
+  .text:00000000008E8312                 movzx   eax, cs:byte_C60AC8
+  .text:00000000008E8319                 test    al, al
+  .text:00000000008E831B                 jz      loc_8E8880
+  .text:00000000008E8321                 mov     rdx, cs:qword_9702C0
+  .text:00000000008E8328                 lea     r8, qword_C609C8
+  .text:00000000008E832F                 test    cs:byte_C609C7, 40h
+  .text:00000000008E8336                 jnz     short loc_8E8351
+  .text:00000000008E8338                 test    dword ptr cs:unk_C609C4, 3FFFFFFFh
+  .text:00000000008E8342                 lea     r8, s1
+  .text:00000000008E8349                 cmovnz  r8, cs:qword_C609C8
+  .text:00000000008E8351                 mov     ecx, 7FFFFFFFh
+  .text:00000000008E8356                 mov     rsi, r13
+  .text:00000000008E8359                 mov     [rbp+var_50], r12
+  .text:00000000008E835D                 mov     rdi, rbx
+  .text:00000000008E8360                 mov     [rbp+var_40], 0
+  .text:00000000008E8368                 lea     rax, CNetworkServerService_OnServerEndSimulate
+  .text:00000000008E836F                 mov     [rbp+var_48], rax
+  .text:00000000008E8373                 call    RegisterEventListener_Abstract
+  .text:00000000008E8378                 movzx   eax, cs:byte_C609A8
+  .text:00000000008E837F                 test    al, al
+  .text:00000000008E8381                 jz      loc_8E88E0
+  .text:00000000008E8387                 mov     rdx, cs:qword_9701A0
+  .text:00000000008E838E                 lea     r8, qword_C608A8
+  .text:00000000008E8395                 test    cs:byte_C608A7, 40h
+  .text:00000000008E839C                 jnz     short loc_8E83B7
+  .text:00000000008E839E                 test    dword ptr cs:unk_C608A4, 3FFFFFFFh
+  .text:00000000008E83A8                 lea     r8, s1
+  .text:00000000008E83AF                 cmovnz  r8, cs:qword_C608A8
+  .text:00000000008E83B7                 xor     ecx, ecx
+  .text:00000000008E83B9                 mov     rsi, r13
+  .text:00000000008E83BC                 mov     [rbp+var_50], r12
+  .text:00000000008E83C0                 mov     rdi, rbx
+  .text:00000000008E83C3                 mov     [rbp+var_40], 0
+  .text:00000000008E83CB                 lea     rax, CNetworkServerService_OnServerPostSimulate
+  .text:00000000008E83D2                 mov     [rbp+var_48], rax
+  .text:00000000008E83D6                 call    RegisterEventListener_Abstract
+  .text:00000000008E83DB                 movzx   eax, cs:byte_C60888
+  .text:00000000008E83E2                 test    al, al
+  .text:00000000008E83E4                 jz      loc_8E8940
+  .text:00000000008E83EA                 mov     rdx, cs:qword_970CA0
+  .text:00000000008E83F1                 lea     r8, qword_C60788
+  .text:00000000008E83F8                 test    cs:byte_C60787, 40h
+  .text:00000000008E83FF                 jnz     short loc_8E841A
+  .text:00000000008E8401                 test    dword ptr cs:unk_C60784, 3FFFFFFFh
+  .text:00000000008E840B                 lea     r8, s1
+  .text:00000000008E8412                 cmovnz  r8, cs:qword_C60788
+  .text:00000000008E841A                 mov     ecx, 80000000h
+  .text:00000000008E841F                 mov     rsi, r13
+  .text:00000000008E8422                 mov     [rbp+var_50], r12
+  .text:00000000008E8426                 mov     rdi, rbx
+  .text:00000000008E8429                 mov     [rbp+var_40], 0
+  .text:00000000008E8431                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
+  .text:00000000008E8438                 mov     [rbp+var_48], rax
+  .text:00000000008E843C                 call    RegisterEventListener_Abstract
+  .text:00000000008E8441                 movzx   eax, cs:byte_C60768
+  .text:00000000008E8448                 test    al, al
+  .text:00000000008E844A                 jz      loc_8E89A0
+  .text:00000000008E8450                 mov     rdx, cs:qword_970B00
+  .text:00000000008E8457                 lea     r8, qword_C60668
+  .text:00000000008E845E                 test    cs:byte_C60667, 40h
+  .text:00000000008E8465                 jnz     short loc_8E8480
+  .text:00000000008E8467                 test    dword ptr cs:unk_C60664, 3FFFFFFFh
+  .text:00000000008E8471                 lea     r8, s1
+  .text:00000000008E8478                 cmovnz  r8, cs:qword_C60668
+  .text:00000000008E8480                 mov     ecx, 80000000h
+  .text:00000000008E8485                 mov     rsi, r13
+  .text:00000000008E8488                 mov     [rbp+var_50], r12
+  .text:00000000008E848C                 mov     rdi, rbx
+  .text:00000000008E848F                 mov     [rbp+var_40], 0
+  .text:00000000008E8497                 lea     rax, CNetworkServerService_OnServerBeginAsyncPostTickWork
+  .text:00000000008E849E                 mov     [rbp+var_48], rax
+  .text:00000000008E84A2                 call    RegisterEventListener_Abstract
+  .text:00000000008E84A7                 movzx   eax, cs:byte_C60648
+  .text:00000000008E84AE                 test    al, al
+  .text:00000000008E84B0                 jz      loc_8E8A00
+  .text:00000000008E84B6                 mov     rdx, cs:qword_971160
+  .text:00000000008E84BD                 lea     r8, qword_C60548
+  .text:00000000008E84C4                 test    cs:byte_C60547, 40h
+  .text:00000000008E84CB                 jnz     short loc_8E84E6
+  .text:00000000008E84CD                 test    dword ptr cs:unk_C60544, 3FFFFFFFh
+  .text:00000000008E84D7                 lea     r8, s1
+  .text:00000000008E84DE                 cmovnz  r8, cs:qword_C60548
+  .text:00000000008E84E6                 mov     ecx, 7FFFFFFFh
+  .text:00000000008E84EB                 mov     rsi, r13
+  .text:00000000008E84EE                 mov     [rbp+var_50], r12
+  .text:00000000008E84F2                 mov     rdi, rbx
+  .text:00000000008E84F5                 mov     [rbp+var_40], 0
+  .text:00000000008E84FD                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000000008E8504                 mov     [rbp+var_48], rax
+  .text:00000000008E8508                 call    RegisterEventListener_Abstract
+  .text:00000000008E850D                 movzx   eax, cs:byte_C60528
+  .text:00000000008E8514                 test    al, al
+  .text:00000000008E8516                 jz      loc_8E8A60
+  .text:00000000008E851C                 mov     rdx, cs:qword_970500
+  .text:00000000008E8523                 lea     r8, qword_C60428
+  .text:00000000008E852A                 test    cs:byte_C60427, 40h
+  .text:00000000008E8531                 jnz     short loc_8E854C
+  .text:00000000008E8533                 test    dword ptr cs:unk_C60424, 3FFFFFFFh
+  .text:00000000008E853D                 lea     r8, s1
+  .text:00000000008E8544                 cmovnz  r8, cs:qword_C60428
+  .text:00000000008E854C                 mov     ecx, 1
+  .text:00000000008E8551                 mov     rsi, r13
+  .text:00000000008E8554                 mov     [rbp+var_50], r12
+  .text:00000000008E8558                 mov     rdi, rbx
+  .text:00000000008E855B                 mov     [rbp+var_40], 0
+  .text:00000000008E8563                 lea     rax, CNetworkServerService_OnClientPollNetworking
+  .text:00000000008E856A                 mov     [rbp+var_48], rax
+  .text:00000000008E856E                 call    RegisterEventListener_Abstract
+  .text:00000000008E8573                 movzx   eax, cs:byte_C60408
+  .text:00000000008E857A                 test    al, al
+  .text:00000000008E857C                 jz      loc_8E8AC0
+  .text:00000000008E8582                 mov     rdx, cs:qword_971BA0
+  .text:00000000008E8589                 lea     r8, qword_C60308
+  .text:00000000008E8590                 test    cs:byte_C60307, 40h
+  .text:00000000008E8597                 jnz     short loc_8E85B2
+  .text:00000000008E8599                 test    dword ptr cs:unk_C60304, 3FFFFFFFh
+  .text:00000000008E85A3                 lea     r8, s1
+  .text:00000000008E85AA                 cmovnz  r8, cs:qword_C60308
+  .text:00000000008E85B2                 mov     rsi, r13
+  .text:00000000008E85B5                 mov     rdi, rbx
+  .text:00000000008E85B8                 mov     [rbp+var_50], r12
+  .text:00000000008E85BC                 xor     ecx, ecx
+  .text:00000000008E85BE                 mov     [rbp+var_40], 0
+  .text:00000000008E85C6                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
+  .text:00000000008E85CD                 mov     [rbp+var_48], rax
+  .text:00000000008E85D1                 call    RegisterEventListener_Abstract
+  .text:00000000008E85D6                 add     rsp, 28h
+  .text:00000000008E85DA                 pop     rbx
+  .text:00000000008E85DB                 pop     r12
+  .text:00000000008E85DD                 pop     r13
+  .text:00000000008E85DF                 pop     r14
+  .text:00000000008E85E1                 pop     r15
+  .text:00000000008E85E3                 pop     rbp
+  .text:00000000008E85E4                 retn
+  .text:00000000008E85E8                 mov     rdx, cs:qword_970F00
+  .text:00000000008E85EF                 lea     r13, [rbp+var_50]
+  .text:00000000008E85F3                 mov     [rbp+var_50], rsi
+  .text:00000000008E85F7                 lea     rax, CNetworkServerService_OnServerAdvanceTick
+  .text:00000000008E85FE                 mov     rsi, r13
+  .text:00000000008E8601                 mov     [rbp+var_40], 0
+  .text:00000000008E8609                 mov     [rbp+var_48], rax
+  .text:00000000008E860D                 call    sub_551120
+  .text:00000000008E8612                 mov     rsi, r13
+  .text:00000000008E8615                 mov     rdi, rbx
+  .text:00000000008E8618                 mov     [rbp+var_50], r12
+  .text:00000000008E861C                 mov     rdx, cs:qword_970580
+  .text:00000000008E8623                 lea     rax, CNetworkServerService_OnServerPollNetworking
+  .text:00000000008E862A                 mov     [rbp+var_40], 0
+  .text:00000000008E8632                 mov     [rbp+var_48], rax
+  .text:00000000008E8636                 call    sub_551120
+  .text:00000000008E863B                 mov     rsi, r13
+  .text:00000000008E863E                 mov     rdi, rbx
+  .text:00000000008E8641                 mov     [rbp+var_50], r12
+  .text:00000000008E8645                 mov     rdx, cs:qword_970460
+  .text:00000000008E864C                 lea     rax, CNetworkServerService_OnServerProcessNetworking
+  .text:00000000008E8653                 mov     [rbp+var_40], 0
+  .text:00000000008E865B                 mov     [rbp+var_48], rax
+  .text:00000000008E865F                 call    sub_551120
+  .text:00000000008E8664                 mov     rsi, r13
+  .text:00000000008E8667                 mov     rdi, rbx
+  .text:00000000008E866A                 mov     [rbp+var_50], r12
+  .text:00000000008E866E                 mov     rdx, cs:qword_970340
+  .text:00000000008E8675                 lea     rax, CNetworkServerService_OnServerBeginSimulate
+  .text:00000000008E867C                 mov     [rbp+var_40], 0
+  .text:00000000008E8684                 mov     [rbp+var_48], rax
+  .text:00000000008E8688                 call    sub_551120
+  .text:00000000008E868D                 mov     rsi, r13
+  .text:00000000008E8690                 mov     rdi, rbx
+  .text:00000000008E8693                 mov     [rbp+var_50], r12
+  .text:00000000008E8697                 mov     rdx, cs:qword_9702C0
+  .text:00000000008E869E                 lea     rax, CNetworkServerService_OnServerEndSimulate
+  .text:00000000008E86A5                 mov     [rbp+var_40], 0
+  .text:00000000008E86AD                 mov     [rbp+var_48], rax
+  .text:00000000008E86B1                 call    sub_551120
+  .text:00000000008E86B6                 mov     rsi, r13
+  .text:00000000008E86B9                 mov     rdi, rbx
+  .text:00000000008E86BC                 mov     [rbp+var_50], r12
+  .text:00000000008E86C0                 mov     rdx, cs:qword_9701A0
+  .text:00000000008E86C7                 lea     rax, CNetworkServerService_OnServerPostSimulate
+  .text:00000000008E86CE                 mov     [rbp+var_40], 0
+  .text:00000000008E86D6                 mov     [rbp+var_48], rax
+  .text:00000000008E86DA                 call    sub_551120
+  .text:00000000008E86DF                 mov     rsi, r13
+  .text:00000000008E86E2                 mov     rdi, rbx
+  .text:00000000008E86E5                 mov     [rbp+var_50], r12
+  .text:00000000008E86E9                 mov     rdx, cs:qword_970CA0
+  .text:00000000008E86F0                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
+  .text:00000000008E86F7                 mov     [rbp+var_40], 0
+  .text:00000000008E86FF                 mov     [rbp+var_48], rax
+  .text:00000000008E8703                 call    sub_551120
+  .text:00000000008E8708                 mov     rsi, r13
+  .text:00000000008E870B                 mov     rdi, rbx
+  .text:00000000008E870E                 mov     [rbp+var_50], r12
+  .text:00000000008E8712                 mov     rdx, cs:qword_970B00
+  .text:00000000008E8719                 lea     rax, CNetworkServerService_OnServerBeginAsyncPostTickWork
+  .text:00000000008E8720                 mov     [rbp+var_40], 0
+  .text:00000000008E8728                 mov     [rbp+var_48], rax
+  .text:00000000008E872C                 call    sub_551120
+  .text:00000000008E8731                 mov     rsi, r13
+  .text:00000000008E8734                 mov     rdi, rbx
+  .text:00000000008E8737                 mov     [rbp+var_50], r12
+  .text:00000000008E873B                 mov     rdx, cs:qword_971160
+  .text:00000000008E8742                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000000008E8749                 mov     [rbp+var_40], 0
+  .text:00000000008E8751                 mov     [rbp+var_48], rax
+  .text:00000000008E8755                 call    sub_551120
+  .text:00000000008E875A                 mov     rsi, r13
+  .text:00000000008E875D                 mov     rdi, rbx
+  .text:00000000008E8760                 mov     [rbp+var_50], r12
+  .text:00000000008E8764                 mov     rdx, cs:qword_970500
+  .text:00000000008E876B                 lea     rax, CNetworkServerService_OnClientPollNetworking
+  .text:00000000008E8772                 mov     [rbp+var_40], 0
+  .text:00000000008E877A                 mov     [rbp+var_48], rax
+  .text:00000000008E877E                 call    sub_551120
+  .text:00000000008E8783                 mov     rsi, r13
+  .text:00000000008E8786                 mov     rdi, rbx
+  .text:00000000008E8789                 mov     [rbp+var_50], r12
+  .text:00000000008E878D                 mov     rdx, cs:qword_971BA0
+  .text:00000000008E8794                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
+  .text:00000000008E879B                 mov     [rbp+var_40], 0
+  .text:00000000008E87A3                 mov     [rbp+var_48], rax
+  .text:00000000008E87A7                 call    sub_551120
+  .text:00000000008E87AC                 add     rsp, 28h
+  .text:00000000008E87B0                 pop     rbx
+  .text:00000000008E87B1                 pop     r12
+  .text:00000000008E87B3                 pop     r13
+  .text:00000000008E87B5                 pop     r14
+  .text:00000000008E87B7                 pop     r15
+  .text:00000000008E87B9                 pop     rbp
+  .text:00000000008E87BA                 retn
+  .text:00000000008E87C0                 lea     r13, byte_C60F48
+  .text:00000000008E87C7                 ; _QWORD
+  .text:00000000008E87C7                 mov     rdi, r13; _QWORD
+  .text:00000000008E87CA                 call    ___cxa_guard_acquire
+  .text:00000000008E87CF                 test    eax, eax
+  .text:00000000008E87D1                 jz      loc_8E818E
+  .text:00000000008E87D7                 lea     r14, unk_C60E40
+  .text:00000000008E87DE                 xor     eax, eax
+  .text:00000000008E87E0                 lea     rcx, aOnserveradvanc; "OnServerAdvanceTick"
+  .text:00000000008E87E7                 mov     rdi, r14
+  .text:00000000008E87EA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E87F1                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E87F8                 call    sub_489C00
+  .text:00000000008E87FD                 ; _QWORD
+  .text:00000000008E87FD                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8804                 ; _QWORD
+  .text:00000000008E8804                 mov     rsi, r14; _QWORD
+  .text:00000000008E8807                 ; _QWORD
+  .text:00000000008E8807                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E880E                 call    ___cxa_atexit
+  .text:00000000008E8813                 ; _QWORD
+  .text:00000000008E8813                 mov     rdi, r13; _QWORD
+  .text:00000000008E8816                 call    ___cxa_guard_release
+  .text:00000000008E881B                 jmp     loc_8E818E
+  .text:00000000008E8820                 lea     r14, byte_C60BE8
+  .text:00000000008E8827                 ; _QWORD
+  .text:00000000008E8827                 mov     rdi, r14; _QWORD
+  .text:00000000008E882A                 call    ___cxa_guard_acquire
+  .text:00000000008E882F                 test    eax, eax
+  .text:00000000008E8831                 jz      loc_8E82BB
+  .text:00000000008E8837                 lea     r15, unk_C60AE0
+  .text:00000000008E883E                 xor     eax, eax
+  .text:00000000008E8840                 lea     rcx, aOnserverbegins; "OnServerBeginSimulate"
+  .text:00000000008E8847                 mov     rdi, r15
+  .text:00000000008E884A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8851                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8858                 call    sub_489C00
+  .text:00000000008E885D                 ; _QWORD
+  .text:00000000008E885D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8864                 ; _QWORD
+  .text:00000000008E8864                 mov     rsi, r15; _QWORD
+  .text:00000000008E8867                 ; _QWORD
+  .text:00000000008E8867                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E886E                 call    ___cxa_atexit
+  .text:00000000008E8873                 ; _QWORD
+  .text:00000000008E8873                 mov     rdi, r14; _QWORD
+  .text:00000000008E8876                 call    ___cxa_guard_release
+  .text:00000000008E887B                 jmp     loc_8E82BB
+  .text:00000000008E8880                 lea     r14, byte_C60AC8
+  .text:00000000008E8887                 ; _QWORD
+  .text:00000000008E8887                 mov     rdi, r14; _QWORD
+  .text:00000000008E888A                 call    ___cxa_guard_acquire
+  .text:00000000008E888F                 test    eax, eax
+  .text:00000000008E8891                 jz      loc_8E8321
+  .text:00000000008E8897                 lea     r15, unk_C609C0
+  .text:00000000008E889E                 xor     eax, eax
+  .text:00000000008E88A0                 lea     rcx, aOnserverendsim; "OnServerEndSimulate"
+  .text:00000000008E88A7                 mov     rdi, r15
+  .text:00000000008E88AA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E88B1                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E88B8                 call    sub_489C00
+  .text:00000000008E88BD                 ; _QWORD
+  .text:00000000008E88BD                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E88C4                 ; _QWORD
+  .text:00000000008E88C4                 mov     rsi, r15; _QWORD
+  .text:00000000008E88C7                 ; _QWORD
+  .text:00000000008E88C7                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E88CE                 call    ___cxa_atexit
+  .text:00000000008E88D3                 ; _QWORD
+  .text:00000000008E88D3                 mov     rdi, r14; _QWORD
+  .text:00000000008E88D6                 call    ___cxa_guard_release
+  .text:00000000008E88DB                 jmp     loc_8E8321
+  .text:00000000008E88E0                 lea     r14, byte_C609A8
+  .text:00000000008E88E7                 ; _QWORD
+  .text:00000000008E88E7                 mov     rdi, r14; _QWORD
+  .text:00000000008E88EA                 call    ___cxa_guard_acquire
+  .text:00000000008E88EF                 test    eax, eax
+  .text:00000000008E88F1                 jz      loc_8E8387
+  .text:00000000008E88F7                 lea     r15, unk_C608A0
+  .text:00000000008E88FE                 xor     eax, eax
+  .text:00000000008E8900                 lea     rcx, aOnserverpostsi; "OnServerPostSimulate"
+  .text:00000000008E8907                 mov     rdi, r15
+  .text:00000000008E890A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8911                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8918                 call    sub_489C00
+  .text:00000000008E891D                 ; _QWORD
+  .text:00000000008E891D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8924                 ; _QWORD
+  .text:00000000008E8924                 mov     rsi, r15; _QWORD
+  .text:00000000008E8927                 ; _QWORD
+  .text:00000000008E8927                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E892E                 call    ___cxa_atexit
+  .text:00000000008E8933                 ; _QWORD
+  .text:00000000008E8933                 mov     rdi, r14; _QWORD
+  .text:00000000008E8936                 call    ___cxa_guard_release
+  .text:00000000008E893B                 jmp     loc_8E8387
+  .text:00000000008E8940                 lea     r14, byte_C60888
+  .text:00000000008E8947                 ; _QWORD
+  .text:00000000008E8947                 mov     rdi, r14; _QWORD
+  .text:00000000008E894A                 call    ___cxa_guard_acquire
+  .text:00000000008E894F                 test    eax, eax
+  .text:00000000008E8951                 jz      loc_8E83EA
+  .text:00000000008E8957                 lea     r15, unk_C60780
+  .text:00000000008E895E                 xor     eax, eax
+  .text:00000000008E8960                 lea     rcx, aOnserverpostad; "OnServerPostAdvanceTick"
+  .text:00000000008E8967                 mov     rdi, r15
+  .text:00000000008E896A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8971                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8978                 call    sub_489C00
+  .text:00000000008E897D                 ; _QWORD
+  .text:00000000008E897D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8984                 ; _QWORD
+  .text:00000000008E8984                 mov     rsi, r15; _QWORD
+  .text:00000000008E8987                 ; _QWORD
+  .text:00000000008E8987                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E898E                 call    ___cxa_atexit
+  .text:00000000008E8993                 ; _QWORD
+  .text:00000000008E8993                 mov     rdi, r14; _QWORD
+  .text:00000000008E8996                 call    ___cxa_guard_release
+  .text:00000000008E899B                 jmp     loc_8E83EA
+  .text:00000000008E89A0                 lea     r14, byte_C60768
+  .text:00000000008E89A7                 ; _QWORD
+  .text:00000000008E89A7                 mov     rdi, r14; _QWORD
+  .text:00000000008E89AA                 call    ___cxa_guard_acquire
+  .text:00000000008E89AF                 test    eax, eax
+  .text:00000000008E89B1                 jz      loc_8E8450
+  .text:00000000008E89B7                 lea     r15, unk_C60660
+  .text:00000000008E89BE                 xor     eax, eax
+  .text:00000000008E89C0                 lea     rcx, aOnserverbegina; "OnServerBeginAsyncPostTickWork"
+  .text:00000000008E89C7                 mov     rdi, r15
+  .text:00000000008E89CA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E89D1                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E89D8                 call    sub_489C00
+  .text:00000000008E89DD                 ; _QWORD
+  .text:00000000008E89DD                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E89E4                 ; _QWORD
+  .text:00000000008E89E4                 mov     rsi, r15; _QWORD
+  .text:00000000008E89E7                 ; _QWORD
+  .text:00000000008E89E7                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E89EE                 call    ___cxa_atexit
+  .text:00000000008E89F3                 ; _QWORD
+  .text:00000000008E89F3                 mov     rdi, r14; _QWORD
+  .text:00000000008E89F6                 call    ___cxa_guard_release
+  .text:00000000008E89FB                 jmp     loc_8E8450
+  .text:00000000008E8A00                 lea     r14, byte_C60648
+  .text:00000000008E8A07                 ; _QWORD
+  .text:00000000008E8A07                 mov     rdi, r14; _QWORD
+  .text:00000000008E8A0A                 call    ___cxa_guard_acquire
+  .text:00000000008E8A0F                 test    eax, eax
+  .text:00000000008E8A11                 jz      loc_8E84B6
+  .text:00000000008E8A17                 lea     r15, unk_C60540
+  .text:00000000008E8A1E                 xor     eax, eax
+  .text:00000000008E8A20                 lea     rcx, aOnframeboundar; "OnFrameBoundary"
+  .text:00000000008E8A27                 mov     rdi, r15
+  .text:00000000008E8A2A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8A31                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8A38                 call    sub_489C00
+  .text:00000000008E8A3D                 ; _QWORD
+  .text:00000000008E8A3D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8A44                 ; _QWORD
+  .text:00000000008E8A44                 mov     rsi, r15; _QWORD
+  .text:00000000008E8A47                 ; _QWORD
+  .text:00000000008E8A47                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E8A4E                 call    ___cxa_atexit
+  .text:00000000008E8A53                 ; _QWORD
+  .text:00000000008E8A53                 mov     rdi, r14; _QWORD
+  .text:00000000008E8A56                 call    ___cxa_guard_release
+  .text:00000000008E8A5B                 jmp     loc_8E84B6
+  .text:00000000008E8A60                 lea     r14, byte_C60528
+  .text:00000000008E8A67                 ; _QWORD
+  .text:00000000008E8A67                 mov     rdi, r14; _QWORD
+  .text:00000000008E8A6A                 call    ___cxa_guard_acquire
+  .text:00000000008E8A6F                 test    eax, eax
+  .text:00000000008E8A71                 jz      loc_8E851C
+  .text:00000000008E8A77                 lea     r15, unk_C60420
+  .text:00000000008E8A7E                 xor     eax, eax
+  .text:00000000008E8A80                 lea     rcx, aOnclientpollne; "OnClientPollNetworking"
+  .text:00000000008E8A87                 mov     rdi, r15
+  .text:00000000008E8A8A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8A91                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8A98                 call    sub_489C00
+  .text:00000000008E8A9D                 ; _QWORD
+  .text:00000000008E8A9D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8AA4                 ; _QWORD
+  .text:00000000008E8AA4                 mov     rsi, r15; _QWORD
+  .text:00000000008E8AA7                 ; _QWORD
+  .text:00000000008E8AA7                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E8AAE                 call    ___cxa_atexit
+  .text:00000000008E8AB3                 ; _QWORD
+  .text:00000000008E8AB3                 mov     rdi, r14; _QWORD
+  .text:00000000008E8AB6                 call    ___cxa_guard_release
+  .text:00000000008E8ABB                 jmp     loc_8E851C
+  .text:00000000008E8AC0                 lea     r14, byte_C60408
+  .text:00000000008E8AC7                 ; _QWORD
+  .text:00000000008E8AC7                 mov     rdi, r14; _QWORD
+  .text:00000000008E8ACA                 call    ___cxa_guard_acquire
+  .text:00000000008E8ACF                 test    eax, eax
+  .text:00000000008E8AD1                 jz      loc_8E8582
+  .text:00000000008E8AD7                 lea     r15, unk_C60300
+  .text:00000000008E8ADE                 xor     eax, eax
+  .text:00000000008E8AE0                 lea     rcx, aOnsimpleloopfr; "OnSimpleLoopFrameUpdate"
+  .text:00000000008E8AE7                 mov     rdi, r15
+  .text:00000000008E8AEA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8AF1                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8AF8                 call    sub_489C00
+  .text:00000000008E8AFD                 ; _QWORD
+  .text:00000000008E8AFD                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8B04                 ; _QWORD
+  .text:00000000008E8B04                 mov     rsi, r15; _QWORD
+  .text:00000000008E8B07                 ; _QWORD
+  .text:00000000008E8B07                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E8B0E                 call    ___cxa_atexit
+  .text:00000000008E8B13                 ; _QWORD
+  .text:00000000008E8B13                 mov     rdi, r14; _QWORD
+  .text:00000000008E8B16                 call    ___cxa_guard_release
+  .text:00000000008E8B1B                 jmp     loc_8E8582
+  .text:00000000008E8B20                 lea     r14, byte_C60E28
+  .text:00000000008E8B27                 ; _QWORD
+  .text:00000000008E8B27                 mov     rdi, r14; _QWORD
+  .text:00000000008E8B2A                 call    ___cxa_guard_acquire
+  .text:00000000008E8B2F                 test    eax, eax
+  .text:00000000008E8B31                 jz      loc_8E81F5
+  .text:00000000008E8B37                 lea     r15, unk_C60D20
+  .text:00000000008E8B3E                 xor     eax, eax
+  .text:00000000008E8B40                 lea     rcx, aOnserverpollne; "OnServerPollNetworking"
+  .text:00000000008E8B47                 mov     rdi, r15
+  .text:00000000008E8B4A                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8B51                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8B58                 call    sub_489C00
+  .text:00000000008E8B5D                 ; _QWORD
+  .text:00000000008E8B5D                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8B64                 ; _QWORD
+  .text:00000000008E8B64                 mov     rsi, r15; _QWORD
+  .text:00000000008E8B67                 ; _QWORD
+  .text:00000000008E8B67                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E8B6E                 call    ___cxa_atexit
+  .text:00000000008E8B73                 ; _QWORD
+  .text:00000000008E8B73                 mov     rdi, r14; _QWORD
+  .text:00000000008E8B76                 call    ___cxa_guard_release
+  .text:00000000008E8B7B                 jmp     loc_8E81F5
+  .text:00000000008E8B80                 lea     r14, byte_C60D08
+  .text:00000000008E8B87                 ; _QWORD
+  .text:00000000008E8B87                 mov     rdi, r14; _QWORD
+  .text:00000000008E8B8A                 call    ___cxa_guard_acquire
+  .text:00000000008E8B8F                 test    eax, eax
+  .text:00000000008E8B91                 jz      loc_8E8258
+  .text:00000000008E8B97                 lea     r15, unk_C60C00
+  .text:00000000008E8B9E                 xor     eax, eax
+  .text:00000000008E8BA0                 lea     rcx, aOnserverproces; "OnServerProcessNetworking"
+  .text:00000000008E8BA7                 mov     rdi, r15
+  .text:00000000008E8BAA                 lea     rdx, aCnetworkserver_6; "CNetworkServerService"
+  .text:00000000008E8BB1                 lea     rsi, aSS_3; "%s::%s"
+  .text:00000000008E8BB8                 call    sub_489C00
+  .text:00000000008E8BBD                 ; _QWORD
+  .text:00000000008E8BBD                 lea     rdx, off_96CC60; _QWORD
+  .text:00000000008E8BC4                 ; _QWORD
+  .text:00000000008E8BC4                 mov     rsi, r15; _QWORD
+  .text:00000000008E8BC7                 ; _QWORD
+  .text:00000000008E8BC7                 lea     rdi, sub_5365C0; _QWORD
+  .text:00000000008E8BCE                 call    ___cxa_atexit
+  .text:00000000008E8BD3                 ; _QWORD
+  .text:00000000008E8BD3                 mov     rdi, r14; _QWORD
+  .text:00000000008E8BD6                 call    ___cxa_guard_release
+  .text:00000000008E8BDB                 jmp     loc_8E8258
 procedure: |-
-  __int64 __fastcall CNetworkServerService_RegisterEventMapInternal(__int64 a1, __int64 a2, int a3)
+  void __fastcall CNetworkServerService_RegisterEventMapInternal(unsigned int *a1, __int64 a2, int a3)
   {
     __int64 *v3; // r8
     __int64 *v4; // r8
@@ -539,434 +594,333 @@ procedure: |-
     __int64 *v11; // r8
     __int64 *v12; // r8
     __int64 *v13; // r8
-    __int64 v15; // rcx
-    __int64 v16; // r8
-    __int64 v17; // r9
-    __int64 v18; // rcx
-    __int64 v19; // r8
-    __int64 v20; // r9
-    __int64 v21; // rcx
-    __int64 v22; // r8
-    __int64 v23; // r9
-    __int64 v24; // rcx
-    __int64 v25; // r8
-    __int64 v26; // r9
-    __int64 v27; // rcx
-    __int64 v28; // r8
-    __int64 v29; // r9
-    __int64 v30; // rcx
-    __int64 v31; // r8
-    __int64 v32; // r9
-    __int64 v33; // rcx
-    __int64 v34; // r8
-    __int64 v35; // r9
-    __int64 v36; // rcx
-    __int64 v37; // r8
-    __int64 v38; // r9
-    __int64 v39; // rcx
-    __int64 v40; // r8
-    __int64 v41; // r9
-    __int64 v42; // rcx
-    __int64 v43; // r8
-    __int64 v44; // r9
-    int v45; // r8d
-    int v46; // r9d
-    int v47; // r8d
-    int v48; // r9d
-    int v49; // r8d
-    int v50; // r9d
-    int v51; // r8d
-    int v52; // r9d
-    int v53; // r8d
-    int v54; // r9d
-    int v55; // r8d
-    int v56; // r9d
-    int v57; // r8d
-    int v58; // r9d
-    int v59; // r8d
-    int v60; // r9d
-    int v61; // r8d
-    int v62; // r9d
-    int v63; // r8d
-    int v64; // r9d
-    int v65; // r8d
-    int v66; // r9d
-    __int64 v67; // [rsp+0h] [rbp-50h] BYREF
-    __int64 (__fastcall *v68)(); // [rsp+8h] [rbp-48h]
-    __int64 v69; // [rsp+10h] [rbp-40h]
+    int v14; // r8d
+    int v15; // r9d
+    int v16; // r8d
+    int v17; // r9d
+    int v18; // r8d
+    int v19; // r9d
+    int v20; // r8d
+    int v21; // r9d
+    int v22; // r8d
+    int v23; // r9d
+    int v24; // r8d
+    int v25; // r9d
+    int v26; // r8d
+    int v27; // r9d
+    int v28; // r8d
+    int v29; // r9d
+    int v30; // r8d
+    int v31; // r9d
+    int v32; // r8d
+    int v33; // r9d
+    int v34; // r8d
+    int v35; // r9d
+    __int64 v36; // [rsp+0h] [rbp-50h] BYREF
+    __int64 (__fastcall *v37)(); // [rsp+8h] [rbp-48h]
+    __int64 v38; // [rsp+10h] [rbp-40h]
 
     if ( a3 )
     {
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerAdvanceTick;
-      ((void (__fastcall *)(__int64, __int64 *, __int64))sub_550600)(a1, &v67, qword_968E20);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPollNetworking;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_9684A0,
-        v15,
-        v16,
-        v17);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerProcessNetworking;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_968380,
-        v18,
-        v19,
-        v20);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerBeginSimulate;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_968260,
-        v21,
-        v22,
-        v23);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerEndSimulate;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_9681E0,
-        v24,
-        v25,
-        v26);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPostSimulate;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_9680C0,
-        v27,
-        v28,
-        v29);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPostAdvanceTick;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_968BC0,
-        v30,
-        v31,
-        v32);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerBeginAsyncPostTickWork;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_968A20,
-        v33,
-        v34,
-        v35);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnFrameBoundary;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_969080,
-        v36,
-        v37,
-        v38);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnClientPollNetworking;
-      ((void (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-        a1,
-        &v67,
-        qword_968420,
-        v39,
-        v40,
-        v41);
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnSimpleLoopFrameUpdate;
-      return ((__int64 (__fastcall *)(__int64, __int64 *, __int64, __int64, __int64, __int64))sub_550600)(
-               a1,
-               &v67,
-               qword_969A40,
-               v42,
-               v43,
-               v44);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
+      sub_551120(a1, (__int64)&v36, qword_970F00);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
+      sub_551120(a1, (__int64)&v36, qword_970580);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
+      sub_551120(a1, (__int64)&v36, qword_970460);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginSimulate;
+      sub_551120(a1, (__int64)&v36, qword_970340);
+      v36 = a2;
+      v38 = 0;
+      v37 = CNetworkServerService_OnServerEndSimulate;
+      sub_551120(a1, (__int64)&v36, qword_9702C0);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
+      sub_551120(a1, (__int64)&v36, qword_9701A0);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
+      sub_551120(a1, (__int64)&v36, qword_970CA0);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginAsyncPostTickWork;
+      sub_551120(a1, (__int64)&v36, qword_970B00);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      sub_551120(a1, (__int64)&v36, qword_971160);
+      v36 = a2;
+      v38 = 0;
+      v37 = CNetworkServerService_OnClientPollNetworking;
+      sub_551120(a1, (__int64)&v36, qword_970500);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
+      sub_551120(a1, (__int64)&v36, qword_971BA0);
     }
     else
     {
-      if ( !byte_C56DA8 && (unsigned int)sub_2A6DE0(&byte_C56DA8) )
+      if ( !(_BYTE)byte_C60F48 && (unsigned int)__cxa_guard_acquire(&byte_C60F48) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56CA0,
+        sub_489C00(
+          (unsigned int)&unk_C60E40,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerAdvanceTick",
-          v45,
-          v46,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56CA0, &off_964B60);
-        sub_2A6E00(&byte_C56DA8);
+          v14,
+          v15);
+        __cxa_atexit(sub_5365C0, &unk_C60E40, &off_96CC60);
+        __cxa_guard_release(&byte_C60F48);
       }
-      v3 = &qword_C56CA8;
-      if ( (byte_C56CA7 & 0x40) == 0 )
+      v3 = &qword_C60E48;
+      if ( (byte_C60E47 & 0x40) == 0 )
       {
-        v3 = (__int64 *)&byte_26801C;
-        if ( (unk_C56CA4 & 0x3FFFFFFF) != 0 )
-          v3 = (__int64 *)qword_C56CA8;
+        v3 = (__int64 *)&s1;
+        if ( (unk_C60E44 & 0x3FFFFFFF) != 0 )
+          v3 = (__int64 *)qword_C60E48;
       }
-      v69 = 0;
-      v67 = a2;
-      v68 = CNetworkServerService_OnServerAdvanceTick;
-      sub_8E15B0(a1, &v67, qword_968E20, 0, v3);
-      if ( !byte_C56C88 && (unsigned int)sub_2A6DE0(&byte_C56C88) )
+      v38 = 0;
+      v36 = a2;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
+      RegisterEventListener_Abstract(a1, &v36, qword_970F00, 0, v3);
+      if ( !(_BYTE)byte_C60E28 && (unsigned int)__cxa_guard_acquire(&byte_C60E28) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56B80,
+        sub_489C00(
+          (unsigned int)&unk_C60D20,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerPollNetworking",
-          v63,
-          v64,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56B80, &off_964B60);
-        sub_2A6E00(&byte_C56C88);
+          v32,
+          v33);
+        __cxa_atexit(sub_5365C0, &unk_C60D20, &off_96CC60);
+        __cxa_guard_release(&byte_C60E28);
       }
-      v4 = &qword_C56B88;
-      if ( (byte_C56B87 & 0x40) == 0 )
+      v4 = &qword_C60D28;
+      if ( (byte_C60D27 & 0x40) == 0 )
       {
-        v4 = (__int64 *)&byte_26801C;
-        if ( (unk_C56B84 & 0x3FFFFFFF) != 0 )
-          v4 = (__int64 *)qword_C56B88;
+        v4 = (__int64 *)&s1;
+        if ( (unk_C60D24 & 0x3FFFFFFF) != 0 )
+          v4 = (__int64 *)qword_C60D28;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPollNetworking;
-      sub_8E15B0(a1, &v67, qword_9684A0, 0, v4);
-      if ( !byte_C56B68 && (unsigned int)sub_2A6DE0(&byte_C56B68) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
+      RegisterEventListener_Abstract(a1, &v36, qword_970580, 0, v4);
+      if ( !(_BYTE)byte_C60D08 && (unsigned int)__cxa_guard_acquire(&byte_C60D08) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56A60,
+        sub_489C00(
+          (unsigned int)&unk_C60C00,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerProcessNetworking",
-          v65,
-          v66,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56A60, &off_964B60);
-        sub_2A6E00(&byte_C56B68);
+          v34,
+          v35);
+        __cxa_atexit(sub_5365C0, &unk_C60C00, &off_96CC60);
+        __cxa_guard_release(&byte_C60D08);
       }
-      v5 = &qword_C56A68;
-      if ( (byte_C56A67 & 0x40) == 0 )
+      v5 = &qword_C60C08;
+      if ( (byte_C60C07 & 0x40) == 0 )
       {
-        v5 = (__int64 *)&byte_26801C;
-        if ( (unk_C56A64 & 0x3FFFFFFF) != 0 )
-          v5 = (__int64 *)qword_C56A68;
+        v5 = (__int64 *)&s1;
+        if ( (unk_C60C04 & 0x3FFFFFFF) != 0 )
+          v5 = (__int64 *)qword_C60C08;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerProcessNetworking;
-      sub_8E15B0(a1, &v67, qword_968380, 0, v5);
-      if ( !byte_C56A48 && (unsigned int)sub_2A6DE0(&byte_C56A48) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
+      RegisterEventListener_Abstract(a1, &v36, qword_970460, 0, v5);
+      if ( !(_BYTE)byte_C60BE8 && (unsigned int)__cxa_guard_acquire(&byte_C60BE8) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56940,
+        sub_489C00(
+          (unsigned int)&unk_C60AE0,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerBeginSimulate",
-          v47,
-          v48,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56940, &off_964B60);
-        sub_2A6E00(&byte_C56A48);
+          v16,
+          v17);
+        __cxa_atexit(sub_5365C0, &unk_C60AE0, &off_96CC60);
+        __cxa_guard_release(&byte_C60BE8);
       }
-      v6 = &qword_C56948;
-      if ( (byte_C56947 & 0x40) == 0 )
+      v6 = &qword_C60AE8;
+      if ( (byte_C60AE7 & 0x40) == 0 )
       {
-        v6 = (__int64 *)&byte_26801C;
-        if ( (unk_C56944 & 0x3FFFFFFF) != 0 )
-          v6 = (__int64 *)qword_C56948;
+        v6 = (__int64 *)&s1;
+        if ( (unk_C60AE4 & 0x3FFFFFFF) != 0 )
+          v6 = (__int64 *)qword_C60AE8;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerBeginSimulate;
-      sub_8E15B0(a1, &v67, qword_968260, 0x80000000LL, v6);
-      if ( !byte_C56928 && (unsigned int)sub_2A6DE0(&byte_C56928) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginSimulate;
+      RegisterEventListener_Abstract(a1, &v36, qword_970340, 0x80000000LL, v6);
+      if ( !(_BYTE)byte_C60AC8 && (unsigned int)__cxa_guard_acquire(&byte_C60AC8) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56820,
+        sub_489C00(
+          (unsigned int)&unk_C609C0,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerEndSimulate",
-          v49,
-          v50,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56820, &off_964B60);
-        sub_2A6E00(&byte_C56928);
+          v18,
+          v19);
+        __cxa_atexit(sub_5365C0, &unk_C609C0, &off_96CC60);
+        __cxa_guard_release(&byte_C60AC8);
       }
-      v7 = &qword_C56828;
-      if ( (byte_C56827 & 0x40) == 0 )
+      v7 = &qword_C609C8;
+      if ( (byte_C609C7 & 0x40) == 0 )
       {
-        v7 = (__int64 *)&byte_26801C;
-        if ( (unk_C56824 & 0x3FFFFFFF) != 0 )
-          v7 = (__int64 *)qword_C56828;
+        v7 = (__int64 *)&s1;
+        if ( (unk_C609C4 & 0x3FFFFFFF) != 0 )
+          v7 = (__int64 *)qword_C609C8;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerEndSimulate;
-      sub_8E15B0(a1, &v67, qword_9681E0, 0x7FFFFFFF, v7);
-      if ( !byte_C56808 && (unsigned int)sub_2A6DE0(&byte_C56808) )
+      v36 = a2;
+      v38 = 0;
+      v37 = CNetworkServerService_OnServerEndSimulate;
+      RegisterEventListener_Abstract(a1, &v36, qword_9702C0, 0x7FFFFFFF, v7);
+      if ( !(_BYTE)byte_C609A8 && (unsigned int)__cxa_guard_acquire(&byte_C609A8) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56700,
+        sub_489C00(
+          (unsigned int)&unk_C608A0,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerPostSimulate",
-          v51,
-          v52,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56700, &off_964B60);
-        sub_2A6E00(&byte_C56808);
+          v20,
+          v21);
+        __cxa_atexit(sub_5365C0, &unk_C608A0, &off_96CC60);
+        __cxa_guard_release(&byte_C609A8);
       }
-      v8 = &qword_C56708;
-      if ( (byte_C56707 & 0x40) == 0 )
+      v8 = &qword_C608A8;
+      if ( (byte_C608A7 & 0x40) == 0 )
       {
-        v8 = (__int64 *)&byte_26801C;
-        if ( (unk_C56704 & 0x3FFFFFFF) != 0 )
-          v8 = (__int64 *)qword_C56708;
+        v8 = (__int64 *)&s1;
+        if ( (unk_C608A4 & 0x3FFFFFFF) != 0 )
+          v8 = (__int64 *)qword_C608A8;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPostSimulate;
-      sub_8E15B0(a1, &v67, qword_9680C0, 0, v8);
-      if ( !byte_C566E8 && (unsigned int)sub_2A6DE0(&byte_C566E8) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
+      RegisterEventListener_Abstract(a1, &v36, qword_9701A0, 0, v8);
+      if ( !(_BYTE)byte_C60888 && (unsigned int)__cxa_guard_acquire(&byte_C60888) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C565E0,
+        sub_489C00(
+          (unsigned int)&unk_C60780,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerPostAdvanceTick",
-          v53,
-          v54,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C565E0, &off_964B60);
-        sub_2A6E00(&byte_C566E8);
+          v22,
+          v23);
+        __cxa_atexit(sub_5365C0, &unk_C60780, &off_96CC60);
+        __cxa_guard_release(&byte_C60888);
       }
-      v9 = &qword_C565E8;
-      if ( (byte_C565E7 & 0x40) == 0 )
+      v9 = &qword_C60788;
+      if ( (byte_C60787 & 0x40) == 0 )
       {
-        v9 = (__int64 *)&byte_26801C;
-        if ( (unk_C565E4 & 0x3FFFFFFF) != 0 )
-          v9 = (__int64 *)qword_C565E8;
+        v9 = (__int64 *)&s1;
+        if ( (unk_C60784 & 0x3FFFFFFF) != 0 )
+          v9 = (__int64 *)qword_C60788;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerPostAdvanceTick;
-      sub_8E15B0(a1, &v67, qword_968BC0, 0x80000000LL, v9);
-      if ( !byte_C565C8 && (unsigned int)sub_2A6DE0(&byte_C565C8) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
+      RegisterEventListener_Abstract(a1, &v36, qword_970CA0, 0x80000000LL, v9);
+      if ( !(_BYTE)byte_C60768 && (unsigned int)__cxa_guard_acquire(&byte_C60768) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C564C0,
+        sub_489C00(
+          (unsigned int)&unk_C60660,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnServerBeginAsyncPostTickWork",
-          v55,
-          v56,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C564C0, &off_964B60);
-        sub_2A6E00(&byte_C565C8);
+          v24,
+          v25);
+        __cxa_atexit(sub_5365C0, &unk_C60660, &off_96CC60);
+        __cxa_guard_release(&byte_C60768);
       }
-      v10 = &qword_C564C8;
-      if ( (byte_C564C7 & 0x40) == 0 )
+      v10 = &qword_C60668;
+      if ( (byte_C60667 & 0x40) == 0 )
       {
-        v10 = (__int64 *)&byte_26801C;
-        if ( (unk_C564C4 & 0x3FFFFFFF) != 0 )
-          v10 = (__int64 *)qword_C564C8;
+        v10 = (__int64 *)&s1;
+        if ( (unk_C60664 & 0x3FFFFFFF) != 0 )
+          v10 = (__int64 *)qword_C60668;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnServerBeginAsyncPostTickWork;
-      sub_8E15B0(a1, &v67, qword_968A20, 0x80000000LL, v10);
-      if ( !byte_C564A8 && (unsigned int)sub_2A6DE0(&byte_C564A8) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginAsyncPostTickWork;
+      RegisterEventListener_Abstract(a1, &v36, qword_970B00, 0x80000000LL, v10);
+      if ( !(_BYTE)byte_C60648 && (unsigned int)__cxa_guard_acquire(&byte_C60648) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C563A0,
+        sub_489C00(
+          (unsigned int)&unk_C60540,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnFrameBoundary",
-          v57,
-          v58,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C563A0, &off_964B60);
-        sub_2A6E00(&byte_C564A8);
+          v26,
+          v27);
+        __cxa_atexit(sub_5365C0, &unk_C60540, &off_96CC60);
+        __cxa_guard_release(&byte_C60648);
       }
-      v11 = &qword_C563A8;
-      if ( (byte_C563A7 & 0x40) == 0 )
+      v11 = &qword_C60548;
+      if ( (byte_C60547 & 0x40) == 0 )
       {
-        v11 = (__int64 *)&byte_26801C;
-        if ( (unk_C563A4 & 0x3FFFFFFF) != 0 )
-          v11 = (__int64 *)qword_C563A8;
+        v11 = (__int64 *)&s1;
+        if ( (unk_C60544 & 0x3FFFFFFF) != 0 )
+          v11 = (__int64 *)qword_C60548;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnFrameBoundary;
-      sub_8E15B0(a1, &v67, qword_969080, 0x7FFFFFFF, v11);
-      if ( !byte_C56388 && (unsigned int)sub_2A6DE0(&byte_C56388) )
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      RegisterEventListener_Abstract(a1, &v36, qword_971160, 0x7FFFFFFF, v11);
+      if ( !(_BYTE)byte_C60528 && (unsigned int)__cxa_guard_acquire(&byte_C60528) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56280,
+        sub_489C00(
+          (unsigned int)&unk_C60420,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnClientPollNetworking",
-          v59,
-          v60,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56280, &off_964B60);
-        sub_2A6E00(&byte_C56388);
+          v28,
+          v29);
+        __cxa_atexit(sub_5365C0, &unk_C60420, &off_96CC60);
+        __cxa_guard_release(&byte_C60528);
       }
-      v12 = &qword_C56288;
-      if ( (byte_C56287 & 0x40) == 0 )
+      v12 = &qword_C60428;
+      if ( (byte_C60427 & 0x40) == 0 )
       {
-        v12 = (__int64 *)&byte_26801C;
-        if ( (unk_C56284 & 0x3FFFFFFF) != 0 )
-          v12 = (__int64 *)qword_C56288;
+        v12 = (__int64 *)&s1;
+        if ( (unk_C60424 & 0x3FFFFFFF) != 0 )
+          v12 = (__int64 *)qword_C60428;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnClientPollNetworking;
-      sub_8E15B0(a1, &v67, qword_968420, 1, v12);
-      if ( !byte_C56268 && (unsigned int)sub_2A6DE0(&byte_C56268) )
+      v36 = a2;
+      v38 = 0;
+      v37 = CNetworkServerService_OnClientPollNetworking;
+      RegisterEventListener_Abstract(a1, &v36, qword_970500, 1, v12);
+      if ( !(_BYTE)byte_C60408 && (unsigned int)__cxa_guard_acquire(&byte_C60408) )
       {
-        sub_4886F0(
-          (unsigned int)&unk_C56160,
+        sub_489C00(
+          (unsigned int)&unk_C60300,
           (unsigned int)"%s::%s",
           (unsigned int)"CNetworkServerService",
           (unsigned int)"OnSimpleLoopFrameUpdate",
-          v61,
-          v62,
-          v67);
-        sub_2B41A0(sub_535D60, &unk_C56160, &off_964B60);
-        sub_2A6E00(&byte_C56268);
+          v30,
+          v31);
+        __cxa_atexit(sub_5365C0, &unk_C60300, &off_96CC60);
+        __cxa_guard_release(&byte_C60408);
       }
-      v13 = &qword_C56168;
-      if ( (byte_C56167 & 0x40) == 0 )
+      v13 = &qword_C60308;
+      if ( (byte_C60307 & 0x40) == 0 )
       {
-        v13 = (__int64 *)&byte_26801C;
-        if ( (unk_C56164 & 0x3FFFFFFF) != 0 )
-          v13 = (__int64 *)qword_C56168;
+        v13 = (__int64 *)&s1;
+        if ( (unk_C60304 & 0x3FFFFFFF) != 0 )
+          v13 = (__int64 *)qword_C60308;
       }
-      v67 = a2;
-      v69 = 0;
-      v68 = CNetworkServerService_OnSimpleLoopFrameUpdate;
-      return sub_8E15B0(a1, &v67, qword_969A40, 0, v13);
+      v36 = a2;
+      v38 = 0;
+      v37 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
+      RegisterEventListener_Abstract(a1, &v36, qword_971BA0, 0, v13);
     }
   }

--- a/ida_preprocessor_scripts/references/engine/CNetworkServerService_RegisterEventMapInternal.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkServerService_RegisterEventMapInternal.windows.yaml
@@ -1,1064 +1,1106 @@
 func_name: CNetworkServerService_RegisterEventMapInternal
-func_va: '0x1801e90b0'
+func_va: '0x1801ddac0'
 disasm_code: |-
-  .text:00000001801E90B0                 mov     rax, rsp
-  .text:00000001801E90B3                 push    rbp
-  .text:00000001801E90B4                 push    rbx
-  .text:00000001801E90B5                 push    rsi
-  .text:00000001801E90B6                 push    r14
-  .text:00000001801E90B8                 mov     rbp, rsp
-  .text:00000001801E90BB                 sub     rsp, 58h
-  .text:00000001801E90BF                 mov     rsi, rdx
-  .text:00000001801E90C2                 mov     r14, rcx
-  .text:00000001801E90C5                 test    r8d, r8d
-  .text:00000001801E90C8                 jnz     loc_1801E96E6
-  .text:00000001801E90CE                 mov     r8d, cs:TlsIndex
-  .text:00000001801E90D5                 mov     [rax+8], rdi
-  .text:00000001801E90D9                 mov     [rax+18h], r12
-  .text:00000001801E90DD                 mov     [rax+20h], r13
-  .text:00000001801E90E1                 mov     [rax-28h], r15
-  .text:00000001801E90E5                 mov     rax, gs:58h
-  .text:00000001801E90EE                 mov     ecx, 68h ; 'h'
-  .text:00000001801E90F3                 mov     r15, [rax+r8*8]
-  .text:00000001801E90F7                 add     r15, rcx
-  .text:00000001801E90FA                 mov     eax, [r15]
-  .text:00000001801E90FD                 cmp     cs:dword_180910888, eax
-  .text:00000001801E9103                 jg      loc_1801E996E
-  .text:00000001801E9109                 lea     rdx, qword_18060F400
-  .text:00000001801E9110                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9114                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9119                 mov     rax, cs:qword_180910894
-  .text:00000001801E9120                 lea     rdi, unk_1805262BF
-  .text:00000001801E9127                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E912B                 bt      eax, 1Eh
-  .text:00000001801E912F                 jnb     short loc_1801E913A
-  .text:00000001801E9131                 lea     r12, qword_180910894+4
-  .text:00000001801E9138                 jmp     short loc_1801E914A
-  .text:00000001801E913A                 test    eax, 3FFFFFFFh
-  .text:00000001801E913F                 mov     r12, rdi
-  .text:00000001801E9142                 cmova   r12, cs:qword_180910894+4
-  .text:00000001801E914A                 lea     rax, CNetworkServerService_OnServerAdvanceTick
-  .text:00000001801E9151                 mov     rcx, rsi
-  .text:00000001801E9154                 mov     [rbp+var_10], rax
-  .text:00000001801E9158                 call    sub_180046DE0
-  .text:00000001801E915D                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E9162                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9166                 xor     r13d, r13d
-  .text:00000001801E9169                 mov     [rbp+var_18], rax
-  .text:00000001801E916D                 mov     [rsp+58h+var_30], r13d
-  .text:00000001801E9172                 mov     r9b, 1
-  .text:00000001801E9175                 mov     r8d, 1
-  .text:00000001801E917B                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9180                 mov     rcx, r14
-  .text:00000001801E9183                 call    RegisterEventListener_Abstract
-  .text:00000001801E9188                 mov     eax, [r15]
-  .text:00000001801E918B                 cmp     cs:dword_180910998, eax
-  .text:00000001801E9191                 jg      loc_1801E99C5
-  .text:00000001801E9197                 lea     rdx, qword_18060E7C0
-  .text:00000001801E919E                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E91A2                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E91A7                 mov     rax, cs:qword_1809109A4
-  .text:00000001801E91AE                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E91B2                 bt      eax, 1Eh
-  .text:00000001801E91B6                 jnb     short loc_1801E91C1
-  .text:00000001801E91B8                 lea     r12, qword_1809109A4+4
-  .text:00000001801E91BF                 jmp     short loc_1801E91D1
-  .text:00000001801E91C1                 test    eax, 3FFFFFFFh
-  .text:00000001801E91C6                 mov     r12, rdi
-  .text:00000001801E91C9                 cmova   r12, cs:qword_1809109A4+4
-  .text:00000001801E91D1                 lea     rax, CNetworkServerService_OnServerPollNetworking
-  .text:00000001801E91D8                 mov     rcx, rsi
-  .text:00000001801E91DB                 mov     [rbp+var_10], rax
-  .text:00000001801E91DF                 call    sub_180046DE0
-  .text:00000001801E91E4                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E91E9                 lea     rdx, [rbp+var_18]
-  .text:00000001801E91ED                 mov     [rsp+58h+var_30], r13d
-  .text:00000001801E91F2                 mov     r9b, 1
-  .text:00000001801E91F5                 mov     r8d, 1
-  .text:00000001801E91FB                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9200                 mov     rcx, r14
-  .text:00000001801E9203                 mov     [rbp+var_18], rax
-  .text:00000001801E9207                 call    RegisterEventListener_Abstract
-  .text:00000001801E920C                 mov     eax, [r15]
-  .text:00000001801E920F                 cmp     cs:dword_180910AA8, eax
-  .text:00000001801E9215                 jg      loc_1801E9A1C
-  .text:00000001801E921B                 lea     rdx, qword_18060E830
-  .text:00000001801E9222                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9226                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E922B                 mov     rax, cs:qword_180910AB4
-  .text:00000001801E9232                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9236                 bt      eax, 1Eh
-  .text:00000001801E923A                 jnb     short loc_1801E9245
-  .text:00000001801E923C                 lea     r12, qword_180910AB4+4
-  .text:00000001801E9243                 jmp     short loc_1801E9255
-  .text:00000001801E9245                 test    eax, 3FFFFFFFh
-  .text:00000001801E924A                 mov     r12, rdi
-  .text:00000001801E924D                 cmova   r12, cs:qword_180910AB4+4
-  .text:00000001801E9255                 lea     rax, CNetworkServerService_OnServerProcessNetworking
-  .text:00000001801E925C                 mov     rcx, rsi
-  .text:00000001801E925F                 mov     [rbp+var_10], rax
-  .text:00000001801E9263                 call    sub_180046DE0
-  .text:00000001801E9268                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E926D                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9271                 mov     [rsp+58h+var_30], r13d
-  .text:00000001801E9276                 mov     r9b, 1
-  .text:00000001801E9279                 mov     r8d, 1
-  .text:00000001801E927F                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9284                 mov     rcx, r14
-  .text:00000001801E9287                 mov     [rbp+var_18], rax
-  .text:00000001801E928B                 call    RegisterEventListener_Abstract
-  .text:00000001801E9290                 mov     eax, [r15]
-  .text:00000001801E9293                 cmp     cs:dword_180910BB8, eax
-  .text:00000001801E9299                 jg      loc_1801E9A73
-  .text:00000001801E929F                 lea     rdx, qword_18060E8A0
-  .text:00000001801E92A6                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E92AA                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E92AF                 mov     rax, cs:qword_180910BC4
-  .text:00000001801E92B6                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E92BA                 bt      eax, 1Eh
-  .text:00000001801E92BE                 jnb     short loc_1801E92C9
-  .text:00000001801E92C0                 lea     r12, qword_180910BC4+4
-  .text:00000001801E92C7                 jmp     short loc_1801E92D9
-  .text:00000001801E92C9                 test    eax, 3FFFFFFFh
-  .text:00000001801E92CE                 mov     r12, rdi
-  .text:00000001801E92D1                 cmova   r12, cs:qword_180910BC4+4
-  .text:00000001801E92D9                 lea     rax, CNetworkServerService_OnServerBeginSimulate
-  .text:00000001801E92E0                 mov     rcx, rsi
-  .text:00000001801E92E3                 mov     [rbp+var_10], rax
-  .text:00000001801E92E7                 call    sub_180046DE0
-  .text:00000001801E92EC                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E92F1                 lea     rdx, [rbp+var_18]
-  .text:00000001801E92F5                 mov     [rsp+58h+var_30], 80000000h
-  .text:00000001801E92FD                 mov     r9b, 1
-  .text:00000001801E9300                 mov     r8d, 1
-  .text:00000001801E9306                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E930B                 mov     rcx, r14
-  .text:00000001801E930E                 mov     [rbp+var_18], rax
-  .text:00000001801E9312                 call    RegisterEventListener_Abstract
-  .text:00000001801E9317                 mov     eax, [r15]
-  .text:00000001801E931A                 cmp     cs:dword_180910CC8, eax
-  .text:00000001801E9320                 jg      loc_1801E9ACA
-  .text:00000001801E9326                 lea     rdx, qword_18060E910
-  .text:00000001801E932D                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9331                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9336                 mov     rax, cs:qword_180910CD4
-  .text:00000001801E933D                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9341                 bt      eax, 1Eh
-  .text:00000001801E9345                 jnb     short loc_1801E9350
-  .text:00000001801E9347                 lea     r12, qword_180910CD4+4
-  .text:00000001801E934E                 jmp     short loc_1801E9360
-  .text:00000001801E9350                 test    eax, 3FFFFFFFh
-  .text:00000001801E9355                 mov     r12, rdi
-  .text:00000001801E9358                 cmova   r12, cs:qword_180910CD4+4
-  .text:00000001801E9360                 lea     rax, sub_1801EAC20; = CNetworkServerService_OnServerEndSimulate (not a requested target)
-  .text:00000001801E9367                 mov     rcx, rsi
-  .text:00000001801E936A                 mov     [rbp+var_10], rax
-  .text:00000001801E936E                 call    sub_180046DE0
-  .text:00000001801E9373                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E9378                 lea     rdx, [rbp+var_18]
-  .text:00000001801E937C                 mov     [rsp+58h+var_30], 7FFFFFFFh
-  .text:00000001801E9384                 mov     r9b, 1
-  .text:00000001801E9387                 mov     r8d, 1
-  .text:00000001801E938D                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9392                 mov     rcx, r14
-  .text:00000001801E9395                 mov     [rbp+var_18], rax
-  .text:00000001801E9399                 call    RegisterEventListener_Abstract
-  .text:00000001801E939E                 mov     eax, [r15]
-  .text:00000001801E93A1                 cmp     cs:dword_180910DD8, eax
-  .text:00000001801E93A7                 jg      loc_1801E9B21
-  .text:00000001801E93AD                 lea     rdx, qword_18060E600
-  .text:00000001801E93B4                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E93B8                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E93BD                 mov     rax, cs:qword_180910DE4
-  .text:00000001801E93C4                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E93C8                 bt      eax, 1Eh
-  .text:00000001801E93CC                 jnb     short loc_1801E93D7
-  .text:00000001801E93CE                 lea     r12, qword_180910DE4+4
-  .text:00000001801E93D5                 jmp     short loc_1801E93E7
-  .text:00000001801E93D7                 test    eax, 3FFFFFFFh
-  .text:00000001801E93DC                 mov     r12, rdi
-  .text:00000001801E93DF                 cmova   r12, cs:qword_180910DE4+4
-  .text:00000001801E93E7                 lea     rax, CNetworkServerService_OnServerPostSimulate
-  .text:00000001801E93EE                 mov     rcx, rsi
-  .text:00000001801E93F1                 mov     [rbp+var_10], rax
-  .text:00000001801E93F5                 call    sub_180046DE0
-  .text:00000001801E93FA                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E93FF                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9403                 mov     [rsp+58h+var_30], r13d
-  .text:00000001801E9408                 mov     r9b, 1
-  .text:00000001801E940B                 mov     r8d, 1
-  .text:00000001801E9411                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9416                 mov     rcx, r14
-  .text:00000001801E9419                 mov     [rbp+var_18], rax
-  .text:00000001801E941D                 call    RegisterEventListener_Abstract
-  .text:00000001801E9422                 mov     eax, [r15]
-  .text:00000001801E9425                 cmp     cs:dword_180910EE8, eax
-  .text:00000001801E942B                 jg      loc_1801E9B78
-  .text:00000001801E9431                 lea     rdx, qword_18060F470
-  .text:00000001801E9438                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E943C                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9441                 mov     rax, cs:qword_180910EF4
-  .text:00000001801E9448                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E944C                 bt      eax, 1Eh
-  .text:00000001801E9450                 jnb     short loc_1801E945B
-  .text:00000001801E9452                 lea     r12, qword_180910EF4+4
-  .text:00000001801E9459                 jmp     short loc_1801E946B
-  .text:00000001801E945B                 test    eax, 3FFFFFFFh
-  .text:00000001801E9460                 mov     r12, rdi
-  .text:00000001801E9463                 cmova   r12, cs:qword_180910EF4+4
-  .text:00000001801E946B                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
-  .text:00000001801E9472                 mov     rcx, rsi
-  .text:00000001801E9475                 mov     [rbp+var_10], rax
-  .text:00000001801E9479                 call    sub_180046DE0
-  .text:00000001801E947E                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E9483                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9487                 mov     [rsp+58h+var_30], 80000000h
-  .text:00000001801E948F                 mov     r9b, 1
-  .text:00000001801E9492                 mov     r8d, 1
-  .text:00000001801E9498                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E949D                 mov     rcx, r14
-  .text:00000001801E94A0                 mov     [rbp+var_18], rax
-  .text:00000001801E94A4                 call    RegisterEventListener_Abstract
-  .text:00000001801E94A9                 mov     eax, [r15]
-  .text:00000001801E94AC                 cmp     cs:dword_180910FF8, eax
-  .text:00000001801E94B2                 jg      loc_1801E9BCF
-  .text:00000001801E94B8                 lea     rdx, qword_18060F160
-  .text:00000001801E94BF                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E94C3                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E94C8                 mov     rax, cs:qword_180911004
-  .text:00000001801E94CF                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E94D3                 bt      eax, 1Eh
-  .text:00000001801E94D7                 jnb     short loc_1801E94E2
-  .text:00000001801E94D9                 lea     r12, qword_180911004+4
-  .text:00000001801E94E0                 jmp     short loc_1801E94F2
-  .text:00000001801E94E2                 test    eax, 3FFFFFFFh
-  .text:00000001801E94E7                 mov     r12, rdi
-  .text:00000001801E94EA                 cmova   r12, cs:qword_180911004+4
-  .text:00000001801E94F2                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000001801E94F9                 mov     rcx, rsi
-  .text:00000001801E94FC                 mov     [rbp+var_10], rax
-  .text:00000001801E9500                 call    sub_180046DE0
-  .text:00000001801E9505                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E950A                 lea     rdx, [rbp+var_18]
-  .text:00000001801E950E                 mov     [rsp+58h+var_30], 80000000h
-  .text:00000001801E9516                 mov     r9b, 1
-  .text:00000001801E9519                 mov     r8d, 1
-  .text:00000001801E951F                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9524                 mov     rcx, r14
-  .text:00000001801E9527                 mov     [rbp+var_18], rax
-  .text:00000001801E952B                 call    RegisterEventListener_Abstract
-  .text:00000001801E9530                 mov     eax, [r15]
-  .text:00000001801E9533                 cmp     cs:dword_180911108, eax
-  .text:00000001801E9539                 jg      loc_1801E9C26
-  .text:00000001801E953F                 lea     rdx, qword_18060ED00
-  .text:00000001801E9546                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E954A                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E954F                 mov     rax, cs:qword_180911114
-  .text:00000001801E9556                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E955A                 bt      eax, 1Eh
-  .text:00000001801E955E                 jnb     short loc_1801E9569
-  .text:00000001801E9560                 lea     r12, qword_180911114+4
-  .text:00000001801E9567                 jmp     short loc_1801E9579
-  .text:00000001801E9569                 test    eax, 3FFFFFFFh
-  .text:00000001801E956E                 mov     r12, rdi
-  .text:00000001801E9571                 cmova   r12, cs:qword_180911114+4
-  .text:00000001801E9579                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000001801E9580                 mov     rcx, rsi
-  .text:00000001801E9583                 mov     [rbp+var_10], rax
-  .text:00000001801E9587                 call    sub_180046DE0
-  .text:00000001801E958C                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E9591                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9595                 mov     [rsp+58h+var_30], 7FFFFFFFh
-  .text:00000001801E959D                 mov     r9b, 1
-  .text:00000001801E95A0                 mov     r8d, 1
-  .text:00000001801E95A6                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E95AB                 mov     rcx, r14
-  .text:00000001801E95AE                 mov     [rbp+var_18], rax
-  .text:00000001801E95B2                 call    RegisterEventListener_Abstract
-  .text:00000001801E95B7                 mov     eax, [r15]
-  .text:00000001801E95BA                 cmp     cs:dword_180911218, eax
-  .text:00000001801E95C0                 jg      loc_1801E9C7D
-  .text:00000001801E95C6                 lea     rdx, qword_18060EFA0
-  .text:00000001801E95CD                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E95D1                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E95D6                 mov     rax, cs:qword_180911224
-  .text:00000001801E95DD                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E95E1                 bt      eax, 1Eh
-  .text:00000001801E95E5                 jnb     short loc_1801E95F0
-  .text:00000001801E95E7                 lea     r12, qword_180911224+4
-  .text:00000001801E95EE                 jmp     short loc_1801E9600
-  .text:00000001801E95F0                 test    eax, 3FFFFFFFh
-  .text:00000001801E95F5                 mov     r12, rdi
-  .text:00000001801E95F8                 cmova   r12, cs:qword_180911224+4
-  .text:00000001801E9600                 lea     rax, CNetworkServerService_OnClientPollNetworking
-  .text:00000001801E9607                 mov     rcx, rsi
-  .text:00000001801E960A                 mov     [rbp+var_10], rax
-  .text:00000001801E960E                 call    sub_180046DE0
-  .text:00000001801E9613                 mov     [rsp+58h+var_28], r12
-  .text:00000001801E9618                 lea     rdx, [rbp+var_18]
-  .text:00000001801E961C                 mov     [rsp+58h+var_30], 1
-  .text:00000001801E9624                 mov     r9b, 1
-  .text:00000001801E9627                 mov     r8d, 1
-  .text:00000001801E962D                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E9632                 mov     rcx, r14
-  .text:00000001801E9635                 mov     [rbp+var_18], rax
-  .text:00000001801E9639                 call    RegisterEventListener_Abstract
-  .text:00000001801E963E                 mov     eax, [r15]
-  .text:00000001801E9641                 cmp     cs:dword_180911328, eax
-  .text:00000001801E9647                 mov     r15, [rsp+58h+var_8]
-  .text:00000001801E964C                 mov     r12, [rsp+58h+arg_10]
-  .text:00000001801E9654                 jg      loc_1801E9CD4
-  .text:00000001801E965A                 lea     rdx, qword_18060F5C0
-  .text:00000001801E9661                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9665                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E966A                 mov     rax, cs:qword_180911334
-  .text:00000001801E9671                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9675                 bt      eax, 1Eh
-  .text:00000001801E9679                 jnb     short loc_1801E9684
-  .text:00000001801E967B                 lea     rdi, qword_180911334+4
-  .text:00000001801E9682                 jmp     short loc_1801E9691
-  .text:00000001801E9684                 test    eax, 3FFFFFFFh
-  .text:00000001801E9689                 cmova   rdi, cs:qword_180911334+4
-  .text:00000001801E9691                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
-  .text:00000001801E9698                 mov     rcx, rsi
-  .text:00000001801E969B                 mov     [rbp+var_10], rax
-  .text:00000001801E969F                 call    sub_180046DE0
-  .text:00000001801E96A4                 mov     [rsp+58h+var_28], rdi
-  .text:00000001801E96A9                 lea     rdx, [rbp+var_18]
-  .text:00000001801E96AD                 mov     [rsp+58h+var_30], r13d
-  .text:00000001801E96B2                 mov     r9b, 1
-  .text:00000001801E96B5                 mov     r8d, 1
-  .text:00000001801E96BB                 mov     [rsp+58h+var_38], rbx
-  .text:00000001801E96C0                 mov     rcx, r14
-  .text:00000001801E96C3                 mov     [rbp+var_18], rax
-  .text:00000001801E96C7                 call    RegisterEventListener_Abstract
-  .text:00000001801E96CC                 mov     r13, [rsp+58h+arg_18]
-  .text:00000001801E96D4                 mov     rdi, [rsp+58h+arg_0]
-  .text:00000001801E96DC                 add     rsp, 58h
-  .text:00000001801E96E0                 pop     r14
-  .text:00000001801E96E2                 pop     rsi
-  .text:00000001801E96E3                 pop     rbx
-  .text:00000001801E96E4                 pop     rbp
-  .text:00000001801E96E5                 retn
-  .text:00000001801E96E6                 lea     rdx, qword_18060F400
-  .text:00000001801E96ED                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E96F1                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E96F6                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E96FA                 lea     rax, CNetworkServerService_OnServerAdvanceTick
-  .text:00000001801E9701                 mov     rcx, rsi
-  .text:00000001801E9704                 mov     [rbp+var_10], rax
-  .text:00000001801E9708                 call    sub_180046DE0
-  .text:00000001801E970D                 mov     r8, rbx
-  .text:00000001801E9710                 mov     [rbp+var_18], rax
-  .text:00000001801E9714                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9718                 mov     rcx, r14
-  .text:00000001801E971B                 call    UnregisterEventListener_Abstract
-  .text:00000001801E9720                 lea     rdx, qword_18060E7C0
-  .text:00000001801E9727                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E972B                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9730                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9734                 lea     rax, CNetworkServerService_OnServerPollNetworking
-  .text:00000001801E973B                 mov     rcx, rsi
-  .text:00000001801E973E                 mov     [rbp+var_10], rax
-  .text:00000001801E9742                 call    sub_180046DE0
-  .text:00000001801E9747                 mov     r8, rbx
-  .text:00000001801E974A                 mov     [rbp+var_18], rax
-  .text:00000001801E974E                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9752                 mov     rcx, r14
-  .text:00000001801E9755                 call    UnregisterEventListener_Abstract
-  .text:00000001801E975A                 lea     rdx, qword_18060E830
-  .text:00000001801E9761                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9765                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E976A                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E976E                 lea     rax, CNetworkServerService_OnServerProcessNetworking
-  .text:00000001801E9775                 mov     rcx, rsi
-  .text:00000001801E9778                 mov     [rbp+var_10], rax
-  .text:00000001801E977C                 call    sub_180046DE0
-  .text:00000001801E9781                 mov     r8, rbx
-  .text:00000001801E9784                 mov     [rbp+var_18], rax
-  .text:00000001801E9788                 lea     rdx, [rbp+var_18]
-  .text:00000001801E978C                 mov     rcx, r14
-  .text:00000001801E978F                 call    UnregisterEventListener_Abstract
-  .text:00000001801E9794                 lea     rdx, qword_18060E8A0
-  .text:00000001801E979B                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E979F                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E97A4                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E97A8                 lea     rax, CNetworkServerService_OnServerBeginSimulate
-  .text:00000001801E97AF                 mov     rcx, rsi
-  .text:00000001801E97B2                 mov     [rbp+var_10], rax
-  .text:00000001801E97B6                 call    sub_180046DE0
-  .text:00000001801E97BB                 mov     r8, rbx
-  .text:00000001801E97BE                 mov     [rbp+var_18], rax
-  .text:00000001801E97C2                 lea     rdx, [rbp+var_18]
-  .text:00000001801E97C6                 mov     rcx, r14
-  .text:00000001801E97C9                 call    UnregisterEventListener_Abstract
-  .text:00000001801E97CE                 lea     rdx, qword_18060E910
-  .text:00000001801E97D5                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E97D9                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E97DE                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E97E2                 lea     rax, sub_1801EAC20; = CNetworkServerService_OnServerEndSimulate (not a requested target)
-  .text:00000001801E97E9                 mov     rcx, rsi
-  .text:00000001801E97EC                 mov     [rbp+var_10], rax
-  .text:00000001801E97F0                 call    sub_180046DE0
-  .text:00000001801E97F5                 mov     r8, rbx
-  .text:00000001801E97F8                 mov     [rbp+var_18], rax
-  .text:00000001801E97FC                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9800                 mov     rcx, r14
-  .text:00000001801E9803                 call    UnregisterEventListener_Abstract
-  .text:00000001801E9808                 lea     rdx, qword_18060E600
-  .text:00000001801E980F                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9813                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9818                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E981C                 lea     rax, CNetworkServerService_OnServerPostSimulate
-  .text:00000001801E9823                 mov     rcx, rsi
-  .text:00000001801E9826                 mov     [rbp+var_10], rax
-  .text:00000001801E982A                 call    sub_180046DE0
-  .text:00000001801E982F                 mov     r8, rbx
-  .text:00000001801E9832                 mov     [rbp+var_18], rax
-  .text:00000001801E9836                 lea     rdx, [rbp+var_18]
-  .text:00000001801E983A                 mov     rcx, r14
-  .text:00000001801E983D                 call    UnregisterEventListener_Abstract
-  .text:00000001801E9842                 lea     rdx, qword_18060F470
-  .text:00000001801E9849                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E984D                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9852                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9856                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
-  .text:00000001801E985D                 mov     rcx, rsi
-  .text:00000001801E9860                 mov     [rbp+var_10], rax
-  .text:00000001801E9864                 call    sub_180046DE0
-  .text:00000001801E9869                 mov     r8, rbx
-  .text:00000001801E986C                 mov     [rbp+var_18], rax
-  .text:00000001801E9870                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9874                 mov     rcx, r14
-  .text:00000001801E9877                 call    UnregisterEventListener_Abstract
-  .text:00000001801E987C                 lea     rdx, qword_18060F160
-  .text:00000001801E9883                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9887                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E988C                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9890                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000001801E9897                 mov     rcx, rsi
-  .text:00000001801E989A                 mov     [rbp+var_10], rax
-  .text:00000001801E989E                 call    sub_180046DE0
-  .text:00000001801E98A3                 mov     r8, rbx
-  .text:00000001801E98A6                 mov     [rbp+var_18], rax
-  .text:00000001801E98AA                 lea     rdx, [rbp+var_18]
-  .text:00000001801E98AE                 mov     rcx, r14
-  .text:00000001801E98B1                 call    UnregisterEventListener_Abstract
-  .text:00000001801E98B6                 lea     rdx, qword_18060ED00
-  .text:00000001801E98BD                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E98C1                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E98C6                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E98CA                 lea     rax, CNetworkServerService_OnFrameBoundary
-  .text:00000001801E98D1                 mov     rcx, rsi
-  .text:00000001801E98D4                 mov     [rbp+var_10], rax
-  .text:00000001801E98D8                 call    sub_180046DE0
-  .text:00000001801E98DD                 mov     r8, rbx
-  .text:00000001801E98E0                 mov     [rbp+var_18], rax
-  .text:00000001801E98E4                 lea     rdx, [rbp+var_18]
-  .text:00000001801E98E8                 mov     rcx, r14
-  .text:00000001801E98EB                 call    UnregisterEventListener_Abstract
-  .text:00000001801E98F0                 lea     rdx, qword_18060EFA0
-  .text:00000001801E98F7                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E98FB                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E9900                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E9904                 lea     rax, CNetworkServerService_OnClientPollNetworking
-  .text:00000001801E990B                 mov     rcx, rsi
-  .text:00000001801E990E                 mov     [rbp+var_10], rax
-  .text:00000001801E9912                 call    sub_180046DE0
-  .text:00000001801E9917                 mov     r8, rbx
-  .text:00000001801E991A                 mov     [rbp+var_18], rax
-  .text:00000001801E991E                 lea     rdx, [rbp+var_18]
-  .text:00000001801E9922                 mov     rcx, r14
-  .text:00000001801E9925                 call    UnregisterEventListener_Abstract
-  .text:00000001801E992A                 lea     rdx, qword_18060F5C0
-  .text:00000001801E9931                 lea     rcx, [rbp+arg_8]
-  .text:00000001801E9935                 call    unknown_libname_11; Microsoft VisualC v7/14 64bit runtime
-  .text:00000001801E993A                 mov     rbx, [rbp+arg_8]
-  .text:00000001801E993E                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
-  .text:00000001801E9945                 mov     rcx, rsi
-  .text:00000001801E9948                 mov     [rbp+var_10], rax
-  .text:00000001801E994C                 call    sub_180046DE0
-  .text:00000001801E9951                 mov     r8, rbx
-  .text:00000001801E9954                 mov     [rbp+var_18], rax
-  .text:00000001801E9958                 lea     rdx, [rbp+var_18]
-  .text:00000001801E995C                 mov     rcx, r14
-  .text:00000001801E995F                 call    UnregisterEventListener_Abstract
-  .text:00000001801E9964                 add     rsp, 58h
-  .text:00000001801E9968                 pop     r14
-  .text:00000001801E996A                 pop     rsi
-  .text:00000001801E996B                 pop     rbx
-  .text:00000001801E996C                 pop     rbp
-  .text:00000001801E996D                 retn
-  .text:00000001801E996E                 lea     rcx, dword_180910888
-  .text:00000001801E9975                 call    sub_180422B18
-  .text:00000001801E997A                 cmp     cs:dword_180910888, 0FFFFFFFFh
-  .text:00000001801E9981                 jnz     loc_1801E9109
-  .text:00000001801E9987                 lea     r9, aOnserveradvanc; "OnServerAdvanceTick"
-  .text:00000001801E998E                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9995                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E999C                 lea     rcx, unk_180910890
-  .text:00000001801E99A3                 call    sub_180025170
-  .text:00000001801E99A8                 ; void (__cdecl *)()
-  .text:00000001801E99A8                 lea     rcx, sub_18047D0C0; void (__cdecl *)()
-  .text:00000001801E99AF                 call    atexit
-  .text:00000001801E99B4                 lea     rcx, dword_180910888
-  .text:00000001801E99BB                 call    sub_180422AAC
-  .text:00000001801E99C0                 jmp     loc_1801E9109
-  .text:00000001801E99C5                 lea     rcx, dword_180910998
-  .text:00000001801E99CC                 call    sub_180422B18
-  .text:00000001801E99D1                 cmp     cs:dword_180910998, 0FFFFFFFFh
-  .text:00000001801E99D8                 jnz     loc_1801E9197
-  .text:00000001801E99DE                 lea     r9, aOnserverpollne; "OnServerPollNetworking"
-  .text:00000001801E99E5                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E99EC                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E99F3                 lea     rcx, unk_1809109A0
-  .text:00000001801E99FA                 call    sub_180025170
-  .text:00000001801E99FF                 ; void (__cdecl *)()
-  .text:00000001801E99FF                 lea     rcx, sub_18047D0B0; void (__cdecl *)()
-  .text:00000001801E9A06                 call    atexit
-  .text:00000001801E9A0B                 lea     rcx, dword_180910998
-  .text:00000001801E9A12                 call    sub_180422AAC
-  .text:00000001801E9A17                 jmp     loc_1801E9197
-  .text:00000001801E9A1C                 lea     rcx, dword_180910AA8
-  .text:00000001801E9A23                 call    sub_180422B18
-  .text:00000001801E9A28                 cmp     cs:dword_180910AA8, 0FFFFFFFFh
-  .text:00000001801E9A2F                 jnz     loc_1801E921B
-  .text:00000001801E9A35                 lea     r9, aOnserverproces; "OnServerProcessNetworking"
-  .text:00000001801E9A3C                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9A43                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9A4A                 lea     rcx, unk_180910AB0
-  .text:00000001801E9A51                 call    sub_180025170
-  .text:00000001801E9A56                 ; void (__cdecl *)()
-  .text:00000001801E9A56                 lea     rcx, sub_18047D0A0; void (__cdecl *)()
-  .text:00000001801E9A5D                 call    atexit
-  .text:00000001801E9A62                 lea     rcx, dword_180910AA8
-  .text:00000001801E9A69                 call    sub_180422AAC
-  .text:00000001801E9A6E                 jmp     loc_1801E921B
-  .text:00000001801E9A73                 lea     rcx, dword_180910BB8
-  .text:00000001801E9A7A                 call    sub_180422B18
-  .text:00000001801E9A7F                 cmp     cs:dword_180910BB8, 0FFFFFFFFh
-  .text:00000001801E9A86                 jnz     loc_1801E929F
-  .text:00000001801E9A8C                 lea     r9, aOnserverbegins; "OnServerBeginSimulate"
-  .text:00000001801E9A93                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9A9A                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9AA1                 lea     rcx, unk_180910BC0
-  .text:00000001801E9AA8                 call    sub_180025170
-  .text:00000001801E9AAD                 ; void (__cdecl *)()
-  .text:00000001801E9AAD                 lea     rcx, sub_18047D090; void (__cdecl *)()
-  .text:00000001801E9AB4                 call    atexit
-  .text:00000001801E9AB9                 lea     rcx, dword_180910BB8
-  .text:00000001801E9AC0                 call    sub_180422AAC
-  .text:00000001801E9AC5                 jmp     loc_1801E929F
-  .text:00000001801E9ACA                 lea     rcx, dword_180910CC8
-  .text:00000001801E9AD1                 call    sub_180422B18
-  .text:00000001801E9AD6                 cmp     cs:dword_180910CC8, 0FFFFFFFFh
-  .text:00000001801E9ADD                 jnz     loc_1801E9326
-  .text:00000001801E9AE3                 lea     r9, aOnserverendsim; "OnServerEndSimulate"
-  .text:00000001801E9AEA                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9AF1                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9AF8                 lea     rcx, unk_180910CD0
-  .text:00000001801E9AFF                 call    sub_180025170
-  .text:00000001801E9B04                 ; void (__cdecl *)()
-  .text:00000001801E9B04                 lea     rcx, sub_18047D080; void (__cdecl *)()
-  .text:00000001801E9B0B                 call    atexit
-  .text:00000001801E9B10                 lea     rcx, dword_180910CC8
-  .text:00000001801E9B17                 call    sub_180422AAC
-  .text:00000001801E9B1C                 jmp     loc_1801E9326
-  .text:00000001801E9B21                 lea     rcx, dword_180910DD8
-  .text:00000001801E9B28                 call    sub_180422B18
-  .text:00000001801E9B2D                 cmp     cs:dword_180910DD8, 0FFFFFFFFh
-  .text:00000001801E9B34                 jnz     loc_1801E93AD
-  .text:00000001801E9B3A                 lea     r9, aOnserverpostsi; "OnServerPostSimulate"
-  .text:00000001801E9B41                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9B48                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9B4F                 lea     rcx, unk_180910DE0
-  .text:00000001801E9B56                 call    sub_180025170
-  .text:00000001801E9B5B                 ; void (__cdecl *)()
-  .text:00000001801E9B5B                 lea     rcx, sub_18047D070; void (__cdecl *)()
-  .text:00000001801E9B62                 call    atexit
-  .text:00000001801E9B67                 lea     rcx, dword_180910DD8
-  .text:00000001801E9B6E                 call    sub_180422AAC
-  .text:00000001801E9B73                 jmp     loc_1801E93AD
-  .text:00000001801E9B78                 lea     rcx, dword_180910EE8
-  .text:00000001801E9B7F                 call    sub_180422B18
-  .text:00000001801E9B84                 cmp     cs:dword_180910EE8, 0FFFFFFFFh
-  .text:00000001801E9B8B                 jnz     loc_1801E9431
-  .text:00000001801E9B91                 lea     r9, aOnserverpostad; "OnServerPostAdvanceTick"
-  .text:00000001801E9B98                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9B9F                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9BA6                 lea     rcx, unk_180910EF0
-  .text:00000001801E9BAD                 call    sub_180025170
-  .text:00000001801E9BB2                 ; void (__cdecl *)()
-  .text:00000001801E9BB2                 lea     rcx, sub_18047D060; void (__cdecl *)()
-  .text:00000001801E9BB9                 call    atexit
-  .text:00000001801E9BBE                 lea     rcx, dword_180910EE8
-  .text:00000001801E9BC5                 call    sub_180422AAC
-  .text:00000001801E9BCA                 jmp     loc_1801E9431
-  .text:00000001801E9BCF                 lea     rcx, dword_180910FF8
-  .text:00000001801E9BD6                 call    sub_180422B18
-  .text:00000001801E9BDB                 cmp     cs:dword_180910FF8, 0FFFFFFFFh
-  .text:00000001801E9BE2                 jnz     loc_1801E94B8
-  .text:00000001801E9BE8                 lea     r9, aOnserverbegina; "OnServerBeginAsyncPostTickWork"
-  .text:00000001801E9BEF                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9BF6                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9BFD                 lea     rcx, unk_180911000
-  .text:00000001801E9C04                 call    sub_180025170
-  .text:00000001801E9C09                 ; void (__cdecl *)()
-  .text:00000001801E9C09                 lea     rcx, sub_18047D050; void (__cdecl *)()
-  .text:00000001801E9C10                 call    atexit
-  .text:00000001801E9C15                 lea     rcx, dword_180910FF8
-  .text:00000001801E9C1C                 call    sub_180422AAC
-  .text:00000001801E9C21                 jmp     loc_1801E94B8
-  .text:00000001801E9C26                 lea     rcx, dword_180911108
-  .text:00000001801E9C2D                 call    sub_180422B18
-  .text:00000001801E9C32                 cmp     cs:dword_180911108, 0FFFFFFFFh
-  .text:00000001801E9C39                 jnz     loc_1801E953F
-  .text:00000001801E9C3F                 lea     r9, aOnframeboundar; "OnFrameBoundary"
-  .text:00000001801E9C46                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9C4D                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9C54                 lea     rcx, unk_180911110
-  .text:00000001801E9C5B                 call    sub_180025170
-  .text:00000001801E9C60                 ; void (__cdecl *)()
-  .text:00000001801E9C60                 lea     rcx, sub_18047D040; void (__cdecl *)()
-  .text:00000001801E9C67                 call    atexit
-  .text:00000001801E9C6C                 lea     rcx, dword_180911108
-  .text:00000001801E9C73                 call    sub_180422AAC
-  .text:00000001801E9C78                 jmp     loc_1801E953F
-  .text:00000001801E9C7D                 lea     rcx, dword_180911218
-  .text:00000001801E9C84                 call    sub_180422B18
-  .text:00000001801E9C89                 cmp     cs:dword_180911218, 0FFFFFFFFh
-  .text:00000001801E9C90                 jnz     loc_1801E95C6
-  .text:00000001801E9C96                 lea     r9, aOnclientpollne; "OnClientPollNetworking"
-  .text:00000001801E9C9D                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9CA4                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9CAB                 lea     rcx, unk_180911220
-  .text:00000001801E9CB2                 call    sub_180025170
-  .text:00000001801E9CB7                 ; void (__cdecl *)()
-  .text:00000001801E9CB7                 lea     rcx, sub_18047D030; void (__cdecl *)()
-  .text:00000001801E9CBE                 call    atexit
-  .text:00000001801E9CC3                 lea     rcx, dword_180911218
-  .text:00000001801E9CCA                 call    sub_180422AAC
-  .text:00000001801E9CCF                 jmp     loc_1801E95C6
-  .text:00000001801E9CD4                 lea     rcx, dword_180911328
-  .text:00000001801E9CDB                 call    sub_180422B18
-  .text:00000001801E9CE0                 cmp     cs:dword_180911328, 0FFFFFFFFh
-  .text:00000001801E9CE7                 jnz     loc_1801E965A
-  .text:00000001801E9CED                 lea     r9, aOnsimpleloopfr; "OnSimpleLoopFrameUpdate"
-  .text:00000001801E9CF4                 lea     r8, aCnetworkserver; "CNetworkServerService"
-  .text:00000001801E9CFB                 lea     rdx, aSS_5; "%s::%s"
-  .text:00000001801E9D02                 lea     rcx, unk_180911330
-  .text:00000001801E9D09                 call    sub_180025170
-  .text:00000001801E9D0E                 ; void (__cdecl *)()
-  .text:00000001801E9D0E                 lea     rcx, sub_18047D020; void (__cdecl *)()
-  .text:00000001801E9D15                 call    atexit
-  .text:00000001801E9D1A                 lea     rcx, dword_180911328
-  .text:00000001801E9D21                 call    sub_180422AAC
-  .text:00000001801E9D26                 jmp     loc_1801E965A
+  .text:00000001801DDAC0                 mov     rax, rsp
+  .text:00000001801DDAC3                 push    rbp
+  .text:00000001801DDAC4                 push    rbx
+  .text:00000001801DDAC5                 push    rsi
+  .text:00000001801DDAC6                 push    r14
+  .text:00000001801DDAC8                 mov     rbp, rsp
+  .text:00000001801DDACB                 sub     rsp, 58h
+  .text:00000001801DDACF                 mov     rsi, rdx
+  .text:00000001801DDAD2                 mov     r14, rcx
+  .text:00000001801DDAD5                 test    r8d, r8d
+  .text:00000001801DDAD8                 jnz     loc_1801DE0F6
+  .text:00000001801DDADE                 mov     r8d, cs:TlsIndex
+  .text:00000001801DDAE5                 mov     [rax+8], rdi
+  .text:00000001801DDAE9                 mov     [rax+18h], r12
+  .text:00000001801DDAED                 mov     [rax+20h], r13
+  .text:00000001801DDAF1                 mov     [rax-28h], r15
+  .text:00000001801DDAF5                 mov     rax, gs:58h
+  .text:00000001801DDAFE                 mov     ecx, 68h ; 'h'
+  .text:00000001801DDB03                 mov     r15, [rax+r8*8]
+  .text:00000001801DDB07                 add     r15, rcx
+  .text:00000001801DDB0A                 mov     eax, [r15]
+  .text:00000001801DDB0D                 cmp     cs:dword_1809114B8, eax
+  .text:00000001801DDB13                 jg      loc_1801DE37E
+  .text:00000001801DDB19                 lea     rdx, unk_18060D150
+  .text:00000001801DDB20                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDB24                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDB29                 mov     rax, cs:qword_1809114C4
+  .text:00000001801DDB30                 lea     rdi, unk_180524F9F
+  .text:00000001801DDB37                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDB3B                 bt      eax, 1Eh
+  .text:00000001801DDB3F                 jnb     short loc_1801DDB4A
+  .text:00000001801DDB41                 lea     r12, qword_1809114C4+4
+  .text:00000001801DDB48                 jmp     short loc_1801DDB5A
+  .text:00000001801DDB4A                 test    eax, 3FFFFFFFh
+  .text:00000001801DDB4F                 mov     r12, rdi
+  .text:00000001801DDB52                 cmova   r12, cs:qword_1809114C4+4
+  .text:00000001801DDB5A                 lea     rax, CNetworkServerService_OnServerAdvanceTick
+  .text:00000001801DDB61                 mov     rcx, rsi
+  .text:00000001801DDB64                 mov     [rbp+var_10], rax
+  .text:00000001801DDB68                 call    sub_180043D40
+  .text:00000001801DDB6D                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDB72                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDB76                 xor     r13d, r13d
+  .text:00000001801DDB79                 mov     [rbp+var_18], rax
+  .text:00000001801DDB7D                 mov     [rsp+58h+var_30], r13d
+  .text:00000001801DDB82                 mov     r9b, 1
+  .text:00000001801DDB85                 mov     r8d, 1
+  .text:00000001801DDB8B                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDB90                 mov     rcx, r14
+  .text:00000001801DDB93                 call    sub_18013D400
+  .text:00000001801DDB98                 mov     eax, [r15]
+  .text:00000001801DDB9B                 cmp     cs:dword_1809115C8, eax
+  .text:00000001801DDBA1                 jg      loc_1801DE3D5
+  .text:00000001801DDBA7                 lea     rdx, unk_18060DA10
+  .text:00000001801DDBAE                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDBB2                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDBB7                 mov     rax, cs:qword_1809115D4
+  .text:00000001801DDBBE                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDBC2                 bt      eax, 1Eh
+  .text:00000001801DDBC6                 jnb     short loc_1801DDBD1
+  .text:00000001801DDBC8                 lea     r12, qword_1809115D4+4
+  .text:00000001801DDBCF                 jmp     short loc_1801DDBE1
+  .text:00000001801DDBD1                 test    eax, 3FFFFFFFh
+  .text:00000001801DDBD6                 mov     r12, rdi
+  .text:00000001801DDBD9                 cmova   r12, cs:qword_1809115D4+4
+  .text:00000001801DDBE1                 lea     rax, CNetworkServerService_OnServerPollNetworking
+  .text:00000001801DDBE8                 mov     rcx, rsi
+  .text:00000001801DDBEB                 mov     [rbp+var_10], rax
+  .text:00000001801DDBEF                 call    sub_180043D40
+  .text:00000001801DDBF4                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDBF9                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDBFD                 mov     [rsp+58h+var_30], r13d
+  .text:00000001801DDC02                 mov     r9b, 1
+  .text:00000001801DDC05                 mov     r8d, 1
+  .text:00000001801DDC0B                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDC10                 mov     rcx, r14
+  .text:00000001801DDC13                 mov     [rbp+var_18], rax
+  .text:00000001801DDC17                 call    sub_18013D400
+  .text:00000001801DDC1C                 mov     eax, [r15]
+  .text:00000001801DDC1F                 cmp     cs:dword_1809116D8, eax
+  .text:00000001801DDC25                 jg      loc_1801DE42C
+  .text:00000001801DDC2B                 lea     rdx, unk_18060D9A0
+  .text:00000001801DDC32                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDC36                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDC3B                 mov     rax, cs:qword_1809116E4
+  .text:00000001801DDC42                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDC46                 bt      eax, 1Eh
+  .text:00000001801DDC4A                 jnb     short loc_1801DDC55
+  .text:00000001801DDC4C                 lea     r12, qword_1809116E4+4
+  .text:00000001801DDC53                 jmp     short loc_1801DDC65
+  .text:00000001801DDC55                 test    eax, 3FFFFFFFh
+  .text:00000001801DDC5A                 mov     r12, rdi
+  .text:00000001801DDC5D                 cmova   r12, cs:qword_1809116E4+4
+  .text:00000001801DDC65                 lea     rax, CNetworkServerService_OnServerProcessNetworking
+  .text:00000001801DDC6C                 mov     rcx, rsi
+  .text:00000001801DDC6F                 mov     [rbp+var_10], rax
+  .text:00000001801DDC73                 call    sub_180043D40
+  .text:00000001801DDC78                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDC7D                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDC81                 mov     [rsp+58h+var_30], r13d
+  .text:00000001801DDC86                 mov     r9b, 1
+  .text:00000001801DDC89                 mov     r8d, 1
+  .text:00000001801DDC8F                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDC94                 mov     rcx, r14
+  .text:00000001801DDC97                 mov     [rbp+var_18], rax
+  .text:00000001801DDC9B                 call    sub_18013D400
+  .text:00000001801DDCA0                 mov     eax, [r15]
+  .text:00000001801DDCA3                 cmp     cs:dword_1809117E8, eax
+  .text:00000001801DDCA9                 jg      loc_1801DE483
+  .text:00000001801DDCAF                 lea     rdx, unk_18060DAF0
+  .text:00000001801DDCB6                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDCBA                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDCBF                 mov     rax, cs:qword_1809117F4
+  .text:00000001801DDCC6                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDCCA                 bt      eax, 1Eh
+  .text:00000001801DDCCE                 jnb     short loc_1801DDCD9
+  .text:00000001801DDCD0                 lea     r12, qword_1809117F4+4
+  .text:00000001801DDCD7                 jmp     short loc_1801DDCE9
+  .text:00000001801DDCD9                 test    eax, 3FFFFFFFh
+  .text:00000001801DDCDE                 mov     r12, rdi
+  .text:00000001801DDCE1                 cmova   r12, cs:qword_1809117F4+4
+  .text:00000001801DDCE9                 lea     rax, CNetworkServerService_OnServerBeginSimulate
+  .text:00000001801DDCF0                 mov     rcx, rsi
+  .text:00000001801DDCF3                 mov     [rbp+var_10], rax
+  .text:00000001801DDCF7                 call    sub_180043D40
+  .text:00000001801DDCFC                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDD01                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDD05                 mov     [rsp+58h+var_30], 80000000h
+  .text:00000001801DDD0D                 mov     r9b, 1
+  .text:00000001801DDD10                 mov     r8d, 1
+  .text:00000001801DDD16                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDD1B                 mov     rcx, r14
+  .text:00000001801DDD1E                 mov     [rbp+var_18], rax
+  .text:00000001801DDD22                 call    sub_18013D400
+  .text:00000001801DDD27                 mov     eax, [r15]
+  .text:00000001801DDD2A                 cmp     cs:dword_1809118F8, eax
+  .text:00000001801DDD30                 jg      loc_1801DE4DA
+  .text:00000001801DDD36                 lea     rdx, unk_18060DA80
+  .text:00000001801DDD3D                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDD41                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDD46                 mov     rax, cs:qword_180911904
+  .text:00000001801DDD4D                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDD51                 bt      eax, 1Eh
+  .text:00000001801DDD55                 jnb     short loc_1801DDD60
+  .text:00000001801DDD57                 lea     r12, qword_180911904+4
+  .text:00000001801DDD5E                 jmp     short loc_1801DDD70
+  .text:00000001801DDD60                 test    eax, 3FFFFFFFh
+  .text:00000001801DDD65                 mov     r12, rdi
+  .text:00000001801DDD68                 cmova   r12, cs:qword_180911904+4
+  .text:00000001801DDD70                 lea     rax, CNetworkServerService_OnServerEndSimulate
+  .text:00000001801DDD77                 mov     rcx, rsi
+  .text:00000001801DDD7A                 mov     [rbp+var_10], rax
+  .text:00000001801DDD7E                 call    sub_180043D40
+  .text:00000001801DDD83                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDD88                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDD8C                 mov     [rsp+58h+var_30], 7FFFFFFFh
+  .text:00000001801DDD94                 mov     r9b, 1
+  .text:00000001801DDD97                 mov     r8d, 1
+  .text:00000001801DDD9D                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDDA2                 mov     rcx, r14
+  .text:00000001801DDDA5                 mov     [rbp+var_18], rax
+  .text:00000001801DDDA9                 call    sub_18013D400
+  .text:00000001801DDDAE                 mov     eax, [r15]
+  .text:00000001801DDDB1                 cmp     cs:dword_180911A08, eax
+  .text:00000001801DDDB7                 jg      loc_1801DE531
+  .text:00000001801DDDBD                 lea     rdx, unk_18060DBD0
+  .text:00000001801DDDC4                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDDC8                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDDCD                 mov     rax, cs:qword_180911A14
+  .text:00000001801DDDD4                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDDD8                 bt      eax, 1Eh
+  .text:00000001801DDDDC                 jnb     short loc_1801DDDE7
+  .text:00000001801DDDDE                 lea     r12, qword_180911A14+4
+  .text:00000001801DDDE5                 jmp     short loc_1801DDDF7
+  .text:00000001801DDDE7                 test    eax, 3FFFFFFFh
+  .text:00000001801DDDEC                 mov     r12, rdi
+  .text:00000001801DDDEF                 cmova   r12, cs:qword_180911A14+4
+  .text:00000001801DDDF7                 lea     rax, CNetworkServerService_OnServerPostSimulate
+  .text:00000001801DDDFE                 mov     rcx, rsi
+  .text:00000001801DDE01                 mov     [rbp+var_10], rax
+  .text:00000001801DDE05                 call    sub_180043D40
+  .text:00000001801DDE0A                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDE0F                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDE13                 mov     [rsp+58h+var_30], r13d
+  .text:00000001801DDE18                 mov     r9b, 1
+  .text:00000001801DDE1B                 mov     r8d, 1
+  .text:00000001801DDE21                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDE26                 mov     rcx, r14
+  .text:00000001801DDE29                 mov     [rbp+var_18], rax
+  .text:00000001801DDE2D                 call    sub_18013D400
+  .text:00000001801DDE32                 mov     eax, [r15]
+  .text:00000001801DDE35                 cmp     cs:dword_180911B18, eax
+  .text:00000001801DDE3B                 jg      loc_1801DE588
+  .text:00000001801DDE41                 lea     rdx, unk_18060D0E0
+  .text:00000001801DDE48                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDE4C                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDE51                 mov     rax, cs:qword_180911B24
+  .text:00000001801DDE58                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDE5C                 bt      eax, 1Eh
+  .text:00000001801DDE60                 jnb     short loc_1801DDE6B
+  .text:00000001801DDE62                 lea     r12, qword_180911B24+4
+  .text:00000001801DDE69                 jmp     short loc_1801DDE7B
+  .text:00000001801DDE6B                 test    eax, 3FFFFFFFh
+  .text:00000001801DDE70                 mov     r12, rdi
+  .text:00000001801DDE73                 cmova   r12, cs:qword_180911B24+4
+  .text:00000001801DDE7B                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
+  .text:00000001801DDE82                 mov     rcx, rsi
+  .text:00000001801DDE85                 mov     [rbp+var_10], rax
+  .text:00000001801DDE89                 call    sub_180043D40
+  .text:00000001801DDE8E                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDE93                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDE97                 mov     [rsp+58h+var_30], 80000000h
+  .text:00000001801DDE9F                 mov     r9b, 1
+  .text:00000001801DDEA2                 mov     r8d, 1
+  .text:00000001801DDEA8                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDEAD                 mov     rcx, r14
+  .text:00000001801DDEB0                 mov     [rbp+var_18], rax
+  .text:00000001801DDEB4                 call    sub_18013D400
+  .text:00000001801DDEB9                 mov     eax, [r15]
+  .text:00000001801DDEBC                 cmp     cs:dword_180911C28, eax
+  .text:00000001801DDEC2                 jg      loc_1801DE5DF
+  .text:00000001801DDEC8                 lea     rdx, unk_18060D230
+  .text:00000001801DDECF                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDED3                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDED8                 mov     rax, cs:qword_180911C34
+  .text:00000001801DDEDF                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDEE3                 bt      eax, 1Eh
+  .text:00000001801DDEE7                 jnb     short loc_1801DDEF2
+  .text:00000001801DDEE9                 lea     r12, qword_180911C34+4
+  .text:00000001801DDEF0                 jmp     short loc_1801DDF02
+  .text:00000001801DDEF2                 test    eax, 3FFFFFFFh
+  .text:00000001801DDEF7                 mov     r12, rdi
+  .text:00000001801DDEFA                 cmova   r12, cs:qword_180911C34+4
+  .text:00000001801DDF02                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000001801DDF09                 mov     rcx, rsi
+  .text:00000001801DDF0C                 mov     [rbp+var_10], rax
+  .text:00000001801DDF10                 call    sub_180043D40
+  .text:00000001801DDF15                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDF1A                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDF1E                 mov     [rsp+58h+var_30], 80000000h
+  .text:00000001801DDF26                 mov     r9b, 1
+  .text:00000001801DDF29                 mov     r8d, 1
+  .text:00000001801DDF2F                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDF34                 mov     rcx, r14
+  .text:00000001801DDF37                 mov     [rbp+var_18], rax
+  .text:00000001801DDF3B                 call    sub_18013D400
+  .text:00000001801DDF40                 mov     eax, [r15]
+  .text:00000001801DDF43                 cmp     cs:dword_180911D38, eax
+  .text:00000001801DDF49                 jg      loc_1801DE636
+  .text:00000001801DDF4F                 lea     rdx, unk_18060D4D0
+  .text:00000001801DDF56                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDF5A                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDF5F                 mov     rax, cs:qword_180911D44
+  .text:00000001801DDF66                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDF6A                 bt      eax, 1Eh
+  .text:00000001801DDF6E                 jnb     short loc_1801DDF79
+  .text:00000001801DDF70                 lea     r12, qword_180911D44+4
+  .text:00000001801DDF77                 jmp     short loc_1801DDF89
+  .text:00000001801DDF79                 test    eax, 3FFFFFFFh
+  .text:00000001801DDF7E                 mov     r12, rdi
+  .text:00000001801DDF81                 cmova   r12, cs:qword_180911D44+4
+  .text:00000001801DDF89                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000001801DDF90                 mov     rcx, rsi
+  .text:00000001801DDF93                 mov     [rbp+var_10], rax
+  .text:00000001801DDF97                 call    sub_180043D40
+  .text:00000001801DDF9C                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DDFA1                 lea     rdx, [rbp+var_18]
+  .text:00000001801DDFA5                 mov     [rsp+58h+var_30], 7FFFFFFFh
+  .text:00000001801DDFAD                 mov     r9b, 1
+  .text:00000001801DDFB0                 mov     r8d, 1
+  .text:00000001801DDFB6                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DDFBB                 mov     rcx, r14
+  .text:00000001801DDFBE                 mov     [rbp+var_18], rax
+  .text:00000001801DDFC2                 call    sub_18013D400
+  .text:00000001801DDFC7                 mov     eax, [r15]
+  .text:00000001801DDFCA                 cmp     cs:dword_180911E48, eax
+  .text:00000001801DDFD0                 jg      loc_1801DE68D
+  .text:00000001801DDFD6                 lea     rdx, unk_18060D850
+  .text:00000001801DDFDD                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DDFE1                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DDFE6                 mov     rax, cs:qword_180911E54
+  .text:00000001801DDFED                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DDFF1                 bt      eax, 1Eh
+  .text:00000001801DDFF5                 jnb     short loc_1801DE000
+  .text:00000001801DDFF7                 lea     r12, qword_180911E54+4
+  .text:00000001801DDFFE                 jmp     short loc_1801DE010
+  .text:00000001801DE000                 test    eax, 3FFFFFFFh
+  .text:00000001801DE005                 mov     r12, rdi
+  .text:00000001801DE008                 cmova   r12, cs:qword_180911E54+4
+  .text:00000001801DE010                 lea     rax, CNetworkServerService_OnClientPollNetworking
+  .text:00000001801DE017                 mov     rcx, rsi
+  .text:00000001801DE01A                 mov     [rbp+var_10], rax
+  .text:00000001801DE01E                 call    sub_180043D40
+  .text:00000001801DE023                 mov     [rsp+58h+var_28], r12
+  .text:00000001801DE028                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE02C                 mov     [rsp+58h+var_30], 1
+  .text:00000001801DE034                 mov     r9b, 1
+  .text:00000001801DE037                 mov     r8d, 1
+  .text:00000001801DE03D                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DE042                 mov     rcx, r14
+  .text:00000001801DE045                 mov     [rbp+var_18], rax
+  .text:00000001801DE049                 call    sub_18013D400
+  .text:00000001801DE04E                 mov     eax, [r15]
+  .text:00000001801DE051                 cmp     cs:dword_180911F58, eax
+  .text:00000001801DE057                 mov     r15, [rsp+58h+var_8]
+  .text:00000001801DE05C                 mov     r12, [rsp+58h+arg_10]
+  .text:00000001801DE064                 jg      loc_1801DE6E4
+  .text:00000001801DE06A                 lea     rdx, unk_18060CF90
+  .text:00000001801DE071                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE075                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE07A                 mov     rax, cs:qword_180911F64
+  .text:00000001801DE081                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE085                 bt      eax, 1Eh
+  .text:00000001801DE089                 jnb     short loc_1801DE094
+  .text:00000001801DE08B                 lea     rdi, qword_180911F64+4
+  .text:00000001801DE092                 jmp     short loc_1801DE0A1
+  .text:00000001801DE094                 test    eax, 3FFFFFFFh
+  .text:00000001801DE099                 cmova   rdi, cs:qword_180911F64+4
+  .text:00000001801DE0A1                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
+  .text:00000001801DE0A8                 mov     rcx, rsi
+  .text:00000001801DE0AB                 mov     [rbp+var_10], rax
+  .text:00000001801DE0AF                 call    sub_180043D40
+  .text:00000001801DE0B4                 mov     [rsp+58h+var_28], rdi
+  .text:00000001801DE0B9                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE0BD                 mov     [rsp+58h+var_30], r13d
+  .text:00000001801DE0C2                 mov     r9b, 1
+  .text:00000001801DE0C5                 mov     r8d, 1
+  .text:00000001801DE0CB                 mov     [rsp+58h+var_38], rbx
+  .text:00000001801DE0D0                 mov     rcx, r14
+  .text:00000001801DE0D3                 mov     [rbp+var_18], rax
+  .text:00000001801DE0D7                 call    sub_18013D400
+  .text:00000001801DE0DC                 mov     r13, [rsp+58h+arg_18]
+  .text:00000001801DE0E4                 mov     rdi, [rsp+58h+arg_0]
+  .text:00000001801DE0EC                 add     rsp, 58h
+  .text:00000001801DE0F0                 pop     r14
+  .text:00000001801DE0F2                 pop     rsi
+  .text:00000001801DE0F3                 pop     rbx
+  .text:00000001801DE0F4                 pop     rbp
+  .text:00000001801DE0F5                 retn
+  .text:00000001801DE0F6                 lea     rdx, unk_18060D150
+  .text:00000001801DE0FD                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE101                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE106                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE10A                 lea     rax, CNetworkServerService_OnServerAdvanceTick
+  .text:00000001801DE111                 mov     rcx, rsi
+  .text:00000001801DE114                 mov     [rbp+var_10], rax
+  .text:00000001801DE118                 call    sub_180043D40
+  .text:00000001801DE11D                 mov     r8, rbx
+  .text:00000001801DE120                 mov     [rbp+var_18], rax
+  .text:00000001801DE124                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE128                 mov     rcx, r14
+  .text:00000001801DE12B                 call    sub_18013D2C0
+  .text:00000001801DE130                 lea     rdx, unk_18060DA10
+  .text:00000001801DE137                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE13B                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE140                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE144                 lea     rax, CNetworkServerService_OnServerPollNetworking
+  .text:00000001801DE14B                 mov     rcx, rsi
+  .text:00000001801DE14E                 mov     [rbp+var_10], rax
+  .text:00000001801DE152                 call    sub_180043D40
+  .text:00000001801DE157                 mov     r8, rbx
+  .text:00000001801DE15A                 mov     [rbp+var_18], rax
+  .text:00000001801DE15E                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE162                 mov     rcx, r14
+  .text:00000001801DE165                 call    sub_18013D2C0
+  .text:00000001801DE16A                 lea     rdx, unk_18060D9A0
+  .text:00000001801DE171                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE175                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE17A                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE17E                 lea     rax, CNetworkServerService_OnServerProcessNetworking
+  .text:00000001801DE185                 mov     rcx, rsi
+  .text:00000001801DE188                 mov     [rbp+var_10], rax
+  .text:00000001801DE18C                 call    sub_180043D40
+  .text:00000001801DE191                 mov     r8, rbx
+  .text:00000001801DE194                 mov     [rbp+var_18], rax
+  .text:00000001801DE198                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE19C                 mov     rcx, r14
+  .text:00000001801DE19F                 call    sub_18013D2C0
+  .text:00000001801DE1A4                 lea     rdx, unk_18060DAF0
+  .text:00000001801DE1AB                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE1AF                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE1B4                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE1B8                 lea     rax, CNetworkServerService_OnServerBeginSimulate
+  .text:00000001801DE1BF                 mov     rcx, rsi
+  .text:00000001801DE1C2                 mov     [rbp+var_10], rax
+  .text:00000001801DE1C6                 call    sub_180043D40
+  .text:00000001801DE1CB                 mov     r8, rbx
+  .text:00000001801DE1CE                 mov     [rbp+var_18], rax
+  .text:00000001801DE1D2                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE1D6                 mov     rcx, r14
+  .text:00000001801DE1D9                 call    sub_18013D2C0
+  .text:00000001801DE1DE                 lea     rdx, unk_18060DA80
+  .text:00000001801DE1E5                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE1E9                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE1EE                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE1F2                 lea     rax, CNetworkServerService_OnServerEndSimulate
+  .text:00000001801DE1F9                 mov     rcx, rsi
+  .text:00000001801DE1FC                 mov     [rbp+var_10], rax
+  .text:00000001801DE200                 call    sub_180043D40
+  .text:00000001801DE205                 mov     r8, rbx
+  .text:00000001801DE208                 mov     [rbp+var_18], rax
+  .text:00000001801DE20C                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE210                 mov     rcx, r14
+  .text:00000001801DE213                 call    sub_18013D2C0
+  .text:00000001801DE218                 lea     rdx, unk_18060DBD0
+  .text:00000001801DE21F                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE223                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE228                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE22C                 lea     rax, CNetworkServerService_OnServerPostSimulate
+  .text:00000001801DE233                 mov     rcx, rsi
+  .text:00000001801DE236                 mov     [rbp+var_10], rax
+  .text:00000001801DE23A                 call    sub_180043D40
+  .text:00000001801DE23F                 mov     r8, rbx
+  .text:00000001801DE242                 mov     [rbp+var_18], rax
+  .text:00000001801DE246                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE24A                 mov     rcx, r14
+  .text:00000001801DE24D                 call    sub_18013D2C0
+  .text:00000001801DE252                 lea     rdx, unk_18060D0E0
+  .text:00000001801DE259                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE25D                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE262                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE266                 lea     rax, CNetworkServerService_OnServerPostAdvanceTick
+  .text:00000001801DE26D                 mov     rcx, rsi
+  .text:00000001801DE270                 mov     [rbp+var_10], rax
+  .text:00000001801DE274                 call    sub_180043D40
+  .text:00000001801DE279                 mov     r8, rbx
+  .text:00000001801DE27C                 mov     [rbp+var_18], rax
+  .text:00000001801DE280                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE284                 mov     rcx, r14
+  .text:00000001801DE287                 call    sub_18013D2C0
+  .text:00000001801DE28C                 lea     rdx, unk_18060D230
+  .text:00000001801DE293                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE297                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE29C                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE2A0                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000001801DE2A7                 mov     rcx, rsi
+  .text:00000001801DE2AA                 mov     [rbp+var_10], rax
+  .text:00000001801DE2AE                 call    sub_180043D40
+  .text:00000001801DE2B3                 mov     r8, rbx
+  .text:00000001801DE2B6                 mov     [rbp+var_18], rax
+  .text:00000001801DE2BA                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE2BE                 mov     rcx, r14
+  .text:00000001801DE2C1                 call    sub_18013D2C0
+  .text:00000001801DE2C6                 lea     rdx, unk_18060D4D0
+  .text:00000001801DE2CD                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE2D1                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE2D6                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE2DA                 lea     rax, CNetworkServerService_OnFrameBoundary
+  .text:00000001801DE2E1                 mov     rcx, rsi
+  .text:00000001801DE2E4                 mov     [rbp+var_10], rax
+  .text:00000001801DE2E8                 call    sub_180043D40
+  .text:00000001801DE2ED                 mov     r8, rbx
+  .text:00000001801DE2F0                 mov     [rbp+var_18], rax
+  .text:00000001801DE2F4                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE2F8                 mov     rcx, r14
+  .text:00000001801DE2FB                 call    sub_18013D2C0
+  .text:00000001801DE300                 lea     rdx, unk_18060D850
+  .text:00000001801DE307                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE30B                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE310                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE314                 lea     rax, CNetworkServerService_OnClientPollNetworking
+  .text:00000001801DE31B                 mov     rcx, rsi
+  .text:00000001801DE31E                 mov     [rbp+var_10], rax
+  .text:00000001801DE322                 call    sub_180043D40
+  .text:00000001801DE327                 mov     r8, rbx
+  .text:00000001801DE32A                 mov     [rbp+var_18], rax
+  .text:00000001801DE32E                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE332                 mov     rcx, r14
+  .text:00000001801DE335                 call    sub_18013D2C0
+  .text:00000001801DE33A                 lea     rdx, unk_18060CF90
+  .text:00000001801DE341                 lea     rcx, [rbp+arg_8]
+  .text:00000001801DE345                 call    unknown_libname_12; Microsoft VisualC v7/14 64bit runtime
+  .text:00000001801DE34A                 mov     rbx, [rbp+arg_8]
+  .text:00000001801DE34E                 lea     rax, CNetworkServerService_OnSimpleLoopFrameUpdate
+  .text:00000001801DE355                 mov     rcx, rsi
+  .text:00000001801DE358                 mov     [rbp+var_10], rax
+  .text:00000001801DE35C                 call    sub_180043D40
+  .text:00000001801DE361                 mov     r8, rbx
+  .text:00000001801DE364                 mov     [rbp+var_18], rax
+  .text:00000001801DE368                 lea     rdx, [rbp+var_18]
+  .text:00000001801DE36C                 mov     rcx, r14
+  .text:00000001801DE36F                 call    sub_18013D2C0
+  .text:00000001801DE374                 add     rsp, 58h
+  .text:00000001801DE378                 pop     r14
+  .text:00000001801DE37A                 pop     rsi
+  .text:00000001801DE37B                 pop     rbx
+  .text:00000001801DE37C                 pop     rbp
+  .text:00000001801DE37D                 retn
+  .text:00000001801DE37E                 lea     rcx, dword_1809114B8
+  .text:00000001801DE385                 call    sub_180424408
+  .text:00000001801DE38A                 cmp     cs:dword_1809114B8, 0FFFFFFFFh
+  .text:00000001801DE391                 jnz     loc_1801DDB19
+  .text:00000001801DE397                 lea     r9, aOnserveradvanc; "OnServerAdvanceTick"
+  .text:00000001801DE39E                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE3A5                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE3AC                 lea     rcx, unk_1809114C0
+  .text:00000001801DE3B3                 call    sub_1800249B0
+  .text:00000001801DE3B8                 ; void (__cdecl *)()
+  .text:00000001801DE3B8                 lea     rcx, sub_18047B6F0; void (__cdecl *)()
+  .text:00000001801DE3BF                 call    atexit
+  .text:00000001801DE3C4                 lea     rcx, dword_1809114B8
+  .text:00000001801DE3CB                 call    sub_18042439C
+  .text:00000001801DE3D0                 jmp     loc_1801DDB19
+  .text:00000001801DE3D5                 lea     rcx, dword_1809115C8
+  .text:00000001801DE3DC                 call    sub_180424408
+  .text:00000001801DE3E1                 cmp     cs:dword_1809115C8, 0FFFFFFFFh
+  .text:00000001801DE3E8                 jnz     loc_1801DDBA7
+  .text:00000001801DE3EE                 lea     r9, aOnserverpollne; "OnServerPollNetworking"
+  .text:00000001801DE3F5                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE3FC                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE403                 lea     rcx, unk_1809115D0
+  .text:00000001801DE40A                 call    sub_1800249B0
+  .text:00000001801DE40F                 ; void (__cdecl *)()
+  .text:00000001801DE40F                 lea     rcx, sub_18047B6E0; void (__cdecl *)()
+  .text:00000001801DE416                 call    atexit
+  .text:00000001801DE41B                 lea     rcx, dword_1809115C8
+  .text:00000001801DE422                 call    sub_18042439C
+  .text:00000001801DE427                 jmp     loc_1801DDBA7
+  .text:00000001801DE42C                 lea     rcx, dword_1809116D8
+  .text:00000001801DE433                 call    sub_180424408
+  .text:00000001801DE438                 cmp     cs:dword_1809116D8, 0FFFFFFFFh
+  .text:00000001801DE43F                 jnz     loc_1801DDC2B
+  .text:00000001801DE445                 lea     r9, aOnserverproces; "OnServerProcessNetworking"
+  .text:00000001801DE44C                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE453                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE45A                 lea     rcx, unk_1809116E0
+  .text:00000001801DE461                 call    sub_1800249B0
+  .text:00000001801DE466                 ; void (__cdecl *)()
+  .text:00000001801DE466                 lea     rcx, sub_18047B6D0; void (__cdecl *)()
+  .text:00000001801DE46D                 call    atexit
+  .text:00000001801DE472                 lea     rcx, dword_1809116D8
+  .text:00000001801DE479                 call    sub_18042439C
+  .text:00000001801DE47E                 jmp     loc_1801DDC2B
+  .text:00000001801DE483                 lea     rcx, dword_1809117E8
+  .text:00000001801DE48A                 call    sub_180424408
+  .text:00000001801DE48F                 cmp     cs:dword_1809117E8, 0FFFFFFFFh
+  .text:00000001801DE496                 jnz     loc_1801DDCAF
+  .text:00000001801DE49C                 lea     r9, aOnserverbegins; "OnServerBeginSimulate"
+  .text:00000001801DE4A3                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE4AA                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE4B1                 lea     rcx, unk_1809117F0
+  .text:00000001801DE4B8                 call    sub_1800249B0
+  .text:00000001801DE4BD                 ; void (__cdecl *)()
+  .text:00000001801DE4BD                 lea     rcx, sub_18047B6C0; void (__cdecl *)()
+  .text:00000001801DE4C4                 call    atexit
+  .text:00000001801DE4C9                 lea     rcx, dword_1809117E8
+  .text:00000001801DE4D0                 call    sub_18042439C
+  .text:00000001801DE4D5                 jmp     loc_1801DDCAF
+  .text:00000001801DE4DA                 lea     rcx, dword_1809118F8
+  .text:00000001801DE4E1                 call    sub_180424408
+  .text:00000001801DE4E6                 cmp     cs:dword_1809118F8, 0FFFFFFFFh
+  .text:00000001801DE4ED                 jnz     loc_1801DDD36
+  .text:00000001801DE4F3                 lea     r9, aOnserverendsim; "OnServerEndSimulate"
+  .text:00000001801DE4FA                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE501                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE508                 lea     rcx, unk_180911900
+  .text:00000001801DE50F                 call    sub_1800249B0
+  .text:00000001801DE514                 ; void (__cdecl *)()
+  .text:00000001801DE514                 lea     rcx, sub_18047B6B0; void (__cdecl *)()
+  .text:00000001801DE51B                 call    atexit
+  .text:00000001801DE520                 lea     rcx, dword_1809118F8
+  .text:00000001801DE527                 call    sub_18042439C
+  .text:00000001801DE52C                 jmp     loc_1801DDD36
+  .text:00000001801DE531                 lea     rcx, dword_180911A08
+  .text:00000001801DE538                 call    sub_180424408
+  .text:00000001801DE53D                 cmp     cs:dword_180911A08, 0FFFFFFFFh
+  .text:00000001801DE544                 jnz     loc_1801DDDBD
+  .text:00000001801DE54A                 lea     r9, aOnserverpostsi; "OnServerPostSimulate"
+  .text:00000001801DE551                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE558                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE55F                 lea     rcx, unk_180911A10
+  .text:00000001801DE566                 call    sub_1800249B0
+  .text:00000001801DE56B                 ; void (__cdecl *)()
+  .text:00000001801DE56B                 lea     rcx, sub_18047B6A0; void (__cdecl *)()
+  .text:00000001801DE572                 call    atexit
+  .text:00000001801DE577                 lea     rcx, dword_180911A08
+  .text:00000001801DE57E                 call    sub_18042439C
+  .text:00000001801DE583                 jmp     loc_1801DDDBD
+  .text:00000001801DE588                 lea     rcx, dword_180911B18
+  .text:00000001801DE58F                 call    sub_180424408
+  .text:00000001801DE594                 cmp     cs:dword_180911B18, 0FFFFFFFFh
+  .text:00000001801DE59B                 jnz     loc_1801DDE41
+  .text:00000001801DE5A1                 lea     r9, aOnserverpostad; "OnServerPostAdvanceTick"
+  .text:00000001801DE5A8                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE5AF                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE5B6                 lea     rcx, unk_180911B20
+  .text:00000001801DE5BD                 call    sub_1800249B0
+  .text:00000001801DE5C2                 ; void (__cdecl *)()
+  .text:00000001801DE5C2                 lea     rcx, sub_18047B690; void (__cdecl *)()
+  .text:00000001801DE5C9                 call    atexit
+  .text:00000001801DE5CE                 lea     rcx, dword_180911B18
+  .text:00000001801DE5D5                 call    sub_18042439C
+  .text:00000001801DE5DA                 jmp     loc_1801DDE41
+  .text:00000001801DE5DF                 lea     rcx, dword_180911C28
+  .text:00000001801DE5E6                 call    sub_180424408
+  .text:00000001801DE5EB                 cmp     cs:dword_180911C28, 0FFFFFFFFh
+  .text:00000001801DE5F2                 jnz     loc_1801DDEC8
+  .text:00000001801DE5F8                 lea     r9, aOnserverbegina; "OnServerBeginAsyncPostTickWork"
+  .text:00000001801DE5FF                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE606                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE60D                 lea     rcx, unk_180911C30
+  .text:00000001801DE614                 call    sub_1800249B0
+  .text:00000001801DE619                 ; void (__cdecl *)()
+  .text:00000001801DE619                 lea     rcx, sub_18047B680; void (__cdecl *)()
+  .text:00000001801DE620                 call    atexit
+  .text:00000001801DE625                 lea     rcx, dword_180911C28
+  .text:00000001801DE62C                 call    sub_18042439C
+  .text:00000001801DE631                 jmp     loc_1801DDEC8
+  .text:00000001801DE636                 lea     rcx, dword_180911D38
+  .text:00000001801DE63D                 call    sub_180424408
+  .text:00000001801DE642                 cmp     cs:dword_180911D38, 0FFFFFFFFh
+  .text:00000001801DE649                 jnz     loc_1801DDF4F
+  .text:00000001801DE64F                 lea     r9, aOnframeboundar; "OnFrameBoundary"
+  .text:00000001801DE656                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE65D                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE664                 lea     rcx, unk_180911D40
+  .text:00000001801DE66B                 call    sub_1800249B0
+  .text:00000001801DE670                 ; void (__cdecl *)()
+  .text:00000001801DE670                 lea     rcx, sub_18047B670; void (__cdecl *)()
+  .text:00000001801DE677                 call    atexit
+  .text:00000001801DE67C                 lea     rcx, dword_180911D38
+  .text:00000001801DE683                 call    sub_18042439C
+  .text:00000001801DE688                 jmp     loc_1801DDF4F
+  .text:00000001801DE68D                 lea     rcx, dword_180911E48
+  .text:00000001801DE694                 call    sub_180424408
+  .text:00000001801DE699                 cmp     cs:dword_180911E48, 0FFFFFFFFh
+  .text:00000001801DE6A0                 jnz     loc_1801DDFD6
+  .text:00000001801DE6A6                 lea     r9, aOnclientpollne; "OnClientPollNetworking"
+  .text:00000001801DE6AD                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE6B4                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE6BB                 lea     rcx, unk_180911E50
+  .text:00000001801DE6C2                 call    sub_1800249B0
+  .text:00000001801DE6C7                 ; void (__cdecl *)()
+  .text:00000001801DE6C7                 lea     rcx, sub_18047B660; void (__cdecl *)()
+  .text:00000001801DE6CE                 call    atexit
+  .text:00000001801DE6D3                 lea     rcx, dword_180911E48
+  .text:00000001801DE6DA                 call    sub_18042439C
+  .text:00000001801DE6DF                 jmp     loc_1801DDFD6
+  .text:00000001801DE6E4                 lea     rcx, dword_180911F58
+  .text:00000001801DE6EB                 call    sub_180424408
+  .text:00000001801DE6F0                 cmp     cs:dword_180911F58, 0FFFFFFFFh
+  .text:00000001801DE6F7                 jnz     loc_1801DE06A
+  .text:00000001801DE6FD                 lea     r9, aOnsimpleloopfr; "OnSimpleLoopFrameUpdate"
+  .text:00000001801DE704                 lea     r8, aCnetworkserver; "CNetworkServerService"
+  .text:00000001801DE70B                 lea     rdx, aSS_5; "%s::%s"
+  .text:00000001801DE712                 lea     rcx, unk_180911F60
+  .text:00000001801DE719                 call    sub_1800249B0
+  .text:00000001801DE71E                 ; void (__cdecl *)()
+  .text:00000001801DE71E                 lea     rcx, sub_18047B650; void (__cdecl *)()
+  .text:00000001801DE725                 call    atexit
+  .text:00000001801DE72A                 lea     rcx, dword_180911F58
+  .text:00000001801DE731                 call    sub_18042439C
+  .text:00000001801DE736                 jmp     loc_1801DE06A
 procedure: |-
-  void __fastcall CNetworkServerService_RegisterEventMapInternal(__int64 a1, __int64 a2, int a3, __int64 a4)
+  __int64 __fastcall CNetworkServerService_RegisterEventMapInternal(__int64 a1, __int64 a2, int a3, __int64 a4)
   {
     _DWORD *v6; // r15
     char *v7; // rdi
     __int64 v8; // rbx
     char *v9; // r12
-    __int64 v10; // rdx
-    __int64 v11; // r8
-    __int64 v12; // r9
-    __int64 v13; // rbx
-    char *v14; // r12
-    __int64 v15; // rdx
-    __int64 v16; // r8
-    __int64 v17; // r9
-    __int64 v18; // rbx
-    char *v19; // r12
-    __int64 v20; // rdx
-    __int64 v21; // r8
-    __int64 v22; // r9
-    __int64 v23; // rbx
-    char *v24; // r12
+    int v10; // r9d
+    __int64 v11; // rdx
+    __int64 v12; // r8
+    __int64 v13; // r9
+    __int64 v14; // rbx
+    char *v15; // r12
+    __int64 v16; // rax
+    int v17; // r9d
+    __int64 v18; // rdx
+    __int64 v19; // r8
+    __int64 v20; // r9
+    __int64 v21; // rbx
+    char *v22; // r12
+    __int64 v23; // rax
+    int v24; // r9d
     __int64 v25; // rdx
     __int64 v26; // r8
     __int64 v27; // r9
     __int64 v28; // rbx
     char *v29; // r12
-    __int64 v30; // rdx
-    __int64 v31; // r8
-    __int64 v32; // r9
-    __int64 v33; // rbx
-    char *v34; // r12
-    __int64 v35; // rdx
-    __int64 v36; // r8
-    __int64 v37; // r9
-    __int64 v38; // rbx
-    char *v39; // r12
-    __int64 v40; // rdx
-    __int64 v41; // r8
-    __int64 v42; // r9
-    __int64 v43; // rbx
-    char *v44; // r12
-    __int64 v45; // rdx
-    __int64 v46; // r8
-    __int64 v47; // r9
-    __int64 v48; // rbx
-    char *v49; // r12
-    __int64 v50; // rdx
-    __int64 v51; // r8
-    __int64 v52; // r9
-    __int64 v53; // rbx
-    char *v54; // r12
-    __int64 v55; // rdx
-    __int64 v56; // r8
-    __int64 v57; // r9
-    __int64 v58; // rbx
-    __int64 v59; // rbx
-    __int64 v60; // rbx
-    __int64 v61; // rbx
-    __int64 v62; // rbx
+    __int64 v30; // rax
+    int v31; // r9d
+    __int64 v32; // rdx
+    __int64 v33; // r8
+    __int64 v34; // r9
+    __int64 v35; // rbx
+    char *v36; // r12
+    __int64 v37; // rax
+    int v38; // r9d
+    __int64 v39; // rdx
+    __int64 v40; // r8
+    __int64 v41; // r9
+    __int64 v42; // rbx
+    char *v43; // r12
+    __int64 v44; // rax
+    int v45; // r9d
+    __int64 v46; // rdx
+    __int64 v47; // r8
+    __int64 v48; // r9
+    __int64 v49; // rbx
+    char *v50; // r12
+    __int64 v51; // rax
+    int v52; // r9d
+    __int64 v53; // rdx
+    __int64 v54; // r8
+    __int64 v55; // r9
+    __int64 v56; // rbx
+    char *v57; // r12
+    __int64 v58; // rax
+    int v59; // r9d
+    __int64 v60; // rdx
+    __int64 v61; // r8
+    __int64 v62; // r9
     __int64 v63; // rbx
-    __int64 v64; // rbx
-    __int64 v65; // rbx
-    __int64 v66; // rbx
-    __int64 v67; // rbx
-    __int64 v68; // rbx
-    __int64 v69; // rbx
-    __int64 v70; // [rsp+40h] [rbp-18h] BYREF
-    __int64 (__fastcall *v71)(); // [rsp+48h] [rbp-10h]
-    __int64 v72; // [rsp+88h] [rbp+30h] BYREF
+    char *v64; // r12
+    __int64 v65; // rax
+    int v66; // r9d
+    __int64 v67; // rdx
+    __int64 v68; // r8
+    __int64 v69; // r9
+    __int64 v70; // rbx
+    char *v71; // r12
+    __int64 v72; // rax
+    int v73; // r9d
+    __int64 v74; // rdx
+    __int64 v75; // r8
+    __int64 v76; // r9
+    __int64 v77; // rbx
+    __int64 v78; // rax
+    int v79; // r9d
+    __int64 v81; // rbx
+    __int64 v82; // rbx
+    __int64 v83; // rbx
+    __int64 v84; // rbx
+    __int64 v85; // rbx
+    __int64 v86; // rbx
+    __int64 v87; // rbx
+    __int64 v88; // rbx
+    __int64 v89; // rbx
+    __int64 v90; // rbx
+    __int64 v91; // rbx
+    __int64 v92; // [rsp+40h] [rbp-18h] BYREF
+    __int64 (__fastcall *v93)(); // [rsp+48h] [rbp-10h]
+    __int64 v94; // [rsp+88h] [rbp+30h] BYREF
 
     if ( a3 )
     {
-      unknown_libname_11(&v72, &qword_18060F400);
-      v59 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v59);
-      unknown_libname_11(&v72, &qword_18060E7C0);
-      v60 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v60);
-      unknown_libname_11(&v72, &qword_18060E830);
-      v61 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v61);
-      unknown_libname_11(&v72, &qword_18060E8A0);
-      v62 = v72;
-      v71 = CNetworkServerService_OnServerBeginSimulate;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v62);
-      unknown_libname_11(&v72, &qword_18060E910);
-      v63 = v72;
-      v71 = sub_1801EAC20; // = CNetworkServerService_OnServerEndSimulate (not a requested target)
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v63);
-      unknown_libname_11(&v72, &qword_18060E600);
-      v64 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v64);
-      unknown_libname_11(&v72, &qword_18060F470);
-      v65 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v65);
-      unknown_libname_11(&v72, &qword_18060F160);
-      v66 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v66);
-      unknown_libname_11(&v72, &qword_18060ED00);
-      v67 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v67);
-      unknown_libname_11(&v72, &qword_18060EFA0);
-      v68 = v72;
-      v71 = CNetworkServerService_OnClientPollNetworking;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v68);
-      unknown_libname_11(&v72, &qword_18060F5C0);
-      v69 = v72;
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
-      v70 = sub_180046DE0(a2);
-      UnregisterEventListener_Abstract(a1, &v70, v69);
+      unknown_libname_12(&v94, &unk_18060D150);
+      v81 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v81);
+      unknown_libname_12(&v94, &unk_18060DA10);
+      v82 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v82);
+      unknown_libname_12(&v94, &unk_18060D9A0);
+      v83 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v83);
+      unknown_libname_12(&v94, &unk_18060DAF0);
+      v84 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginSimulate;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v84);
+      unknown_libname_12(&v94, &unk_18060DA80);
+      v85 = v94;
+      v93 = CNetworkServerService_OnServerEndSimulate;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v85);
+      unknown_libname_12(&v94, &unk_18060DBD0);
+      v86 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v86);
+      unknown_libname_12(&v94, &unk_18060D0E0);
+      v87 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v87);
+      unknown_libname_12(&v94, &unk_18060D230);
+      v88 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v88);
+      unknown_libname_12(&v94, &unk_18060D4D0);
+      v89 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v89);
+      unknown_libname_12(&v94, &unk_18060D850);
+      v90 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnClientPollNetworking;
+      v92 = sub_180043D40(a2);
+      sub_18013D2C0(a1, &v92, v90);
+      unknown_libname_12(&v94, &unk_18060CF90);
+      v91 = v94;
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
+      v92 = sub_180043D40(a2);
+      return sub_18013D2C0(a1, &v92, v91);
     }
     else
     {
       v6 = (_DWORD *)(*((_QWORD *)NtCurrentTeb()->ThreadLocalStoragePointer + (unsigned int)TlsIndex) + 104LL);
-      if ( dword_180910888 > *v6 )
+      if ( dword_1809114B8 > *v6 )
       {
-        sub_180422B18(&dword_180910888, a2, (unsigned int)TlsIndex, a4);
-        if ( dword_180910888 == -1 )
+        sub_180424408(&dword_1809114B8, a2, (unsigned int)TlsIndex, a4);
+        if ( dword_1809114B8 == -1 )
         {
-          sub_180025170((__int64)&unk_180910890, "%s::%s", "CNetworkServerService", "OnServerAdvanceTick");
-          atexit(sub_18047D0C0);
-          sub_180422AAC(&dword_180910888);
+          sub_1800249B0(&unk_1809114C0, "%s::%s", "CNetworkServerService", "OnServerAdvanceTick");
+          atexit(sub_18047B6F0);
+          sub_18042439C(&dword_1809114B8);
         }
       }
-      unknown_libname_11(&v72, &qword_18060F400);
-      v7 = (char *)&unk_1805262BF;
-      v8 = v72;
-      if ( (qword_180910894 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D150);
+      v7 = (char *)&unk_180524F9F;
+      v8 = v94;
+      if ( (qword_1809114C4 & 0x40000000) != 0 )
       {
-        v9 = (char *)&qword_180910894 + 4;
+        v9 = (char *)&qword_1809114C4 + 4;
       }
       else
       {
-        v9 = (char *)&unk_1805262BF;
-        if ( (qword_180910894 & 0x3FFFFFFF) != 0 )
-          v9 = *(char **)((char *)&qword_180910894 + 4);
+        v9 = (char *)&unk_180524F9F;
+        if ( (qword_1809114C4 & 0x3FFFFFFF) != 0 )
+          v9 = *(char **)((char *)&qword_1809114C4 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v8, 0, (__int64)v9);
-      if ( dword_180910998 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerAdvanceTick;
+      v92 = sub_180043D40(a2);
+      LOBYTE(v10) = 1;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v10, v8, 0, (__int64)v9);
+      if ( dword_1809115C8 > *v6 )
       {
-        sub_180422B18(&dword_180910998, v10, v11, v12);
-        if ( dword_180910998 == -1 )
+        sub_180424408(&dword_1809115C8, v11, v12, v13);
+        if ( dword_1809115C8 == -1 )
         {
-          sub_180025170((__int64)&unk_1809109A0, "%s::%s", "CNetworkServerService", "OnServerPollNetworking");
-          atexit(sub_18047D0B0);
-          sub_180422AAC(&dword_180910998);
+          sub_1800249B0(&unk_1809115D0, "%s::%s", "CNetworkServerService", "OnServerPollNetworking");
+          atexit(sub_18047B6E0);
+          sub_18042439C(&dword_1809115C8);
         }
       }
-      unknown_libname_11(&v72, &qword_18060E7C0);
-      v13 = v72;
-      if ( (qword_1809109A4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060DA10);
+      v14 = v94;
+      if ( (qword_1809115D4 & 0x40000000) != 0 )
       {
-        v14 = (char *)&qword_1809109A4 + 4;
+        v15 = (char *)&qword_1809115D4 + 4;
       }
       else
       {
-        v14 = (char *)&unk_1805262BF;
-        if ( (qword_1809109A4 & 0x3FFFFFFF) != 0 )
-          v14 = *(char **)((char *)&qword_1809109A4 + 4);
+        v15 = (char *)&unk_180524F9F;
+        if ( (qword_1809115D4 & 0x3FFFFFFF) != 0 )
+          v15 = *(char **)((char *)&qword_1809115D4 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v13, 0, (__int64)v14);
-      if ( dword_180910AA8 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPollNetworking;
+      v16 = sub_180043D40(a2);
+      LOBYTE(v17) = 1;
+      v92 = v16;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v17, v14, 0, (__int64)v15);
+      if ( dword_1809116D8 > *v6 )
       {
-        sub_180422B18(&dword_180910AA8, v15, v16, v17);
-        if ( dword_180910AA8 == -1 )
+        sub_180424408(&dword_1809116D8, v18, v19, v20);
+        if ( dword_1809116D8 == -1 )
         {
-          sub_180025170((__int64)&unk_180910AB0, "%s::%s", "CNetworkServerService", "OnServerProcessNetworking");
-          atexit(sub_18047D0A0);
-          sub_180422AAC(&dword_180910AA8);
+          sub_1800249B0(&unk_1809116E0, "%s::%s", "CNetworkServerService", "OnServerProcessNetworking");
+          atexit(sub_18047B6D0);
+          sub_18042439C(&dword_1809116D8);
         }
       }
-      unknown_libname_11(&v72, &qword_18060E830);
-      v18 = v72;
-      if ( (qword_180910AB4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D9A0);
+      v21 = v94;
+      if ( (qword_1809116E4 & 0x40000000) != 0 )
       {
-        v19 = (char *)&qword_180910AB4 + 4;
+        v22 = (char *)&qword_1809116E4 + 4;
       }
       else
       {
-        v19 = (char *)&unk_1805262BF;
-        if ( (qword_180910AB4 & 0x3FFFFFFF) != 0 )
-          v19 = *(char **)((char *)&qword_180910AB4 + 4);
+        v22 = (char *)&unk_180524F9F;
+        if ( (qword_1809116E4 & 0x3FFFFFFF) != 0 )
+          v22 = *(char **)((char *)&qword_1809116E4 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v18, 0, (__int64)v19);
-      if ( dword_180910BB8 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerProcessNetworking;
+      v23 = sub_180043D40(a2);
+      LOBYTE(v24) = 1;
+      v92 = v23;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v24, v21, 0, (__int64)v22);
+      if ( dword_1809117E8 > *v6 )
       {
-        sub_180422B18(&dword_180910BB8, v20, v21, v22);
-        if ( dword_180910BB8 == -1 )
+        sub_180424408(&dword_1809117E8, v25, v26, v27);
+        if ( dword_1809117E8 == -1 )
         {
-          sub_180025170((__int64)&unk_180910BC0, "%s::%s", "CNetworkServerService", "OnServerBeginSimulate");
-          atexit(sub_18047D090);
-          sub_180422AAC(&dword_180910BB8);
+          sub_1800249B0(&unk_1809117F0, "%s::%s", "CNetworkServerService", "OnServerBeginSimulate");
+          atexit(sub_18047B6C0);
+          sub_18042439C(&dword_1809117E8);
         }
       }
-      unknown_libname_11(&v72, &qword_18060E8A0);
-      v23 = v72;
-      if ( (qword_180910BC4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060DAF0);
+      v28 = v94;
+      if ( (qword_1809117F4 & 0x40000000) != 0 )
       {
-        v24 = (char *)&qword_180910BC4 + 4;
+        v29 = (char *)&qword_1809117F4 + 4;
       }
       else
       {
-        v24 = (char *)&unk_1805262BF;
-        if ( (qword_180910BC4 & 0x3FFFFFFF) != 0 )
-          v24 = *(char **)((char *)&qword_180910BC4 + 4);
+        v29 = (char *)&unk_180524F9F;
+        if ( (qword_1809117F4 & 0x3FFFFFFF) != 0 )
+          v29 = *(char **)((char *)&qword_1809117F4 + 4);
       }
-      v71 = CNetworkServerService_OnServerBeginSimulate;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v23, 0x80000000, (__int64)v24);
-      if ( dword_180910CC8 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerBeginSimulate;
+      v30 = sub_180043D40(a2);
+      LOBYTE(v31) = 1;
+      v92 = v30;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v31, v28, 0x80000000, (__int64)v29);
+      if ( dword_1809118F8 > *v6 )
       {
-        sub_180422B18(&dword_180910CC8, v25, v26, v27);
-        if ( dword_180910CC8 == -1 )
+        sub_180424408(&dword_1809118F8, v32, v33, v34);
+        if ( dword_1809118F8 == -1 )
         {
-          sub_180025170((__int64)&unk_180910CD0, "%s::%s", "CNetworkServerService", "OnServerEndSimulate");
-          atexit(sub_18047D080);
-          sub_180422AAC(&dword_180910CC8);
+          sub_1800249B0(&unk_180911900, "%s::%s", "CNetworkServerService", "OnServerEndSimulate");
+          atexit(sub_18047B6B0);
+          sub_18042439C(&dword_1809118F8);
         }
       }
-      unknown_libname_11(&v72, &qword_18060E910);
-      v28 = v72;
-      if ( (qword_180910CD4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060DA80);
+      v35 = v94;
+      if ( (qword_180911904 & 0x40000000) != 0 )
       {
-        v29 = (char *)&qword_180910CD4 + 4;
+        v36 = (char *)&qword_180911904 + 4;
       }
       else
       {
-        v29 = (char *)&unk_1805262BF;
-        if ( (qword_180910CD4 & 0x3FFFFFFF) != 0 )
-          v29 = *(char **)((char *)&qword_180910CD4 + 4);
+        v36 = (char *)&unk_180524F9F;
+        if ( (qword_180911904 & 0x3FFFFFFF) != 0 )
+          v36 = *(char **)((char *)&qword_180911904 + 4);
       }
-      v71 = sub_1801EAC20; // = CNetworkServerService_OnServerEndSimulate (not a requested target)
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v28, 0x7FFFFFFF, (__int64)v29);
-      if ( dword_180910DD8 > *v6 )
+      v93 = CNetworkServerService_OnServerEndSimulate;
+      v37 = sub_180043D40(a2);
+      LOBYTE(v38) = 1;
+      v92 = v37;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v38, v35, 0x7FFFFFFF, (__int64)v36);
+      if ( dword_180911A08 > *v6 )
       {
-        sub_180422B18(&dword_180910DD8, v30, v31, v32);
-        if ( dword_180910DD8 == -1 )
+        sub_180424408(&dword_180911A08, v39, v40, v41);
+        if ( dword_180911A08 == -1 )
         {
-          sub_180025170((__int64)&unk_180910DE0, "%s::%s", "CNetworkServerService", "OnServerPostSimulate");
-          atexit(sub_18047D070);
-          sub_180422AAC(&dword_180910DD8);
+          sub_1800249B0(&unk_180911A10, "%s::%s", "CNetworkServerService", "OnServerPostSimulate");
+          atexit(sub_18047B6A0);
+          sub_18042439C(&dword_180911A08);
         }
       }
-      unknown_libname_11(&v72, &qword_18060E600);
-      v33 = v72;
-      if ( (qword_180910DE4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060DBD0);
+      v42 = v94;
+      if ( (qword_180911A14 & 0x40000000) != 0 )
       {
-        v34 = (char *)&qword_180910DE4 + 4;
+        v43 = (char *)&qword_180911A14 + 4;
       }
       else
       {
-        v34 = (char *)&unk_1805262BF;
-        if ( (qword_180910DE4 & 0x3FFFFFFF) != 0 )
-          v34 = *(char **)((char *)&qword_180910DE4 + 4);
+        v43 = (char *)&unk_180524F9F;
+        if ( (qword_180911A14 & 0x3FFFFFFF) != 0 )
+          v43 = *(char **)((char *)&qword_180911A14 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v33, 0, (__int64)v34);
-      if ( dword_180910EE8 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostSimulate;
+      v44 = sub_180043D40(a2);
+      LOBYTE(v45) = 1;
+      v92 = v44;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v45, v42, 0, (__int64)v43);
+      if ( dword_180911B18 > *v6 )
       {
-        sub_180422B18(&dword_180910EE8, v35, v36, v37);
-        if ( dword_180910EE8 == -1 )
+        sub_180424408(&dword_180911B18, v46, v47, v48);
+        if ( dword_180911B18 == -1 )
         {
-          sub_180025170((__int64)&unk_180910EF0, "%s::%s", "CNetworkServerService", "OnServerPostAdvanceTick");
-          atexit(sub_18047D060);
-          sub_180422AAC(&dword_180910EE8);
+          sub_1800249B0(&unk_180911B20, "%s::%s", "CNetworkServerService", "OnServerPostAdvanceTick");
+          atexit(sub_18047B690);
+          sub_18042439C(&dword_180911B18);
         }
       }
-      unknown_libname_11(&v72, &qword_18060F470);
-      v38 = v72;
-      if ( (qword_180910EF4 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D0E0);
+      v49 = v94;
+      if ( (qword_180911B24 & 0x40000000) != 0 )
       {
-        v39 = (char *)&qword_180910EF4 + 4;
+        v50 = (char *)&qword_180911B24 + 4;
       }
       else
       {
-        v39 = (char *)&unk_1805262BF;
-        if ( (qword_180910EF4 & 0x3FFFFFFF) != 0 )
-          v39 = *(char **)((char *)&qword_180910EF4 + 4);
+        v50 = (char *)&unk_180524F9F;
+        if ( (qword_180911B24 & 0x3FFFFFFF) != 0 )
+          v50 = *(char **)((char *)&qword_180911B24 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v38, 0x80000000, (__int64)v39);
-      if ( dword_180910FF8 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnServerPostAdvanceTick;
+      v51 = sub_180043D40(a2);
+      LOBYTE(v52) = 1;
+      v92 = v51;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v52, v49, 0x80000000, (__int64)v50);
+      if ( dword_180911C28 > *v6 )
       {
-        sub_180422B18(&dword_180910FF8, v40, v41, v42);
-        if ( dword_180910FF8 == -1 )
+        sub_180424408(&dword_180911C28, v53, v54, v55);
+        if ( dword_180911C28 == -1 )
         {
-          sub_180025170((__int64)&unk_180911000, "%s::%s", "CNetworkServerService", "OnServerBeginAsyncPostTickWork");
-          atexit(sub_18047D050);
-          sub_180422AAC(&dword_180910FF8);
+          sub_1800249B0(&unk_180911C30, "%s::%s", "CNetworkServerService", "OnServerBeginAsyncPostTickWork");
+          atexit(sub_18047B680);
+          sub_18042439C(&dword_180911C28);
         }
       }
-      unknown_libname_11(&v72, &qword_18060F160);
-      v43 = v72;
-      if ( (qword_180911004 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D230);
+      v56 = v94;
+      if ( (qword_180911C34 & 0x40000000) != 0 )
       {
-        v44 = (char *)&qword_180911004 + 4;
+        v57 = (char *)&qword_180911C34 + 4;
       }
       else
       {
-        v44 = (char *)&unk_1805262BF;
-        if ( (qword_180911004 & 0x3FFFFFFF) != 0 )
-          v44 = *(char **)((char *)&qword_180911004 + 4);
+        v57 = (char *)&unk_180524F9F;
+        if ( (qword_180911C34 & 0x3FFFFFFF) != 0 )
+          v57 = *(char **)((char *)&qword_180911C34 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v43, 0x80000000, (__int64)v44);
-      if ( dword_180911108 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      v58 = sub_180043D40(a2);
+      LOBYTE(v59) = 1;
+      v92 = v58;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v59, v56, 0x80000000, (__int64)v57);
+      if ( dword_180911D38 > *v6 )
       {
-        sub_180422B18(&dword_180911108, v45, v46, v47);
-        if ( dword_180911108 == -1 )
+        sub_180424408(&dword_180911D38, v60, v61, v62);
+        if ( dword_180911D38 == -1 )
         {
-          sub_180025170((__int64)&unk_180911110, "%s::%s", "CNetworkServerService", "OnFrameBoundary");
-          atexit(sub_18047D040);
-          sub_180422AAC(&dword_180911108);
+          sub_1800249B0(&unk_180911D40, "%s::%s", "CNetworkServerService", "OnFrameBoundary");
+          atexit(sub_18047B670);
+          sub_18042439C(&dword_180911D38);
         }
       }
-      unknown_libname_11(&v72, &qword_18060ED00);
-      v48 = v72;
-      if ( (qword_180911114 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D4D0);
+      v63 = v94;
+      if ( (qword_180911D44 & 0x40000000) != 0 )
       {
-        v49 = (char *)&qword_180911114 + 4;
+        v64 = (char *)&qword_180911D44 + 4;
       }
       else
       {
-        v49 = (char *)&unk_1805262BF;
-        if ( (qword_180911114 & 0x3FFFFFFF) != 0 )
-          v49 = *(char **)((char *)&qword_180911114 + 4);
+        v64 = (char *)&unk_180524F9F;
+        if ( (qword_180911D44 & 0x3FFFFFFF) != 0 )
+          v64 = *(char **)((char *)&qword_180911D44 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v48, 0x7FFFFFFF, (__int64)v49);
-      if ( dword_180911218 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnFrameBoundary;
+      v65 = sub_180043D40(a2);
+      LOBYTE(v66) = 1;
+      v92 = v65;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v66, v63, 0x7FFFFFFF, (__int64)v64);
+      if ( dword_180911E48 > *v6 )
       {
-        sub_180422B18(&dword_180911218, v50, v51, v52);
-        if ( dword_180911218 == -1 )
+        sub_180424408(&dword_180911E48, v67, v68, v69);
+        if ( dword_180911E48 == -1 )
         {
-          sub_180025170((__int64)&unk_180911220, "%s::%s", "CNetworkServerService", "OnClientPollNetworking");
-          atexit(sub_18047D030);
-          sub_180422AAC(&dword_180911218);
+          sub_1800249B0(&unk_180911E50, "%s::%s", "CNetworkServerService", "OnClientPollNetworking");
+          atexit(sub_18047B660);
+          sub_18042439C(&dword_180911E48);
         }
       }
-      unknown_libname_11(&v72, &qword_18060EFA0);
-      v53 = v72;
-      if ( (qword_180911224 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060D850);
+      v70 = v94;
+      if ( (qword_180911E54 & 0x40000000) != 0 )
       {
-        v54 = (char *)&qword_180911224 + 4;
+        v71 = (char *)&qword_180911E54 + 4;
       }
       else
       {
-        v54 = (char *)&unk_1805262BF;
-        if ( (qword_180911224 & 0x3FFFFFFF) != 0 )
-          v54 = *(char **)((char *)&qword_180911224 + 4);
+        v71 = (char *)&unk_180524F9F;
+        if ( (qword_180911E54 & 0x3FFFFFFF) != 0 )
+          v71 = *(char **)((char *)&qword_180911E54 + 4);
       }
-      v71 = CNetworkServerService_OnClientPollNetworking;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v53, 1, (__int64)v54);
-      if ( dword_180911328 > *v6 )
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnClientPollNetworking;
+      v72 = sub_180043D40(a2);
+      LOBYTE(v73) = 1;
+      v92 = v72;
+      sub_18013D400(a1, (unsigned int)&v92, 1, v73, v70, 1, (__int64)v71);
+      if ( dword_180911F58 > *v6 )
       {
-        sub_180422B18(&dword_180911328, v55, v56, v57);
-        if ( dword_180911328 == -1 )
+        sub_180424408(&dword_180911F58, v74, v75, v76);
+        if ( dword_180911F58 == -1 )
         {
-          sub_180025170((__int64)&unk_180911330, "%s::%s", "CNetworkServerService", "OnSimpleLoopFrameUpdate");
-          atexit(sub_18047D020);
-          sub_180422AAC(&dword_180911328);
+          sub_1800249B0(&unk_180911F60, "%s::%s", "CNetworkServerService", "OnSimpleLoopFrameUpdate");
+          atexit(sub_18047B650);
+          sub_18042439C(&dword_180911F58);
         }
       }
-      unknown_libname_11(&v72, &qword_18060F5C0);
-      v58 = v72;
-      if ( (qword_180911334 & 0x40000000) != 0 )
+      unknown_libname_12(&v94, &unk_18060CF90);
+      v77 = v94;
+      if ( (qword_180911F64 & 0x40000000) != 0 )
       {
-        v7 = (char *)&qword_180911334 + 4;
+        v7 = (char *)&qword_180911F64 + 4;
       }
-      else if ( (qword_180911334 & 0x3FFFFFFF) != 0 )
+      else if ( (qword_180911F64 & 0x3FFFFFFF) != 0 )
       {
-        v7 = *(char **)((char *)&qword_180911334 + 4);
+        v7 = *(char **)((char *)&qword_180911F64 + 4);
       }
-      v71 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
-      v70 = sub_180046DE0(a2);
-      RegisterEventListener_Abstract(a1, (__int64)&v70, 1u, 1u, v58, 0, (__int64)v7);
+      v93 = (__int64 (__fastcall *)())CNetworkServerService_OnSimpleLoopFrameUpdate;
+      v78 = sub_180043D40(a2);
+      LOBYTE(v79) = 1;
+      v92 = v78;
+      return sub_18013D400(a1, (unsigned int)&v92, 1, v79, v77, 0, (__int64)v7);
     }
   }

--- a/prune_pr_expected_output_bin.py
+++ b/prune_pr_expected_output_bin.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Prune PR-added expected_output YAMLs from the copied bin/ cache.
+
+Used by .github/workflows/pr-self-runner.yml right after the persisted
+bin/<gamever> YAML cache is copied into the PR workspace. It deletes the
+expected_output YAML artifacts that the PR *adds* to config.yaml (the set
+difference of expected_output between the PR base and PR head), so
+ida_analyze_bin.py is forced to regenerate them (full validation) instead of
+skipping skills whose outputs already exist on disk.
+
+Usage:
+    python prune_pr_expected_output_bin.py -gamever <version> -baseref <gitref>
+    python prune_pr_expected_output_bin.py -gamever <version> -baseconfigyaml <path>
+
+    -gamever: Game version subdirectory under bindir (required)
+    -bindir: Root directory of copied binaries/YAML (default: bin)
+    -configyaml: Path to the head config.yaml (default: config.yaml)
+    -baseref: Git ref of the PR base; the base config is read via
+              `git show <ref>:<configyaml>` (configyaml must be repo-root-relative)
+    -baseconfigyaml: Path to the base config.yaml file (alternative to -baseref)
+
+Exactly one of -baseref / -baseconfigyaml must be provided.
+
+Requirements:
+    uv sync
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tempfile
+
+try:
+    import yaml
+except ImportError as e:
+    print(f"Error: Missing required dependency: {e.name}")
+    print("Please install required dependencies with: uv sync")
+    sys.exit(1)
+
+import ida_analyze_bin
+
+DEFAULT_BIN_DIR = "bin"
+DEFAULT_CONFIG_FILE = "config.yaml"
+PLATFORMS = ("windows", "linux")
+ARG_ERROR_EXIT = 2
+
+
+def parse_args(argv=None):
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Delete PR-added expected_output YAMLs from bin/ so validation re-runs them",
+    )
+    parser.add_argument("-gamever", required=True, help="Game version subdirectory under bindir (required)")
+    parser.add_argument(
+        "-bindir", default=DEFAULT_BIN_DIR, help=f"Root directory of copied binaries (default: {DEFAULT_BIN_DIR})"
+    )
+    parser.add_argument(
+        "-configyaml",
+        default=DEFAULT_CONFIG_FILE,
+        help=f"Path to the head config.yaml (default: {DEFAULT_CONFIG_FILE})",
+    )
+    parser.add_argument(
+        "-baseref",
+        default=None,
+        help="Git ref of the PR base; base config read via `git show <ref>:<configyaml>`",
+    )
+    parser.add_argument(
+        "-baseconfigyaml",
+        default=None,
+        help="Path to the base config.yaml file (alternative to -baseref)",
+    )
+    return parser.parse_args(argv)
+
+
+def collect_required_output_paths(modules, gamever, bindir):
+    """
+    Return the set of absolute expected_output YAML paths declared by modules.
+
+    Mirrors the skip logic in ida_analyze_bin.py: for every skill the required
+    outputs are expected_output + expected_output_{platform}, resolved under
+    bin/<gamever>/<module>/ with {platform} expanded. Skills pinned to a single
+    platform contribute only that platform's outputs. Paths that fail to resolve
+    (e.g. escape the gamever root) are logged and skipped rather than raising.
+    """
+    outputs = set()
+    for module in modules:
+        module_name = module["name"]
+        binary_dir = os.path.join(bindir, gamever, module_name)
+        for skill in module.get("skills", []) or []:
+            skill_platform = skill.get("platform")
+            for platform in PLATFORMS:
+                if skill_platform and skill_platform != platform:
+                    continue
+                try:
+                    required, _optional, _combined = ida_analyze_bin.expand_skill_output_paths(
+                        binary_dir, skill, platform
+                    )
+                except ValueError as exc:
+                    print(
+                        f"  Warning: skipping unresolved output for {module_name}/{skill.get('name')} ({platform}): {exc}"
+                    )
+                    continue
+                outputs.update(required)
+    return outputs
+
+
+def compute_added_output_paths(head_modules, base_modules, gamever, bindir):
+    """Return sorted absolute expected_output paths present in head but not base."""
+    head_outputs = collect_required_output_paths(head_modules, gamever, bindir)
+    base_outputs = collect_required_output_paths(base_modules, gamever, bindir)
+    return sorted(head_outputs - base_outputs)
+
+
+def delete_paths(paths):
+    """Delete existing files; return (deleted, absent). A missing file is a no-op."""
+    deleted = []
+    absent = []
+    for path in paths:
+        if os.path.exists(path):
+            os.remove(path)
+            deleted.append(path)
+        else:
+            absent.append(path)
+    return deleted, absent
+
+
+def load_base_modules(baseref, configyaml):
+    """Read the base config.yaml via `git show <baseref>:<configyaml>` and parse it."""
+    rev = f"{baseref}:{configyaml}"
+    result = subprocess.run(
+        ["git", "show", rev],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        message = result.stderr.strip() or f"git show {rev} failed"
+        raise RuntimeError(message)
+
+    handle = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8")
+    try:
+        handle.write(result.stdout)
+        handle.close()
+        return ida_analyze_bin.parse_config(handle.name)
+    finally:
+        os.remove(handle.name)
+
+
+def _display_path(path):
+    """Best-effort path relative to cwd for readable logging."""
+    try:
+        return os.path.relpath(path)
+    except ValueError:
+        return path
+
+
+def main(argv=None):
+    """Main entry point."""
+    args = parse_args(argv)
+
+    if bool(args.baseref) == bool(args.baseconfigyaml):
+        print("Error: provide exactly one of -baseref or -baseconfigyaml")
+        return ARG_ERROR_EXIT
+
+    if not os.path.exists(args.configyaml):
+        print(f"Error: head config file not found: {args.configyaml}")
+        return ARG_ERROR_EXIT
+
+    print(f"Head config: {args.configyaml}")
+    print(f"Binary directory: {args.bindir}")
+    print(f"Game version: {args.gamever}")
+
+    try:
+        head_modules = ida_analyze_bin.parse_config(args.configyaml)
+    except (ValueError, yaml.YAMLError) as exc:
+        print(f"Error: failed to parse head config: {exc}")
+        return ARG_ERROR_EXIT
+
+    try:
+        if args.baseconfigyaml:
+            print(f"Base config: {args.baseconfigyaml}")
+            if not os.path.exists(args.baseconfigyaml):
+                print(f"Error: base config file not found: {args.baseconfigyaml}")
+                return ARG_ERROR_EXIT
+            base_modules = ida_analyze_bin.parse_config(args.baseconfigyaml)
+        else:
+            print(f"Base config: git show {args.baseref}:{args.configyaml}")
+            base_modules = load_base_modules(args.baseref, args.configyaml)
+    except (ValueError, yaml.YAMLError, RuntimeError) as exc:
+        print(f"Error: failed to load base config: {exc}")
+        return 1
+
+    added = compute_added_output_paths(head_modules, base_modules, args.gamever, args.bindir)
+
+    if not added:
+        print("\nNo PR-added expected_output artifacts; nothing to prune.")
+        return 0
+
+    deleted, absent = delete_paths(added)
+
+    print(f"\n{'=' * 50}")
+    print(f"PR-added expected_output artifacts: {len(added)}")
+    print(f"Deleted from bin: {len(deleted)}; not present (no-op): {len(absent)}")
+    for path in deleted:
+        print(f"  [DELETED] {_display_path(path)}")
+    for path in absent:
+        print(f"  [ABSENT ] {_display_path(path)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_prune_pr_expected_output_bin.py
+++ b/tests/test_prune_pr_expected_output_bin.py
@@ -1,0 +1,214 @@
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import ida_analyze_bin
+import prune_pr_expected_output_bin as prune
+
+GAMEVER = "14141"
+
+HEAD_CONFIG = (
+    """
+modules:
+  - name: engine
+    path_windows: game/bin/win64/engine2.dll
+    path_linux: game/bin/linuxsteamrt64/libengine2.so
+    skills:
+      - name: find-added
+        expected_output:
+          - Added.{platform}.yaml
+      - name: find-unchanged
+        expected_output:
+          - Unchanged.{platform}.yaml
+      - name: find-windows-only
+        expected_output_windows:
+          - WindowsOnly.{platform}.yaml
+      - name: find-platwin
+        platform: windows
+        expected_output:
+          - PlatWin.{platform}.yaml
+""".strip()
+    + "\n"
+)
+
+BASE_CONFIG = (
+    """
+modules:
+  - name: engine
+    path_windows: game/bin/win64/engine2.dll
+    path_linux: game/bin/linuxsteamrt64/libengine2.so
+    skills:
+      - name: find-unchanged
+        expected_output:
+          - Unchanged.{platform}.yaml
+      - name: find-base-only
+        expected_output:
+          - BaseOnly.{platform}.yaml
+""".strip()
+    + "\n"
+)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _basenames(paths):
+    return {os.path.basename(path) for path in paths}
+
+
+class TestComputeAddedOutputPaths(unittest.TestCase):
+    def _added(self, bindir):
+        head = ida_analyze_bin.parse_config(str(Path(bindir).parent / "head.yaml"))
+        base = ida_analyze_bin.parse_config(str(Path(bindir).parent / "base.yaml"))
+        return prune.compute_added_output_paths(head, base, GAMEVER, bindir)
+
+    def test_added_outputs_are_the_head_minus_base_set(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "head.yaml", HEAD_CONFIG)
+            _write(root / "base.yaml", BASE_CONFIG)
+            bindir = str(root / "bin")
+
+            added = self._added(bindir)
+
+        self.assertEqual(
+            {
+                "Added.windows.yaml",
+                "Added.linux.yaml",
+                "WindowsOnly.windows.yaml",
+                "PlatWin.windows.yaml",
+            },
+            _basenames(added),
+        )
+
+    def test_platform_pinned_skill_excludes_other_platform(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "head.yaml", HEAD_CONFIG)
+            _write(root / "base.yaml", BASE_CONFIG)
+            added = self._added(str(root / "bin"))
+
+        # find-platwin has platform: windows, so its linux artifact is never targeted.
+        self.assertNotIn("PlatWin.linux.yaml", _basenames(added))
+
+    def test_unchanged_and_base_only_outputs_are_not_added(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _write(root / "head.yaml", HEAD_CONFIG)
+            _write(root / "base.yaml", BASE_CONFIG)
+            added = _basenames(self._added(str(root / "bin")))
+
+        self.assertNotIn("Unchanged.windows.yaml", added)
+        self.assertNotIn("Unchanged.linux.yaml", added)
+        self.assertNotIn("BaseOnly.windows.yaml", added)
+
+
+class TestCollectRequiredOutputPathsSkipsEscapes(unittest.TestCase):
+    def test_path_escaping_gamever_root_is_skipped_not_raised(self) -> None:
+        modules = [
+            {
+                "name": "engine",
+                "skills": [
+                    {
+                        "name": "evil",
+                        "expected_output": ["../../evil.{platform}.yaml"],
+                    }
+                ],
+            }
+        ]
+
+        # Must not raise; the escaping artifact is dropped from the result.
+        outputs = prune.collect_required_output_paths(modules, GAMEVER, "bin")
+
+        self.assertEqual(set(), outputs)
+
+
+class TestDeletePaths(unittest.TestCase):
+    def test_deletes_existing_and_records_absent_without_error(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            present = Path(temp_dir) / "present.yaml"
+            present.write_text("func_name: present\n", encoding="utf-8")
+            missing = Path(temp_dir) / "missing.yaml"
+
+            deleted, absent = prune.delete_paths([str(present), str(missing)])
+
+        self.assertEqual([str(present)], deleted)
+        self.assertEqual([str(missing)], absent)
+        self.assertFalse(present.exists())
+
+
+class TestMain(unittest.TestCase):
+    def _setup_workspace(self, temp_dir):
+        root = Path(temp_dir)
+        _write(root / "head.yaml", HEAD_CONFIG)
+        _write(root / "base.yaml", BASE_CONFIG)
+        engine_dir = root / "bin" / GAMEVER / "engine"
+        engine_dir.mkdir(parents=True, exist_ok=True)
+        # Seed the cache: some added outputs exist, one added output is absent,
+        # and the unchanged / base-only / platform-gated files must survive.
+        seeded = [
+            "Added.windows.yaml",
+            "Added.linux.yaml",
+            "PlatWin.windows.yaml",
+            "PlatWin.linux.yaml",
+            "Unchanged.windows.yaml",
+            "BaseOnly.windows.yaml",
+        ]
+        for name in seeded:
+            (engine_dir / name).write_text(f"func_name: {name}\n", encoding="utf-8")
+        # WindowsOnly.windows.yaml is intentionally NOT created (tests the no-op path).
+        return root, engine_dir
+
+    def test_main_prunes_only_added_outputs(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root, engine_dir = self._setup_workspace(temp_dir)
+
+            exit_code = prune.main(
+                [
+                    "-gamever",
+                    GAMEVER,
+                    "-bindir",
+                    str(root / "bin"),
+                    "-configyaml",
+                    str(root / "head.yaml"),
+                    "-baseconfigyaml",
+                    str(root / "base.yaml"),
+                ]
+            )
+
+            self.assertEqual(0, exit_code)
+            # Added outputs removed.
+            self.assertFalse((engine_dir / "Added.windows.yaml").exists())
+            self.assertFalse((engine_dir / "Added.linux.yaml").exists())
+            self.assertFalse((engine_dir / "PlatWin.windows.yaml").exists())
+            # Untouched: platform-gated, unchanged, and base-only artifacts.
+            self.assertTrue((engine_dir / "PlatWin.linux.yaml").exists())
+            self.assertTrue((engine_dir / "Unchanged.windows.yaml").exists())
+            self.assertTrue((engine_dir / "BaseOnly.windows.yaml").exists())
+
+    def test_main_requires_exactly_one_base_source(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root, _ = self._setup_workspace(temp_dir)
+            common = [
+                "-gamever",
+                GAMEVER,
+                "-bindir",
+                str(root / "bin"),
+                "-configyaml",
+                str(root / "head.yaml"),
+            ]
+
+            # Neither base source provided.
+            self.assertEqual(prune.ARG_ERROR_EXIT, prune.main(common))
+            # Both base sources provided.
+            self.assertEqual(
+                prune.ARG_ERROR_EXIT,
+                prune.main(common + ["-baseref", "HEAD^1", "-baseconfigyaml", str(root / "base.yaml")]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add preprocessor scripts and tests for the network game server lifecycle (init/shutdown/poll) and related service helpers.

- Add find-CNetworkGameServerBase_ServerPollNetworking preprocessor script
- Add find-CNetworkServerService_StartupServer preprocessor script
- Add find-CNetworkGameServerBase_Shutdown preprocessor script (linux/windows variants)
- Add find-CNetworkGameServerBase_ShutdownInternal preprocessor script (linux)
- Add find-CNetworkServerService_DisconnectGameNow preprocessor script
- Add find-CNetworkGameServerBase_RegisterLoadingSpawnGroups preprocessor script
- Add find-CNetworkGameServerBase_Init preprocessor script
- Add find-CNetworkGameServer_Init preprocessor script
- Add find-CNetworkGameServer_Shutdown preprocessor script
- Add cpp_tests for CNetworkGameServerBase and INetworkGameServer
- Fix hl2sdk_cs2 submodule
- Fix CEntitySystem_m_entityIONotifiers