### PR TITLE
fix(release): avoid indented PowerShell here-string

### DIFF
--- a/.github/workflows/promote-release-after-output-merge.yml
+++ b/.github/workflows/promote-release-after-output-merge.yml
@@ -141,11 +141,9 @@ jobs:
             throw "Release manifest $gamever lacks analysis_config_sha256; refusing archive promotion."
           }
           try {
-            $extractScript = @'
-            import pathlib, subprocess, sys
-            pathlib.Path(sys.argv[2]).write_bytes(subprocess.check_output(["git", "show", f"{sys.argv[1]}:configs/{sys.argv[3]}.yaml"]))
-            '@
-            $extractScript | uv run python - "$sourceSha" "$configPath" "$gamever"
+            uv run python -c `
+              "import pathlib, subprocess, sys; pathlib.Path(sys.argv[2]).write_bytes(subprocess.check_output(['git', 'show', f'{sys.argv[1]}:configs/{sys.argv[3]}.yaml']))" `
+              "$sourceSha" "$configPath" "$gamever"
             if ($LASTEXITCODE -ne 0) { throw "Failed to extract source analysis config from $sourceSha." }
             $actualConfigHash = (Get-FileHash -LiteralPath $configPath -Algorithm SHA256).Hash.ToLowerInvariant()
             if ($actualConfigHash -ne $expectedConfigHash.ToLowerInvariant()) {

--- a/tests/test_build_self_runner_workflow.py
+++ b/tests/test_build_self_runner_workflow.py
@@ -179,7 +179,9 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
         self.assertIn(".release-tools/release_workflow.py verify-promotion", self.promotion)
         self.assertIn('"configs\\$gamever.yaml"', self.promotion)
         self.assertIn("analysis_config_sha256", self.promotion)
-        self.assertIn('git", "show", f"{sys.argv[1]}:configs/{sys.argv[3]}.yaml"', self.promotion)
+        self.assertIn("['git', 'show', f'{sys.argv[1]}:configs/{sys.argv[3]}.yaml']", self.promotion)
+        self.assertIn("uv run python -c `", self.promotion)
+        self.assertNotIn("$extractScript = @'", self.promotion)
 
     def test_bump_merge_dispatches_without_creating_tag(self) -> None:
         workflow = Path(".github/workflows/tag-bump-after-merge.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
﻿## Summary

- Replace the indentation-sensitive PowerShell here-string with the repository's established Python command pattern.
- Preserve byte-for-byte config extraction from the accepted source commit.
- Add regression assertions that reject the broken here-string form.

## Validation

- actionlint .github/workflows/promote-release-after-output-merge.yml
- Parsed the extracted Create release archives script with the PowerShell parser.
- Verified Python native argument passing and git-show extraction locally.
- uv run python -m unittest tests.test_build_self_runner_workflow -v (20 passed)
- uv run python -m unittest discover -s tests -b (942 passed, 3 skipped)
- uv run python format_repo_files.py --check

Failure reference: https://github.com/HLND2T/CS2_VibeSignatures/actions/runs/29687670863/job/88194748881
