### PR TITLE
fix(mcp): wait for inactive IDA worker startup

### DIFF
--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -68,6 +68,7 @@ from ida_skill_preprocessor import (
 from ida_mcp_session import (
     McpConnectionError,
     McpContractError,
+    McpDatabaseNotReadyError,
     McpDatabaseSelectionError,
     McpToolCallError,
     check_ida_mcp_supervisor_health,
@@ -752,9 +753,11 @@ def verify_opened_binary_via_mcp(
     port=DEFAULT_PORT,
     debug=False,
     verify_timeout=OPENED_BINARY_VERIFY_TIMEOUT,
+    worker_ready_timeout=MCP_STARTUP_TIMEOUT,
     retry_interval=OPENED_BINARY_VERIFY_RETRY_INTERVAL,
 ):
-    deadline = time.monotonic() + max(0.0, verify_timeout)
+    worker_ready_deadline = time.monotonic() + max(0.0, worker_ready_timeout)
+    metadata_deadline = None
     while True:
         try:
             survey = asyncio.run(
@@ -765,6 +768,16 @@ def verify_opened_binary_via_mcp(
                     expected_binary=binary_path,
                 )
             )
+        except McpDatabaseNotReadyError as exc:
+            if time.monotonic() >= worker_ready_deadline:
+                print("  Failed: opened binary verification failed")
+                print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
+                print(f"    Reason: timed out waiting for the IDA worker to become active: {exc}")
+                return False
+            if debug:
+                print("  Matching IDA database is still starting; retrying verification...")
+            time.sleep(max(0.0, retry_interval))
+            continue
         except (McpConnectionError, McpContractError, McpDatabaseSelectionError, McpToolCallError) as exc:
             print("  Failed: opened binary verification failed")
             print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
@@ -777,11 +790,15 @@ def verify_opened_binary_via_mcp(
             ["survey_binary returned no metadata"],
             ["path mismatch: opened metadata path is missing"],
         )
-        if not retryable or time.monotonic() >= deadline:
+        if not retryable:
+            break
+        if metadata_deadline is None:
+            metadata_deadline = time.monotonic() + max(0.0, verify_timeout)
+        if time.monotonic() >= metadata_deadline:
             break
         if debug:
             print("  Opened binary metadata is not ready; retrying verification...")
-        time.sleep(retry_interval)
+        time.sleep(max(0.0, retry_interval))
 
     metadata = survey.get("metadata") if isinstance(survey, dict) else {}
     opened_path = metadata.get("path") if isinstance(metadata, dict) else None

--- a/ida_mcp_session.py
+++ b/ida_mcp_session.py
@@ -27,6 +27,10 @@ class McpDatabaseSelectionError(RuntimeError):
     pass
 
 
+class McpDatabaseNotReadyError(McpDatabaseSelectionError):
+    pass
+
+
 class McpConnectionError(RuntimeError):
     pass
 
@@ -102,12 +106,22 @@ def select_database_session(
     ]
     if explicit_database:
         matches = [session for session in routable if session["session_id"] == explicit_database]
-        if len(matches) != 1:
-            raise McpDatabaseSelectionError(
-                f"MCP database {explicit_database!r} is not an active routable session; "
+        if len(matches) == 1:
+            return matches[0]
+        discovered = [
+            session
+            for session in sessions
+            if session.get("session_id") == explicit_database and session.get("is_active") is not True
+        ]
+        if discovered:
+            raise McpDatabaseNotReadyError(
+                f"MCP database {explicit_database!r} exists but is not active yet; "
                 f"candidates: {_session_summary(sessions)}"
             )
-        return matches[0]
+        raise McpDatabaseSelectionError(
+            f"MCP database {explicit_database!r} is not an active routable session; "
+            f"candidates: {_session_summary(sessions)}"
+        )
 
     if expected_binary:
         expected = normalize_binary_identity_path(expected_binary)
@@ -116,6 +130,19 @@ def select_database_session(
         ]
         if len(matches) == 1:
             return matches[0]
+        discovered = [
+            session
+            for session in sessions
+            if isinstance(session.get("session_id"), str)
+            and session["session_id"].strip()
+            and normalize_binary_identity_path(session.get("input_path", "")) == expected
+            and session.get("is_active") is not True
+        ]
+        if not matches and discovered:
+            raise McpDatabaseNotReadyError(
+                f"MCP database for expected binary {expected_binary!r} exists but is not active yet; "
+                f"candidates: {_session_summary(sessions)}"
+            )
         label = "no" if not matches else "multiple"
         raise McpDatabaseSelectionError(
             f"{label} active MCP database matched expected binary {expected_binary!r}; "

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -454,6 +454,64 @@ class TestMcpEntrypointRouting(unittest.IsolatedAsyncioTestCase):
 
 
 class TestOpenedBinaryIdentityValidation(unittest.TestCase):
+    def test_verification_retries_while_matching_database_is_starting(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_path = Path(temp_dir) / "libclient.so"
+            binary_path.write_bytes(b"client-binary")
+            ready_survey = {"metadata": {"path": str(binary_path)}}
+
+            with (
+                patch.object(
+                    ida_analyze_bin,
+                    "survey_binary_via_mcp",
+                    new=AsyncMock(
+                        side_effect=[
+                            ida_analyze_bin.McpDatabaseNotReadyError("matching database is not active yet"),
+                            ready_survey,
+                        ]
+                    ),
+                ) as survey_binary,
+                patch.object(ida_analyze_bin.time, "sleep") as sleep,
+            ):
+                verified = ida_analyze_bin.verify_opened_binary_via_mcp(
+                    str(binary_path),
+                    "linux",
+                    worker_ready_timeout=1.0,
+                    retry_interval=0.01,
+                )
+
+        self.assertTrue(verified)
+        self.assertEqual(2, survey_binary.await_count)
+        sleep.assert_called_once_with(0.01)
+
+    def test_verification_stops_after_worker_ready_timeout(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_path = Path(temp_dir) / "libclient.so"
+            binary_path.write_bytes(b"client-binary")
+
+            with (
+                patch.object(
+                    ida_analyze_bin,
+                    "survey_binary_via_mcp",
+                    new=AsyncMock(
+                        side_effect=ida_analyze_bin.McpDatabaseNotReadyError("matching database is not active yet")
+                    ),
+                ) as survey_binary,
+                patch.object(ida_analyze_bin.time, "sleep") as sleep,
+                patch("sys.stdout", new_callable=io.StringIO) as stdout,
+            ):
+                verified = ida_analyze_bin.verify_opened_binary_via_mcp(
+                    str(binary_path),
+                    "linux",
+                    worker_ready_timeout=0.0,
+                    retry_interval=0.01,
+                )
+
+        self.assertFalse(verified)
+        self.assertEqual(1, survey_binary.await_count)
+        sleep.assert_not_called()
+        self.assertIn("timed out waiting for the IDA worker", stdout.getvalue())
+
     def test_verification_does_not_retry_mcp_tool_error(self) -> None:
         with TemporaryDirectory() as temp_dir:
             binary_path = Path(temp_dir) / "server.dll"

--- a/tests/test_ida_mcp_session.py
+++ b/tests/test_ida_mcp_session.py
@@ -12,6 +12,7 @@ from ida_mcp_session import (
     McpConnectionError,
     McpContractError,
     McpDatabaseBinding,
+    McpDatabaseNotReadyError,
     McpDatabaseSelectionError,
     McpToolCallError,
     detect_database_requirement,
@@ -112,6 +113,15 @@ class TestSelectDatabaseSession(unittest.TestCase):
         )
 
         self.assertEqual("server-db", selected["session_id"])
+
+    def test_matching_inactive_database_is_reported_as_not_ready(self) -> None:
+        inactive_server = {**ACTIVE_SERVER, "is_active": False}
+
+        with self.assertRaisesRegex(McpDatabaseNotReadyError, "not active yet"):
+            select_database_session(
+                [inactive_server],
+                expected_binary=r"D:\repo\tests\bin\ida-mcp-smoke.dll",
+            )
 
     def test_single_active_routable_session_is_selected(self) -> None:
         selected = select_database_session([ACTIVE_SERVER])


### PR DESCRIPTION
## Summary
- distinguish matching inactive IDA databases from permanent routing failures
- retry opened-binary verification while the IDA worker is still starting
- keep worker readiness and binary metadata verification on separate bounded timeouts
- add regression coverage for recovery and timeout behavior

## Validation
- `uv run python -m unittest tests.test_ida_mcp_session tests.test_ida_analyze_bin` (165 tests passed)
- `uv run python -m unittest tests.test_ida_mcp_session.TestSelectDatabaseSession tests.test_ida_analyze_bin.TestOpenedBinaryIdentityValidation` (16 tests passed after formatting)
- `uv run python format_repo_files.py --check`
- `uv run ruff check ida_analyze_bin.py ida_mcp_session.py tests/test_ida_analyze_bin.py tests/test_ida_mcp_session.py`
- `git diff --check`