### PR TITLE
Add INetworkGameServer_GetMaxClients and CNetworkGameServerBase_GetMaxClients

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -481,6 +481,17 @@ modules:
           - CNetworkGameServer_SpawnServer.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_SpawnServer-decompiles
+        expected_output:
+          - INetworkGameServer_GetMaxClients.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_SpawnServer.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetMaxClients
+        expected_output:
+          - CNetworkGameServerBase_GetMaxClients.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - INetworkGameServer_GetMaxClients.{platform}.yaml
       - name: find-CNetworkGameServerBase_ServerPollNetworking
         expected_output:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
@@ -1710,6 +1721,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::SpawnServer
+      - name: CNetworkGameServerBase_GetMaxClients
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetMaxClients
       - name: CNetworkGameServerBase_SetMaxClients
         category: vfunc
         alias:
@@ -1967,6 +1982,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkServerService::DisconnectGameNow
+      - name: INetworkGameServer_GetMaxClients
+        category: vfunc
+        alias:
+          - INetworkGameServer::GetMaxClients
       - name: INetworkGameServer_PreWorldUpdate
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetMaxClients.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetMaxClients.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetMaxClients skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_GetMaxClients",
+        "CNetworkGameServerBase",
+        "INetworkGameServer_GetMaxClients",
+        False,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_GetMaxClients",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve GetMaxClients by inherited vfunc slot without emitting func_sig."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_SpawnServer-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_SpawnServer-decompiles.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_SpawnServer-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkGameServer_GetMaxClients",
+]
+
+LLM_DECOMPILE = [
+    # (symbol_name, path_to_prompt, path_to_reference)
+    (
+        "INetworkGameServer_GetMaxClients",
+        "prompt/call_llm_decompile.md",
+        "references/engine/CNetworkGameServer_SpawnServer.{platform}.yaml",
+    ),
+]
+
+# INetworkGameServer is an abstract interface -- no vtable YAML needed; vtable_name is metadata only
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkGameServer_GetMaxClients", "INetworkGameServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "INetworkGameServer_GetMaxClients",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate INetworkGameServer_GetMaxClients from CNetworkGameServer_SpawnServer."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_SpawnServer.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_SpawnServer.linux.yaml
@@ -1,0 +1,667 @@
+func_name: CNetworkGameServer_SpawnServer
+func_va: '0x6a4cc0'
+disasm_code: |-
+  .text:00000000006A4CC0                 push    rbp
+  .text:00000000006A4CC1                 mov     rbp, rsp
+  .text:00000000006A4CC4                 push    r15
+  .text:00000000006A4CC6                 push    r14
+  .text:00000000006A4CC8                 push    r13
+  .text:00000000006A4CCA                 push    r12
+  .text:00000000006A4CCC                 mov     r12, rsi
+  .text:00000000006A4CCF                 push    rbx
+  .text:00000000006A4CD0                 mov     rbx, rdi
+  .text:00000000006A4CD3                 sub     rsp, 88h
+  .text:00000000006A4CDA                 test    rsi, rsi
+  .text:00000000006A4CDD                 ; _QWORD
+  .text:00000000006A4CDD                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A4CE3                 ; _QWORD
+  .text:00000000006A4CE3                 mov     esi, 2; _QWORD
+  .text:00000000006A4CE8                 jz      loc_6A51F0
+  .text:00000000006A4CEE                 cmp     byte ptr [r12], 0
+  .text:00000000006A4CF3                 jnz     loc_6A5150
+  .text:00000000006A4CF9                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000006A4CFE                 test    al, al
+  .text:00000000006A4D00                 jnz     loc_6A5038
+  .text:00000000006A4D06                 mov     rdi, rbx
+  .text:00000000006A4D09                 call    sub_698780
+  .text:00000000006A4D0E                 ; this
+  .text:00000000006A4D0E                 lea     rdi, [rbx+6F8h]; this
+  .text:00000000006A4D15                 ; char *
+  .text:00000000006A4D15                 mov     rsi, r12; char *
+  .text:00000000006A4D18                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:00000000006A4D1D                 mov     rax, [rbx]
+  .text:00000000006A4D20                 lea     rdx, sub_696CD0
+  .text:00000000006A4D27                 mov     rax, [rax+60h]; 0x60 = 96 = INetworkGameServer_GetMaxClients
+  .text:00000000006A4D2B                 cmp     rax, rdx
+  .text:00000000006A4D2E                 jnz     loc_6A51A0
+  .text:00000000006A4D34                 mov     eax, [rbx+2A4h]
+  .text:00000000006A4D3A                 mov     [rbx+68h], eax
+  .text:00000000006A4D3D                 lea     rdx, [rbx+700h]
+  .text:00000000006A4D44                 mov     rdi, rbx
+  .text:00000000006A4D47                 mov     byte ptr [rbx+2748h], 1
+  .text:00000000006A4D4E                 lea     rsi, [rbx+728h]
+  .text:00000000006A4D55                 call    sub_6CE770
+  .text:00000000006A4D5A                 mov     r12d, eax
+  .text:00000000006A4D5D                 test    al, al
+  .text:00000000006A4D5F                 jz      loc_6A5100
+  .text:00000000006A4D65                 lea     rax, qword_977818
+  .text:00000000006A4D6C                 pxor    xmm0, xmm0
+  .text:00000000006A4D70                 movaps  [rbp+var_50], xmm0
+  .text:00000000006A4D74                 lea     rdx, sub_67C9D0
+  .text:00000000006A4D7B                 mov     [rbp+var_88], 0
+  .text:00000000006A4D86                 mov     [rbp+var_80], 0
+  .text:00000000006A4D8D                 mov     [rbp+var_7C], 0FFh
+  .text:00000000006A4D91                 mov     qword ptr [rbp+var_50+8], rax
+  .text:00000000006A4D95                 lea     rax, off_9582C0
+  .text:00000000006A4D9C                 mov     [rbp+var_90], rax
+  .text:00000000006A4DA3                 add     rax, 40h ; '@'
+  .text:00000000006A4DA7                 mov     [rbp+var_60], rax
+  .text:00000000006A4DAB                 mov     rax, [rbx]
+  .text:00000000006A4DAE                 mov     [rbp+var_78], 0FFFFFFFFFFFFFFFFh
+  .text:00000000006A4DB6                 mov     [rbp+var_70], 0BF800000h
+  .text:00000000006A4DBD                 mov     [rbp+var_68], 0FFFFFFFFFFFFFFFFh
+  .text:00000000006A4DC5                 mov     rax, [rax+178h]
+  .text:00000000006A4DCC                 mov     [rbp+var_58], 0
+  .text:00000000006A4DD4                 mov     [rbp+var_40], 0
+  .text:00000000006A4DDC                 cmp     rax, rdx
+  .text:00000000006A4DDF                 jnz     loc_6A5240
+  .text:00000000006A4DE5                 movzx   eax, byte ptr [rbx+45Dh]
+  .text:00000000006A4DEC                 lea     rsi, s1
+  .text:00000000006A4DF3                 test    al, al
+  .text:00000000006A4DF5                 jnz     loc_6A5080
+  .text:00000000006A4DFB                 mov     rax, [rbp+var_58]
+  .text:00000000006A4DFF                 or      dword ptr [rbp+var_50], 1
+  .text:00000000006A4E03                 mov     rdx, rax
+  .text:00000000006A4E06                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000000006A4E0A                 test    al, 1
+  .text:00000000006A4E0C                 jnz     loc_6A5270
+  .text:00000000006A4E12                 lea     rdi, [rbp+var_50+8]
+  .text:00000000006A4E16                 call    sub_4B8940
+  .text:00000000006A4E1B                 mov     rdi, cs:qword_980C50
+  .text:00000000006A4E22                 mov     dword ptr [rbp+var_40], 5
+  .text:00000000006A4E29                 lea     r12, [rbp+var_90]
+  .text:00000000006A4E30                 or      dword ptr [rbp+var_50], 2
+  .text:00000000006A4E34                 lea     r13, [rbx+210h]
+  .text:00000000006A4E3B                 mov     rdx, r12
+  .text:00000000006A4E3E                 mov     rsi, r13
+  .text:00000000006A4E41                 mov     rax, [rdi]
+  .text:00000000006A4E44                 call    qword ptr [rax+18h]
+  .text:00000000006A4E47                 mov     r12d, eax
+  .text:00000000006A4E4A                 test    al, al
+  .text:00000000006A4E4C                 jz      loc_6A50B0
+  .text:00000000006A4E52                 cmp     byte ptr [rbx+230h], 0
+  .text:00000000006A4E59                 jnz     loc_6A50B0
+  .text:00000000006A4E5F                 mov     rdi, cs:qword_97E658
+  .text:00000000006A4E66                 mov     rsi, r13
+  .text:00000000006A4E69                 mov     rax, [rdi]
+  .text:00000000006A4E6C                 call    qword ptr [rax+70h]
+  .text:00000000006A4E6F                 mov     rax, [rbx]
+  .text:00000000006A4E72                 mov     esi, 2
+  .text:00000000006A4E77                 mov     rdi, rbx
+  .text:00000000006A4E7A                 call    qword ptr [rax+118h]
+  .text:00000000006A4E80                 mov     rax, [rbx]
+  .text:00000000006A4E83                 lea     rdx, sub_68D810
+  .text:00000000006A4E8A                 mov     rax, [rax+0E0h]
+  .text:00000000006A4E91                 cmp     rax, rdx
+  .text:00000000006A4E94                 jnz     loc_6A5260
+  .text:00000000006A4E9A                 pxor    xmm0, xmm0
+  .text:00000000006A4E9E                 cvtsi2ss xmm0, dword ptr [rbx+44h]
+  .text:00000000006A4EA3                 mulss   xmm0, cs:dword_255D4C
+  .text:00000000006A4EAB                 movss   dword ptr [rbp+var_A8], xmm0
+  .text:00000000006A4EB3                 call    _ThreadGetCurrentId
+  .text:00000000006A4EB8                 movss   xmm0, dword ptr [rbp+var_A8]
+  .text:00000000006A4EC0                 mov     dword ptr [rbx+0A8h], 0
+  .text:00000000006A4ECA                 mov     [rbx+0B0h], rax
+  .text:00000000006A4ED1                 movss   dword ptr [rbx+88h], xmm0
+  .text:00000000006A4ED9                 mulss   xmm0, cs:dword_255DCC
+  .text:00000000006A4EE1                 addss   xmm0, cs:dword_255D7C
+  .text:00000000006A4EE9                 cvttss2si edx, xmm0
+  .text:00000000006A4EED                 mov     [rbx+9Ch], edx
+  .text:00000000006A4EF3                 call    _ThreadInMainThread
+  .text:00000000006A4EF8                 test    al, al
+  .text:00000000006A4EFA                 jz      short loc_6A4F0F
+  .text:00000000006A4EFC                 lea     rdi, qword_97FA80
+  .text:00000000006A4F03                 xor     edx, edx
+  .text:00000000006A4F05                 mov     esi, 8
+  .text:00000000006A4F0A                 call    sub_749860
+  .text:00000000006A4F0F                 lea     rdi, aInitializeenti; "InitializeEntityDLLFields"
+  .text:00000000006A4F16                 xor     eax, eax
+  .text:00000000006A4F18                 call    _COM_TimestampedLog
+  .text:00000000006A4F1D                 mov     rax, [rbx+150h]
+  .text:00000000006A4F24                 lea     rdx, s1
+  .text:00000000006A4F2B                 mov     rdi, cs:qword_97DDC8
+  .text:00000000006A4F32                 lea     rcx, sub_51F8D0
+  .text:00000000006A4F39                 test    rax, rax
+  .text:00000000006A4F3C                 cmovz   rax, rdx
+  .text:00000000006A4F40                 mov     [rbx+0B8h], rax
+  .text:00000000006A4F47                 mov     rax, [rbx+6F8h]
+  .text:00000000006A4F4E                 test    rax, rax
+  .text:00000000006A4F51                 cmovz   rax, rdx
+  .text:00000000006A4F55                 mov     [rbx+0C0h], rax
+  .text:00000000006A4F5C                 mov     rax, [rdi]
+  .text:00000000006A4F5F                 mov     rax, [rax+150h]
+  .text:00000000006A4F66                 cmp     rax, rcx
+  .text:00000000006A4F69                 jnz     loc_6A5250
+  .text:00000000006A4F6F                 mov     rsi, [rdi+0B0h]
+  .text:00000000006A4F76                 test    rsi, rsi
+  .text:00000000006A4F79                 ; char *
+  .text:00000000006A4F79                 cmovz   rsi, rdx; char *
+  .text:00000000006A4F7D                 ; this
+  .text:00000000006A4F7D                 lea     rdi, [rbx+158h]; this
+  .text:00000000006A4F84                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:00000000006A4F89                 mov     rdi, cs:qword_97FB08
+  .text:00000000006A4F90                 test    rdi, rdi
+  .text:00000000006A4F93                 jz      short loc_6A4FA2
+  .text:00000000006A4F95                 mov     rax, [rdi]
+  .text:00000000006A4F98                 lea     rsi, aMapLoad; "map_load"
+  .text:00000000006A4F9F                 call    qword ptr [rax+60h]
+  .text:00000000006A4FA2                 movzx   r15d, word ptr [rbx+310h]
+  .text:00000000006A4FAA                 mov     [rbp+var_98], 0
+  .text:00000000006A4FB5                 cmp     r15w, 0FFFFh
+  .text:00000000006A4FBA                 jnz     loc_6A5280
+  .text:00000000006A4FC0                 lea     rdx, s1
+  .text:00000000006A4FC7                 lea     rsi, aStartedS; "Started:  \"%s\"\n"
+  .text:00000000006A4FCE                 xor     eax, eax
+  .text:00000000006A4FD0                 lea     rdi, qword_97FC00
+  .text:00000000006A4FD7                 call    sub_8F7910
+  .text:00000000006A4FDC                 cmp     [rbp+var_98], 0
+  .text:00000000006A4FE4                 jz      short loc_6A4FF2
+  .text:00000000006A4FE6                 ; this
+  .text:00000000006A4FE6                 lea     rdi, [rbp+var_98]; this
+  .text:00000000006A4FED                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:00000000006A4FF2                 lea     rdi, aSvSpawnserverF; "SV_SpawnServer -- Finished"
+  .text:00000000006A4FF9                 xor     eax, eax
+  .text:00000000006A4FFB                 call    _COM_TimestampedLog
+  .text:00000000006A5000                 lea     rax, off_94B1C8
+  .text:00000000006A5007                 mov     [rbp+var_90], rax
+  .text:00000000006A500E                 lea     rdi, [rbp+var_60]
+  .text:00000000006A5012                 add     rax, 40h ; '@'
+  .text:00000000006A5016                 mov     [rbp+var_60], rax
+  .text:00000000006A501A                 call    sub_4C0520
+  .text:00000000006A501F                 add     rsp, 88h
+  .text:00000000006A5026                 mov     eax, r12d
+  .text:00000000006A5029                 pop     rbx
+  .text:00000000006A502A                 pop     r12
+  .text:00000000006A502C                 pop     r13
+  .text:00000000006A502E                 pop     r14
+  .text:00000000006A5030                 pop     r15
+  .text:00000000006A5032                 pop     rbp
+  .text:00000000006A5033                 retn
+  .text:00000000006A5038                 ; _QWORD
+  .text:00000000006A5038                 mov     rcx, [rbx+150h]; _QWORD
+  .text:00000000006A503F                 test    rcx, rcx
+  .text:00000000006A5042                 jz      loc_6A51B0
+  .text:00000000006A5048                 ; _QWORD
+  .text:00000000006A5048                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A504E                 lea     rdx, aSvSpawnServerS; "SV:  Spawn Server: %s\n"
+  .text:00000000006A5055                 ; _QWORD
+  .text:00000000006A5055                 mov     esi, 2; _QWORD
+  .text:00000000006A505A                 xor     eax, eax
+  .text:00000000006A505C                 call    _LoggingSystem_Log
+  .text:00000000006A5061                 mov     rdi, rbx
+  .text:00000000006A5064                 call    sub_698780
+  .text:00000000006A5069                 lea     rax, s1
+  .text:00000000006A5070                 test    r12, r12
+  .text:00000000006A5073                 cmovz   r12, rax
+  .text:00000000006A5077                 jmp     loc_6A4D0E
+  .text:00000000006A5080                 mov     rdi, cs:qword_9D1D18
+  .text:00000000006A5087                 mov     esi, 0FFFFFFFFh
+  .text:00000000006A508C                 call    sub_911FE0
+  .text:00000000006A5091                 test    rax, rax
+  .text:00000000006A5094                 jz      loc_6A51D8
+  .text:00000000006A509A                 mov     rsi, [rax]
+  .text:00000000006A509D                 lea     rax, s1
+  .text:00000000006A50A4                 test    rsi, rsi
+  .text:00000000006A50A7                 cmovz   rsi, rax
+  .text:00000000006A50AB                 jmp     loc_6A4DFB
+  .text:00000000006A50B0                 ; _QWORD
+  .text:00000000006A50B0                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A50B6                 ; _QWORD
+  .text:00000000006A50B6                 mov     esi, 3; _QWORD
+  .text:00000000006A50BB                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000006A50C0                 test    al, al
+  .text:00000000006A50C2                 jz      short loc_6A50F4
+  .text:00000000006A50C4                 cmp     byte ptr [rbx+230h], 0
+  .text:00000000006A50CB                 lea     rcx, aFailure; "failure"
+  .text:00000000006A50D2                 jz      short loc_6A50DB
+  .text:00000000006A50D4                 lea     rcx, aOverflow; "overflow"
+  .text:00000000006A50DB                 ; _QWORD
+  .text:00000000006A50DB                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A50E1                 lea     rdx, aSvSerializingC; "SV:  Serializing CSVCMsg_VoiceInit_t %s"...
+  .text:00000000006A50E8                 ; _QWORD
+  .text:00000000006A50E8                 mov     esi, 3; _QWORD
+  .text:00000000006A50ED                 xor     eax, eax
+  .text:00000000006A50EF                 call    _LoggingSystem_Log
+  .text:00000000006A50F4                 xor     r12d, r12d
+  .text:00000000006A50F7                 jmp     loc_6A5000
+  .text:00000000006A5100                 ; _QWORD
+  .text:00000000006A5100                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A5106                 ; _QWORD
+  .text:00000000006A5106                 mov     esi, 3; _QWORD
+  .text:00000000006A510B                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000006A5110                 test    al, al
+  .text:00000000006A5112                 jz      loc_6A501F
+  .text:00000000006A5118                 cmp     byte ptr [rbx+720h], 0
+  .text:00000000006A511F                 lea     rcx, aUnknownFailure; "UNKNOWN FAILURE"
+  .text:00000000006A5126                 jz      short loc_6A512F
+  .text:00000000006A5128                 lea     rcx, aOverflowFailur; "OVERFLOW FAILURE"
+  .text:00000000006A512F                 ; _QWORD
+  .text:00000000006A512F                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A5135                 lea     rdx, aSvSpawnserverW; "SV:  SpawnServer WriteClassInfosAndSeri"...
+  .text:00000000006A513C                 ; _QWORD
+  .text:00000000006A513C                 mov     esi, 3; _QWORD
+  .text:00000000006A5141                 xor     eax, eax
+  .text:00000000006A5143                 call    _LoggingSystem_Log
+  .text:00000000006A5148                 jmp     loc_6A501F
+  .text:00000000006A5150                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000006A5155                 test    al, al
+  .text:00000000006A5157                 jz      loc_6A4D06
+  .text:00000000006A515D                 mov     rcx, [rbx+150h]
+  .text:00000000006A5164                 lea     rax, s1
+  .text:00000000006A516B                 mov     r8, r12
+  .text:00000000006A516E                 ; _QWORD
+  .text:00000000006A516E                 mov     esi, 2; _QWORD
+  .text:00000000006A5173                 ; _QWORD
+  .text:00000000006A5173                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A5179                 lea     rdx, aSvSpawnServerS_0; "SV:  Spawn Server: %s: [%s]\n"
+  .text:00000000006A5180                 test    rcx, rcx
+  .text:00000000006A5183                 ; _QWORD
+  .text:00000000006A5183                 cmovz   rcx, rax; _QWORD
+  .text:00000000006A5187                 xor     eax, eax
+  .text:00000000006A5189                 call    _LoggingSystem_Log
+  .text:00000000006A518E                 mov     rdi, rbx
+  .text:00000000006A5191                 call    sub_698780
+  .text:00000000006A5196                 jmp     loc_6A4D0E
+  .text:00000000006A51A0                 mov     rdi, rbx
+  .text:00000000006A51A3                 call    rax; INetworkGameServer_GetMaxClients
+  .text:00000000006A51A5                 jmp     loc_6A4D3A
+  .text:00000000006A51B0                 ; _QWORD
+  .text:00000000006A51B0                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A51B6                 ; _QWORD
+  .text:00000000006A51B6                 lea     rcx, s1; _QWORD
+  .text:00000000006A51BD                 ; _QWORD
+  .text:00000000006A51BD                 mov     esi, 2; _QWORD
+  .text:00000000006A51C2                 xor     eax, eax
+  .text:00000000006A51C4                 lea     rdx, aSvSpawnServerS; "SV:  Spawn Server: %s\n"
+  .text:00000000006A51CB                 call    _LoggingSystem_Log
+  .text:00000000006A51D0                 jmp     loc_6A4D06
+  .text:00000000006A51D8                 mov     rax, cs:qword_9D1D18
+  .text:00000000006A51DF                 mov     rax, [rax+8]
+  .text:00000000006A51E3                 jmp     loc_6A509A
+  .text:00000000006A51F0                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000006A51F5                 test    al, al
+  .text:00000000006A51F7                 jz      short loc_6A5222
+  .text:00000000006A51F9                 ; _QWORD
+  .text:00000000006A51F9                 mov     rcx, [rbx+150h]; _QWORD
+  .text:00000000006A5200                 test    rcx, rcx
+  .text:00000000006A5203                 jz      loc_6A53BD
+  .text:00000000006A5209                 ; _QWORD
+  .text:00000000006A5209                 mov     edi, cs:dword_980968; _QWORD
+  .text:00000000006A520F                 lea     rdx, aSvSpawnServerS; "SV:  Spawn Server: %s\n"
+  .text:00000000006A5216                 ; _QWORD
+  .text:00000000006A5216                 mov     esi, 2; _QWORD
+  .text:00000000006A521B                 xor     eax, eax
+  .text:00000000006A521D                 call    _LoggingSystem_Log
+  .text:00000000006A5222                 lea     r12, s1
+  .text:00000000006A5229                 mov     rdi, rbx
+  .text:00000000006A522C                 call    sub_698780
+  .text:00000000006A5231                 jmp     loc_6A4D0E
+  .text:00000000006A5240                 mov     rdi, rbx
+  .text:00000000006A5243                 call    rax
+  .text:00000000006A5245                 jmp     loc_6A4DEC
+  .text:00000000006A5250                 call    rax
+  .text:00000000006A5252                 mov     rsi, rax
+  .text:00000000006A5255                 jmp     loc_6A4F7D
+  .text:00000000006A5260                 mov     rdi, rbx
+  .text:00000000006A5263                 call    rax
+  .text:00000000006A5265                 jmp     loc_6A4EAB
+  .text:00000000006A5270                 mov     rdx, [rdx]
+  .text:00000000006A5273                 jmp     loc_6A4E12
+  .text:00000000006A5280                 movzx   edi, word ptr [rbx+302h]
+  .text:00000000006A5287                 mov     esi, edi
+  .text:00000000006A5289                 and     si, 7FFFh
+  .text:00000000006A528E                 jmp     short loc_6A52D8
+  .text:00000000006A52C0                 mov     rdx, [rbx+308h]
+  .text:00000000006A52C7                 lea     rcx, [rdx+rcx*8]
+  .text:00000000006A52CB                 movzx   ecx, word ptr [rcx]
+  .text:00000000006A52CE                 cmp     cx, 0FFFFh
+  .text:00000000006A52D2                 jz      short loc_6A52F3
+  .text:00000000006A52D4                 movzx   r15d, cx
+  .text:00000000006A52D8                 movzx   eax, r15w
+  .text:00000000006A52DC                 lea     rcx, [rax+rax*2]
+  .text:00000000006A52E0                 test    si, si
+  .text:00000000006A52E3                 jnz     short loc_6A52C0
+  .text:00000000006A52E5                 movzx   ecx, word ptr ds:dword_0[rcx*8]
+  .text:00000000006A52ED                 cmp     cx, 0FFFFh
+  .text:00000000006A52F1                 jnz     short loc_6A52D4
+  .text:00000000006A52F3                 lea     rdx, [rbx+300h]
+  .text:00000000006A52FA                 lea     r14, sub_54F6B0
+  .text:00000000006A5301                 mov     [rbp+var_A8], rdx
+  .text:00000000006A5308                 lea     r13, [rbp+var_98]
+  .text:00000000006A530F                 jmp     short loc_6A5375
+  .text:00000000006A5318                 mov     rsi, [rdi+78h]
+  .text:00000000006A531C                 lea     rax, s1
+  .text:00000000006A5323                 test    rsi, rsi
+  .text:00000000006A5326                 ; _QWORD
+  .text:00000000006A5326                 cmovz   rsi, rax; _QWORD
+  .text:00000000006A532A                 ; _QWORD
+  .text:00000000006A532A                 mov     rdi, r13; _QWORD
+  .text:00000000006A532D                 call    __ZN10CUtlStringpLEPKc; CUtlString::operator+=(char const*)
+  .text:00000000006A5332                 movzx   eax, word ptr [rbx+312h]
+  .text:00000000006A5339                 sub     eax, 1
+  .text:00000000006A533C                 cmp     r15d, eax
+  .text:00000000006A533F                 jz      short loc_6A5350
+  .text:00000000006A5341                 lea     rsi, asc_26740E; "+"
+  .text:00000000006A5348                 ; _QWORD
+  .text:00000000006A5348                 mov     rdi, r13; _QWORD
+  .text:00000000006A534B                 call    __ZN10CUtlStringpLEPKc; CUtlString::operator+=(char const*)
+  .text:00000000006A5350                 mov     rdi, [rbp+var_A8]
+  .text:00000000006A5357                 mov     esi, r15d
+  .text:00000000006A535A                 call    sub_698DC0
+  .text:00000000006A535F                 movzx   r15d, ax
+  .text:00000000006A5363                 cmp     r15w, 0FFFFh
+  .text:00000000006A5368                 jz      short loc_6A53A8
+  .text:00000000006A536A                 movzx   edi, word ptr [rbx+302h]
+  .text:00000000006A5371                 movzx   eax, r15w
+  .text:00000000006A5375                 xor     ecx, ecx
+  .text:00000000006A5377                 test    di, 7FFFh
+  .text:00000000006A537C                 jz      short loc_6A5385
+  .text:00000000006A537E                 mov     rcx, [rbx+308h]
+  .text:00000000006A5385                 lea     rax, [rax+rax*2]
+  .text:00000000006A5389                 mov     rdi, [rcx+rax*8+10h]
+  .text:00000000006A538E                 mov     rax, [rdi]
+  .text:00000000006A5391                 mov     rax, [rax]
+  .text:00000000006A5394                 cmp     rax, r14
+  .text:00000000006A5397                 jz      loc_6A5318
+  .text:00000000006A539D                 call    rax
+  .text:00000000006A539F                 mov     rsi, rax
+  .text:00000000006A53A2                 jmp     short loc_6A532A
+  .text:00000000006A53A8                 mov     rdx, [rbp+var_98]
+  .text:00000000006A53AF                 test    rdx, rdx
+  .text:00000000006A53B2                 jnz     loc_6A4FC7
+  .text:00000000006A53B8                 jmp     loc_6A4FC0
+  .text:00000000006A53BD                 lea     rcx, s1
+  .text:00000000006A53C4                 jmp     loc_6A5048
+procedure: |-
+  __int64 __fastcall CNetworkGameServer_SpawnServer(__int64 *a1, const char *a2)
+  {
+    const char *v2; // r12
+    __int64 (__fastcall *v4)(); // rax
+    int v5; // eax
+    unsigned int v6; // r12d
+    float v7; // xmm0_4
+    __int64 v8; // rax
+    __int64 (__fastcall *v9)(); // rax
+    char v10; // al
+    const char *v11; // rsi
+    __int64 v12; // rsi
+    __int64 (__fastcall *v13)(); // rax
+    __int64 CurrentId; // rax
+    const char *v15; // rax
+    _QWORD *v16; // rdi
+    const char *v17; // rax
+    __int64 (__fastcall *v18)(); // rax
+    const char *v19; // rsi
+    int v20; // ecx
+    int v21; // r8d
+    int v22; // r9d
+    unsigned int v23; // r15d
+    const char *v24; // rdx
+    const char *v26; // rcx
+    const char **v27; // rax
+    const char *v28; // rcx
+    const char *v29; // rcx
+    const char *v30; // rcx
+    __int64 v31; // rcx
+    __int16 v32; // di
+    unsigned __int16 v33; // cx
+    __int64 v34; // rax
+    const char *v35; // rsi
+    __int64 v36; // rcx
+    __int64 v37; // rdi
+    __int64 (*v38)(void); // rax
+    __int64 v39; // [rsp+18h] [rbp-98h] BYREF
+    _QWORD v40[2]; // [rsp+20h] [rbp-90h] BYREF
+    int v41; // [rsp+30h] [rbp-80h]
+    char v42; // [rsp+34h] [rbp-7Ch]
+    __int64 v43; // [rsp+38h] [rbp-78h]
+    int v44; // [rsp+40h] [rbp-70h]
+    __int64 v45; // [rsp+48h] [rbp-68h]
+    __int64 (__fastcall **v46)(); // [rsp+50h] [rbp-60h] BYREF
+    __int64 v47; // [rsp+58h] [rbp-58h]
+    __int64 v48; // [rsp+60h] [rbp-50h]
+    __int64 *v49; // [rsp+68h] [rbp-48h] BYREF
+    __int64 v50; // [rsp+70h] [rbp-40h]
+
+    v2 = a2;
+    if ( !a2 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_980968, 2) )
+      {
+        v31 = a1[42];
+        if ( !v31 )
+        {
+          v26 = &s1;
+          goto LABEL_34;
+        }
+        LoggingSystem_Log((unsigned int)dword_980968, 2, "SV:  Spawn Server: %s\n", v31);
+      }
+      v2 = &s1;
+      sub_698780(a1);
+      goto LABEL_5;
+    }
+    if ( *a2 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_980968, 2) )
+      {
+        v30 = (const char *)a1[42];
+        if ( !v30 )
+          v30 = &s1;
+        LoggingSystem_Log((unsigned int)dword_980968, 2, "SV:  Spawn Server: %s: [%s]\n", v30);
+        sub_698780(a1);
+        goto LABEL_5;
+      }
+      goto LABEL_4;
+    }
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_980968, 2) )
+    {
+      v26 = (const char *)a1[42];
+      if ( !v26 )
+      {
+        LoggingSystem_Log((unsigned int)dword_980968, 2, "SV:  Spawn Server: %s\n", &s1);
+        goto LABEL_4;
+      }
+  LABEL_34:
+      LoggingSystem_Log((unsigned int)dword_980968, 2, "SV:  Spawn Server: %s\n", v26);
+      sub_698780(a1);
+      if ( !a2 )
+        v2 = &s1;
+      goto LABEL_5;
+    }
+  LABEL_4:
+    sub_698780(a1);
+  LABEL_5:
+    CUtlString::Set((CUtlString *)(a1 + 223), v2);
+    v4 = *(__int64 (__fastcall **)())(*a1 + 96);// 96LL = 0x60 = INetworkGameServer_GetMaxClients
+    if ( v4 == sub_696CD0 )
+      v5 = *((_DWORD *)a1 + 169);
+    else
+      v5 = ((__int64 (__fastcall *)(__int64 *))v4)(a1);// INetworkGameServer_GetMaxClients
+    *((_DWORD *)a1 + 26) = v5;
+    *((_BYTE *)a1 + 10056) = 1;
+    v6 = sub_6CE770(a1, a1 + 229, a1 + 224);
+    if ( !(_BYTE)v6 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_980968, 3) )
+      {
+        v29 = "UNKNOWN FAILURE";
+        if ( *((_BYTE *)a1 + 1824) )
+          v29 = "OVERFLOW FAILURE";
+        LoggingSystem_Log(
+          (unsigned int)dword_980968,
+          3,
+          "SV:  SpawnServer WriteClassInfosAndSerializesToBuffer %s.\n",
+          v29);
+      }
+      return v6;
+    }
+    v7 = 0.0;
+    v48 = 0;
+    v40[1] = 0;
+    v41 = 0;
+    v42 = -1;
+    v49 = &qword_977818;
+    v40[0] = &off_9582C0;
+    v46 = off_958300;
+    v8 = *a1;
+    v43 = -1;
+    v44 = -1082130432;
+    v45 = -1;
+    v9 = *(__int64 (__fastcall **)())(v8 + 376);
+    v47 = 0;
+    v50 = 0;
+    if ( v9 == sub_67C9D0 )
+      v10 = *((_BYTE *)a1 + 1117);
+    else
+      v10 = ((__int64 (__fastcall *)(__int64 *))v9)(a1);
+    v11 = &s1;
+    if ( v10 )
+    {
+      v27 = (const char **)sub_911FE0(qword_9D1D18, 0xFFFFFFFFLL);
+      if ( !v27 )
+        v27 = *(const char ***)(qword_9D1D18 + 8);
+      v11 = *v27;
+      if ( !*v27 )
+        v11 = &s1;
+    }
+    LODWORD(v48) = v48 | 1;
+    sub_4B8940(&v49, v11, v47 & 0xFFFFFFFFFFFFFFFCLL);
+    LODWORD(v50) = 5;
+    LODWORD(v48) = v48 | 2;
+    v6 = (*(__int64 (__fastcall **)(__int64, __int64 *, _QWORD *))(*(_QWORD *)qword_980C50 + 24LL))(
+           qword_980C50,
+           a1 + 66,
+           v40);
+    if ( !(_BYTE)v6 || *((_BYTE *)a1 + 560) )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_980968, 3) )
+      {
+        v28 = "failure";
+        if ( *((_BYTE *)a1 + 560) )
+          v28 = "overflow";
+        LoggingSystem_Log((unsigned int)dword_980968, 3, "SV:  Serializing CSVCMsg_VoiceInit_t %s.\n", v28);
+      }
+      v6 = 0;
+      goto LABEL_31;
+    }
+    (*(void (__fastcall **)(__int64, __int64 *))(*(_QWORD *)qword_97E658 + 112LL))(qword_97E658, a1 + 66);
+    v12 = 2;
+    (*(void (__fastcall **)(__int64 *, __int64))(*a1 + 280))(a1, 2);
+    v13 = *(__int64 (__fastcall **)())(*a1 + 224);
+    if ( v13 == sub_68D810 )
+      v7 = (float)*((int *)a1 + 17) * 0.015625;
+    else
+      ((void (__fastcall *)(__int64 *))v13)(a1);
+    CurrentId = ThreadGetCurrentId();
+    *((_DWORD *)a1 + 42) = 0;
+    a1[22] = CurrentId;
+    *((float *)a1 + 34) = v7;
+    *((_DWORD *)a1 + 39) = (int)(float)((float)(v7 * 64.0) + 0.5);
+    if ( (unsigned __int8)ThreadInMainThread() )
+    {
+      v12 = 8;
+      sub_749860(&qword_97FA80, 8, 0);
+    }
+    COM_TimestampedLog("InitializeEntityDLLFields");
+    v15 = (const char *)a1[42];
+    v16 = (_QWORD *)qword_97DDC8;
+    if ( !v15 )
+      v15 = &s1;
+    a1[23] = (__int64)v15;
+    v17 = (const char *)a1[223];
+    if ( !v17 )
+      v17 = &s1;
+    a1[24] = (__int64)v17;
+    v18 = *(__int64 (__fastcall **)())(*v16 + 336LL);
+    if ( v18 == sub_51F8D0 )
+    {
+      v19 = (const char *)v16[22];
+      if ( !v19 )
+        v19 = &s1;
+    }
+    else
+    {
+      v19 = (const char *)((__int64 (__fastcall *)(_QWORD *, __int64, const char *, __int64 (__fastcall *)()))v18)(
+                            v16,
+                            v12,
+                            &s1,
+                            sub_51F8D0);
+    }
+    CUtlString::Set((CUtlString *)(a1 + 43), v19);
+    if ( qword_97FB08 )
+      (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)qword_97FB08 + 96LL))(qword_97FB08, "map_load");
+    v23 = *((unsigned __int16 *)a1 + 392);
+    v39 = 0;
+    if ( (_WORD)v23 == 0xFFFF )
+    {
+  LABEL_27:
+      v24 = &s1;
+      goto LABEL_28;
+    }
+    v32 = *((_WORD *)a1 + 385);
+    while ( 1 )
+    {
+      v34 = (unsigned __int16)v23;
+      if ( (*((_WORD *)a1 + 385) & 0x7FFF) == 0 )
+        break;
+      v33 = *(_WORD *)(a1[97] + 24LL * (unsigned __int16)v23);
+      if ( v33 == 0xFFFF )
+        goto LABEL_76;
+  LABEL_66:
+      v23 = v33;
+    }
+    v33 = *(_WORD *)(24LL * (unsigned __int16)v23);
+    if ( v33 != 0xFFFF )
+      goto LABEL_66;
+    while ( 1 )
+    {
+  LABEL_76:
+      v36 = 0;
+      if ( (v32 & 0x7FFF) != 0 )
+        v36 = a1[97];
+      v37 = *(_QWORD *)(v36 + 24 * v34 + 16);
+      v38 = **(__int64 (***)(void))v37;
+      if ( v38 == sub_54F6B0 )
+      {
+        v35 = *(const char **)(v37 + 120);
+        if ( !v35 )
+          v35 = &s1;
+      }
+      else
+      {
+        v35 = (const char *)v38();
+      }
+      CUtlString::operator+=(&v39, v35);
+      if ( v23 != *((unsigned __int16 *)a1 + 393) - 1 )
+        CUtlString::operator+=(&v39, "+");
+      LOWORD(v34) = sub_698DC0(a1 + 96, v23);
+      v23 = (unsigned __int16)v34;
+      if ( (_WORD)v34 == 0xFFFF )
+        break;
+      v32 = *((_WORD *)a1 + 385);
+      v34 = (unsigned __int16)v34;
+    }
+    LODWORD(v24) = v39;
+    if ( !v39 )
+      goto LABEL_27;
+  LABEL_28:
+    sub_8F7910((unsigned int)&qword_97FC00, (unsigned int)"Started:  \"%s\"\n", (_DWORD)v24, v20, v21, v22);
+    if ( v39 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v39);
+    COM_TimestampedLog("SV_SpawnServer -- Finished");
+  LABEL_31:
+    v40[0] = &off_94B1C8;
+    v46 = off_94B208;
+    sub_4C0520(&v46);
+    return v6;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_SpawnServer.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_SpawnServer.windows.yaml
@@ -1,0 +1,582 @@
+func_name: CNetworkGameServer_SpawnServer
+func_va: '0x18009f4a0'
+disasm_code: |-
+  .text:000000018009F4A0                 mov     [rsp-8+arg_18], rbx
+  .text:000000018009F4A5                 push    rbp
+  .text:000000018009F4A6                 push    rsi
+  .text:000000018009F4A7                 push    rdi
+  .text:000000018009F4A8                 push    r12
+  .text:000000018009F4AA                 push    r14
+  .text:000000018009F4AC                 lea     rbp, [rsp-37h]
+  .text:000000018009F4B1                 sub     rsp, 0C0h
+  .text:000000018009F4B8                 xor     ebx, ebx
+  .text:000000018009F4BA                 lea     r14, unk_180524F9F
+  .text:000000018009F4C1                 mov     rsi, rdx
+  .text:000000018009F4C4                 mov     rdi, rcx
+  .text:000000018009F4C7                 test    rdx, rdx
+  .text:000000018009F4CA                 jz      short loc_18009F515
+  .text:000000018009F4CC                 cmp     [rdx], bl
+  .text:000000018009F4CE                 jz      short loc_18009F515
+  .text:000000018009F4D0                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F4D6                 mov     edx, 2
+  .text:000000018009F4DB                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009F4E1                 test    al, al
+  .text:000000018009F4E3                 jz      short loc_18009F553
+  .text:000000018009F4E5                 mov     rax, [rdi+150h]
+  .text:000000018009F4EC                 lea     r8, aSvSpawnServerS; "SV:  Spawn Server: %s: [%s]\n"
+  .text:000000018009F4F3                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F4F9                 test    rax, rax
+  .text:000000018009F4FC                 mov     r9, r14
+  .text:000000018009F4FF                 mov     [rsp+0E0h+var_C0], rsi
+  .text:000000018009F504                 cmovnz  r9, rax
+  .text:000000018009F508                 mov     edx, 2
+  .text:000000018009F50D                 call    cs:LoggingSystem_Log
+  .text:000000018009F513                 jmp     short loc_18009F553
+  .text:000000018009F515                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F51B                 mov     edx, 2
+  .text:000000018009F520                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009F526                 test    al, al
+  .text:000000018009F528                 jz      short loc_18009F553
+  .text:000000018009F52A                 mov     rax, [rdi+150h]
+  .text:000000018009F531                 lea     r8, aSvSpawnServerS_0; "SV:  Spawn Server: %s\n"
+  .text:000000018009F538                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F53E                 test    rax, rax
+  .text:000000018009F541                 mov     r9, r14
+  .text:000000018009F544                 mov     edx, 2
+  .text:000000018009F549                 cmovnz  r9, rax
+  .text:000000018009F54D                 call    cs:LoggingSystem_Log
+  .text:000000018009F553                 mov     rcx, rdi
+  .text:000000018009F556                 call    sub_1800B2E90
+  .text:000000018009F55B                 test    rsi, rsi
+  .text:000000018009F55E                 lea     rcx, [rdi+6F8h]
+  .text:000000018009F565                 mov     rdx, r14
+  .text:000000018009F568                 cmovnz  rdx, rsi
+  .text:000000018009F56C                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018009F572                 mov     rax, [rdi]
+  .text:000000018009F575                 mov     rcx, rdi
+  .text:000000018009F578                 call    qword ptr [rax+60h]; 0x60 = 96 = INetworkGameServer_GetMaxClients
+  .text:000000018009F57B                 lea     r8, [rdi+700h]
+  .text:000000018009F582                 mov     byte ptr [rdi+2748h], 1
+  .text:000000018009F589                 lea     rdx, [rdi+728h]
+  .text:000000018009F590                 mov     [rdi+68h], eax
+  .text:000000018009F593                 call    sub_1800D4390
+  .text:000000018009F598                 test    al, al
+  .text:000000018009F59A                 jnz     short loc_18009F5E8
+  .text:000000018009F59C                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F5A2                 mov     edx, 3
+  .text:000000018009F5A7                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009F5AD                 test    al, al
+  .text:000000018009F5AF                 jz      short loc_18009F5E1
+  .text:000000018009F5B1                 cmp     [rdi+720h], bl
+  .text:000000018009F5B7                 lea     rax, aOverflowFailur; "OVERFLOW FAILURE"
+  .text:000000018009F5BE                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F5C4                 lea     r9, aUnknownFailure; "UNKNOWN FAILURE"
+  .text:000000018009F5CB                 cmovnz  r9, rax
+  .text:000000018009F5CF                 lea     r8, aSvSpawnserverW; "SV:  SpawnServer WriteClassInfosAndSeri"...
+  .text:000000018009F5D6                 mov     edx, 3
+  .text:000000018009F5DB                 call    cs:LoggingSystem_Log
+  .text:000000018009F5E1                 xor     al, al
+  .text:000000018009F5E3                 jmp     loc_18009FA22
+  .text:000000018009F5E8                 xor     eax, eax
+  .text:000000018009F5EA                 mov     [rsp+0E0h+arg_8], r15
+  .text:000000018009F5F2                 mov     [rbp+57h+var_70], rax
+  .text:000000018009F5F6                 xorps   xmm0, xmm0
+  .text:000000018009F5F9                 lea     rax, qword_18062AA30
+  .text:000000018009F600                 movsd   [rbp+57h+var_A8], xmm0
+  .text:000000018009F605                 mov     [rbp+57h+var_68], rax
+  .text:000000018009F609                 mov     rsi, 0FFFFFFFFFFFFFFFFh
+  .text:000000018009F610                 lea     rax, ??_7CSVCMsg_VoiceInit_t@@6B@; const CSVCMsg_VoiceInit_t::`vftable'
+  .text:000000018009F617                 mov     [rbp+57h+var_A0], ebx
+  .text:000000018009F61A                 mov     [rbp+57h+var_B0], rax
+  .text:000000018009F61E                 mov     rcx, rdi
+  .text:000000018009F621                 lea     rax, ??_7CSVCMsg_VoiceInit_t@@6B@_0; const CSVCMsg_VoiceInit_t::`vftable'
+  .text:000000018009F628                 mov     [rbp+57h+var_9C], 0FFh
+  .text:000000018009F62C                 mov     [rbp+57h+var_80], rax
+  .text:000000018009F630                 mov     rax, [rdi]
+  .text:000000018009F633                 mov     [rbp+57h+var_98], rsi
+  .text:000000018009F637                 mov     [rbp+57h+var_90], 0BF800000h
+  .text:000000018009F63E                 mov     [rbp+57h+var_88], rsi
+  .text:000000018009F642                 mov     [rbp+57h+var_78], rbx
+  .text:000000018009F646                 mov     dword ptr [rbp+57h+var_70+4], ebx
+  .text:000000018009F649                 mov     [rbp+57h+var_60], rbx
+  .text:000000018009F64D                 call    qword ptr [rax+178h]
+  .text:000000018009F653                 test    al, al
+  .text:000000018009F655                 jz      short loc_18009F687
+  .text:000000018009F657                 mov     edx, 0FFFFFFFFh
+  .text:000000018009F65C                 lea     rcx, unk_18068AF48
+  .text:000000018009F663                 call    sub_1803FC6F0
+  .text:000000018009F668                 test    rax, rax
+  .text:000000018009F66B                 jnz     short loc_18009F678
+  .text:000000018009F66D                 mov     rax, cs:qword_18068AF50
+  .text:000000018009F674                 mov     rax, [rax+8]
+  .text:000000018009F678                 mov     rax, [rax]
+  .text:000000018009F67B                 mov     rdx, r14
+  .text:000000018009F67E                 test    rax, rax
+  .text:000000018009F681                 cmovnz  rdx, rax
+  .text:000000018009F685                 jmp     short loc_18009F68A
+  .text:000000018009F687                 mov     rdx, r14
+  .text:000000018009F68A                 or      dword ptr [rbp+57h+var_70], 1
+  .text:000000018009F68E                 test    byte ptr [rbp+57h+var_78], 1
+  .text:000000018009F692                 jz      short loc_18009F6A1
+  .text:000000018009F694                 mov     rax, [rbp+57h+var_78]
+  .text:000000018009F698                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:000000018009F69C                 mov     r15, [rax]
+  .text:000000018009F69F                 jmp     short loc_18009F6A9
+  .text:000000018009F6A1                 mov     r15, [rbp+57h+var_78]
+  .text:000000018009F6A5                 and     r15, 0FFFFFFFFFFFFFFFCh
+  .text:000000018009F6A9                 xorps   xmm0, xmm0
+  .text:000000018009F6AC                 xorps   xmm1, xmm1
+  .text:000000018009F6AF                 movups  [rbp+57h+var_50], xmm0
+  .text:000000018009F6B3                 movdqu  [rbp+57h+var_40], xmm1
+  .text:000000018009F6B8                 inc     rsi
+  .text:000000018009F6BB                 cmp     [rdx+rsi], bl
+  .text:000000018009F6BE                 jnz     short loc_18009F6B8
+  .text:000000018009F6C0                 mov     r8, rsi
+  .text:000000018009F6C3                 lea     rcx, [rbp+57h+var_50]
+  .text:000000018009F6C7                 call    sub_180043DF0
+  .text:000000018009F6CC                 mov     r8, r15
+  .text:000000018009F6CF                 lea     rdx, [rbp+57h+var_50]
+  .text:000000018009F6D3                 lea     rcx, [rbp+57h+var_68]
+  .text:000000018009F6D7                 call    sub_180251460
+  .text:000000018009F6DC                 mov     rax, qword ptr [rbp+57h+var_40+8]
+  .text:000000018009F6E0                 cmp     rax, 0Fh
+  .text:000000018009F6E4                 jbe     short loc_18009F71D
+  .text:000000018009F6E6                 mov     rdx, qword ptr [rbp+57h+var_50]
+  .text:000000018009F6EA                 inc     rax
+  .text:000000018009F6ED                 mov     rcx, rdx
+  .text:000000018009F6F0                 cmp     rax, 1000h
+  .text:000000018009F6F6                 jb      short loc_18009F70D
+  .text:000000018009F6F8                 mov     rdx, [rdx-8]
+  .text:000000018009F6FC                 sub     rcx, rdx
+  .text:000000018009F6FF                 lea     rax, [rcx-8]
+  .text:000000018009F703                 cmp     rax, 1Fh
+  .text:000000018009F707                 ja      loc_18009FA39
+  .text:000000018009F70D                 mov     rax, cs:g_pMemAlloc
+  .text:000000018009F714                 mov     rcx, [rax]
+  .text:000000018009F717                 mov     rax, [rcx]
+  .text:000000018009F71A                 call    qword ptr [rax+18h]
+  .text:000000018009F71D                 mov     rcx, cs:g_pNetworkMessages
+  .text:000000018009F724                 lea     r8, [rbp+57h+var_B0]
+  .text:000000018009F728                 movdqa  xmm0, cs:xmmword_1805838F0
+  .text:000000018009F730                 lea     rdx, [rdi+210h]
+  .text:000000018009F737                 or      dword ptr [rbp+57h+var_70], 2
+  .text:000000018009F73B                 movdqu  [rbp+57h+var_40], xmm0
+  .text:000000018009F740                 mov     byte ptr [rbp+57h+var_50], bl
+  .text:000000018009F743                 mov     dword ptr [rbp+57h+var_60], 5
+  .text:000000018009F74A                 mov     rax, [rcx]
+  .text:000000018009F74D                 call    qword ptr [rax+18h]
+  .text:000000018009F750                 test    al, al
+  .text:000000018009F752                 jz      loc_18009F950
+  .text:000000018009F758                 cmp     [rdi+230h], bl
+  .text:000000018009F75E                 jnz     loc_18009F950
+  .text:000000018009F764                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009F76B                 lea     rdx, [rdi+210h]
+  .text:000000018009F772                 mov     [rsp+0E0h+arg_0], r13
+  .text:000000018009F77A                 mov     rax, [rcx]
+  .text:000000018009F77D                 call    qword ptr [rax+70h]
+  .text:000000018009F780                 mov     rax, [rdi]
+  .text:000000018009F783                 mov     edx, 2
+  .text:000000018009F788                 mov     rcx, rdi
+  .text:000000018009F78B                 call    qword ptr [rax+118h]
+  .text:000000018009F791                 mov     rax, [rdi]
+  .text:000000018009F794                 mov     rcx, rdi
+  .text:000000018009F797                 call    qword ptr [rax+0E0h]
+  .text:000000018009F79D                 movaps  xmm3, xmm0
+  .text:000000018009F7A0                 lea     r8, [rdi+58h]
+  .text:000000018009F7A4                 lea     rdx, aCBuildworkerCs_18; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:000000018009F7AB                 lea     rcx, [rbp+57h+var_50]
+  .text:000000018009F7AF                 call    sub_180077750
+  .text:000000018009F7B4                 xor     r8d, r8d
+  .text:000000018009F7B7                 lea     rcx, off_1806102A0
+  .text:000000018009F7BE                 mov     edx, 8
+  .text:000000018009F7C3                 call    sub_18013C530
+  .text:000000018009F7C8                 lea     rcx, aInitializeenti; "InitializeEntityDLLFields"
+  .text:000000018009F7CF                 call    cs:COM_TimestampedLog
+  .text:000000018009F7D5                 mov     rax, [rdi+150h]
+  .text:000000018009F7DC                 mov     rcx, r14
+  .text:000000018009F7DF                 test    rax, rax
+  .text:000000018009F7E2                 cmovnz  rcx, rax
+  .text:000000018009F7E6                 mov     [rdi+0B8h], rcx
+  .text:000000018009F7ED                 mov     rcx, r14
+  .text:000000018009F7F0                 mov     rax, [rdi+6F8h]
+  .text:000000018009F7F7                 test    rax, rax
+  .text:000000018009F7FA                 cmovnz  rcx, rax
+  .text:000000018009F7FE                 mov     [rdi+0C0h], rcx
+  .text:000000018009F805                 mov     rcx, cs:g_pEngineServiceMgr
+  .text:000000018009F80C                 mov     rax, [rcx]
+  .text:000000018009F80F                 call    qword ptr [rax+150h]
+  .text:000000018009F815                 mov     rdx, rax
+  .text:000000018009F818                 lea     rcx, [rdi+158h]
+  .text:000000018009F81F                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018009F825                 mov     rcx, cs:g_pTestScriptMgr
+  .text:000000018009F82C                 test    rcx, rcx
+  .text:000000018009F82F                 jz      short loc_18009F83E
+  .text:000000018009F831                 mov     rax, [rcx]
+  .text:000000018009F834                 lea     rdx, aMapLoad; "map_load"
+  .text:000000018009F83B                 call    qword ptr [rax+60h]
+  .text:000000018009F83E                 movzx   esi, word ptr [rdi+310h]
+  .text:000000018009F845                 mov     r12d, 0FFFFh
+  .text:000000018009F84B                 mov     [rbp+57h+arg_10], rbx
+  .text:000000018009F84F                 mov     r13d, 7FFFh
+  .text:000000018009F855                 cmp     si, r12w
+  .text:000000018009F859                 jz      loc_18009F8FF
+  .text:000000018009F85F                 mov     rdx, rbx
+  .text:000000018009F862                 test    [rdi+302h], r13w
+  .text:000000018009F86A                 jz      short loc_18009F873
+  .text:000000018009F86C                 mov     rdx, [rdi+308h]
+  .text:000000018009F873                 movzx   eax, si
+  .text:000000018009F876                 lea     rcx, [rax+rax*2]
+  .text:000000018009F87A                 movzx   eax, word ptr [rdx+rcx*8]
+  .text:000000018009F87E                 cmp     ax, r12w
+  .text:000000018009F882                 jz      short loc_18009F890
+  .text:000000018009F884                 movzx   esi, ax
+  .text:000000018009F887                 jmp     short loc_18009F855
+  .text:000000018009F890                 mov     rdx, rbx
+  .text:000000018009F893                 test    [rdi+302h], r13w
+  .text:000000018009F89B                 jz      short loc_18009F8A4
+  .text:000000018009F89D                 mov     rdx, [rdi+308h]
+  .text:000000018009F8A4                 movzx   eax, si
+  .text:000000018009F8A7                 lea     rcx, [rax+rax*2]
+  .text:000000018009F8AB                 mov     rcx, [rdx+rcx*8+10h]
+  .text:000000018009F8B0                 mov     rax, [rcx]
+  .text:000000018009F8B3                 call    qword ptr [rax]
+  .text:000000018009F8B5                 mov     rdx, rax
+  .text:000000018009F8B8                 lea     rcx, [rbp+57h+arg_10]
+  .text:000000018009F8BC                 call    cs:??YCUtlString@@QEAAAEAV0@PEBD@Z; CUtlString::operator+=(char const *)
+  .text:000000018009F8C2                 movzx   ecx, word ptr [rdi+312h]
+  .text:000000018009F8C9                 dec     ecx
+  .text:000000018009F8CB                 movzx   eax, si
+  .text:000000018009F8CE                 cmp     eax, ecx
+  .text:000000018009F8D0                 jz      short loc_18009F8E3
+  .text:000000018009F8D2                 lea     rdx, asc_180539DA0; "+"
+  .text:000000018009F8D9                 lea     rcx, [rbp+57h+arg_10]
+  .text:000000018009F8DD                 call    cs:??YCUtlString@@QEAAAEAV0@PEBD@Z; CUtlString::operator+=(char const *)
+  .text:000000018009F8E3                 movzx   edx, si
+  .text:000000018009F8E6                 lea     rcx, [rdi+300h]
+  .text:000000018009F8ED                 call    sub_180090CA0
+  .text:000000018009F8F2                 movzx   esi, ax
+  .text:000000018009F8F5                 cmp     ax, r12w
+  .text:000000018009F8F9                 jnz     short loc_18009F890
+  .text:000000018009F8FB                 mov     rbx, [rbp+57h+arg_10]
+  .text:000000018009F8FF                 test    rbx, rbx
+  .text:000000018009F902                 lea     rdx, aStartedS; "Started:  \"%s\"\n"
+  .text:000000018009F909                 lea     rcx, qword_1808C9A90
+  .text:000000018009F910                 cmovnz  r14, rbx
+  .text:000000018009F914                 mov     r8, r14
+  .text:000000018009F917                 call    sub_1800E31E0
+  .text:000000018009F91C                 cmp     [rbp+57h+arg_10], 0
+  .text:000000018009F921                 mov     r13, [rsp+0E0h+arg_0]
+  .text:000000018009F929                 jz      short loc_18009F935
+  .text:000000018009F92B                 lea     rcx, [rbp+57h+arg_10]
+  .text:000000018009F92F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018009F935                 lea     rcx, aSvSpawnserverF; "SV_SpawnServer -- Finished"
+  .text:000000018009F93C                 call    cs:COM_TimestampedLog
+  .text:000000018009F942                 lea     rcx, [rbp+57h+var_50]
+  .text:000000018009F946                 mov     dil, 1
+  .text:000000018009F949                 call    sub_18005F450
+  .text:000000018009F94E                 jmp     short loc_18009F998
+  .text:000000018009F950                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F956                 mov     edx, 3
+  .text:000000018009F95B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009F961                 test    al, al
+  .text:000000018009F963                 jz      short loc_18009F995
+  .text:000000018009F965                 cmp     [rdi+230h], bl
+  .text:000000018009F96B                 lea     rax, aOverflow; "overflow"
+  .text:000000018009F972                 mov     ecx, cs:dword_1808C9378
+  .text:000000018009F978                 lea     r9, aFailure; "failure"
+  .text:000000018009F97F                 cmovnz  r9, rax
+  .text:000000018009F983                 lea     r8, aSvSerializingC; "SV:  Serializing CSVCMsg_VoiceInit_t %s"...
+  .text:000000018009F98A                 mov     edx, 3
+  .text:000000018009F98F                 call    cs:LoggingSystem_Log
+  .text:000000018009F995                 xor     dil, dil
+  .text:000000018009F998                 lea     rax, ??_7?$CNetMessagePB@$0CO@VCSVCMsg_VoiceInit@@$09$00$0A@@@6B@; const CNetMessagePB<46,CSVCMsg_VoiceInit,10,1,0>::`vftable'
+  .text:000000018009F99F                 mov     [rbp+57h+var_B0], rax
+  .text:000000018009F9A3                 lea     rax, ??_7CSVCMsg_VoiceInit@@6B@; const CSVCMsg_VoiceInit::`vftable'
+  .text:000000018009F9AA                 mov     [rbp+57h+var_80], rax
+  .text:000000018009F9AE                 movzx   eax, byte ptr [rbp+57h+var_78]
+  .text:000000018009F9B2                 test    al, 1
+  .text:000000018009F9B4                 jz      short loc_18009F9CB
+  .text:000000018009F9B6                 lea     rcx, [rbp+57h+var_78]
+  .text:000000018009F9BA                 call    sub_180146130
+  .text:000000018009F9BF                 mov     rcx, [rbp+57h+var_78]
+  .text:000000018009F9C3                 mov     rdx, rax
+  .text:000000018009F9C6                 mov     rax, rcx
+  .text:000000018009F9C9                 jmp     short loc_18009F9D6
+  .text:000000018009F9CB                 mov     rcx, [rbp+57h+var_78]
+  .text:000000018009F9CF                 mov     rdx, rcx
+  .text:000000018009F9D2                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:000000018009F9D6                 test    rdx, rdx
+  .text:000000018009F9D9                 jnz     short loc_18009F9EB
+  .text:000000018009F9DB                 lea     rcx, [rbp+57h+var_68]
+  .text:000000018009F9DF                 call    sub_180251200
+  .text:000000018009F9E4                 mov     rcx, [rbp+57h+var_78]
+  .text:000000018009F9E8                 movzx   eax, cl
+  .text:000000018009F9EB                 shr     al, 1
+  .text:000000018009F9ED                 test    al, 1
+  .text:000000018009F9EF                 jz      short loc_18009FA16
+  .text:000000018009F9F1                 lea     rbx, [rcx-2]
+  .text:000000018009F9F5                 test    rbx, rbx
+  .text:000000018009F9F8                 jz      short loc_18009FA16
+  .text:000000018009F9FA                 mov     rcx, rbx
+  .text:000000018009F9FD                 call    sub_1802C09D0
+  .text:000000018009FA02                 mov     rcx, cs:g_pMemAlloc
+  .text:000000018009FA09                 mov     rdx, rbx
+  .text:000000018009FA0C                 mov     rcx, [rcx]
+  .text:000000018009FA0F                 mov     r8, [rcx]
+  .text:000000018009FA12                 call    qword ptr [r8+18h]
+  .text:000000018009FA16                 mov     r15, [rsp+0E0h+arg_8]
+  .text:000000018009FA1E                 movzx   eax, dil
+  .text:000000018009FA22                 mov     rbx, [rsp+0E0h+arg_18]
+  .text:000000018009FA2A                 add     rsp, 0C0h
+  .text:000000018009FA31                 pop     r14
+  .text:000000018009FA33                 pop     r12
+  .text:000000018009FA35                 pop     rdi
+  .text:000000018009FA36                 pop     rsi
+  .text:000000018009FA37                 pop     rbp
+  .text:000000018009FA38                 retn
+  .text:000000018009FA39                 call    _invalid_parameter_noinfo_noreturn
+procedure: |-
+  char __fastcall CNetworkGameServer_SpawnServer(__int64 *a1, const char *a2)
+  {
+    void *v2; // rbx
+    void *v3; // r14
+    void *v6; // r9
+    void *v7; // r9
+    const char *v8; // rdx
+    int v9; // eax
+    __int64 v10; // rcx
+    const char *v11; // r9
+    __int64 v13; // rsi
+    __int64 v14; // rax
+    void **v15; // rax
+    _BYTE *v16; // rax
+    _BYTE *v17; // rdx
+    void *v18; // rcx
+    void *v19; // rcx
+    const char *v20; // rax
+    unsigned __int16 v21; // si
+    __int64 v22; // rdx
+    __int64 v23; // rdx
+    __int64 (__fastcall ***v24)(_QWORD); // rcx
+    __int64 v25; // rax
+    char v26; // di
+    const char *v27; // r9
+    char v28; // al
+    __int64 v29; // rax
+    __int64 v30; // rcx
+    unsigned __int64 v31; // rdx
+    __int64 v32; // rbx
+    _QWORD v33[2]; // [rsp+30h] [rbp-59h] BYREF
+    int v34; // [rsp+40h] [rbp-49h]
+    char v35; // [rsp+44h] [rbp-45h]
+    __int64 v36; // [rsp+48h] [rbp-41h]
+    int v37; // [rsp+50h] [rbp-39h]
+    __int64 v38; // [rsp+58h] [rbp-31h]
+    void **v39; // [rsp+60h] [rbp-29h]
+    __int64 v40; // [rsp+68h] [rbp-21h] BYREF
+    __int64 v41; // [rsp+70h] [rbp-19h]
+    __int64 *v42; // [rsp+78h] [rbp-11h] BYREF
+    __int64 v43; // [rsp+80h] [rbp-9h]
+    __int128 v44; // [rsp+90h] [rbp+7h] BYREF
+    __m128i si128; // [rsp+A0h] [rbp+17h]
+    void *v46; // [rsp+100h] [rbp+77h] BYREF
+
+    v2 = nullptr;
+    v3 = &unk_180524F9F;
+    if ( a2 && *a2 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808C9378, 2) )
+      {
+        v6 = &unk_180524F9F;
+        if ( a1[42] )
+          v6 = (void *)a1[42];
+        LoggingSystem_Log((unsigned int)dword_1808C9378, 2, "SV:  Spawn Server: %s: [%s]\n", v6, a2);
+      }
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808C9378, 2) )
+    {
+      v7 = &unk_180524F9F;
+      if ( a1[42] )
+        v7 = (void *)a1[42];
+      LoggingSystem_Log((unsigned int)dword_1808C9378, 2, "SV:  Spawn Server: %s\n", v7);
+    }
+    sub_1800B2E90(a1);
+    v8 = (const char *)&unk_180524F9F;
+    if ( a2 )
+      v8 = a2;
+    CUtlString::Set((CUtlString *)(a1 + 223), v8);
+    v9 = (*(__int64 (__fastcall **)(__int64 *))(*a1 + 96))(a1);// 96LL = 0x60 = INetworkGameServer_GetMaxClients
+    *((_BYTE *)a1 + 10056) = 1;
+    *((_DWORD *)a1 + 26) = v9;
+    if ( (unsigned __int8)sub_1800D4390(v10, a1 + 229, a1 + 224) )
+    {
+      v41 = 0;
+      v33[1] = 0;
+      v42 = &qword_18062AA30;
+      v13 = -1;
+      v34 = 0;
+      v33[0] = &CSVCMsg_VoiceInit_t::`vftable';
+      v35 = -1;
+      v39 = &CSVCMsg_VoiceInit_t::`vftable';
+      v14 = *a1;
+      v36 = -1;
+      v37 = -1082130432;
+      v38 = -1;
+      v40 = 0;
+      v43 = 0;
+      if ( (*(unsigned __int8 (__fastcall **)(__int64 *))(v14 + 376))(a1) )
+      {
+        v15 = (void **)sub_1803FC6F0(&unk_18068AF48, 0xFFFFFFFFLL);
+        if ( !v15 )
+          v15 = *(void ***)(qword_18068AF50 + 8);
+        v16 = *v15;
+        v17 = &unk_180524F9F;
+        if ( v16 )
+          v17 = v16;
+      }
+      else
+      {
+        v17 = &unk_180524F9F;
+      }
+      LODWORD(v41) = v41 | 1;
+      v44 = 0;
+      si128 = 0;
+      do
+        ++v13;
+      while ( v17[v13] );
+      sub_180043DF0(&v44, v17, v13);
+      sub_180251460(&v42, &v44, 0);
+      if ( si128.m128i_i64[1] > 0xFuLL )
+      {
+        if ( (unsigned __int64)(si128.m128i_i64[1] + 1) >= 0x1000
+          && (unsigned __int64)(v44 - *(_QWORD *)(v44 - 8) - 8) > 0x1F )
+        {
+          invalid_parameter_noinfo_noreturn();
+        }
+        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+      }
+      LODWORD(v41) = v41 | 2;
+      si128 = _mm_load_si128((const __m128i *)&xmmword_1805838F0);
+      LOBYTE(v44) = 0;
+      LODWORD(v43) = 5;
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64 *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+              g_pNetworkMessages,
+              a1 + 66,
+              v33)
+        || *((_BYTE *)a1 + 560) )
+      {
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808C9378, 3) )
+        {
+          v27 = "failure";
+          if ( *((_BYTE *)a1 + 560) )
+            v27 = "overflow";
+          LoggingSystem_Log((unsigned int)dword_1808C9378, 3, "SV:  Serializing CSVCMsg_VoiceInit_t %s.\n", v27);
+        }
+        v26 = 0;
+      }
+      else
+      {
+        (*(void (__fastcall **)(__int64, __int64 *))(*(_QWORD *)g_pSource2Server + 112LL))(g_pSource2Server, a1 + 66);
+        (*(void (__fastcall **)(__int64 *, __int64))(*a1 + 280))(a1, 2);
+        (*(void (__fastcall **)(__int64 *))(*a1 + 224))(a1);
+        sub_180077750(&v44, "C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\networkgameserver.cpp:988", a1 + 11);
+        sub_18013C530(&off_1806102A0, 8, 0);
+        COM_TimestampedLog("InitializeEntityDLLFields");
+        v18 = &unk_180524F9F;
+        if ( a1[42] )
+          v18 = (void *)a1[42];
+        a1[23] = (__int64)v18;
+        v19 = &unk_180524F9F;
+        if ( a1[223] )
+          v19 = (void *)a1[223];
+        a1[24] = (__int64)v19;
+        v20 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineServiceMgr + 336LL))(g_pEngineServiceMgr);
+        CUtlString::Set((CUtlString *)(a1 + 43), v20);
+        if ( g_pTestScriptMgr )
+          (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)g_pTestScriptMgr + 96LL))(
+            g_pTestScriptMgr,
+            "map_load");
+        v21 = *((_WORD *)a1 + 392);
+        v46 = nullptr;
+        while ( v21 != 0xFFFF )
+        {
+          v22 = 0;
+          if ( (*((_WORD *)a1 + 385) & 0x7FFF) != 0 )
+            v22 = a1[97];
+          if ( *(_WORD *)(v22 + 24LL * v21) == 0xFFFF )
+          {
+            do
+            {
+              v23 = 0;
+              if ( (*((_WORD *)a1 + 385) & 0x7FFF) != 0 )
+                v23 = a1[97];
+              v24 = *(__int64 (__fastcall ****)(_QWORD))(v23 + 24LL * v21 + 16);
+              v25 = (**v24)(v24);
+              CUtlString::operator+=(&v46, v25);
+              if ( v21 != *((unsigned __int16 *)a1 + 393) - 1 )
+                CUtlString::operator+=(&v46, "+");
+              v21 = sub_180090CA0(a1 + 96, v21);
+            }
+            while ( v21 != 0xFFFF );
+            v2 = v46;
+            break;
+          }
+          v21 = *(_WORD *)(v22 + 24LL * v21);
+        }
+        if ( v2 )
+          v3 = v2;
+        sub_1800E31E0(&qword_1808C9A90, "Started:  \"%s\"\n", v3);
+        if ( v46 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v46);
+        COM_TimestampedLog("SV_SpawnServer -- Finished");
+        v26 = 1;
+        sub_18005F450((__int64)&v44);
+      }
+      v33[0] = &CNetMessagePB<46,CSVCMsg_VoiceInit,10,1,0>::`vftable';
+      v39 = &CSVCMsg_VoiceInit::`vftable';
+      v28 = v40;
+      if ( (v40 & 1) != 0 )
+      {
+        v29 = sub_180146130(&v40);
+        v30 = v40;
+        v31 = v29;
+        v28 = v40;
+      }
+      else
+      {
+        v30 = v40;
+        v31 = v40 & 0xFFFFFFFFFFFFFFFCuLL;
+      }
+      if ( !v31 )
+      {
+        sub_180251200(&v42);
+        v30 = v40;
+        v28 = v40;
+      }
+      if ( (v28 & 2) != 0 )
+      {
+        v32 = v30 - 2;
+        if ( v30 != 2 )
+        {
+          sub_1802C09D0(v30 - 2);
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v32);
+        }
+      }
+      return v26;
+    }
+    else
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808C9378, 3) )
+      {
+        v11 = "UNKNOWN FAILURE";
+        if ( *((_BYTE *)a1 + 1824) )
+          v11 = "OVERFLOW FAILURE";
+        LoggingSystem_Log(
+          (unsigned int)dword_1808C9378,
+          3,
+          "SV:  SpawnServer WriteClassInfosAndSerializesToBuffer %s.\n",
+          v11);
+      }
+      return 0;
+    }
+  }


### PR DESCRIPTION
Adds preprocessor finder scripts and reference YAMLs for:
- \CNetworkGameServerBase_GetMaxClients\
- \CNetworkGameServer_SpawnServer\ (decompile-based discovery)