### PR TITLE
Add find-CEngineServer_IsDedicatedServer preprocessor scripts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -865,6 +865,11 @@ modules:
       - name: find-CEngineServer_ShowFrameTimeReport_Impl
         expected_output:
           - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
+      - name: find-NET_IsDedicated
+        expected_output:
+          - NET_IsDedicated.{platform}.yaml
+        expected_input:
+          - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
       - name: find-CEngineServer_ShowFrameTimeReport
         expected_output:
           - CEngineServer_ShowFrameTimeReport.{platform}.yaml
@@ -1689,6 +1694,10 @@ modules:
         category: func
         alias:
           - CEngineServer::ShowFrameTimeReport
+      - name: NET_IsDedicated
+        category: func
+        alias:
+          - NET_IsDedicated
       - name: CEngineServer_ShowFrameTimeReport
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -844,6 +844,13 @@ modules:
       - name: find-CTier1Application_vtable
         expected_output:
           - CTier1Application_vtable.{platform}.yaml
+      - name: find-CTier1Application_GetGameMode-linux
+        platform: linux
+        expected_output:
+          - CTier1Application_GetGameMode.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_Connect.{platform}.yaml
+          - CTier1Application_vtable.{platform}.yaml
       - name: find-CEngineServer_DumpNetStats
         expected_output:
           - CEngineServer_DumpNetStats.{platform}.yaml
@@ -1688,6 +1695,10 @@ modules:
         category: vtable
       - name: CTier1Application_vtable
         category: vtable
+      - name: CTier1Application_GetGameMode
+        category: vfunc
+        alias:
+          - CTier1Application::GetGameMode
       - name: CEngineServer_DumpNetStats
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -841,6 +841,9 @@ modules:
       - name: find-CMapListService_vtable
         expected_output:
           - CMapListService_vtable.{platform}.yaml
+      - name: find-CTier1Application_vtable
+        expected_output:
+          - CTier1Application_vtable.{platform}.yaml
       - name: find-CEngineServer_DumpNetStats
         expected_output:
           - CEngineServer_DumpNetStats.{platform}.yaml
@@ -1682,6 +1685,8 @@ modules:
       - name: CEngineServer_vtable
         category: vtable
       - name: CMapListService_vtable
+        category: vtable
+      - name: CTier1Application_vtable
         category: vtable
       - name: CEngineServer_DumpNetStats
         category: vfunc

--- a/config.yaml
+++ b/config.yaml
@@ -870,6 +870,13 @@ modules:
           - NET_IsDedicated.{platform}.yaml
         expected_input:
           - CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml
+      - name: find-CEngineServer_IsDedicatedServer-windows
+        platform: windows
+        expected_output:
+          - CEngineServer_IsDedicatedServer.{platform}.yaml
+        expected_input:
+          - NET_IsDedicated.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_ShowFrameTimeReport
         expected_output:
           - CEngineServer_ShowFrameTimeReport.{platform}.yaml
@@ -1698,6 +1705,10 @@ modules:
         category: func
         alias:
           - NET_IsDedicated
+      - name: CEngineServer_IsDedicatedServer
+        category: vfunc
+        alias:
+          - CEngineServer::IsDedicatedServer
       - name: CEngineServer_ShowFrameTimeReport
         category: vfunc
         alias:

--- a/config.yaml
+++ b/config.yaml
@@ -892,6 +892,13 @@ modules:
         expected_input:
           - NET_IsDedicated.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_IsDedicatedServer-linux
+        platform: linux
+        expected_output:
+          - CEngineServer_IsDedicatedServer.{platform}.yaml
+        expected_input:
+          - CTier1Application_GetGameMode.{platform}.yaml
+          - CEngineServer_vtable.{platform}.yaml
       - name: find-CEngineServer_ShowFrameTimeReport
         expected_output:
           - CEngineServer_ShowFrameTimeReport.{platform}.yaml

--- a/config.yaml
+++ b/config.yaml
@@ -640,6 +640,11 @@ modules:
       - name: find-CNetworkClientService_vtable
         expected_output:
           - CNetworkClientService_vtable.{platform}.yaml
+      - name: find-CNetworkClientService_Connect
+        expected_output:
+          - CNetworkClientService_Connect.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_vtable.{platform}.yaml
       - name: find-CNetworkClientService_ReceivedServerInfo
         expected_output:
           - CNetworkClientService_ReceivedServerInfo.{platform}.yaml
@@ -1514,6 +1519,10 @@ modules:
         category: func
       - name: CNetworkClientService_vtable
         category: vtable
+      - name: CNetworkClientService_Connect
+        category: vfunc
+        alias:
+          - CNetworkClientService::Connect
       - name: CNetworkClientService_ReceivedServerInfo
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_IsDedicatedServer-linux.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsDedicatedServer-linux.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsDedicatedServer-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_IsDedicatedServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_IsDedicatedServer",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CTier1Application_GetGameMode"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_IsDedicatedServer", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_IsDedicatedServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_IsDedicatedServer-windows.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsDedicatedServer-windows.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsDedicatedServer-windows skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_IsDedicatedServer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_IsDedicatedServer",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["NET_IsDedicated"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+# CEngineServer_IsDedicatedServer is a vfunc of CEngineServer
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineServer_IsDedicatedServer", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineServer_IsDedicatedServer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_Connect.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_Connect.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkClientService_Connect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkClientService_Connect",
+        "xref_strings": [
+            "FULLMATCH:reservationid",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+# CNetworkClientService_Connect is a vfunc of CNetworkClientService
+FUNC_VTABLE_RELATIONS = [
+    ("CNetworkClientService_Connect", "CNetworkClientService_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkClientService_Connect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CTier1Application_GetGameMode-linux.py
+++ b/ida_preprocessor_scripts/find-CTier1Application_GetGameMode-linux.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CTier1Application_GetGameMode-linux skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CTier1Application_GetGameMode",
+]
+
+LLM_DECOMPILE = [
+    (
+        "CTier1Application_GetGameMode",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkClientService_Connect.{platform}.yaml",
+    ),
+]
+
+# CTier1Application_GetGameMode is a vfunc of CTier1Application
+FUNC_VTABLE_RELATIONS = [
+    ("CTier1Application_GetGameMode", "CTier1Application_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CTier1Application_GetGameMode",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CTier1Application_vtable.py
+++ b/ida_preprocessor_scripts/find-CTier1Application_vtable.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CTier1Application_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CTier1Application"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CTier1Application",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate CTier1Application vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-NET_IsDedicated.py
+++ b/ida_preprocessor_scripts/find-NET_IsDedicated.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-NET_IsDedicated skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "NET_IsDedicated",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "NET_IsDedicated",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CEngineServer_ShowFrameTimeReport_Impl.{platform}.yaml",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "NET_IsDedicated",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CEngineServer_ShowFrameTimeReport_Impl.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CEngineServer_ShowFrameTimeReport_Impl.linux.yaml
@@ -1,0 +1,585 @@
+func_name: CEngineServer_ShowFrameTimeReport_Impl
+func_va: '0x536b40'
+disasm_code: |-
+  .text:0000000000536B40                 push    rbp
+  .text:0000000000536B41                 mov     rbp, rsp
+  .text:0000000000536B44                 push    r15
+  .text:0000000000536B46                 push    r14
+  .text:0000000000536B48                 push    r13
+  .text:0000000000536B4A                 push    r12
+  .text:0000000000536B4C                 mov     r12, rdi
+  .text:0000000000536B4F                 push    rbx
+  .text:0000000000536B50                 mov     ebx, edx
+  .text:0000000000536B52                 sub     rsp, 48h
+  .text:0000000000536B56                 test    edx, edx
+  .text:0000000000536B58                 jns     short loc_536B63
+  .text:0000000000536B5A                 mov     rax, cs:LOG_VPROF_ptr
+  .text:0000000000536B61                 mov     ebx, [rax]
+  .text:0000000000536B63                 mov     edi, [r12+8]
+  .text:0000000000536B68                 test    edi, edi
+  .text:0000000000536B6A                 jz      loc_536D10
+  .text:0000000000536B70                 mov     r13, [r12+10h]
+  .text:0000000000536B75                 mov     ecx, [r13+10h]
+  .text:0000000000536B79                 test    ecx, ecx
+  .text:0000000000536B7B                 jle     loc_536D10
+  .text:0000000000536B81                 test    sil, sil
+  .text:0000000000536B84                 jz      loc_536CD0
+  .text:0000000000536B8A                 mov     esi, 2
+  .text:0000000000536B8F                 mov     edi, ebx
+  .text:0000000000536B91                 call    sub_2B35E0
+  .text:0000000000536B96                 test    al, al
+  .text:0000000000536B98                 jnz     loc_536DF0
+  .text:0000000000536B9E                 mov     esi, 2
+  .text:0000000000536BA3                 mov     edi, ebx
+  .text:0000000000536BA5                 call    sub_2B35E0
+  .text:0000000000536BAA                 test    al, al
+  .text:0000000000536BAC                 jnz     loc_536DD0
+  .text:0000000000536BB2                 mov     esi, 2
+  .text:0000000000536BB7                 mov     edi, ebx
+  .text:0000000000536BB9                 call    sub_2B35E0
+  .text:0000000000536BBE                 test    al, al
+  .text:0000000000536BC0                 jnz     loc_536DA0
+  .text:0000000000536BC6                 call    NET_IsDedicated
+  .text:0000000000536BCB                 test    al, al
+  .text:0000000000536BCD                 jz      loc_536D48
+  .text:0000000000536BD3                 mov     esi, 2
+  .text:0000000000536BD8                 mov     edi, ebx
+  .text:0000000000536BDA                 call    sub_2B35E0
+  .text:0000000000536BDF                 test    al, al
+  .text:0000000000536BE1                 jnz     loc_536E38
+  .text:0000000000536BE7                 movsxd  rdx, dword ptr [r12+8]
+  .text:0000000000536BEC                 mov     [rbp+var_50], 0
+  .text:0000000000536BF4                 mov     r13, [r12+10h]
+  .text:0000000000536BF9                 mov     [rbp+var_48], 0
+  .text:0000000000536C01                 mov     [rbp+var_40], 0
+  .text:0000000000536C09                 imul    rdx, 70h ; 'p'
+  .text:0000000000536C0D                 lea     r14, [r13+rdx+0]
+  .text:0000000000536C12                 cmp     r14, r13
+  .text:0000000000536C15                 jz      loc_5371A0
+  .text:0000000000536C1B                 lea     rax, [rbp+var_48]
+  .text:0000000000536C1F                 xor     r12d, r12d
+  .text:0000000000536C22                 movss   xmm0, cs:dword_255B4C
+  .text:0000000000536C2A                 mov     r15d, 1
+  .text:0000000000536C30                 mov     [rbp+var_68], rax
+  .text:0000000000536C34                 jmp     short loc_536C5F
+  .text:0000000000536C40                 add     eax, 1
+  .text:0000000000536C43                 mov     dword ptr [rbp+var_50], eax
+  .text:0000000000536C46                 mov     rax, [rbp+var_48]
+  .text:0000000000536C4A                 mov     [rax+r12*8], r13
+  .text:0000000000536C4E                 movsxd  r12, dword ptr [rbp+var_50]
+  .text:0000000000536C52                 add     r13, 70h ; 'p'
+  .text:0000000000536C56                 cmp     r14, r13
+  .text:0000000000536C59                 jz      loc_536E58
+  .text:0000000000536C5F                 add     r15d, 1
+  .text:0000000000536C63                 cmp     r15d, 0Ah
+  .text:0000000000536C67                 jle     short loc_536C7F
+  .text:0000000000536C69                 comiss  xmm0, dword ptr [r13+18h]
+  .text:0000000000536C6E                 jbe     short loc_536C7F
+  .text:0000000000536C70                 movss   xmm2, cs:dword_255E18
+  .text:0000000000536C78                 comiss  xmm2, dword ptr [r13+28h]
+  .text:0000000000536C7D                 ja      short loc_536C52
+  .text:0000000000536C7F                 mov     eax, r12d
+  .text:0000000000536C82                 cmp     dword ptr [rbp+var_40], r12d
+  .text:0000000000536C86                 jnz     short loc_536C40
+  .text:0000000000536C88                 mov     edx, dword ptr [rbp+var_40+4]
+  .text:0000000000536C8B                 cmp     edx, 3FFFFFFFh
+  .text:0000000000536C91                 jbe     short loc_536CA1
+  .text:0000000000536C93                 and     edx, 0C0000000h
+  .text:0000000000536C99                 cmp     edx, 80000000h
+  .text:0000000000536C9F                 jnz     short loc_536C40
+  .text:0000000000536CA1                 cmp     r12d, 7FFFFFFFh
+  .text:0000000000536CA8                 jz      loc_537188
+  .text:0000000000536CAE                 mov     rdi, [rbp+var_68]
+  .text:0000000000536CB2                 call    sub_8FF840
+  .text:0000000000536CB7                 mov     eax, dword ptr [rbp+var_50]
+  .text:0000000000536CBA                 movss   xmm0, cs:dword_255B4C
+  .text:0000000000536CC2                 jmp     loc_536C40
+  .text:0000000000536CD0                 mov     esi, 2
+  .text:0000000000536CD5                 mov     edi, ebx
+  .text:0000000000536CD7                 call    sub_2B35E0
+  .text:0000000000536CDC                 test    al, al
+  .text:0000000000536CDE                 jnz     loc_536E10
+  .text:0000000000536CE4                 call    NET_IsDedicated
+  .text:0000000000536CE9                 mov     esi, 2
+  .text:0000000000536CEE                 mov     edi, ebx
+  .text:0000000000536CF0                 call    sub_2B35E0
+  .text:0000000000536CF5                 test    al, al
+  .text:0000000000536CF7                 jnz     loc_5370D0
+  .text:0000000000536CFD                 lea     rsp, [rbp-28h]
+  .text:0000000000536D01                 pop     rbx
+  .text:0000000000536D02                 pop     r12
+  .text:0000000000536D04                 pop     r13
+  .text:0000000000536D06                 pop     r14
+  .text:0000000000536D08                 pop     r15
+  .text:0000000000536D0A                 pop     rbp
+  .text:0000000000536D0B                 retn
+  .text:0000000000536D10                 mov     esi, 2
+  .text:0000000000536D15                 mov     edi, ebx
+  .text:0000000000536D17                 call    sub_2B35E0
+  .text:0000000000536D1C                 test    al, al
+  .text:0000000000536D1E                 jz      short loc_536CFD
+  .text:0000000000536D20                 lea     rsp, [rbp-28h]
+  .text:0000000000536D24                 mov     edi, ebx
+  .text:0000000000536D26                 mov     esi, 2
+  .text:0000000000536D2B                 pop     rbx
+  .text:0000000000536D2C                 lea     rdx, aNoVprofLiteDat; "No vprof lite data recorded\n"
+  .text:0000000000536D33                 xor     eax, eax
+  .text:0000000000536D35                 pop     r12
+  .text:0000000000536D37                 pop     r13
+  .text:0000000000536D39                 pop     r14
+  .text:0000000000536D3B                 pop     r15
+  .text:0000000000536D3D                 pop     rbp
+  .text:0000000000536D3E                 jmp     sub_2B27F0
+  .text:0000000000536D48                 mov     esi, 2
+  .text:0000000000536D4D                 mov     edi, ebx
+  .text:0000000000536D4F                 call    sub_2B35E0
+  .text:0000000000536D54                 test    al, al
+  .text:0000000000536D56                 jz      loc_536BD3
+  .text:0000000000536D5C                 movss   xmm0, cs:dword_2553CC
+  .text:0000000000536D64                 lea     rdx, aFpsAvg1fP11f; "FPS: Avg=%.1f, P1=%.1f\n"
+  .text:0000000000536D6B                 mov     esi, 2
+  .text:0000000000536D70                 mov     edi, ebx
+  .text:0000000000536D72                 mov     eax, 2
+  .text:0000000000536D77                 movaps  xmm1, xmm0
+  .text:0000000000536D7A                 divss   xmm0, dword ptr [r13+2Ch]
+  .text:0000000000536D80                 divss   xmm1, dword ptr [r13+3Ch]
+  .text:0000000000536D86                 cvtss2sd xmm0, xmm0
+  .text:0000000000536D8A                 cvtss2sd xmm1, xmm1
+  .text:0000000000536D8E                 call    sub_2B27F0
+  .text:0000000000536D93                 jmp     loc_536BD3
+  .text:0000000000536DA0                 mov     ecx, [r13+10h]
+  .text:0000000000536DA4                 lea     rdx, aSummaryOfDFram; "Summary of %d frames and %d 1-second in"...
+  .text:0000000000536DAB                 mov     edi, ebx
+  .text:0000000000536DAD                 xor     eax, eax
+  .text:0000000000536DAF                 mov     r9d, [r12]
+  .text:0000000000536DB3                 mov     esi, 2
+  .text:0000000000536DB8                 mov     r8d, [r13+14h]
+  .text:0000000000536DBC                 call    sub_2B27F0
+  .text:0000000000536DC1                 jmp     loc_536BC6
+  .text:0000000000536DD0                 lea     rdx, aPerformanceRep; "-- Performance report --\n"
+  .text:0000000000536DD7                 mov     esi, 2
+  .text:0000000000536DDC                 mov     edi, ebx
+  .text:0000000000536DDE                 xor     eax, eax
+  .text:0000000000536DE0                 call    sub_2B27F0
+  .text:0000000000536DE5                 jmp     loc_536BB2
+  .text:0000000000536DF0                 lea     rdx, asc_269586; "\n"
+  .text:0000000000536DF7                 mov     esi, 2
+  .text:0000000000536DFC                 mov     edi, ebx
+  .text:0000000000536DFE                 xor     eax, eax
+  .text:0000000000536E00                 call    sub_2B27F0
+  .text:0000000000536E05                 jmp     loc_536B9E
+  .text:0000000000536E10                 mov     ecx, [r13+10h]
+  .text:0000000000536E14                 lea     rdx, aSummaryOfDFram_0; "Summary of %d frames.  (%d frames exclu"...
+  .text:0000000000536E1B                 mov     edi, ebx
+  .text:0000000000536E1D                 xor     eax, eax
+  .text:0000000000536E1F                 mov     r8d, [r12]
+  .text:0000000000536E23                 mov     esi, 2
+  .text:0000000000536E28                 call    sub_2B27F0
+  .text:0000000000536E2D                 jmp     loc_536CE4
+  .text:0000000000536E38                 lea     rdx, asc_269586; "\n"
+  .text:0000000000536E3F                 mov     esi, 2
+  .text:0000000000536E44                 mov     edi, ebx
+  .text:0000000000536E46                 xor     eax, eax
+  .text:0000000000536E48                 call    sub_2B27F0
+  .text:0000000000536E4D                 jmp     loc_536BE7
+  .text:0000000000536E58                 mov     r13, [rbp+var_48]
+  .text:0000000000536E5C                 lea     r14, [r13+r12*8+0]
+  .text:0000000000536E61                 cmp     r14, r13
+  .text:0000000000536E64                 jz      loc_5371A0
+  .text:0000000000536E6A                 movdqa  xmm0, cs:xmmword_254AB0
+  .text:0000000000536E72                 movd    r12d, xmm0
+  .text:0000000000536E77                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000536E80                 mov     rax, [r13+0]
+  .text:0000000000536E84                 mov     rdi, [rax+8]
+  .text:0000000000536E88                 test    rdi, rdi
+  .text:0000000000536E8B                 jz      loc_5370B0
+  .text:0000000000536E91                 call    sub_2B5480
+  .text:0000000000536E96                 cmp     r12d, eax
+  .text:0000000000536E99                 cmovl   r12d, eax
+  .text:0000000000536E9D                 add     r13, 8
+  .text:0000000000536EA1                 movd    xmm0, r12d
+  .text:0000000000536EA6                 cmp     r13, r14
+  .text:0000000000536EA9                 jnz     short loc_536E80
+  .text:0000000000536EAB                 mov     [rbp+var_58], 0
+  .text:0000000000536EB3                 test    r12d, r12d
+  .text:0000000000536EB6                 jle     short loc_536EE4
+  .text:0000000000536EB8                 lea     r15, [rbp+var_58]
+  .text:0000000000536EBC                 xor     r13d, r13d
+  .text:0000000000536EBF                 lea     r14, asc_2692A8; "-"
+  .text:0000000000536EC6                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000536ED0                 mov     rsi, r14
+  .text:0000000000536ED3                 mov     rdi, r15
+  .text:0000000000536ED6                 add     r13d, 1
+  .text:0000000000536EDA                 call    sub_2B2880
+  .text:0000000000536EDF                 cmp     r12d, r13d
+  .text:0000000000536EE2                 jg      short loc_536ED0
+  .text:0000000000536EE4                 mov     esi, 2
+  .text:0000000000536EE9                 mov     edi, ebx
+  .text:0000000000536EEB                 call    sub_2B35E0
+  .text:0000000000536EF0                 test    al, al
+  .text:0000000000536EF2                 jnz     loc_537138
+  .text:0000000000536EF8                 mov     esi, 2
+  .text:0000000000536EFD                 mov     edi, ebx
+  .text:0000000000536EFF                 call    sub_2B35E0
+  .text:0000000000536F04                 test    al, al
+  .text:0000000000536F06                 jnz     loc_537160
+  .text:0000000000536F0C                 mov     esi, 2
+  .text:0000000000536F11                 mov     edi, ebx
+  .text:0000000000536F13                 call    sub_2B35E0
+  .text:0000000000536F18                 test    al, al
+  .text:0000000000536F1A                 jz      short loc_536F46
+  .text:0000000000536F1C                 mov     rax, [rbp+var_58]
+  .text:0000000000536F20                 lea     r8, byte_2686F8
+  .text:0000000000536F27                 mov     ecx, r12d
+  .text:0000000000536F2A                 mov     edi, ebx
+  .text:0000000000536F2C                 lea     rdx, aS_4; "%*s ------ ------   ------ ------ -----"...
+  .text:0000000000536F33                 mov     esi, 2
+  .text:0000000000536F38                 test    rax, rax
+  .text:0000000000536F3B                 cmovnz  r8, rax
+  .text:0000000000536F3F                 xor     eax, eax
+  .text:0000000000536F41                 call    sub_2B27F0
+  .text:0000000000536F46                 mov     r14, [rbp+var_48]
+  .text:0000000000536F4A                 movsxd  rax, dword ptr [rbp+var_50]
+  .text:0000000000536F4E                 lea     r15, [r14+rax*8]
+  .text:0000000000536F52                 cmp     r15, r14
+  .text:0000000000536F55                 jnz     short loc_536F6D
+  .text:0000000000536F57                 jmp     loc_53704B
+  .text:0000000000536F60                 add     r14, 8
+  .text:0000000000536F64                 cmp     r15, r14
+  .text:0000000000536F67                 jz      loc_53704B
+  .text:0000000000536F6D                 mov     esi, 2
+  .text:0000000000536F72                 mov     edi, ebx
+  .text:0000000000536F74                 mov     r13, [r14]
+  .text:0000000000536F77                 call    sub_2B35E0
+  .text:0000000000536F7C                 test    al, al
+  .text:0000000000536F7E                 jz      short loc_536F60
+  .text:0000000000536F80                 mov     eax, [r13+14h]
+  .text:0000000000536F84                 sub     rsp, 8
+  .text:0000000000536F88                 mov     ecx, r12d
+  .text:0000000000536F8B                 mov     esi, 2
+  .text:0000000000536F90                 movss   xmm7, dword ptr [r13+4Ch]
+  .text:0000000000536F96                 lea     rdx, aS72f72f9d72f72; "%*s%7.2f%7.2f%9d%7.2f%7.2f%9.2f%7.2f%9d"...
+  .text:0000000000536F9D                 mov     edi, ebx
+  .text:0000000000536F9F                 add     r14, 8
+  .text:0000000000536FA3                 movss   xmm6, dword ptr [r13+48h]
+  .text:0000000000536FA9                 movss   xmm5, dword ptr [r13+60h]
+  .text:0000000000536FAF                 movss   xmm4, dword ptr [r13+5Ch]
+  .text:0000000000536FB5                 movss   xmm3, dword ptr [r13+28h]
+  .text:0000000000536FBB                 movss   xmm2, dword ptr [r13+18h]
+  .text:0000000000536FC1                 movss   xmm1, dword ptr [r13+3Ch]
+  .text:0000000000536FC7                 movss   xmm0, dword ptr [r13+2Ch]
+  .text:0000000000536FCD                 mulss   xmm7, cs:dword_255BC8
+  .text:0000000000536FD5                 mulss   xmm6, cs:dword_255BC8
+  .text:0000000000536FDD                 mulss   xmm5, cs:dword_255BC8
+  .text:0000000000536FE5                 mulss   xmm4, cs:dword_255BC8
+  .text:0000000000536FED                 mulss   xmm3, cs:dword_255BC8
+  .text:0000000000536FF5                 cvtss2sd xmm7, xmm7
+  .text:0000000000536FF9                 mulss   xmm2, cs:dword_255BC8
+  .text:0000000000537001                 cvtss2sd xmm6, xmm6
+  .text:0000000000537005                 mov     r9d, [r13+10h]
+  .text:0000000000537009                 cvtss2sd xmm5, xmm5
+  .text:000000000053700D                 mulss   xmm1, cs:dword_255BC8
+  .text:0000000000537015                 cvtss2sd xmm4, xmm4
+  .text:0000000000537019                 mulss   xmm0, cs:dword_255BC8
+  .text:0000000000537021                 cvtss2sd xmm3, xmm3
+  .text:0000000000537025                 mov     r8, [r13+8]
+  .text:0000000000537029                 push    rax
+  .text:000000000053702A                 mov     eax, 8
+  .text:000000000053702F                 cvtss2sd xmm2, xmm2
+  .text:0000000000537033                 cvtss2sd xmm1, xmm1
+  .text:0000000000537037                 cvtss2sd xmm0, xmm0
+  .text:000000000053703B                 call    sub_2B27F0
+  .text:0000000000537040                 pop     rax
+  .text:0000000000537041                 pop     rdx
+  .text:0000000000537042                 cmp     r15, r14
+  .text:0000000000537045                 jnz     loc_536F6D
+  .text:000000000053704B                 mov     esi, 2
+  .text:0000000000537050                 mov     edi, ebx
+  .text:0000000000537052                 call    sub_2B35E0
+  .text:0000000000537057                 test    al, al
+  .text:0000000000537059                 jnz     loc_537118
+  .text:000000000053705F                 cmp     [rbp+var_58], 0
+  .text:0000000000537064                 jz      short loc_53706F
+  .text:0000000000537066                 lea     rdi, [rbp+var_58]
+  .text:000000000053706A                 call    sub_2B49D0
+  .text:000000000053706F                 cmp     dword ptr [rbp+var_40+4], 3FFFFFFFh
+  .text:0000000000537076                 mov     dword ptr [rbp+var_50], 0
+  .text:000000000053707D                 ja      loc_536CFD
+  .text:0000000000537083                 lea     rbx, [rbp+var_48]
+  .text:0000000000537087                 mov     rdi, rbx
+  .text:000000000053708A                 call    sub_489520
+  .text:000000000053708F                 cmp     dword ptr [rbp+var_40+4], 3FFFFFFFh
+  .text:0000000000537096                 ja      loc_536CFD
+  .text:000000000053709C                 mov     rdi, rbx
+  .text:000000000053709F                 call    sub_489520
+  .text:00000000005370A4                 jmp     loc_536CFD
+  .text:00000000005370B0                 pxor    xmm1, xmm1
+  .text:00000000005370B4                 add     r13, 8
+  .text:00000000005370B8                 pmaxsd  xmm0, xmm1
+  .text:00000000005370BD                 movd    r12d, xmm0
+  .text:00000000005370C2                 cmp     r14, r13
+  .text:00000000005370C5                 jnz     loc_536E80
+  .text:00000000005370CB                 jmp     loc_536EAB
+  .text:00000000005370D0                 movss   xmm0, cs:dword_2553CC
+  .text:00000000005370D8                 mov     edi, ebx
+  .text:00000000005370DA                 mov     esi, 2
+  .text:00000000005370DF                 mov     eax, 2
+  .text:00000000005370E4                 lea     rdx, aFpsAvg1fP11f; "FPS: Avg=%.1f, P1=%.1f\n"
+  .text:00000000005370EB                 movaps  xmm1, xmm0
+  .text:00000000005370EE                 divss   xmm0, dword ptr [r13+2Ch]
+  .text:00000000005370F4                 divss   xmm1, dword ptr [r13+3Ch]
+  .text:00000000005370FA                 cvtss2sd xmm0, xmm0
+  .text:00000000005370FE                 lea     rsp, [rbp-28h]
+  .text:0000000000537102                 cvtss2sd xmm1, xmm1
+  .text:0000000000537106                 pop     rbx
+  .text:0000000000537107                 pop     r12
+  .text:0000000000537109                 pop     r13
+  .text:000000000053710B                 pop     r14
+  .text:000000000053710D                 pop     r15
+  .text:000000000053710F                 pop     rbp
+  .text:0000000000537110                 jmp     sub_2B27F0
+  .text:0000000000537118                 lea     rdx, asc_269586; "\n"
+  .text:000000000053711F                 mov     esi, 2
+  .text:0000000000537124                 mov     edi, ebx
+  .text:0000000000537126                 xor     eax, eax
+  .text:0000000000537128                 call    sub_2B27F0
+  .text:000000000053712D                 jmp     loc_53705F
+  .text:0000000000537138                 lea     r8, byte_2686F8
+  .text:000000000053713F                 mov     ecx, r12d
+  .text:0000000000537142                 mov     esi, 2
+  .text:0000000000537147                 lea     rdx, aSAllFramesActi; "%*s  All frames         Active frames  "...
+  .text:000000000053714E                 mov     edi, ebx
+  .text:0000000000537150                 xor     eax, eax
+  .text:0000000000537152                 call    sub_2B27F0
+  .text:0000000000537157                 jmp     loc_536EF8
+  .text:0000000000537160                 lea     r8, byte_2686F8
+  .text:0000000000537167                 mov     ecx, r12d
+  .text:000000000053716A                 mov     esi, 2
+  .text:000000000053716F                 lea     rdx, aSAvgP99NAvgP99; "%*s    Avg    P99        N    Avg    P9"...
+  .text:0000000000537176                 mov     edi, ebx
+  .text:0000000000537178                 xor     eax, eax
+  .text:000000000053717A                 call    sub_2B27F0
+  .text:000000000053717F                 jmp     loc_536F0C
+  .text:0000000000537188                 mov     esi, 1
+  .text:000000000053718D                 mov     edi, 7FFFFFFFh
+  .text:0000000000537192                 call    sub_2B4A00
+  .text:0000000000537197                 jmp     loc_536CAE
+  .text:00000000005371A0                 mov     [rbp+var_58], 0
+  .text:00000000005371A8                 mov     r12d, 0Ah
+  .text:00000000005371AE                 jmp     loc_536EB8
+procedure: |-
+  __int64 __fastcall sub_536B40(_DWORD *a1, char a2, int a3, __m128i si128)
+  {
+    unsigned int v4; // ebx
+    __int64 v5; // r13
+    __int64 v6; // rdx
+    __int64 v7; // r13
+    __int64 v8; // r14
+    __int64 v9; // r12
+    int v10; // r15d
+    int v11; // eax
+    __int64 result; // rax
+    __int64 *v13; // r13
+    __int64 *v14; // r14
+    signed int v15; // r12d
+    signed int v16; // eax
+    signed int i; // r13d
+    const char *v18; // r8
+    __int64 *v19; // r14
+    __int64 *v20; // r15
+    __int64 v21; // r13
+    const char *v22; // [rsp+18h] [rbp-58h] BYREF
+    __int64 v23; // [rsp+20h] [rbp-50h]
+    __int64 *v24; // [rsp+28h] [rbp-48h] BYREF
+    __int64 v25; // [rsp+30h] [rbp-40h]
+
+    v4 = a3;
+    if ( a3 < 0 )
+      v4 = LOG_VPROF;
+    if ( !a1[2] || (v5 = *((_QWORD *)a1 + 2), *(int *)(v5 + 16) <= 0) )
+    {
+      result = sub_2B35E0(v4, 2);
+      if ( (_BYTE)result )
+        return sub_2B27F0(v4, 2, "No vprof lite data recorded\n");
+      return result;
+    }
+    if ( !a2 )
+    {
+      if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+        sub_2B27F0(v4, 2, "Summary of %d frames.  (%d frames excluded from analysis.)\n", *(_DWORD *)(v5 + 16), *a1);
+      NET_IsDedicated();
+      result = sub_2B35E0(v4, 2);
+      if ( (_BYTE)result )
+        return sub_2B27F0(
+                 v4,
+                 2,
+                 "FPS: Avg=%.1f, P1=%.1f\n",
+                 (float)(1.0 / *(float *)(v5 + 44)),
+                 (float)(1.0 / *(float *)(v5 + 60)));
+      return result;
+    }
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(v4, 2, "\n");
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(v4, 2, "-- Performance report --\n");
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(
+        v4,
+        2,
+        "Summary of %d frames and %d 1-second intervals.  (%d frames excluded from analysis.)\n",
+        *(_DWORD *)(v5 + 16),
+        *(_DWORD *)(v5 + 20),
+        *a1);
+    if ( !(unsigned __int8)NET_IsDedicated() && (unsigned __int8)sub_2B35E0(v4, 2) )
+    {
+      *(double *)si128.m128i_i64 = (float)(1.0 / *(float *)(v5 + 44));
+      sub_2B27F0(v4, 2, "FPS: Avg=%.1f, P1=%.1f\n", *(double *)si128.m128i_i64, (float)(1.0 / *(float *)(v5 + 60)));
+    }
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(v4, 2, "\n");
+    v6 = (int)a1[2];
+    v23 = 0;
+    v7 = *((_QWORD *)a1 + 2);
+    v24 = nullptr;
+    v25 = 0;
+    v6 *= 112;
+    v8 = v7 + v6;
+    if ( v7 + v6 == v7 )
+      goto LABEL_68;
+    v9 = 0;
+    si128.m128i_i64[0] = 953267991;
+    v10 = 1;
+    do
+    {
+      if ( ++v10 <= 10 || *(float *)(v7 + 24) >= 0.000099999997 || *(float *)(v7 + 40) >= 0.00050000002 )
+      {
+        v11 = v9;
+        if ( (_DWORD)v25 == (_DWORD)v9 && (HIDWORD(v25) <= 0x3FFFFFFF || (HIDWORD(v25) & 0xC0000000) == 0x80000000) )
+        {
+          if ( (_DWORD)v9 == 0x7FFFFFFF )
+            sub_2B4A00(0x7FFFFFFF, 1, COERCE_DOUBLE(953267991));
+          sub_8FF840(&v24, COERCE_DOUBLE(953267991));
+          v11 = v23;
+          si128.m128i_i64[0] = 953267991;
+        }
+        LODWORD(v23) = v11 + 1;
+        v24[v9] = v7;
+        v9 = (int)v23;
+      }
+      v7 += 112;
+    }
+    while ( v8 != v7 );
+    v13 = v24;
+    v14 = &v24[v9];
+    if ( v14 == v24 )
+    {
+  LABEL_68:
+      v22 = nullptr;
+      v15 = 10;
+    }
+    else
+    {
+      si128 = _mm_load_si128((const __m128i *)&xmmword_254AB0);
+      v15 = _mm_cvtsi128_si32(si128);
+      do
+      {
+        while ( !*(_QWORD *)(*v13 + 8) )
+        {
+          ++v13;
+          si128 = _mm_max_epi32(si128, (__m128i)0LL);
+          v15 = _mm_cvtsi128_si32(si128);
+          if ( v14 == v13 )
+            goto LABEL_42;
+        }
+        v16 = sub_2B5480();
+        if ( v15 < v16 )
+          v15 = v16;
+        ++v13;
+        si128 = _mm_cvtsi32_si128(v15);
+      }
+      while ( v13 != v14 );
+  LABEL_42:
+      v22 = nullptr;
+      if ( v15 <= 0 )
+        goto LABEL_45;
+    }
+    for ( i = 0; i < v15; ++i )
+      sub_2B2880(&v22, "-", *(double *)si128.m128i_i64);
+  LABEL_45:
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(
+        v4,
+        2,
+        "%*s  All frames         Active frames       1s max (all)      1s max (active)  \n",
+        v15,
+        &byte_2686F8);
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+      sub_2B27F0(
+        v4,
+        2,
+        "%*s    Avg    P99        N    Avg    P99      P50    P95        N    P50    P95\n",
+        v15,
+        &byte_2686F8);
+    if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+    {
+      v18 = &byte_2686F8;
+      if ( v22 )
+        v18 = v22;
+      sub_2B27F0(
+        v4,
+        2,
+        "%*s ------ ------   ------ ------ ------   ------ ------   ------ ------ ------\n",
+        (unsigned int)v15,
+        v18,
+        *(double *)si128.m128i_i64);
+    }
+    v19 = v24;
+    v20 = &v24[(int)v23];
+    if ( v20 != v24 )
+    {
+      do
+      {
+        while ( 1 )
+        {
+          v21 = *v19;
+          if ( (unsigned __int8)sub_2B35E0(v4, 2) )
+            break;
+          if ( v20 == ++v19 )
+            goto LABEL_58;
+        }
+        ++v19;
+        *(double *)si128.m128i_i64 = (float)(*(float *)(v21 + 44) * 1000.0);
+        sub_2B27F0(
+          v4,
+          2,
+          "%*s%7.2f%7.2f%9d%7.2f%7.2f%9.2f%7.2f%9d%7.2f%7.2f\n",
+          v15,
+          *(const char **)(v21 + 8),
+          *(double *)si128.m128i_i64,
+          (float)(*(float *)(v21 + 60) * 1000.0),
+          *(_DWORD *)(v21 + 16),
+          (float)(*(float *)(v21 + 24) * 1000.0),
+          (float)(*(float *)(v21 + 40) * 1000.0),
+          (float)(*(float *)(v21 + 92) * 1000.0),
+          (float)(*(float *)(v21 + 96) * 1000.0),
+          *(_DWORD *)(v21 + 20),
+          (float)(*(float *)(v21 + 72) * 1000.0),
+          (float)(*(float *)(v21 + 76) * 1000.0));
+      }
+      while ( v20 != v19 );
+    }
+  LABEL_58:
+    result = sub_2B35E0(v4, 2);
+    if ( (_BYTE)result )
+      result = sub_2B27F0(v4, 2, "\n", *(double *)si128.m128i_i64);
+    if ( v22 )
+      result = sub_2B49D0(&v22, *(double *)si128.m128i_i64);
+    LODWORD(v23) = 0;
+    if ( HIDWORD(v25) <= 0x3FFFFFFF )
+    {
+      result = sub_489520(&v24, *(double *)si128.m128i_i64);
+      if ( HIDWORD(v25) <= 0x3FFFFFFF )
+        return sub_489520(&v24, *(double *)si128.m128i_i64);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CEngineServer_ShowFrameTimeReport_Impl.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CEngineServer_ShowFrameTimeReport_Impl.windows.yaml
@@ -1,0 +1,587 @@
+func_name: CEngineServer_ShowFrameTimeReport_Impl
+func_va: '0x18021f7c0'
+disasm_code: |-
+  .text:000000018021F7C0                 mov     [rsp+arg_10], r8d
+  .text:000000018021F7C5                 push    rbp
+  .text:000000018021F7C6                 push    rsi
+  .text:000000018021F7C7                 push    rdi
+  .text:000000018021F7C8                 sub     rsp, 100h
+  .text:000000018021F7CF                 mov     edi, r8d
+  .text:000000018021F7D2                 movzx   ebp, dl
+  .text:000000018021F7D5                 mov     rsi, rcx
+  .text:000000018021F7D8                 test    r8d, r8d
+  .text:000000018021F7DB                 jns     short loc_18021F7ED
+  .text:000000018021F7DD                 mov     rax, cs:LOG_VPROF
+  .text:000000018021F7E4                 mov     edi, [rax]
+  .text:000000018021F7E6                 mov     [rsp+118h+arg_10], edi
+  .text:000000018021F7ED                 cmp     dword ptr [rcx+8], 0
+  .text:000000018021F7F1                 mov     [rsp+118h+arg_8], rbx
+  .text:000000018021F7F9                 jz      loc_18021FDA9
+  .text:000000018021F7FF                 mov     rbx, [rcx+10h]
+  .text:000000018021F803                 cmp     dword ptr [rbx+10h], 1
+  .text:000000018021F807                 jl      loc_18021FDA9
+  .text:000000018021F80D                 mov     edx, 2
+  .text:000000018021F812                 mov     ecx, edi
+  .text:000000018021F814                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021F81A                 test    bpl, bpl
+  .text:000000018021F81D                 jz      short loc_18021F894
+  .text:000000018021F81F                 test    al, al
+  .text:000000018021F821                 jz      short loc_18021F837
+  .text:000000018021F823                 lea     r8, asc_180525034; "\n"
+  .text:000000018021F82A                 mov     edx, 2
+  .text:000000018021F82F                 mov     ecx, edi
+  .text:000000018021F831                 call    cs:LoggingSystem_Log
+  .text:000000018021F837                 mov     edx, 2
+  .text:000000018021F83C                 mov     ecx, edi
+  .text:000000018021F83E                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021F844                 test    al, al
+  .text:000000018021F846                 jz      short loc_18021F85C
+  .text:000000018021F848                 lea     r8, aPerformanceRep; "-- Performance report --\n"
+  .text:000000018021F84F                 mov     edx, 2
+  .text:000000018021F854                 mov     ecx, edi
+  .text:000000018021F856                 call    cs:LoggingSystem_Log
+  .text:000000018021F85C                 mov     edx, 2
+  .text:000000018021F861                 mov     ecx, edi
+  .text:000000018021F863                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021F869                 test    al, al
+  .text:000000018021F86B                 jz      short loc_18021F8B6
+  .text:000000018021F86D                 mov     eax, [rsi]
+  .text:000000018021F86F                 lea     r8, aSummaryOfDFram; "Summary of %d frames and %d 1-second in"...
+  .text:000000018021F876                 mov     r9d, [rbx+10h]
+  .text:000000018021F87A                 mov     edx, 2
+  .text:000000018021F87F                 mov     dword ptr [rsp+118h+var_F0], eax
+  .text:000000018021F883                 mov     ecx, edi
+  .text:000000018021F885                 mov     eax, [rbx+14h]
+  .text:000000018021F888                 mov     dword ptr [rsp+118h+var_F8], eax
+  .text:000000018021F88C                 call    cs:LoggingSystem_Log
+  .text:000000018021F892                 jmp     short loc_18021F8B6
+  .text:000000018021F894                 test    al, al
+  .text:000000018021F896                 jz      short loc_18021F8B6
+  .text:000000018021F898                 mov     eax, [rsi]
+  .text:000000018021F89A                 lea     r8, aSummaryOfDFram_0; "Summary of %d frames.  (%d frames exclu"...
+  .text:000000018021F8A1                 mov     r9d, [rbx+10h]
+  .text:000000018021F8A5                 mov     edx, 2
+  .text:000000018021F8AA                 mov     ecx, edi
+  .text:000000018021F8AC                 mov     dword ptr [rsp+118h+var_F8], eax
+  .text:000000018021F8B0                 call    cs:LoggingSystem_Log
+  .text:000000018021F8B6                 call    NET_IsDedicated
+  .text:000000018021F8BB                 test    al, al
+  .text:000000018021F8BD                 jz      short loc_18021F8C4
+  .text:000000018021F8BF                 test    bpl, bpl
+  .text:000000018021F8C2                 jnz     short loc_18021F918
+  .text:000000018021F8C4                 mov     edx, 2
+  .text:000000018021F8C9                 mov     ecx, edi
+  .text:000000018021F8CB                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021F8D1                 test    al, al
+  .text:000000018021F8D3                 jz      short loc_18021F90F
+  .text:000000018021F8D5                 movss   xmm2, cs:dword_18058368C
+  .text:000000018021F8DD                 lea     r8, aFpsAvg1fP11f; "FPS: Avg=%.1f, P1=%.1f\n"
+  .text:000000018021F8E4                 movaps  xmm0, xmm2
+  .text:000000018021F8E7                 mov     edx, 2
+  .text:000000018021F8EC                 divss   xmm2, dword ptr [rbx+2Ch]
+  .text:000000018021F8F1                 mov     ecx, edi
+  .text:000000018021F8F3                 divss   xmm0, dword ptr [rbx+3Ch]
+  .text:000000018021F8F8                 cvtps2pd xmm3, xmm2
+  .text:000000018021F8FB                 cvtps2pd xmm1, xmm0
+  .text:000000018021F8FE                 movq    r9, xmm3
+  .text:000000018021F903                 movsd   [rsp+118h+var_F8], xmm1
+  .text:000000018021F909                 call    cs:LoggingSystem_Log
+  .text:000000018021F90F                 test    bpl, bpl
+  .text:000000018021F912                 jz      loc_18021FD96
+  .text:000000018021F918                 mov     [rsp+118h+var_20], r12
+  .text:000000018021F920                 mov     edx, 2
+  .text:000000018021F925                 mov     [rsp+118h+var_28], r13
+  .text:000000018021F92D                 mov     ecx, edi
+  .text:000000018021F92F                 mov     [rsp+118h+var_30], r14
+  .text:000000018021F937                 mov     [rsp+118h+var_38], r15
+  .text:000000018021F93F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021F945                 test    al, al
+  .text:000000018021F947                 jz      short loc_18021F95D
+  .text:000000018021F949                 lea     r8, asc_180525034; "\n"
+  .text:000000018021F950                 mov     edx, 2
+  .text:000000018021F955                 mov     ecx, edi
+  .text:000000018021F957                 call    cs:LoggingSystem_Log
+  .text:000000018021F95D                 mov     rbp, [rsi+10h]
+  .text:000000018021F961                 xor     r12d, r12d
+  .text:000000018021F964                 movsxd  rax, dword ptr [rsi+8]
+  .text:000000018021F968                 xor     ebx, ebx
+  .text:000000018021F96A                 imul    rdx, rax, 70h ; 'p'
+  .text:000000018021F96E                 movaps  [rsp+118h+var_48], xmm6
+  .text:000000018021F976                 movaps  [rsp+118h+var_58], xmm7
+  .text:000000018021F97E                 xor     r13d, r13d
+  .text:000000018021F981                 mov     [rsp+118h+var_90], r12
+  .text:000000018021F989                 add     rdx, rbp
+  .text:000000018021F98C                 xor     r15d, r15d
+  .text:000000018021F98F                 mov     [rsp+118h+var_88], rdx
+  .text:000000018021F997                 mov     ecx, 1
+  .text:000000018021F99C                 cmp     rbp, rdx
+  .text:000000018021F99F                 jz      loc_18021FAD2
+  .text:000000018021F9A5                 movss   xmm6, cs:dword_1805835B0
+  .text:000000018021F9AD                 mov     edi, ebx
+  .text:000000018021F9AF                 movss   xmm7, cs:dword_1805835B8
+  .text:000000018021F9B7                 nop     word ptr [rax+rax+00000000h]
+  .text:000000018021F9C0                 inc     ecx
+  .text:000000018021F9C2                 mov     [rsp+118h+arg_0], ecx
+  .text:000000018021F9C9                 cmp     ecx, 0Ah
+  .text:000000018021F9CC                 jle     short loc_18021F9DE
+  .text:000000018021F9CE                 comiss  xmm6, dword ptr [rbp+18h]
+  .text:000000018021F9D2                 jbe     short loc_18021F9DE
+  .text:000000018021F9D4                 comiss  xmm7, dword ptr [rbp+28h]
+  .text:000000018021F9D8                 ja      loc_18021FAAF
+  .text:000000018021F9DE                 mov     eax, r15d
+  .text:000000018021F9E1                 cmp     r15d, ebx
+  .text:000000018021F9E4                 jnz     loc_18021FAA6
+  .text:000000018021F9EA                 mov     r14d, edi
+  .text:000000018021F9ED                 and     r14d, 0C0000000h
+  .text:000000018021F9F4                 test    r14d, 7FFFFFFFh
+  .text:000000018021F9FB                 jnz     loc_18021FAA6
+  .text:000000018021FA01                 movsxd  r12, ebx
+  .text:000000018021FA04                 cmp     r12, 7FFFFFFEh
+  .text:000000018021FA0B                 jle     short loc_18021FA1A
+  .text:000000018021FA0D                 mov     edx, 1
+  .text:000000018021FA12                 mov     ecx, ebx
+  .text:000000018021FA14                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:000000018021FA1A                 mov     r13d, edi
+  .text:000000018021FA1D                 lea     esi, [rbx+1]
+  .text:000000018021FA20                 and     r13d, 3FFFFFFFh
+  .text:000000018021FA27                 mov     r9d, 8
+  .text:000000018021FA2D                 mov     edx, r13d
+  .text:000000018021FA30                 mov     r8d, esi
+  .text:000000018021FA33                 mov     ecx, ebx
+  .text:000000018021FA35                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:000000018021FA3B                 mov     ebx, eax
+  .text:000000018021FA3D                 cmp     eax, esi
+  .text:000000018021FA3F                 jge     short loc_18021FA5F
+  .text:000000018021FA41                 test    eax, eax
+  .text:000000018021FA43                 jnz     short loc_18021FA51
+  .text:000000018021FA45                 cmp     esi, 0FFFFFFFFh
+  .text:000000018021FA48                 jg      short loc_18021FA51
+  .text:000000018021FA4A                 mov     ebx, 0FFFFFFFFh
+  .text:000000018021FA4F                 jmp     short loc_18021FA5F
+  .text:000000018021FA51                 lea     eax, [rbx+rsi]
+  .text:000000018021FA54                 cdq
+  .text:000000018021FA55                 sub     eax, edx
+  .text:000000018021FA57                 sar     eax, 1
+  .text:000000018021FA59                 mov     ebx, eax
+  .text:000000018021FA5B                 cmp     eax, esi
+  .text:000000018021FA5D                 jl      short loc_18021FA51
+  .text:000000018021FA5F                 mov     rcx, [rsp+118h+var_90]
+  .text:000000018021FA67                 lea     r9, ds:0[r12*8]
+  .text:000000018021FA6F                 movsxd  r8, ebx
+  .text:000000018021FA72                 shl     r8, 3
+  .text:000000018021FA76                 test    r14d, r14d
+  .text:000000018021FA79                 setz    dl
+  .text:000000018021FA7C                 call    cs:UtlVectorMemory_Alloc
+  .text:000000018021FA82                 mov     ecx, [rsp+118h+arg_0]
+  .text:000000018021FA89                 test    r14d, r14d
+  .text:000000018021FA8C                 mov     rdx, [rsp+118h+var_88]
+  .text:000000018021FA94                 mov     r12, rax
+  .text:000000018021FA97                 mov     [rsp+118h+var_90], rax
+  .text:000000018021FA9F                 cmovnz  edi, r13d
+  .text:000000018021FAA3                 mov     eax, r15d
+  .text:000000018021FAA6                 cdqe
+  .text:000000018021FAA8                 inc     r15d
+  .text:000000018021FAAB                 mov     [r12+rax*8], rbp
+  .text:000000018021FAAF                 add     rbp, 70h ; 'p'
+  .text:000000018021FAB3                 cmp     rbp, rdx
+  .text:000000018021FAB6                 jnz     loc_18021F9C0
+  .text:000000018021FABC                 mov     [rsp+118h+arg_0], edi
+  .text:000000018021FAC3                 mov     r13d, [rsp+118h+arg_0]
+  .text:000000018021FACB                 mov     edi, [rsp+118h+arg_10]
+  .text:000000018021FAD2                 movsxd  rax, r15d
+  .text:000000018021FAD5                 mov     ebx, 0Ah
+  .text:000000018021FADA                 mov     r15, [rsp+118h+var_38]
+  .text:000000018021FAE2                 mov     rdx, r12
+  .text:000000018021FAE5                 lea     r14, [r12+rax*8]
+  .text:000000018021FAE9                 cmp     r12, r14
+  .text:000000018021FAEC                 jz      short loc_18021FB17
+  .text:000000018021FAEE                 xchg    ax, ax
+  .text:000000018021FAF0                 mov     rax, [rdx]
+  .text:000000018021FAF3                 mov     rcx, [rax+8]
+  .text:000000018021FAF7                 mov     rax, 0FFFFFFFFFFFFFFFFh
+  .text:000000018021FAFE                 xchg    ax, ax
+  .text:000000018021FB00                 inc     rax
+  .text:000000018021FB03                 cmp     byte ptr [rcx+rax], 0
+  .text:000000018021FB07                 jnz     short loc_18021FB00
+  .text:000000018021FB09                 cmp     ebx, eax
+  .text:000000018021FB0B                 cmovle  ebx, eax
+  .text:000000018021FB0E                 add     rdx, 8
+  .text:000000018021FB12                 cmp     rdx, r14
+  .text:000000018021FB15                 jnz     short loc_18021FAF0
+  .text:000000018021FB17                 mov     [rsp+118h+var_98], 0
+  .text:000000018021FB23                 test    ebx, ebx
+  .text:000000018021FB25                 jle     short loc_18021FB4B
+  .text:000000018021FB27                 mov     esi, ebx
+  .text:000000018021FB29                 nop     dword ptr [rax+00000000h]
+  .text:000000018021FB30                 lea     rdx, asc_18057E6C8; "-"
+  .text:000000018021FB37                 lea     rcx, [rsp+118h+var_98]
+  .text:000000018021FB3F                 call    cs:?Append@CUtlString@@QEAAXPEBD@Z; CUtlString::Append(char const *)
+  .text:000000018021FB45                 sub     rsi, 1
+  .text:000000018021FB49                 jnz     short loc_18021FB30
+  .text:000000018021FB4B                 mov     edx, 2
+  .text:000000018021FB50                 mov     ecx, edi
+  .text:000000018021FB52                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FB58                 lea     rsi, unk_180524F9F
+  .text:000000018021FB5F                 test    al, al
+  .text:000000018021FB61                 jz      short loc_18021FB7F
+  .text:000000018021FB63                 mov     r9d, ebx
+  .text:000000018021FB66                 mov     [rsp+118h+var_F8], rsi
+  .text:000000018021FB6B                 lea     r8, aSAllFramesActi; "%*s  All frames         Active frames  "...
+  .text:000000018021FB72                 mov     edx, 2
+  .text:000000018021FB77                 mov     ecx, edi
+  .text:000000018021FB79                 call    cs:LoggingSystem_Log
+  .text:000000018021FB7F                 mov     edx, 2
+  .text:000000018021FB84                 mov     ecx, edi
+  .text:000000018021FB86                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FB8C                 test    al, al
+  .text:000000018021FB8E                 jz      short loc_18021FBAC
+  .text:000000018021FB90                 mov     r9d, ebx
+  .text:000000018021FB93                 mov     [rsp+118h+var_F8], rsi
+  .text:000000018021FB98                 lea     r8, aSAvgP99NAvgP99; "%*s    Avg    P99        N    Avg    P9"...
+  .text:000000018021FB9F                 mov     edx, 2
+  .text:000000018021FBA4                 mov     ecx, edi
+  .text:000000018021FBA6                 call    cs:LoggingSystem_Log
+  .text:000000018021FBAC                 mov     edx, 2
+  .text:000000018021FBB1                 mov     ecx, edi
+  .text:000000018021FBB3                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FBB9                 test    al, al
+  .text:000000018021FBBB                 jz      short loc_18021FBE8
+  .text:000000018021FBBD                 mov     rax, [rsp+118h+var_98]
+  .text:000000018021FBC5                 lea     r8, aS_23; "%*s ------ ------   ------ ------ -----"...
+  .text:000000018021FBCC                 test    rax, rax
+  .text:000000018021FBCF                 mov     r9d, ebx
+  .text:000000018021FBD2                 mov     edx, 2
+  .text:000000018021FBD7                 mov     ecx, edi
+  .text:000000018021FBD9                 cmovnz  rsi, rax
+  .text:000000018021FBDD                 mov     [rsp+118h+var_F8], rsi
+  .text:000000018021FBE2                 call    cs:LoggingSystem_Log
+  .text:000000018021FBE8                 mov     rsi, r12
+  .text:000000018021FBEB                 cmp     r12, r14
+  .text:000000018021FBEE                 jz      loc_18021FD0F
+  .text:000000018021FBF4                 movaps  [rsp+118h+var_78], xmm9
+  .text:000000018021FBFD                 movss   xmm9, cs:dword_1805837C4
+  .text:000000018021FC06                 movaps  [rsp+118h+var_68], xmm8
+  .text:000000018021FC0F                 nop
+  .text:000000018021FC10                 mov     rbp, [rsi]
+  .text:000000018021FC13                 mov     edx, 2
+  .text:000000018021FC18                 mov     ecx, edi
+  .text:000000018021FC1A                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FC20                 test    al, al
+  .text:000000018021FC22                 jz      loc_18021FCF0
+  .text:000000018021FC28                 movss   xmm0, dword ptr [rbp+4Ch]
+  .text:000000018021FC2D                 lea     r8, aS72f72f9d72f72; "%*s%7.2f%7.2f%9d%7.2f%7.2f%9.2f%7.2f%9d"...
+  .text:000000018021FC34                 movss   xmm1, dword ptr [rbp+48h]
+  .text:000000018021FC39                 mov     r9d, ebx
+  .text:000000018021FC3C                 mov     eax, [rbp+14h]
+  .text:000000018021FC3F                 mov     edx, 2
+  .text:000000018021FC44                 mulss   xmm0, xmm9
+  .text:000000018021FC49                 mov     ecx, edi
+  .text:000000018021FC4B                 mulss   xmm1, xmm9
+  .text:000000018021FC50                 cvtps2pd xmm8, xmm0
+  .text:000000018021FC54                 movss   xmm0, dword ptr [rbp+60h]
+  .text:000000018021FC59                 movsd   [rsp+118h+var_A8], xmm8
+  .text:000000018021FC60                 cvtps2pd xmm6, xmm1
+  .text:000000018021FC63                 movss   xmm1, dword ptr [rbp+5Ch]
+  .text:000000018021FC68                 movsd   [rsp+118h+var_B0], xmm6
+  .text:000000018021FC6E                 mov     [rsp+118h+var_B8], eax
+  .text:000000018021FC72                 mov     eax, [rbp+10h]
+  .text:000000018021FC75                 mulss   xmm0, xmm9
+  .text:000000018021FC7A                 mulss   xmm1, xmm9
+  .text:000000018021FC7F                 cvtps2pd xmm7, xmm0
+  .text:000000018021FC82                 movss   xmm0, dword ptr [rbp+28h]
+  .text:000000018021FC87                 movsd   [rsp+118h+var_C0], xmm7
+  .text:000000018021FC8D                 cvtps2pd xmm5, xmm1
+  .text:000000018021FC90                 movss   xmm1, dword ptr [rbp+18h]
+  .text:000000018021FC95                 movsd   [rsp+118h+var_C8], xmm5
+  .text:000000018021FC9B                 mulss   xmm0, xmm9
+  .text:000000018021FCA0                 mulss   xmm1, xmm9
+  .text:000000018021FCA5                 cvtps2pd xmm4, xmm0
+  .text:000000018021FCA8                 movss   xmm0, dword ptr [rbp+3Ch]
+  .text:000000018021FCAD                 movsd   [rsp+118h+var_D0], xmm4
+  .text:000000018021FCB3                 cvtps2pd xmm2, xmm1
+  .text:000000018021FCB6                 movss   xmm1, dword ptr [rbp+2Ch]
+  .text:000000018021FCBB                 movsd   [rsp+118h+var_D8], xmm2
+  .text:000000018021FCC1                 mov     [rsp+118h+var_E0], eax
+  .text:000000018021FCC5                 mov     rax, [rbp+8]
+  .text:000000018021FCC9                 mulss   xmm0, xmm9
+  .text:000000018021FCCE                 mulss   xmm1, xmm9
+  .text:000000018021FCD3                 cvtps2pd xmm3, xmm0
+  .text:000000018021FCD6                 cvtps2pd xmm0, xmm1
+  .text:000000018021FCD9                 movsd   [rsp+118h+var_E8], xmm3
+  .text:000000018021FCDF                 movsd   [rsp+118h+var_F0], xmm0
+  .text:000000018021FCE5                 mov     [rsp+118h+var_F8], rax
+  .text:000000018021FCEA                 call    cs:LoggingSystem_Log
+  .text:000000018021FCF0                 add     rsi, 8
+  .text:000000018021FCF4                 cmp     rsi, r14
+  .text:000000018021FCF7                 jnz     loc_18021FC10
+  .text:000000018021FCFD                 movaps  xmm9, [rsp+118h+var_78]
+  .text:000000018021FD06                 movaps  xmm8, [rsp+118h+var_68]
+  .text:000000018021FD0F                 mov     edx, 2
+  .text:000000018021FD14                 mov     ecx, edi
+  .text:000000018021FD16                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FD1C                 movaps  xmm7, [rsp+118h+var_58]
+  .text:000000018021FD24                 movaps  xmm6, [rsp+118h+var_48]
+  .text:000000018021FD2C                 mov     r14, [rsp+118h+var_30]
+  .text:000000018021FD34                 test    al, al
+  .text:000000018021FD36                 jz      short loc_18021FD4C
+  .text:000000018021FD38                 lea     r8, asc_180525034; "\n"
+  .text:000000018021FD3F                 mov     edx, 2
+  .text:000000018021FD44                 mov     ecx, edi
+  .text:000000018021FD46                 call    cs:LoggingSystem_Log
+  .text:000000018021FD4C                 cmp     [rsp+118h+var_98], 0
+  .text:000000018021FD55                 jz      short loc_18021FD65
+  .text:000000018021FD57                 lea     rcx, [rsp+118h+var_98]
+  .text:000000018021FD5F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018021FD65                 test    r13d, 0C0000000h
+  .text:000000018021FD6C                 mov     r13, [rsp+118h+var_28]
+  .text:000000018021FD74                 jnz     short loc_18021FD8E
+  .text:000000018021FD76                 test    r12, r12
+  .text:000000018021FD79                 jz      short loc_18021FD8E
+  .text:000000018021FD7B                 mov     rax, cs:g_pMemAlloc
+  .text:000000018021FD82                 mov     rdx, r12
+  .text:000000018021FD85                 mov     rcx, [rax]
+  .text:000000018021FD88                 mov     rax, [rcx]
+  .text:000000018021FD8B                 call    qword ptr [rax+18h]
+  .text:000000018021FD8E                 mov     r12, [rsp+118h+var_20]
+  .text:000000018021FD96                 mov     rbx, [rsp+118h+arg_8]
+  .text:000000018021FD9E                 add     rsp, 100h
+  .text:000000018021FDA5                 pop     rdi
+  .text:000000018021FDA6                 pop     rsi
+  .text:000000018021FDA7                 pop     rbp
+  .text:000000018021FDA8                 retn
+  .text:000000018021FDA9                 mov     edx, 2
+  .text:000000018021FDAE                 mov     ecx, edi
+  .text:000000018021FDB0                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018021FDB6                 test    al, al
+  .text:000000018021FDB8                 jz      short loc_18021FD96
+  .text:000000018021FDBA                 lea     r8, aNoVprofLiteDat_0; "No vprof lite data recorded\n"
+  .text:000000018021FDC1                 mov     edx, 2
+  .text:000000018021FDC6                 mov     ecx, edi
+  .text:000000018021FDC8                 call    cs:LoggingSystem_Log
+  .text:000000018021FDCE                 jmp     short loc_18021FD96
+procedure: |-
+  void __fastcall sub_18021F7C0(_DWORD *a1, char a2, int a3)
+  {
+    unsigned int v3; // edi
+    __int64 v6; // rbx
+    char IsChannelEnabled; // al
+    __int64 v8; // rbp
+    __int64 *v9; // r12
+    __int64 v10; // rax
+    int v11; // ebx
+    __int64 v12; // rdx
+    int v13; // r15d
+    int v14; // ecx
+    int v15; // eax
+    __int64 v16; // r12
+    int v17; // esi
+    int v18; // eax
+    __int64 v19; // rdx
+    __int64 v20; // rax
+    int v21; // ebx
+    __int64 *v22; // rdx
+    __int64 *v23; // r14
+    __int64 v24; // rax
+    __int64 v25; // rsi
+    void *v26; // rsi
+    __int64 *i; // rsi
+    __int64 v28; // rbp
+    void *v29; // [rsp+80h] [rbp-98h] BYREF
+    __int64 v30; // [rsp+88h] [rbp-90h]
+    __int64 v31; // [rsp+90h] [rbp-88h]
+    int v32; // [rsp+120h] [rbp+8h]
+    int v33; // [rsp+130h] [rbp+18h]
+
+    v33 = a3;
+    v3 = a3;
+    if ( a3 < 0 )
+    {
+      v3 = LOG_VPROF;
+      v33 = LOG_VPROF;
+    }
+    if ( a1[2] && (v6 = *((_QWORD *)a1 + 2), *(int *)(v6 + 16) >= 1) )
+    {
+      IsChannelEnabled = LoggingSystem_IsChannelEnabled(v3, 2);
+      if ( a2 )
+      {
+        if ( IsChannelEnabled )
+          LoggingSystem_Log(v3, 2, "\n");
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(v3, 2, "-- Performance report --\n");
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(
+            v3,
+            2,
+            "Summary of %d frames and %d 1-second intervals.  (%d frames excluded from analysis.)\n",
+            *(_DWORD *)(v6 + 16),
+            *(_DWORD *)(v6 + 20),
+            *a1);
+      }
+      else if ( IsChannelEnabled )
+      {
+        LoggingSystem_Log(
+          v3,
+          2,
+          "Summary of %d frames.  (%d frames excluded from analysis.)\n",
+          *(_DWORD *)(v6 + 16),
+          *a1);
+      }
+      if ( (unsigned __int8)NET_IsDedicated() && a2 )
+        goto LABEL_69;
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+        LoggingSystem_Log(
+          v3,
+          2,
+          "FPS: Avg=%.1f, P1=%.1f\n",
+          (float)(1.0 / *(float *)(v6 + 44)),
+          (float)(1.0 / *(float *)(v6 + 60)));
+      if ( a2 )
+      {
+  LABEL_69:
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(v3, 2, "\n");
+        v8 = *((_QWORD *)a1 + 2);
+        v9 = nullptr;
+        v10 = (int)a1[2];
+        v11 = 0;
+        v30 = 0;
+        v12 = v8 + 112 * v10;
+        v13 = 0;
+        v31 = v12;
+        v14 = 1;
+        if ( v8 != v12 )
+        {
+          do
+          {
+            v32 = ++v14;
+            if ( v14 <= 10 || *(float *)(v8 + 24) >= 0.000099999997 || *(float *)(v8 + 40) >= 0.00050000002 )
+            {
+              v15 = v13;
+              if ( v13 == v11 )
+              {
+                v16 = v11;
+                if ( v11 > 2147483646LL )
+                  UtlVectorMemory_FailedAllocation((unsigned int)v11, 1);
+                v17 = v11 + 1;
+                v18 = UtlVectorMemory_CalcNewAllocationCount((unsigned int)v11, 0, (unsigned int)(v11 + 1), 8);
+                v11 = v18;
+                if ( v18 < v17 )
+                {
+                  if ( v18 || v17 > -1 )
+                  {
+                    do
+                    {
+                      v19 = (unsigned int)((v11 + v17) >> 31);
+                      v11 = (v11 + v17) / 2;
+                    }
+                    while ( v11 < v17 );
+                  }
+                  else
+                  {
+                    v11 = -1;
+                  }
+                }
+                LOBYTE(v19) = 1;
+                v20 = UtlVectorMemory_Alloc(v30, v19, 8LL * v11, 8 * v16);
+                v14 = v32;
+                v12 = v31;
+                v9 = (__int64 *)v20;
+                v30 = v20;
+                v15 = v13;
+              }
+              ++v13;
+              v9[v15] = v8;
+            }
+            v8 += 112;
+          }
+          while ( v8 != v12 );
+          v3 = v33;
+        }
+        v21 = 10;
+        v22 = v9;
+        v23 = &v9[v13];
+        if ( v9 != v23 )
+        {
+          do
+          {
+            v24 = -1;
+            do
+              ++v24;
+            while ( *(_BYTE *)(*(_QWORD *)(*v22 + 8) + v24) );
+            if ( v21 <= (int)v24 )
+              v21 = v24;
+            ++v22;
+          }
+          while ( v22 != v23 );
+        }
+        v29 = nullptr;
+        if ( v21 > 0 )
+        {
+          v25 = (unsigned int)v21;
+          do
+          {
+            CUtlString::Append((CUtlString *)&v29, "-");
+            --v25;
+          }
+          while ( v25 );
+        }
+        v26 = &unk_180524F9F;
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(
+            v3,
+            2,
+            "%*s  All frames         Active frames       1s max (all)      1s max (active)  \n",
+            v21,
+            (const char *)&unk_180524F9F);
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(
+            v3,
+            2,
+            "%*s    Avg    P99        N    Avg    P99      P50    P95        N    P50    P95\n",
+            v21,
+            (const char *)&unk_180524F9F);
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+        {
+          if ( v29 )
+            v26 = v29;
+          LoggingSystem_Log(
+            v3,
+            2,
+            "%*s ------ ------   ------ ------ ------   ------ ------   ------ ------ ------\n",
+            (unsigned int)v21,
+            v26);
+        }
+        for ( i = v9; i != v23; ++i )
+        {
+          v28 = *i;
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+            LoggingSystem_Log(
+              v3,
+              2,
+              "%*s%7.2f%7.2f%9d%7.2f%7.2f%9.2f%7.2f%9d%7.2f%7.2f\n",
+              v21,
+              *(const char **)(v28 + 8),
+              (float)(*(float *)(v28 + 44) * 1000.0),
+              (float)(*(float *)(v28 + 60) * 1000.0),
+              *(_DWORD *)(v28 + 16),
+              (float)(*(float *)(v28 + 24) * 1000.0),
+              (float)(*(float *)(v28 + 40) * 1000.0),
+              (float)(*(float *)(v28 + 92) * 1000.0),
+              (float)(*(float *)(v28 + 96) * 1000.0),
+              *(_DWORD *)(v28 + 20),
+              (float)(*(float *)(v28 + 72) * 1000.0),
+              (float)(*(float *)(v28 + 76) * 1000.0));
+        }
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+          LoggingSystem_Log(v3, 2, "\n");
+        if ( v29 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v29);
+        if ( v9 )
+          (*(void (__fastcall **)(_QWORD, __int64 *))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v9);
+      }
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(v3, 2) )
+    {
+      LoggingSystem_Log(v3, 2, "No vprof lite data recorded\n");
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkClientService_Connect.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkClientService_Connect.linux.yaml
@@ -1,0 +1,188 @@
+func_name: CNetworkClientService_Connect
+func_va: '0x5bef40'
+disasm_code: |-
+  .text:00000000005BEF40                 push    rbp
+  .text:00000000005BEF41                 lea     rdx, sub_5A3FB0
+  .text:00000000005BEF48                 mov     rbp, rsp
+  .text:00000000005BEF4B                 push    r15
+  .text:00000000005BEF4D                 push    r14
+  .text:00000000005BEF4F                 push    r13
+  .text:00000000005BEF51                 mov     r13, rsi
+  .text:00000000005BEF54                 push    r12
+  .text:00000000005BEF56                 mov     r12, rdi
+  .text:00000000005BEF59                 push    rbx
+  .text:00000000005BEF5A                 sub     rsp, 18h
+  .text:00000000005BEF5E                 mov     rdi, cs:qword_9C4B20
+  .text:00000000005BEF65                 mov     rax, [rdi]
+  .text:00000000005BEF68                 mov     rax, [rax+0C0h]
+  .text:00000000005BEF6F                 cmp     rax, rdx
+  .text:00000000005BEF72                 jnz     loc_5BF110
+  .text:00000000005BEF78                 cmp     byte ptr [rdi+34h], 0
+  .text:00000000005BEF7C                 jnz     short loc_5BEF83
+  .text:00000000005BEF7E                 call    sub_5A3CD0
+  .text:00000000005BEF83                 mov     rdi, cs:qword_97D470
+  .text:00000000005BEF8A                 lea     rdx, sub_4F8E10
+  .text:00000000005BEF91                 mov     rax, [rdi]
+  .text:00000000005BEF94                 mov     rax, [rax+120h]; 0x120 = 288 = CTier1Application_GetGameMode
+  .text:00000000005BEF9B                 cmp     rax, rdx
+  .text:00000000005BEF9E                 ; CTier1Application_GetApplicationMode
+  .text:00000000005BEF9E                 jnz     loc_5BF0F0; CTier1Application_GetApplicationMode
+  .text:00000000005BEFA4                 mov     rax, [rdi+8]
+  .text:00000000005BEFA8                 cmp     byte ptr [rax+0FBh], 0
+  .text:00000000005BEFAF                 jz      short loc_5BEFBE
+  .text:00000000005BEFB1                 cmp     byte ptr [rax+0FCh], 0
+  .text:00000000005BEFB8                 jnz     loc_5BF0FB
+  .text:00000000005BEFBE                 lea     rsi, aAddress; "address"
+  .text:00000000005BEFC5                 mov     rdi, r13
+  .text:00000000005BEFC8                 call    sub_2B4790
+  .text:00000000005BEFCD                 lea     rsi, aLoopback; "loopback"
+  .text:00000000005BEFD4                 test    rax, rax
+  .text:00000000005BEFD7                 jz      short loc_5BEFE8
+  .text:00000000005BEFD9                 xor     ecx, ecx
+  .text:00000000005BEFDB                 xor     edx, edx
+  .text:00000000005BEFDD                 mov     rdi, rax
+  .text:00000000005BEFE0                 call    sub_2B4720
+  .text:00000000005BEFE5                 mov     rsi, rax
+  .text:00000000005BEFE8                 lea     r14, [rbp+var_38]
+  .text:00000000005BEFEC                 mov     [rbp+var_38], 0
+  .text:00000000005BEFF4                 mov     rdi, r14
+  .text:00000000005BEFF7                 call    sub_2B4370
+  .text:00000000005BEFFC                 mov     edi, 2CD1C0h
+  .text:00000000005BF001                 call    sub_2B1430
+  .text:00000000005BF006                 mov     rbx, rax
+  .text:00000000005BF009                 mov     rdi, rax
+  .text:00000000005BF00C                 call    sub_665240
+  .text:00000000005BF011                 mov     rax, [rbx]
+  .text:00000000005BF014                 xor     esi, esi
+  .text:00000000005BF016                 mov     rdi, rbx
+  .text:00000000005BF019                 mov     r15d, [r12+94h]
+  .text:00000000005BF021                 mov     [r12+0A0h], rbx
+  .text:00000000005BF029                 add     dword ptr [rbx+248h], 1
+  .text:00000000005BF030                 call    qword ptr [rax+430h]
+  .text:00000000005BF036                 mov     rax, [r12+0A0h]
+  .text:00000000005BF03E                 xor     edx, edx
+  .text:00000000005BF040                 mov     rdi, r13
+  .text:00000000005BF043                 mov     [rbx+24Ch], r15d
+  .text:00000000005BF04A                 lea     rsi, aReservationid; "reservationid"
+  .text:00000000005BF051                 mov     rbx, [rax+168h]
+  .text:00000000005BF058                 call    sub_2B4400
+  .text:00000000005BF05D                 xor     edx, edx
+  .text:00000000005BF05F                 mov     rdi, r13
+  .text:00000000005BF062                 lea     rsi, aHltv; "hltv"
+  .text:00000000005BF069                 mov     r15, rax
+  .text:00000000005BF06C                 call    sub_2B3100
+  .text:00000000005BF071                 mov     rsi, [rbp+var_38]
+  .text:00000000005BF075                 lea     rdi, [rbx+28h]
+  .text:00000000005BF079                 test    eax, eax
+  .text:00000000005BF07B                 mov     byte ptr [rbx+0C5h], 1
+  .text:00000000005BF082                 lea     rax, byte_2686F8
+  .text:00000000005BF089                 setnz   r13b
+  .text:00000000005BF08D                 test    rsi, rsi
+  .text:00000000005BF090                 cmovz   rsi, rax
+  .text:00000000005BF094                 mov     eax, cs:dword_97DEF4
+  .text:00000000005BF09A                 mov     [rbx+0A0h], eax
+  .text:00000000005BF0A0                 call    sub_2B4370
+  .text:00000000005BF0A5                 mov     [rbx+0C6h], r13b
+  .text:00000000005BF0AC                 mov     [rbx+0B0h], r15
+  .text:00000000005BF0B3                 mov     rdi, [r12+0A0h]
+  .text:00000000005BF0BB                 sub     dword ptr [rdi+248h], 1
+  .text:00000000005BF0C2                 jnz     short loc_5BF0CD
+  .text:00000000005BF0C4                 mov     rax, [rdi]
+  .text:00000000005BF0C7                 call    qword ptr [rax+238h]
+  .text:00000000005BF0CD                 cmp     [rbp+var_38], 0
+  .text:00000000005BF0D2                 jz      short loc_5BF0DC
+  .text:00000000005BF0D4                 mov     rdi, r14
+  .text:00000000005BF0D7                 call    sub_2B49D0
+  .text:00000000005BF0DC                 add     rsp, 18h
+  .text:00000000005BF0E0                 pop     rbx
+  .text:00000000005BF0E1                 pop     r12
+  .text:00000000005BF0E3                 pop     r13
+  .text:00000000005BF0E5                 pop     r14
+  .text:00000000005BF0E7                 pop     r15
+  .text:00000000005BF0E9                 pop     rbp
+  .text:00000000005BF0EA                 retn
+  .text:00000000005BF0F0                 call    rax
+  .text:00000000005BF0F2                 cmp     eax, 2
+  .text:00000000005BF0F5                 jnz     loc_5BEFBE
+  .text:00000000005BF0FB                 mov     eax, cs:dword_971E7C
+  .text:00000000005BF101                 mov     [r12+94h], eax
+  .text:00000000005BF109                 jmp     loc_5BEFBE
+  .text:00000000005BF110                 call    rax
+  .text:00000000005BF112                 jmp     loc_5BEF83
+procedure: |-
+  __int64 __fastcall sub_5BEF40(__int64 a1, __int64 a2, double a3)
+  {
+    void (*v4)(void); // rax
+    unsigned int (*v5)(void); // rax
+    __int64 v6; // rax
+    __int64 v7; // rax
+    const char *v8; // rsi
+    __int64 v9; // rbx
+    __int64 v10; // rax
+    int v11; // r15d
+    __int64 v12; // rax
+    __int64 v13; // rbx
+    __int64 v14; // r15
+    int v15; // eax
+    const char *v16; // rsi
+    bool v17; // r13
+    __int64 result; // rax
+    _DWORD *v19; // rdi
+    _QWORD v21[7]; // [rsp+8h] [rbp-38h] BYREF
+
+    v4 = *(void (**)(void))(*(_QWORD *)qword_9C4B20 + 192LL);
+    if ( (char *)v4 == (char *)sub_5A3FB0 )
+    {
+      if ( !*(_BYTE *)(qword_9C4B20 + 52) )
+        sub_5A3CD0();
+    }
+    else
+    {
+      v4();
+    }
+    v5 = *(unsigned int (**)(void))(*(_QWORD *)qword_97D470 + 288LL);// 0x120 = 288 = CTier1Application_GetGameMode
+    if ( (char *)v5 != (char *)sub_4F8E10 )       // CTier1Application_GetGameMode
+    {
+      if ( v5() != 2 )
+        goto LABEL_7;
+      goto LABEL_17;
+    }
+    v6 = *(_QWORD *)(qword_97D470 + 8);
+    if ( *(_BYTE *)(v6 + 251) && *(_BYTE *)(v6 + 252) )
+  LABEL_17:
+      *(_DWORD *)(a1 + 148) = dword_971E7C;
+  LABEL_7:
+    v7 = sub_2B4790(a2, "address");
+    v8 = "loopback";
+    if ( v7 )
+      v8 = (const char *)sub_2B4720(v7, "loopback", 0, 0);
+    v21[0] = 0;
+    sub_2B4370(v21, v8);
+    v9 = sub_2B1430(2937280);
+    sub_665240(v9);
+    v10 = *(_QWORD *)v9;
+    v11 = *(_DWORD *)(a1 + 148);
+    *(_QWORD *)(a1 + 160) = v9;
+    ++*(_DWORD *)(v9 + 584);
+    (*(void (__fastcall **)(__int64, _QWORD))(v10 + 1072))(v9, 0);
+    v12 = *(_QWORD *)(a1 + 160);
+    *(_DWORD *)(v9 + 588) = v11;
+    v13 = *(_QWORD *)(v12 + 360);
+    v14 = sub_2B4400(a2, "reservationid", 0);
+    v15 = sub_2B3100(a2, "hltv", 0);
+    v16 = (const char *)v21[0];
+    *(_BYTE *)(v13 + 197) = 1;
+    v17 = v15 != 0;
+    if ( !v16 )
+      v16 = &byte_2686F8;
+    *(_DWORD *)(v13 + 160) = dword_97DEF4;
+    result = sub_2B4370(v13 + 40, v16);
+    *(_BYTE *)(v13 + 198) = v17;
+    *(_QWORD *)(v13 + 176) = v14;
+    v19 = *(_DWORD **)(a1 + 160);
+    if ( v19[146]-- == 1 )
+      result = (*(__int64 (__fastcall **)(_DWORD *))(*(_QWORD *)v19 + 568LL))(v19);
+    if ( v21[0] )
+      return sub_2B49D0(v21, a3);
+    return result;
+  }


### PR DESCRIPTION
## Summary

- Add `find-NET_IsDedicated` script — discovers `NET_IsDedicated` global via `"NET_IsDedicated"` string xref (both platforms)
- Add `find-CEngineServer_IsDedicatedServer-windows` script — finds `CEngineServer_IsDedicatedServer` vfunc via `NET_IsDedicated` xref + `CEngineServer_vtable` intersection (windows)
- Add `find-CEngineServer_IsDedicatedServer-linux` script — finds `CEngineServer_IsDedicatedServer` vfunc via `CTier1Application_GetGameMode` data-xref (14 callers) intersected with `CEngineServer_vtable` entries (123 vfuncs) to yield exactly 1 candidate (linux)
- Add `find-CTier1Application_vtable` and `find-CTier1Application_GetGameMode-linux` as prerequisite scripts
- Add `find-CNetworkClientService_Connect` as prerequisite for `CTier1Application_GetGameMode` linux discovery
- Add reference YAMLs for `CEngineServer_ShowFrameTimeReport_Impl` and `CNetworkClientService_Connect`

## Test plan

- [ ] Format check passes: `uv run python format_repo_files.py --check`
- [ ] Regression tests pass (2 pre-existing failures unrelated to this branch): `uv run python -m unittest discover -s tests -b`
- [ ] Linux discovery logic verified in IDA: xref_funcs on `CTier1Application_GetGameMode` (14 data-xref candidates) ∩ `CEngineServer_vtable` entries (123) = exactly `sub_6A2EC0` = `CEngineServer_IsDedicatedServer`