### PR TITLE
feat(preprocessor): add hostage and secondary shoot finders

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -5391,6 +5391,9 @@ modules:
         expected_input:
           - CCSPlayer_ItemServices_DropActivePlayerWeapon.{platform}.yaml
           - CCSPlayer_WeaponServices_vtable.{platform}.yaml
+      - name: find-CBasePlayerWeapon_Shoot_Secondary
+        expected_output:
+          - CBasePlayerWeapon_Shoot_Secondary.{platform}.yaml
       - name: find-CCSPlayer_WeaponServices_SelectItem
         expected_output:
           - CCSPlayer_WeaponServices_SelectItem.{platform}.yaml
@@ -8896,6 +8899,10 @@ modules:
         category: vfunc
         alias:
           - CCSPlayer_WeaponServices::DropWeapon
+      - name: CBasePlayerWeapon_Shoot_Secondary
+        category: func
+        alias:
+          - CBasePlayerWeapon::Shoot_Secondary
       - name: CCSPlayer_ItemServices_RemoveWeapons
         category: vfunc
         alias:

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -5676,6 +5676,12 @@ modules:
       - name: find-CCSBot_PrintIfWatched
         expected_output:
           - CCSBot_PrintIfWatched.{platform}.yaml
+      - name: find-CHostage_Follow
+        expected_output:
+          - CHostage_Follow.{platform}.yaml
+      - name: find-CHostage_DropHostage
+        expected_output:
+          - CHostage_DropHostage.{platform}.yaml
       - name: find-HideState_vtable
         expected_output:
           - HideState_vtable.{platform}.yaml
@@ -8814,6 +8820,14 @@ modules:
         category: func
         alias:
           - CCSBot::PrintIfWatched
+      - name: CHostage_Follow
+        category: func
+        alias:
+          - CHostage::Follow
+      - name: CHostage_DropHostage
+        category: func
+        alias:
+          - CHostage::DropHostage
       - name: HideState_vtable
         category: vtable
       - name: HideState_OnUpdate

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:2545f444baff8ea915a9c05f35a7c6ee840ed50e0cc345cb913fe6f54c982bc3
-file_count: 2936
+config_sha256: sha256:0ed41bb6134a447b32b6a0fd3fd0d9a346a6cb5248fa2feea9ac7121b4705b06
+file_count: 2940
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -27466,6 +27466,30 @@ files:
     vtable_size: '0x50'
     vtable_symbol: ??_7?$CGameSystemReallocatingFactory@VCSource2EntitySystem@@V1@@@6B@
     vtable_va: '0x181795ad8'
+  server/CHostage_DropHostage.linux.yaml:
+    func_name: CHostage_DropHostage
+    func_rva: '0xcbe410'
+    func_sig: 55 48 89 E5 41 57 41 89 D7 41 56 41 55 49 89 F5 41 54 53
+    func_size: '0x68c'
+    func_va: '0xcbe410'
+  server/CHostage_DropHostage.windows.yaml:
+    func_name: CHostage_DropHostage
+    func_rva: '0x343ee0'
+    func_sig: 48 8B C4 55 41 56 48 8D 6C 24 ??
+    func_size: '0x49d'
+    func_va: '0x180343ee0'
+  server/CHostage_Follow.linux.yaml:
+    func_name: CHostage_Follow
+    func_rva: '0x13a7c40'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 49 89 FC 53 48 89 F3 48 83 EC ?? 48 85 F6
+    func_size: '0x56a'
+    func_va: '0x13a7c40'
+  server/CHostage_Follow.windows.yaml:
+    func_name: CHostage_Follow
+    func_rva: '0x916050'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 81 EC ?? ?? ?? ??
+    func_size: '0x42a'
+    func_va: '0x180916050'
   server/CInferno_InfernoThink.linux.yaml:
     func_name: CInferno_InfernoThink
     func_rva: '0xcab7e0'

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:0ed41bb6134a447b32b6a0fd3fd0d9a346a6cb5248fa2feea9ac7121b4705b06
-file_count: 2940
+config_sha256: sha256:1383dab63dbfee628c6525778110b02c7b1c5bb2b96bae4f06ebe533294c9cf6
+file_count: 2942
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -17126,6 +17126,18 @@ files:
     vtable_size: '0xc68'
     vtable_symbol: ??_7CBasePlayerPawn@@6B@
     vtable_va: '0x1817b0f90'
+  server/CBasePlayerWeapon_Shoot_Secondary.linux.yaml:
+    func_name: CBasePlayerWeapon_Shoot_Secondary
+    func_rva: '0x1440c10'
+    func_sig: 55 48 8D 15 ?? ?? ?? ?? 48 89 E5 41 54 41 89 F4 53 48 8B 07 48 89 FB 48 8B 80 ?? ?? ?? ?? 48 39 D0 0F 85 ?? ?? ?? ??
+    func_size: '0x2ea'
+    func_va: '0x1440c10'
+  server/CBasePlayerWeapon_Shoot_Secondary.windows.yaml:
+    func_name: CBasePlayerWeapon_Shoot_Secondary
+    func_rva: '0x9bbc30'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 48 8B 01 48 8B F9 0F BF DA
+    func_size: '0x1c7'
+    func_va: '0x1809bbc30'
   server/CBaseTrigger_EndTouch.linux.yaml:
     func_name: CBaseTrigger_EndTouch
     func_rva: '0xd23d90'

--- a/ida_preprocessor_scripts/find-CBasePlayerWeapon_Shoot_Secondary.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerWeapon_Shoot_Secondary.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerWeapon_Shoot_Secondary skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerWeapon_Shoot_Secondary",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerWeapon_Shoot_Secondary",
+        "xref_strings": ["FULLMATCH:shoot_secondary"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerWeapon_Shoot_Secondary",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CHostage_DropHostage.py
+++ b/ida_preprocessor_scripts/find-CHostage_DropHostage.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CHostage_DropHostage skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CHostage_DropHostage",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CHostage_DropHostage",
+        "xref_strings": ["dropped off a hostage"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CHostage_DropHostage",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CHostage_Follow.py
+++ b/ida_preprocessor_scripts/find-CHostage_Follow.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CHostage_Follow skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CHostage_Follow",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CHostage_Follow",
+        "xref_strings": ["FULLMATCH:StartFollowing"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CHostage_Follow",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary

Adds new preprocessor finder scripts for CS2 server binaries.

### Changes
- \ind-CBasePlayerWeapon_Shoot_Secondary.py\ — locates the secondary shoot vfunc
- \ind-CHostage_DropHostage.py\ — locates the DropHostage vfunc
- \ind-CHostage_Follow.py\ — locates the Follow vfunc
- Wires new skills and symbol entries in \configs/14172.yaml\
- Updates tracked game-symbol snapshot \gamesymbols/14172.yaml\ with new offsets

### Commits
- \eat(preprocessor): add hostage finder scripts\ (9e101473)
- \eat(preprocessor): add secondary shoot finder\ (3bb38e04)

### Diff stat
\\\
 configs/14172.yaml                                 | 21 ++++++++
 gamesymbols/14172.yaml                             | 40 +++++++++++++-
 ida_preprocessor_scripts/find-CBasePlayerWeapon_Shoot_Secondary.py      | 61 ++++++++++++++++++++++
 ida_preprocessor_scripts/find-CHostage_DropHostage.py                   | 61 ++++++++++++++++++++++
 ida_preprocessor_scripts/find-CHostage_Follow.py   | 61 ++++++++++++++++++++++
 5 files changed, 242 insertions(+), 2 deletions(-)
\\\
