### PR TITLE
fix(release): stabilize staged abandonment dispatch

### DIFF
--- a/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
+++ b/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
@@ -328,11 +328,7 @@ def discover_run(root: Path, known_ids: set[int], *, pr_number: int, source_sha:
     for _attempt in range(RUN_DISCOVERY_ATTEMPTS):
         for run in list_runs(root):
             run_id = int(run.get("databaseId", 0))
-            if (
-                run_id not in known_ids
-                and run.get("event") == "workflow_dispatch"
-                and run.get("headSha") == source_sha
-            ):
+            if run_id not in known_ids and run.get("event") == "workflow_dispatch" and run.get("headSha") == source_sha:
                 display_title = str(run.get("displayTitle", ""))
                 run_url = str(run.get("url", ""))
                 if display_title == expected_title:
@@ -340,9 +336,7 @@ def discover_run(root: Path, known_ids: set[int], *, pr_number: int, source_sha:
                 if display_title == RUN_TITLE_PREFIX:
                     unexpected[run_id] = (display_title, run_url)
         if unexpected:
-            details = ", ".join(
-                f"{url} (displayTitle={title!r})" for title, url in unexpected.values()
-            )
+            details = ", ".join(f"{url} (displayTitle={title!r})" for title, url in unexpected.values())
             raise AbandonError(
                 f"workflow was dispatched, but matching Actions run(s) used an unexpected title: {details}; "
                 f"expected {expected_title!r}"

--- a/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
+++ b/.claude/skills/abandon-staged-release/scripts/abandon_staged_release.py
@@ -22,6 +22,7 @@ BLOCKING_READY_RE = re.compile(
 )
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 WORKFLOW = "abandon-staged-release.yml"
+RUN_TITLE_PREFIX = "Abandon staged release PR"
 BUILD_WORKFLOW_PATH = ".github/workflows/build-on-self-runner.yml"
 RUN_LIST_LIMIT = "50"
 RUN_DISCOVERY_ATTEMPTS = 10
@@ -281,10 +282,18 @@ def list_runs(root: Path) -> list[dict]:
 
 def require_no_duplicate(root: Path, pr_number: int) -> set[int]:
     runs = list_runs(root)
-    title = f"Abandon staged release PR #{pr_number}"
+    title = f"{RUN_TITLE_PREFIX} #{pr_number}"
     for run in runs:
-        if run.get("status") in {"queued", "in_progress"} and run.get("displayTitle") == title:
+        if run.get("status") not in {"queued", "in_progress"}:
+            continue
+        display_title = run.get("displayTitle")
+        if display_title == title:
             raise AbandonError(f"an abandonment workflow is already active for PR #{pr_number}: {run.get('url')}")
+        if display_title == RUN_TITLE_PREFIX:
+            raise AbandonError(
+                "an abandonment workflow with a legacy-truncated title is already active: "
+                f"{run.get('url')}; inspect it before dispatching PR #{pr_number}"
+            )
     return {int(run["databaseId"]) for run in runs if "databaseId" in run}
 
 
@@ -314,16 +323,30 @@ def dispatch(root: Path, identity: dict) -> None:
 
 
 def discover_run(root: Path, known_ids: set[int], *, pr_number: int, source_sha: str) -> str:
+    expected_title = f"{RUN_TITLE_PREFIX} #{pr_number}"
+    unexpected: dict[int, tuple[str, str]] = {}
     for _attempt in range(RUN_DISCOVERY_ATTEMPTS):
         for run in list_runs(root):
             run_id = int(run.get("databaseId", 0))
             if (
                 run_id not in known_ids
-                and run.get("displayTitle") == f"Abandon staged release PR #{pr_number}"
                 and run.get("event") == "workflow_dispatch"
                 and run.get("headSha") == source_sha
             ):
-                return str(run.get("url"))
+                display_title = str(run.get("displayTitle", ""))
+                run_url = str(run.get("url", ""))
+                if display_title == expected_title:
+                    return run_url
+                if display_title == RUN_TITLE_PREFIX:
+                    unexpected[run_id] = (display_title, run_url)
+        if unexpected:
+            details = ", ".join(
+                f"{url} (displayTitle={title!r})" for title, url in unexpected.values()
+            )
+            raise AbandonError(
+                f"workflow was dispatched, but matching Actions run(s) used an unexpected title: {details}; "
+                f"expected {expected_title!r}"
+            )
         time.sleep(RUN_DISCOVERY_DELAY_SECONDS)
     raise AbandonError("workflow was dispatched but its Actions run URL could not be discovered")
 

--- a/.github/workflows/abandon-staged-release.yml
+++ b/.github/workflows/abandon-staged-release.yml
@@ -1,5 +1,5 @@
 name: Abandon Staged Release
-run-name: Abandon staged release PR #${{ inputs.pr_number }}
+run-name: "Abandon staged release PR #${{ inputs.pr_number }}"
 
 on:
   workflow_dispatch:
@@ -102,8 +102,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
-
-      - uses: astral-sh/setup-uv@v6
 
       - name: Abandon only the validated unpromoted pending state
         shell: pwsh

--- a/tests/test_abandon_staged_release.py
+++ b/tests/test_abandon_staged_release.py
@@ -213,6 +213,50 @@ class TestAbandonStagedRelease(unittest.TestCase):
             with self.assertRaisesRegex(abandon.AbandonError, "already active"):
                 abandon.require_no_duplicate(Path("."), 582)
 
+    def test_legacy_truncated_active_workflow_is_rejected(self) -> None:
+        runs = [
+            {
+                "databaseId": 123,
+                "displayTitle": "Abandon staged release PR",
+                "status": "queued",
+                "url": "https://github.com/example/legacy-run",
+            }
+        ]
+        with patch.object(abandon, "list_runs", return_value=runs):
+            with self.assertRaisesRegex(abandon.AbandonError, "legacy-truncated title"):
+                abandon.require_no_duplicate(Path("."), 582)
+
+    def test_discover_run_reports_matching_new_run_url(self) -> None:
+        run = {
+            "databaseId": 124,
+            "displayTitle": "Abandon staged release PR #582",
+            "status": "queued",
+            "url": "https://github.com/example/run/124",
+            "headSha": "a" * 40,
+            "event": "workflow_dispatch",
+        }
+        with patch.object(abandon, "list_runs", return_value=[run]):
+            self.assertEqual(
+                "https://github.com/example/run/124",
+                abandon.discover_run(Path("."), {123}, pr_number=582, source_sha="a" * 40),
+            )
+
+    def test_discover_run_reports_unexpected_title_and_candidate_url(self) -> None:
+        run = {
+            "databaseId": 124,
+            "displayTitle": "Abandon staged release PR",
+            "status": "queued",
+            "url": "https://github.com/example/run/124",
+            "headSha": "a" * 40,
+            "event": "workflow_dispatch",
+        }
+        with patch.object(abandon, "list_runs", return_value=[run]):
+            with self.assertRaisesRegex(
+                abandon.AbandonError,
+                "unexpected title.*https://github.com/example/run/124",
+            ):
+                abandon.discover_run(Path("."), {123}, pr_number=582, source_sha="a" * 40)
+
     def test_dispatch_uses_only_discovered_identity_and_audit_inputs(self) -> None:
         identity = {
             "pr_number": 582,
@@ -264,6 +308,8 @@ class TestAbandonStagedRelease(unittest.TestCase):
     def test_recovery_workflow_still_derives_identity_and_uses_promotion_concurrency(self) -> None:
         workflow = Path(".github/workflows/abandon-staged-release.yml").read_text(encoding="utf-8")
         self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn('run-name: "Abandon staged release PR #${{ inputs.pr_number }}"', workflow)
+        self.assertNotIn("astral-sh/setup-uv", workflow)
         self.assertNotIn("gamever:\n        description:", workflow)
         self.assertNotIn("build_id:\n        description:", workflow)
         self.assertIn('gh api "repos/${{ github.repository }}/pulls/$env:PR_NUMBER"', workflow)


### PR DESCRIPTION
## Summary
- quote the abandonment workflow `run-name` so the PR number is not parsed as a YAML comment
- remove `setup-uv` from the Windows self-hosted recovery job, matching existing build and promotion jobs that use the runner-provided `uv`
- reject active legacy-truncated runs and report their candidate Actions URLs after dispatch
- add regression coverage for run naming, duplicate protection, discovery diagnostics, and uv setup

## Root causes
- unquoted `#` truncated the Actions display title to `Abandon staged release PR`, so the client could not discover dispatched runs
- run 29693629091 failed in `astral-sh/setup-uv@v6` with a Node/libuv `UV_HANDLE_CLOSING` assertion before `abandon-pending` executed

## Verification
- `git diff --check`
- tests not run locally per repository instruction; PR CI will run repository validation