### PR TITLE
feat(release): discover staged release PR from build identity

### DIFF
--- a/.claude/skills/abandon-staged-release/SKILL.md
+++ b/.claude/skills/abandon-staged-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: abandon-staged-release
-description: Safely dispatch the protected recovery workflow that explicitly abandons one merged generated-output PR's unpromoted staged release state. Use only when the user explicitly asks to abandon or clean a specific blocked staged build after promotion failed before promote-bin.
+description: Safely discover the unique trusted merged generated-output PR and dispatch the protected recovery workflow for one explicitly identified unpromoted staged release. Use only when the user explicitly asks to abandon or clean a GAMEVER/BUILD_ID, or supplies a trusted GitHub Actions run/job URL for the staged build or a run uniquely blocked by it, after promotion failed before promote-bin.
 ---
 
 # Abandon Staged Release
@@ -10,18 +10,31 @@ remove staging paths manually, accept a user-supplied SHA/path, resume promotion
 
 ## Procedure
 
-1. Require an explicit merged generated-output PR number, exact confirmation, and one-line reason.
-2. Run from any directory:
+1. Require an explicit `GAMEVER/BUILD_ID` or trusted GitHub Actions run/job URL, exact confirmation, and one-line
+   reason. A run URL may identify the staged build itself or a failed release build whose logs uniquely report that
+   staged build as its READY blocker.
+2. Run from any directory with the build identity:
 
    ```powershell
    uv run python .claude/skills/abandon-staged-release/scripts/abandon_staged_release.py `
-     <PR_NUMBER> `
+     <GAMEVER>/<BUILD_ID> `
      --confirm "ABANDON <GAMEVER>/<BUILD_ID>" `
      --reason "<WHY_PROMOTION_IS_BEING_ABANDONED>"
    ```
 
-3. Report the PR URL, derived game version/build ID/head SHA, reason, and Actions run URL.
-4. If the script or workflow refuses the operation, surface the exact safety reason and stop. Never bypass repository,
+   Or use a run/job URL as independent target evidence:
+
+   ```powershell
+   uv run python .claude/skills/abandon-staged-release/scripts/abandon_staged_release.py `
+     <GITHUB_ACTIONS_RUN_OR_JOB_URL> `
+     --confirm "ABANDON <GAMEVER>/<BUILD_ID>" `
+     --reason "<WHY_PROMOTION_IS_BEING_ABANDONED>"
+   ```
+
+3. The script automatically discovers the exact output branch and requires exactly one trusted merged Bot PR from
+   the same repository into `main`; it derives the PR number and head SHA rather than accepting either from the user.
+4. Report the target evidence, discovered PR URL, game version/build ID/head SHA, reason, and Actions run URL.
+5. If the script or workflow refuses the operation, surface the exact safety reason and stop. Never bypass repository,
    PR author/repository/base/branch, confirmation, active-run, promotion-marker, recovery-path, or index/manifest checks.
 
 The workflow only removes the matching staged directory and PR index. It refuses any state containing

--- a/.claude/skills/abandon-staged-release/agents/openai.yaml
+++ b/.claude/skills/abandon-staged-release/agents/openai.yaml
@@ -1,6 +1,7 @@
 interface:
   display_name: "Abandon Staged Release"
-  short_description: "Safely abandon an unpromoted staged release"
-  default_prompt: "Use $abandon-staged-release to explicitly abandon a specific unpromoted staged release build."
+  short_description: "Discover and abandon a staged release safely"
+  default_prompt: "Use $abandon-staged-release to abandon a GAMEVER/BUILD_ID or a staged build identified by an Actions run\
+    \ URL."
 policy:
   allow_implicit_invocation: false

--- a/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
+++ b/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Dispatch the protected workflow that abandons one unpromoted staged release."""
+"""Discover and abandon one explicitly identified unpromoted staged release."""
 
 import argparse
 import json
@@ -8,12 +8,21 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+from urllib.parse import urlparse
 
 
 ALLOWED_REPOSITORIES = {"HLND2T/CS2_VibeSignatures", "hzqst/CS2_VibeSignatures"}
 OUTPUT_BRANCH_RE = re.compile(r"^gamesymbols/build/(?P<gamever>[0-9]{4,10}[a-z]?)/(?P<build_id>[0-9]+-[0-9]+)$")
+TARGET_RE = re.compile(r"^(?P<gamever>[0-9]{4,10}[a-z]?)/(?P<build_id>[0-9]+-[0-9]+)$")
+CONFIRMATION_RE = re.compile(r"^ABANDON (?P<gamever>[0-9]{4,10}[a-z]?)/(?P<build_id>[0-9]+-[0-9]+)$")
+RUN_TITLE_RE = re.compile(r"^Release build (?P<gamever>[0-9]{4,10}[a-z]?)$")
+BLOCKING_READY_RE = re.compile(
+    r"another ready staged build blocks (?P<gamever>[0-9]{4,10}[a-z]?): "
+    r"[^\r\n]*[\\/](?P=gamever)[\\/](?P<build_id>[0-9]+-[0-9]+)"
+)
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 WORKFLOW = "abandon-staged-release.yml"
+BUILD_WORKFLOW_PATH = ".github/workflows/build-on-self-runner.yml"
 RUN_LIST_LIMIT = "50"
 RUN_DISCOVERY_ATTEMPTS = 10
 RUN_DISCOVERY_DELAY_SECONDS = 2
@@ -106,38 +115,150 @@ def validate_reason(reason: str) -> str:
     return reason
 
 
-def load_pr_identity(root: Path, repository: str, pr_number: int, confirmation: str, reason: str) -> dict:
-    raw = run_command(["gh", "api", f"repos/{repository}/pulls/{pr_number}"], root).stdout
-    pull = parse_json_object(raw, "pull request lookup")
+def parse_confirmation(confirmation: str) -> tuple[str, str]:
+    match = CONFIRMATION_RE.fullmatch(confirmation)
+    if not match:
+        raise AbandonError("confirmation must exactly equal 'ABANDON <gamever>/<build-id>'")
+    return match.group("gamever"), match.group("build_id")
+
+
+def parse_run_url(target: str, repository: str) -> int | None:
+    parsed = urlparse(target)
+    if not parsed.scheme and not parsed.netloc:
+        return None
+    if parsed.scheme != "https" or parsed.netloc.lower() != "github.com":
+        raise AbandonError("run URL must use https://github.com")
+    parts = [part for part in parsed.path.split("/") if part]
+    if len(parts) not in {5, 7} or parts[2:4] != ["actions", "runs"]:
+        raise AbandonError("target must be GAMEVER/BUILD_ID or a GitHub Actions run/job URL")
+    if len(parts) == 7 and (parts[5] != "job" or not parts[6].isdigit()):
+        raise AbandonError("target must be GAMEVER/BUILD_ID or a GitHub Actions run/job URL")
+    url_repository = f"{parts[0]}/{parts[1]}"
+    if url_repository.lower() != repository.lower():
+        raise AbandonError(f"run URL repository does not match {repository}")
+    if not parts[4].isdigit() or int(parts[4]) <= 0:
+        raise AbandonError("run URL contains an invalid run ID")
+    return int(parts[4])
+
+
+def _load_build_run(root: Path, repository: str, run_id: int) -> dict:
+    raw = run_command(["gh", "api", f"repos/{repository}/actions/runs/{run_id}"], root).stdout
+    run = parse_json_object(raw, "Actions run lookup")
+    if run.get("id") != run_id:
+        raise AbandonError("Actions run lookup returned a different run ID")
+    run_repository = (run.get("repository") or {}).get("full_name")
+    if run_repository != repository or run.get("path") != BUILD_WORKFLOW_PATH:
+        raise AbandonError("run URL does not identify a trusted release build workflow")
+    if run.get("event") not in {"workflow_dispatch", "repository_dispatch"}:
+        raise AbandonError("release build run has an unsupported event type")
+    if run.get("status") != "completed":
+        raise AbandonError("release build run must be completed before abandonment")
+    attempt = run.get("run_attempt")
+    if not isinstance(attempt, int) or attempt <= 0:
+        raise AbandonError("release build run attempt is invalid")
+    title = RUN_TITLE_RE.fullmatch(str(run.get("display_title", "")))
+    if not title:
+        raise AbandonError("release build run title does not contain a valid game version")
+    return {**run, "resolved_gamever": title.group("gamever")}
+
+
+def _blocking_targets(log: str) -> set[tuple[str, str]]:
+    return {(match.group("gamever"), match.group("build_id")) for match in BLOCKING_READY_RE.finditer(log)}
+
+
+def validate_run_target(root: Path, repository: str, run_id: int, *, gamever: str, build_id: str) -> None:
+    run = _load_build_run(root, repository, run_id)
+    if run["resolved_gamever"] != gamever:
+        raise AbandonError("run URL game version does not match confirmation")
+    if f"{run_id}-{run['run_attempt']}" == build_id:
+        return
+    if run.get("conclusion") != "failure":
+        raise AbandonError("run URL does not identify the confirmed staged build")
+    log = run_command(["gh", "run", "view", str(run_id), "--repo", repository, "--log-failed"], root).stdout
+    targets = _blocking_targets(log)
+    expected = (gamever, build_id)
+    if targets != {expected}:
+        if expected not in targets:
+            raise AbandonError("run URL does not report the confirmed READY build as its blocker")
+        raise AbandonError("run URL reports multiple READY build identities; refusing ambiguous abandonment")
+
+
+def resolve_target_identity(root: Path, repository: str, target: str, confirmation: str) -> tuple[str, str]:
+    gamever, build_id = parse_confirmation(confirmation)
+    direct = TARGET_RE.fullmatch(target)
+    if direct:
+        if (direct.group("gamever"), direct.group("build_id")) != (gamever, build_id):
+            raise AbandonError("target GAMEVER/BUILD_ID does not match confirmation")
+        return gamever, build_id
+    run_id = parse_run_url(target, repository)
+    if run_id is None:
+        raise AbandonError("target must be GAMEVER/BUILD_ID or a GitHub Actions run/job URL")
+    validate_run_target(root, repository, run_id, gamever=gamever, build_id=build_id)
+    return gamever, build_id
+
+
+def _trusted_pr_identity(pull: dict, repository: str, gamever: str, build_id: str) -> dict | None:
     head = pull.get("head") or {}
     head_repo = head.get("repo") or {}
     base = pull.get("base") or {}
     author = pull.get("user") or {}
     if pull.get("state") != "closed" or not pull.get("merged_at"):
-        raise AbandonError(f"PR #{pr_number} must be merged before its staged build can be abandoned")
+        return None
     if author.get("login") != "github-actions[bot]":
-        raise AbandonError(f"PR #{pr_number} was not created by github-actions[bot]")
+        return None
     if head_repo.get("full_name") != repository or base.get("ref") != "main":
-        raise AbandonError(f"PR #{pr_number} does not match the trusted same-repository main-branch contract")
+        return None
     match = OUTPUT_BRANCH_RE.fullmatch(str(head.get("ref", "")))
-    if not match:
-        raise AbandonError(f"PR #{pr_number} does not use the generated-output branch protocol")
+    if not match or (match.group("gamever"), match.group("build_id")) != (gamever, build_id):
+        return None
     head_sha = str(head.get("sha", "")).lower()
     if not SHA_RE.fullmatch(head_sha):
-        raise AbandonError(f"PR #{pr_number} head did not resolve to a full commit SHA")
-    gamever, build_id = match.group("gamever"), match.group("build_id")
-    expected_confirmation = f"ABANDON {gamever}/{build_id}"
-    if confirmation != expected_confirmation:
-        raise AbandonError(f"confirmation must exactly equal {expected_confirmation!r}")
+        return None
+    pr_number = pull.get("number")
+    if not isinstance(pr_number, int) or pr_number <= 0:
+        return None
     return {
         "pr_number": pr_number,
         "pr_url": str(pull.get("html_url", "")),
         "gamever": gamever,
         "build_id": build_id,
         "head_sha": head_sha,
-        "confirmation": confirmation,
-        "reason": validate_reason(reason),
     }
+
+
+def discover_pr_identity(root: Path, repository: str, gamever: str, build_id: str) -> dict:
+    branch = f"gamesymbols/build/{gamever}/{build_id}"
+    owner = repository.split("/", 1)[0]
+    result = run_command(
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            f"repos/{repository}/pulls",
+            "-f",
+            "state=closed",
+            "-f",
+            f"head={owner}:{branch}",
+            "-f",
+            "base=main",
+            "-f",
+            "per_page=100",
+        ],
+        root,
+    )
+    pulls = parse_json_list(result.stdout, "generated-output PR discovery")
+    trusted = [
+        identity
+        for pull in pulls
+        if (identity := _trusted_pr_identity(pull, repository, gamever, build_id)) is not None
+    ]
+    if not trusted:
+        raise AbandonError(f"no trusted merged generated-output PR matches {gamever}/{build_id}")
+    if len(trusted) != 1:
+        numbers = ", ".join(f"#{identity['pr_number']}" for identity in trusted)
+        raise AbandonError(f"multiple trusted merged generated-output PRs match {gamever}/{build_id}: {numbers}")
+    return trusted[0]
 
 
 def list_runs(root: Path) -> list[dict]:
@@ -207,33 +328,35 @@ def discover_run(root: Path, known_ids: set[int], *, pr_number: int, source_sha:
     raise AbandonError("workflow was dispatched but its Actions run URL could not be discovered")
 
 
-def execute(pr_number: int, confirmation: str, reason: str) -> dict:
+def execute(target: str, confirmation: str, reason: str) -> dict:
     root = repository_root()
     repository = require_repository(root)
     require_github_access(root, repository)
     source_sha = resolve_main(root)
-    identity = load_pr_identity(root, repository, pr_number, confirmation, reason)
-    known_ids = require_no_duplicate(root, pr_number)
+    reason = validate_reason(reason)
+    gamever, build_id = resolve_target_identity(root, repository, target, confirmation)
+    identity = discover_pr_identity(root, repository, gamever, build_id)
+    identity.update({"target": target, "confirmation": confirmation, "reason": reason})
+    known_ids = require_no_duplicate(root, identity["pr_number"])
     require_main_unchanged(root, source_sha)
     dispatch(root, identity)
-    identity["run_url"] = discover_run(root, known_ids, pr_number=pr_number, source_sha=source_sha)
+    identity["run_url"] = discover_run(root, known_ids, pr_number=identity["pr_number"], source_sha=source_sha)
     identity["source_sha"] = source_sha
     return identity
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("pr_number", type=int, help="Merged generated-output PR number")
+    parser.add_argument("target", help="GAMEVER/BUILD_ID or trusted GitHub Actions run/job URL")
     parser.add_argument("--confirm", required=True, help="Exact ABANDON <gamever>/<build-id> confirmation")
     parser.add_argument("--reason", required=True, help="One-line audit reason")
     args = parser.parse_args(argv)
-    if args.pr_number <= 0:
-        parser.error("pr_number must be positive")
     try:
-        result = execute(args.pr_number, args.confirm, args.reason)
+        result = execute(args.target, args.confirm, args.reason)
     except (AbandonError, OSError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
         return 1
+    print(f"Target: {result['target']}")
     print(f"PR: #{result['pr_number']} ({result['pr_url']})")
     print(f"GAMEVER: {result['gamever']}")
     print(f"BUILD_ID: {result['build_id']}")

--- a/.serena/memories/build-on-self-runner.md
+++ b/.serena/memories/build-on-self-runner.md
@@ -48,8 +48,9 @@
 - archive/tag/upload 失败：READY、private manifest、staged bin 和 promoted backup 保留，promotion 可重跑。
 - `promote-bin` 在触碰 accepted bin 前写 `PROMOTION_STARTED`；显式 abandon 仅允许该 marker、`PROMOTED.json`、
   `PROMOTION_COMPLETE` 及 matching incoming/backup 全部不存在时删除 staged directory 与 PR index。
-- `.claude/skills/abandon-staged-release/` 只 dispatch 受保护的 `abandon-staged-release.yml`；workflow 从 merged Bot PR
-  推导 gamever/build/head SHA，并复用 per-version promotion concurrency 与 `win64` environment。
+- `.claude/skills/abandon-staged-release/` 接受显式 `GAMEVER/BUILD_ID`，或 staged build 自身 / 唯一被其 READY
+  状态阻塞的可信 Actions run URL；客户端从 exact output branch 自动发现唯一 merged Bot PR 与 head SHA，再只 dispatch
+  受保护的 `abandon-staged-release.yml`。workflow 继续复用 per-version promotion concurrency 与 `win64` environment。
 - existing target 已等于 staged inventory：`promote-bin` 作为幂等重试成功返回，不重复 swap。
 - Release assets 使用 `--clobber`，随后下载每个 asset 并比较 SHA-256；未验证成功前不写 completion marker。
 
@@ -58,7 +59,8 @@
 - `tests/test_release_workflow.py`：manifest/hash/path/reparse/index/cleanup/swap/idempotency/tag guards/stale merge。
 - `tests/test_build_self_runner_workflow.py`：trigger/checkout/order/no-premerge-publication/promotion/tag/bump/lightweight check。
 - `tests/test_trigger_release_build.py`：repository/auth/version/tag/Release/duplicate/dispatch/run URL。
-- `tests/test_abandon_staged_release.py`：Skill 显式调用、PR identity、confirmation/reason、duplicate dispatch 与 recovery workflow。
+- `tests/test_abandon_staged_release.py`：Skill 显式 target、run/log blocker identity、唯一可信 merged PR 自动发现、
+  confirmation/reason、duplicate dispatch 与 recovery workflow。
 - 完成门：全仓 unittest、formatter、Ruff、YAML parse、actionlint 与 CLI non-publishing smoke。
 
 ## Explicit Legacy Bootstrap

--- a/tests/test_abandon_staged_release.py
+++ b/tests/test_abandon_staged_release.py
@@ -17,12 +17,12 @@ def completed(command, *, stdout="", returncode=0, stderr=""):
     return subprocess.CompletedProcess(command, returncode, stdout=stdout, stderr=stderr)
 
 
-def pull_request_payload(**overrides) -> dict:
+def pull_request_payload(number=582, **overrides) -> dict:
     payload = {
-        "number": 582,
+        "number": number,
         "state": "closed",
         "merged_at": "2026-07-19T12:48:13Z",
-        "html_url": "https://github.com/HLND2T/CS2_VibeSignatures/pull/582",
+        "html_url": f"https://github.com/HLND2T/CS2_VibeSignatures/pull/{number}",
         "user": {"login": "github-actions[bot]"},
         "head": {
             "ref": "gamesymbols/build/14168/29686825445-1",
@@ -30,6 +30,21 @@ def pull_request_payload(**overrides) -> dict:
             "repo": {"full_name": "HLND2T/CS2_VibeSignatures"},
         },
         "base": {"ref": "main"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def build_run_payload(run_id=29686825445, *, attempt=1, conclusion="success", **overrides) -> dict:
+    payload = {
+        "id": run_id,
+        "run_attempt": attempt,
+        "path": ".github/workflows/build-on-self-runner.yml",
+        "event": "workflow_dispatch",
+        "status": "completed",
+        "conclusion": conclusion,
+        "display_title": "Release build 14168",
+        "repository": {"full_name": "HLND2T/CS2_VibeSignatures"},
     }
     payload.update(overrides)
     return payload
@@ -45,83 +60,145 @@ class TestAbandonStagedRelease(unittest.TestCase):
         skill = Path(".claude/skills/abandon-staged-release/SKILL.md").read_text(encoding="utf-8")
         agent = Path(".claude/skills/abandon-staged-release/agents/openai.yaml").read_text(encoding="utf-8")
         self.assertIn("Use only when the user explicitly asks", skill)
+        self.assertIn("GAMEVER/BUILD_ID", skill)
+        self.assertIn("Actions run/job URL", skill)
+        self.assertIn("automatically discovers", skill)
         self.assertIn("allow_implicit_invocation: false", agent)
         self.assertIn("bundled script as the only remote-operation entry point", skill)
         self.assertIn("Do not run `cleanup-unmerged`", skill)
         self.assertIn("never automatically reruns a release build", skill)
 
-    def test_pr_identity_is_derived_from_the_trusted_merged_output_pr(self) -> None:
-        with patch.object(
-            abandon,
-            "run_command",
-            return_value=completed([], stdout=json.dumps(pull_request_payload())),
-        ):
-            identity = abandon.load_pr_identity(
+    def test_direct_target_must_match_exact_confirmation(self) -> None:
+        self.assertEqual(
+            ("14168", "29686825445-1"),
+            abandon.resolve_target_identity(
                 Path("."),
                 "HLND2T/CS2_VibeSignatures",
-                582,
+                "14168/29686825445-1",
                 "ABANDON 14168/29686825445-1",
-                "Promotion failed before promote-bin",
-            )
-        self.assertEqual("14168", identity["gamever"])
-        self.assertEqual("29686825445-1", identity["build_id"])
-        self.assertEqual("6a44f19be35e6fc876d9e74b46f494f214b383d1", identity["head_sha"])
-
-    def test_pr_identity_rejects_untrusted_or_unmerged_requests(self) -> None:
-        cases = (
-            ({"merged_at": None}, "must be merged"),
-            ({"user": {"login": "someone"}}, "github-actions"),
-            (
-                {
-                    "head": {
-                        "ref": "gamesymbols/build/14168/29686825445-1",
-                        "sha": "6a44f19be35e6fc876d9e74b46f494f214b383d1",
-                        "repo": {"full_name": "other/repository"},
-                    }
-                },
-                "trusted same-repository",
             ),
         )
-        for overrides, message in cases:
-            with (
-                self.subTest(message=message),
-                patch.object(
-                    abandon,
-                    "run_command",
-                    return_value=completed([], stdout=json.dumps(pull_request_payload(**overrides))),
-                ),
-            ):
-                with self.assertRaisesRegex(abandon.AbandonError, message):
-                    abandon.load_pr_identity(
-                        Path("."),
-                        "HLND2T/CS2_VibeSignatures",
-                        582,
-                        "ABANDON 14168/29686825445-1",
-                        "Promotion failed before promote-bin",
-                    )
+        with self.assertRaisesRegex(abandon.AbandonError, "does not match confirmation"):
+            abandon.resolve_target_identity(
+                Path("."),
+                "HLND2T/CS2_VibeSignatures",
+                "14168/29686825445-2",
+                "ABANDON 14168/29686825445-1",
+            )
 
     def test_confirmation_and_reason_are_strict(self) -> None:
+        with self.assertRaisesRegex(abandon.AbandonError, "confirmation"):
+            abandon.parse_confirmation("ABANDON 14168/wrong")
+        with self.assertRaisesRegex(abandon.AbandonError, "one non-empty line"):
+            abandon.validate_reason("bad\nreason")
+
+    def test_run_url_can_identify_the_staged_build_itself(self) -> None:
+        run = build_run_payload()
+        with patch.object(abandon, "run_command", return_value=completed([], stdout=json.dumps(run))) as command:
+            identity = abandon.resolve_target_identity(
+                Path("."),
+                "HLND2T/CS2_VibeSignatures",
+                "https://github.com/HLND2T/CS2_VibeSignatures/actions/runs/29686825445/job/1",
+                "ABANDON 14168/29686825445-1",
+            )
+        self.assertEqual(("14168", "29686825445-1"), identity)
+        self.assertIn("repos/HLND2T/CS2_VibeSignatures/actions/runs/29686825445", command.call_args.args[0])
+
+    def test_blocked_run_url_can_identify_its_unique_ready_blocker(self) -> None:
+        run = build_run_payload(run_id=29688978009, conclusion="failure")
+        log = "Error: another ready staged build blocks 14168: ***\\release-staging\\14168\\29686825445-1\n"
         with patch.object(
             abandon,
             "run_command",
-            return_value=completed([], stdout=json.dumps(pull_request_payload())),
-        ):
-            with self.assertRaisesRegex(abandon.AbandonError, "confirmation"):
-                abandon.load_pr_identity(
+            side_effect=[completed([], stdout=json.dumps(run)), completed([], stdout=log)],
+        ) as command:
+            identity = abandon.resolve_target_identity(
+                Path("."),
+                "HLND2T/CS2_VibeSignatures",
+                "https://github.com/HLND2T/CS2_VibeSignatures/actions/runs/29688978009/job/88198248637",
+                "ABANDON 14168/29686825445-1",
+            )
+        self.assertEqual(("14168", "29686825445-1"), identity)
+        self.assertIn("--log-failed", command.call_args_list[1].args[0])
+
+    def test_run_url_rejects_untrusted_or_ambiguous_evidence(self) -> None:
+        cases = (
+            (
+                build_run_payload(path=".github/workflows/other.yml"),
+                "",
+                "trusted release build workflow",
+            ),
+            (
+                build_run_payload(run_id=29688978009, conclusion="failure"),
+                "Error: another ready staged build blocks 14168: ***\\release-staging\\14168\\111-1\n",
+                "does not report the confirmed READY build",
+            ),
+            (
+                build_run_payload(run_id=29688978009, conclusion="failure"),
+                "Error: another ready staged build blocks 14168: "
+                "***\\release-staging\\14168\\29686825445-1\n"
+                "Error: another ready staged build blocks 14168: "
+                "***\\release-staging\\14168\\111-1\n",
+                "multiple READY build identities",
+            ),
+        )
+        for run, log, message in cases:
+            responses = [completed([], stdout=json.dumps(run))]
+            if log:
+                responses.append(completed([], stdout=log))
+            with (
+                self.subTest(message=message),
+                patch.object(abandon, "run_command", side_effect=responses),
+                self.assertRaisesRegex(abandon.AbandonError, message),
+            ):
+                abandon.resolve_target_identity(
                     Path("."),
                     "HLND2T/CS2_VibeSignatures",
-                    582,
-                    "ABANDON 14168/wrong",
-                    "Promotion failed before promote-bin",
-                )
-            with self.assertRaisesRegex(abandon.AbandonError, "one non-empty line"):
-                abandon.load_pr_identity(
-                    Path("."),
-                    "HLND2T/CS2_VibeSignatures",
-                    582,
+                    f"https://github.com/HLND2T/CS2_VibeSignatures/actions/runs/{run['id']}",
                     "ABANDON 14168/29686825445-1",
-                    "bad\nreason",
                 )
+
+    def test_run_url_must_match_the_owning_repository(self) -> None:
+        with self.assertRaisesRegex(abandon.AbandonError, "repository does not match"):
+            abandon.resolve_target_identity(
+                Path("."),
+                "HLND2T/CS2_VibeSignatures",
+                "https://github.com/other/repository/actions/runs/29686825445",
+                "ABANDON 14168/29686825445-1",
+            )
+
+    def test_unique_trusted_merged_pr_is_discovered_from_build_identity(self) -> None:
+        pulls = [pull_request_payload()]
+        with patch.object(abandon, "run_command", return_value=completed([], stdout=json.dumps(pulls))) as command:
+            identity = abandon.discover_pr_identity(Path("."), "HLND2T/CS2_VibeSignatures", "14168", "29686825445-1")
+        self.assertEqual(582, identity["pr_number"])
+        self.assertEqual("6a44f19be35e6fc876d9e74b46f494f214b383d1", identity["head_sha"])
+        discovery = command.call_args.args[0]
+        self.assertIn("head=HLND2T:gamesymbols/build/14168/29686825445-1", discovery)
+        self.assertNotIn("582", discovery)
+
+    def test_pr_discovery_rejects_missing_untrusted_or_ambiguous_matches(self) -> None:
+        untrusted = pull_request_payload(user={"login": "someone"})
+        duplicate = pull_request_payload(
+            number=583,
+            head={
+                "ref": "gamesymbols/build/14168/29686825445-1",
+                "sha": "7a44f19be35e6fc876d9e74b46f494f214b383d1",
+                "repo": {"full_name": "HLND2T/CS2_VibeSignatures"},
+            },
+        )
+        cases = (
+            ([], "no trusted merged"),
+            ([untrusted], "no trusted merged"),
+            ([pull_request_payload(), duplicate], "multiple trusted merged"),
+        )
+        for pulls, message in cases:
+            with (
+                self.subTest(message=message),
+                patch.object(abandon, "run_command", return_value=completed([], stdout=json.dumps(pulls))),
+                self.assertRaisesRegex(abandon.AbandonError, message),
+            ):
+                abandon.discover_pr_identity(Path("."), "HLND2T/CS2_VibeSignatures", "14168", "29686825445-1")
 
     def test_duplicate_active_workflow_is_rejected(self) -> None:
         runs = [
@@ -136,7 +213,7 @@ class TestAbandonStagedRelease(unittest.TestCase):
             with self.assertRaisesRegex(abandon.AbandonError, "already active"):
                 abandon.require_no_duplicate(Path("."), 582)
 
-    def test_dispatch_uses_only_derived_identity_and_audit_inputs(self) -> None:
+    def test_dispatch_uses_only_discovered_identity_and_audit_inputs(self) -> None:
         identity = {
             "pr_number": 582,
             "confirmation": "ABANDON 14168/29686825445-1",
@@ -158,22 +235,25 @@ class TestAbandonStagedRelease(unittest.TestCase):
             "gamever": "14168",
             "build_id": "29686825445-1",
             "head_sha": "6" * 40,
-            "confirmation": "ABANDON 14168/29686825445-1",
-            "reason": "Promotion failed before promote-bin",
         }
         with (
             patch.object(abandon, "repository_root", return_value=Path(".")),
             patch.object(abandon, "require_repository", return_value="HLND2T/CS2_VibeSignatures"),
             patch.object(abandon, "require_github_access"),
             patch.object(abandon, "resolve_main", return_value="a" * 40),
-            patch.object(abandon, "load_pr_identity", return_value=identity.copy()),
+            patch.object(
+                abandon,
+                "resolve_target_identity",
+                return_value=("14168", "29686825445-1"),
+            ),
+            patch.object(abandon, "discover_pr_identity", return_value=identity.copy()),
             patch.object(abandon, "require_no_duplicate", return_value={1}),
             patch.object(abandon, "require_main_unchanged"),
             patch.object(abandon, "dispatch") as dispatch,
             patch.object(abandon, "discover_run", return_value="https://github.com/example/run"),
         ):
             result = abandon.execute(
-                582,
+                "14168/29686825445-1",
                 "ABANDON 14168/29686825445-1",
                 "Promotion failed before promote-bin",
             )
@@ -181,13 +261,16 @@ class TestAbandonStagedRelease(unittest.TestCase):
         self.assertEqual("https://github.com/example/run", result["run_url"])
         self.assertEqual("a" * 40, result["source_sha"])
 
-    def test_recovery_workflow_derives_identity_and_uses_promotion_concurrency(self) -> None:
+    def test_recovery_workflow_still_derives_identity_and_uses_promotion_concurrency(self) -> None:
         workflow = Path(".github/workflows/abandon-staged-release.yml").read_text(encoding="utf-8")
         self.assertIn("workflow_dispatch:", workflow)
         self.assertNotIn("gamever:\n        description:", workflow)
         self.assertNotIn("build_id:\n        description:", workflow)
         self.assertIn('gh api "repos/${{ github.repository }}/pulls/$env:PR_NUMBER"', workflow)
-        self.assertIn("release-promotion-${{ github.repository }}-${{ needs.resolve.outputs.gamever }}", workflow)
+        self.assertIn(
+            "release-promotion-${{ github.repository }}-${{ needs.resolve.outputs.gamever }}",
+            workflow,
+        )
         self.assertIn("runs-on: [self-hosted, windows, x64]", workflow)
         self.assertIn("environment: win64", workflow)
         self.assertIn("release_workflow.py abandon-pending", workflow)


### PR DESCRIPTION
## Summary

- accept explicit GAMEVER/BUILD_ID or trusted Actions run/job URLs as abandonment targets
- discover exactly one trusted merged generated-output PR and derive its head SHA automatically
- validate blocked-run logs, exact confirmation, reason, and existing recovery safety gates
- update skill guidance, metadata, Serena memory, and regression coverage

## Verification

- uv run python format_repo_files.py --check
- uv run ruff check .claude/skills/abandon-staged-release/scripts/abandon_staged_release.py tests/test_abandon_staged_release.py
- uv run python -m unittest discover -s tests -b (960 tests, 3 skipped)
- skill-creator quick_validate.py
- real read-only smoke against run 29688978009/job/88198248637 discovered 14168/29686825445-1 and PR #582