### PR TITLE
fix(release): warn on undeclared symbol YAML

### DIFF
--- a/.claude/skills/run-validation-until-no-failure/SKILL.md
+++ b/.claude/skills/run-validation-until-no-failure/SKILL.md
@@ -2,9 +2,12 @@
 name: run-validation-until-no-failure
 description: |
   Use when the user wants to run the IDA validation pipeline (`uv run ida_analyze_bin.py -debug`)
-  repeatedly until it reports zero failures, recording each failing skill's reason and disabling it
-  in configs/<GAMEVER>.yaml so the run can proceed. Use after a game-version bump or a large batch of new skills
-  when several skills may fail and you want an automated triage-and-quarantine pass.
+  repeatedly until it reports zero failures. For each failing skill, diagnose the failure, ask the
+  user how to proceed, and offer several viable solutions. Only when the user explicitly says the
+  failure cannot be solved now and asks to temporarily disable the skill, comment it out in
+  configs/<GAMEVER>.yaml and record it in docs/ida_validation_failure-<GAMEVER>.md. Use after a
+  game-version bump or a large batch of new skills when several skills may fail and you want a
+  guided triage-and-quarantine pass.
   Triggers: run validation until no failure, validate until green, get validation passing,
   disable failing skills, quarantine failing skills, loop ida_analyze_bin until no failures
 disable-model-invocation: true
@@ -14,11 +17,14 @@ disable-model-invocation: true
 
 Loop the analysis/validation pipeline until it reports **`Failed: 0`**. Each iteration: run
 `ida_analyze_bin.py -debug`; if a skill failed (the pipeline is fail-fast, so it's exactly one),
-record *why* in a dated doc and comment that skill out of `configs/<GAMEVER>.yaml`. Then run the unittest suite
-before resuming validation. If the config dependency test reports consumers whose `expected_input`
-can no longer be produced, quarantine those dependent skills one at a time and re-run unittest until
-it passes. Environment / infrastructure failures are **not** skill bugs — STOP and surface those
-instead of quarantining a skill.
+diagnose *why*, present several concrete resolution options, and ask the user which option to take.
+Do not disable or record the skill before the user answers. If the user explicitly answers that it
+cannot be solved now and asks to temporarily disable the skill, append the failure to
+`docs/ida_validation_failure-<GAMEVER>.md`, comment that skill out of `configs/<GAMEVER>.yaml`, and
+run the unittest suite before resuming validation. If the config dependency test reports consumers
+whose `expected_input` can no longer be produced, apply the same ask-before-action rule to each
+dependent skill. Environment / infrastructure failures are **not** skill bugs — STOP and surface
+those instead of quarantining a skill.
 
 Resolve `GAMEVER` from the user's explicit request or `CS2VIBE_GAMEVER`; use only
 `configs/$GAMEVER.yaml` for the validation run and all quarantine edits.
@@ -43,33 +49,45 @@ Resolve `GAMEVER` from the user's explicit request or `CS2VIBE_GAMEVER`; use onl
   ```
 - It is **fully fail-fast**: the first failing skill aborts the remaining skills, the remaining
   platforms, **and** the remaining modules. So each run surfaces **exactly one** actionable failing
-  skill — that is why you disable one skill per iteration.
+  skill — handle at most one validation-failing skill per iteration.
 - Skills whose `expected_output` YAML already exist on disk are **skipped** on re-runs, so each
   iteration advances quickly to the next unresolved skill.
 
 ## Safety Rules — STOP conditions (never loop forever)
 
-- **Infra / environment failure → STOP and report.** If the failure is not attributable to a
-  specific skill's logic, do **not** comment out a skill. Signals:
+For every STOP condition, stop the automatic loop, report the evidence, offer concrete next-step
+options, and ask the user how to proceed. Do not resume until the user answers.
+
+- **Infra / environment failure → STOP and ask.** If the failure is not attributable to a specific
+  skill's logic, do **not** comment out a skill. Signals:
   - `Failed: IDB lock file detected (...)`
   - `Failed: opened binary verification failed` / `Aborting current binary after opened binary verification failure`
   - `Failed to restore MCP connection ...`
   - `Error: Binary file not found` or any `idalib-mcp` startup error
-  These mean the toolchain / binary / IDB is broken, not the skill. Fix the environment or ask the user.
-- **`-gamever` required error → STOP.** The command relies on `$CS2VIBE_GAMEVER`. If the run errors,
-  `{gamever}` can be obtained from `.env` -> `CS2VIBE_GAMEVER`,
-  gamever is required, ask the user for the version if not specified.
-- **No progress → STOP.** If a run's failing skill is the *same* one you just commented (the config
-  edit didn't take), or the `Failed` count did not go down, STOP and report. Never re-comment the same
-  block or force past it.
-- **Unrelated unittest failure → STOP and report.** Only dependency gaps reported by
+  These mean the toolchain / binary / IDB is broken, not the skill. Offer relevant recovery options
+  such as clearing a confirmed stale lock, correcting the binary path, or restarting the MCP/IDA
+  session, then ask the user which action to take.
+- **`-gamever` required error → STOP and ask.** The command relies on `$CS2VIBE_GAMEVER`. If the run
+  errors, offer to use the user's explicit version, read `CS2VIBE_GAMEVER` from `.env`, or inspect
+  available `configs/*.yaml` files with the user; do not guess the game version.
+- **No progress → STOP and ask.** If a run's failing skill is the *same* one you just commented (the
+  config edit didn't take), or the `Failed` count did not go down, report the evidence and offer
+  investigation options. Never re-comment the same block or force past it.
+- **Unrelated unittest failure → STOP and ask.** Only dependency gaps reported by
   `TestConfigSkillDependencyGraph.test_config_module_skills_have_no_expected_input_order_gaps` may
-  quarantine more skills. Do not hide failures from any other test, exception, import error, or test
-  infrastructure problem by commenting out config entries.
-- **Only** two kinds of edits are allowed: append to the dated failure doc, and comment (prefix `#`)
-  a validation-failing skill or dependency-broken descendant's block in `configs/<GAMEVER>.yaml`. Comment one
-  skill block at a time, re-run the relevant gate, do not delete config entries, do not touch unrelated
-  skills, and do not uncomment anything.
+  lead to asking whether to quarantine more skills. Do not hide failures from any other test,
+  exception, import error, or test infrastructure problem by commenting out config entries. Offer
+  repair or investigation options and ask the user how to proceed.
+- **User decision is required before skill edits.** Present several viable, failure-specific repair
+  options and wait for the user's answer. If the user selects a repair, make only the edits authorized
+  by that choice and run the relevant tests before resuming validation. Quarantine only after an
+  explicit answer such as `解决不了，先屏蔽该skill` (or an unambiguous equivalent); do not interpret
+  silence, a generic approval, or uncertainty as permission to quarantine.
+- **Quarantine edits are comment-only.** After explicit quarantine approval, append to
+  `docs/ida_validation_failure-<GAMEVER>.md` and comment (prefix `#`) the validation-failing skill or
+  dependency-broken descendant's block in `configs/<GAMEVER>.yaml`. Comment one skill block at a
+  time, re-run the relevant gate, do not delete config entries, do not touch unrelated skills, and
+  do not uncomment anything unless the user separately requests it.
 
 ## Method
 
@@ -107,14 +125,35 @@ context:
 - **Reason** = the indented lines of that skill's block (e.g. `missing expected_input: ...`,
   `Skill file not found: ...`, preprocess diagnostics).
 
-Now apply the **Safety Rules**: if this is an infra failure, STOP here.
+Now apply the **Safety Rules**: if this is an infra failure, stop the loop, offer recovery options,
+and ask the user how to proceed. Do not continue to the skill-quarantine steps.
 
-### Step 4 — Append the failure reason to the dated doc
+### Step 4 — Ask the user how to resolve the failure
 
-Compute the date once as ISO `YYYY-MM-DD` (`date +%F`). File: `docs/validation_failure-<DATE>.md`.
-Create it if missing, otherwise **append** a new section (several skills can fail across iterations on
-the same day). Record: skill name, module, platform, the verbatim failure block from the log, and a
-one-line diagnosis.
+Report the skill name, module, platform, verbatim failure block, and a one-line diagnosis. Then offer
+2-4 concrete, viable options tailored to the failure and ask the user which one to take. Prefer
+specific options such as:
+
+1. Fix the failing skill or preprocessor logic, then run its targeted tests and validation again.
+2. Repair a missing or invalid dependency, config entry, or generated artifact, then re-run the
+   dependency test and validation.
+3. Investigate ambiguous environment or toolchain evidence before changing any skill.
+4. If it cannot be solved now, temporarily disable the failing skill.
+
+Do not present irrelevant boilerplate options. **Stop and wait for the user's answer.** Then:
+
+- If the user selects a repair or investigation option, carry it out within the user's chosen scope,
+  run the relevant tests, and return to Step 1. Do not write a quarantine record.
+- If the user explicitly answers `解决不了，先屏蔽该skill` or gives an unambiguous equivalent that
+  both defers the fix and requests temporary disabling, continue to Step 5.
+- If the answer is ambiguous, ask a concise follow-up. Do not quarantine by inference.
+
+### Step 5 — Record the approved quarantine in the game-version doc
+
+File: `docs/ida_validation_failure-<GAMEVER>.md`, using the resolved `GAMEVER` verbatim in the
+filename. Create it if missing; otherwise **append** a new section. Record: skill name, module,
+platform, the verbatim failure block from the log, a one-line diagnosis, and that the user chose to
+temporarily disable the skill.
 
 ```markdown
 ## find-ConnectInterfaces  (module: engine2, platform: windows/linux)
@@ -134,14 +173,16 @@ Failure (from `ida_analyze_bin.py -debug`):
 
 Diagnosis: preprocessor could not locate ConnectInterfaces and no agent SKILL.md exists to fall back
 to. Needs a preprocessor fix or a find-ConnectInterfaces SKILL.md.
+
+Decision: user chose to temporarily disable this skill because it could not be resolved now.
 ```
 
-### Step 5 — Comment the failing skill out of configs/<GAMEVER>.yaml
+### Step 6 — Comment the failing skill out of configs/<GAMEVER>.yaml
 
 Comment the skill's entire list-item block **under the correct module**, and add one `Awaiting fix`
-line above it that points at the dated doc. The rule: insert a `#` right after the 6-space base indent
-on every line of the block, keeping `{platform}` placeholders verbatim (this disables it for all
-platforms).
+line above it that points at the game-version failure doc. The rule: insert a `#` right after the
+6-space base indent on every line of the block, keeping `{platform}` placeholders verbatim (this
+disables it for all platforms).
 
 Before:
 
@@ -156,7 +197,7 @@ Before:
 After:
 
 ```yaml
-      #  Awaiting fix, failure reason has been written into "docs/validation_failure-2026-07-09.md"
+      #  Awaiting fix, failure reason has been written into "docs/ida_validation_failure-13990.md"
       #- name: find-ConnectInterfaces
       #  expected_output:
       #    - ConnectInterfaces.{platform}.yaml
@@ -173,7 +214,7 @@ in Step 3. Use the Edit tool with an `old_string` that includes the *preceding s
 (which differs per module) so the match is unique — a bare block match would silently hit the wrong
 module.
 
-### Step 6 — Run unittest after every configs/<GAMEVER>.yaml quarantine
+### Step 7 — Run unittest after every configs/<GAMEVER>.yaml quarantine
 
 Immediately after commenting out any skill block, run the non-MCP unittest suite:
 
@@ -185,7 +226,7 @@ The command excludes the IDA MCP adapter and smoke modules (`test_ida_mcp_sessio
 `test_smoke_ida_mcp_2`) because this loop does not modify MCP routing or lifecycle code. Run them
 separately whenever MCP code changes.
 
-- **All tests pass** → the active `configs/<GAMEVER>.yaml` dependency chain is intact; continue to Step 7.
+- **All tests pass** → the active `configs/<GAMEVER>.yaml` dependency chain is intact; continue to Step 8.
 - **Only**
   `TestConfigSkillDependencyGraph.test_config_module_skills_have_no_expected_input_order_gaps`
   fails → inspect its dependency-gap list. Each entry identifies a consumer whose `expected_input`
@@ -195,17 +236,23 @@ separately whenever MCP code changes.
   windows module[2] server/find-ChildSkill missing: _artifacts/server/Parent.windows.yaml
   ```
 
-  Here `server/find-ChildSkill` is the child skill to quarantine. Append its unittest failure and a
-  one-line dependency diagnosis to the same dated failure doc, then comment that child's full block
-  under the named module using the Step 5 rules. Re-run the full unittest suite immediately.
-- **Any other unittest failure** → STOP and report it. It is not evidence that another skill should
-  be quarantined.
+  Here `server/find-ChildSkill` is the affected child skill. Report the gap, provide viable options
+  such as repairing/restoring the producer, changing the consumer dependency when semantically
+  correct, or temporarily disabling the child, and ask the user how to proceed. Stop and wait for the
+  answer. If the user selects a repair, implement it and re-run the full unittest suite. Only if the
+  user explicitly says it cannot be solved now and asks to temporarily disable that child, append
+  its unittest failure, dependency diagnosis, and decision to
+  `docs/ida_validation_failure-<GAMEVER>.md`; then comment that child's full block under the named
+  module using the Step 6 rules and re-run the full unittest suite immediately.
+- **Any other unittest failure** → STOP and ask. It is not evidence that another skill should be
+  quarantined.
 
-Quarantine one unique child skill per unittest iteration. A child may be listed once per platform;
-comment its all-platform `{platform}` block only once. Keep following newly exposed descendants and
+Handle one unique child skill per unittest iteration. A child may be listed once per platform;
+comment its all-platform `{platform}` block only once after explicit approval. Ask again for each
+newly exposed descendant; a previous quarantine decision does not authorize later descendants. Keep
 re-running unittest until the suite passes. Do not return to IDA validation while unittest is red.
 
-### Step 7 — Resume the validation loop
+### Step 8 — Resume the validation loop
 
 Go back to Step 1. The just-disabled skill is now skipped, and previously-successful skills are
 skipped (their outputs exist), so the next run reaches the next failure quickly. Repeat until
@@ -214,32 +261,34 @@ skipped (their outputs exist), so the next run reaches the next failure quickly.
 > **Cascading is expected and must be resolved before validation resumes.** Disabling a producer can
 > break a consumer whose `expected_input` names the disabled output. The unittest dependency graph
 > catches this immediately, even when stale YAML artifacts would otherwise let the validation run
-> skip past the broken config chain. Quarantine descendants until unittest passes, and call the full
-> dependency chain out in the report.
+> skip past the broken config chain. Ask the user how to resolve each descendant, apply the selected
+> repair or explicitly approved quarantine, and call the full dependency chain out in the report.
 
 ## Quick reference — failure signal lines
 
 | Log line (2-space indent) | Meaning | Action |
 |---|---|---|
-| `Failed: <skill> (missing expected_input: ...)` | dependency YAML absent | quarantine skill |
-| `Failed: <skill> (invalid expected_input ...)` | dependency YAML malformed | quarantine skill |
-| `Pre-processed but missing expected_output: <skill> (...)` | preprocess ran, output not written | quarantine skill |
-| `Preprocess failed: <skill>; falling back to AGENT SKILL` → `    Failed` | preprocess AND agent fallback failed | quarantine skill |
-| `Failed: <skill> (<exception>)` | skill raised | quarantine skill |
+| `Failed: <skill> (missing expected_input: ...)` | dependency YAML absent | diagnose, offer solutions, ask user |
+| `Failed: <skill> (invalid expected_input ...)` | dependency YAML malformed | diagnose, offer solutions, ask user |
+| `Pre-processed but missing expected_output: <skill> (...)` | preprocess ran, output not written | diagnose, offer solutions, ask user |
+| `Preprocess failed: <skill>; falling back to AGENT SKILL` → `    Failed` | preprocess AND agent fallback failed | diagnose, offer solutions, ask user |
+| `Failed: <skill> (<exception>)` | skill raised | diagnose, offer solutions, ask user |
 | `Failed: IDB lock file detected ...` | stale lock / another IDA instance | **STOP** (infra) |
 | `Failed: opened binary verification failed` | wrong/broken binary open | **STOP** (infra) |
 | `Failed to restore MCP connection ...` | idalib-mcp died | **STOP** (infra) |
-| unittest dependency gap: `<module>/<skill> missing: <artifact>` | active consumer has no active producer | quarantine that child, re-run unittest |
+| unittest dependency gap: `<module>/<skill> missing: <artifact>` | active consumer has no active producer | offer repair/quarantine options, ask user |
 | any other unittest failure | unrelated code/test/infrastructure failure | **STOP** |
 
 ## Notes
 
 - `tail -15` is only for the verdict; always parse the **full** `/tmp/ida_validation_output.txt` to
   identify the failing skill and its reason.
-- IDA validation quarantines one skill per iteration (fail-fast). The mandatory unittest loop may
-  quarantine several dependency descendants, still one block per unittest iteration.
+- IDA validation surfaces one actionable skill per iteration (fail-fast). The mandatory unittest
+  loop may surface several dependency descendants; ask about and handle one block per unittest
+  iteration.
 - Never run the next IDA validation iteration until the non-MCP unittest command above passes with
   zero failures.
-- Purely additive to `configs/<GAMEVER>.yaml` (commenting only). Re-enabling a skill once it's fixed is a
-  separate manual step — the commented blocks plus the dated doc are the resulting to-do list.
+- On the quarantine path, edit `configs/<GAMEVER>.yaml` by commenting only. Re-enabling a skill once
+  it's fixed is a separate manual step — the commented blocks plus
+  `docs/ida_validation_failure-<GAMEVER>.md` are the resulting to-do list.
 - This skill does not `git commit`; leave staging/committing to the user unless they ask.

--- a/gamesymbol_snapshot_lib/operations.py
+++ b/gamesymbol_snapshot_lib/operations.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -20,6 +21,9 @@ from gamesymbol_snapshot_lib.paths import (
     iter_yaml_paths,
     path_from_key,
 )
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _load_yaml_mapping(path: Path) -> dict:
@@ -48,18 +52,20 @@ def collect_actual_files(contract, strict=True) -> dict[str, dict]:
         raise SnapshotMismatchError(f"Missing required symbol YAML:\n{lines}")
     actual_keys = _actual_yaml_keys(contract)
     undeclared = sorted(actual_keys - contract.formal_paths)
-    if strict and undeclared:
+    if undeclared:
         lines = "\n".join(f"  {path}" for path in undeclared)
-        raise SnapshotMismatchError(f"Undeclared symbol YAML:\n{lines}")
+        if strict:
+            raise SnapshotMismatchError(f"Undeclared symbol YAML:\n{lines}")
+        LOGGER.warning("WARNING: Ignoring undeclared symbol YAML:\n%s", lines)
     selected = sorted(contract.required_paths | (contract.optional_paths & actual_keys))
     return {path: _load_yaml_mapping(path_from_key(contract.game_root, path)) for path in selected}
 
 
-def build_actual_document(contract) -> dict:
+def build_actual_document(contract, *, strict: bool = False) -> dict:
     return build_snapshot_document(
         contract.game_version,
         contract.config_sha256,
-        collect_actual_files(contract, strict=True),
+        collect_actual_files(contract, strict=strict),
     )
 
 

--- a/tests/test_gamesymbol_snapshot_ops.py
+++ b/tests/test_gamesymbol_snapshot_ops.py
@@ -4,8 +4,9 @@ from tempfile import TemporaryDirectory
 
 import yaml
 
+from gamesymbol_snapshot_lib.config import load_contract
 from gamesymbol_snapshot_lib.errors import SnapshotMismatchError, SnapshotSchemaError
-from gamesymbol_snapshot_lib.operations import pack_snapshot, restore_snapshot, verify_snapshot
+from gamesymbol_snapshot_lib.operations import build_actual_document, pack_snapshot, restore_snapshot, verify_snapshot
 from gamesymbol_snapshot_lib.snapshot_cli import main as snapshot_main
 from tests.gamesymbol_snapshot_test_support import module, skill, write_config, write_yaml
 
@@ -64,7 +65,7 @@ class TestPack(unittest.TestCase):
 
         self.assertIn("server/Optional.windows.yaml", data["files"])
 
-    def test_pack_rejects_missing_required_and_undeclared_without_overwriting(self) -> None:
+    def test_pack_rejects_missing_required_without_overwriting(self) -> None:
         with TemporaryDirectory() as temp_dir:
             workspace = SnapshotWorkspace(Path(temp_dir))
             workspace.snapshot.parent.mkdir(parents=True)
@@ -73,11 +74,27 @@ class TestPack(unittest.TestCase):
                 workspace.pack()
             self.assertEqual(b"existing\n", workspace.snapshot.read_bytes())
 
+    def test_pack_warns_and_ignores_undeclared_yaml(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            workspace = SnapshotWorkspace(Path(temp_dir))
             workspace.write_required()
             write_yaml(workspace.bindir / "14168/server/Stale.windows.yaml", {"stale": True})
-            with self.assertRaises(SnapshotMismatchError):
-                workspace.pack()
-            self.assertEqual(b"existing\n", workspace.snapshot.read_bytes())
+            with self.assertLogs("gamesymbol_snapshot_lib.operations", "WARNING") as logs:
+                data = yaml.safe_load(workspace.pack())
+
+        self.assertEqual(2, data["file_count"])
+        self.assertNotIn("server/Stale.windows.yaml", data["files"])
+        self.assertIn("WARNING: Ignoring undeclared symbol YAML:\n  server/Stale.windows.yaml", logs.output[0])
+
+    def test_strict_build_rejects_undeclared_yaml(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            workspace = SnapshotWorkspace(Path(temp_dir))
+            workspace.write_required()
+            write_yaml(workspace.bindir / "14168/server/Stale.windows.yaml", {"stale": True})
+            contract = load_contract(workspace.config, "14168", workspace.bindir)
+
+            with self.assertRaisesRegex(SnapshotMismatchError, "Undeclared symbol YAML"):
+                build_actual_document(contract, strict=True)
 
     def test_pack_rejects_top_level_non_mapping_yaml(self) -> None:
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_process_scheduler_redis.py
+++ b/tests/test_process_scheduler_redis.py
@@ -16,6 +16,9 @@ from process_reporter_redis import RedisProcessReporter
 from process_scheduler_redis import RedisProcessScheduler, RedisRunQueue, RunRequest
 
 
+TEST_GAMEVER = "14168"
+
+
 class FakePopenFactory:
     def __init__(self, exit_codes=None):
         self.exit_codes = exit_codes or {}
@@ -123,8 +126,8 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_submit_creates_fifo_stream_and_safe_queued_metadata(self) -> None:
         queue = self._queue()
-        first = RunRequest.create("100", run_id="run-first", agent="codex")
-        second = RunRequest.create("101", run_id="run-second", agent="claude")
+        first = RunRequest.create(TEST_GAMEVER, run_id="run-first", agent="codex")
+        second = RunRequest.create(TEST_GAMEVER, run_id="run-second", agent="claude")
 
         first_id = queue.submit(first)
         second_id = queue.submit(second)
@@ -132,7 +135,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
         self.assertLess(tuple(map(int, first_id.split("-"))), tuple(map(int, second_id.split("-"))))
         meta = self.redis.hgetall(queue.keys.run_meta(first.run_id))
         self.assertEqual("queued", meta["status"])
-        self.assertEqual("100", meta["gamever"])
+        self.assertEqual(TEST_GAMEVER, meta["gamever"])
         self.assertNotIn("redis_url", meta)
         self.assertEqual(
             [first.run_id, second.run_id], [fields["run_id"] for _, fields in self.redis.xrange(queue.keys.run_queue)]
@@ -140,7 +143,10 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_runs_in_fifo_order_with_single_active_process_and_acks(self) -> None:
         queue = self._queue()
-        requests = [RunRequest.create(str(gamever), run_id=f"run-{gamever}") for gamever in (100, 101)]
+        requests = [
+            RunRequest.create(TEST_GAMEVER, run_id="run-first"),
+            RunRequest.create(TEST_GAMEVER, run_id="run-second"),
+        ]
         for request in requests:
             queue.submit(request)
         popen = FakePopenFactory()
@@ -157,7 +163,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_failed_process_finalizes_run_and_acks(self) -> None:
         queue = self._queue()
-        request = RunRequest.create("100", run_id="run-failed")
+        request = RunRequest.create(TEST_GAMEVER, run_id="run-failed")
         queue.submit(request)
         scheduler = self._scheduler(queue, FakePopenFactory({request.run_id: 7}))
 
@@ -170,7 +176,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_pending_entry_is_claimed_and_executed_after_restart(self) -> None:
         original = self._queue(consumer="old-consumer")
-        request = RunRequest.create("100", run_id="run-recovered-queued")
+        request = RunRequest.create(TEST_GAMEVER, run_id="run-recovered-queued")
         original.submit(request)
         original.ensure_group()
         original.client.xreadgroup(original.group, original.consumer, {original.keys.run_queue: ">"}, count=1)
@@ -185,7 +191,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_reporter_attaches_to_scheduler_created_run(self) -> None:
         queue = self._queue()
-        request = RunRequest.create("100", run_id="run-attach")
+        request = RunRequest.create(TEST_GAMEVER, run_id="run-attach")
         queue.submit(request)
         entry = queue.next_entry(block_ms=1)
         queue.transition(entry, RunStatus.STARTING)
@@ -208,7 +214,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_live_heartbeat_prevents_duplicate_then_expiry_aborts(self) -> None:
         original = self._queue(consumer="old-consumer")
-        request = RunRequest.create("100", run_id="run-live")
+        request = RunRequest.create(TEST_GAMEVER, run_id="run-live")
         original.submit(request)
         original.ensure_group()
         response = original.client.xreadgroup(
@@ -237,7 +243,7 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_redis_connection_details_are_only_passed_via_environment(self) -> None:
         queue = self._queue()
-        request = RunRequest.create("100", run_id="run-command", skill_filter="find-A", agent="codex")
+        request = RunRequest.create(TEST_GAMEVER, run_id="run-command", skill_filter="find-A", agent="codex")
         scheduler = self._scheduler(queue, FakePopenFactory())
 
         command = scheduler.build_command(request)
@@ -250,7 +256,10 @@ class TestRedisProcessSchedulerIntegration(unittest.TestCase):
 
     def test_real_subprocess_smoke_runs_two_requests_strictly_in_sequence(self) -> None:
         queue = self._queue()
-        requests = [RunRequest.create(str(gamever), run_id=f"run-smoke-{gamever}") for gamever in (100, 101)]
+        requests = [
+            RunRequest.create(TEST_GAMEVER, run_id="run-smoke-first"),
+            RunRequest.create(TEST_GAMEVER, run_id="run-smoke-second"),
+        ]
         for request in requests:
             queue.submit(request)
         analyzer = Path(__file__).parent / "fixtures" / "process_scheduler_smoke_analyzer.py"


### PR DESCRIPTION
## Summary
- Warn and ignore undeclared symbol YAML during normal snapshot packaging while preserving strict validation.
- Replace invalid scheduler game-version fixtures with a valid version.
- Document the validation failure handling workflow.

## Testing
- `PYTHONPATH=. uv run --with pytest python -m pytest tests/test_gamesymbol_snapshot_ops.py tests/test_process_scheduler_redis.py -q`
  - 14 passed, 8 skipped