### PR TITLE
test(cpp-tests): add IGameEventManager2 layout validation

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -10790,3 +10790,29 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - engine  # bin/{gamever}/engine/CNetworkGameServerBase_*.{platform}.yaml
+  - name: IGameEventManager2_MSVC
+    symbol: IGameEventManager2
+    alias_symbols:
+      - CGameEventManager
+    cpp: cpp_tests/igameeventmanager2.cpp
+    headers:
+      - hl2sdk_cs2/public/igameevents.h  # Used by the fix-cppheaders SKILL
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+      - hl2sdk_cs2/public/mathlib
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - client  # bin/{gamever}/client/CGameEventManager_*.{platform}.yaml

--- a/cpp_tests/igameeventmanager2.cpp
+++ b/cpp_tests/igameeventmanager2.cpp
@@ -1,0 +1,14 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+#include <igameevents.h>
+
+IGameEventManager2 * gameeventmanager();
+
+int main() {
+
+    gameeventmanager()->Reset();
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds vtable-layout validation for the IGameEventManager2 hl2sdk_cs2 interface against binary reference YAMLs.

## Changes

- cpp_tests/igameeventmanager2.cpp: new cpp_tests entry validating the IGameEventManager2 vtable layout.
- configs/14172.yaml: registers the new cpp_tests entry for game version 14172.

## Commit

- 8b0d8b06 test(cpp-tests): add IGameEventManager2 layout validation