### PR TITLE
fix(release): preserve canonical manifest LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 configs/*.yaml -text
 gamesymbols/*.yaml text eol=lf
+release-manifests/*.json text eol=lf


### PR DESCRIPTION
## Summary

- force tracked release manifests to use LF endings on every platform
- prevent Windows `core.autocrlf=true` checkouts from changing canonical manifest bytes

## Validation

- `git check-attr --all -- release-manifests/14171.json`
- verified checkout-filtered bytes exactly match canonical JSON bytes
- verified checkout output contains no CRLF and ends with one LF
- `git diff --check`