### PR TITLE
fix(snapshot): preserve canonical LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 configs/*.yaml -text
+gamesymbols/*.yaml text eol=lf


### PR DESCRIPTION
## Summary
- force tracked canonical snapshots under gamesymbols/ to use LF checkouts
- prevent core.autocrlf on Windows from materializing noncanonical CRLF snapshot bytes

## Verification
- confirmed gamesymbols/14167.yaml and gamesymbols/14168.yaml report index/worktree LF via git ls-files --eol
- confirmed both files exactly match canonical_snapshot_bytes after parsing
- confirmed the PR diff only changes .gitattributes