### PR TITLE
feat(preprocessor): add find-CEngineServer_IsLogEnabled

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -5079,6 +5079,11 @@ modules:
         expected_input:
           - CSource2Server_GameFrame.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
+      - name: find-CEngineServer_IsLogEnabled
+        expected_output:
+          - CEngineServer_IsLogEnabled.{platform}.yaml
+        expected_input:
+          - CSource2Server_GameFrame.{platform}.yaml
       - name: find-CSource2Server_Init-decompiles
         expected_output:
           - CGameEventManager_Init.{platform}.yaml
@@ -8097,6 +8102,10 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::GameFrame
+      - name: CEngineServer_IsLogEnabled
+        category: vfunc
+        alias:
+          - CEngineServer::IsLogEnabled
       - name: CGameEventManager_Init
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CEngineServer_IsLogEnabled.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_IsLogEnabled.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_IsLogEnabled skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_IsLogEnabled",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CEngineServer_IsLogEnabled",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSource2Server_GameFrame.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSource2Server_GameFrame.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    # CEngineServer vtable name is metadata only -- the vfunc offset/signature is
+    # anchored on the indirect call site inside CSource2Server_GameFrame (server.dll),
+    # so no CEngineServer_vtable YAML lookup is required.
+    ("CEngineServer_IsLogEnabled", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C -- not a downstream predecessor, so no func_va/func_rva/func_size.
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "CEngineServer_IsLogEnabled",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever vfunc slot; fallback to LLM_DECOMPILE on CSource2Server_GameFrame."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CSource2Server_GameFrame.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2Server_GameFrame.linux.yaml
@@ -1,0 +1,503 @@
+func_name: CSource2Server_GameFrame
+func_va: '0x18dd320'
+disasm_code: |-
+  .text:00000000018DD320                 push    rbp
+  .text:00000000018DD321                 lea     rax, aGameinterfaceC; "./gameinterface.cpp"
+  .text:00000000018DD328                 mov     rbp, rsp
+  .text:00000000018DD32B                 push    r15
+  .text:00000000018DD32D                 push    r14
+  .text:00000000018DD32F                 mov     r14d, edx
+  .text:00000000018DD332                 push    r13
+  .text:00000000018DD334                 mov     r13d, ecx
+  .text:00000000018DD337                 push    r12
+  .text:00000000018DD339                 mov     r12d, esi
+  .text:00000000018DD33C                 push    rbx
+  .text:00000000018DD33D                 lea     rsi, off_261F890; "Server Game"
+  .text:00000000018DD344                 mov     rbx, rdi
+  .text:00000000018DD347                 lea     rdi, aGameframe; "GameFrame"
+  .text:00000000018DD34E                 sub     rsp, 68h
+  .text:00000000018DD352                 mov     [rbp+var_50], rax
+  .text:00000000018DD356                 lea     rax, [rbp+var_50]
+  .text:00000000018DD35A                 mov     dword ptr [rbp+var_48], 3B3h
+  .text:00000000018DD361                 mov     rdx, rax
+  .text:00000000018DD364                 mov     [rbp+var_40], rdi
+  .text:00000000018DD368                 mov     [rbp+var_70], rax
+  .text:00000000018DD36C                 call    sub_9F0FB0
+  .text:00000000018DD371                 mov     r15, rax
+  .text:00000000018DD374                 mov     [rbp+var_68], rax
+  .text:00000000018DD378                 call    sub_1711870
+  .text:00000000018DD37D                 test    al, al
+  .text:00000000018DD37F                 jnz     short loc_18DD398
+  .text:00000000018DD381                 add     rsp, 68h
+  .text:00000000018DD385                 mov     rax, r15
+  .text:00000000018DD388                 pop     rbx
+  .text:00000000018DD389                 pop     r12
+  .text:00000000018DD38B                 pop     r13
+  .text:00000000018DD38D                 pop     r14
+  .text:00000000018DD38F                 pop     r15
+  .text:00000000018DD391                 pop     rbp
+  .text:00000000018DD392                 jmp     rax
+  .text:00000000018DD398                 xor     edi, edi
+  .text:00000000018DD39A                 call    sub_1711D70
+  .text:00000000018DD39F                 call    sub_A77820
+  .text:00000000018DD3A4                 mov     rdi, rbx
+  .text:00000000018DD3A7                 call    sub_18DD220
+  .text:00000000018DD3AC                 test    r13b, r13b
+  .text:00000000018DD3AF                 jz      short loc_18DD3C5
+  .text:00000000018DD3B1                 pxor    xmm0, xmm0
+  .text:00000000018DD3B5                 ucomiss xmm0, dword ptr [rbx+38h]
+  .text:00000000018DD3B9                 jp      loc_18DD620
+  .text:00000000018DD3BF                 jnz     loc_18DD620
+  .text:00000000018DD3C5                 mov     rdi, cs:qword_2868848
+  .text:00000000018DD3CC                 mov     rax, [rdi]
+  .text:00000000018DD3CF                 call    qword ptr [rax+1B8h]; 0x1B8 = 440LL = CEngineServer_IsLogEnabled
+  .text:00000000018DD3D5                 mov     rbx, cs:off_261F8A8
+  .text:00000000018DD3DC                 lea     rdx, byte_2652678
+  .text:00000000018DD3E3                 movq    xmm0, qword ptr [rbx+30h]
+  .text:00000000018DD3E8                 mov     [rdx], al
+  .text:00000000018DD3EA                 movlps  [rbp+var_90], xmm0
+  .text:00000000018DD3F1                 call    sub_9F0970
+  .text:00000000018DD3F6                 mov     rcx, [rbx+30h]
+  .text:00000000018DD3FA                 movq    xmm0, [rbp+var_90]
+  .text:00000000018DD402                 movss   xmm2, dword ptr [rbx+50h]
+  .text:00000000018DD407                 mov     dword ptr [rbx+50h], 0
+  .text:00000000018DD40E                 movlps  qword ptr [rbx+30h], xmm0
+  .text:00000000018DD412                 mulss   xmm0, cs:dword_8CDC10
+  .text:00000000018DD41A                 mov     [rbp+var_88], rcx
+  .text:00000000018DD421                 mov     ecx, [rbx+44h]
+  .text:00000000018DD424                 addss   xmm0, dword ptr cs:xmmword_8CBF80
+  .text:00000000018DD42C                 movss   [rbp+var_78], xmm2
+  .text:00000000018DD431                 mov     [rbp+var_74], ecx
+  .text:00000000018DD434                 mov     rcx, [rbx+58h]
+  .text:00000000018DD438                 cvttss2si edx, xmm0
+  .text:00000000018DD43C                 mov     [rbx+58h], rax
+  .text:00000000018DD440                 lea     rax, g_pGameEntitySystem
+  .text:00000000018DD447                 mov     [rbx+44h], edx
+  .text:00000000018DD44A                 mov     rdi, [rax]
+  .text:00000000018DD44D                 mov     [rbp+var_80], rcx
+  .text:00000000018DD451                 call    sub_16A5700
+  .text:00000000018DD456                 mov     esi, 0FFFFFFFFh
+  .text:00000000018DD45B                 lea     rdi, unk_28688B0
+  .text:00000000018DD462                 call    sub_1C56A50
+  .text:00000000018DD467                 test    rax, rax
+  .text:00000000018DD46A                 jz      loc_18DD720
+  .text:00000000018DD470                 movzx   eax, byte ptr [rax]
+  .text:00000000018DD473                 test    al, al
+  .text:00000000018DD475                 jz      short loc_18DD487
+  .text:00000000018DD477                 mov     rdi, cs:qword_2868768
+  .text:00000000018DD47E                 mov     rax, [rdi]
+  .text:00000000018DD481                 call    qword ptr [rax+90h]
+  .text:00000000018DD487                 mov     edi, cs:dword_25B4520
+  .text:00000000018DD48D                 movzx   r15d, r14b
+  .text:00000000018DD491                 mov     ecx, r13d
+  .text:00000000018DD494                 mov     eax, r15d
+  .text:00000000018DD497                 mov     ah, cl
+  .text:00000000018DD499                 mov     r15d, eax
+  .text:00000000018DD49C                 mov     [rbp+var_52], ax
+  .text:00000000018DD4A0                 test    edi, edi
+  .text:00000000018DD4A2                 js      loc_18DD730
+  .text:00000000018DD4A8                 lea     r14, [rbp+var_52]
+  .text:00000000018DD4AC                 xor     edx, edx
+  .text:00000000018DD4AE                 mov     esi, 0F9h
+  .text:00000000018DD4B3                 mov     rcx, r14
+  .text:00000000018DD4B6                 call    sub_EC6CF0
+  .text:00000000018DD4BB                 lea     rax, byte_27DC4C0
+  .text:00000000018DD4C2                 cmp     byte ptr [rax], 0
+  .text:00000000018DD4C5                 jz      loc_18DD6F0
+  .text:00000000018DD4CB                 lea     rax, g_pNavMesh
+  .text:00000000018DD4D2                 mov     rdi, [rax]
+  .text:00000000018DD4D5                 test    rdi, rdi
+  .text:00000000018DD4D8                 jz      short loc_18DD4E0
+  .text:00000000018DD4DA                 mov     rax, [rdi]
+  .text:00000000018DD4DD                 call    qword ptr [rax+58h]
+  .text:00000000018DD4E0                 lea     rax, qword_28B8860
+  .text:00000000018DD4E7                 mov     rdi, [rax]
+  .text:00000000018DD4EA                 test    rdi, rdi
+  .text:00000000018DD4ED                 jz      short loc_18DD4F5
+  .text:00000000018DD4EF                 mov     rax, [rdi]
+  .text:00000000018DD4F2                 call    qword ptr [rax+10h]
+  .text:00000000018DD4F5                 mov     cs:dword_2868720, 0
+  .text:00000000018DD4FF                 mov     cs:qword_2868728, 0
+  .text:00000000018DD50A                 mov     cs:dword_2868730, 0
+  .text:00000000018DD514                 mov     cs:qword_2868738, 0
+  .text:00000000018DD51F                 mov     cs:qword_2868740, 0
+  .text:00000000018DD52A                 call    sub_1A68A10
+  .text:00000000018DD52F                 lea     rax, off_25B6110
+  .text:00000000018DD536                 movzx   esi, r12b
+  .text:00000000018DD53A                 mov     rdi, [rax]
+  .text:00000000018DD53D                 mov     rax, [rdi]
+  .text:00000000018DD540                 call    qword ptr [rax]
+  .text:00000000018DD542                 lea     r12, g_pEntitySystem
+  .text:00000000018DD549                 mov     rdi, [r12]
+  .text:00000000018DD54D                 call    sub_211A170
+  .text:00000000018DD552                 mov     edi, cs:dword_25B451C
+  .text:00000000018DD558                 mov     [rbp+var_52], r15w
+  .text:00000000018DD55D                 test    edi, edi
+  .text:00000000018DD55F                 js      loc_18DD790
+  .text:00000000018DD565                 xor     edx, edx
+  .text:00000000018DD567                 mov     rcx, r14
+  .text:00000000018DD56A                 mov     esi, 101h
+  .text:00000000018DD56F                 call    sub_EC6CF0
+  .text:00000000018DD574                 call    sub_1AB2BC0
+  .text:00000000018DD579                 test    al, al
+  .text:00000000018DD57B                 jnz     loc_18DD6E0
+  .text:00000000018DD581                 lea     rax, g_pGameEntitySystem
+  .text:00000000018DD588                 mov     rdi, [rax]
+  .text:00000000018DD58B                 call    sub_16A5700
+  .text:00000000018DD590                 call    sub_17DB080
+  .text:00000000018DD595                 mov     rdi, cs:g_pGameRules
+  .text:00000000018DD59C                 test    rdi, rdi
+  .text:00000000018DD59F                 jz      short loc_18DD5BB
+  .text:00000000018DD5A1                 mov     rax, [rdi]
+  .text:00000000018DD5A4                 lea     rdx, nullsub_1645
+  .text:00000000018DD5AB                 mov     rax, [rax+1A8h]
+  .text:00000000018DD5B2                 cmp     rax, rdx
+  .text:00000000018DD5B5                 jnz     loc_18DD7E8
+  .text:00000000018DD5BB                 lea     rdi, qword_2868850
+  .text:00000000018DD5C2                 call    sub_1AA4FC0
+  .text:00000000018DD5C7                 mov     rdi, [r12]
+  .text:00000000018DD5CB                 xor     esi, esi
+  .text:00000000018DD5CD                 call    sub_21221C0
+  .text:00000000018DD5D2                 mov     rdi, cs:qword_2868768
+  .text:00000000018DD5D9                 mov     rax, [rdi]
+  .text:00000000018DD5DC                 call    qword ptr [rax+90h]
+  .text:00000000018DD5E2                 mov     rax, [rbp+var_88]
+  .text:00000000018DD5E9                 movss   xmm3, [rbp+var_78]
+  .text:00000000018DD5EE                 movss   dword ptr [rbx+50h], xmm3
+  .text:00000000018DD5F3                 mov     [rbx+30h], rax
+  .text:00000000018DD5F7                 mov     eax, [rbp+var_74]
+  .text:00000000018DD5FA                 mov     [rbx+44h], eax
+  .text:00000000018DD5FD                 mov     rax, [rbp+var_80]
+  .text:00000000018DD601                 mov     [rbx+58h], rax
+  .text:00000000018DD605                 mov     rax, [rbp+var_68]
+  .text:00000000018DD609                 add     rsp, 68h
+  .text:00000000018DD60D                 pop     rbx
+  .text:00000000018DD60E                 pop     r12
+  .text:00000000018DD610                 pop     r13
+  .text:00000000018DD612                 pop     r14
+  .text:00000000018DD614                 pop     r15
+  .text:00000000018DD616                 pop     rbp
+  .text:00000000018DD617                 jmp     rax
+  .text:00000000018DD620                 xor     edi, edi
+  .text:00000000018DD622                 call    sub_12F8910
+  .text:00000000018DD627                 movss   xmm1, dword ptr [rbx+38h]
+  .text:00000000018DD62C                 comiss  xmm1, xmm0
+  .text:00000000018DD62F                 jp      loc_18DD3C5
+  .text:00000000018DD635                 jz      loc_18DD3C5
+  .text:00000000018DD63B                 ja      loc_18DD3C5
+  .text:00000000018DD641                 mov     rax, cs:off_261F8A8
+  .text:00000000018DD648                 test    rax, rax
+  .text:00000000018DD64B                 jz      loc_18DD6D0
+  .text:00000000018DD651                 cmp     dword ptr [rax+10h], 1
+  .text:00000000018DD655                 jg      short loc_18DD6D0
+  .text:00000000018DD657                 xor     edi, edi
+  .text:00000000018DD659                 call    sub_15DC350
+  .text:00000000018DD65E                 mov     r15, rax
+  .text:00000000018DD661                 test    rax, rax
+  .text:00000000018DD664                 jz      short loc_18DD6D0
+  .text:00000000018DD666                 pxor    xmm0, xmm0
+  .text:00000000018DD66A                 ucomiss xmm0, dword ptr [rax+0E7Ch]
+  .text:00000000018DD671                 jp      loc_18DD862
+  .text:00000000018DD677                 jnz     loc_18DD862
+  .text:00000000018DD67D                 mov     rdi, cs:g_pGameRules
+  .text:00000000018DD684                 lea     rcx, sub_12E3270
+  .text:00000000018DD68B                 mov     rax, [rdi]
+  .text:00000000018DD68E                 mov     rax, [rax+298h]
+  .text:00000000018DD695                 cmp     rax, rcx
+  .text:00000000018DD698                 jnz     loc_18DD88C
+  .text:00000000018DD69E                 mov     rdi, r15
+  .text:00000000018DD6A1                 call    sub_17D7A30
+  .text:00000000018DD6A6                 pxor    xmm0, xmm0
+  .text:00000000018DD6AA                 cvtsi2ss xmm0, eax
+  .text:00000000018DD6AE                 comiss  xmm0, dword ptr [rbx+3Ch]
+  .text:00000000018DD6B2                 jb      short loc_18DD6D0
+  .text:00000000018DD6B4                 mov     rdi, cs:qword_2868848
+  .text:00000000018DD6BB                 lea     rsi, aAutosavedanger_1; "autosavedangerousissafe\n"
+  .text:00000000018DD6C2                 mov     rax, [rdi]
+  .text:00000000018DD6C5                 call    qword ptr [rax+168h]
+  .text:00000000018DD6CB                 nop     dword ptr [rax+rax+00h]
+  .text:00000000018DD6D0                 mov     qword ptr [rbx+38h], 0
+  .text:00000000018DD6D8                 jmp     loc_18DD3C5
+  .text:00000000018DD6E0                 call    sub_1ACD890
+  .text:00000000018DD6E5                 jmp     loc_18DD581
+  .text:00000000018DD6F0                 mov     esi, 0FFFFFFFFh
+  .text:00000000018DD6F5                 mov     r13, cs:off_261F8A8
+  .text:00000000018DD6FC                 lea     rdi, unk_286AE60
+  .text:00000000018DD703                 call    sub_1C56A50
+  .text:00000000018DD708                 test    rax, rax
+  .text:00000000018DD70B                 jz      loc_18DD7F0
+  .text:00000000018DD711                 movzx   eax, byte ptr [rax]
+  .text:00000000018DD714                 mov     [r13+74h], al
+  .text:00000000018DD718                 jmp     loc_18DD4CB
+  .text:00000000018DD720                 mov     rax, cs:qword_28688B8
+  .text:00000000018DD727                 mov     rax, [rax+8]
+  .text:00000000018DD72B                 jmp     loc_18DD470
+  .text:00000000018DD730                 lea     r13, off_23C1238
+  .text:00000000018DD737                 mov     [rbp+var_48], 0
+  .text:00000000018DD73F                 mov     [rbp+var_50], r13
+  .text:00000000018DD743                 movzx   eax, cs:byte_2727740
+  .text:00000000018DD74A                 test    al, al
+  .text:00000000018DD74C                 jz      loc_18DD830
+  .text:00000000018DD752                 mov     r14, [rbp+var_70]
+  .text:00000000018DD756                 mov     rax, cs:qword_2727748
+  .text:00000000018DD75D                 mov     rdi, r14
+  .text:00000000018DD760                 mov     [rbp+var_50], rax
+  .text:00000000018DD764                 call    qword ptr [rax+0F8h]
+  .text:00000000018DD76A                 mov     rdi, r14
+  .text:00000000018DD76D                 mov     [rbp+var_50], r13
+  .text:00000000018DD771                 mov     cs:dword_25B4520, eax
+  .text:00000000018DD777                 call    nullsub_653
+  .text:00000000018DD77C                 mov     edi, cs:dword_25B4520
+  .text:00000000018DD782                 jmp     loc_18DD4A8
+  .text:00000000018DD790                 lea     r13, off_23C1238
+  .text:00000000018DD797                 mov     [rbp+var_48], 0
+  .text:00000000018DD79F                 mov     [rbp+var_50], r13
+  .text:00000000018DD7A3                 movzx   eax, cs:byte_2727730
+  .text:00000000018DD7AA                 test    al, al
+  .text:00000000018DD7AC                 jz      short loc_18DD800
+  .text:00000000018DD7AE                 mov     r15, [rbp+var_70]
+  .text:00000000018DD7B2                 mov     rax, cs:qword_2727738
+  .text:00000000018DD7B9                 mov     rdi, r15
+  .text:00000000018DD7BC                 mov     [rbp+var_50], rax
+  .text:00000000018DD7C0                 call    qword ptr [rax+100h]
+  .text:00000000018DD7C6                 mov     rdi, r15
+  .text:00000000018DD7C9                 mov     [rbp+var_50], r13
+  .text:00000000018DD7CD                 mov     cs:dword_25B451C, eax
+  .text:00000000018DD7D3                 call    nullsub_653
+  .text:00000000018DD7D8                 mov     edi, cs:dword_25B451C
+  .text:00000000018DD7DE                 jmp     loc_18DD565
+  .text:00000000018DD7E8                 call    rax
+  .text:00000000018DD7EA                 jmp     loc_18DD5BB
+  .text:00000000018DD7F0                 mov     rax, cs:qword_286AE68
+  .text:00000000018DD7F7                 mov     rax, [rax+8]
+  .text:00000000018DD7FB                 jmp     loc_18DD711
+  .text:00000000018DD800                 lea     rdi, byte_2727730
+  .text:00000000018DD807                 call    sub_9E6760
+  .text:00000000018DD80C                 test    eax, eax
+  .text:00000000018DD80E                 jz      short loc_18DD7AE
+  .text:00000000018DD810                 mov     rax, cs:off_25B3F08
+  .text:00000000018DD817                 lea     rdi, byte_2727730
+  .text:00000000018DD81E                 mov     cs:qword_2727738, rax
+  .text:00000000018DD825                 call    sub_9E6780
+  .text:00000000018DD82A                 jmp     short loc_18DD7AE
+  .text:00000000018DD830                 lea     r14, byte_2727740
+  .text:00000000018DD837                 mov     rdi, r14
+  .text:00000000018DD83A                 call    sub_9E6760
+  .text:00000000018DD83F                 test    eax, eax
+  .text:00000000018DD841                 jz      loc_18DD752
+  .text:00000000018DD847                 mov     rax, cs:off_25B3F10
+  .text:00000000018DD84E                 mov     rdi, r14
+  .text:00000000018DD851                 mov     cs:qword_2727748, rax
+  .text:00000000018DD858                 call    sub_9E6780
+  .text:00000000018DD85D                 jmp     loc_18DD752
+  .text:00000000018DD862                 xor     edi, edi
+  .text:00000000018DD864                 call    sub_12F8910
+  .text:00000000018DD869                 movss   xmm1, dword ptr [r15+0E7Ch]
+  .text:00000000018DD872                 comiss  xmm1, xmm0
+  .text:00000000018DD875                 jp      loc_18DD6D0
+  .text:00000000018DD87B                 jz      loc_18DD6D0
+  .text:00000000018DD881                 ja      loc_18DD67D
+  .text:00000000018DD887                 jmp     loc_18DD6D0
+  .text:00000000018DD88C                 call    rax
+  .text:00000000018DD88E                 test    al, al
+  .text:00000000018DD890                 jnz     loc_18DD6D0
+  .text:00000000018DD896                 jmp     loc_18DD69E
+procedure: |-
+  __int64 __fastcall CSource2Server_GameFrame(__int64 a1, unsigned __int8 a2, char a3, char a4)
+  {
+    __int64 (*v6)(void); // r15
+    char v8; // al
+    _QWORD *v9; // rbx
+    __m128 v10; // xmm0
+    __int64 v11; // rax
+    __int64 v12; // rcx
+    __m128 v13; // xmm0
+    int v14; // xmm2_4
+    __int64 v15; // rcx
+    _BYTE *v16; // rax
+    __int64 v17; // rdi
+    __int16 v18; // ax
+    __int16 v19; // r15
+    __int64 v20; // rdi
+    void (*v21)(void); // rax
+    __int64 v22; // rax
+    float v23; // xmm0_4
+    float v24; // xmm1_4
+    __int64 v25; // rax
+    __int64 v26; // r15
+    double v27; // xmm0_8
+    __int64 (__fastcall *v28)(); // rax
+    _BYTE *v29; // r13
+    _BYTE *v30; // rax
+    const char **v31; // r14
+    int v32; // eax
+    const char **v33; // r15
+    int v34; // eax
+    float v35; // xmm1_4
+    __m128i v36; // [rsp+0h] [rbp-90h] BYREF
+    __int64 v37; // [rsp+10h] [rbp-80h]
+    int v38; // [rsp+18h] [rbp-78h]
+    int v39; // [rsp+1Ch] [rbp-74h]
+    const char **v40; // [rsp+20h] [rbp-70h]
+    __int64 (*v41)(void); // [rsp+28h] [rbp-68h]
+    __int16 v42; // [rsp+3Eh] [rbp-52h] BYREF
+    const char *v43; // [rsp+40h] [rbp-50h] BYREF
+    __int64 v44; // [rsp+48h] [rbp-48h]
+    const char *v45; // [rsp+50h] [rbp-40h]
+
+    v43 = "./gameinterface.cpp";
+    LODWORD(v44) = 947;
+    v45 = "GameFrame";
+    v40 = &v43;
+    v6 = (__int64 (*)(void))sub_9F0FB0("GameFrame", &off_261F890, &v43);
+    v41 = v6;
+    if ( !(unsigned __int8)sub_1711870() )
+      return v6();
+    sub_1711D70(0);
+    sub_A77820();
+    sub_18DD220(a1);
+    if ( a4 )
+    {
+      if ( *(float *)(a1 + 56) != 0.0 )
+      {
+        v23 = sub_12F8910(0);
+        v24 = *(float *)(a1 + 56);
+        if ( v24 != v23 && v24 <= v23 )
+        {
+          if ( off_261F8A8 )
+          {
+            if ( *((int *)off_261F8A8 + 4) <= 1 )
+            {
+              v25 = sub_15DC350(0);
+              v26 = v25;
+              if ( v25 )
+              {
+                v27 = 0.0;
+                if ( *(float *)(v25 + 3708) == 0.0
+                  || (*(float *)&v27 = sub_12F8910(0), v35 = *(float *)(v26 + 3708), v35 != *(float *)&v27)
+                  && v35 > *(float *)&v27 )
+                {
+                  v28 = *(__int64 (__fastcall **)())(*(_QWORD *)g_pGameRules + 664LL);
+                  if ( (v28 == sub_12E3270 || !((unsigned __int8 (__fastcall *)(double))v28)(v27))
+                    && (float)(int)sub_17D7A30(v26) >= *(float *)(a1 + 60) )
+                  {
+                    (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)qword_2868848 + 360LL))(
+                      qword_2868848,
+                      "autosavedangerousissafe\n");
+                  }
+                }
+              }
+            }
+          }
+          *(_QWORD *)(a1 + 56) = 0;
+        }
+      }
+    }
+    v8 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_2868848 + 440LL))(qword_2868848);// 440LL = 0x1B8 = CEngineServer_IsLogEnabled
+    v9 = off_261F8A8;
+    v10 = (__m128)_mm_loadl_epi64((const __m128i *)off_261F8A8 + 3);
+    byte_2652678 = v8;
+    _mm_storel_ps((double *)v36.m128i_i64, v10);
+    v11 = sub_9F0970();
+    v12 = v9[6];
+    v13 = (__m128)_mm_loadl_epi64(&v36);
+    v14 = *((_DWORD *)v9 + 20);
+    *((_DWORD *)v9 + 20) = 0;
+    _mm_storel_ps((double *)v9 + 6, v13);
+    v36.m128i_i64[1] = v12;
+    LODWORD(v12) = *((_DWORD *)v9 + 17);
+    v38 = v14;
+    v39 = v12;
+    v15 = v9[11];
+    v9[11] = v11;
+    *((_DWORD *)v9 + 17) = (int)(float)((float)(v13.m128_f32[0] * 64.0) + 0.5);
+    v37 = v15;
+    sub_16A5700(g_pGameEntitySystem);
+    v16 = (_BYTE *)sub_1C56A50(&unk_28688B0, 0xFFFFFFFFLL);
+    if ( !v16 )
+      v16 = *(_BYTE **)(qword_28688B8 + 8);
+    if ( *v16 )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_2868768 + 144LL))(qword_2868768);
+    v17 = (unsigned int)dword_25B4520;
+    LOBYTE(v18) = a3;
+    HIBYTE(v18) = a4;
+    v19 = v18;
+    v42 = v18;
+    if ( dword_25B4520 < 0 )
+    {
+      v44 = 0;
+      v43 = (const char *)off_23C1238;
+      if ( !byte_2727740 && (unsigned int)sub_9E6760(&byte_2727740) )
+      {
+        qword_2727748 = (__int64)off_25B3F10[0];
+        sub_9E6780(&byte_2727740);
+      }
+      v31 = v40;
+      v43 = (const char *)qword_2727748;
+      v32 = (*(__int64 (__fastcall **)(const char **))(qword_2727748 + 248))(v40);
+      v43 = (const char *)off_23C1238;
+      dword_25B4520 = v32;
+      nullsub_653(v31);
+      v17 = (unsigned int)dword_25B4520;
+    }
+    sub_EC6CF0(v17, 249, 0, &v42);
+    if ( !byte_27DC4C0 )
+    {
+      v29 = off_261F8A8;
+      v30 = (_BYTE *)sub_1C56A50(&unk_286AE60, 0xFFFFFFFFLL);
+      if ( !v30 )
+        v30 = *(_BYTE **)(qword_286AE68 + 8);
+      v29[116] = *v30;
+    }
+    if ( g_pNavMesh )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pNavMesh + 88LL))(g_pNavMesh);
+    if ( qword_28B8860 )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_28B8860 + 16LL))(qword_28B8860);
+    dword_2868720 = 0;
+    qword_2868728 = 0;
+    dword_2868730 = 0;
+    qword_2868738 = 0;
+    qword_2868740 = 0;
+    sub_1A68A10();
+    (**(void (__fastcall ***)(void *, _QWORD))off_25B6110)(off_25B6110, a2);
+    sub_211A170(g_pEntitySystem);
+    v20 = (unsigned int)dword_25B451C;
+    v42 = v19;
+    if ( dword_25B451C < 0 )
+    {
+      v44 = 0;
+      v43 = (const char *)off_23C1238;
+      if ( !byte_2727730 && (unsigned int)sub_9E6760(&byte_2727730) )
+      {
+        qword_2727738 = (__int64)off_25B3F08[0];
+        sub_9E6780(&byte_2727730);
+      }
+      v33 = v40;
+      v43 = (const char *)qword_2727738;
+      v34 = (*(__int64 (__fastcall **)(const char **))(qword_2727738 + 256))(v40);
+      v43 = (const char *)off_23C1238;
+      dword_25B451C = v34;
+      nullsub_653(v33);
+      v20 = (unsigned int)dword_25B451C;
+    }
+    sub_EC6CF0(v20, 257, 0, &v42);
+    if ( (unsigned __int8)sub_1AB2BC0() )
+      sub_1ACD890();
+    sub_16A5700(g_pGameEntitySystem);
+    sub_17DB080();
+    if ( g_pGameRules )
+    {
+      v21 = *(void (**)(void))(*(_QWORD *)g_pGameRules + 424LL);
+      if ( (char *)v21 != (char *)nullsub_1645 )
+        v21();
+    }
+    sub_1AA4FC0(&qword_2868850);
+    sub_21221C0(g_pEntitySystem, 0);
+    (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_2868768 + 144LL))(qword_2868768);
+    v22 = v36.m128i_i64[1];
+    *((_DWORD *)v9 + 20) = v38;
+    v9[6] = v22;
+    *((_DWORD *)v9 + 17) = v39;
+    v9[11] = v37;
+    return v41();
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2Server_GameFrame.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2Server_GameFrame.windows.yaml
@@ -1,0 +1,570 @@
+func_name: CSource2Server_GameFrame
+func_va: '0x180d14cb0'
+disasm_code: |-
+  .text:0000000180D14CB0                 mov     [rsp-8+arg_18], rbx
+  .text:0000000180D14CB5                 mov     [rsp-8+arg_8], dl
+  .text:0000000180D14CB9                 push    rbp
+  .text:0000000180D14CBA                 push    r12
+  .text:0000000180D14CBC                 push    r13
+  .text:0000000180D14CBE                 push    r14
+  .text:0000000180D14CC0                 push    r15
+  .text:0000000180D14CC2                 lea     rbp, [rsp-37h]
+  .text:0000000180D14CC7                 sub     rsp, 0C0h
+  .text:0000000180D14CCE                 lea     rax, aCBuildworkerCs_50; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180D14CD5                 mov     qword ptr [rbp+57h+var_B0+8], 3B3h
+  .text:0000000180D14CDD                 mov     qword ptr [rbp+57h+var_B0], rax
+  .text:0000000180D14CE1                 lea     rdx, off_181C700C0; "Server Game"
+  .text:0000000180D14CE8                 movups  xmm0, [rbp+57h+var_B0]
+  .text:0000000180D14CEC                 lea     rax, aGameframe; "GameFrame"
+  .text:0000000180D14CF3                 movzx   r12d, r8b
+  .text:0000000180D14CF7                 mov     [rbp+57h+var_A0], rax
+  .text:0000000180D14CFB                 lea     r8, [rbp+57h+var_90]
+  .text:0000000180D14CFF                 movsd   xmm1, [rbp+57h+var_A0]
+  .text:0000000180D14D04                 mov     r14, rcx
+  .text:0000000180D14D07                 lea     rcx, aCsource2server_2; "CSource2Server::GameFrame"
+  .text:0000000180D14D0E                 movsd   [rbp+57h+var_80], xmm1
+  .text:0000000180D14D13                 movzx   r15d, r9b
+  .text:0000000180D14D17                 movaps  [rbp+57h+var_90], xmm0
+  .text:0000000180D14D1B                 xor     r13d, r13d
+  .text:0000000180D14D1E                 call    cs:?EnterScopeInternalBudgetFlags@?$VProfScopeHelper@$0A@$0A@@@SAP6AXXZPEBDAEAUVProfBudgetGroupCallSite@@AEBVCUtlSourceLocation@@@Z; VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(char const *,VProfBudgetGroupCallSite &,CUtlSourceLocation const &)
+  .text:0000000180D14D24                 mov     rbx, rax
+  .text:0000000180D14D27                 call    sub_180BD9B10
+  .text:0000000180D14D2C                 test    al, al
+  .text:0000000180D14D2E                 jz      loc_180D15263
+  .text:0000000180D14D34                 mov     [rsp+0E0h+arg_0], rsi
+  .text:0000000180D14D3C                 xor     ecx, ecx
+  .text:0000000180D14D3E                 mov     [rsp+0E0h+arg_10], rdi
+  .text:0000000180D14D46                 movaps  [rsp+0E0h+var_30], xmm6
+  .text:0000000180D14D4E                 movaps  [rsp+0E0h+var_40], xmm7
+  .text:0000000180D14D56                 movaps  [rsp+0E0h+var_50], xmm8
+  .text:0000000180D14D5F                 movaps  [rsp+0E0h+var_60], xmm9
+  .text:0000000180D14D68                 movaps  [rsp+0E0h+var_70], xmm10
+  .text:0000000180D14D6E                 call    sub_180BDE580
+  .text:0000000180D14D73                 call    sub_1801A0820
+  .text:0000000180D14D78                 mov     edx, 0FFFFFFFFh
+  .text:0000000180D14D7D                 lea     rcx, unk_181FDF280
+  .text:0000000180D14D84                 call    sub_181517330
+  .text:0000000180D14D89                 test    rax, rax
+  .text:0000000180D14D8C                 jnz     short loc_180D14D99
+  .text:0000000180D14D8E                 mov     rax, cs:qword_181FDF288
+  .text:0000000180D14D95                 mov     rax, [rax+8]
+  .text:0000000180D14D99                 cmp     [rax], r13b
+  .text:0000000180D14D9C                 jz      loc_180D14E4F
+  .text:0000000180D14DA2                 mov     rcx, cs:qword_181FDFC78
+  .text:0000000180D14DA9                 xor     edx, edx
+  .text:0000000180D14DAB                 mov     rax, [rcx]
+  .text:0000000180D14DAE                 call    qword ptr [rax+148h]
+  .text:0000000180D14DB4                 mov     rdi, rax
+  .text:0000000180D14DB7                 test    rax, rax
+  .text:0000000180D14DBA                 jz      loc_180D14E4F
+  .text:0000000180D14DC0                 mov     rcx, [rax]
+  .text:0000000180D14DC3                 mov     edx, 1
+  .text:0000000180D14DC8                 mov     r8, [rcx+78h]
+  .text:0000000180D14DCC                 mov     rcx, rax
+  .text:0000000180D14DCF                 call    r8
+  .text:0000000180D14DD2                 mov     rcx, [rdi]
+  .text:0000000180D14DD5                 movaps  xmm7, xmm0
+  .text:0000000180D14DD8                 mulss   xmm7, cs:dword_1815F19C0
+  .text:0000000180D14DE0                 xor     edx, edx
+  .text:0000000180D14DE2                 mov     r8, [rcx+78h]
+  .text:0000000180D14DE6                 mov     rcx, rdi
+  .text:0000000180D14DE9                 call    r8
+  .text:0000000180D14DEC                 comiss  xmm7, cs:dword_181FDF060
+  .text:0000000180D14DF3                 mulss   xmm0, cs:dword_1815F19C0
+  .text:0000000180D14DFB                 jbe     short loc_180D14E05
+  .text:0000000180D14DFD                 movss   cs:dword_181FDF060, xmm7
+  .text:0000000180D14E05                 comiss  xmm0, cs:dword_181FDF070
+  .text:0000000180D14E0C                 movsd   xmm2, cs:qword_181FDF068
+  .text:0000000180D14E14                 xorps   xmm1, xmm1
+  .text:0000000180D14E17                 cvtss2sd xmm1, xmm7
+  .text:0000000180D14E1B                 addsd   xmm2, xmm1
+  .text:0000000180D14E1F                 movsd   cs:qword_181FDF068, xmm2
+  .text:0000000180D14E27                 jbe     short loc_180D14E31
+  .text:0000000180D14E29                 movss   cs:dword_181FDF070, xmm0
+  .text:0000000180D14E31                 movsd   xmm1, cs:qword_181FDF078
+  .text:0000000180D14E39                 inc     cs:dword_181FDF080
+  .text:0000000180D14E3F                 cvtss2sd xmm0, xmm0
+  .text:0000000180D14E43                 addsd   xmm1, xmm0
+  .text:0000000180D14E47                 movsd   cs:qword_181FDF078, xmm1
+  .text:0000000180D14E4F                 xorps   xmm6, xmm6
+  .text:0000000180D14E52                 test    r15b, r15b
+  .text:0000000180D14E55                 jz      loc_180D14F42
+  .text:0000000180D14E5B                 movss   xmm0, dword ptr [r14+38h]
+  .text:0000000180D14E61                 ucomiss xmm0, xmm6
+  .text:0000000180D14E64                 jp      short loc_180D14E6C
+  .text:0000000180D14E66                 jz      loc_180D14F42
+  .text:0000000180D14E6C                 mov     edx, r13d
+  .text:0000000180D14E6F                 lea     rcx, [rbp+57h+var_BC]
+  .text:0000000180D14E73                 call    sub_1808C47A0
+  .text:0000000180D14E78                 mov     r8, rax
+  .text:0000000180D14E7B                 lea     rdx, [rbp+57h+var_C0]
+  .text:0000000180D14E7F                 lea     rcx, [r14+38h]
+  .text:0000000180D14E83                 call    sub_180185450
+  .text:0000000180D14E88                 cmp     byte ptr [rax], 0FFh
+  .text:0000000180D14E8B                 jnz     loc_180D14F42
+  .text:0000000180D14E91                 mov     rax, cs:off_181C6FAE8
+  .text:0000000180D14E98                 test    rax, rax
+  .text:0000000180D14E9B                 jz      loc_180D14F30
+  .text:0000000180D14EA1                 cmp     dword ptr [rax+10h], 1
+  .text:0000000180D14EA5                 jg      loc_180D14F30
+  .text:0000000180D14EAB                 xor     ecx, ecx
+  .text:0000000180D14EAD                 call    sub_180B0FE20
+  .text:0000000180D14EB2                 mov     rdi, rax
+  .text:0000000180D14EB5                 test    rax, rax
+  .text:0000000180D14EB8                 jz      short loc_180D14F30
+  .text:0000000180D14EBA                 movss   xmm0, dword ptr [rax+0B9Ch]
+  .text:0000000180D14EC2                 ucomiss xmm0, xmm6
+  .text:0000000180D14EC5                 jp      short loc_180D14EC9
+  .text:0000000180D14EC7                 jz      short loc_180D14EEF
+  .text:0000000180D14EC9                 mov     edx, r13d
+  .text:0000000180D14ECC                 movss   [rbp+57h+var_BC], xmm0
+  .text:0000000180D14ED1                 lea     rcx, [rbp+57h+var_B8]
+  .text:0000000180D14ED5                 call    sub_1808C47A0
+  .text:0000000180D14EDA                 mov     r8, rax
+  .text:0000000180D14EDD                 lea     rdx, [rbp+57h+var_C0]
+  .text:0000000180D14EE1                 lea     rcx, [rbp+57h+var_BC]
+  .text:0000000180D14EE5                 call    sub_180185450
+  .text:0000000180D14EEA                 cmp     [rax], r13b
+  .text:0000000180D14EED                 jle     short loc_180D14F30
+  .text:0000000180D14EEF                 mov     rcx, cs:g_pGameRules
+  .text:0000000180D14EF6                 mov     rax, [rcx]
+  .text:0000000180D14EF9                 call    qword ptr [rax+290h]
+  .text:0000000180D14EFF                 test    al, al
+  .text:0000000180D14F01                 jnz     short loc_180D14F30
+  .text:0000000180D14F03                 mov     rcx, rdi
+  .text:0000000180D14F06                 call    sub_180C62ED0
+  .text:0000000180D14F0B                 movd    xmm0, eax
+  .text:0000000180D14F0F                 cvtdq2ps xmm0, xmm0
+  .text:0000000180D14F12                 comiss  xmm0, dword ptr [r14+3Ch]
+  .text:0000000180D14F17                 jb      short loc_180D14F30
+  .text:0000000180D14F19                 mov     rcx, cs:qword_181FDFC78
+  .text:0000000180D14F20                 lea     rdx, aAutosavedanger_2; "autosavedangerousissafe\n"
+  .text:0000000180D14F27                 mov     rax, [rcx]
+  .text:0000000180D14F2A                 call    qword ptr [rax+168h]
+  .text:0000000180D14F30                 movss   xmm0, cs:dword_1815E0754
+  .text:0000000180D14F38                 movss   dword ptr [r14+38h], xmm0
+  .text:0000000180D14F3E                 mov     [r14+3Ch], r13d
+  .text:0000000180D14F42                 mov     rcx, cs:qword_181FDFC78
+  .text:0000000180D14F49                 mov     rax, [rcx]
+  .text:0000000180D14F4C                 ; 0x1B8 = 440LL = CEngineServer_IsLogEnabled
+  .text:0000000180D14F4C                 call    qword ptr [rax+1B8h]; 0x1B8 = 440LL = CEngineServer_IsLogEnabled
+  .text:0000000180D14F52                 mov     rsi, cs:off_181C6FAE8
+  .text:0000000180D14F59                 mov     cs:byte_181CA15F8, al
+  .text:0000000180D14F5F                 movss   xmm7, dword ptr [rsi+34h]
+  .text:0000000180D14F64                 movss   xmm6, dword ptr [rsi+30h]
+  .text:0000000180D14F69                 call    cs:GetCurrentThreadId
+  .text:0000000180D14F6F                 mov     edx, [rsi+58h]
+  .text:0000000180D14F72                 movaps  xmm0, xmm6
+  .text:0000000180D14F75                 mulss   xmm0, cs:dword_1815E3CE4
+  .text:0000000180D14F7D                 xor     edi, edi
+  .text:0000000180D14F7F                 mov     r13d, [rsi+44h]
+  .text:0000000180D14F83                 movss   xmm8, dword ptr [rsi+30h]
+  .text:0000000180D14F89                 movss   xmm9, dword ptr [rsi+50h]
+  .text:0000000180D14F8F                 addss   xmm0, cs:dword_1815DF66C
+  .text:0000000180D14F97                 movss   xmm10, dword ptr [rsi+34h]
+  .text:0000000180D14F9D                 movss   dword ptr [rsi+30h], xmm6
+  .text:0000000180D14FA2                 movss   dword ptr [rsi+34h], xmm7
+  .text:0000000180D14FA7                 mov     [rsi+50h], edi
+  .text:0000000180D14FAA                 cvttss2si ecx, xmm0
+  .text:0000000180D14FAE                 mov     [rsi+58h], eax
+  .text:0000000180D14FB1                 mov     [rbp+57h+var_BC], edx
+  .text:0000000180D14FB4                 mov     [rsi+44h], ecx
+  .text:0000000180D14FB7                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180D14FBE                 call    sub_180B765E0
+  .text:0000000180D14FC3                 mov     edx, 0FFFFFFFFh
+  .text:0000000180D14FC8                 lea     rcx, unk_181FDF180
+  .text:0000000180D14FCF                 call    sub_181517330
+  .text:0000000180D14FD4                 movaps  xmm7, [rsp+0E0h+var_40]
+  .text:0000000180D14FDC                 movaps  xmm6, [rsp+0E0h+var_30]
+  .text:0000000180D14FE4                 test    rax, rax
+  .text:0000000180D14FE7                 jnz     short loc_180D14FF4
+  .text:0000000180D14FE9                 mov     rax, cs:qword_181FDF188
+  .text:0000000180D14FF0                 mov     rax, [rax+8]
+  .text:0000000180D14FF4                 cmp     [rax], dil
+  .text:0000000180D14FF7                 jz      short loc_180D15009
+  .text:0000000180D14FF9                 mov     rcx, cs:qword_181FDFC88
+  .text:0000000180D15000                 mov     rax, [rcx]
+  .text:0000000180D15003                 call    qword ptr [rax+90h]
+  .text:0000000180D15009                 mov     ecx, cs:dword_181BE64DC
+  .text:0000000180D1500F                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180D15016                 mov     r14d, cs:TlsIndex
+  .text:0000000180D1501D                 mov     [rbp+57h+var_C0], r12b
+  .text:0000000180D15021                 mov     [rbp+57h+var_BF], r15b
+  .text:0000000180D15025                 mov     edx, 238h
+  .text:0000000180D1502A                 test    ecx, ecx
+  .text:0000000180D1502C                 jns     short loc_180D15085
+  .text:0000000180D1502E                 mov     qword ptr [rbp+57h+var_B0], rax
+  .text:0000000180D15032                 mov     rax, gs:58h
+  .text:0000000180D1503B                 mov     qword ptr [rbp+57h+var_B0+8], rdi
+  .text:0000000180D1503F                 mov     rax, [rax+r14*8]
+  .text:0000000180D15043                 mov     eax, [rdx+rax]
+  .text:0000000180D15046                 cmp     cs:dword_181E3F3E8, eax
+  .text:0000000180D1504C                 jg      loc_180D152B6
+  .text:0000000180D15052                 mov     rax, cs:qword_181E3F3E0
+  .text:0000000180D15059                 lea     rcx, [rbp+57h+var_B0]
+  .text:0000000180D1505D                 mov     rdi, qword ptr [rbp+57h+var_B0]
+  .text:0000000180D15061                 mov     qword ptr [rbp+57h+var_B0], rax
+  .text:0000000180D15065                 call    sub_180500F44
+  .text:0000000180D1506A                 lea     rcx, [rbp+57h+var_B0]
+  .text:0000000180D1506E                 mov     qword ptr [rbp+57h+var_B0], rdi
+  .text:0000000180D15072                 mov     cs:dword_181BE64DC, eax
+  .text:0000000180D15078                 call    sub_1805006A0
+  .text:0000000180D1507D                 mov     ecx, cs:dword_181BE64DC
+  .text:0000000180D15083                 xor     edi, edi
+  .text:0000000180D15085                 lea     r8, [rbp+57h+var_C0]
+  .text:0000000180D15089                 lea     rdx, sub_180500F44
+  .text:0000000180D15090                 call    sub_180509290
+  .text:0000000180D15095                 cmp     cs:byte_181F5A0BD, 0
+  .text:0000000180D1509C                 jnz     short loc_180D150CC
+  .text:0000000180D1509E                 mov     edx, 0FFFFFFFFh
+  .text:0000000180D150A3                 lea     rcx, unk_181FDF0D0
+  .text:0000000180D150AA                 call    sub_181517330
+  .text:0000000180D150AF                 test    rax, rax
+  .text:0000000180D150B2                 jnz     short loc_180D150BF
+  .text:0000000180D150B4                 mov     rax, cs:qword_181FDF0D8
+  .text:0000000180D150BB                 mov     rax, [rax+8]
+  .text:0000000180D150BF                 movzx   ecx, byte ptr [rax]
+  .text:0000000180D150C2                 mov     rax, cs:off_181C6FAE8
+  .text:0000000180D150C9                 mov     [rax+74h], cl
+  .text:0000000180D150CC                 mov     rcx, cs:g_pNavMesh
+  .text:0000000180D150D3                 test    rcx, rcx
+  .text:0000000180D150D6                 jz      short loc_180D150DE
+  .text:0000000180D150D8                 mov     rax, [rcx]
+  .text:0000000180D150DB                 call    qword ptr [rax+50h]
+  .text:0000000180D150DE                 mov     rcx, cs:qword_18202D350
+  .text:0000000180D150E5                 test    rcx, rcx
+  .text:0000000180D150E8                 jz      short loc_180D150F0
+  .text:0000000180D150EA                 mov     rax, [rcx]
+  .text:0000000180D150ED                 call    qword ptr [rax+8]
+  .text:0000000180D150F0                 xorps   xmm0, xmm0
+  .text:0000000180D150F3                 mov     cs:dword_181FDF060, 0
+  .text:0000000180D150FD                 movsd   cs:qword_181FDF068, xmm0
+  .text:0000000180D15105                 movsd   cs:qword_181FDF078, xmm0
+  .text:0000000180D1510D                 mov     cs:dword_181FDF070, 0
+  .text:0000000180D15117                 mov     cs:dword_181FDF080, edi
+  .text:0000000180D1511D                 call    sub_180E62720
+  .text:0000000180D15122                 mov     rcx, cs:off_181BE7108
+  .text:0000000180D15129                 movzx   edx, [rbp+57h+arg_8]
+  .text:0000000180D1512D                 mov     rax, [rcx]
+  .text:0000000180D15130                 call    qword ptr [rax]
+  .text:0000000180D15132                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180D15139                 call    sub_18122BD90
+  .text:0000000180D1513E                 mov     ecx, cs:dword_181BE64E0
+  .text:0000000180D15144                 mov     [rbp+57h+var_C0], r12b
+  .text:0000000180D15148                 mov     [rbp+57h+var_BF], r15b
+  .text:0000000180D1514C                 test    ecx, ecx
+  .text:0000000180D1514E                 jns     short loc_180D151B1
+  .text:0000000180D15150                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180D15157                 mov     edx, 238h
+  .text:0000000180D1515C                 mov     qword ptr [rbp+57h+var_B0], rax
+  .text:0000000180D15160                 mov     rax, gs:58h
+  .text:0000000180D15169                 mov     qword ptr [rbp+57h+var_B0+8], rdi
+  .text:0000000180D1516D                 mov     rax, [rax+r14*8]
+  .text:0000000180D15171                 mov     eax, [rdx+rax]
+  .text:0000000180D15174                 cmp     cs:dword_181E3F3F8, eax
+  .text:0000000180D1517A                 jg      loc_180D1527E
+  .text:0000000180D15180                 mov     rax, cs:qword_181E3F3F0
+  .text:0000000180D15187                 lea     rcx, [rbp+57h+var_B0]
+  .text:0000000180D1518B                 mov     rdi, qword ptr [rbp+57h+var_B0]
+  .text:0000000180D1518F                 mov     qword ptr [rbp+57h+var_B0], rax
+  .text:0000000180D15193                 call    sub_180500CE4
+  .text:0000000180D15198                 lea     rcx, [rbp+57h+var_B0]
+  .text:0000000180D1519C                 mov     qword ptr [rbp+57h+var_B0], rdi
+  .text:0000000180D151A0                 mov     cs:dword_181BE64E0, eax
+  .text:0000000180D151A6                 call    sub_1805006A0
+  .text:0000000180D151AB                 mov     ecx, cs:dword_181BE64E0
+  .text:0000000180D151B1                 lea     r8, [rbp+57h+var_C0]
+  .text:0000000180D151B5                 lea     rdx, sub_180500CE4
+  .text:0000000180D151BC                 call    sub_180509290
+  .text:0000000180D151C1                 call    sub_180E7EC20
+  .text:0000000180D151C6                 mov     rdi, [rsp+0E0h+arg_10]
+  .text:0000000180D151CE                 test    al, al
+  .text:0000000180D151D0                 jz      short loc_180D151D7
+  .text:0000000180D151D2                 call    sub_180E7EBA0
+  .text:0000000180D151D7                 mov     rcx, cs:g_pGameEntitySystem
+  .text:0000000180D151DE                 call    sub_180B765E0
+  .text:0000000180D151E3                 call    sub_180C81C80
+  .text:0000000180D151E8                 mov     rcx, cs:g_pGameRules
+  .text:0000000180D151EF                 test    rcx, rcx
+  .text:0000000180D151F2                 jz      short loc_180D151FD
+  .text:0000000180D151F4                 mov     rax, [rcx]
+  .text:0000000180D151F7                 call    qword ptr [rax+1A0h]
+  .text:0000000180D151FD                 lea     rcx, dword_181FDF1D0
+  .text:0000000180D15204                 call    sub_180E85180
+  .text:0000000180D15209                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180D15210                 xor     edx, edx
+  .text:0000000180D15212                 call    sub_181220300
+  .text:0000000180D15217                 mov     rcx, cs:qword_181FDFC88
+  .text:0000000180D1521E                 mov     rax, [rcx]
+  .text:0000000180D15221                 call    qword ptr [rax+90h]
+  .text:0000000180D15227                 mov     eax, [rbp+57h+var_BC]
+  .text:0000000180D1522A                 movss   dword ptr [rsi+30h], xmm8
+  .text:0000000180D15230                 movaps  xmm8, [rsp+0E0h+var_50]
+  .text:0000000180D15239                 movss   dword ptr [rsi+34h], xmm10
+  .text:0000000180D1523F                 movaps  xmm10, [rsp+0E0h+var_70]
+  .text:0000000180D15245                 movss   dword ptr [rsi+50h], xmm9
+  .text:0000000180D1524B                 movaps  xmm9, [rsp+0E0h+var_60]
+  .text:0000000180D15254                 mov     [rsi+58h], eax
+  .text:0000000180D15257                 mov     [rsi+44h], r13d
+  .text:0000000180D1525B                 mov     rsi, [rsp+0E0h+arg_0]
+  .text:0000000180D15263                 call    rbx
+  .text:0000000180D15265                 mov     rbx, [rsp+0E0h+arg_18]
+  .text:0000000180D1526D                 add     rsp, 0C0h
+  .text:0000000180D15274                 pop     r15
+  .text:0000000180D15276                 pop     r14
+  .text:0000000180D15278                 pop     r13
+  .text:0000000180D1527A                 pop     r12
+  .text:0000000180D1527C                 pop     rbp
+  .text:0000000180D1527D                 retn
+  .text:0000000180D1527E                 lea     rcx, dword_181E3F3F8
+  .text:0000000180D15285                 call    sub_18152F5F4
+  .text:0000000180D1528A                 cmp     cs:dword_181E3F3F8, 0FFFFFFFFh
+  .text:0000000180D15291                 jnz     loc_180D15180
+  .text:0000000180D15297                 mov     rax, cs:off_181BE6610
+  .text:0000000180D1529E                 lea     rcx, dword_181E3F3F8
+  .text:0000000180D152A5                 mov     cs:qword_181E3F3F0, rax
+  .text:0000000180D152AC                 call    sub_18152F588
+  .text:0000000180D152B1                 jmp     loc_180D15180
+  .text:0000000180D152B6                 lea     rcx, dword_181E3F3E8
+  .text:0000000180D152BD                 call    sub_18152F5F4
+  .text:0000000180D152C2                 cmp     cs:dword_181E3F3E8, 0FFFFFFFFh
+  .text:0000000180D152C9                 jnz     loc_180D15052
+  .text:0000000180D152CF                 mov     rax, cs:off_181BE6608
+  .text:0000000180D152D6                 lea     rcx, dword_181E3F3E8
+  .text:0000000180D152DD                 mov     cs:qword_181E3F3E0, rax
+  .text:0000000180D152E4                 call    sub_18152F588
+  .text:0000000180D152E9                 jmp     loc_180D15052
+procedure: |-
+  __int64 __fastcall CSource2Server_GameFrame(__int64 a1, unsigned __int8 a2, char a3, char a4)
+  {
+    __int64 (__fastcall *v7)(__int64); // rbx
+    __int64 v8; // rcx
+    _BYTE *v9; // rax
+    __int64 v10; // rax
+    __int64 v11; // rdi
+    double v12; // xmm0_8
+    float v13; // xmm7_4
+    float v14; // xmm0_4
+    __int64 v15; // rax
+    __int64 v16; // rax
+    __int64 v17; // rdi
+    __int64 v18; // rax
+    char v19; // al
+    float *v20; // rsi
+    int v21; // xmm7_4
+    float v22; // xmm6_4
+    DWORD CurrentThreadId; // eax
+    int v24; // edx
+    int v25; // r13d
+    int v26; // xmm8_4
+    int v27; // xmm9_4
+    int v28; // xmm10_4
+    _BYTE *v29; // rax
+    __int64 v30; // rcx
+    __int64 v31; // r14
+    __int64 v32; // rdx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v34; // rdi
+    int v35; // eax
+    _BYTE *v36; // rax
+    __int64 v37; // rcx
+    __int64 v38; // rcx
+    _QWORD *v39; // rax
+    __int64 v40; // rdi
+    int v41; // eax
+    __int64 v42; // rcx
+    __int64 v43; // rcx
+    __int64 v44; // rcx
+    int v45; // eax
+    char v47; // [rsp+20h] [rbp-69h] BYREF
+    char v48; // [rsp+21h] [rbp-68h]
+    int v49; // [rsp+24h] [rbp-65h] BYREF
+    _BYTE v50[8]; // [rsp+28h] [rbp-61h] BYREF
+    __int128 v51; // [rsp+30h] [rbp-59h] BYREF
+    const char *v52; // [rsp+40h] [rbp-49h]
+    __int128 v53; // [rsp+50h] [rbp-39h] BYREF
+    const char *v54; // [rsp+60h] [rbp-29h]
+
+    *((_QWORD *)&v51 + 1) = 947;
+    *(_QWORD *)&v51 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\server\\gameinterface.cpp";
+    v52 = "GameFrame";
+    v54 = "GameFrame";
+    v53 = v51;
+    v7 = (__int64 (__fastcall *)(__int64))VProfScopeHelper<0,0>::EnterScopeInternalBudgetFlags(
+                                            "CSource2Server::GameFrame",
+                                            &off_181C700C0,
+                                            &v53);
+    if ( (unsigned __int8)sub_180BD9B10() )
+    {
+      sub_180BDE580(0);
+      sub_1801A0820();
+      v9 = (_BYTE *)sub_181517330(&unk_181FDF280, 0xFFFFFFFFLL);
+      if ( !v9 )
+        v9 = *(_BYTE **)(qword_181FDF288 + 8);
+      if ( *v9 )
+      {
+        v10 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)qword_181FDFC78 + 328LL))(qword_181FDFC78, 0);
+        v11 = v10;
+        if ( v10 )
+        {
+          v12 = (*(double (__fastcall **)(__int64, __int64))(*(_QWORD *)v10 + 120LL))(v10, 1);
+          v13 = *(float *)&v12 * 0.0009765625;
+          v14 = (*(float (__fastcall **)(__int64, _QWORD))(*(_QWORD *)v11 + 120LL))(v11, 0) * 0.0009765625;
+          if ( v13 > *(float *)&dword_181FDF060 )
+            dword_181FDF060 = LODWORD(v13);
+          *(double *)&qword_181FDF068 = *(double *)&qword_181FDF068 + v13;
+          if ( v14 > *(float *)&dword_181FDF070 )
+            dword_181FDF070 = LODWORD(v14);
+          ++dword_181FDF080;
+          *(double *)&qword_181FDF078 = *(double *)&qword_181FDF078 + v14;
+        }
+      }
+      if ( a4 )
+      {
+        if ( *(float *)(a1 + 56) != 0.0 )
+        {
+          sub_1808C47A0(&v49, 0);
+          if ( *(_BYTE *)sub_180185450(a1 + 56, &v47, v15) == 0xFF )
+          {
+            if ( off_181C6FAE8 )
+            {
+              if ( *((int *)off_181C6FAE8 + 4) <= 1 )
+              {
+                v16 = sub_180B0FE20(0);
+                v17 = v16;
+                if ( v16 )
+                {
+                  if ( *(float *)(v16 + 2972) == 0.0
+                    || (v49 = *(_DWORD *)(v16 + 2972), sub_1808C47A0(v50, 0), *(char *)sub_180185450(&v49, &v47, v18) > 0) )
+                  {
+                    if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pGameRules + 656LL))(g_pGameRules)
+                      && (float)(int)sub_180C62ED0(v17) >= *(float *)(a1 + 60) )
+                    {
+                      (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)qword_181FDFC78 + 360LL))(
+                        qword_181FDFC78,
+                        "autosavedangerousissafe\n");
+                    }
+                  }
+                }
+              }
+            }
+            *(_DWORD *)(a1 + 56) = 0;
+            *(_DWORD *)(a1 + 60) = 0;
+          }
+        }
+      }
+      v19 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_181FDFC78 + 440LL))(qword_181FDFC78);// 0x1B8 = 440LL = CEngineServer_IsLogEnabled
+      v20 = (float *)off_181C6FAE8;
+      byte_181CA15F8 = v19;
+      v21 = *((_DWORD *)off_181C6FAE8 + 13);
+      v22 = *((float *)off_181C6FAE8 + 12);
+      CurrentThreadId = GetCurrentThreadId();
+      v24 = *((_DWORD *)v20 + 22);
+      v25 = *((_DWORD *)v20 + 17);
+      v26 = *((_DWORD *)v20 + 12);
+      v27 = *((_DWORD *)v20 + 20);
+      v28 = *((_DWORD *)v20 + 13);
+      v20[12] = v22;
+      *((_DWORD *)v20 + 13) = v21;
+      v20[20] = 0.0;
+      *((_DWORD *)v20 + 22) = CurrentThreadId;
+      v49 = v24;
+      *((_DWORD *)v20 + 17) = (int)(float)((float)(v22 * 64.0) + 0.5);
+      sub_180B765E0(g_pGameEntitySystem);
+      v29 = (_BYTE *)sub_181517330(&unk_181FDF180, 0xFFFFFFFFLL);
+      if ( !v29 )
+        v29 = *(_BYTE **)(qword_181FDF188 + 8);
+      if ( *v29 )
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_181FDFC88 + 144LL))(qword_181FDFC88);
+      v30 = (unsigned int)dword_181BE64DC;
+      v31 = (unsigned int)TlsIndex;
+      v47 = a3;
+      v48 = a4;
+      v32 = 568;
+      if ( dword_181BE64DC < 0 )
+      {
+        *(_QWORD *)&v51 = &CDontUseThisGameSystem::`vftable';
+        ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+        *((_QWORD *)&v51 + 1) = 0;
+        if ( dword_181E3F3E8 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 568LL) )
+        {
+          sub_18152F5F4(&dword_181E3F3E8);
+          if ( dword_181E3F3E8 == -1 )
+          {
+            qword_181E3F3E0 = (__int64)off_181BE6608[0];
+            sub_18152F588(&dword_181E3F3E8);
+          }
+        }
+        v34 = v51;
+        *(_QWORD *)&v51 = qword_181E3F3E0;
+        v35 = sub_180500F44(&v51, v32);
+        *(_QWORD *)&v51 = v34;
+        dword_181BE64DC = v35;
+        sub_1805006A0(&v51);
+        v30 = (unsigned int)dword_181BE64DC;
+      }
+      sub_180509290(v30, sub_180500F44, &v47);
+      if ( !byte_181F5A0BD )
+      {
+        v36 = (_BYTE *)sub_181517330(&unk_181FDF0D0, 0xFFFFFFFFLL);
+        if ( !v36 )
+          v36 = *(_BYTE **)(qword_181FDF0D8 + 8);
+        *((_BYTE *)off_181C6FAE8 + 116) = *v36;
+      }
+      if ( g_pNavMesh )
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pNavMesh + 80LL))(g_pNavMesh);
+      v37 = qword_18202D350;
+      if ( qword_18202D350 )
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_18202D350 + 8LL))(qword_18202D350);
+      dword_181FDF060 = 0;
+      qword_181FDF068 = 0;
+      qword_181FDF078 = 0;
+      dword_181FDF070 = 0;
+      dword_181FDF080 = 0;
+      sub_180E62720(v37);
+      ((void (__fastcall *)(__int64 (__fastcall ***)(), _QWORD))**off_181BE7108)(off_181BE7108, a2);
+      sub_18122BD90(g_pEntitySystem);
+      v38 = (unsigned int)dword_181BE64E0;
+      v47 = a3;
+      v48 = a4;
+      if ( dword_181BE64E0 < 0 )
+      {
+        *(_QWORD *)&v51 = &CDontUseThisGameSystem::`vftable';
+        v39 = NtCurrentTeb()->ThreadLocalStoragePointer;
+        *((_QWORD *)&v51 + 1) = 0;
+        if ( dword_181E3F3F8 > *(_DWORD *)(v39[v31] + 568LL) )
+        {
+          sub_18152F5F4(&dword_181E3F3F8);
+          if ( dword_181E3F3F8 == -1 )
+          {
+            qword_181E3F3F0 = (__int64)off_181BE6610[0];
+            sub_18152F588(&dword_181E3F3F8);
+          }
+        }
+        v40 = v51;
+        *(_QWORD *)&v51 = qword_181E3F3F0;
+        v41 = sub_180500CE4(&v51);
+        *(_QWORD *)&v51 = v40;
+        dword_181BE64E0 = v41;
+        sub_1805006A0(&v51);
+        v38 = (unsigned int)dword_181BE64E0;
+      }
+      sub_180509290(v38, sub_180500CE4, &v47);
+      if ( (unsigned __int8)sub_180E7EC20(v42) )
+        sub_180E7EBA0(v43);
+      sub_180B765E0(g_pGameEntitySystem);
+      sub_180C81C80(v44);
+      if ( g_pGameRules )
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pGameRules + 416LL))(g_pGameRules);
+      sub_180E85180(&dword_181FDF1D0);
+      sub_181220300(g_pEntitySystem, 0);
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_181FDFC88 + 144LL))(qword_181FDFC88);
+      v45 = v49;
+      *((_DWORD *)v20 + 12) = v26;
+      *((_DWORD *)v20 + 13) = v28;
+      *((_DWORD *)v20 + 20) = v27;
+      *((_DWORD *)v20 + 22) = v45;
+      *((_DWORD *)v20 + 17) = v25;
+    }
+    return v7(v8);
+  }


### PR DESCRIPTION
## Summary
Adds a new **Pattern C** (virtual function via `LLM_DECOMPILE`) preprocessor that discovers `CEngineServer::IsLogEnabled` by decompiling the predecessor `CSource2Server_GameFrame` (server module) and reading the indirect vfunc call site.

Resolved consistently on both platforms:
- `vtable_name: CEngineServer`
- `vfunc_offset: 0x1b8`
- `vfunc_index: 55`
- `vfunc_sig` present (mandatory for Pattern C)

## Files
- `ida_preprocessor_scripts/find-CEngineServer_IsLogEnabled.py` — new Pattern C finder (slim field set: `func_name, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`).
- `configs/14172.yaml` — adds the `find-CEngineServer_IsLogEnabled` skill (server module) and the `CEngineServer_IsLogEnabled` symbol (category `vfunc`, alias `CEngineServer::IsLogEnabled`).
- `ida_preprocessor_scripts/references/server/CSource2Server_GameFrame.{windows,linux}.yaml` — annotated predecessor reference YAMLs marking the `call [rax+1B8h]` site.

Note: `CEngineServer` vtable name is metadata only — the offset/signature anchor on the call site inside `CSource2Server_GameFrame` (server.dll), so no `CEngineServer_vtable` lookup is required, enabling cross-module discovery. Gamedata still resolves the symbol from the server bin dir (server is a reference module of `IVEngineServer2_MSVC`).

## Validation
- `ida_analyze_bin.py` run: **Failed: 0**; both platform output YAMLs produced with the values above.
- `format_repo_files.py --check`: clean.
- Non-MCP unittest suite: green.

## Not included
- The `hl2sdk_cs2` submodule is untouched (not part of this PR).
- The C++ layout gate + gamesymbol pack were not run locally (SDK submodule/clang toolchain unavailable in this environment); the self-hosted CI runner regenerates the snapshot/gamedata.