### PR TITLE
feat(release): add staged release abandonment workflow

### DIFF
--- a/.claude/skills/abandon-staged-release/SKILL.md
+++ b/.claude/skills/abandon-staged-release/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: abandon-staged-release
+description: Safely dispatch the protected recovery workflow that explicitly abandons one merged generated-output PR's unpromoted staged release state. Use only when the user explicitly asks to abandon or clean a specific blocked staged build after promotion failed before promote-bin.
+---
+
+# Abandon Staged Release
+
+Use the bundled script as the only remote-operation entry point. Do not run `cleanup-unmerged`, delete `READY`,
+remove staging paths manually, accept a user-supplied SHA/path, resume promotion, or trigger a replacement build.
+
+## Procedure
+
+1. Require an explicit merged generated-output PR number, exact confirmation, and one-line reason.
+2. Run from any directory:
+
+   ```powershell
+   uv run python .claude/skills/abandon-staged-release/scripts/abandon_staged_release.py `
+     <PR_NUMBER> `
+     --confirm "ABANDON <GAMEVER>/<BUILD_ID>" `
+     --reason "<WHY_PROMOTION_IS_BEING_ABANDONED>"
+   ```
+
+3. Report the PR URL, derived game version/build ID/head SHA, reason, and Actions run URL.
+4. If the script or workflow refuses the operation, surface the exact safety reason and stop. Never bypass repository,
+   PR author/repository/base/branch, confirmation, active-run, promotion-marker, recovery-path, or index/manifest checks.
+
+The workflow only removes the matching staged directory and PR index. It refuses any state containing
+`PROMOTION_STARTED`, `PROMOTED.json`, `PROMOTION_COMPLETE`, or matching accepted-bin incoming/backup paths. It never
+modifies accepted `bin/<GAMEVER>` and never automatically reruns a release build.

--- a/.claude/skills/abandon-staged-release/agents/openai.yaml
+++ b/.claude/skills/abandon-staged-release/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Abandon Staged Release"
+  short_description: "Safely abandon an unpromoted staged release"
+  default_prompt: "Use $abandon-staged-release to explicitly abandon a specific unpromoted staged release build."
+policy:
+  allow_implicit_invocation: false

--- a/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
+++ b/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Dispatch the protected workflow that abandons one unpromoted staged release."""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+ALLOWED_REPOSITORIES = {"HLND2T/CS2_VibeSignatures", "hzqst/CS2_VibeSignatures"}
+OUTPUT_BRANCH_RE = re.compile(r"^gamesymbols/build/(?P<gamever>[0-9]{4,10}[a-z]?)/(?P<build_id>[0-9]+-[0-9]+)$")
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+WORKFLOW = "abandon-staged-release.yml"
+RUN_LIST_LIMIT = "50"
+RUN_DISCOVERY_ATTEMPTS = 10
+RUN_DISCOVERY_DELAY_SECONDS = 2
+REASON_MAX_LENGTH = 500
+
+
+class AbandonError(Exception):
+    """Raised when an explicit staged-release abandonment is unsafe."""
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip() or f"exit code {result.returncode}"
+        raise AbandonError(f"{' '.join(command)} failed: {detail}")
+    return result
+
+
+def repository_root() -> Path:
+    expected = Path(__file__).resolve().parents[4]
+    result = run_command(["git", "rev-parse", "--show-toplevel"], expected)
+    actual = Path(result.stdout.strip()).resolve()
+    if actual != expected:
+        raise AbandonError(f"skill is not running in its owning repository: {actual}")
+    return actual
+
+
+def parse_repository(remote_url: str) -> str:
+    patterns = (
+        r"^https://github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+        r"^git@github\.com:(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+        r"^ssh://git@github\.com/(?P<repo>[^/]+/[^/]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.fullmatch(pattern, remote_url.strip())
+        if match:
+            return match.group("repo")
+    raise AbandonError(f"unsupported origin URL: {remote_url}")
+
+
+def require_repository(root: Path) -> str:
+    remote = run_command(["git", "remote", "get-url", "origin"], root).stdout.strip()
+    repository = parse_repository(remote)
+    if repository not in ALLOWED_REPOSITORIES:
+        raise AbandonError(f"origin repository is not allowlisted: {repository}")
+    return repository
+
+
+def require_github_access(root: Path, repository: str) -> None:
+    run_command(["gh", "auth", "status", "--hostname", "github.com"], root)
+    permission = run_command(["gh", "api", f"repos/{repository}", "--jq", ".permissions.push"], root).stdout.strip()
+    if permission != "true":
+        raise AbandonError(f"authenticated GitHub account cannot dispatch Actions for {repository}")
+    run_command(["gh", "api", f"repos/{repository}/actions/workflows/{WORKFLOW}", "--jq", ".id"], root)
+
+
+def parse_json_object(raw: str, label: str) -> dict:
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AbandonError(f"{label} returned invalid JSON") from exc
+    if not isinstance(value, dict):
+        raise AbandonError(f"{label} did not return a JSON object")
+    return value
+
+
+def parse_json_list(raw: str, label: str) -> list[dict]:
+    try:
+        value = json.loads(raw or "[]")
+    except json.JSONDecodeError as exc:
+        raise AbandonError(f"{label} returned invalid JSON") from exc
+    if not isinstance(value, list) or any(not isinstance(item, dict) for item in value):
+        raise AbandonError(f"{label} did not return a JSON list")
+    return value
+
+
+def resolve_main(root: Path) -> str:
+    run_command(["git", "fetch", "origin", "main", "--quiet"], root)
+    source_sha = run_command(["git", "rev-parse", "refs/remotes/origin/main"], root).stdout.strip().lower()
+    if not SHA_RE.fullmatch(source_sha):
+        raise AbandonError("origin/main did not resolve to a full commit SHA")
+    run_command(["git", "cat-file", "-e", f"{source_sha}:.github/workflows/{WORKFLOW}"], root)
+    return source_sha
+
+
+def validate_reason(reason: str) -> str:
+    reason = reason.strip()
+    if not reason or len(reason) > REASON_MAX_LENGTH or any(char in reason for char in "\r\n"):
+        raise AbandonError("reason must be one non-empty line of at most 500 characters")
+    return reason
+
+
+def load_pr_identity(root: Path, repository: str, pr_number: int, confirmation: str, reason: str) -> dict:
+    raw = run_command(["gh", "api", f"repos/{repository}/pulls/{pr_number}"], root).stdout
+    pull = parse_json_object(raw, "pull request lookup")
+    head = pull.get("head") or {}
+    head_repo = head.get("repo") or {}
+    base = pull.get("base") or {}
+    author = pull.get("user") or {}
+    if pull.get("state") != "closed" or not pull.get("merged_at"):
+        raise AbandonError(f"PR #{pr_number} must be merged before its staged build can be abandoned")
+    if author.get("login") != "github-actions[bot]":
+        raise AbandonError(f"PR #{pr_number} was not created by github-actions[bot]")
+    if head_repo.get("full_name") != repository or base.get("ref") != "main":
+        raise AbandonError(f"PR #{pr_number} does not match the trusted same-repository main-branch contract")
+    match = OUTPUT_BRANCH_RE.fullmatch(str(head.get("ref", "")))
+    if not match:
+        raise AbandonError(f"PR #{pr_number} does not use the generated-output branch protocol")
+    head_sha = str(head.get("sha", "")).lower()
+    if not SHA_RE.fullmatch(head_sha):
+        raise AbandonError(f"PR #{pr_number} head did not resolve to a full commit SHA")
+    gamever, build_id = match.group("gamever"), match.group("build_id")
+    expected_confirmation = f"ABANDON {gamever}/{build_id}"
+    if confirmation != expected_confirmation:
+        raise AbandonError(f"confirmation must exactly equal {expected_confirmation!r}")
+    return {
+        "pr_number": pr_number,
+        "pr_url": str(pull.get("html_url", "")),
+        "gamever": gamever,
+        "build_id": build_id,
+        "head_sha": head_sha,
+        "confirmation": confirmation,
+        "reason": validate_reason(reason),
+    }
+
+
+def list_runs(root: Path) -> list[dict]:
+    result = run_command(
+        [
+            "gh",
+            "run",
+            "list",
+            "--workflow",
+            WORKFLOW,
+            "--limit",
+            RUN_LIST_LIMIT,
+            "--json",
+            "databaseId,displayTitle,status,url,headSha,event",
+        ],
+        root,
+    )
+    return parse_json_list(result.stdout, "gh run list")
+
+
+def require_no_duplicate(root: Path, pr_number: int) -> set[int]:
+    runs = list_runs(root)
+    title = f"Abandon staged release PR #{pr_number}"
+    for run in runs:
+        if run.get("status") in {"queued", "in_progress"} and run.get("displayTitle") == title:
+            raise AbandonError(f"an abandonment workflow is already active for PR #{pr_number}: {run.get('url')}")
+    return {int(run["databaseId"]) for run in runs if "databaseId" in run}
+
+
+def require_main_unchanged(root: Path, source_sha: str) -> None:
+    if resolve_main(root) != source_sha:
+        raise AbandonError("origin/main advanced during validation; rerun the skill")
+
+
+def dispatch(root: Path, identity: dict) -> None:
+    run_command(
+        [
+            "gh",
+            "workflow",
+            "run",
+            WORKFLOW,
+            "--ref",
+            "main",
+            "-f",
+            f"pr_number={identity['pr_number']}",
+            "-f",
+            f"confirmation={identity['confirmation']}",
+            "-f",
+            f"reason={identity['reason']}",
+        ],
+        root,
+    )
+
+
+def discover_run(root: Path, known_ids: set[int], *, pr_number: int, source_sha: str) -> str:
+    for _attempt in range(RUN_DISCOVERY_ATTEMPTS):
+        for run in list_runs(root):
+            run_id = int(run.get("databaseId", 0))
+            if (
+                run_id not in known_ids
+                and run.get("displayTitle") == f"Abandon staged release PR #{pr_number}"
+                and run.get("event") == "workflow_dispatch"
+                and run.get("headSha") == source_sha
+            ):
+                return str(run.get("url"))
+        time.sleep(RUN_DISCOVERY_DELAY_SECONDS)
+    raise AbandonError("workflow was dispatched but its Actions run URL could not be discovered")
+
+
+def execute(pr_number: int, confirmation: str, reason: str) -> dict:
+    root = repository_root()
+    repository = require_repository(root)
+    require_github_access(root, repository)
+    source_sha = resolve_main(root)
+    identity = load_pr_identity(root, repository, pr_number, confirmation, reason)
+    known_ids = require_no_duplicate(root, pr_number)
+    require_main_unchanged(root, source_sha)
+    dispatch(root, identity)
+    identity["run_url"] = discover_run(root, known_ids, pr_number=pr_number, source_sha=source_sha)
+    identity["source_sha"] = source_sha
+    return identity
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("pr_number", type=int, help="Merged generated-output PR number")
+    parser.add_argument("--confirm", required=True, help="Exact ABANDON <gamever>/<build-id> confirmation")
+    parser.add_argument("--reason", required=True, help="One-line audit reason")
+    args = parser.parse_args(argv)
+    if args.pr_number <= 0:
+        parser.error("pr_number must be positive")
+    try:
+        result = execute(args.pr_number, args.confirm, args.reason)
+    except (AbandonError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    print(f"PR: #{result['pr_number']} ({result['pr_url']})")
+    print(f"GAMEVER: {result['gamever']}")
+    print(f"BUILD_ID: {result['build_id']}")
+    print(f"PR_HEAD_SHA: {result['head_sha']}")
+    print(f"Reason: {result['reason']}")
+    print(f"Actions run: {result['run_url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/abandon-staged-release.yml
+++ b/.github/workflows/abandon-staged-release.yml
@@ -1,0 +1,151 @@
+name: Abandon Staged Release
+run-name: Abandon staged release PR #${{ inputs.pr_number }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Merged generated-output PR number
+        required: true
+        type: string
+      confirmation:
+        description: Exact ABANDON <gamever>/<build-id> confirmation
+        required: true
+        type: string
+      reason:
+        description: One-line audit reason for abandoning the staged build
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.identity.outputs.pr_number }}
+      gamever: ${{ steps.identity.outputs.gamever }}
+      build_id: ${{ steps.identity.outputs.build_id }}
+      pr_head_sha: ${{ steps.identity.outputs.pr_head_sha }}
+    steps:
+      - name: Resolve and validate abandonment identity
+        id: identity
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          $allowedRepositories = @("HLND2T/CS2_VibeSignatures", "hzqst/CS2_VibeSignatures")
+          if ($allowedRepositories -notcontains "${{ github.repository }}") {
+            throw "Repository is not allowlisted."
+          }
+          if ($env:PR_NUMBER -notmatch '^[1-9][0-9]*$') {
+            throw "PR number must be a positive integer."
+          }
+          $pr = gh api "repos/${{ github.repository }}/pulls/$env:PR_NUMBER" | ConvertFrom-Json
+          if ($LASTEXITCODE -ne 0) { throw "Failed to load PR #$env:PR_NUMBER." }
+          if ($pr.state -ne "closed" -or -not $pr.merged_at) {
+            throw "PR #$env:PR_NUMBER must be merged."
+          }
+          if ([string]$pr.user.login -ne "github-actions[bot]") {
+            throw "PR #$env:PR_NUMBER was not created by github-actions[bot]."
+          }
+          if ([string]$pr.head.repo.full_name -ne "${{ github.repository }}") {
+            throw "PR #$env:PR_NUMBER must originate from this repository."
+          }
+          if ([string]$pr.base.ref -ne "${{ github.event.repository.default_branch }}") {
+            throw "PR #$env:PR_NUMBER does not target the default branch."
+          }
+          if ([string]$pr.head.ref -notmatch '^gamesymbols/build/(?<gamever>[0-9]{4,10}[a-z]?)/(?<build_id>[0-9]+-[0-9]+)$') {
+            throw "PR #$env:PR_NUMBER does not use the generated-output branch protocol."
+          }
+          $gamever = $Matches.gamever
+          $buildId = $Matches.build_id
+          $headSha = ([string]$pr.head.sha).ToLowerInvariant()
+          if ($headSha -notmatch '^[0-9a-f]{40}$') { throw "PR head SHA is invalid." }
+          $expectedConfirmation = "ABANDON $gamever/$buildId"
+          if ($env:CONFIRMATION -cne $expectedConfirmation) {
+            throw "Confirmation must exactly equal '$expectedConfirmation'."
+          }
+          $reason = [string]$env:REASON
+          if ([string]::IsNullOrWhiteSpace($reason) -or $reason.Length -gt 500 -or $reason -match '[\r\n]') {
+            throw "Reason must be one non-empty line of at most 500 characters."
+          }
+          "pr_number=$env:PR_NUMBER" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "gamever=$gamever" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "build_id=$buildId" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          "pr_head_sha=$headSha" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          @(
+            "### Validated staged-release abandonment",
+            "",
+            "- PR: #$env:PR_NUMBER",
+            "- GAMEVER: $gamever",
+            "- BUILD_ID: $buildId",
+            "- PR_HEAD_SHA: $headSha",
+            "- Reason: $reason"
+          ) | Out-File $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append
+
+  abandon:
+    needs: resolve
+    environment: win64
+    runs-on: [self-hosted, windows, x64]
+    concurrency:
+      group: release-promotion-${{ github.repository }}-${{ needs.resolve.outputs.gamever }}
+      cancel-in-progress: false
+    env:
+      PERSISTED_WORKSPACE: ${{ secrets.PERSISTED_WORKSPACE }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Abandon only the validated unpromoted pending state
+        shell: pwsh
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          GAMEVER: ${{ needs.resolve.outputs.gamever }}
+          BUILD_ID: ${{ needs.resolve.outputs.build_id }}
+          PR_HEAD_SHA: ${{ needs.resolve.outputs.pr_head_sha }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:PERSISTED_WORKSPACE)) {
+            throw "PERSISTED_WORKSPACE is not configured."
+          }
+          uv run release_workflow.py abandon-pending `
+            --staging-root "$env:PERSISTED_WORKSPACE\release-staging" `
+            --persisted-root "$env:PERSISTED_WORKSPACE" `
+            --gamever "$env:GAMEVER" `
+            --build-id "$env:BUILD_ID" `
+            --pr-number "$env:PR_NUMBER" `
+            --event-head-sha "$env:PR_HEAD_SHA" `
+            --confirmation "$env:CONFIRMATION" `
+            --reason "$env:REASON"
+          if ($LASTEXITCODE -ne 0) { throw "Failed to abandon staged release." }
+
+      - name: Verify no ready staged build still blocks the version
+        shell: pwsh
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          GAMEVER: ${{ needs.resolve.outputs.gamever }}
+          BUILD_ID: ${{ needs.resolve.outputs.build_id }}
+        run: |
+          uv run release_workflow.py check-pending `
+            --staging-root "$env:PERSISTED_WORKSPACE\release-staging" `
+            --gamever "$env:GAMEVER" `
+            --build-id "${{ github.run_id }}-${{ github.run_attempt }}"
+          if ($LASTEXITCODE -ne 0) { throw "Another READY build still blocks this version." }
+          @(
+            "### Staged release abandoned",
+            "",
+            "- PR: #$env:PR_NUMBER",
+            "- GAMEVER: $env:GAMEVER",
+            "- BUILD_ID: $env:BUILD_ID",
+            "- Accepted bin was not modified."
+          ) | Out-File $env:GITHUB_STEP_SUMMARY -Encoding utf8 -Append

--- a/.serena/memories/build-on-self-runner.md
+++ b/.serena/memories/build-on-self-runner.md
@@ -46,6 +46,10 @@
 
 - output PR 未 merge：cleanup 只能通过 matching PR index 删除 pending staging，不能访问 accepted bin。
 - archive/tag/upload 失败：READY、private manifest、staged bin 和 promoted backup 保留，promotion 可重跑。
+- `promote-bin` 在触碰 accepted bin 前写 `PROMOTION_STARTED`；显式 abandon 仅允许该 marker、`PROMOTED.json`、
+  `PROMOTION_COMPLETE` 及 matching incoming/backup 全部不存在时删除 staged directory 与 PR index。
+- `.claude/skills/abandon-staged-release/` 只 dispatch 受保护的 `abandon-staged-release.yml`；workflow 从 merged Bot PR
+  推导 gamever/build/head SHA，并复用 per-version promotion concurrency 与 `win64` environment。
 - existing target 已等于 staged inventory：`promote-bin` 作为幂等重试成功返回，不重复 swap。
 - Release assets 使用 `--clobber`，随后下载每个 asset 并比较 SHA-256；未验证成功前不写 completion marker。
 
@@ -54,6 +58,7 @@
 - `tests/test_release_workflow.py`：manifest/hash/path/reparse/index/cleanup/swap/idempotency/tag guards/stale merge。
 - `tests/test_build_self_runner_workflow.py`：trigger/checkout/order/no-premerge-publication/promotion/tag/bump/lightweight check。
 - `tests/test_trigger_release_build.py`：repository/auth/version/tag/Release/duplicate/dispatch/run URL。
+- `tests/test_abandon_staged_release.py`：Skill 显式调用、PR identity、confirmation/reason、duplicate dispatch 与 recovery workflow。
 - 完成门：全仓 unittest、formatter、Ruff、YAML parse、actionlint 与 CLI non-publishing smoke。
 
 ## Explicit Legacy Bootstrap
@@ -70,3 +75,4 @@
 
 - `repository_dispatch.types: [build-on-self-runner]`
 - `workflow_dispatch(gamever, source_sha, mode, allow_legacy_bootstrap=false)`，通常仅由 trigger SKILL 调用
+- `workflow_dispatch(pr_number, confirmation, reason)`：仅由 `abandon-staged-release` Skill 显式调用

--- a/release_workflow_lib/cli.py
+++ b/release_workflow_lib/cli.py
@@ -14,6 +14,7 @@ from release_workflow_lib.promotion import (
     verify_promotion,
 )
 from release_workflow_lib.staging import (
+    abandon_pending,
     assert_no_other_ready_build,
     cleanup_incomplete,
     cleanup_unmerged,
@@ -130,6 +131,16 @@ def _add_promotion_parsers(commands) -> None:
     complete.add_argument("--pr-number", required=True, type=int)
     complete.add_argument("--event-head-sha", required=True)
     complete.add_argument("--output-merge-sha", required=True)
+
+    abandon = commands.add_parser("abandon-pending")
+    abandon.add_argument("--staging-root", required=True)
+    abandon.add_argument("--persisted-root", required=True)
+    abandon.add_argument("--gamever", required=True)
+    abandon.add_argument("--build-id", required=True)
+    abandon.add_argument("--pr-number", required=True, type=int)
+    abandon.add_argument("--event-head-sha", required=True)
+    abandon.add_argument("--confirmation", required=True)
+    abandon.add_argument("--reason", required=True)
 
     cleanup = commands.add_parser("cleanup-unmerged")
     cleanup.add_argument("--staging-root", required=True)
@@ -286,6 +297,17 @@ def _run_promotion(args) -> object:
             pr_number=args.pr_number,
             event_head_sha=args.event_head_sha,
             output_merge_sha=args.output_merge_sha,
+        )
+    if args.command == "abandon-pending":
+        return abandon_pending(
+            staging_root=args.staging_root,
+            persisted_root=args.persisted_root,
+            gamever=args.gamever,
+            build_id=args.build_id,
+            pr_number=args.pr_number,
+            event_head_sha=args.event_head_sha,
+            confirmation=args.confirmation,
+            reason=args.reason,
         )
     if args.command == "cleanup-unmerged":
         return cleanup_unmerged(args.staging_root, args.pr_number, args.event_head_sha)

--- a/release_workflow_lib/promotion.py
+++ b/release_workflow_lib/promotion.py
@@ -21,6 +21,8 @@ from release_workflow_lib.manifests import (
     SCHEMA_VERSION,
     load_tracked_manifest,
     parse_output_branch,
+    require_build_id,
+    require_gamever,
     require_sha,
     verify_tracked_outputs,
 )
@@ -204,6 +206,8 @@ def _swap_verified_bin(
 
 
 def promote_bin(*, persisted_root: Path, stage_dir: Path, gamever: str, build_id: str) -> dict:
+    gamever = require_gamever(gamever)
+    build_id = require_build_id(build_id)
     persisted_root = Path(persisted_root)
     reject_reparse_components(persisted_root, persisted_root)
     persisted_root = persisted_root.resolve()
@@ -212,6 +216,8 @@ def promote_bin(*, persisted_root: Path, stage_dir: Path, gamever: str, build_id
     source = contained_path(stage_dir, "bin", gamever)
     reject_reparse_components(stage_dir, stage_dir / "manifest.json")
     pending = load_json_object(stage_dir / "manifest.json")
+    if (pending.get("gamever"), pending.get("build_id")) != (gamever, build_id):
+        raise ReleaseWorkflowError("promotion request does not match private pending manifest")
     expected_files = pending.get("bin_files", [])
     expected_hash = pending.get("bin_manifest_sha256")
     if verify_inventory(source, expected_files) != expected_hash:
@@ -224,6 +230,12 @@ def promote_bin(*, persisted_root: Path, stage_dir: Path, gamever: str, build_id
     backup = contained_path(accepted_root, f".{gamever}.{build_id}.backup")
     lock_path = contained_path(persisted_root, "release-staging", "locks", f"{gamever}.lock")
     with _version_lock(lock_path):
+        started_path = stage_dir / "PROMOTION_STARTED"
+        reject_reparse_components(stage_dir, started_path)
+        write_canonical_json(
+            started_path,
+            {"schema_version": SCHEMA_VERSION, "gamever": gamever, "build_id": build_id},
+        )
         if target.is_dir() and inventory_sha256(file_inventory(target)) == expected_hash:
             return _write_promoted_state(stage_dir=stage_dir, target=target, backup=backup if backup.exists() else None)
         moved_old = _swap_verified_bin(

--- a/release_workflow_lib/staging.py
+++ b/release_workflow_lib/staging.py
@@ -21,12 +21,17 @@ from release_workflow_lib.manifests import (
     build_tracked_manifest,
     load_tracked_manifest,
     parse_output_branch,
+    require_build_id,
     require_gamever,
     require_sha,
     validate_tracked_manifest,
     verify_tracked_outputs,
 )
 from gamesymbol_snapshot_lib.operations import load_snapshot_context
+
+
+ABANDON_REASON_MAX_LENGTH = 500
+PROMOTION_STATE_MARKERS = ("PROMOTION_STARTED", "PROMOTED.json", "PROMOTION_COMPLETE")
 
 
 def staging_directory(staging_root: Path, gamever: str, build_id: str) -> Path:
@@ -256,10 +261,68 @@ def load_indexed_pending(staging_root: Path, pr_number: int, event_head_sha: str
 
 def cleanup_unmerged(staging_root: Path, pr_number: int, event_head_sha: str) -> None:
     _index, _pending, stage_dir = load_indexed_pending(staging_root, pr_number, event_head_sha)
+    _remove_indexed_pending(staging_root, pr_number, stage_dir)
+
+
+def _remove_indexed_pending(staging_root: Path, pr_number: int, stage_dir: Path) -> None:
     index_path = contained_path(Path(staging_root), "pr-index", f"{pr_number}.json")
     reject_reparse_points(stage_dir)
     shutil.rmtree(stage_dir)
     index_path.unlink()
+
+
+def abandon_pending(
+    *,
+    staging_root: Path,
+    persisted_root: Path,
+    gamever: str,
+    build_id: str,
+    pr_number: int,
+    event_head_sha: str,
+    confirmation: str,
+    reason: str,
+) -> dict:
+    gamever = require_gamever(gamever)
+    build_id = require_build_id(build_id)
+    expected_confirmation = f"ABANDON {gamever}/{build_id}"
+    if confirmation != expected_confirmation:
+        raise ReleaseWorkflowError(f"confirmation must exactly equal {expected_confirmation!r}")
+    reason = str(reason).strip()
+    if not reason or len(reason) > ABANDON_REASON_MAX_LENGTH or any(char in reason for char in "\r\n"):
+        raise ReleaseWorkflowError("abandon reason must be one non-empty line of at most 500 characters")
+
+    index, pending, stage_dir = load_indexed_pending(staging_root, pr_number, event_head_sha)
+    expected_identity = (gamever, build_id)
+    if (index.get("gamever"), index.get("build_id")) != expected_identity:
+        raise ReleaseWorkflowError("requested build identity does not match pending PR index")
+    if (pending.get("gamever"), pending.get("build_id")) != expected_identity:
+        raise ReleaseWorkflowError("requested build identity does not match private pending manifest")
+
+    for marker in PROMOTION_STATE_MARKERS:
+        marker_path = stage_dir / marker
+        reject_reparse_components(staging_root, marker_path)
+        if marker_path.exists():
+            raise ReleaseWorkflowError(
+                f"promotion state exists; recovery must resume instead of abandon: {marker_path}"
+            )
+
+    persisted_root = Path(persisted_root)
+    reject_reparse_components(persisted_root, persisted_root)
+    accepted_root = contained_path(persisted_root, "bin")
+    for suffix in ("incoming", "backup"):
+        recovery_path = contained_path(accepted_root, f".{gamever}.{build_id}.{suffix}")
+        reject_reparse_components(persisted_root, recovery_path)
+        if recovery_path.exists():
+            raise ReleaseWorkflowError(f"promotion recovery path exists; refusing abandon: {recovery_path}")
+
+    _remove_indexed_pending(staging_root, pr_number, stage_dir)
+    return {
+        "gamever": gamever,
+        "build_id": build_id,
+        "pr_number": pr_number,
+        "pr_head_sha": require_sha(event_head_sha, "event head SHA"),
+        "reason": reason,
+    }
 
 
 def cleanup_incomplete(staging_root: Path, gamever: str, build_id: str) -> bool:

--- a/tests/test_abandon_staged_release.py
+++ b/tests/test_abandon_staged_release.py
@@ -1,0 +1,198 @@
+import importlib.util
+import json
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(".claude/skills/abandon-staged-release/scripts/abandon_staged_release.py")
+SPEC = importlib.util.spec_from_file_location("abandon_staged_release", SCRIPT)
+abandon = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(abandon)
+
+
+def completed(command, *, stdout="", returncode=0, stderr=""):
+    return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr=stderr)
+
+
+def pull_request_payload(**overrides) -> dict:
+    payload = {
+        "number": 582,
+        "state": "closed",
+        "merged_at": "2026-07-19T12:48:13Z",
+        "html_url": "https://github.com/HLND2T/CS2_VibeSignatures/pull/582",
+        "user": {"login": "github-actions[bot]"},
+        "head": {
+            "ref": "gamesymbols/build/14168/29686825445-1",
+            "sha": "6a44f19be35e6fc876d9e74b46f494f214b383d1",
+            "repo": {"full_name": "HLND2T/CS2_VibeSignatures"},
+        },
+        "base": {"ref": "main"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestAbandonStagedRelease(unittest.TestCase):
+    def test_script_resolves_its_own_repository_root(self) -> None:
+        expected = SCRIPT.resolve().parents[4]
+        with patch.object(abandon, "run_command", return_value=completed([], stdout=f"{expected}\n")):
+            self.assertEqual(expected, abandon.repository_root())
+
+    def test_skill_is_explicit_and_uses_only_the_bundled_dispatch_script(self) -> None:
+        skill = Path(".claude/skills/abandon-staged-release/SKILL.md").read_text(encoding="utf-8")
+        agent = Path(".claude/skills/abandon-staged-release/agents/openai.yaml").read_text(encoding="utf-8")
+        self.assertIn("Use only when the user explicitly asks", skill)
+        self.assertIn("allow_implicit_invocation: false", agent)
+        self.assertIn("bundled script as the only remote-operation entry point", skill)
+        self.assertIn("Do not run `cleanup-unmerged`", skill)
+        self.assertIn("never automatically reruns a release build", skill)
+
+    def test_pr_identity_is_derived_from_the_trusted_merged_output_pr(self) -> None:
+        with patch.object(
+            abandon,
+            "run_command",
+            return_value=completed([], stdout=json.dumps(pull_request_payload())),
+        ):
+            identity = abandon.load_pr_identity(
+                Path("."),
+                "HLND2T/CS2_VibeSignatures",
+                582,
+                "ABANDON 14168/29686825445-1",
+                "Promotion failed before promote-bin",
+            )
+        self.assertEqual("14168", identity["gamever"])
+        self.assertEqual("29686825445-1", identity["build_id"])
+        self.assertEqual("6a44f19be35e6fc876d9e74b46f494f214b383d1", identity["head_sha"])
+
+    def test_pr_identity_rejects_untrusted_or_unmerged_requests(self) -> None:
+        cases = (
+            ({"merged_at": None}, "must be merged"),
+            ({"user": {"login": "someone"}}, "github-actions"),
+            (
+                {
+                    "head": {
+                        "ref": "gamesymbols/build/14168/29686825445-1",
+                        "sha": "6a44f19be35e6fc876d9e74b46f494f214b383d1",
+                        "repo": {"full_name": "other/repository"},
+                    }
+                },
+                "trusted same-repository",
+            ),
+        )
+        for overrides, message in cases:
+            with self.subTest(message=message), patch.object(
+                abandon,
+                "run_command",
+                return_value=completed([], stdout=json.dumps(pull_request_payload(**overrides))),
+            ):
+                with self.assertRaisesRegex(abandon.AbandonError, message):
+                    abandon.load_pr_identity(
+                        Path("."),
+                        "HLND2T/CS2_VibeSignatures",
+                        582,
+                        "ABANDON 14168/29686825445-1",
+                        "Promotion failed before promote-bin",
+                    )
+
+    def test_confirmation_and_reason_are_strict(self) -> None:
+        with patch.object(
+            abandon,
+            "run_command",
+            return_value=completed([], stdout=json.dumps(pull_request_payload())),
+        ):
+            with self.assertRaisesRegex(abandon.AbandonError, "confirmation"):
+                abandon.load_pr_identity(
+                    Path("."),
+                    "HLND2T/CS2_VibeSignatures",
+                    582,
+                    "ABANDON 14168/wrong",
+                    "Promotion failed before promote-bin",
+                )
+            with self.assertRaisesRegex(abandon.AbandonError, "one non-empty line"):
+                abandon.load_pr_identity(
+                    Path("."),
+                    "HLND2T/CS2_VibeSignatures",
+                    582,
+                    "ABANDON 14168/29686825445-1",
+                    "bad\nreason",
+                )
+
+    def test_duplicate_active_workflow_is_rejected(self) -> None:
+        runs = [
+            {
+                "databaseId": 123,
+                "displayTitle": "Abandon staged release PR #582",
+                "status": "in_progress",
+                "url": "https://github.com/example/run",
+            }
+        ]
+        with patch.object(abandon, "list_runs", return_value=runs):
+            with self.assertRaisesRegex(abandon.AbandonError, "already active"):
+                abandon.require_no_duplicate(Path("."), 582)
+
+    def test_dispatch_uses_only_derived_identity_and_audit_inputs(self) -> None:
+        identity = {
+            "pr_number": 582,
+            "confirmation": "ABANDON 14168/29686825445-1",
+            "reason": "Promotion failed before promote-bin",
+        }
+        with patch.object(abandon, "run_command", return_value=completed([])) as run:
+            abandon.dispatch(Path("."), identity)
+        command = run.call_args.args[0]
+        self.assertIn("abandon-staged-release.yml", command)
+        self.assertIn("pr_number=582", command)
+        self.assertIn("confirmation=ABANDON 14168/29686825445-1", command)
+        self.assertIn("reason=Promotion failed before promote-bin", command)
+        self.assertNotIn("staging_root", " ".join(command))
+
+    def test_execute_reports_the_dispatched_recovery_run(self) -> None:
+        identity = {
+            "pr_number": 582,
+            "pr_url": "https://github.com/HLND2T/CS2_VibeSignatures/pull/582",
+            "gamever": "14168",
+            "build_id": "29686825445-1",
+            "head_sha": "6" * 40,
+            "confirmation": "ABANDON 14168/29686825445-1",
+            "reason": "Promotion failed before promote-bin",
+        }
+        with (
+            patch.object(abandon, "repository_root", return_value=Path(".")),
+            patch.object(abandon, "require_repository", return_value="HLND2T/CS2_VibeSignatures"),
+            patch.object(abandon, "require_github_access"),
+            patch.object(abandon, "resolve_main", return_value="a" * 40),
+            patch.object(abandon, "load_pr_identity", return_value=identity.copy()),
+            patch.object(abandon, "require_no_duplicate", return_value={1}),
+            patch.object(abandon, "require_main_unchanged"),
+            patch.object(abandon, "dispatch") as dispatch,
+            patch.object(abandon, "discover_run", return_value="https://github.com/example/run"),
+        ):
+            result = abandon.execute(
+                582,
+                "ABANDON 14168/29686825445-1",
+                "Promotion failed before promote-bin",
+            )
+        dispatch.assert_called_once()
+        self.assertEqual("https://github.com/example/run", result["run_url"])
+        self.assertEqual("a" * 40, result["source_sha"])
+
+    def test_recovery_workflow_derives_identity_and_uses_promotion_concurrency(self) -> None:
+        workflow = Path(".github/workflows/abandon-staged-release.yml").read_text(encoding="utf-8")
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("gamever:\n        description:", workflow)
+        self.assertNotIn("build_id:\n        description:", workflow)
+        self.assertIn("gh api \"repos/${{ github.repository }}/pulls/$env:PR_NUMBER\"", workflow)
+        self.assertIn("release-promotion-${{ github.repository }}-${{ needs.resolve.outputs.gamever }}", workflow)
+        self.assertIn("runs-on: [self-hosted, windows, x64]", workflow)
+        self.assertIn("environment: win64", workflow)
+        self.assertIn("release_workflow.py abandon-pending", workflow)
+        self.assertIn("secrets.PERSISTED_WORKSPACE", workflow)
+        self.assertIn("--pr-number \"$env:PR_NUMBER\"", workflow)
+        self.assertNotIn("--pr-number \"${{ inputs.pr_number }}\"", workflow)
+        self.assertNotIn("cleanup-unmerged", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_abandon_staged_release.py
+++ b/tests/test_abandon_staged_release.py
@@ -83,10 +83,13 @@ class TestAbandonStagedRelease(unittest.TestCase):
             ),
         )
         for overrides, message in cases:
-            with self.subTest(message=message), patch.object(
-                abandon,
-                "run_command",
-                return_value=completed([], stdout=json.dumps(pull_request_payload(**overrides))),
+            with (
+                self.subTest(message=message),
+                patch.object(
+                    abandon,
+                    "run_command",
+                    return_value=completed([], stdout=json.dumps(pull_request_payload(**overrides))),
+                ),
             ):
                 with self.assertRaisesRegex(abandon.AbandonError, message):
                     abandon.load_pr_identity(
@@ -183,14 +186,14 @@ class TestAbandonStagedRelease(unittest.TestCase):
         self.assertIn("workflow_dispatch:", workflow)
         self.assertNotIn("gamever:\n        description:", workflow)
         self.assertNotIn("build_id:\n        description:", workflow)
-        self.assertIn("gh api \"repos/${{ github.repository }}/pulls/$env:PR_NUMBER\"", workflow)
+        self.assertIn('gh api "repos/${{ github.repository }}/pulls/$env:PR_NUMBER"', workflow)
         self.assertIn("release-promotion-${{ github.repository }}-${{ needs.resolve.outputs.gamever }}", workflow)
         self.assertIn("runs-on: [self-hosted, windows, x64]", workflow)
         self.assertIn("environment: win64", workflow)
         self.assertIn("release_workflow.py abandon-pending", workflow)
         self.assertIn("secrets.PERSISTED_WORKSPACE", workflow)
-        self.assertIn("--pr-number \"$env:PR_NUMBER\"", workflow)
-        self.assertNotIn("--pr-number \"${{ inputs.pr_number }}\"", workflow)
+        self.assertIn('--pr-number "$env:PR_NUMBER"', workflow)
+        self.assertNotIn('--pr-number "${{ inputs.pr_number }}"', workflow)
         self.assertNotIn("cleanup-unmerged", workflow)
 
 

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -355,6 +355,7 @@ class TestReleaseWorkflow(unittest.TestCase):
                 build_id=fixture.build_id,
             )
 
+            self.assertTrue((stage_dir / "PROMOTION_STARTED").is_file())
             self.assertEqual(file_inventory(stage_dir / "bin" / fixture.gamever), file_inventory(accepted))
             self.assertTrue(Path(state["backup"]).is_dir())
             finalize_promotion(

--- a/tests/test_release_workflow_guards.py
+++ b/tests/test_release_workflow_guards.py
@@ -9,7 +9,7 @@ from gamesymbol_snapshot_lib.config import load_contract
 from release_workflow_lib.cli import _parser
 from release_workflow_lib.errors import ReleaseWorkflowError
 from release_workflow_lib.promotion import verify_output_pr, verify_promotion
-from release_workflow_lib.staging import cleanup_incomplete, cleanup_unmerged
+from release_workflow_lib.staging import abandon_pending, cleanup_incomplete, cleanup_unmerged
 from release_workflow_lib.validation import invalidate_republish, validate_build_input
 from tests.test_release_workflow import ReleaseFixture
 from tests.release_branch_protocol import LEGACY_OUTPUT_BRANCH
@@ -262,6 +262,98 @@ class TestReleaseWorkflowGuards(unittest.TestCase):
 
             self.assertFalse(stage_dir.exists())
             self.assertEqual(b"accepted", marker.read_bytes())
+
+    def test_explicit_abandon_removes_only_matching_unpromoted_pending_state(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            fixture.stage()
+            stage_dir = fixture.finalize_and_index()
+            accepted = fixture.root / "persisted" / "bin" / fixture.gamever
+            accepted.mkdir(parents=True)
+            marker = accepted / "accepted.dll"
+            marker.write_bytes(b"accepted")
+
+            result = abandon_pending(
+                staging_root=fixture.staging,
+                persisted_root=fixture.root / "persisted",
+                gamever=fixture.gamever,
+                build_id=fixture.build_id,
+                pr_number=42,
+                event_head_sha=fixture.head_sha,
+                confirmation=f"ABANDON {fixture.gamever}/{fixture.build_id}",
+                reason="Promotion failed before promote-bin",
+            )
+
+            self.assertEqual(fixture.build_id, result["build_id"])
+            self.assertFalse(stage_dir.exists())
+            self.assertFalse((fixture.staging / "pr-index" / "42.json").exists())
+            self.assertEqual(b"accepted", marker.read_bytes())
+
+    def test_explicit_abandon_requires_exact_confirmation_and_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = ReleaseFixture(Path(tmp))
+            fixture.stage()
+            stage_dir = fixture.finalize_and_index()
+            kwargs = {
+                "staging_root": fixture.staging,
+                "persisted_root": fixture.root / "persisted",
+                "gamever": fixture.gamever,
+                "build_id": fixture.build_id,
+                "pr_number": 42,
+                "event_head_sha": fixture.head_sha,
+                "reason": "Promotion failed before promote-bin",
+            }
+
+            with self.assertRaisesRegex(ReleaseWorkflowError, "confirmation"):
+                abandon_pending(confirmation="ABANDON wrong/build", **kwargs)
+            with self.assertRaisesRegex(ReleaseWorkflowError, "build identity"):
+                abandon_pending(
+                    confirmation=f"ABANDON {fixture.gamever}/999-1",
+                    **{**kwargs, "build_id": "999-1"},
+                )
+            self.assertTrue(stage_dir.exists())
+
+    def test_explicit_abandon_refuses_any_started_promotion_state(self) -> None:
+        for marker_name in ("PROMOTION_STARTED", "PROMOTED.json", "PROMOTION_COMPLETE"):
+            with self.subTest(marker=marker_name), tempfile.TemporaryDirectory() as tmp:
+                fixture = ReleaseFixture(Path(tmp))
+                fixture.stage()
+                stage_dir = fixture.finalize_and_index()
+                (stage_dir / marker_name).write_text("{}\n", encoding="utf-8")
+
+                with self.assertRaisesRegex(ReleaseWorkflowError, "resume instead of abandon"):
+                    abandon_pending(
+                        staging_root=fixture.staging,
+                        persisted_root=fixture.root / "persisted",
+                        gamever=fixture.gamever,
+                        build_id=fixture.build_id,
+                        pr_number=42,
+                        event_head_sha=fixture.head_sha,
+                        confirmation=f"ABANDON {fixture.gamever}/{fixture.build_id}",
+                        reason="Promotion failed before promote-bin",
+                    )
+
+    def test_explicit_abandon_refuses_transaction_recovery_paths(self) -> None:
+        for suffix in ("incoming", "backup"):
+            with self.subTest(suffix=suffix), tempfile.TemporaryDirectory() as tmp:
+                fixture = ReleaseFixture(Path(tmp))
+                fixture.stage()
+                stage_dir = fixture.finalize_and_index()
+                recovery = fixture.root / "persisted" / "bin" / f".{fixture.gamever}.{fixture.build_id}.{suffix}"
+                recovery.mkdir(parents=True)
+
+                with self.assertRaisesRegex(ReleaseWorkflowError, "recovery path exists"):
+                    abandon_pending(
+                        staging_root=fixture.staging,
+                        persisted_root=fixture.root / "persisted",
+                        gamever=fixture.gamever,
+                        build_id=fixture.build_id,
+                        pr_number=42,
+                        event_head_sha=fixture.head_sha,
+                        confirmation=f"ABANDON {fixture.gamever}/{fixture.build_id}",
+                        reason="Promotion failed before promote-bin",
+                    )
+                self.assertTrue(stage_dir.exists())
 
     def test_incomplete_cleanup_removes_only_state_without_ready_marker(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- add an explicit-only abandon-staged-release project Skill and audited dispatch script
- add a protected self-hosted recovery workflow with trusted PR identity derivation and per-version promotion concurrency
- add abandon-pending lifecycle guards plus PROMOTION_STARTED crash-window protection
- add release workflow, Skill, dispatch, and safety regression tests

## Validation

- uv run python -m unittest discover -s tests -b (955 tests passed, 3 skipped)
- uv run python -m unittest tests.test_abandon_staged_release tests.test_release_workflow_guards tests.test_release_workflow -b (42 tests passed)
- uv run python format_repo_files.py --check
- uv run ruff check release_workflow_lib tests/test_abandon_staged_release.py .claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
- actionlint .github/workflows/abandon-staged-release.yml
- skill-creator quick_validate.py
- release_workflow.py abandon-pending --help and Skill script --help smoke