### PR TITLE
fix(release): stabilize tracked output manifest hashes

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -321,6 +321,12 @@ jobs:
       - name: Stage validated pending state and tracked manifest
         shell: pwsh
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$env:OUTPUT_BRANCH"
+          if ($LASTEXITCODE -ne 0) { throw "Failed to create immutable output branch." }
+          git add -- "gamesymbols/$env:GAMEVER.yaml" dist
+          if ($LASTEXITCODE -ne 0) { throw "Failed to stage generated release output." }
           uv run release_workflow.py stage-build `
             --staging-root "$env:PERSISTED_WORKSPACE\release-staging" `
             --bin-source "bin\$env:GAMEVER" --candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT" `
@@ -335,11 +341,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: pwsh
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$env:OUTPUT_BRANCH"
-          if ($LASTEXITCODE -ne 0) { throw "Failed to create immutable output branch." }
-          git add -- "gamesymbols/$env:GAMEVER.yaml" dist "release-manifests/$env:GAMEVER.json"
+          git add -- "release-manifests/$env:GAMEVER.json"
+          if ($LASTEXITCODE -ne 0) { throw "Failed to stage tracked release manifest." }
           git commit -m "chore(gamesymbols): publish $env:GAMEVER build $env:BUILD_ID" `
             -m "Co-Authored-By: Codex (GPT-5.x)"
           if ($LASTEXITCODE -ne 0) { throw "Failed to commit generated release output." }

--- a/release_workflow_lib/hashing.py
+++ b/release_workflow_lib/hashing.py
@@ -2,12 +2,14 @@ import hashlib
 import json
 import os
 import stat
+import subprocess
 from pathlib import Path, PurePosixPath
 
 from release_workflow_lib.errors import ReleaseWorkflowError
 
 HEX_SHA256_LENGTH = 64
 READ_CHUNK_SIZE = 1024 * 1024
+REGULAR_GIT_MODES = {"100644", "100755"}
 
 
 def canonical_json_bytes(value: object) -> bytes:
@@ -131,18 +133,42 @@ def verify_inventory(root: Path, expected: list[dict]) -> str:
     return inventory_sha256(actual)
 
 
+def _git_bytes(repo_root: Path, arguments: list[str]) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *arguments],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise ReleaseWorkflowError(detail or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def _git_index_inventory(repo_root: Path, pathspecs: list[str]) -> list[dict]:
+    raw_entries = _git_bytes(repo_root, ["ls-files", "--stage", "-z", "--", *pathspecs])
+    inventory = []
+    seen = set()
+    for record in raw_entries.split(b"\0"):
+        if not record:
+            continue
+        metadata, raw_path = record.split(b"\t", 1)
+        mode, object_id, stage = metadata.decode("ascii").split()
+        relative = normalized_relative_path(os.fsdecode(raw_path).replace("\\", "/"))
+        if stage != "0" or mode not in REGULAR_GIT_MODES or relative in seen:
+            raise ReleaseWorkflowError(f"tracked output has an unsupported Git index entry: {relative}")
+        blob = _git_bytes(repo_root, ["cat-file", "blob", object_id])
+        inventory.append({"path": relative, "size": len(blob), "sha256": sha256_bytes(blob)})
+        seen.add(relative)
+    return sorted(inventory, key=lambda item: item["path"])
+
+
 def tracked_output_inventory(repo_root: Path, gamever: str) -> list[dict]:
     repo_root = Path(repo_root)
-    paths = [repo_root / "gamesymbols" / f"{gamever}.yaml"]
-    dist = repo_root / "dist"
-    if dist.is_dir():
-        paths.extend(sorted(item for item in dist.rglob("*") if item.is_file()))
-    inventory = []
-    for path in paths:
-        if not path.is_file():
-            raise ReleaseWorkflowError(f"required tracked output is missing: {path}")
-        relative = normalized_relative_path(path.relative_to(repo_root).as_posix())
-        inventory.append({"path": relative, "size": path.stat().st_size, "sha256": sha256_file(path)})
+    snapshot = f"gamesymbols/{gamever}.yaml"
+    inventory = _git_index_inventory(repo_root, [snapshot, "dist"])
+    if snapshot not in {item["path"] for item in inventory}:
+        raise ReleaseWorkflowError(f"required tracked output is missing from the Git index: {snapshot}")
     return inventory
 
 

--- a/release_workflow_lib/manifests.py
+++ b/release_workflow_lib/manifests.py
@@ -164,8 +164,9 @@ def verify_tracked_outputs(repo_root: Path, manifest: dict) -> list[dict]:
     inventory = tracked_output_inventory(repo_root, manifest["gamever"])
     if inventory_sha256(inventory) != manifest["tracked_output_manifest_sha256"]:
         raise ReleaseWorkflowError("tracked output manifest hash mismatch")
-    snapshot = Path(repo_root) / "gamesymbols" / f"{manifest['gamever']}.yaml"
-    if sha256_file(snapshot) != manifest["candidate_sha256"]:
+    snapshot_path = f"gamesymbols/{manifest['gamever']}.yaml"
+    snapshot = next(item for item in inventory if item["path"] == snapshot_path)
+    if snapshot["sha256"] != manifest["candidate_sha256"]:
         raise ReleaseWorkflowError("published snapshot does not match candidate hash")
     return inventory
 

--- a/tests/test_build_self_runner_workflow.py
+++ b/tests/test_build_self_runner_workflow.py
@@ -51,7 +51,10 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
         cpp_tests = self.workflow.index("uv run run_cpp_tests.py")
         sdk_restore = self.workflow.index("- name: Restore pinned SDK revision")
         publish = self.workflow.index("gamesymbol_candidate.py publish")
+        stage_outputs = self.workflow.index('git add -- "gamesymbols/$env:GAMEVER.yaml" dist')
         stage = self.workflow.index("release_workflow.py stage-build")
+        stage_manifest = self.workflow.index('git add -- "release-manifests/$env:GAMEVER.json"')
+        commit = self.workflow.index("git commit -m")
         output_pr = self.workflow.index("gh pr create")
         self.assertLess(analyze, candidate)
         self.assertLess(candidate, gamedata)
@@ -59,7 +62,10 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
         self.assertLess(sdk_select, cpp_tests)
         self.assertLess(cpp_tests, sdk_restore)
         self.assertLess(sdk_restore, publish)
-        self.assertLess(publish, stage)
+        self.assertLess(publish, stage_outputs)
+        self.assertLess(stage_outputs, stage)
+        self.assertLess(stage, stage_manifest)
+        self.assertLess(stage_manifest, commit)
         self.assertLess(stage, output_pr)
 
     def test_cpp_validation_selects_versioned_sdk_with_pinned_fallback(self) -> None:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,4 +1,5 @@
 import hashlib
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -50,6 +51,12 @@ class ReleaseFixture:
         (self.repo / "dist" / "nested" / "gamedata.txt").write_text("gamedata\n", encoding="utf-8")
         (self.bin_source / "client.dll").write_bytes(b"dll")
         (self.bin_source / "client.yaml").write_text("value: 1\n", encoding="utf-8")
+        (self.repo / ".gitignore").write_text("__pycache__/\n*.pyc\n", encoding="utf-8")
+        self.git("init", "--quiet")
+        self.git("add", "--", "gamesymbols", "dist")
+
+    def git(self, *arguments: str) -> None:
+        subprocess.run(["git", *arguments], cwd=self.repo, check=True, capture_output=True)
 
     def stage(self) -> dict:
         return stage_build(
@@ -191,6 +198,7 @@ class TestReleaseWorkflow(unittest.TestCase):
             fixture = ReleaseFixture(Path(tmp))
             fixture.stage()
             (fixture.repo / "dist" / "nested" / "gamedata.txt").write_text("tampered\n", encoding="utf-8")
+            fixture.git("add", "--", "dist/nested/gamedata.txt")
 
             with self.assertRaisesRegex(ReleaseWorkflowError, "tracked output manifest hash mismatch"):
                 finalize_stage(
@@ -200,6 +208,29 @@ class TestReleaseWorkflow(unittest.TestCase):
                     build_id=fixture.build_id,
                     pr_head_sha=fixture.head_sha,
                 )
+
+    def test_untracked_dist_cache_is_excluded_from_tracked_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            cache = fixture.repo / "dist" / "nested" / "__pycache__" / "gamedata.pyc"
+            cache.parent.mkdir(parents=True)
+            cache.write_bytes(b"cache")
+
+            pending = fixture.stage()
+            fixture.finalize_and_index()
+
+            self.assertNotIn(
+                cache.relative_to(fixture.repo).as_posix(), {item["path"] for item in pending["tracked_files"]}
+            )
+
+    def test_worktree_line_endings_do_not_change_index_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            fixture.stage()
+            output = fixture.repo / "dist" / "nested" / "gamedata.txt"
+            output.write_bytes(b"gamedata\r\n")
+
+            fixture.finalize_and_index()
 
     def test_disallowed_generated_output_path_is_rejected(self) -> None:
         with self.assertRaisesRegex(ReleaseWorkflowError, "disallowed paths"):


### PR DESCRIPTION
## Summary
- calculate tracked output inventories from staged Git blobs
- stage release outputs before generating their tracked manifest
- cover ignored cache files and worktree line-ending differences

## Testing
- Not run (not requested).