### PR TITLE
Split find-CEngineServer_ChangeLevel into inline/noinline fallback chain

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1105,11 +1105,27 @@ modules:
         expected_input:
           - GetSteamUniverse.{platform}.yaml
           - CEngineServer_vtable.{platform}.yaml
-      - name: find-CEngineServer_ChangeLevel
+      - name: find-CNetworkGameServerBase_ChangeLevel
+        optional_output:
+          - CNetworkGameServerBase_ChangeLevel.{platform}.yaml
+        skip_if_exists:
+          - CEngineServer_ChangeLevel.{platform}.yaml
+      - name: find-CEngineServer_ChangeLevel-noinline
+        optional_output:
+          - CEngineServer_ChangeLevel.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+        prerequisite:
+          - find-CNetworkGameServerBase_ChangeLevel
+      - name: find-CEngineServer_ChangeLevel-inlined
         expected_output:
           - CEngineServer_ChangeLevel.{platform}.yaml
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
+        skip_if_exists:
+          - CEngineServer_ChangeLevel.{platform}.yaml
+        prerequisite:
+          - find-CEngineServer_ChangeLevel-noinline
       - name: find-CMapListService_IsMapValid-windows
         platform: windows
         expected_output:

--- a/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel-inlined.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel-inlined.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CEngineServer_ChangeLevel skill."""
+"""Preprocess script for find-CEngineServer_ChangeLevel-inlined skill.
+
+Resolves ``CEngineServer_ChangeLevel`` (a vfunc of ``CEngineServer_vtable``)
+directly from the ``"Changelevel %s %s"`` string reference.  This applies when
+``CNetworkGameServerBase_ChangeLevel`` is inlined into ``CEngineServer_ChangeLevel``
+so the string lives inside the vfunc body.  It is the fallback for the
+``find-CEngineServer_ChangeLevel-noinline`` path (which handles the de-inlined
+case) and is skipped whenever ``CEngineServer_ChangeLevel.{platform}.yaml``
+already exists.
+"""
 
 from ida_analyze_util import preprocess_common_skill
 

--- a/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel-noinline.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_ChangeLevel-noinline.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_ChangeLevel-noinline skill.
+
+Resolves ``CEngineServer_ChangeLevel`` (a vfunc of ``CEngineServer_vtable``) as
+the single caller of the standalone ``CNetworkGameServerBase_ChangeLevel``.  This
+path only applies when ``CNetworkGameServerBase_ChangeLevel`` is NOT inlined into
+``CEngineServer_ChangeLevel``; when it is inlined the xref callee is absent and
+this skill legitimately produces nothing (its output is optional), so the
+``find-CEngineServer_ChangeLevel-inlined`` fallback runs instead.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_ChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineServer_ChangeLevel",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CNetworkGameServerBase_ChangeLevel",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_ChangeLevel", "CEngineServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_ChangeLevel",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_ChangeLevel.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_ChangeLevel.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_ChangeLevel skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_ChangeLevel",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_ChangeLevel",
+        "xref_strings": [
+            "Changelevel %s %s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_ChangeLevel",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- `CNetworkGameServerBase::ChangeLevel` is inlined into `CEngineServer::ChangeLevel` in current game versions but compiled as a separate function starting in 14168+, breaking the single xref_strings+vtable finder once de-inlined (the `"Changelevel %s %s"` string no longer lives in the vtable member's body).
- Replaces the single `find-CEngineServer_ChangeLevel` skill with a 3-skill fallback chain:
  - `find-CNetworkGameServerBase_ChangeLevel` (Pattern A, xref_strings, optional_output, skip_if_exists `CEngineServer_ChangeLevel`)
  - `find-CEngineServer_ChangeLevel-noinline` (Pattern B, xref_funcs off the above, vfunc of `CEngineServer_vtable`, optional_output, prerequisite on the above)
  - `find-CEngineServer_ChangeLevel-inlined` (renamed original xref_strings+vtable skill, skip_if_exists, prerequisite on the noinline skill)

## Test plan
- [x] Validated via `ida_analyze_bin.py` on 14167 (inlined case) and 14168 (de-inlined case), both platforms: Failed 0