### PR TITLE
feat(preprocessor): expand game event and command finder coverage

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -3227,6 +3227,30 @@ modules:
       - name: find-CGameEntitySystem_vtable
         expected_output:
           - CGameEntitySystem_vtable.{platform}.yaml
+      - name: find-CGameEventManager_vtable
+        expected_output:
+          - CGameEventManager_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_OnSource1Source1LegacyGameEvent
+        expected_output:
+          - CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml
+      - name: find-CNetworkGameClient_OnSource1Source1LegacyGameEvent-decompiles
+        expected_output:
+          - IGameEventManager2_UnserializeEvent.{platform}.yaml
+          - IGameEventManager2_FireEventClientSide.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml
+      - name: find-CGameEventManager_FireEventClientSide
+        expected_output:
+          - CGameEventManager_FireEventClientSide.{platform}.yaml
+        expected_input:
+          - CGameEventManager_vtable.{platform}.yaml
+          - IGameEventManager2_FireEventClientSide.{platform}.yaml
+      - name: find-CGameEventManager_UnserializeEvent
+        expected_output:
+          - CGameEventManager_UnserializeEvent.{platform}.yaml
+        expected_input:
+          - CGameEventManager_vtable.{platform}.yaml
+          - IGameEventManager2_UnserializeEvent.{platform}.yaml
       - name: find-CSteamworksGameStats_OnReceivedSessionID
         expected_output:
           - CSteamworksGameStats_OnReceivedSessionID.{platform}.yaml
@@ -3811,6 +3835,28 @@ modules:
           - IGameSystem::OnClientPreEntityThink
       - name: CGameEntitySystem_vtable
         category: vtable
+      - name: CGameEventManager_vtable
+        category: vtable
+      - name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+        category: func
+        alias:
+          - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+      - name: IGameEventManager2_UnserializeEvent
+        category: vfunc
+        alias:
+          - IGameEventManager2::UnserializeEvent
+      - name: IGameEventManager2_FireEventClientSide
+        category: vfunc
+        alias:
+          - IGameEventManager2::FireEventClientSide
+      - name: CGameEventManager_FireEventClientSide
+        category: vfunc
+        alias:
+          - CGameEventManager::FireEventClientSide
+      - name: CGameEventManager_UnserializeEvent
+        category: vfunc
+        alias:
+          - CGameEventManager::UnserializeEvent
       - name: CSteamworksGameStats_OnReceivedSessionID
         category: func
         alias:

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -727,6 +727,9 @@ modules:
           - CNetworkGameServerBase_BroadcastPrintf.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_WriteDeltaEntities
+        expected_output:
+          - CNetworkGameServerBase_WriteDeltaEntities.{platform}.yaml
       - name: find-CNetworkGameServerBase_ReserveServerForQueuedGame
         expected_output:
           - CNetworkGameServerBase_ReserveServerForQueuedGame.{platform}.yaml
@@ -781,6 +784,9 @@ modules:
       - name: find-CDemoRecorder_WriteSpawnGroups
         expected_output:
           - CDemoRecorder_WriteSpawnGroups.{platform}.yaml
+      - name: find-CHLTVDemoRecorder_WriteFrameImmediate
+        expected_output:
+          - CHLTVDemoRecorder_WriteFrameImmediate.{platform}.yaml
       - name: find-INetworkMessages_FindNetworkMessageById
         expected_output:
           - INetworkMessages_FindNetworkMessageById.{platform}.yaml
@@ -1607,6 +1613,9 @@ modules:
           - CHLTVClient_ProcessSetConVar.{platform}.yaml
         expected_input:
           - CHLTVClient_vtable.{platform}.yaml
+      - name: find-CHLTVBroadcast_RecordSnapshot
+        expected_output:
+          - CHLTVBroadcast_RecordSnapshot.{platform}.yaml
       - name: find-CServerSideClientBase_vtable
         expected_output:
           - CServerSideClientBase_vtable.{platform}.yaml
@@ -1826,6 +1835,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::BroadcastPrintf
+      - name: CNetworkGameServerBase_WriteDeltaEntities
+        category: func
+        alias:
+          - CNetworkGameServerBase::WriteDeltaEntities
       - name: CNetworkGameServerBase_ReserveServerForQueuedGame
         category: vfunc
         alias:
@@ -1976,6 +1989,10 @@ modules:
         category: func
         alias:
           - CDemoRecorder::WriteSpawnGroups
+      - name: CHLTVDemoRecorder_WriteFrameImmediate
+        category: func
+        alias:
+          - CHLTVDemoRecorder::WriteFrameImmediate
       - name: INetworkMessages_SerializeAbstract
         category: vfunc
         alias:
@@ -2585,6 +2602,10 @@ modules:
         category: vfunc
         alias:
           - CHLTVClient::ProcessSetConVar
+      - name: CHLTVBroadcast_RecordSnapshot
+        category: func
+        alias:
+          - CHLTVBroadcast::RecordSnapshot
       - name: CServerSideClientBase_vtable
         category: vtable
       - name: CDelayedCall2_CServerSideClientBase_UpdateAcknowledgedFramecountCall_vtable

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -2281,6 +2281,14 @@ modules:
         category: vfunc
         alias:
           - CEngineClient::DumpNetStats
+      - name: CEngineClient_SendStringCmd
+        category: vfunc
+        alias:
+          - CEngineClient::SendStringCmd
+      - name: INetworkGameClient_SendStringCmd
+        category: vfunc
+        alias:
+          - INetworkGameClient::SendStringCmd
       - name: CEngineServer_vtable
         category: vtable
       - name: CMapListService_vtable
@@ -3239,6 +3247,14 @@ modules:
           - IGameEventManager2_FireEventClientSide.{platform}.yaml
         expected_input:
           - CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml
+      - name: find-CMapAnNodeManager_FireGameEvent
+        expected_output:
+          - CMapAnNodeManager_FireGameEvent.{platform}.yaml
+      - name: find-IVEngineClient2_SendStringCmd
+        expected_output:
+          - IVEngineClient2_SendStringCmd.{platform}.yaml
+        expected_input:
+          - CMapAnNodeManager_FireGameEvent.{platform}.yaml
       - name: find-CGameEventManager_FireEventClientSide
         expected_output:
           - CGameEventManager_FireEventClientSide.{platform}.yaml
@@ -3841,6 +3857,14 @@ modules:
         category: func
         alias:
           - CNetworkGameClient::OnSource1Source1LegacyGameEvent
+      - name: CMapAnNodeManager_FireGameEvent
+        category: func
+        alias:
+          - CMapAnNodeManager::FireGameEvent
+      - name: IVEngineClient2_SendStringCmd
+        category: vfunc
+        alias:
+          - IVEngineClient2::SendStringCmd
       - name: IGameEventManager2_UnserializeEvent
         category: vfunc
         alias:
@@ -10060,6 +10084,17 @@ modules:
     path_windows: game/bin/win64/engine2.dll
     path_linux: game/bin/linuxsteamrt64/libengine2.so
     skills:
+      - name: find-CEngineClient_SendStringCmd
+        expected_output:
+          - CEngineClient_SendStringCmd.{platform}.yaml
+        expected_input:
+          - CEngineClient_vtable.{platform}.yaml
+          - ../client/IVEngineClient2_SendStringCmd.{platform}.yaml
+      - name: find-INetworkGameClient_SendStringCmd
+        expected_output:
+          - INetworkGameClient_SendStringCmd.{platform}.yaml
+        expected_input:
+          - CEngineClient_SendStringCmd.{platform}.yaml
       - name: find-CNetworkClientService_SendNetMessage
         platform: windows
         expected_output:

--- a/gamedata/14172/plugify-plugin-s2sdk/assets/gamedata.jsonc
+++ b/gamedata/14172/plugify-plugin-s2sdk/assets/gamedata.jsonc
@@ -11,7 +11,7 @@
       "CSScript::ResolveModule": {
         "library": "server",
         "win64": "48 89 5C 24 ? 48 89 54 24 ? 48 89 4C 24 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ? ? ? ? 48 81 EC ? ? ? ? 49 8B F8",
-        "linuxsteamrt64": "55 48 89 E5 41 57 49 89 F7 41 56 41 55 41 54 53 48 89 FB 48 81 EC ? ? ? ? 48 89 B5 ? ? ? ? E8 ? ? ? ? 48 89 C7",
+        "linuxsteamrt64": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 41 54 53 48 89 FB 48 81 EC ? ? ? ? E8 ? ? ? ? 48 89 C7",
         "refs": [
           {
             "string": "Unexpected module request."

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,6 +1,7 @@
+analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:60925b04877f37c301970e51a467a925a6af63016da7edb431c3bf42005e3e8a
-file_count: 2910
+config_sha256: sha256:2fda95fe6895d00da95826244ec17aecd6dc34182008d272f1cd0b9b555dc2d7
+file_count: 2916
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -5776,6 +5777,18 @@ files:
     vtable_size: '0x160'
     vtable_symbol: ??_7CGameResourceService@@6B@
     vtable_va: '0x18056f120'
+  engine/CHLTVBroadcast_RecordSnapshot.linux.yaml:
+    func_name: CHLTVBroadcast_RecordSnapshot
+    func_rva: '0x5ad550'
+    func_sig: 55 66 41 0F 6E C0 48 89 E5 41 57 41 56
+    func_size: '0x490'
+    func_va: '0x5ad550'
+  engine/CHLTVBroadcast_RecordSnapshot.windows.yaml:
+    func_name: CHLTVBroadcast_RecordSnapshot
+    func_rva: '0x11e040'
+    func_sig: 48 8B C4 48 89 58 ?? 48 89 70 ?? 48 89 78 ?? 55 41 54 41 55 41 56 41 57 48 8D 68 ?? 48 81 EC ?? ?? ?? ?? 4D 8B E0
+    func_size: '0x467'
+    func_va: '0x18011e040'
   engine/CHLTVClient_ProcessSetConVar.linux.yaml:
     func_name: CHLTVClient_ProcessSetConVar
     func_rva: '0x59d180'
@@ -5970,6 +5983,18 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CHLTVClient@@6B@
     vtable_va: '0x180551f00'
+  engine/CHLTVDemoRecorder_WriteFrameImmediate.linux.yaml:
+    func_name: CHLTVDemoRecorder_WriteFrameImmediate
+    func_rva: '0x5a62c0'
+    func_sig: 55 48 8D 05 ?? ?? ?? ?? 48 89 E5 41 57 49 89 FF 41 56 41 55 49 89 D5
+    func_size: '0xa9b'
+    func_va: '0x5a62c0'
+  engine/CHLTVDemoRecorder_WriteFrameImmediate.windows.yaml:
+    func_name: CHLTVDemoRecorder_WriteFrameImmediate
+    func_rva: '0x129190'
+    func_sig: 48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??
+    func_size: '0xa87'
+    func_va: '0x180129190'
   engine/CL_NET_PrintSummary_CommandHandler.linux.yaml:
     func_name: CL_NET_PrintSummary_CommandHandler
     func_rva: '0x4e4e00'
@@ -8685,6 +8710,18 @@ files:
     vfunc_index: 75
     vfunc_offset: '0x258'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_WriteDeltaEntities.linux.yaml:
+    func_name: CNetworkGameServerBase_WriteDeltaEntities
+    func_rva: '0x541d80'
+    func_sig: 55 48 8D 05 ?? ?? ?? ?? 48 89 E5 41 57 4C 8D BD ?? ?? ?? ??
+    func_size: '0x1de5'
+    func_va: '0x541d80'
+  engine/CNetworkGameServerBase_WriteDeltaEntities.windows.yaml:
+    func_name: CNetworkGameServerBase_WriteDeltaEntities
+    func_rva: '0xd21d0'
+    func_sig: 4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 4C 8B AD ?? ?? ?? ??
+    func_size: '0x1144'
+    func_va: '0x1800d21d0'
   engine/CNetworkGameServerBase_vtable.linux.yaml:
     vtable_class: CNetworkGameServerBase
     vtable_entries:
@@ -37661,4 +37698,4 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-schema_version: 2
+schema_version: 3

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:2fda95fe6895d00da95826244ec17aecd6dc34182008d272f1cd0b9b555dc2d7
-file_count: 2916
+config_sha256: sha256:65770d7269daaf65d71ce363faab46534b2383068ec1fb35aa01205013d43f57
+file_count: 2928
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -386,6 +386,91 @@ files:
     vtable_size: '0xc0'
     vtable_symbol: ??_7CGameEntitySystem@@6B@
     vtable_va: '0x181acece8'
+  client/CGameEventManager_FireEventClientSide.linux.yaml:
+    func_name: CGameEventManager_FireEventClientSide
+    func_rva: '0x169cbf0'
+    func_sig: B9 01 00 00 00 31 D2 E9 B4 FA ?? ??
+    func_size: '0xc'
+    func_va: '0x169cbf0'
+    vfunc_index: 9
+    vfunc_offset: '0x48'
+    vtable_name: CGameEventManager
+  client/CGameEventManager_FireEventClientSide.windows.yaml:
+    func_name: CGameEventManager_FireEventClientSide
+    func_rva: '0x996a80'
+    func_sig: 40 53 41 54 41 56 48 83 EC ?? 4C 8B F2
+    func_size: '0x259'
+    func_va: '0x180996a80'
+    vfunc_index: 8
+    vfunc_offset: '0x40'
+    vtable_name: CGameEventManager
+  client/CGameEventManager_UnserializeEvent.linux.yaml:
+    func_name: CGameEventManager_UnserializeEvent
+    func_rva: '0x1699730'
+    func_sig: 55 48 8D 87 ?? ?? ?? ?? 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4
+    func_size: '0x62b'
+    func_va: '0x1699730'
+    vfunc_index: 13
+    vfunc_offset: '0x68'
+    vtable_name: CGameEventManager
+  client/CGameEventManager_UnserializeEvent.windows.yaml:
+    func_name: CGameEventManager_UnserializeEvent
+    func_rva: '0x9d12f0'
+    func_sig: 48 8B C4 48 89 50 ?? 55 41 54 41 55 41 56
+    func_size: '0x6e4'
+    func_va: '0x1809d12f0'
+    vfunc_index: 12
+    vfunc_offset: '0x60'
+    vtable_name: CGameEventManager
+  client/CGameEventManager_vtable.linux.yaml:
+    vtable_class: CGameEventManager
+    vtable_entries:
+      0: '0x16c4800'
+      1: '0x16c4cb0'
+      10: '0x1699610'
+      11: '0x1683970'
+      12: '0x168a820'
+      13: '0x1699730'
+      14: '0x16cce20'
+      15: '0x16871a0'
+      16: '0x16ccda0'
+      2: '0x16ea6c0'
+      3: '0x16c3fe0'
+      4: '0x16ccf90'
+      5: '0x16cd120'
+      6: '0x1686600'
+      7: '0x16cc3a0'
+      8: '0x169cb30'
+      9: '0x169cbf0'
+    vtable_numvfunc: 17
+    vtable_rva: '0x43aa8d8'
+    vtable_size: '0x88'
+    vtable_symbol: _ZTV17CGameEventManager + 0x10
+    vtable_va: '0x43aa8d8'
+  client/CGameEventManager_vtable.windows.yaml:
+    vtable_class: CGameEventManager
+    vtable_entries:
+      0: '0x18097c0f0'
+      1: '0x1809a9770'
+      10: '0x1809970d0'
+      11: '0x1809c20f0'
+      12: '0x1809d12f0'
+      13: '0x1809aa880'
+      14: '0x1809af1b0'
+      15: '0x1809825e0'
+      2: '0x1809b7f10'
+      3: '0x18097e080'
+      4: '0x180995cc0'
+      5: '0x1809b4c00'
+      6: '0x180988530'
+      7: '0x1809967a0'
+      8: '0x180996a80'
+      9: '0x18098cb20'
+    vtable_numvfunc: 16
+    vtable_rva: '0x1ad1c58'
+    vtable_size: '0x80'
+    vtable_symbol: ??_7CGameEventManager@@6B@
+    vtable_va: '0x181ad1c58'
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675980'
@@ -982,6 +1067,18 @@ files:
     offset_sig_disp: 0
     size: 4
     struct_name: CModelState
+  client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.linux.yaml:
+    func_name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    func_rva: '0x16da1a0'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 49 89 FC 53 48 8D 3D ?? ?? ?? ?? 48 89 F3 BE ?? ?? ?? ?? 48 83 EC ?? E8 ?? ?? ?? ?? 48 85 C0 74 ?? 0F B6 00 84 C0 74 ??
+    func_size: '0x2c4'
+    func_va: '0x16da1a0'
+  client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.windows.yaml:
+    func_name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+    func_rva: '0x9ac4d0'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 48 8B FA 48 8B D9 BA ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 85 C0 75 ?? 48 8B 05 ?? ?? ?? ?? 48 8B 40 ?? 48 89 74 24 ??
+    func_size: '0x17b'
+    func_va: '0x1809ac4d0'
   client/CNetworkSerializerBindingBuildFilter_GetFieldPriority.linux.yaml:
     func_name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
     func_rva: '0x2df8170'
@@ -2148,6 +2245,33 @@ files:
     vfunc_offset: '0xe8'
     vfunc_sig: FF 90 E8 00 00 00 48 8B D8 E8 ?? ?? ?? ?? 48 8B 15 ?? ?? ?? ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 4C 8B 44 24 ?? 48 8D 05 ?? ?? ?? ?? 48 89 44 24 ??
     vtable_name: IEngineServiceMgr
+  client/IGameEventManager2_FireEventClientSide.linux.yaml:
+    func_name: IGameEventManager2_FireEventClientSide
+    vfunc_index: 9
+    vfunc_offset: '0x48'
+    vfunc_sig: 48 8B 40 48 48 39 D0 0F 85 ?? ?? ?? ?? 48 83 C4 ??
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: IGameEventManager2
+  client/IGameEventManager2_FireEventClientSide.windows.yaml:
+    func_name: IGameEventManager2_FireEventClientSide
+    vfunc_index: 8
+    vfunc_offset: '0x40'
+    vfunc_sig: 48 FF 60 40 CC CC CC CC CC 48 8B C4
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: IGameEventManager2
+  client/IGameEventManager2_UnserializeEvent.linux.yaml:
+    func_name: IGameEventManager2_UnserializeEvent
+    vfunc_index: 13
+    vfunc_offset: '0x68'
+    vfunc_sig: FF 50 68 49 89 C4 48 85 C0 0F 84 ?? ?? ?? ?? 83 7B ?? ??
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: IGameEventManager2
+  client/IGameEventManager2_UnserializeEvent.windows.yaml:
+    func_name: IGameEventManager2_UnserializeEvent
+    vfunc_index: 12
+    vfunc_offset: '0x60'
+    vfunc_sig: FF 50 60 48 8B F0 48 85 C0
+    vtable_name: IGameEventManager2
   client/IGameSystemFactory_CreateGameSystem.linux.yaml:
     func_name: IGameSystemFactory_CreateGameSystem
     vfunc_index: 3

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:65770d7269daaf65d71ce363faab46534b2383068ec1fb35aa01205013d43f57
-file_count: 2928
+config_sha256: sha256:85769f526a034c1471cff91bfd0ff2eb260e3def2bc0a599978977556b5631ed
+file_count: 2936
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -1040,6 +1040,18 @@ files:
     vtable_size: '0x48'
     vtable_symbol: ??_7CLoopModeGame@@6B@
     vtable_va: '0x181ad5460'
+  client/CMapAnNodeManager_FireGameEvent.linux.yaml:
+    func_name: CMapAnNodeManager_FireGameEvent
+    func_rva: '0x1a28420'
+    func_sig: 55 48 89 E5 41 56 41 55 41 54 53 48 83 C4 ??
+    func_size: '0x2d0'
+    func_va: '0x1a28420'
+  client/CMapAnNodeManager_FireGameEvent.windows.yaml:
+    func_name: CMapAnNodeManager_FireGameEvent
+    func_rva: '0xbd1dd0'
+    func_sig: 48 8B C4 48 89 70 ?? 57 48 81 EC ?? ?? ?? ?? 48 83 3D ?? ?? ?? ?? ??
+    func_size: '0x370'
+    func_va: '0x180bd1dd0'
   client/CModelState_SetupJointState.windows.yaml:
     func_name: CModelState_SetupJointState
     func_rva: '0xa59cc0'
@@ -3051,6 +3063,18 @@ files:
     vfunc_index: 41
     vfunc_offset: '0x148'
     vtable_name: IVEngineClient2
+  client/IVEngineClient2_SendStringCmd.linux.yaml:
+    func_name: IVEngineClient2_SendStringCmd
+    vfunc_index: 50
+    vfunc_offset: '0x190'
+    vfunc_sig: FF 90 90 01 00 00 48 83 EC ??
+    vtable_name: IVEngineClient2
+  client/IVEngineClient2_SendStringCmd.windows.yaml:
+    func_name: IVEngineClient2_SendStringCmd
+    vfunc_index: 50
+    vfunc_offset: '0x190'
+    vfunc_sig: FF 90 90 01 00 00 48 8B 9C 24 ?? ?? ?? ?? 48 8B AC 24 ?? ?? ?? ??
+    vtable_name: IVEngineClient2
   client/RegisterEventListener_Abstract.linux.yaml:
     func_name: RegisterEventListener_Abstract
     func_rva: '0x1664b60'
@@ -4179,6 +4203,24 @@ files:
     vfunc_index: 184
     vfunc_offset: '0x5c0'
     vtable_name: CEngineClient_vtable
+  engine/CEngineClient_SendStringCmd.linux.yaml:
+    func_name: CEngineClient_SendStringCmd
+    func_rva: '0x4e5230'
+    func_sig: 48 8D 05 F1 2A 4F ??
+    func_size: '0x13'
+    func_va: '0x4e5230'
+    vfunc_index: 101
+    vfunc_offset: '0x328'
+    vtable_name: CEngineClient
+  engine/CEngineClient_SendStringCmd.windows.yaml:
+    func_name: CEngineClient_SendStringCmd
+    func_rva: '0x75420'
+    func_sig: 48 8B 0D ?? ?? ?? ?? 48 85 C9 74 ?? 48 8B 01 83 FA ??
+    func_size: '0x24'
+    func_va: '0x180075420'
+    vfunc_index: 50
+    vfunc_offset: '0x190'
+    vtable_name: CEngineClient
   engine/CEngineClient_vtable.linux.yaml:
     vtable_class: CEngineClient
     vtable_entries:
@@ -10652,6 +10694,16 @@ files:
     vfunc_offset: '0x100'
     vfunc_sig: FF 90 00 01 00 00 84 C0 0F 84 ?? ?? ?? ?? 48 8B 1D ?? ?? ?? ??
     vtable_name: INetworkClientService
+  engine/INetworkGameClient_SendStringCmd.linux.yaml:
+    func_name: INetworkGameClient_SendStringCmd
+    vfunc_index: 38
+    vfunc_offset: '0x130'
+    vtable_name: INetworkGameClient
+  engine/INetworkGameClient_SendStringCmd.windows.yaml:
+    func_name: INetworkGameClient_SendStringCmd
+    vfunc_index: 38
+    vfunc_offset: '0x130'
+    vtable_name: INetworkGameClient
   engine/INetworkGameServer_GetMaxClients.linux.yaml:
     func_name: INetworkGameServer_GetMaxClients
     vfunc_index: 12

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -68,8 +68,8 @@ from ida_skill_preprocessor import (
 from ida_mcp_session import (
     McpConnectionError,
     McpContractError,
-    McpDatabaseNotReadyError,
     McpDatabaseSelectionError,
+    McpDatabaseUnavailableError,
     McpToolCallError,
     check_ida_mcp_supervisor_health,
     normalize_binary_identity_path,
@@ -119,12 +119,26 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 13337
 POST_PROCESS_FUNC_RENAME_BATCH_SIZE = 50
 MCP_STARTUP_TIMEOUT = 1200  # seconds to wait for MCP server
+MCP_SHUTDOWN_TIMEOUT = 10.0
 QEXIT_CONNECTION_RESET_MARKER = "[WinError 10054]"
 OPENED_BINARY_VERIFY_TIMEOUT = 60.0
 OPENED_BINARY_VERIFY_RETRY_INTERVAL = 2.0
 _ARTIFACT_SYMBOL_CATEGORY_CACHE = {}
 _BINARY_HASH_CACHE = {}
 _PE_STYLE_BASE_ADDRESS = 0x180000000
+
+
+class McpRecoveryBudget:
+    """Limit lifecycle-owner MCP restarts for one binary processing run."""
+
+    def __init__(self, restart_limit=1):
+        self.remaining_restarts = max(0, int(restart_limit))
+
+    def consume_restart(self):
+        if self.remaining_restarts <= 0:
+            return False
+        self.remaining_restarts -= 1
+        return True
 
 
 class AnalysisReporting:
@@ -753,11 +767,9 @@ def verify_opened_binary_via_mcp(
     port=DEFAULT_PORT,
     debug=False,
     verify_timeout=OPENED_BINARY_VERIFY_TIMEOUT,
-    worker_ready_timeout=MCP_STARTUP_TIMEOUT,
     retry_interval=OPENED_BINARY_VERIFY_RETRY_INTERVAL,
 ):
-    worker_ready_deadline = time.monotonic() + max(0.0, worker_ready_timeout)
-    metadata_deadline = None
+    deadline = time.monotonic() + max(0.0, verify_timeout)
     while True:
         try:
             survey = asyncio.run(
@@ -768,16 +780,8 @@ def verify_opened_binary_via_mcp(
                     expected_binary=binary_path,
                 )
             )
-        except McpDatabaseNotReadyError as exc:
-            if time.monotonic() >= worker_ready_deadline:
-                print("  Failed: opened binary verification failed")
-                print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
-                print(f"    Reason: timed out waiting for the IDA worker to become active: {exc}")
-                return False
-            if debug:
-                print("  Matching IDA database is still starting; retrying verification...")
-            time.sleep(max(0.0, retry_interval))
-            continue
+        except McpDatabaseUnavailableError:
+            raise
         except (McpConnectionError, McpContractError, McpDatabaseSelectionError, McpToolCallError) as exc:
             print("  Failed: opened binary verification failed")
             print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
@@ -790,11 +794,7 @@ def verify_opened_binary_via_mcp(
             ["survey_binary returned no metadata"],
             ["path mismatch: opened metadata path is missing"],
         )
-        if not retryable:
-            break
-        if metadata_deadline is None:
-            metadata_deadline = time.monotonic() + max(0.0, verify_timeout)
-        if time.monotonic() >= metadata_deadline:
+        if not retryable or time.monotonic() >= deadline:
             break
         if debug:
             print("  Opened binary metadata is not ready; retrying verification...")
@@ -972,7 +972,15 @@ async def preprocess_single_vcall_object_via_mcp(
         )
 
 
-def ensure_mcp_available(process, binary_path, host, port, ida_args, debug):
+def ensure_mcp_available(
+    process,
+    binary_path,
+    host,
+    port,
+    ida_args,
+    debug,
+    recovery_budget=None,
+):
     """
     Ensure idalib-mcp is running and responsive. Restart if necessary.
 
@@ -991,6 +999,8 @@ def ensure_mcp_available(process, binary_path, host, port, ida_args, debug):
         Tuple of (new_process, ok) where new_process may be the same object
         if no restart was needed, and ok indicates whether MCP is available.
     """
+    restart_authorized = False
+
     # Step 1: check if the process has already exited
     if process is not None and process.poll() is not None:
         if debug:
@@ -1002,16 +1012,78 @@ def ensure_mcp_available(process, binary_path, host, port, ida_args, debug):
         healthy = asyncio.run(check_mcp_worker_health(host, port, binary_path))
         if healthy:
             return process, True
-        print("  MCP health check failed, restarting idalib-mcp...")
+        print("  MCP health check failed")
+        if recovery_budget is not None:
+            restart_authorized = recovery_budget.consume_restart()
+            if not restart_authorized:
+                print("  MCP recovery restart already used; not restarting idalib-mcp again")
+                return process, False
         quit_ida_gracefully(process, host, port, expected_binary=binary_path, debug=debug)
         process = None
 
     # Step 3: restart idalib-mcp
+    if recovery_budget is not None and not restart_authorized:
+        if not recovery_budget.consume_restart():
+            print("  MCP recovery restart already used; not restarting idalib-mcp again")
+            return process, False
+    if is_port_in_use(host, port):
+        if debug:
+            print(f"  Waiting for MCP port {host}:{port} to be released before restart...")
+        if not wait_for_port_release(host, port):
+            print(f"  Failed: MCP port {host}:{port} remained in use; recovery restart aborted")
+            return None, False
     print("  Restarting idalib-mcp...")
     new_process = start_idalib_mcp(binary_path, host, port, ida_args, debug)
     if new_process is None:
         return None, False
     return new_process, True
+
+
+def verify_owned_mcp_with_single_recovery(
+    process,
+    binary_path,
+    platform,
+    host,
+    port,
+    ida_args,
+    debug,
+    recovery_budget=None,
+):
+    """Verify the opened binary and recover an unavailable owned worker once."""
+    try:
+        return process, verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug)
+    except McpDatabaseUnavailableError as exc:
+        print("  Opened binary verification found an unavailable MCP worker; checking recovery...")
+        print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
+        print(f"    Reason: {exc}")
+
+    original_process = process
+    process, mcp_ok = ensure_mcp_available(
+        process,
+        binary_path,
+        host,
+        port,
+        ida_args,
+        debug,
+        recovery_budget=recovery_budget,
+    )
+    if not mcp_ok:
+        print("  Failed: unable to recover the unavailable MCP worker")
+        return process, False
+
+    if process is original_process and debug:
+        print("  MCP worker recovered without a restart; re-verifying opened binary...")
+    elif process is not original_process:
+        print("  Re-verifying opened binary after the single MCP recovery restart...")
+
+    try:
+        verified = verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug)
+    except McpDatabaseUnavailableError as exc:
+        print("  Failed: MCP worker remained unavailable after recovery")
+        print(f"    Expected: {_absolute_path_preserve_spelling(binary_path)}")
+        print(f"    Reason: {exc}")
+        verified = False
+    return process, verified
 
 
 async def quit_ida_via_mcp(host, port, *, expected_binary, auto_started):
@@ -1059,6 +1131,14 @@ async def quit_ida_gracefully_async(process, host, port, *, expected_binary, deb
         pass
 
     await asyncio.to_thread(stop_idalib_mcp_process, process, debug=debug)
+    released = await asyncio.to_thread(
+        wait_for_port_release,
+        host,
+        port,
+        MCP_SHUTDOWN_TIMEOUT,
+    )
+    if debug and not released:
+        print(f"  MCP port {host}:{port} remained in use after shutdown")
 
 
 def quit_ida_gracefully(process, host, port, *, expected_binary, debug=False):
@@ -2713,6 +2793,16 @@ def is_port_in_use(host, port):
         return False
 
 
+def wait_for_port_release(host, port, timeout=MCP_SHUTDOWN_TIMEOUT, retry_interval=0.1):
+    """Wait for a stopped local supervisor to release its listening port."""
+    deadline = time.monotonic() + max(0.0, timeout)
+    while is_port_in_use(host, port):
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(max(0.0, retry_interval))
+    return True
+
+
 def start_idalib_mcp(
     binary_path,
     host=DEFAULT_HOST,
@@ -3060,8 +3150,19 @@ def process_binary(
     if reporting is not None and job_id is not None:
         reporting.emit_task_status(job_id, TaskStatus.RUNNING, ProcessPhase.VALIDATING_BINARY)
     force_local_process_stop = False
+    recovery_budget = McpRecoveryBudget()
     try:
-        if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+        process, verified = verify_owned_mcp_with_single_recovery(
+            process,
+            binary_path,
+            platform,
+            host,
+            port,
+            ida_args,
+            debug,
+            recovery_budget=recovery_budget,
+        )
+        if not verified:
             pending_count = _pending_binary_work_count(
                 skills_to_process=skills_to_process,
                 vcall_targets=vcall_targets,
@@ -3140,11 +3241,24 @@ def process_binary(
             _report_skill_status(reporting, job_id, skill_name, TaskStatus.RUNNING, ProcessPhase.WAITING_FOR_MCP)
 
             # Ensure MCP connection is alive before running the skill
-            process, mcp_ok = ensure_mcp_available(process, binary_path, host, port, ida_args, debug)
+            process, mcp_ok = ensure_mcp_available(
+                process,
+                binary_path,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
             if not mcp_ok:
-                remaining = len(skills_to_process) - skill_index
+                remaining = _pending_binary_work_count(
+                    skills_to_process=skills_to_process,
+                    skill_index=skill_index,
+                    vcall_targets=vcall_targets,
+                    post_process_yaml_items=startup_post_process_yaml_items,
+                )
                 fail_count += remaining
-                print(f"  Failed to restore MCP connection, aborting remaining {remaining} skill(s)")
+                print(f"  Failed to restore MCP connection, aborting remaining {remaining} work item(s)")
                 _abort_binary_reporting(
                     reporting,
                     job_id,
@@ -3153,7 +3267,17 @@ def process_binary(
                 )
                 abort_binary_processing = True
                 break
-            if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+            process, verified = verify_owned_mcp_with_single_recovery(
+                process,
+                binary_path,
+                platform,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
+            if not verified:
                 remaining = _pending_binary_work_count(
                     skills_to_process=skills_to_process,
                     skill_index=skill_index,
@@ -3301,7 +3425,17 @@ def process_binary(
                     payload={"invalid_optional_inputs": invalid_optional_inputs},
                 )
                 continue
-            if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+            process, verified = verify_owned_mcp_with_single_recovery(
+                process,
+                binary_path,
+                platform,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
+            if not verified:
                 remaining = _pending_binary_work_count(
                     skills_to_process=skills_to_process,
                     skill_index=skill_index,
@@ -3465,7 +3599,17 @@ def process_binary(
                 )
                 continue
 
-            if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+            process, verified = verify_owned_mcp_with_single_recovery(
+                process,
+                binary_path,
+                platform,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
+            if not verified:
                 remaining = _pending_binary_work_count(
                     skills_to_process=skills_to_process,
                     skill_index=skill_index,
@@ -3544,7 +3688,15 @@ def process_binary(
                 TaskStatus.RUNNING,
                 ProcessPhase.WAITING_FOR_MCP,
             )
-            process, mcp_ok = ensure_mcp_available(process, binary_path, host, port, ida_args, debug)
+            process, mcp_ok = ensure_mcp_available(
+                process,
+                binary_path,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
             if not mcp_ok:
                 remaining = len(vcall_targets) - object_index
                 fail_count += remaining
@@ -3557,7 +3709,17 @@ def process_binary(
                     "MCP connection could not be restored",
                 )
                 break
-            if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+            process, verified = verify_owned_mcp_with_single_recovery(
+                process,
+                binary_path,
+                platform,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
+            if not verified:
                 remaining = _pending_binary_work_count(
                     vcall_targets=vcall_targets,
                     vcall_index=object_index,
@@ -3702,7 +3864,15 @@ def process_binary(
                 TaskStatus.RUNNING,
                 ProcessPhase.POSTPROCESSING,
             )
-            process, mcp_ok = ensure_mcp_available(process, binary_path, host, port, ida_args, debug)
+            process, mcp_ok = ensure_mcp_available(
+                process,
+                binary_path,
+                host,
+                port,
+                ida_args,
+                debug,
+                recovery_budget=recovery_budget,
+            )
             if not mcp_ok:
                 fail_count += 1
                 print("  Failed to restore MCP connection, skipping post_process")
@@ -3714,7 +3884,17 @@ def process_binary(
                     reason=ProcessReason.MCP_UNAVAILABLE,
                 )
             else:
-                if not verify_opened_binary_via_mcp(binary_path, platform, host, port, debug=debug):
+                process, verified = verify_owned_mcp_with_single_recovery(
+                    process,
+                    binary_path,
+                    platform,
+                    host,
+                    port,
+                    ida_args,
+                    debug,
+                    recovery_budget=recovery_budget,
+                )
+                if not verified:
                     fail_count += 1
                     force_local_process_stop = True
                     print("  Aborting current binary after opened binary verification failure (1 pending work item(s))")
@@ -3769,6 +3949,9 @@ def process_binary(
         if force_local_process_stop:
             print("  Stopping current idalib-mcp after opened binary verification failure")
             stop_idalib_mcp_process(process, debug=debug)
+            released = wait_for_port_release(host, port)
+            if debug and not released:
+                print(f"  MCP port {host}:{port} remained in use after shutdown")
         else:
             quit_ida_gracefully(process, host, port, expected_binary=binary_path, debug=debug)
 

--- a/ida_mcp_session.py
+++ b/ida_mcp_session.py
@@ -27,7 +27,7 @@ class McpDatabaseSelectionError(RuntimeError):
     pass
 
 
-class McpDatabaseNotReadyError(McpDatabaseSelectionError):
+class McpDatabaseUnavailableError(McpDatabaseSelectionError):
     pass
 
 
@@ -80,12 +80,14 @@ def detect_database_requirement(tools: Sequence[Any]) -> bool:
 def _session_summary(sessions: Sequence[Mapping[str, Any]]) -> str:
     return "; ".join(
         "session_id={session_id!r}, input_path={input_path!r}, backend={backend!r}, "
-        "owned={owned!r}, is_active={is_active!r}".format(
+        "owned={owned!r}, is_active={is_active!r}, pid={pid!r}, worker_pid={worker_pid!r}".format(
             session_id=session.get("session_id"),
             input_path=session.get("input_path"),
             backend=session.get("backend"),
             owned=session.get("owned"),
             is_active=session.get("is_active"),
+            pid=session.get("pid"),
+            worker_pid=session.get("worker_pid"),
         )
         for session in sessions
     )
@@ -114,8 +116,8 @@ def select_database_session(
             if session.get("session_id") == explicit_database and session.get("is_active") is not True
         ]
         if discovered:
-            raise McpDatabaseNotReadyError(
-                f"MCP database {explicit_database!r} exists but is not active yet; "
+            raise McpDatabaseUnavailableError(
+                f"MCP database {explicit_database!r} exists but is inactive or unreachable; "
                 f"candidates: {_session_summary(sessions)}"
             )
         raise McpDatabaseSelectionError(
@@ -139,8 +141,8 @@ def select_database_session(
             and session.get("is_active") is not True
         ]
         if not matches and discovered:
-            raise McpDatabaseNotReadyError(
-                f"MCP database for expected binary {expected_binary!r} exists but is not active yet; "
+            raise McpDatabaseUnavailableError(
+                f"MCP database for expected binary {expected_binary!r} exists but is inactive or unreachable; "
                 f"candidates: {_session_summary(sessions)}"
             )
         label = "no" if not matches else "multiple"

--- a/ida_preprocessor_scripts/find-CEngineClient_SendStringCmd.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_SendStringCmd.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_SendStringCmd skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineClient_SendStringCmd",
+]
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEngineClient_SendStringCmd",
+        "CEngineClient",
+        "../client/IVEngineClient2_SendStringCmd",
+        True,
+    ),
+]
+
+# The Linux CEngineClient composite vtable places this IVEngineClient2 override
+# at a different slot. Its tail dispatch to INetworkGameClient is unique and
+# lets the normal vtable relation recover that platform's actual slot.
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CEngineClient_SendStringCmd",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [
+            "48 8D 05 ?? ?? ?? ?? 48 8B 38 48 8B 07 FF A0 30 01 00 00",
+        ],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineClient_SendStringCmd", "CEngineClient"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineClient_SendStringCmd",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CEngineClient's SendStringCmd implementation on each ABI."""
+    _ = skill_name
+
+    if platform == "linux":
+        return await preprocess_common_skill(
+            session=session,
+            expected_outputs=expected_outputs,
+            old_yaml_map=old_yaml_map,
+            new_binary_dir=new_binary_dir,
+            platform=platform,
+            image_base=image_base,
+            func_names=TARGET_FUNCTION_NAMES,
+            func_xrefs=FUNC_XREFS_LINUX,
+            func_vtable_relations=FUNC_VTABLE_RELATIONS,
+            generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+            debug=debug,
+        )
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEventManager_FireEventClientSide.py
+++ b/ida_preprocessor_scripts/find-CGameEventManager_FireEventClientSide.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEventManager_FireEventClientSide skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CGameEventManager_FireEventClientSide",
+        "CGameEventManager",
+        "IGameEventManager2_FireEventClientSide",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CGameEventManager_FireEventClientSide",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Inherit the IGameEventManager2 slot and resolve CGameEventManager's implementation."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEventManager_UnserializeEvent.py
+++ b/ida_preprocessor_scripts/find-CGameEventManager_UnserializeEvent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEventManager_UnserializeEvent skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CGameEventManager_UnserializeEvent",
+        "CGameEventManager",
+        "IGameEventManager2_UnserializeEvent",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CGameEventManager_UnserializeEvent",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Inherit the IGameEventManager2 slot and resolve CGameEventManager's implementation."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CGameEventManager_vtable.py
+++ b/ida_preprocessor_scripts/find-CGameEventManager_vtable.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEventManager_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CGameEventManager"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEventManager",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate CGameEventManager vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CHLTVBroadcast_RecordSnapshot.py
+++ b/ida_preprocessor_scripts/find-CHLTVBroadcast_RecordSnapshot.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CHLTVBroadcast_RecordSnapshot skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CHLTVBroadcast_RecordSnapshot",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CHLTVBroadcast_RecordSnapshot",
+        "xref_strings": [
+            "CHLTVBroadcast::RecordSnapshot tick %.1f ms",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CHLTVBroadcast_RecordSnapshot",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CHLTVDemoRecorder_WriteFrameImmediate.py
+++ b/ida_preprocessor_scripts/find-CHLTVDemoRecorder_WriteFrameImmediate.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CHLTVDemoRecorder_WriteFrameImmediate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CHLTVDemoRecorder_WriteFrameImmediate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CHLTVDemoRecorder_WriteFrameImmediate",
+        "xref_strings": [
+            "CHLTVDemoRecorder::WriteFrameImmediate: Failed to serialize CSVCMsg_PacketEntities_t",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CHLTVDemoRecorder_WriteFrameImmediate",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CMapAnNodeManager_FireGameEvent.py
+++ b/ida_preprocessor_scripts/find-CMapAnNodeManager_FireGameEvent.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CMapAnNodeManager_FireGameEvent skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CMapAnNodeManager_FireGameEvent",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CMapAnNodeManager_FireGameEvent",
+        "xref_strings": [
+            "FULLMATCH:grenade_thrown",
+            "FULLMATCH:smokegrenade_detonate",
+            "FULLMATCH:annotations_file_at_freezetime",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CMapAnNodeManager_FireGameEvent",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate the FireGameEvent handler."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_OnSource1Source1LegacyGameEvent-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_OnSource1Source1LegacyGameEvent-decompiles.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_OnSource1Source1LegacyGameEvent-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IGameEventManager2_UnserializeEvent",
+    "IGameEventManager2_FireEventClientSide",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("IGameEventManager2_UnserializeEvent", "IGameEventManager2"),
+    ("IGameEventManager2_FireEventClientSide", "IGameEventManager2"),
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IGameEventManager2_UnserializeEvent",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "IGameEventManager2_FireEventClientSide",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameClient_OnSource1Source1LegacyGameEvent.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IGameEventManager2_UnserializeEvent",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "IGameEventManager2_FireEventClientSide",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the two abstract IGameEventManager2 slots from the predecessor decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_OnSource1Source1LegacyGameEvent.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_OnSource1Source1LegacyGameEvent.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_OnSource1Source1LegacyGameEvent skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_OnSource1Source1LegacyGameEvent",
+]
+
+FUNC_XREFS_WINDOWS = [
+    {
+        "func_name": "CNetworkGameClient_OnSource1Source1LegacyGameEvent",
+        "xref_strings": [
+            "CNetworkGameClient::OnSource1Source1LegacyGameEvent: UnserializeKeyValue failed.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": ["56 57 48 83 EC 28 48 8B"],
+    },
+]
+
+FUNC_XREFS_LINUX = [
+    {
+        "func_name": "CNetworkGameClient_OnSource1Source1LegacyGameEvent",
+        "xref_strings": [
+            "CNetworkGameClient::OnSource1Source1LegacyGameEvent: UnserializeKeyValue failed.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": ["55 48 89 E5 41 57 41 56 41 55 41 54 53"],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameClient_OnSource1Source1LegacyGameEvent",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse a previous func_sig or find the unique legacy-event error-string xref."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS_WINDOWS if platform == "windows" else FUNC_XREFS_LINUX,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_WriteDeltaEntities.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_WriteDeltaEntities.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_WriteDeltaEntities skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_WriteDeltaEntities",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_WriteDeltaEntities",
+        "xref_strings": [
+            "FULLMATCH:Delta Entities Overhead",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_WriteDeltaEntities",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-INetworkGameClient_SendStringCmd.py
+++ b/ida_preprocessor_scripts/find-INetworkGameClient_SendStringCmd.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkGameClient_SendStringCmd skill.
+
+INetworkGameClient::SendStringCmd is an abstract-interface vfunc dispatched by
+CEngineClient::SendStringCmd. Its slot is resolved by scanning the source
+function for its unique register-indirect virtual call.
+"""
+
+from ida_preprocessor_scripts._indirect_vcall_target_common import (
+    preprocess_indirect_vcall_target_skill,
+)
+
+SOURCE_FUNCTION_NAME = "CEngineClient_SendStringCmd"
+
+TARGET_FUNCTION_NAME = "INetworkGameClient_SendStringCmd"
+VTABLE_CLASS = "INetworkGameClient"
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "INetworkGameClient_SendStringCmd",
+        [
+            "func_name",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Scan CEngineClient::SendStringCmd for its unique indirect vcall."""
+    _ = skill_name, old_yaml_map, image_base
+
+    return await preprocess_indirect_vcall_target_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        source_yaml_stem=SOURCE_FUNCTION_NAME,
+        target_name=TARGET_FUNCTION_NAME,
+        vtable_name=VTABLE_CLASS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        # Linux lowers the vtable dispatch to ``mov reg, [reg+disp]`` + ``jmp reg``.
+        resolve_load_then_branch=True,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IVEngineClient2_SendStringCmd.py
+++ b/ida_preprocessor_scripts/find-IVEngineClient2_SendStringCmd.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IVEngineClient2_SendStringCmd skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IVEngineClient2_SendStringCmd",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IVEngineClient2_SendStringCmd",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CMapAnNodeManager_FireGameEvent.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CMapAnNodeManager_FireGameEvent.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # IVEngineClient2 is abstract; this relation supplies vtable metadata only.
+    ("IVEngineClient2_SendStringCmd", "IVEngineClient2"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IVEngineClient2_SendStringCmd",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the IVEngineClient2 SendStringCmd slot from FireGameEvent."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CMapAnNodeManager_FireGameEvent.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CMapAnNodeManager_FireGameEvent.linux.yaml
@@ -1,0 +1,278 @@
+func_name: CMapAnNodeManager_FireGameEvent
+func_va: '0x1a28420'
+disasm_code: |-
+  .text:0000000001A28420                 push    rbp
+  .text:0000000001A28421                 mov     rbp, rsp
+  .text:0000000001A28424                 push    r14
+  .text:0000000001A28426                 push    r13
+  .text:0000000001A28428                 push    r12
+  .text:0000000001A2842A                 push    rbx
+  .text:0000000001A2842B                 add     rsp, 0FFFFFFFFFFFFFF80h
+  .text:0000000001A2842F                 lea     r14, qword_47FE7D0
+  .text:0000000001A28436                 cmp     qword ptr [r14], 0
+  .text:0000000001A2843A                 jz      loc_1A2851B
+  .text:0000000001A28440                 mov     rax, [rsi]
+  .text:0000000001A28443                 mov     r12, rdi
+  .text:0000000001A28446                 mov     rbx, rsi
+  .text:0000000001A28449                 mov     rdi, rsi
+  .text:0000000001A2844C                 call    qword ptr [rax+10h]
+  .text:0000000001A2844F                 mov     r13, rax
+  .text:0000000001A28452                 call    sub_19BD210
+  .text:0000000001A28457                 test    al, al
+  .text:0000000001A28459                 jz      short loc_1A284A0
+  .text:0000000001A2845B                 lea     rsi, s2; "round_start"
+  .text:0000000001A28462                 ; s1
+  .text:0000000001A28462                 mov     rdi, r13; s1
+  .text:0000000001A28465                 call    strcmp
+  .text:0000000001A2846A                 test    eax, eax
+  .text:0000000001A2846C                 jz      loc_1A28600
+  .text:0000000001A28472                 lea     rsi, aGrenadeThrown; "grenade_thrown"
+  .text:0000000001A28479                 ; s1
+  .text:0000000001A28479                 mov     rdi, r13; s1
+  .text:0000000001A2847C                 call    strcmp
+  .text:0000000001A28481                 test    eax, eax
+  .text:0000000001A28483                 jz      loc_1A28530
+  .text:0000000001A28489                 lea     rsi, aSmokegrenadeDe; "smokegrenade_detonate"
+  .text:0000000001A28490                 ; s1
+  .text:0000000001A28490                 mov     rdi, r13; s1
+  .text:0000000001A28493                 call    strcmp
+  .text:0000000001A28498                 test    eax, eax
+  .text:0000000001A2849A                 jz      loc_1A28580
+  .text:0000000001A284A0                 mov     rax, [rbx]
+  .text:0000000001A284A3                 mov     rdi, rbx
+  .text:0000000001A284A6                 call    qword ptr [rax+10h]
+  .text:0000000001A284A9                 lea     rsi, aRoundFreezeEnd; "round_freeze_end"
+  .text:0000000001A284B0                 cmp     rax, rsi
+  .text:0000000001A284B3                 jz      short loc_1A284C6
+  .text:0000000001A284B5                 test    rax, rax
+  .text:0000000001A284B8                 jz      short loc_1A2851B
+  .text:0000000001A284BA                 ; s1
+  .text:0000000001A284BA                 mov     rdi, rax; s1
+  .text:0000000001A284BD                 call    strcmp
+  .text:0000000001A284C2                 test    eax, eax
+  .text:0000000001A284C4                 jnz     short loc_1A2851B
+  .text:0000000001A284C6                 mov     rax, cs:qword_480C840
+  .text:0000000001A284CD                 lea     rbx, [rbp+var_A0]
+  .text:0000000001A284D4                 ; _QWORD
+  .text:0000000001A284D4                 mov     esi, 80h; _QWORD
+  .text:0000000001A284D9                 lea     rdx, aSS_9; "%s \"%s\""
+  .text:0000000001A284E0                 ; _QWORD
+  .text:0000000001A284E0                 mov     rdi, rbx; _QWORD
+  .text:0000000001A284E3                 lea     rcx, aAnnotationsFil; "annotations_file_at_freezetime"
+  .text:0000000001A284EA                 mov     r8, [rax+48h]
+  .text:0000000001A284EE                 lea     rax, haystack
+  .text:0000000001A284F5                 test    r8, r8
+  .text:0000000001A284F8                 cmovz   r8, rax
+  .text:0000000001A284FC                 xor     eax, eax
+  .text:0000000001A284FE                 call    _V_snprintf
+  .text:0000000001A28503                 lea     rax, qword_47F9B38
+  .text:0000000001A2850A                 mov     rdx, rbx
+  .text:0000000001A2850D                 xor     esi, esi
+  .text:0000000001A2850F                 mov     rdi, [rax]
+  .text:0000000001A28512                 mov     rax, [rdi]
+  .text:0000000001A28515                 call    qword ptr [rax+190h]  ; 190h = IVEngineClient2_SendStringCmd
+  .text:0000000001A2851B                 sub     rsp, 0FFFFFFFFFFFFFF80h
+  .text:0000000001A2851F                 pop     rbx
+  .text:0000000001A28520                 pop     r12
+  .text:0000000001A28522                 pop     r13
+  .text:0000000001A28524                 pop     r14
+  .text:0000000001A28526                 pop     rbp
+  .text:0000000001A28527                 retn
+  .text:0000000001A28530                 mov     rdi, [r14]
+  .text:0000000001A28533                 call    sub_1352B20
+  .text:0000000001A28538                 test    al, al
+  .text:0000000001A2853A                 jz      loc_1A28489
+  .text:0000000001A28540                 lea     rax, qword_47F9B38
+  .text:0000000001A28547                 mov     rdi, [rax]
+  .text:0000000001A2854A                 mov     rax, [rdi]
+  .text:0000000001A2854D                 call    qword ptr [rax+310h]
+  .text:0000000001A28553                 mov     edi, eax
+  .text:0000000001A28555                 call    sub_15D88E0
+  .text:0000000001A2855A                 test    rax, rax
+  .text:0000000001A2855D                 jz      short loc_1A2851B
+  .text:0000000001A2855F                 xor     esi, esi
+  .text:0000000001A28561                 mov     rdi, r12
+  .text:0000000001A28564                 call    sub_19C9B60
+  .text:0000000001A28569                 mov     [r12+90h], rax
+  .text:0000000001A28571                 jmp     loc_1A28489
+  .text:0000000001A28580                 mov     rdi, [r14]
+  .text:0000000001A28583                 call    sub_1352B20
+  .text:0000000001A28588                 test    al, al
+  .text:0000000001A2858A                 jz      short loc_1A2851B
+  .text:0000000001A2858C                 mov     r12, [r12+90h]
+  .text:0000000001A28594                 test    r12, r12
+  .text:0000000001A28597                 jz      short loc_1A2851B
+  .text:0000000001A28599                 lea     rsi, asc_B5C357; "X"
+  .text:0000000001A285A0                 mov     rdi, rbx
+  .text:0000000001A285A3                 pxor    xmm0, xmm0
+  .text:0000000001A285A7                 call    sub_1436490
+  .text:0000000001A285AC                 lea     rsi, aY_0; "Y"
+  .text:0000000001A285B3                 mov     rdi, rbx
+  .text:0000000001A285B6                 movss   dword ptr [rbp+var_A0], xmm0
+  .text:0000000001A285BE                 pxor    xmm0, xmm0
+  .text:0000000001A285C2                 call    sub_1436490
+  .text:0000000001A285C7                 lea     rsi, aZ; "Z"
+  .text:0000000001A285CE                 mov     rdi, rbx
+  .text:0000000001A285D1                 movss   dword ptr [rbp+var_A0+4], xmm0
+  .text:0000000001A285D9                 pxor    xmm0, xmm0
+  .text:0000000001A285DD                 call    sub_1436490
+  .text:0000000001A285E2                 lea     rsi, [rbp+var_A0]
+  .text:0000000001A285E9                 mov     rdi, r12
+  .text:0000000001A285EC                 movss   [rbp+var_98], xmm0
+  .text:0000000001A285F4                 call    sub_1A28240
+  .text:0000000001A285F9                 jmp     loc_1A2851B
+  .text:0000000001A28600                 lea     rax, qword_47F9B38
+  .text:0000000001A28607                 mov     rdi, [rax]
+  .text:0000000001A2860A                 mov     rax, [rdi]
+  .text:0000000001A2860D                 call    qword ptr [rax+208h]
+  .text:0000000001A28613                 mov     esi, 0FFFFFFFFh
+  .text:0000000001A28618                 lea     rdi, unk_480C850
+  .text:0000000001A2861F                 mov     rbx, rax
+  .text:0000000001A28622                 call    sub_20D1310
+  .text:0000000001A28627                 test    rax, rax
+  .text:0000000001A2862A                 jz      loc_1A286E0
+  .text:0000000001A28630                 movzx   eax, byte ptr [rax]
+  .text:0000000001A28633                 test    al, al
+  .text:0000000001A28635                 jz      short loc_1A28690
+  .text:0000000001A28637                 lea     rsi, aEmpty_0; "<empty>"
+  .text:0000000001A2863E                 ; s1
+  .text:0000000001A2863E                 mov     rdi, rbx; s1
+  .text:0000000001A28641                 call    strcmp
+  .text:0000000001A28646                 test    eax, eax
+  .text:0000000001A28648                 jnz     loc_1A286D0
+  .text:0000000001A2864E                 mov     eax, [r12+50h]
+  .text:0000000001A28653                 test    eax, eax
+  .text:0000000001A28655                 jle     loc_1A2851B
+  .text:0000000001A2865B                 xor     ebx, ebx
+  .text:0000000001A2865D                 nop     dword ptr [rax]
+  .text:0000000001A28660                 mov     rax, [r12+58h]
+  .text:0000000001A28665                 mov     rdi, [rax+rbx*8]
+  .text:0000000001A28669                 add     rbx, 1
+  .text:0000000001A2866D                 mov     rax, [rdi]
+  .text:0000000001A28670                 call    qword ptr [rax+28h]
+  .text:0000000001A28673                 cmp     [r12+50h], ebx
+  .text:0000000001A28678                 jg      short loc_1A28660
+  .text:0000000001A2867A                 sub     rsp, 0FFFFFFFFFFFFFF80h
+  .text:0000000001A2867E                 pop     rbx
+  .text:0000000001A2867F                 pop     r12
+  .text:0000000001A28681                 pop     r13
+  .text:0000000001A28683                 pop     r14
+  .text:0000000001A28685                 pop     rbp
+  .text:0000000001A28686                 retn
+  .text:0000000001A28690                 lea     rdi, unk_4680470
+  .text:0000000001A28697                 mov     esi, 0FFFFFFFFh
+  .text:0000000001A2869C                 call    sub_1357750
+  .text:0000000001A286A1                 mov     edx, eax
+  .text:0000000001A286A3                 mov     eax, [r12+50h]
+  .text:0000000001A286A8                 test    edx, edx
+  .text:0000000001A286AA                 jle     short loc_1A28653
+  .text:0000000001A286AC                 test    eax, eax
+  .text:0000000001A286AE                 jnz     short loc_1A28653
+  .text:0000000001A286B0                 lea     rsi, aEmpty_0; "<empty>"
+  .text:0000000001A286B7                 ; s1
+  .text:0000000001A286B7                 mov     rdi, rbx; s1
+  .text:0000000001A286BA                 call    strcmp
+  .text:0000000001A286BF                 test    eax, eax
+  .text:0000000001A286C1                 jz      loc_1A2851B
+  .text:0000000001A286C7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001A286D0                 mov     rsi, rbx
+  .text:0000000001A286D3                 mov     rdi, r12
+  .text:0000000001A286D6                 call    sub_19E80F0
+  .text:0000000001A286DB                 jmp     loc_1A2864E
+  .text:0000000001A286E0                 mov     rax, cs:qword_480C858
+  .text:0000000001A286E7                 mov     rax, [rax+8]
+  .text:0000000001A286EB                 jmp     loc_1A28630
+procedure: |-
+  void __fastcall CMapAnNodeManager_FireGameEvent(__int64 a1, __int64 a2)
+  {
+    const char *v3; // r13
+    const char *v4; // rax
+    const bool *v5; // r8
+    unsigned int v6; // eax
+    __int64 v7; // r12
+    const char *v8; // rbx
+    _BYTE *v9; // rax
+    int v10; // eax
+    __int64 v11; // rbx
+    __int64 v12; // rdi
+    int v13; // edx
+    _DWORD v14[40]; // [rsp+0h] [rbp-A0h] BYREF
+
+    if ( !qword_47FE7D0 )
+      return;
+    v3 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a2 + 16LL))(a2);
+    if ( !(unsigned __int8)sub_19BD210() )
+      goto LABEL_6;
+    if ( !strcmp(v3, "round_start") )
+    {
+      v8 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_47F9B38 + 520LL))(qword_47F9B38);
+      v9 = (_BYTE *)sub_20D1310(&unk_480C850, 0xFFFFFFFFLL);
+      if ( !v9 )
+        v9 = *(_BYTE **)(qword_480C858 + 8);
+      if ( *v9 )
+      {
+        if ( !strcmp(v8, "<empty>") )
+        {
+  LABEL_23:
+          v10 = *(_DWORD *)(a1 + 80);
+          goto LABEL_24;
+        }
+      }
+      else
+      {
+        v13 = sub_1357750(&unk_4680470, 0xFFFFFFFFLL);
+        v10 = *(_DWORD *)(a1 + 80);
+        if ( v13 <= 0 || v10 )
+        {
+  LABEL_24:
+          if ( v10 > 0 )
+          {
+            v11 = 0;
+            do
+            {
+              v12 = *(_QWORD *)(*(_QWORD *)(a1 + 88) + 8 * v11++);
+              (*(void (__fastcall **)(__int64))(*(_QWORD *)v12 + 40LL))(v12);
+            }
+            while ( *(_DWORD *)(a1 + 80) > (int)v11 );
+          }
+          return;
+        }
+        if ( !strcmp(v8, "<empty>") )
+          return;
+      }
+      sub_19E80F0(a1, v8);
+      goto LABEL_23;
+    }
+    if ( !strcmp(v3, "grenade_thrown") && (unsigned __int8)sub_1352B20(qword_47FE7D0) )
+    {
+      v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_47F9B38 + 784LL))(qword_47F9B38);
+      if ( !sub_15D88E0(v6) )
+        return;
+      *(_QWORD *)(a1 + 144) = sub_19C9B60(a1, 0);
+    }
+    if ( strcmp(v3, "smokegrenade_detonate") )
+    {
+  LABEL_6:
+      v4 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a2 + 16LL))(a2);
+      if ( v4 == "round_freeze_end" || v4 && !strcmp(v4, "round_freeze_end") )
+      {
+        v5 = *(const bool **)(qword_480C840 + 72);
+        if ( !v5 )
+          v5 = &haystack;
+        V_snprintf(v14, 128, "%s \"%s\"", "annotations_file_at_freezetime", v5);
+        (*(void (__fastcall **)(__int64, _QWORD, _DWORD *))(*(_QWORD *)qword_47F9B38 + 400LL))(qword_47F9B38, 0, v14);  // 400LL = 0x190 = IVEngineClient2_SendStringCmd
+      }
+      return;
+    }
+    if ( (unsigned __int8)sub_1352B20(qword_47FE7D0) )
+    {
+      v7 = *(_QWORD *)(a1 + 144);
+      if ( v7 )
+      {
+        v14[0] = sub_1436490(a2, "X", 0.0);
+        v14[1] = sub_1436490(a2, "Y", 0.0);
+        v14[2] = sub_1436490(a2, "Z", 0.0);
+        sub_1A28240(v7, v14);
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/client/CMapAnNodeManager_FireGameEvent.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CMapAnNodeManager_FireGameEvent.windows.yaml
@@ -1,0 +1,363 @@
+func_name: CMapAnNodeManager_FireGameEvent
+func_va: '0x180bd1dd0'
+disasm_code: |-
+  .text:0000000180BD1DD0                 mov     rax, rsp
+  .text:0000000180BD1DD3                 mov     [rax+20h], rsi
+  .text:0000000180BD1DD7                 push    rdi
+  .text:0000000180BD1DD8                 sub     rsp, 0D0h
+  .text:0000000180BD1DDF                 cmp     cs:qword_1823A49D8, 0
+  .text:0000000180BD1DE7                 mov     rsi, rdx
+  .text:0000000180BD1DEA                 mov     rdi, rcx
+  .text:0000000180BD1DED                 jz      loc_180BD212F
+  .text:0000000180BD1DF3                 mov     [rax+10h], rbp
+  .text:0000000180BD1DF7                 mov     rcx, rdx
+  .text:0000000180BD1DFA                 mov     [rax+8], rbx
+  .text:0000000180BD1DFE                 mov     rax, [rdx]
+  .text:0000000180BD1E01                 call    qword ptr [rax+8]
+  .text:0000000180BD1E04                 cmp     cs:qword_1823A49D8, 0
+  .text:0000000180BD1E0C                 mov     rbp, rax
+  .text:0000000180BD1E0F                 jz      loc_180BD20A6
+  .text:0000000180BD1E15                 mov     edx, 0FFFFFFFFh
+  .text:0000000180BD1E1A                 lea     rcx, unk_18230CD38
+  .text:0000000180BD1E21                 call    sub_1818622D0
+  .text:0000000180BD1E26                 test    rax, rax
+  .text:0000000180BD1E29                 jnz     short loc_180BD1E36
+  .text:0000000180BD1E2B                 mov     rax, cs:qword_18230CD40
+  .text:0000000180BD1E32                 mov     rax, [rax+8]
+  .text:0000000180BD1E36                 cmp     dword ptr [rax], 0
+  .text:0000000180BD1E39                 jle     loc_180BD20A6
+  .text:0000000180BD1E3F                 mov     edx, 0FFFFFFFFh
+  .text:0000000180BD1E44                 lea     rcx, unk_18230CC58
+  .text:0000000180BD1E4B                 call    sub_1818622D0
+  .text:0000000180BD1E50                 test    rax, rax
+  .text:0000000180BD1E53                 jnz     short loc_180BD1E60
+  .text:0000000180BD1E55                 mov     rax, cs:qword_18230CC60
+  .text:0000000180BD1E5C                 mov     rax, [rax+8]
+  .text:0000000180BD1E60                 cmp     dword ptr [rax], 0FFFFFFFFh
+  .text:0000000180BD1E63                 jz      short loc_180BD1E9C
+  .text:0000000180BD1E65                 mov     edx, 0FFFFFFFFh
+  .text:0000000180BD1E6A                 lea     rcx, unk_18230CC58
+  .text:0000000180BD1E71                 call    sub_1818622D0
+  .text:0000000180BD1E76                 test    rax, rax
+  .text:0000000180BD1E79                 jnz     short loc_180BD1E86
+  .text:0000000180BD1E7B                 mov     rax, cs:qword_18230CC60
+  .text:0000000180BD1E82                 mov     rax, [rax+8]
+  .text:0000000180BD1E86                 mov     rcx, cs:qword_1823A49D8
+  .text:0000000180BD1E8D                 mov     ebx, [rax]
+  .text:0000000180BD1E8F                 call    sub_1807257D0
+  .text:0000000180BD1E94                 cmp     eax, ebx
+  .text:0000000180BD1E96                 jge     loc_180BD20A6
+  .text:0000000180BD1E9C                 lea     rdx, aRoundStart; "round_start"
+  .text:0000000180BD1EA3                 mov     rcx, rbp
+  .text:0000000180BD1EA6                 call    sub_1818BAC90
+  .text:0000000180BD1EAB                 test    eax, eax
+  .text:0000000180BD1EAD                 jnz     loc_180BD1F6E
+  .text:0000000180BD1EB3                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180BD1EBA                 mov     rax, [rcx]
+  .text:0000000180BD1EBD                 call    qword ptr [rax+208h]
+  .text:0000000180BD1EC3                 mov     edx, 0FFFFFFFFh
+  .text:0000000180BD1EC8                 lea     rcx, unk_1823B0790
+  .text:0000000180BD1ECF                 mov     rsi, rax
+  .text:0000000180BD1ED2                 call    sub_1818622D0
+  .text:0000000180BD1ED7                 test    rax, rax
+  .text:0000000180BD1EDA                 jnz     short loc_180BD1EE7
+  .text:0000000180BD1EDC                 mov     rax, cs:qword_1823B0798
+  .text:0000000180BD1EE3                 mov     rax, [rax+8]
+  .text:0000000180BD1EE7                 xor     ebx, ebx
+  .text:0000000180BD1EE9                 cmp     [rax], bl
+  .text:0000000180BD1EEB                 jnz     short loc_180BD1F17
+  .text:0000000180BD1EED                 mov     edx, 0FFFFFFFFh
+  .text:0000000180BD1EF2                 lea     rcx, unk_18230CD38
+  .text:0000000180BD1EF9                 call    sub_1818622D0
+  .text:0000000180BD1EFE                 test    rax, rax
+  .text:0000000180BD1F01                 jnz     short loc_180BD1F0E
+  .text:0000000180BD1F03                 mov     rax, cs:qword_18230CD40
+  .text:0000000180BD1F0A                 mov     rax, [rax+8]
+  .text:0000000180BD1F0E                 cmp     [rax], ebx
+  .text:0000000180BD1F10                 jle     short loc_180BD1F41
+  .text:0000000180BD1F12                 cmp     [rdi+50h], ebx
+  .text:0000000180BD1F15                 jnz     short loc_180BD1F44
+  .text:0000000180BD1F17                 mov     rcx, rbx
+  .text:0000000180BD1F1A                 lea     rdx, aEmpty; "<empty>"
+  .text:0000000180BD1F21                 movzx   eax, byte ptr [rsi+rcx]
+  .text:0000000180BD1F25                 inc     rcx
+  .text:0000000180BD1F28                 cmp     al, [rdx+rcx-1]
+  .text:0000000180BD1F2C                 jnz     short loc_180BD1F36
+  .text:0000000180BD1F2E                 cmp     rcx, 8
+  .text:0000000180BD1F32                 jnz     short loc_180BD1F21
+  .text:0000000180BD1F34                 jmp     short loc_180BD1F41
+  .text:0000000180BD1F36                 mov     rdx, rsi
+  .text:0000000180BD1F39                 mov     rcx, rdi
+  .text:0000000180BD1F3C                 call    sub_180C1D770
+  .text:0000000180BD1F41                 cmp     [rdi+50h], ebx
+  .text:0000000180BD1F44                 jle     loc_180BD211F
+  .text:0000000180BD1F4A                 mov     rsi, rbx
+  .text:0000000180BD1F4D                 nop     dword ptr [rax]
+  .text:0000000180BD1F50                 mov     rax, [rdi+58h]
+  .text:0000000180BD1F54                 mov     rcx, [rsi+rax]
+  .text:0000000180BD1F58                 mov     rax, [rcx]
+  .text:0000000180BD1F5B                 call    qword ptr [rax+20h]
+  .text:0000000180BD1F5E                 inc     ebx
+  .text:0000000180BD1F60                 lea     rsi, [rsi+8]
+  .text:0000000180BD1F64                 cmp     ebx, [rdi+50h]
+  .text:0000000180BD1F67                 jl      short loc_180BD1F50
+  .text:0000000180BD1F69                 jmp     loc_180BD211F
+  .text:0000000180BD1F6E                 lea     rdx, aGrenadeThrown; "grenade_thrown"
+  .text:0000000180BD1F75                 mov     rcx, rbp
+  .text:0000000180BD1F78                 call    sub_1818BAC90
+  .text:0000000180BD1F7D                 test    eax, eax
+  .text:0000000180BD1F7F                 jnz     short loc_180BD1FCA
+  .text:0000000180BD1F81                 mov     rcx, cs:qword_1823A49D8
+  .text:0000000180BD1F88                 call    sub_1807314A0
+  .text:0000000180BD1F8D                 test    al, al
+  .text:0000000180BD1F8F                 jz      short loc_180BD1FCA
+  .text:0000000180BD1F91                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180BD1F98                 lea     rdx, [rsp+0D8h+arg_10]
+  .text:0000000180BD1FA0                 mov     rax, [rcx]
+  .text:0000000180BD1FA3                 call    qword ptr [rax+310h]
+  .text:0000000180BD1FA9                 mov     ecx, [rax]
+  .text:0000000180BD1FAB                 call    sub_1809269B0
+  .text:0000000180BD1FB0                 test    rax, rax
+  .text:0000000180BD1FB3                 jz      loc_180BD211F
+  .text:0000000180BD1FB9                 xor     edx, edx
+  .text:0000000180BD1FBB                 mov     rcx, rdi
+  .text:0000000180BD1FBE                 call    sub_180C10670
+  .text:0000000180BD1FC3                 mov     [rdi+90h], rax
+  .text:0000000180BD1FCA                 lea     rdx, aSmokegrenadeDe; "smokegrenade_detonate"
+  .text:0000000180BD1FD1                 mov     rcx, rbp
+  .text:0000000180BD1FD4                 call    sub_1818BAC90
+  .text:0000000180BD1FD9                 test    eax, eax
+  .text:0000000180BD1FDB                 jnz     loc_180BD20A6
+  .text:0000000180BD1FE1                 mov     rcx, cs:qword_1823A49D8
+  .text:0000000180BD1FE8                 call    sub_1807314A0
+  .text:0000000180BD1FED                 test    al, al
+  .text:0000000180BD1FEF                 jz      loc_180BD211F
+  .text:0000000180BD1FF5                 mov     rbx, [rdi+90h]
+  .text:0000000180BD1FFC                 test    rbx, rbx
+  .text:0000000180BD1FFF                 jz      loc_180BD211F
+  .text:0000000180BD2005                 mov     rax, [rsi]
+  .text:0000000180BD2008                 lea     rcx, asc_181AB29B4; "X"
+  .text:0000000180BD200F                 mov     [rsp+0D8h+var_A0], rcx
+  .text:0000000180BD2014                 lea     rdx, [rsp+0D8h+var_A8]
+  .text:0000000180BD2019                 mov     rcx, rsi
+  .text:0000000180BD201C                 mov     [rsp+0D8h+var_A8], 0FFFFFFFFF38610FFh
+  .text:0000000180BD2025                 xorps   xmm2, xmm2
+  .text:0000000180BD2028                 call    qword ptr [rax+48h]
+  .text:0000000180BD202B                 mov     rax, [rsi]
+  .text:0000000180BD202E                 lea     rcx, aY_0; "Y"
+  .text:0000000180BD2035                 mov     [rsp+0D8h+var_90], rcx
+  .text:0000000180BD203A                 lea     rdx, [rsp+0D8h+var_98]
+  .text:0000000180BD203F                 mov     rcx, rsi
+  .text:0000000180BD2042                 movss   dword ptr [rsp+0D8h+var_A8], xmm0
+  .text:0000000180BD2048                 xorps   xmm2, xmm2
+  .text:0000000180BD204B                 mov     [rsp+0D8h+var_98], 3225AF29h
+  .text:0000000180BD2053                 mov     [rsp+0D8h+var_94], 0FFFFFFFFh
+  .text:0000000180BD205B                 call    qword ptr [rax+48h]
+  .text:0000000180BD205E                 mov     rax, [rsi]
+  .text:0000000180BD2061                 lea     rcx, aZ; "Z"
+  .text:0000000180BD2068                 mov     [rsp+0D8h+var_90], rcx
+  .text:0000000180BD206D                 lea     rdx, [rsp+0D8h+var_98]
+  .text:0000000180BD2072                 mov     rcx, rsi
+  .text:0000000180BD2075                 movss   dword ptr [rsp+0D8h+var_A8+4], xmm0
+  .text:0000000180BD207B                 xorps   xmm2, xmm2
+  .text:0000000180BD207E                 mov     [rsp+0D8h+var_98], 2BF4F9C5h
+  .text:0000000180BD2086                 mov     [rsp+0D8h+var_94], 0FFFFFFFFh
+  .text:0000000180BD208E                 call    qword ptr [rax+48h]
+  .text:0000000180BD2091                 lea     rdx, [rsp+0D8h+var_A8]
+  .text:0000000180BD2096                 mov     rcx, rbx
+  .text:0000000180BD2099                 movss   dword ptr [rsp+0D8h+var_A0], xmm0
+  .text:0000000180BD209F                 call    sub_180BFC7C0
+  .text:0000000180BD20A4                 jmp     short loc_180BD211F
+  .text:0000000180BD20A6                 mov     rax, [rsi]
+  .text:0000000180BD20A9                 mov     rcx, rsi
+  .text:0000000180BD20AC                 call    qword ptr [rax+8]
+  .text:0000000180BD20AF                 lea     rdx, aRoundFreezeEnd; "round_freeze_end"
+  .text:0000000180BD20B6                 cmp     rax, rdx
+  .text:0000000180BD20B9                 jz      short loc_180BD20CC
+  .text:0000000180BD20BB                 test    rax, rax
+  .text:0000000180BD20BE                 jz      short loc_180BD211F
+  .text:0000000180BD20C0                 mov     rcx, rax
+  .text:0000000180BD20C3                 call    sub_1818BAC90
+  .text:0000000180BD20C8                 test    eax, eax
+  .text:0000000180BD20CA                 jnz     short loc_180BD211F
+  .text:0000000180BD20CC                 mov     rax, cs:qword_1823B0570
+  .text:0000000180BD20D3                 lea     r9, aAnnotationsFil; "annotations_file_at_freezetime"
+  .text:0000000180BD20DA                 lea     r8, aSS_9; "%s \"%s\""
+  .text:0000000180BD20E1                 mov     edx, 80h
+  .text:0000000180BD20E6                 mov     rcx, [rax+48h]
+  .text:0000000180BD20EA                 lea     rax, byte_18196B088
+  .text:0000000180BD20F1                 test    rcx, rcx
+  .text:0000000180BD20F4                 cmovnz  rax, rcx
+  .text:0000000180BD20F8                 lea     rcx, [rsp+0D8h+var_88]
+  .text:0000000180BD20FD                 mov     [rsp+0D8h+var_B8], rax
+  .text:0000000180BD2102                 call    cs:V_snprintf
+  .text:0000000180BD2108                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180BD210F                 lea     r8, [rsp+0D8h+var_88]
+  .text:0000000180BD2114                 xor     edx, edx
+  .text:0000000180BD2116                 mov     rax, [rcx]
+  .text:0000000180BD2119                 call    qword ptr [rax+190h]  ; 190h = IVEngineClient2_SendStringCmd
+  .text:0000000180BD211F                 mov     rbx, [rsp+0D8h+arg_0]
+  .text:0000000180BD2127                 mov     rbp, [rsp+0D8h+arg_8]
+  .text:0000000180BD212F                 mov     rsi, [rsp+0D8h+arg_18]
+  .text:0000000180BD2137                 add     rsp, 0D0h
+  .text:0000000180BD213E                 pop     rdi
+  .text:0000000180BD213F                 retn
+procedure: |-
+  __int64 __fastcall sub_180BD1DD0(__int64 a1, __int64 *a2)
+  {
+    __int64 result; // rax
+    __int64 v5; // rbp
+    int *v6; // rax
+    _DWORD *v7; // rax
+    int *v8; // rax
+    int v9; // ebx
+    __int64 v10; // rsi
+    _BYTE *v11; // rax
+    int v12; // ebx
+    bool v13; // cc
+    __int64 v14; // rcx
+    __int64 v15; // rsi
+    unsigned int *v16; // rax
+    __int64 v17; // rbx
+    __int64 v18; // rax
+    double v19; // xmm0_8
+    __int64 v20; // rax
+    double v21; // xmm0_8
+    __int64 v22; // rax
+    char *v23; // rax
+    __int64 v24; // [rsp+30h] [rbp-A8h] BYREF
+    const char *v25; // [rsp+38h] [rbp-A0h]
+    int v26; // [rsp+40h] [rbp-98h] BYREF
+    int v27; // [rsp+44h] [rbp-94h]
+    const char *v28; // [rsp+48h] [rbp-90h]
+    _BYTE v29[136]; // [rsp+50h] [rbp-88h] BYREF
+    _UNKNOWN *retaddr; // [rsp+D8h] [rbp+0h] BYREF
+    char v31; // [rsp+F0h] [rbp+18h] BYREF
+
+    result = (__int64)&retaddr;
+    if ( !qword_1823A49D8 )
+      return result;
+    v5 = (*(__int64 (__fastcall **)(__int64 *))(*a2 + 8))(a2);
+    if ( !qword_1823A49D8 )
+      goto LABEL_38;
+    v6 = (int *)sub_1818622D0(&unk_18230CD38, 0xFFFFFFFFLL);
+    if ( !v6 )
+      v6 = *(int **)(qword_18230CD40 + 8);
+    if ( *v6 <= 0 )
+      goto LABEL_38;
+    v7 = (_DWORD *)sub_1818622D0(&unk_18230CC58, 0xFFFFFFFFLL);
+    if ( !v7 )
+      v7 = *(_DWORD **)(qword_18230CC60 + 8);
+    if ( *v7 != -1 )
+    {
+      v8 = (int *)sub_1818622D0(&unk_18230CC58, 0xFFFFFFFFLL);
+      if ( !v8 )
+        v8 = *(int **)(qword_18230CC60 + 8);
+      v9 = *v8;
+      if ( (int)sub_1807257D0(qword_1823A49D8) >= v9 )
+        goto LABEL_38;
+    }
+    if ( !(unsigned int)sub_1818BAC90(v5, "round_start") )
+    {
+      v10 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 520LL))(g_pEngineClient);
+      v11 = (_BYTE *)sub_1818622D0(&unk_1823B0790, 0xFFFFFFFFLL);
+      if ( !v11 )
+        v11 = *(_BYTE **)(qword_1823B0798 + 8);
+      v12 = 0;
+      if ( !*v11 )
+      {
+        result = sub_1818622D0(&unk_18230CD38, 0xFFFFFFFFLL);
+        if ( !result )
+          result = *(_QWORD *)(qword_18230CD40 + 8);
+        if ( *(int *)result <= 0 )
+        {
+  LABEL_25:
+          v13 = *(_DWORD *)(a1 + 80) <= 0;
+  LABEL_26:
+          if ( !v13 )
+          {
+            v15 = 0;
+            do
+            {
+              result = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)(v15 + *(_QWORD *)(a1 + 88)) + 32LL))(*(_QWORD *)(v15 + *(_QWORD *)(a1 + 88)));
+              ++v12;
+              v15 += 8;
+            }
+            while ( v12 < *(_DWORD *)(a1 + 80) );
+          }
+          return result;
+        }
+        v13 = *(_DWORD *)(a1 + 80) <= 0;
+        if ( *(_DWORD *)(a1 + 80) )
+          goto LABEL_26;
+      }
+      v14 = 0;
+      while ( 1 )
+      {
+        result = *(unsigned __int8 *)(v10 + v14++);
+        if ( (_BYTE)result != aEmpty[v14 - 1] )
+          break;
+        if ( v14 == 8 )
+          goto LABEL_25;
+      }
+      result = sub_180C1D770(a1, v10);
+      goto LABEL_25;
+    }
+    if ( !(unsigned int)sub_1818BAC90(v5, "grenade_thrown") && (unsigned __int8)sub_1807314A0(qword_1823A49D8) )
+    {
+      v16 = (unsigned int *)(*(__int64 (__fastcall **)(__int64, char *))(*(_QWORD *)g_pEngineClient + 784LL))(
+                              g_pEngineClient,
+                              &v31);
+      result = sub_1809269B0(*v16);
+      if ( !result )
+        return result;
+      *(_QWORD *)(a1 + 144) = sub_180C10670(a1, 0);
+    }
+    if ( !(unsigned int)sub_1818BAC90(v5, "smokegrenade_detonate") )
+    {
+      result = sub_1807314A0(qword_1823A49D8);
+      if ( (_BYTE)result )
+      {
+        v17 = *(_QWORD *)(a1 + 144);
+        if ( v17 )
+        {
+          v18 = *a2;
+          v25 = "X";
+          v24 = -209317633;
+          v19 = (*(double (__fastcall **)(__int64 *, __int64 *))(v18 + 72))(a2, &v24);
+          v20 = *a2;
+          v28 = "Y";
+          LODWORD(v24) = LODWORD(v19);
+          v26 = 841330473;
+          v27 = -1;
+          v21 = (*(double (__fastcall **)(__int64 *, int *))(v20 + 72))(a2, &v26);
+          v22 = *a2;
+          v28 = "Z";
+          HIDWORD(v24) = LODWORD(v21);
+          v26 = 737475013;
+          v27 = -1;
+          LODWORD(v25) = (*(float (__fastcall **)(__int64 *, int *))(v22 + 72))(a2, &v26);
+          return sub_180BFC7C0(v17, &v24);
+        }
+      }
+    }
+    else
+    {
+  LABEL_38:
+      result = (*(__int64 (__fastcall **)(__int64 *))(*a2 + 8))(a2);
+      if ( (char *)result == "round_freeze_end"
+        || result && (result = sub_1818BAC90(result, "round_freeze_end"), !(_DWORD)result) )
+      {
+        v23 = &byte_18196B088;
+        if ( *(_QWORD *)(qword_1823B0570 + 72) )
+          v23 = *(char **)(qword_1823B0570 + 72);
+        V_snprintf(v29, 128, "%s \"%s\"", "annotations_file_at_freezetime", v23);
+        return (*(__int64 (__fastcall **)(__int64, _QWORD, _BYTE *))(*(_QWORD *)g_pEngineClient
+                                                                   + 0x190LL))(// 400LL = 0x190 = IVEngineClient2_SendStringCmd
+                 g_pEngineClient,
+                 0,
+                 v29);
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.linux.yaml
@@ -1,0 +1,282 @@
+func_name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+func_va: '0x16da1a0'
+disasm_code: |-
+  .text:00000000016DA1A0                 push    rbp
+  .text:00000000016DA1A1                 mov     rbp, rsp
+  .text:00000000016DA1A4                 push    r15
+  .text:00000000016DA1A6                 push    r14
+  .text:00000000016DA1A8                 push    r13
+  .text:00000000016DA1AA                 push    r12
+  .text:00000000016DA1AC                 mov     r12, rdi
+  .text:00000000016DA1AF                 push    rbx
+  .text:00000000016DA1B0                 lea     rdi, unk_47DECB0
+  .text:00000000016DA1B7                 mov     rbx, rsi
+  .text:00000000016DA1BA                 mov     esi, 0FFFFFFFFh
+  .text:00000000016DA1BF                 sub     rsp, 38h
+  .text:00000000016DA1C3                 call    sub_20D1310
+  .text:00000000016DA1C8                 test    rax, rax
+  .text:00000000016DA1CB                 jz      short loc_16DA240
+  .text:00000000016DA1CD                 movzx   eax, byte ptr [rax]
+  .text:00000000016DA1D0                 test    al, al
+  .text:00000000016DA1D2                 jz      short loc_16DA1DA
+  .text:00000000016DA1D4                 test    byte ptr [rbx+40h], 4
+  .text:00000000016DA1D8                 jnz     short loc_16DA250
+  .text:00000000016DA1DA                 mov     rdi, cs:qword_47DEB90
+  .text:00000000016DA1E1                 mov     rsi, rbx
+  .text:00000000016DA1E4                 mov     rax, [rdi]
+  .text:00000000016DA1E7                 call    qword ptr [rax+68h] ; 68h = IGameEventManager2_UnserializeEvent
+  .text:00000000016DA1EA                 mov     r12, rax
+  .text:00000000016DA1ED                 test    rax, rax
+  .text:00000000016DA1F0                 jz      loc_16DA3D8
+  .text:00000000016DA1F6                 cmp     dword ptr [rbx+70h], 1
+  .text:00000000016DA1FA                 jz      loc_16DA360
+  .text:00000000016DA200                 mov     rdi, cs:qword_47DEB90
+  .text:00000000016DA207                 lea     rdx, sub_169CBF0
+  .text:00000000016DA20E                 mov     rax, [rdi]
+  .text:00000000016DA211                 mov     rax, [rax+48h] ; 48h = IGameEventManager2_FireEventClientSide
+  .text:00000000016DA215                 cmp     rax, rdx
+  .text:00000000016DA218                 jnz     loc_16DA3C0
+  .text:00000000016DA21E                 add     rsp, 38h
+  .text:00000000016DA222                 mov     rsi, r12
+  .text:00000000016DA225                 mov     ecx, 1
+  .text:00000000016DA22A                 pop     rbx
+  .text:00000000016DA22B                 xor     edx, edx
+  .text:00000000016DA22D                 pop     r12
+  .text:00000000016DA22F                 pop     r13
+  .text:00000000016DA231                 pop     r14
+  .text:00000000016DA233                 pop     r15
+  .text:00000000016DA235                 pop     rbp
+  .text:00000000016DA236                 jmp     sub_169C6B0
+  .text:00000000016DA240                 mov     rax, cs:qword_47DECB8
+  .text:00000000016DA247                 mov     rax, [rax+8]
+  .text:00000000016DA24B                 jmp     short loc_16DA1CD
+  .text:00000000016DA250                 lea     rdi, unk_47DECA0
+  .text:00000000016DA257                 mov     esi, 0FFFFFFFFh
+  .text:00000000016DA25C                 mov     r13d, [rbx+6Ch]
+  .text:00000000016DA260                 call    sub_20D1310
+  .text:00000000016DA265                 test    rax, rax
+  .text:00000000016DA268                 jz      loc_16DA3F8
+  .text:00000000016DA26E                 lea     r14, qword_47F9B38
+  .text:00000000016DA275                 mov     eax, [rax]
+  .text:00000000016DA277                 mov     rdi, [r14]
+  .text:00000000016DA27A                 add     r13d, eax
+  .text:00000000016DA27D                 mov     rax, [rdi]
+  .text:00000000016DA280                 call    qword ptr [rax+128h]
+  .text:00000000016DA286                 cmp     eax, r13d
+  .text:00000000016DA289                 jge     loc_16DA1DA
+  .text:00000000016DA28F                 mov     r15d, [r12+448h]
+  .text:00000000016DA297                 mov     edx, [r12+458h]
+  .text:00000000016DA29F                 lea     eax, [r15+1]
+  .text:00000000016DA2A3                 cmp     eax, edx
+  .text:00000000016DA2A5                 jg      loc_16DA448
+  .text:00000000016DA2AB                 mov     [r12+448h], eax
+  .text:00000000016DA2B3                 test    r15d, r15d
+  .text:00000000016DA2B6                 jg      loc_16DA428
+  .text:00000000016DA2BC                 mov     r15, [r12+450h]
+  .text:00000000016DA2C4                 lea     rax, unk_42AC590
+  .text:00000000016DA2CB                 movsd   xmm0, qword ptr [rbx+8]
+  .text:00000000016DA2D0                 lea     rsi, [rbx+30h]
+  .text:00000000016DA2D4                 mov     [r15], rax
+  .text:00000000016DA2D7                 mov     eax, [rbx+10h]
+  .text:00000000016DA2DA                 lea     rdi, [r15+30h]
+  .text:00000000016DA2DE                 movsd   qword ptr [r15+8], xmm0
+  .text:00000000016DA2E4                 movss   xmm0, dword ptr [rbx+20h]
+  .text:00000000016DA2E9                 movss   dword ptr [r15+20h], xmm0
+  .text:00000000016DA2EF                 mov     [r15+10h], eax
+  .text:00000000016DA2F3                 movzx   eax, byte ptr [rbx+14h]
+  .text:00000000016DA2F7                 mov     [r15+14h], al
+  .text:00000000016DA2FB                 mov     rax, [rbx+18h]
+  .text:00000000016DA2FF                 mov     [r15+18h], rax
+  .text:00000000016DA303                 mov     rax, [rbx+28h]
+  .text:00000000016DA307                 mov     [r15+28h], rax
+  .text:00000000016DA30B                 call    sub_123D980
+  .text:00000000016DA310                 lea     rax, off_43AA6D0
+  .text:00000000016DA317                 mov     [r15], rax
+  .text:00000000016DA31A                 mov     rdi, [r14]
+  .text:00000000016DA31D                 add     rax, 40h ; '@'
+  .text:00000000016DA321                 mov     [r15+30h], rax
+  .text:00000000016DA325                 mov     ebx, [r12+448h]
+  .text:00000000016DA32D                 mov     rax, [rdi]
+  .text:00000000016DA330                 call    qword ptr [rax+128h]
+  .text:00000000016DA336                 add     rsp, 38h
+  .text:00000000016DA33A                 mov     r8d, ebx
+  .text:00000000016DA33D                 mov     edx, r13d
+  .text:00000000016DA340                 pop     rbx
+  .text:00000000016DA341                 lea     rsi, aOnsource1sourc; "OnSource1Source1LegacyGameEvent: Early "...
+  .text:00000000016DA348                 mov     ecx, eax
+  .text:00000000016DA34A                 ; _QWORD
+  .text:00000000016DA34A                 mov     edi, 2; _QWORD
+  .text:00000000016DA34F                 pop     r12
+  .text:00000000016DA351                 xor     eax, eax
+  .text:00000000016DA353                 pop     r13
+  .text:00000000016DA355                 pop     r14
+  .text:00000000016DA357                 pop     r15
+  .text:00000000016DA359                 pop     rbp
+  .text:00000000016DA35A                 jmp     _DevMsg
+  .text:00000000016DA360                 mov     rax, [rax]
+  .text:00000000016DA363                 lea     rbx, aRealtimePassth; "realtime_passthrough"
+  .text:00000000016DA36A                 mov     rdi, rbx
+  .text:00000000016DA36D                 mov     r13, [rax+0A8h]
+  .text:00000000016DA374                 call    sub_1674450
+  .text:00000000016DA379                 lea     rdx, sub_166FBC0
+  .text:00000000016DA380                 mov     [rbp+var_4C], 0FFFFFFFFh
+  .text:00000000016DA387                 mov     [rbp+var_50], eax
+  .text:00000000016DA38A                 mov     [rbp+var_48], rbx
+  .text:00000000016DA38E                 cmp     r13, rdx
+  .text:00000000016DA391                 jnz     short loc_16DA410
+  .text:00000000016DA393                 lea     rsi, [rbp+var_40]
+  .text:00000000016DA397                 mov     edx, 1
+  .text:00000000016DA39C                 mov     [rbp+var_40], eax
+  .text:00000000016DA39F                 lea     rdi, [r12+58h]
+  .text:00000000016DA3A4                 mov     [rbp+var_3C], 0FFFFFFFFh
+  .text:00000000016DA3AB                 mov     [rbp+var_38], rbx
+  .text:00000000016DA3AF                 call    sub_20E19E0
+  .text:00000000016DA3B4                 jmp     loc_16DA200
+  .text:00000000016DA3C0                 add     rsp, 38h
+  .text:00000000016DA3C4                 mov     rsi, r12
+  .text:00000000016DA3C7                 pop     rbx
+  .text:00000000016DA3C8                 pop     r12
+  .text:00000000016DA3CA                 pop     r13
+  .text:00000000016DA3CC                 pop     r14
+  .text:00000000016DA3CE                 pop     r15
+  .text:00000000016DA3D0                 pop     rbp
+  .text:00000000016DA3D1                 jmp     rax
+  .text:00000000016DA3D8                 lea     rdi, aCnetworkgamecl; "CNetworkGameClient::OnSource1Source1Leg"...
+  .text:00000000016DA3DF                 add     rsp, 38h
+  .text:00000000016DA3E3                 xor     eax, eax
+  .text:00000000016DA3E5                 pop     rbx
+  .text:00000000016DA3E6                 pop     r12
+  .text:00000000016DA3E8                 pop     r13
+  .text:00000000016DA3EA                 pop     r14
+  .text:00000000016DA3EC                 pop     r15
+  .text:00000000016DA3EE                 pop     rbp
+  .text:00000000016DA3EF                 jmp     __Z6DevMsgPKcz; DevMsg(char const*,...)
+  .text:00000000016DA3F8                 mov     rax, cs:qword_47DECA8
+  .text:00000000016DA3FF                 mov     rax, [rax+8]
+  .text:00000000016DA403                 jmp     loc_16DA26E
+  .text:00000000016DA410                 lea     rsi, [rbp+var_50]
+  .text:00000000016DA414                 mov     edx, 1
+  .text:00000000016DA419                 mov     rdi, r12
+  .text:00000000016DA41C                 call    r13
+  .text:00000000016DA41F                 jmp     loc_16DA200
+  .text:00000000016DA428                 movsxd  rdx, r15d
+  .text:00000000016DA42B                 ; src
+  .text:00000000016DA42B                 mov     rsi, [r12+450h]; src
+  .text:00000000016DA433                 ; n
+  .text:00000000016DA433                 imul    rdx, 78h ; 'x'; n
+  .text:00000000016DA437                 ; dest
+  .text:00000000016DA437                 lea     rdi, [rsi+78h]; dest
+  .text:00000000016DA43B                 call    _memmove
+  .text:00000000016DA440                 jmp     loc_16DA2BC
+  .text:00000000016DA448                 lea     rdi, [r12+450h]
+  .text:00000000016DA450                 mov     esi, eax
+  .text:00000000016DA452                 mov     [rbp+var_54], eax
+  .text:00000000016DA455                 sub     esi, edx
+  .text:00000000016DA457                 call    sub_16DA080
+  .text:00000000016DA45C                 mov     eax, [rbp+var_54]
+  .text:00000000016DA45F                 jmp     loc_16DA2AB
+procedure: |-
+  __int64 __fastcall sub_16DA1A0(__int64 a1, __int64 a2)
+  {
+    _BYTE *v3; // rax
+    __int64 v4; // rax
+    __int64 v5; // r12
+    __int64 (__fastcall *v6)(); // rax
+    int v8; // r13d
+    _DWORD *v9; // rax
+    int v10; // r13d
+    int v11; // r15d
+    int v12; // edx
+    int v13; // eax
+    __int64 v14; // r15
+    __int64 v15; // xmm0_8
+    int v16; // eax
+    __int64 v17; // rdi
+    int v18; // ebx
+    int v19; // eax
+    __int64 (__fastcall *v20)(); // r13
+    int v21; // eax
+    _DWORD v22[2]; // [rsp+10h] [rbp-50h] BYREF
+    const char *v23; // [rsp+18h] [rbp-48h]
+    _DWORD v24[2]; // [rsp+20h] [rbp-40h] BYREF
+    const char *v25; // [rsp+28h] [rbp-38h]
+
+    v3 = (_BYTE *)sub_20D1310(&unk_47DECB0, 0xFFFFFFFFLL);
+    if ( !v3 )
+      v3 = *(_BYTE **)(qword_47DECB8 + 8);
+    if ( !*v3 || (*(_BYTE *)(a2 + 64) & 4) == 0 )
+      goto LABEL_5;
+    v8 = *(_DWORD *)(a2 + 108);
+    v9 = (_DWORD *)sub_20D1310(&unk_47DECA0, 0xFFFFFFFFLL);
+    if ( !v9 )
+      v9 = *(_DWORD **)(qword_47DECA8 + 8);
+    v10 = *v9 + v8;
+    if ( (*(int (__fastcall **)(__int64))(*(_QWORD *)qword_47F9B38 + 296LL))(qword_47F9B38) < v10 )
+    {
+      v11 = *(_DWORD *)(a1 + 1096);
+      v12 = *(_DWORD *)(a1 + 1112);
+      v13 = v11 + 1;
+      if ( v11 + 1 > v12 )
+      {
+        sub_16DA080(a1 + 1104, (unsigned int)(v13 - v12));
+        v13 = v11 + 1;
+      }
+      *(_DWORD *)(a1 + 1096) = v13;
+      if ( v11 > 0 )
+        memmove((void *)(*(_QWORD *)(a1 + 1104) + 120LL), *(const void **)(a1 + 1104), 120LL * v11);
+      v14 = *(_QWORD *)(a1 + 1104);
+      v15 = *(_QWORD *)(a2 + 8);
+      *(_QWORD *)v14 = &unk_42AC590;
+      v16 = *(_DWORD *)(a2 + 16);
+      *(_QWORD *)(v14 + 8) = v15;
+      *(_DWORD *)(v14 + 32) = *(_DWORD *)(a2 + 32);
+      *(_DWORD *)(v14 + 16) = v16;
+      *(_BYTE *)(v14 + 20) = *(_BYTE *)(a2 + 20);
+      *(_QWORD *)(v14 + 24) = *(_QWORD *)(a2 + 24);
+      *(_QWORD *)(v14 + 40) = *(_QWORD *)(a2 + 40);
+      sub_123D980(v14 + 48, a2 + 48);
+      *(_QWORD *)v14 = &off_43AA6D0;
+      v17 = qword_47F9B38;
+      *(_QWORD *)(v14 + 48) = off_43AA710;
+      v18 = *(_DWORD *)(a1 + 1096);
+      v19 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v17 + 296LL))(v17);
+      return DevMsg(2, "OnSource1Source1LegacyGameEvent: Early event sv %d / cl %d. Total in queue %d.\n", v10, v19, v18);
+    }
+    else
+    {
+  LABEL_5:
+      v4 = (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_47DEB90 + 104LL))(qword_47DEB90, a2); // 104LL = 0x68 = IGameEventManager2_UnserializeEvent
+      v5 = v4;
+      if ( v4 )
+      {
+        if ( *(_DWORD *)(a2 + 112) == 1 )
+        {
+          v20 = *(__int64 (__fastcall **)())(*(_QWORD *)v4 + 168LL);
+          v21 = sub_1674450("realtime_passthrough");
+          v22[1] = -1;
+          v22[0] = v21;
+          v23 = "realtime_passthrough";
+          if ( v20 == sub_166FBC0 )
+          {
+            v24[0] = v21;
+            v24[1] = -1;
+            v25 = "realtime_passthrough";
+            sub_20E19E0(v5 + 88, v24, 1);
+          }
+          else
+          {
+            ((void (__fastcall *)(__int64, _DWORD *, __int64))v20)(v5, v22, 1);
+          }
+        }
+        v6 = *(__int64 (__fastcall **)())(*(_QWORD *)qword_47DEB90 + 72LL); // 72LL = 0x48 = IGameEventManager2_FireEventClientSide
+        if ( v6 == sub_169CBF0 )
+          return sub_169C6B0(qword_47DEB90, v5, 0, 1);
+        else
+          return ((__int64 (__fastcall *)(__int64, __int64))v6)(qword_47DEB90, v5);
+      }
+      else
+      {
+        return DevMsg("CNetworkGameClient::OnSource1Source1LegacyGameEvent: UnserializeKeyValue failed.\n");
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.windows.yaml
@@ -1,0 +1,147 @@
+func_name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
+func_va: '0x1809ac4d0'
+disasm_code: |-
+  .text:00000001809AC4D0                 mov     [rsp+arg_8], rbx
+  .text:00000001809AC4D5                 push    rdi
+  .text:00000001809AC4D6                 sub     rsp, 40h
+  .text:00000001809AC4DA                 mov     rdi, rdx
+  .text:00000001809AC4DD                 mov     rbx, rcx
+  .text:00000001809AC4E0                 mov     edx, 0FFFFFFFFh
+  .text:00000001809AC4E5                 lea     rcx, unk_18238C7E0
+  .text:00000001809AC4EC                 call    sub_1818622D0
+  .text:00000001809AC4F1                 test    rax, rax
+  .text:00000001809AC4F4                 jnz     short loc_1809AC501
+  .text:00000001809AC4F6                 mov     rax, cs:qword_18238C7E8
+  .text:00000001809AC4FD                 mov     rax, [rax+8]
+  .text:00000001809AC501                 mov     [rsp+48h+arg_0], rsi
+  .text:00000001809AC506                 cmp     byte ptr [rax], 0
+  .text:00000001809AC509                 jz      loc_1809AC5AA
+  .text:00000001809AC50F                 mov     eax, [rdi+40h]
+  .text:00000001809AC512                 shr     eax, 2
+  .text:00000001809AC515                 test    al, 1
+  .text:00000001809AC517                 jz      loc_1809AC5AA
+  .text:00000001809AC51D                 mov     edx, 0FFFFFFFFh
+  .text:00000001809AC522                 lea     rcx, unk_18238C7F0
+  .text:00000001809AC529                 call    sub_1818622D0
+  .text:00000001809AC52E                 test    rax, rax
+  .text:00000001809AC531                 jnz     short loc_1809AC53E
+  .text:00000001809AC533                 mov     rax, cs:qword_18238C7F8
+  .text:00000001809AC53A                 mov     rax, [rax+8]
+  .text:00000001809AC53E                 mov     rcx, cs:g_pEngineClient
+  .text:00000001809AC545                 mov     esi, [rdi+6Ch]
+  .text:00000001809AC548                 add     esi, [rax]
+  .text:00000001809AC54A                 mov     rax, [rcx]
+  .text:00000001809AC54D                 call    qword ptr [rax+128h]
+  .text:00000001809AC553                 cmp     esi, eax
+  .text:00000001809AC555                 jle     short loc_1809AC5AA
+  .text:00000001809AC557                 mov     r8, rdi
+  .text:00000001809AC55A                 lea     rcx, [rbx+448h]
+  .text:00000001809AC561                 xor     edx, edx
+  .text:00000001809AC563                 call    sub_1809A0A10
+  .text:00000001809AC568                 mov     rcx, cs:g_pEngineClient
+  .text:00000001809AC56F                 mov     ebx, [rbx+448h]
+  .text:00000001809AC575                 mov     rax, [rcx]
+  .text:00000001809AC578                 call    qword ptr [rax+128h]
+  .text:00000001809AC57E                 mov     r8d, esi
+  .text:00000001809AC581                 mov     [rsp+48h+var_28], ebx
+  .text:00000001809AC585                 mov     r9d, eax
+  .text:00000001809AC588                 lea     rdx, aOnsource1sourc; "OnSource1Source1LegacyGameEvent: Early "...
+  .text:00000001809AC58F                 mov     ecx, 2
+  .text:00000001809AC594                 call    cs:DevMsg
+  .text:00000001809AC59A                 mov     rsi, [rsp+48h+arg_0]
+  .text:00000001809AC59F                 mov     rbx, [rsp+48h+arg_8]
+  .text:00000001809AC5A4                 add     rsp, 40h
+  .text:00000001809AC5A8                 pop     rdi
+  .text:00000001809AC5A9                 retn
+  .text:00000001809AC5AA                 mov     rcx, cs:g_pGameEventManager
+  .text:00000001809AC5B1                 mov     rdx, rdi
+  .text:00000001809AC5B4                 mov     rax, [rcx]
+  .text:00000001809AC5B7                 call    qword ptr [rax+60h] ; 60h = IGameEventManager2_UnserializeEvent
+  .text:00000001809AC5BA                 mov     rsi, rax
+  .text:00000001809AC5BD                 test    rax, rax
+  .text:00000001809AC5C0                 jnz     short loc_1809AC5DF
+  .text:00000001809AC5C2                 lea     rcx, aCnetworkgamecl; "CNetworkGameClient::OnSource1Source1Leg"...
+  .text:00000001809AC5C9                 mov     rsi, [rsp+48h+arg_0]
+  .text:00000001809AC5CE                 mov     rbx, [rsp+48h+arg_8]
+  .text:00000001809AC5D3                 add     rsp, 40h
+  .text:00000001809AC5D7                 pop     rdi
+  .text:00000001809AC5D8                 jmp     cs:?DevMsg@@YAXPEBDZZ; DevMsg(char const *,...)
+  .text:00000001809AC5DF                 cmp     dword ptr [rdi+70h], 1
+  .text:00000001809AC5E3                 jnz     short loc_1809AC62B
+  .text:00000001809AC5E5                 mov     rax, [rax]
+  .text:00000001809AC5E8                 lea     rcx, aRealtimePassth+4; "time_passthrough"
+  .text:00000001809AC5EF                 mov     edx, 10h
+  .text:00000001809AC5F4                 mov     r8d, 0CAED6EF2h
+  .text:00000001809AC5FA                 mov     rbx, [rax+0A0h]
+  .text:00000001809AC601                 call    sub_180224E90
+  .text:00000001809AC606                 mov     [rsp+48h+var_18], eax
+  .text:00000001809AC60A                 lea     rdx, [rsp+48h+var_18]
+  .text:00000001809AC60F                 lea     rax, aRealtimePassth; "realtime_passthrough"
+  .text:00000001809AC616                 mov     [rsp+48h+var_14], 0FFFFFFFFh
+  .text:00000001809AC61E                 mov     r8b, 1
+  .text:00000001809AC621                 mov     [rsp+48h+var_10], rax
+  .text:00000001809AC626                 mov     rcx, rsi
+  .text:00000001809AC629                 call    rbx
+  .text:00000001809AC62B                 mov     rcx, cs:g_pGameEventManager
+  .text:00000001809AC632                 mov     rdx, rsi
+  .text:00000001809AC635                 mov     rax, [rcx]
+  .text:00000001809AC638                 mov     rsi, [rsp+48h+arg_0]
+  .text:00000001809AC63D                 mov     rbx, [rsp+48h+arg_8]
+  .text:00000001809AC642                 add     rsp, 40h
+  .text:00000001809AC646                 pop     rdi
+  .text:00000001809AC647                 jmp     qword ptr [rax+40h] ; 40h = IGameEventManager2_FireEventClientSide
+procedure: |-
+  void __fastcall sub_1809AC4D0(__int64 a1, _DWORD *a2)
+  {
+    _BYTE *v4; // rax
+    _DWORD *v5; // rax
+    int v6; // esi
+    int v7; // ebx
+    int v8; // eax
+    __int64 v9; // rax
+    __int64 v10; // rsi
+    void (__fastcall *v11)(__int64, _DWORD *, __int64); // rbx
+    __int64 v12; // r8
+    _DWORD v13[2]; // [rsp+30h] [rbp-18h] BYREF
+    const char *v14; // [rsp+38h] [rbp-10h]
+
+    v4 = (_BYTE *)sub_1818622D0(&unk_18238C7E0, 0xFFFFFFFFLL);
+    if ( !v4 )
+      v4 = *(_BYTE **)(qword_18238C7E8 + 8);
+    if ( !*v4 || (a2[16] & 4) == 0 )
+      goto LABEL_9;
+    v5 = (_DWORD *)sub_1818622D0(&unk_18238C7F0, 0xFFFFFFFFLL);
+    if ( !v5 )
+      v5 = *(_DWORD **)(qword_18238C7F8 + 8);
+    v6 = *v5 + a2[27];
+    if ( v6 > (*(int (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 296LL))(g_pEngineClient) )
+    {
+      sub_1809A0A10(a1 + 1096, 0, a2);
+      v7 = *(_DWORD *)(a1 + 1096);
+      v8 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 296LL))(g_pEngineClient);
+      DevMsg(2, "OnSource1Source1LegacyGameEvent: Early event sv %d / cl %d. Total in queue %d.\n", v6, v8, v7);
+    }
+    else
+    {
+  LABEL_9:
+      v9 = (*(__int64 (__fastcall **)(__int64, _DWORD *))(*(_QWORD *)g_pGameEventManager + 96LL))(g_pGameEventManager, a2); // 96LL = 0x60 = IGameEventManager2_UnserializeEvent
+      v10 = v9;
+      if ( v9 )
+      {
+        if ( a2[28] == 1 )
+        {
+          v11 = *(void (__fastcall **)(__int64, _DWORD *, __int64))(*(_QWORD *)v9 + 160LL);
+          v13[0] = sub_180224E90("time_passthrough", 16, 3404558066LL);
+          v13[1] = -1;
+          LOBYTE(v12) = 1;
+          v14 = "realtime_passthrough";
+          v11(v10, v13, v12);
+        }
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pGameEventManager + 64LL))(g_pGameEventManager, v10); // 64LL = 0x40 = IGameEventManager2_FireEventClientSide
+      }
+      else
+      {
+        DevMsg("CNetworkGameClient::OnSource1Source1LegacyGameEvent: UnserializeKeyValue failed.\n");
+      }
+    }
+  }

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -10,7 +10,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import ida_analyze_bin
-from ida_mcp_session import McpDatabaseBinding, McpDatabaseSelectionError, McpToolCallError
+from ida_mcp_session import (
+    McpDatabaseBinding,
+    McpDatabaseSelectionError,
+    McpDatabaseUnavailableError,
+    McpToolCallError,
+)
 from process_reporter import (
     EdgeType,
     PlanNodeType,
@@ -89,6 +94,7 @@ class TestQuitIdaGracefully(unittest.IsolatedAsyncioTestCase):
                 AsyncMock(return_value=True),
             ) as quit_ida_via_mcp,
             patch.object(ida_analyze_bin, "stop_idalib_mcp_process") as stop_process,
+            patch.object(ida_analyze_bin, "wait_for_port_release", return_value=True) as wait_for_release,
         ):
             await ida_analyze_bin.quit_ida_gracefully_async(
                 process,
@@ -105,6 +111,11 @@ class TestQuitIdaGracefully(unittest.IsolatedAsyncioTestCase):
             auto_started=True,
         )
         stop_process.assert_called_once_with(process, debug=False)
+        wait_for_release.assert_called_once_with(
+            "127.0.0.1",
+            13337,
+            ida_analyze_bin.MCP_SHUTDOWN_TIMEOUT,
+        )
 
     async def test_quit_owned_auto_started_worker(self) -> None:
         session = MagicMock()
@@ -254,6 +265,40 @@ class TestStopIdalibMcpProcess(unittest.TestCase):
         process.terminate.assert_called_once_with()
         process.kill.assert_called_once_with()
         self.assertEqual([call(timeout=10), call(timeout=5)], process.wait.call_args_list)
+
+
+class TestWaitForPortRelease(unittest.TestCase):
+    def test_waits_until_the_supervisor_port_is_released(self) -> None:
+        with (
+            patch.object(ida_analyze_bin, "is_port_in_use", side_effect=[True, True, False]) as port_in_use,
+            patch.object(ida_analyze_bin.time, "sleep") as sleep,
+        ):
+            released = ida_analyze_bin.wait_for_port_release(
+                "127.0.0.1",
+                13337,
+                timeout=1.0,
+                retry_interval=0.01,
+            )
+
+        self.assertTrue(released)
+        self.assertEqual(3, port_in_use.call_count)
+        self.assertEqual(2, sleep.call_count)
+
+    def test_returns_false_when_the_port_does_not_release_before_timeout(self) -> None:
+        with (
+            patch.object(ida_analyze_bin, "is_port_in_use", return_value=True),
+            patch.object(ida_analyze_bin.time, "monotonic", side_effect=[0.0, 1.0]),
+            patch.object(ida_analyze_bin.time, "sleep") as sleep,
+        ):
+            released = ida_analyze_bin.wait_for_port_release(
+                "127.0.0.1",
+                13337,
+                timeout=0.5,
+                retry_interval=0.01,
+            )
+
+        self.assertFalse(released)
+        sleep.assert_not_called()
 
 
 class TestSurveyBinaryViaSession(unittest.IsolatedAsyncioTestCase):
@@ -454,37 +499,7 @@ class TestMcpEntrypointRouting(unittest.IsolatedAsyncioTestCase):
 
 
 class TestOpenedBinaryIdentityValidation(unittest.TestCase):
-    def test_verification_retries_while_matching_database_is_starting(self) -> None:
-        with TemporaryDirectory() as temp_dir:
-            binary_path = Path(temp_dir) / "libclient.so"
-            binary_path.write_bytes(b"client-binary")
-            ready_survey = {"metadata": {"path": str(binary_path)}}
-
-            with (
-                patch.object(
-                    ida_analyze_bin,
-                    "survey_binary_via_mcp",
-                    new=AsyncMock(
-                        side_effect=[
-                            ida_analyze_bin.McpDatabaseNotReadyError("matching database is not active yet"),
-                            ready_survey,
-                        ]
-                    ),
-                ) as survey_binary,
-                patch.object(ida_analyze_bin.time, "sleep") as sleep,
-            ):
-                verified = ida_analyze_bin.verify_opened_binary_via_mcp(
-                    str(binary_path),
-                    "linux",
-                    worker_ready_timeout=1.0,
-                    retry_interval=0.01,
-                )
-
-        self.assertTrue(verified)
-        self.assertEqual(2, survey_binary.await_count)
-        sleep.assert_called_once_with(0.01)
-
-    def test_verification_stops_after_worker_ready_timeout(self) -> None:
+    def test_verification_does_not_retry_an_inactive_database(self) -> None:
         with TemporaryDirectory() as temp_dir:
             binary_path = Path(temp_dir) / "libclient.so"
             binary_path.write_bytes(b"client-binary")
@@ -493,24 +508,19 @@ class TestOpenedBinaryIdentityValidation(unittest.TestCase):
                 patch.object(
                     ida_analyze_bin,
                     "survey_binary_via_mcp",
-                    new=AsyncMock(
-                        side_effect=ida_analyze_bin.McpDatabaseNotReadyError("matching database is not active yet")
-                    ),
+                    new=AsyncMock(side_effect=McpDatabaseUnavailableError("inactive or unreachable")),
                 ) as survey_binary,
                 patch.object(ida_analyze_bin.time, "sleep") as sleep,
-                patch("sys.stdout", new_callable=io.StringIO) as stdout,
             ):
-                verified = ida_analyze_bin.verify_opened_binary_via_mcp(
-                    str(binary_path),
-                    "linux",
-                    worker_ready_timeout=0.0,
-                    retry_interval=0.01,
-                )
+                with self.assertRaisesRegex(McpDatabaseUnavailableError, "inactive or unreachable"):
+                    ida_analyze_bin.verify_opened_binary_via_mcp(
+                        str(binary_path),
+                        "linux",
+                        retry_interval=0.01,
+                    )
 
-        self.assertFalse(verified)
         self.assertEqual(1, survey_binary.await_count)
         sleep.assert_not_called()
-        self.assertIn("timed out waiting for the IDA worker", stdout.getvalue())
 
     def test_verification_does_not_retry_mcp_tool_error(self) -> None:
         with TemporaryDirectory() as temp_dir:
@@ -584,6 +594,214 @@ class TestOpenedBinaryIdentityValidation(unittest.TestCase):
         self.assertEqual(1, survey_binary.await_count)
         sleep.assert_not_called()
 
+
+class TestOwnedMcpVerificationRecovery(unittest.TestCase):
+    def test_restarts_an_unhealthy_owned_worker_once_and_reverifies(self) -> None:
+        original_process = object()
+        restarted_process = object()
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(
+                ida_analyze_bin,
+                "verify_opened_binary_via_mcp",
+                side_effect=[McpDatabaseUnavailableError("inactive or unreachable"), True],
+            ) as verify,
+            patch.object(
+                ida_analyze_bin,
+                "ensure_mcp_available",
+                return_value=(restarted_process, True),
+            ) as ensure,
+            patch("sys.stdout", new_callable=io.StringIO) as stdout,
+        ):
+            process, verified = ida_analyze_bin.verify_owned_mcp_with_single_recovery(
+                original_process,
+                "bin/14172/client/client.dll",
+                "windows",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIs(restarted_process, process)
+        self.assertTrue(verified)
+        self.assertEqual(2, verify.call_count)
+        self.assertNotIn("Failed:", stdout.getvalue())
+        ensure.assert_called_once_with(
+            original_process,
+            "bin/14172/client/client.dll",
+            "127.0.0.1",
+            13337,
+            "",
+            False,
+            recovery_budget=recovery_budget,
+        )
+
+    def test_reverifies_without_restart_when_health_check_recovers(self) -> None:
+        process = object()
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(
+                ida_analyze_bin,
+                "verify_opened_binary_via_mcp",
+                side_effect=[McpDatabaseUnavailableError("inactive or unreachable"), True],
+            ) as verify,
+            patch.object(
+                ida_analyze_bin,
+                "ensure_mcp_available",
+                return_value=(process, True),
+            ) as ensure,
+        ):
+            recovered_process, verified = ida_analyze_bin.verify_owned_mcp_with_single_recovery(
+                process,
+                "bin/14172/client/client.dll",
+                "windows",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIs(process, recovered_process)
+        self.assertTrue(verified)
+        self.assertEqual(2, verify.call_count)
+        ensure.assert_called_once()
+        self.assertEqual(1, recovery_budget.remaining_restarts)
+
+    def test_stops_after_one_unsuccessful_restart(self) -> None:
+        original_process = object()
+        restarted_process = object()
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(
+                ida_analyze_bin,
+                "verify_opened_binary_via_mcp",
+                side_effect=McpDatabaseUnavailableError("inactive or unreachable"),
+            ) as verify,
+            patch.object(
+                ida_analyze_bin,
+                "ensure_mcp_available",
+                return_value=(restarted_process, True),
+            ) as ensure,
+        ):
+            process, verified = ida_analyze_bin.verify_owned_mcp_with_single_recovery(
+                original_process,
+                "bin/14172/client/client.dll",
+                "windows",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIs(restarted_process, process)
+        self.assertFalse(verified)
+        self.assertEqual(2, verify.call_count)
+        ensure.assert_called_once()
+
+
+class TestEnsureMcpAvailableRecoveryBudget(unittest.TestCase):
+    def test_only_one_restart_is_allowed_for_the_binary_lifecycle(self) -> None:
+        original_process = MagicMock()
+        original_process.poll.return_value = None
+        restarted_process = MagicMock()
+        restarted_process.poll.return_value = None
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(ida_analyze_bin, "check_mcp_worker_health", new=AsyncMock(return_value=False)),
+            patch.object(ida_analyze_bin, "quit_ida_gracefully") as quit_ida,
+            patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=restarted_process) as start_ida,
+        ):
+            process, ok = ida_analyze_bin.ensure_mcp_available(
+                original_process,
+                "bin/14172/client/client.dll",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+            second_process, second_ok = ida_analyze_bin.ensure_mcp_available(
+                process,
+                "bin/14172/client/client.dll",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIs(restarted_process, process)
+        self.assertTrue(ok)
+        self.assertIs(restarted_process, second_process)
+        self.assertFalse(second_ok)
+        self.assertEqual(0, recovery_budget.remaining_restarts)
+        quit_ida.assert_called_once()
+        start_ida.assert_called_once()
+
+    def test_waits_for_a_lingering_launcher_port_before_restart(self) -> None:
+        exited_process = MagicMock()
+        exited_process.poll.return_value = 1
+        exited_process.returncode = 1
+        restarted_process = MagicMock()
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(ida_analyze_bin, "is_port_in_use", return_value=True),
+            patch.object(ida_analyze_bin, "wait_for_port_release", return_value=True) as wait_for_release,
+            patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=restarted_process) as start_ida,
+        ):
+            process, ok = ida_analyze_bin.ensure_mcp_available(
+                exited_process,
+                "bin/14172/client/client.dll",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIs(restarted_process, process)
+        self.assertTrue(ok)
+        self.assertEqual(0, recovery_budget.remaining_restarts)
+        wait_for_release.assert_called_once_with("127.0.0.1", 13337)
+        start_ida.assert_called_once()
+
+    def test_aborts_restart_when_the_launcher_port_never_releases(self) -> None:
+        exited_process = MagicMock()
+        exited_process.poll.return_value = 1
+        exited_process.returncode = 1
+        recovery_budget = ida_analyze_bin.McpRecoveryBudget()
+
+        with (
+            patch.object(ida_analyze_bin, "is_port_in_use", return_value=True),
+            patch.object(ida_analyze_bin, "wait_for_port_release", return_value=False),
+            patch.object(ida_analyze_bin, "start_idalib_mcp") as start_ida,
+        ):
+            process, ok = ida_analyze_bin.ensure_mcp_available(
+                exited_process,
+                "bin/14172/client/client.dll",
+                "127.0.0.1",
+                13337,
+                "",
+                False,
+                recovery_budget=recovery_budget,
+            )
+
+        self.assertIsNone(process)
+        self.assertFalse(ok)
+        self.assertEqual(0, recovery_budget.remaining_restarts)
+        start_ida.assert_not_called()
+
+
+class TestOpenedBinaryIdentityValidationHashes(unittest.TestCase):
     def test_accepts_ida_database_suffix_for_expected_binary_path(self) -> None:
         with TemporaryDirectory() as temp_dir:
             binary_path = Path(temp_dir) / "bin" / "14141" / "server" / "libserver.so"
@@ -3586,11 +3804,16 @@ class TestProcessBinaryOpenedBinaryVerification(unittest.TestCase):
             with (
                 patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
                 patch.object(ida_analyze_bin, "verify_opened_binary_via_mcp", return_value=False),
-                patch.object(ida_analyze_bin, "ensure_mcp_available") as mock_ensure,
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ) as mock_ensure,
                 patch.object(ida_analyze_bin, "_run_validate_expected_input_artifacts_via_mcp") as mock_validate,
                 patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp") as mock_preprocess,
                 patch.object(ida_analyze_bin, "run_skill") as mock_run_skill,
                 patch.object(ida_analyze_bin, "quit_ida_gracefully") as mock_quit_ida,
+                patch.object(ida_analyze_bin, "wait_for_port_release", return_value=True) as wait_for_release,
                 patch("sys.stdout", new_callable=io.StringIO) as stdout,
             ):
                 success, fail, skip = ida_analyze_bin.process_binary(
@@ -3619,6 +3842,133 @@ class TestProcessBinaryOpenedBinaryVerification(unittest.TestCase):
         mock_run_skill.assert_not_called()
         mock_quit_ida.assert_not_called()
         self.mock_stop_ida.assert_called_once_with(fake_process, debug=False)
+        wait_for_release.assert_called_once_with("127.0.0.1", 13337)
+
+    def test_process_binary_recovers_initial_inactive_worker_once(self) -> None:
+        original_process = object()
+        restarted_process = object()
+
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14172" / "client"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "client.dll")
+            Path(binary_path).write_bytes(b"client-binary")
+
+            def _fake_preprocess(*, expected_outputs, **_kwargs):
+                Path(expected_outputs[0]).write_text("func_name: Recovered\n", encoding="utf-8")
+                return "success"
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=original_process) as start_ida,
+                patch.object(
+                    ida_analyze_bin,
+                    "verify_opened_binary_via_mcp",
+                    side_effect=[McpDatabaseUnavailableError("inactive or unreachable"), True, True, True],
+                ) as verify,
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    side_effect=[(restarted_process, True), (restarted_process, True)],
+                ) as ensure,
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    side_effect=_fake_preprocess,
+                ),
+                patch.object(ida_analyze_bin, "run_skill", return_value=False),
+                patch.object(ida_analyze_bin, "quit_ida_gracefully") as quit_ida,
+            ):
+                result = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "find-recovered",
+                            "expected_output": ["Recovered.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    agent="codex",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="",
+                    platform="windows",
+                    max_retries=1,
+                )
+
+        self.assertEqual((1, 0, 0), result)
+        start_ida.assert_called_once()
+        self.assertEqual(2, ensure.call_count)
+        self.assertEqual(4, verify.call_count)
+        quit_ida.assert_called_once_with(
+            restarted_process,
+            "127.0.0.1",
+            13337,
+            expected_binary=binary_path,
+            debug=False,
+        )
+        self.mock_stop_ida.assert_not_called()
+
+    def test_process_binary_shares_one_restart_budget_across_later_work(self) -> None:
+        original_process = MagicMock()
+        original_process.poll.return_value = None
+        restarted_process = MagicMock()
+        restarted_process.poll.return_value = None
+
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14172" / "client"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "client.dll")
+            Path(binary_path).write_bytes(b"client-binary")
+
+            with (
+                patch.object(
+                    ida_analyze_bin,
+                    "start_idalib_mcp",
+                    side_effect=[original_process, restarted_process],
+                ) as start_ida,
+                patch.object(
+                    ida_analyze_bin,
+                    "verify_opened_binary_via_mcp",
+                    side_effect=[McpDatabaseUnavailableError("inactive or unreachable"), True],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "check_mcp_worker_health",
+                    new=AsyncMock(return_value=False),
+                ),
+                patch.object(ida_analyze_bin, "is_port_in_use", return_value=False),
+                patch.object(ida_analyze_bin, "quit_ida_gracefully") as quit_ida,
+                patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp") as preprocess,
+                patch.object(ida_analyze_bin, "preprocess_single_vcall_object_via_mcp") as preprocess_vcall,
+            ):
+                result = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "find-budget-consumer",
+                            "expected_output": ["BudgetConsumer.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    agent="codex",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="",
+                    platform="windows",
+                    max_retries=1,
+                    vcall_targets=["g_pBudgetTarget"],
+                )
+
+        self.assertEqual((0, 2, 0), result)
+        self.assertEqual(2, start_ida.call_count)
+        self.assertEqual(2, quit_ida.call_count)
+        preprocess.assert_not_called()
+        preprocess_vcall.assert_not_called()
 
     def test_process_binary_aborts_before_skill_mcp_work_when_recheck_mismatches(self) -> None:
         fake_process = object()

--- a/tests/test_ida_mcp_session.py
+++ b/tests/test_ida_mcp_session.py
@@ -12,8 +12,8 @@ from ida_mcp_session import (
     McpConnectionError,
     McpContractError,
     McpDatabaseBinding,
-    McpDatabaseNotReadyError,
     McpDatabaseSelectionError,
+    McpDatabaseUnavailableError,
     McpToolCallError,
     detect_database_requirement,
     normalize_binary_identity_path,
@@ -114,10 +114,10 @@ class TestSelectDatabaseSession(unittest.TestCase):
 
         self.assertEqual("server-db", selected["session_id"])
 
-    def test_matching_inactive_database_is_reported_as_not_ready(self) -> None:
+    def test_matching_inactive_database_is_reported_as_unavailable(self) -> None:
         inactive_server = {**ACTIVE_SERVER, "is_active": False}
 
-        with self.assertRaisesRegex(McpDatabaseNotReadyError, "not active yet"):
+        with self.assertRaisesRegex(McpDatabaseUnavailableError, "inactive or unreachable"):
             select_database_session(
                 [inactive_server],
                 expected_binary=r"D:\repo\tests\bin\ida-mcp-smoke.dll",


### PR DESCRIPTION
## Summary
- add finder and reference coverage for HLTV/demo snapshots, delta-entity writes, string commands, and legacy game events
- version analysis output contracts and validate generated snapshot candidates
- recover once from an unavailable owned IDA MCP worker

## Testing
- Not run in this session (PR creation only; the changes were already committed)