### PR TITLE
feat(release): add explicit legacy snapshot bootstrap

### DIFF
--- a/.claude/skills/trigger-release-build/SKILL.md
+++ b/.claude/skills/trigger-release-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: trigger-release-build
-description: Safely dispatch a new release build or same-version republish from the immutable current origin/main SHA. Use only when explicitly asked to publish, rebuild, or republish a game version, including requests such as “发布 14170”, “重新发布 14170”, “使用当前 main 重建 14170 的 release”, or “触发最新游戏版本的 release build”.
+description: Safely dispatch a new release build or same-version republish from the immutable current origin/main SHA. Use only when explicitly asked to publish, rebuild, or republish a game version. Enable trusted legacy snapshot bootstrap only when the user separately and explicitly requests that weaker first-republish fallback.
 disable-model-invocation: true
 ---
 
@@ -18,7 +18,16 @@ command, accept a user-supplied SHA, move a tag, edit a Release, cancel work, or
    uv run python .claude/skills/trigger-release-build/scripts/trigger_release_build.py <GAMEVER-or-latest>
    ```
 
-3. Report the script's selected version, selected mode, full `SOURCE_SHA`, commit subject, and Actions run URL.
+   Only when the user explicitly requests using the tracked snapshot without an accepted release manifest, append:
+
+   ```powershell
+   --allow-legacy-bootstrap
+   ```
+
+   Do not infer legacy bootstrap from ordinary publish, rebuild, republish, retry, or same-version wording.
+
+3. Report the script's selected version, selected mode, legacy-bootstrap state, full `SOURCE_SHA`, commit subject,
+   and Actions run URL.
 4. If the script refuses the operation, surface its exact safety reason and stop. Do not bypass repository, auth,
    version, tag/Release, duplicate-work, or `origin/main` checks.
 

--- a/.claude/skills/trigger-release-build/scripts/trigger_release_build.py
+++ b/.claude/skills/trigger-release-build/scripts/trigger_release_build.py
@@ -187,9 +187,18 @@ def require_main_unchanged(root: Path, source_sha: str) -> None:
         raise TriggerError("origin/main advanced while validating the rebuild request; run the skill again")
 
 
-def dispatch(root: Path, gamever: str, source_sha: str, mode: str) -> None:
+def dispatch(
+    root: Path,
+    gamever: str,
+    source_sha: str,
+    mode: str,
+    *,
+    allow_legacy_bootstrap: bool = False,
+) -> None:
     if mode not in RELEASE_MODES:
         raise TriggerError(f"invalid release mode: {mode}")
+    if allow_legacy_bootstrap and mode != "republish":
+        raise TriggerError("legacy bootstrap is only valid for republish mode")
     run_command(
         [
             "gh",
@@ -204,6 +213,8 @@ def dispatch(root: Path, gamever: str, source_sha: str, mode: str) -> None:
             f"source_sha={source_sha}",
             "-f",
             f"mode={mode}",
+            "-f",
+            f"allow_legacy_bootstrap={str(allow_legacy_bootstrap).lower()}",
         ],
         root,
     )
@@ -224,26 +235,40 @@ def discover_run(root: Path, known_ids: set[int], *, gamever: str, source_sha: s
     raise TriggerError("workflow was dispatched but its Actions run URL could not be discovered")
 
 
-def execute(requested: str) -> dict:
+def execute(requested: str, *, allow_legacy_bootstrap: bool = False) -> dict:
     root = repository_root()
     repository = require_repository(root)
     require_github_access(root, repository)
     source_sha, subject = resolve_source(root)
     gamever = select_version(requested, available_versions(root, source_sha))
     mode = resolve_mode(root, repository, gamever)
+    if allow_legacy_bootstrap and mode != "republish":
+        raise TriggerError("legacy bootstrap is only valid for republish mode")
     known_ids = require_no_duplicate(root, gamever)
     require_main_unchanged(root, source_sha)
-    dispatch(root, gamever, source_sha, mode)
+    dispatch(root, gamever, source_sha, mode, allow_legacy_bootstrap=allow_legacy_bootstrap)
     run_url = discover_run(root, known_ids, gamever=gamever, source_sha=source_sha)
-    return {"gamever": gamever, "mode": mode, "source_sha": source_sha, "subject": subject, "run_url": run_url}
+    return {
+        "gamever": gamever,
+        "mode": mode,
+        "source_sha": source_sha,
+        "subject": subject,
+        "run_url": run_url,
+        "allow_legacy_bootstrap": allow_legacy_bootstrap,
+    }
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("gamever", help="A version in download.yaml, or latest")
+    parser.add_argument(
+        "--allow-legacy-bootstrap",
+        action="store_true",
+        help="Explicitly allow a trusted tracked snapshot when the accepted release manifest is absent",
+    )
     args = parser.parse_args(argv)
     try:
-        result = execute(args.gamever)
+        result = execute(args.gamever, allow_legacy_bootstrap=args.allow_legacy_bootstrap)
     except (TriggerError, OSError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
@@ -251,6 +276,7 @@ def main(argv=None) -> int:
     print(f"Mode: {result['mode']}")
     print(f"SOURCE_SHA: {result['source_sha']}")
     print(f"Commit: {result['subject']}")
+    print(f"Legacy bootstrap: {'enabled' if result['allow_legacy_bootstrap'] else 'disabled'}")
     print(f"Actions run: {result['run_url']}")
     return 0
 

--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -17,6 +17,11 @@ on:
         required: true
         type: choice
         options: [new, republish]
+      allow_legacy_bootstrap:
+        description: Explicitly allow trusted tracked-snapshot bootstrap without an accepted manifest
+        required: false
+        default: false
+        type: boolean
   repository_dispatch:
     types: [build-on-self-runner]
 
@@ -37,6 +42,7 @@ jobs:
       gamever: ${{ steps.resolve.outputs.gamever }}
       source_sha: ${{ steps.resolve.outputs.source_sha }}
       mode: ${{ steps.resolve.outputs.mode }}
+      allow_legacy_bootstrap: ${{ steps.resolve.outputs.allow_legacy_bootstrap }}
     steps:
       - name: Checkout default branch for trust validation
         uses: actions/checkout@v4
@@ -55,6 +61,16 @@ jobs:
           $gamever = "${{ inputs.gamever || github.event.client_payload.gamever }}"
           $sourceSha = "${{ inputs.source_sha || github.event.client_payload.source_sha }}"
           $mode = "${{ inputs.mode || github.event.client_payload.mode }}"
+          $allowLegacyBootstrap = "${{ inputs.allow_legacy_bootstrap || github.event.client_payload.allow_legacy_bootstrap || 'false' }}".ToLowerInvariant()
+          if ($allowLegacyBootstrap -notin @("true", "false")) {
+            throw "allow_legacy_bootstrap must be true or false."
+          }
+          if ($allowLegacyBootstrap -eq "true" -and "${{ github.event_name }}" -ne "workflow_dispatch") {
+            throw "Legacy bootstrap is only allowed for workflow_dispatch."
+          }
+          if ($allowLegacyBootstrap -eq "true" -and $mode -ne "republish") {
+            throw "Legacy bootstrap is only allowed for republish mode."
+          }
           git fetch origin --tags --force "+refs/heads/*:refs/remotes/origin/*"
           uv run release_workflow.py validate-build `
             --repository "${{ github.repository }}" `
@@ -80,6 +96,7 @@ jobs:
           "gamever=$gamever" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "source_sha=$sourceSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
           "mode=$mode" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "allow_legacy_bootstrap=$allowLegacyBootstrap" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
 
   build:
     needs: preflight
@@ -89,6 +106,7 @@ jobs:
       GAMEVER: ${{ needs.preflight.outputs.gamever }}
       SOURCE_SHA: ${{ needs.preflight.outputs.source_sha }}
       MODE: ${{ needs.preflight.outputs.mode }}
+      ALLOW_LEGACY_BOOTSTRAP: ${{ needs.preflight.outputs.allow_legacy_bootstrap }}
       BUILD_ID: ${{ github.run_id }}-${{ github.run_attempt }}
       CS2VIBE_AGENT: ${{ secrets.CS2VIBE_AGENT }}
       CS2VIBE_LLM_APIKEY: ${{ secrets.CS2VIBE_LLM_APIKEY }}
@@ -166,8 +184,16 @@ jobs:
         if: env.MODE == 'republish'
         shell: pwsh
         run: |
-          uv run release_workflow.py invalidate-republish `
-            --gamever "$env:GAMEVER" --source-sha "$env:SOURCE_SHA" --bindir bin
+          $args = @(
+            'invalidate-republish',
+            '--gamever', $env:GAMEVER,
+            '--source-sha', $env:SOURCE_SHA,
+            '--bindir', 'bin'
+          )
+          if ($env:ALLOW_LEGACY_BOOTSTRAP -eq "true") {
+            $args += '--allow-legacy-bootstrap'
+          }
+          uv run release_workflow.py @args
 
       - name: Prepare trusted old-version signature baseline
         id: oldgamever

--- a/.serena/memories/build-on-self-runner.md
+++ b/.serena/memories/build-on-self-runner.md
@@ -56,7 +56,17 @@
 - `tests/test_trigger_release_build.py`：repository/auth/version/tag/Release/duplicate/dispatch/run URL。
 - 完成门：全仓 unittest、formatter、Ruff、YAML parse、actionlint 与 CLI non-publishing smoke。
 
+## Explicit Legacy Bootstrap
+
+- `invalidate-republish` 默认仍要求 accepted `release-manifests/<GAMEVER>.json`；缺失时继续保守删除同版本 YAML。
+- 只有 trigger skill 在用户明确要求“无 accepted manifest 时使用 tracked snapshot”后，才传
+  `--allow-legacy-bootstrap` / `allow_legacy_bootstrap=true`；普通 publish、republish、retry 或 same-version 请求不得推断启用。
+- legacy 路径只允许 `workflow_dispatch + mode=republish`，`repository_dispatch` 被 preflight 拒绝。
+- legacy snapshot 从 immutable `SOURCE_SHA` 读取；其最后发布 commit 必须是 `SOURCE_SHA` 祖先，并使用该 commit 的历史
+  versioned config（允许 legacy root config）验证 canonical snapshot contract，再恢复并执行 source/config-aware invalidation。
+- 该开关提供显式 opt-in，而非可证明的“由 skill 发起”身份认证；GitHub workflow 无法区分同权限维护者手工构造的等价 dispatch。
+
 ## Callers
 
 - `repository_dispatch.types: [build-on-self-runner]`
-- `workflow_dispatch(gamever, source_sha, mode)`，通常仅由 trigger SKILL 调用
+- `workflow_dispatch(gamever, source_sha, mode, allow_legacy_bootstrap=false)`，通常仅由 trigger SKILL 调用

--- a/release_workflow_lib/cli.py
+++ b/release_workflow_lib/cli.py
@@ -37,6 +37,7 @@ def _add_build_parsers(commands) -> None:
     invalidate.add_argument("--gamever", required=True)
     invalidate.add_argument("--source-sha", required=True)
     invalidate.add_argument("--bindir", default="bin")
+    invalidate.add_argument("--allow-legacy-bootstrap", action="store_true")
 
     oldgamever = commands.add_parser("prepare-oldgamever")
     oldgamever.add_argument("--repo-root", default=".")
@@ -169,6 +170,7 @@ def _run_build(args) -> object:
             gamever=args.gamever,
             source_sha=args.source_sha,
             bindir=args.bindir,
+            allow_legacy_bootstrap=args.allow_legacy_bootstrap,
         )
     if args.command == "prepare-oldgamever":
         result = prepare_oldgamever_baseline(

--- a/release_workflow_lib/validation.py
+++ b/release_workflow_lib/validation.py
@@ -65,9 +65,30 @@ def validate_build_input(*, repository: str, gamever: str, source_sha: str, mode
         raise ReleaseWorkflowError(f"mode=republish requires tag {gamever} to exist")
 
 
-def _changed_files(base_sha: str, source_sha: str) -> list[str]:
-    output = git_output(["diff", "--name-only", base_sha, source_sha, "--"])
+def _changed_files(repo_root: Path, base_sha: str, source_sha: str) -> list[str]:
+    output = git_output(["-C", str(repo_root), "diff", "--name-only", base_sha, source_sha, "--"])
     return [line for line in output.splitlines() if line]
+
+
+def _require_ancestor(repo_root: Path, base_sha: str, source_sha: str, label: str) -> None:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", base_sha, source_sha],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise ReleaseWorkflowError(f"{label} is not an ancestor of the rebuild SOURCE_SHA")
+
+
+def _git_blob(repo_root: Path, revision: str, repository_path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "show", f"{revision}:{repository_path}"],
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.decode(errors="replace").strip()
+        raise ReleaseWorkflowError(stderr or f"unable to read {repository_path} at {revision}")
+    return result.stdout
 
 
 def _gamever_key(gamever: str) -> tuple[int, int]:
@@ -130,26 +151,96 @@ def prepare_oldgamever_baseline(*, repo_root: str | Path, gamever: str, bindir: 
     }
 
 
-def invalidate_republish(*, repo_root: Path, gamever: str, source_sha: str, bindir: Path) -> int:
-    repo_root = Path(repo_root)
-    gamever = require_gamever(gamever)
-    source_sha = require_sha(source_sha, "SOURCE_SHA")
-    manifest_path = repo_root / "release-manifests" / f"{gamever}.json"
-    if not manifest_path.is_file():
-        game_root = Path(bindir) / gamever
-        ensure_real_tree(Path(bindir), game_root)
-        paths = list(iter_yaml_paths(game_root))
-        for path in paths:
-            path.unlink()
-        print(f"No accepted release manifest exists; conservative baseline invalidated {len(paths)} YAML file(s)")
-        return len(paths)
+def _invalidate_yaml_baseline(bindir: Path, gamever: str) -> int:
+    game_root = bindir / gamever
+    ensure_real_tree(bindir, game_root)
+    paths = list(iter_yaml_paths(game_root))
+    for path in paths:
+        path.unlink()
+    print(f"No accepted release manifest exists; conservative baseline invalidated {len(paths)} YAML file(s)")
+    return len(paths)
+
+
+def _delete_planned_outputs(plan, game_root: Path) -> int:
+    ensure_real_tree(game_root.parent, game_root)
+    deleted = 0
+    for key in sorted(plan.paths):
+        target = path_from_key(game_root, key)
+        if target.is_file():
+            target.unlink()
+            deleted += 1
+    for reason in plan.reasons:
+        print(reason)
+    print(f"Invalidated {len(plan.paths)} affected output(s); deleted {deleted} YAML file(s)")
+    return deleted
+
+
+def _legacy_snapshot_commit(repo_root: Path, source_sha: str, snapshot_repo_path: str) -> str:
+    try:
+        commit = git_output(["-C", str(repo_root), "log", "-1", "--format=%H", source_sha, "--", snapshot_repo_path])
+    except ReleaseWorkflowError as exc:
+        raise ReleaseWorkflowError(f"legacy bootstrap snapshot is missing: {snapshot_repo_path}") from exc
+    if not commit:
+        raise ReleaseWorkflowError(f"legacy bootstrap snapshot is missing: {snapshot_repo_path}")
+    return require_sha(commit, "legacy snapshot publication SHA")
+
+
+def _invalidate_from_legacy_snapshot(repo_root: Path, gamever: str, source_sha: str, bindir: Path) -> int:
+    snapshot_repo_path = f"gamesymbols/{gamever}.yaml"
+    base_sha = _legacy_snapshot_commit(repo_root, source_sha, snapshot_repo_path)
+    _require_ancestor(repo_root, base_sha, source_sha, "legacy snapshot publication SHA")
+    with tempfile.TemporaryDirectory(prefix="release-legacy-base-") as temp_dir:
+        base_config = Path(temp_dir) / "base.yaml"
+        head_config = Path(temp_dir) / "head.yaml"
+        snapshot = Path(temp_dir) / f"{gamever}.yaml"
+        try:
+            base_history = read_analysis_config_at_revision(
+                base_sha,
+                gamever,
+                allow_legacy_root=True,
+                repo_root=repo_root,
+            )
+            head_history = read_analysis_config_at_revision(
+                source_sha,
+                gamever,
+                allow_legacy_root=False,
+                repo_root=repo_root,
+            )
+        except AnalysisConfigError as exc:
+            raise ReleaseWorkflowError(str(exc)) from exc
+        base_config.write_bytes(base_history.data)
+        head_config.write_bytes(head_history.data)
+        snapshot.write_bytes(_git_blob(repo_root, source_sha, snapshot_repo_path))
+        try:
+            base_context = load_snapshot_context(snapshot, base_config, gamever, bindir)
+            restore_snapshot(gamever, bindir, base_config, snapshot, replace=True)
+        except (SnapshotError, OSError, UnicodeError) as exc:
+            raise ReleaseWorkflowError(f"trusted legacy bootstrap snapshot was rejected: {exc}") from exc
+        head_contract = load_contract(head_config, gamever, bindir)
+        plan = build_invalidation_plan(
+            base_context.contract,
+            head_contract,
+            base_context.document,
+            base_context.document,
+            _changed_files(repo_root, base_sha, source_sha),
+            repo_root,
+        )
+    print(f"WARNING: explicitly authorized legacy bootstrap from {snapshot_repo_path} at {base_sha}")
+    return _delete_planned_outputs(plan, head_contract.game_root)
+
+
+def _invalidate_from_accepted_manifest(
+    repo_root: Path,
+    gamever: str,
+    source_sha: str,
+    bindir: Path,
+    manifest_path: Path,
+) -> int:
     manifest = load_tracked_manifest(manifest_path)
     base_sha = require_sha(manifest["source_sha"], "previous SOURCE_SHA")
     if base_sha == source_sha:
         raise ReleaseWorkflowError("republish SOURCE_SHA must be newer than the accepted generator source")
-    result = subprocess.run(["git", "merge-base", "--is-ancestor", base_sha, source_sha], check=False)
-    if result.returncode != 0:
-        raise ReleaseWorkflowError("previous accepted SOURCE_SHA is not an ancestor of the rebuild SOURCE_SHA")
+    _require_ancestor(repo_root, base_sha, source_sha, "previous accepted SOURCE_SHA")
     snapshot = repo_root / "gamesymbols" / f"{gamever}.yaml"
     with tempfile.TemporaryDirectory(prefix="release-base-") as temp_dir:
         base_config = Path(temp_dir) / "base.yaml"
@@ -192,17 +283,29 @@ def invalidate_republish(*, repo_root: Path, gamever: str, source_sha: str, bind
             head_contract,
             base_context.document,
             base_context.document,
-            _changed_files(base_sha, source_sha),
+            _changed_files(repo_root, base_sha, source_sha),
             repo_root,
         )
-    ensure_real_tree(Path(bindir), head_contract.game_root)
-    deleted = 0
-    for key in sorted(plan.paths):
-        target = path_from_key(head_contract.game_root, key)
-        if target.is_file():
-            target.unlink()
-            deleted += 1
-    for reason in plan.reasons:
-        print(reason)
-    print(f"Invalidated {len(plan.paths)} affected output(s); deleted {deleted} YAML file(s)")
-    return deleted
+    return _delete_planned_outputs(plan, head_contract.game_root)
+
+
+def invalidate_republish(
+    *,
+    repo_root: Path,
+    gamever: str,
+    source_sha: str,
+    bindir: Path,
+    allow_legacy_bootstrap: bool = False,
+) -> int:
+    repo_root = Path(repo_root).resolve()
+    gamever = require_gamever(gamever)
+    source_sha = require_sha(source_sha, "SOURCE_SHA")
+    bindir = Path(bindir)
+    if not bindir.is_absolute():
+        bindir = repo_root / bindir
+    manifest_path = repo_root / "release-manifests" / f"{gamever}.json"
+    if manifest_path.is_file():
+        return _invalidate_from_accepted_manifest(repo_root, gamever, source_sha, bindir, manifest_path)
+    if allow_legacy_bootstrap:
+        return _invalidate_from_legacy_snapshot(repo_root, gamever, source_sha, bindir)
+    return _invalidate_yaml_baseline(bindir, gamever)

--- a/tests/test_build_self_runner_workflow.py
+++ b/tests/test_build_self_runner_workflow.py
@@ -31,9 +31,18 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
     def test_workspace_bin_is_real_and_republish_uses_affected_invalidation(self) -> None:
         self.assertIn("Workspace bin must be a real directory", self.workflow)
         self.assertIn("Copied persisted bin/$env:GAMEVER into build workspace", self.workflow)
-        self.assertIn("release_workflow.py invalidate-republish", self.workflow)
+        self.assertIn("'invalidate-republish'", self.workflow)
+        self.assertIn("uv run release_workflow.py @args", self.workflow)
         self.assertIn("if: env.MODE == 'republish'", self.workflow)
         self.assertNotIn("force every preprocessor", self.workflow.lower())
+
+    def test_legacy_bootstrap_is_explicit_and_defaults_off(self) -> None:
+        self.assertIn("allow_legacy_bootstrap:", self.workflow)
+        self.assertIn("default: false", self.workflow)
+        self.assertIn("ALLOW_LEGACY_BOOTSTRAP:", self.workflow)
+        self.assertIn('$env:ALLOW_LEGACY_BOOTSTRAP -eq "true"', self.workflow)
+        self.assertIn("--allow-legacy-bootstrap", self.workflow)
+        self.assertIn("Legacy bootstrap is only allowed for workflow_dispatch", self.workflow)
 
     def test_build_restores_and_explicitly_passes_trusted_oldgamever(self) -> None:
         prepare = self.workflow.index("release_workflow.py prepare-oldgamever")

--- a/tests/test_release_workflow_guards.py
+++ b/tests/test_release_workflow_guards.py
@@ -4,11 +4,77 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from gamesymbol_snapshot_lib.codec import build_snapshot_document, canonical_snapshot_bytes
+from gamesymbol_snapshot_lib.config import load_contract
+from release_workflow_lib.cli import _parser
 from release_workflow_lib.errors import ReleaseWorkflowError
 from release_workflow_lib.promotion import verify_output_pr, verify_promotion
 from release_workflow_lib.staging import cleanup_incomplete, cleanup_unmerged
 from release_workflow_lib.validation import invalidate_republish, validate_build_input
 from tests.test_release_workflow import ReleaseFixture
+
+
+class LegacyBootstrapFixture:
+    gamever = "14170"
+
+    def __init__(self, root: Path) -> None:
+        self.repo = root / "repo"
+        self.repo.mkdir()
+        self.git("init", "-b", "main")
+        self.git("config", "user.email", "tests@example.com")
+        self.git("config", "user.name", "Tests")
+        self.config = self.repo / "configs" / f"{self.gamever}.yaml"
+        self.snapshot = self.repo / "gamesymbols" / f"{self.gamever}.yaml"
+        changed_skill = self.repo / ".claude" / "skills" / "find-Changed" / "SKILL.md"
+        stable_skill = self.repo / ".claude" / "skills" / "find-Stable" / "SKILL.md"
+        self.config.parent.mkdir(parents=True)
+        self.snapshot.parent.mkdir(parents=True)
+        changed_skill.parent.mkdir(parents=True)
+        stable_skill.parent.mkdir(parents=True)
+        self.config.write_text(
+            "modules:\n"
+            "  - name: server\n"
+            "    path_windows: game/bin/win64/server.dll\n"
+            "    skills:\n"
+            "      - name: find-Changed\n"
+            "        platform: windows\n"
+            "        expected_output:\n"
+            "          - Changed.{platform}.yaml\n"
+            "      - name: find-Stable\n"
+            "        platform: windows\n"
+            "        expected_output:\n"
+            "          - Stable.{platform}.yaml\n",
+            encoding="utf-8",
+        )
+        changed_skill.write_text("changed v1\n", encoding="utf-8")
+        stable_skill.write_text("stable v1\n", encoding="utf-8")
+        contract = load_contract(self.config, self.gamever, self.repo / "bin")
+        document = build_snapshot_document(
+            self.gamever,
+            contract.config_sha256,
+            {
+                "server/Changed.windows.yaml": {"func_name": "Changed", "func_rva": "0x10"},
+                "server/Stable.windows.yaml": {"func_name": "Stable", "func_rva": "0x20"},
+            },
+        )
+        self.snapshot.write_bytes(canonical_snapshot_bytes(document))
+        self.git("add", ".")
+        self.git("commit", "-m", "legacy snapshot")
+        self.base_sha = self.git("rev-parse", "HEAD")
+        changed_skill.write_text("changed v2\n", encoding="utf-8")
+        self.git("add", ".")
+        self.git("commit", "-m", "change one producer")
+        self.source_sha = self.git("rev-parse", "HEAD")
+
+    def git(self, *args: str) -> str:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=self.repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
 
 
 class TestReleaseWorkflowGuards(unittest.TestCase):
@@ -61,6 +127,69 @@ class TestReleaseWorkflowGuards(unittest.TestCase):
             self.assertEqual(1, deleted)
             self.assertFalse((game_root / "client.yaml").exists())
             self.assertTrue((game_root / "client.dll").exists())
+
+    def test_legacy_bootstrap_requires_explicit_cli_flag(self) -> None:
+        parser = _parser()
+        common = [
+            "invalidate-republish",
+            "--gamever",
+            "14170",
+            "--source-sha",
+            "1" * 40,
+        ]
+
+        self.assertFalse(parser.parse_args(common).allow_legacy_bootstrap)
+        self.assertTrue(parser.parse_args([*common, "--allow-legacy-bootstrap"]).allow_legacy_bootstrap)
+
+    def test_explicit_legacy_bootstrap_restores_snapshot_and_invalidates_changed_producer(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = LegacyBootstrapFixture(Path(tmp))
+
+            deleted = invalidate_republish(
+                repo_root=fixture.repo,
+                gamever=fixture.gamever,
+                source_sha=fixture.source_sha,
+                bindir=fixture.repo / "bin",
+                allow_legacy_bootstrap=True,
+            )
+
+            game_root = fixture.repo / "bin" / fixture.gamever / "server"
+            self.assertEqual(1, deleted)
+            self.assertFalse((game_root / "Changed.windows.yaml").exists())
+            self.assertTrue((game_root / "Stable.windows.yaml").is_file())
+
+    def test_explicit_legacy_bootstrap_rejects_missing_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            with self.assertRaisesRegex(ReleaseWorkflowError, "legacy bootstrap snapshot"):
+                invalidate_republish(
+                    repo_root=repo,
+                    gamever="14170",
+                    source_sha="1" * 40,
+                    bindir=repo / "bin",
+                    allow_legacy_bootstrap=True,
+                )
+
+    def test_explicit_legacy_bootstrap_rejects_snapshot_contract_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = LegacyBootstrapFixture(Path(tmp))
+            invalid_document = build_snapshot_document(
+                fixture.gamever,
+                "sha256:" + "0" * 64,
+                {"server/Stable.windows.yaml": {"func_name": "Stable", "func_rva": "0x20"}},
+            )
+            fixture.snapshot.write_bytes(canonical_snapshot_bytes(invalid_document))
+            fixture.git("add", ".")
+            fixture.git("commit", "-m", "tamper snapshot contract")
+
+            with self.assertRaisesRegex(ReleaseWorkflowError, "trusted legacy bootstrap snapshot was rejected"):
+                invalidate_republish(
+                    repo_root=fixture.repo,
+                    gamever=fixture.gamever,
+                    source_sha=fixture.git("rev-parse", "HEAD"),
+                    bindir=fixture.repo / "bin",
+                    allow_legacy_bootstrap=True,
+                )
 
     def test_lightweight_output_pr_check_rejects_stale_source(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_trigger_release_build.py
+++ b/tests/test_trigger_release_build.py
@@ -31,6 +31,8 @@ class TestTriggerReleaseBuild(unittest.TestCase):
         self.assertIn("mode=republish", skill)
         self.assertIn("allow_implicit_invocation: false", agent)
         self.assertIn("publish or republish", agent)
+        self.assertIn("--allow-legacy-bootstrap", skill)
+        self.assertIn("Do not infer legacy bootstrap", skill)
 
     def test_latest_uses_last_download_entry(self) -> None:
         self.assertEqual("14169", trigger.select_version("latest", ["14168", "14168b", "14169"]))
@@ -153,12 +155,24 @@ class TestTriggerReleaseBuild(unittest.TestCase):
                     f"source_sha={'1' * 40}",
                     "-f",
                     f"mode={mode}",
+                    "-f",
+                    "allow_legacy_bootstrap=false",
                 ],
                 root,
             )
 
         with self.assertRaisesRegex(trigger.TriggerError, "invalid release mode"):
             trigger.dispatch(root, "14170", "1" * 40, "unsafe")
+
+    def test_dispatch_only_allows_explicit_legacy_bootstrap_for_republish(self) -> None:
+        root = Path("repo")
+        with patch.object(trigger, "run_command", return_value=completed([])) as run:
+            trigger.dispatch(root, "14170", "1" * 40, "republish", allow_legacy_bootstrap=True)
+
+        command = run.call_args.args[0]
+        self.assertIn("allow_legacy_bootstrap=true", command)
+        with self.assertRaisesRegex(trigger.TriggerError, "only valid for republish"):
+            trigger.dispatch(root, "14170", "1" * 40, "new", allow_legacy_bootstrap=True)
 
     def test_dispatch_stops_if_origin_main_advanced(self) -> None:
         with patch.object(trigger, "run_command", return_value=completed([], stdout=f"{'2' * 40}\trefs/heads/main\n")):
@@ -202,7 +216,23 @@ class TestTriggerReleaseBuild(unittest.TestCase):
         access.assert_called_once()
         resolve_mode.assert_called_once_with(root, "HLND2T/CS2_VibeSignatures", "14170")
         unchanged.assert_called_once_with(root, "1" * 40)
-        dispatch.assert_called_once_with(root, "14170", "1" * 40, "new")
+        dispatch.assert_called_once_with(root, "14170", "1" * 40, "new", allow_legacy_bootstrap=False)
+
+    def test_execute_rejects_legacy_bootstrap_for_new_release_before_dispatch(self) -> None:
+        root = Path("repo")
+        with (
+            patch.object(trigger, "repository_root", return_value=root),
+            patch.object(trigger, "require_repository", return_value="HLND2T/CS2_VibeSignatures"),
+            patch.object(trigger, "require_github_access"),
+            patch.object(trigger, "resolve_source", return_value=("1" * 40, "subject")),
+            patch.object(trigger, "available_versions", return_value=["14170"]),
+            patch.object(trigger, "resolve_mode", return_value="new"),
+            patch.object(trigger, "dispatch") as dispatch,
+        ):
+            with self.assertRaisesRegex(trigger.TriggerError, "only valid for republish"):
+                trigger.execute("14170", allow_legacy_bootstrap=True)
+
+        dispatch.assert_not_called()
 
     def test_main_reports_selected_mode(self) -> None:
         result = {
@@ -212,10 +242,13 @@ class TestTriggerReleaseBuild(unittest.TestCase):
             "subject": "subject",
             "run_url": "https://run/11",
         }
-        with patch.object(trigger, "execute", return_value=result), patch("builtins.print") as output:
-            self.assertEqual(0, trigger.main(["14170"]))
+        result["allow_legacy_bootstrap"] = True
+        with patch.object(trigger, "execute", return_value=result) as execute, patch("builtins.print") as output:
+            self.assertEqual(0, trigger.main(["14170", "--allow-legacy-bootstrap"]))
 
+        execute.assert_called_once_with("14170", allow_legacy_bootstrap=True)
         output.assert_any_call("Mode: new")
+        output.assert_any_call("Legacy bootstrap: enabled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add an explicit `--allow-legacy-bootstrap` opt-in for first republish without an accepted manifest
- validate the tracked snapshot against its publication commit and historical config before source-aware invalidation
- keep conservative invalidation as the default and reject legacy bootstrap for new or automated repository dispatch builds
- update the trigger skill contract, workflow plumbing, Serena memory, and regression coverage

## Validation

- `uv run python format_repo_files.py --check`
- `uv run ruff check release_workflow_lib/validation.py release_workflow_lib/cli.py .claude/skills/trigger-release-build/scripts/trigger_release_build.py tests/test_release_workflow_guards.py tests/test_trigger_release_build.py tests/test_build_self_runner_workflow.py`
- `actionlint .github/workflows/build-on-self-runner.yml`
- `uv run python -m unittest discover -s tests -b` — 935 passed, 3 skipped
- real `14168` temporary legacy-bootstrap smoke — restored 2878 YAML files and invalidated 31 affected outputs