### PR TITLE
fix(reference): correct CEntitySystem serialization mode annotation

### DIFF
--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -17,14 +17,14 @@ disasm_code: |-
   .text:0000000001E7C3E0                 sub     rsp, 68h
   .text:0000000001E7C3E4                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
   .text:0000000001E7C3E9                 lea     rax, unk_27C4271
-  .text:0000000001E7C3F0                 mov     [rbx+0BBCh], r13d
+  .text:0000000001E7C3F0                 ; 0xBBC = 3004LL = CEntitySystem::m_eNetworkSerializationMode
+  .text:0000000001E7C3F0                 mov     [rbx+0BBCh], r13d; 0xBBC = 3004LL = CEntitySystem::m_eNetworkSerializationMode
   .text:0000000001E7C3F7                 mov     [rax], r14b
   .text:0000000001E7C3FA                 cmp     r12d, 1
   .text:0000000001E7C3FE                 jz      loc_1E7C748
   .text:0000000001E7C404                 lea     r13, g_pNetworkMessages
   .text:0000000001E7C40B                 xor     eax, eax
-  .text:0000000001E7C40D                 ; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
-  .text:0000000001E7C40D                 mov     [rbx+0BDAh], al; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
+  .text:0000000001E7C40D                 mov     [rbx+0BDAh], al
   .text:0000000001E7C413                 ; bool
   .text:0000000001E7C413                 xor     r8d, r8d; bool
   .text:0000000001E7C416                 ; void *

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -16,7 +16,8 @@ disasm_code: |-
   .text:00000001811F8284                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
   .text:00000001811F828A                 movzx   eax, [rsp+0C8h+arg_20]
   .text:00000001811F8292                 mov     cs:byte_1820B9640, al
-  .text:00000001811F8298                 mov     [rsi+0BBCh], ebx
+  .text:00000001811F8298                 ; 0xBBC = 3004LL = CEntitySystem::m_eNetworkSerializationMode
+  .text:00000001811F8298                 mov     [rsi+0BBCh], ebx; 0xBBC = 3004LL = CEntitySystem::m_eNetworkSerializationMode
   .text:00000001811F829E                 cmp     edi, 1
   .text:00000001811F82A1                 jnz     short loc_1811F82B3
   .text:00000001811F82A3                 cmp     cs:g_pNetworkMessages, 0
@@ -26,8 +27,7 @@ disasm_code: |-
   .text:00000001811F82B3                 xor     al, al
   .text:00000001811F82B5                 ; 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
   .text:00000001811F82B5                 lea     rcx, [rsi+0CB8h]; 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
-  .text:00000001811F82BC                 ; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
-  .text:00000001811F82BC                 mov     [rsi+0BDAh], al; 0xBDA = 3034LL = CEntitySystem::m_eNetworkSerializationMode
+  .text:00000001811F82BC                 mov     [rsi+0BDAh], al
   .text:00000001811F82C2                 xor     r9d, r9d
   .text:00000001811F82C5                 mov     byte ptr [rsp+0C8h+var_A8], 0
   .text:00000001811F82CA                 xor     r8d, r8d


### PR DESCRIPTION
## Summary
- remove incorrect 0xBDA m_eNetworkSerializationMode annotations from Windows and Linux CEntitySystem_Init references
- annotate the 0xBBC initialization writes as m_eNetworkSerializationMode

## Validation
- PYTHONPATH=. uv run pytest tests/test_ida_preprocessor_scripts.py -q (64 passed, 2 subtests passed)
- parsed both reference YAML files with yaml.safe_load
- git diff --check