### PR TITLE
feat(preprocessor): add g_EntitySystem/g_pEntityList finders via CEntitySystem_Init decompiles

### DIFF
--- a/.claude/skills/post-change-update/SKILL.md
+++ b/.claude/skills/post-change-update/SKILL.md
@@ -22,11 +22,17 @@ layouts and does not commit; callers must place `/post-change-validation` betwee
 Stop if the phase is missing or invalid. Stop if no non-empty game version can be resolved.
 Set `ANALYSIS_CONFIG="configs/$GAMEVER.yaml"` and stop if it is not a file.
 
+This workflow is single-version scoped: update only the version resolved as `GAMEVER` (the caller-provided
+value, or `CS2VIBE_GAMEVER` from `.env`). Do not rebuild, repack, publish, or otherwise modify snapshots,
+gamedata, configs, or candidate artifacts for any other game version.
+
 ## Safety Rules
 
 - Run from the repository root.
 - Preserve unrelated pre-existing work and never stage or commit changes.
 - Stop on the first failed command and report its command, exit code, and relevant output.
+- Keep every candidate, snapshot, gamedata, and config path constrained to the resolved `GAMEVER`; never fan out
+  to historical or neighboring versions.
 - Never run downstream validation directly from `bin` or fall back to a tracked head snapshot.
 - Never rebuild or reserialize a candidate after downstream validation begins.
 - Never run the after-validation phase without explicit success from `/post-change-validation` for the same

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -3221,6 +3221,26 @@ modules:
       - name: find-CSource2Client_vtable
         expected_output:
           - CSource2Client_vtable.{platform}.yaml
+      - name: find-CSource2Client_Connect
+        expected_output:
+          - CSource2Client_Connect.{platform}.yaml
+        expected_input:
+          - CSource2Client_vtable.{platform}.yaml
+      - name: find-CSource2Client_Connect-decompiles
+        expected_output:
+          - g_pEngineClient.{platform}.yaml
+        expected_input:
+          - CSource2Client_Connect.{platform}.yaml
+      - name: find-CBasePlayerController_CheckForLocalPlayer
+        expected_output:
+          - CBasePlayerController_CheckForLocalPlayer.{platform}.yaml
+        expected_input:
+          - g_pEngineClient.{platform}.yaml
+      - name: find-CBasePlayerController_CheckForLocalPlayer-decompiles
+        expected_output:
+          - s_pLocalPlayer.{platform}.yaml
+        expected_input:
+          - CBasePlayerController_CheckForLocalPlayer.{platform}.yaml
       - name: find-CSource2Client_OnDisconnect
         expected_output:
           - CSource2Client_OnDisconnect.{platform}.yaml
@@ -3837,6 +3857,18 @@ modules:
           - IGameSystem::OnClientPreRenderAlt
       - name: CSource2Client_vtable
         category: vtable
+      - name: CSource2Client_Connect
+        category: vfunc
+        alias:
+          - CSource2Client::Connect
+      - name: g_pEngineClient
+        category: gv
+      - name: CBasePlayerController_CheckForLocalPlayer
+        category: func
+        alias:
+          - CBasePlayerController::CheckForLocalPlayer
+      - name: s_pLocalPlayer
+        category: gv
       - name: CSource2Client_OnDisconnect
         category: vfunc
         alias:

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -6413,6 +6413,8 @@ modules:
         expected_output:
           - INetworkMessages_SetNetworkSerializationContextData.{platform}.yaml
           - IFlattenedSerializers_CreateFieldChangedEventQueue.{platform}.yaml
+          - g_EntitySystem.{platform}.yaml
+          - g_pEntityList.{platform}.yaml
           - CEntitySystem_m_sEntSystemName.{platform}.yaml
           - CEntitySystem_m_eNetworkSerializationMode.{platform}.yaml
           - CEntitySystem_m_Symbols.{platform}.yaml
@@ -9480,6 +9482,10 @@ modules:
       - name: CEntitySystem_CreateEntitySystem
         category: func
       - name: g_pEntitySystem
+        category: gv
+      - name: g_EntitySystem
+        category: gv
+      - name: g_pEntityList
         category: gv
       - name: CEntitySystem_Init
         category: func

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:1383dab63dbfee628c6525778110b02c7b1c5bb2b96bae4f06ebe533294c9cf6
-file_count: 2942
+config_sha256: sha256:0edba51e09cf17997f31ee0e19ef7c28dce47e0759243cf2b1f66ac33f965f79
+file_count: 2950
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -138,6 +138,18 @@ files:
     func_sig: 40 53 48 83 EC ?? 83 BA ?? ?? ?? ?? ?? 48 8B DA 7D ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 83 C4 ??
     func_size: '0x85'
     func_va: '0x180b28d30'
+  client/CBasePlayerController_CheckForLocalPlayer.linux.yaml:
+    func_name: CBasePlayerController_CheckForLocalPlayer
+    func_rva: '0x15f0280'
+    func_sig: 55 48 89 E5 41 54 49 89 FC 53 89 F3 48 83 EC ?? 83 FE ??
+    func_size: '0xfd'
+    func_va: '0x15f0280'
+  client/CBasePlayerController_CheckForLocalPlayer.windows.yaml:
+    func_name: CBasePlayerController_CheckForLocalPlayer
+    func_rva: '0x8f0b70'
+    func_sig: 40 55 53 57 41 56 41 57 48 8B EC 48 81 EC ?? ?? ?? ??
+    func_size: '0x26d'
+    func_va: '0x1808f0b70'
   client/CEntityInstance_PreDataUpdate.linux.yaml:
     func_name: CEntityInstance_PreDataUpdate
     vfunc_index: 19
@@ -1346,6 +1358,24 @@ files:
     vtable_size: '0x100'
     vtable_symbol: ??_7CSkeletonInstance@@6B@
     vtable_va: '0x181ae0828'
+  client/CSource2Client_Connect.linux.yaml:
+    func_name: CSource2Client_Connect
+    func_rva: '0x1895490'
+    func_sig: 55 48 89 E5 41 57 41 56 4C 8D BD ?? ?? ?? ?? 41 55 4C 8D AD ?? ?? ?? ?? 41 54 49 89 FC
+    func_size: '0x720'
+    func_va: '0x1895490'
+    vfunc_index: 0
+    vfunc_offset: '0x0'
+    vtable_name: CSource2Client_vtable
+  client/CSource2Client_Connect.windows.yaml:
+    func_name: CSource2Client_Connect
+    func_rva: '0xb086f0'
+    func_sig: 40 53 56 57 48 81 EC ?? ?? ?? ?? 48 8B DA
+    func_size: '0x66c'
+    func_va: '0x180b086f0'
+    vfunc_index: 0
+    vfunc_offset: '0x0'
+    vtable_name: CSource2Client_vtable
   client/CSource2Client_OnDisconnect.linux.yaml:
     func_name: CSource2Client_OnDisconnect
     func_rva: '0x18996e0'
@@ -3265,6 +3295,24 @@ files:
     gv_name: g_pEconItemToolModel
     gv_rva: '0x25c9380'
     gv_va: '0x1825c9380'
+  client/g_pEngineClient.linux.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_pEngineClient
+    gv_rva: '0x47f9b38'
+    gv_sig: 48 89 05 ?? ?? ?? ?? 48 85 C0 0F 84 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??
+    gv_sig_va: '0x1895543'
+    gv_va: '0x47f9b38'
+  client/g_pEngineClient.windows.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_pEngineClient
+    gv_rva: '0x23a07f8'
+    gv_sig: 48 89 05 ?? ?? ?? ?? 48 85 C0 0F 84 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    gv_sig_va: '0x180b0878f'
+    gv_va: '0x1823a07f8'
   client/g_pEngineServiceMgr.linux.yaml:
     gv_name: g_pEngineServiceMgr
     gv_rva: '0x48add78'
@@ -4053,6 +4101,24 @@ files:
     gv_name: g_pWorldRendererMgr
     gv_rva: '0x25c9548'
     gv_va: '0x1825c9548'
+  client/s_pLocalPlayer.linux.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: s_pLocalPlayer
+    gv_rva: '0x47cc9b8'
+    gv_sig: 4C 89 25 ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 45 ??
+    gv_sig_va: '0x15f0306'
+    gv_va: '0x47cc9b8'
+  client/s_pLocalPlayer.windows.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: s_pLocalPlayer
+    gv_rva: '0x237fb70'
+    gv_sig: 48 8D 0D ?? ?? ?? ?? 33 F6 4C 89 34 F9
+    gv_sig_va: '0x1808f0bf7'
+    gv_va: '0x18237fb70'
   engine/CDelayedCall2_CServerSideClientBase_ProcessBaselineAckCall_vtable.linux.yaml:
     vtable_class: CDelayedCall2_CServerSideClientBase_ProcessBaselineAckCall
     vtable_entries:

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:0edba51e09cf17997f31ee0e19ef7c28dce47e0759243cf2b1f66ac33f965f79
-file_count: 2950
+config_sha256: sha256:4fed0a7b1420b7413ba0b01dbab6ca7656876f9eef3688d17debefc7650177da
+file_count: 2954
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -36428,6 +36428,24 @@ files:
     func_sig: 40 55 56 41 54 48 83 EC ?? 41 0F B6 C1
     func_size: '0x28a'
     func_va: '0x180a18d30'
+  server/g_EntitySystem.linux.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_EntitySystem
+    gv_rva: '0x2678a68'
+    gv_sig: 48 89 1D ?? ?? ?? ?? 48 89 05 ?? ?? ?? ?? 4D 8B 26
+    gv_sig_va: '0x212f976'
+    gv_va: '0x2678a68'
+  server/g_EntitySystem.windows.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_EntitySystem
+    gv_rva: '0x1e3f308'
+    gv_sig: 48 89 1D ?? ?? ?? ?? 48 85 DB 49 0F 44 C7
+    gv_sig_va: '0x181223336'
+    gv_va: '0x181e3f308'
   server/g_GameTraceManager.linux.yaml:
     gv_inst_disp: 3
     gv_inst_length: 7
@@ -36608,6 +36626,24 @@ files:
     gv_name: g_pEngineServiceMgr
     gv_rva: '0x219ece8'
     gv_va: '0x18219ece8'
+  server/g_pEntityList.linux.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_pEntityList
+    gv_rva: '0x2678a60'
+    gv_sig: 48 89 05 ?? ?? ?? ?? 4D 8B 26
+    gv_sig_va: '0x212f97d'
+    gv_va: '0x2678a60'
+  server/g_pEntityList.windows.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: g_pEntityList
+    gv_rva: '0x1d9ad08'
+    gv_sig: 48 89 05 ?? ?? ?? ?? 48 85 FF 74 ??
+    gv_sig_va: '0x181223344'
+    gv_va: '0x181d9ad08'
   server/g_pEntitySystem.linux.yaml:
     gv_inst_disp: 3
     gv_inst_length: 7

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -12671,6 +12671,9 @@ files:
     func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8D 99 ?? ?? ?? ?? 48 8B FA
     func_size: '0x67'
     func_va: '0x1800d6390'
+    vfunc_index: 21
+    vfunc_offset: '0xa8'
+    vtable_name: CNetworkMessages
   networksystem/CNetworkMessages_IsAdditionalMessageRegistrationAllowed.linux.yaml:
     func_name: CNetworkMessages_IsAdditionalMessageRegistrationAllowed
     func_rva: '0x2a4200'

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -12662,6 +12662,9 @@ files:
     func_sig: 55 48 89 E5 41 56 41 55 4C 8D B7 ?? ?? ?? ?? 41 54 49 89 F4
     func_size: '0x6c'
     func_va: '0x2a4f70'
+    vfunc_index: 21
+    vfunc_offset: '0xa8'
+    vtable_name: CNetworkMessages
   networksystem/CNetworkMessages_GetNetworkSerializationContextData.windows.yaml:
     func_name: CNetworkMessages_GetNetworkSerializationContextData
     func_rva: '0xd6390'

--- a/ida_preprocessor_scripts/find-CBasePlayerController_CheckForLocalPlayer-decompiles.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_CheckForLocalPlayer-decompiles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_CheckForLocalPlayer-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_GLOBALVAR_NAMES = [
+    "s_pLocalPlayer",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "s_pLocalPlayer",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CBasePlayerController_CheckForLocalPlayer.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "CBasePlayerController_CheckForLocalPlayer.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "s_pLocalPlayer",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever gv_sig to locate the target global and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CBasePlayerController_CheckForLocalPlayer.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_CheckForLocalPlayer.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_CheckForLocalPlayer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_CheckForLocalPlayer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerController_CheckForLocalPlayer",
+        "xref_strings": ["snd_soundmixer"],
+        "xref_gvs": ["g_pEngineClient"],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [
+            "FULLMATCH:cl_player_ragdolls_collide",
+            "FULLMATCH:dsp_volume",
+        ],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_CheckForLocalPlayer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate the target function and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
+++ b/ida_preprocessor_scripts/find-CEntitySystem_Init-decompiles.py
@@ -12,6 +12,11 @@ TARGET_FUNCTION_NAMES_LINUX = [
     "CEntitySystem_ProcessEntityRegistration",
 ]
 
+TARGET_GLOBALVAR_NAMES = [
+    "g_EntitySystem",
+    "g_pEntityList",
+]
+
 TARGET_STRUCT_MEMBER_NAMES = [
     "CEntitySystem_m_sEntSystemName",
     "CEntitySystem_m_eNetworkSerializationMode",
@@ -45,6 +50,28 @@ LLM_DECOMPILE = [
             "references/server/CEntitySystem_Init.{platform}.yaml",
         ],
         "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CEntitySystem_Init.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "g_EntitySystem",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CEntitySystem_Init.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "CEntitySystem_Init.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "g_pEntityList",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CEntitySystem_Init.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
         "dependency_policy": {
             "CEntitySystem_Init.{platform}.yaml": "required",
         },
@@ -154,6 +181,32 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",
+        ],
+    ),
+    (
+        "g_EntitySystem",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+    (
+        "g_pEntityList",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
         ],
     ),
     (
@@ -332,6 +385,7 @@ async def preprocess_skill(
         platform=platform,
         image_base=image_base,
         func_names=func_names,
+        gv_names=TARGET_GLOBALVAR_NAMES,
         struct_member_names=struct_member_names,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
         llm_decompile_specs=llm_decompile,

--- a/ida_preprocessor_scripts/find-CSource2Client_Connect-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_Connect-decompiles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_Connect-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_GLOBALVAR_NAMES = [
+    "g_pEngineClient",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "g_pEngineClient",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CSource2Client_Connect.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "CSource2Client_Connect.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "g_pEngineClient",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever gv_sig to locate the target global and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_Connect.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_Connect.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_Connect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Client_Connect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Client_Connect",
+        "xref_strings": [
+            "FULLMATCH:Source2EngineToClient001",
+            "SteamAPI_Init failed.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact)
+    ("CSource2Client_Connect", "CSource2Client_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Client_Connect",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate the target vfunc and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CBasePlayerController_CheckForLocalPlayer.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CBasePlayerController_CheckForLocalPlayer.linux.yaml
@@ -1,0 +1,115 @@
+func_name: CBasePlayerController_CheckForLocalPlayer
+func_va: '0x15f0280'
+disasm_code: |-
+  .text:00000000015F0280                 push    rbp
+  .text:00000000015F0281                 mov     rbp, rsp
+  .text:00000000015F0284                 push    r12
+  .text:00000000015F0286                 mov     r12, rdi
+  .text:00000000015F0289                 push    rbx
+  .text:00000000015F028A                 mov     ebx, esi
+  .text:00000000015F028C                 sub     rsp, 10h
+  .text:00000000015F0290                 cmp     esi, 0FFFFFFFFh
+  .text:00000000015F0293                 jz      short loc_15F02AA
+  .text:00000000015F0295                 lea     rax, g_pEngineClient
+  .text:00000000015F029C                 mov     rdi, [rax]
+  .text:00000000015F029F                 mov     rax, [rdi]
+  .text:00000000015F02A2                 call    qword ptr [rax+110h]
+  .text:00000000015F02A8                 mov     ebx, eax
+  .text:00000000015F02AA                 mov     eax, cs:dword_47CC9B4
+  .text:00000000015F02B0                 test    eax, eax
+  .text:00000000015F02B2                 jz      loc_15F0353
+  .text:00000000015F02B8                 mov     ebx, cs:dword_47CC9B0
+  .text:00000000015F02BE                 cmp     ebx, 0FFFFFFFFh
+  .text:00000000015F02C1                 jnz     loc_15F0350
+  .text:00000000015F02C7                 mov     rdi, r12
+  .text:00000000015F02CA                 call    sub_2DCC8F0
+  .text:00000000015F02CF                 cmp     eax, 0FFFFFFFFh
+  .text:00000000015F02D2                 jnz     loc_15F0378
+  .text:00000000015F02D8                 lea     rbx, [rbp+var_20]
+  .text:00000000015F02DC                 mov     edx, 9
+  .text:00000000015F02E1                 mov     rax, 0FFFFFFFF00000000h
+  .text:00000000015F02EB                 mov     byte ptr [r12+908h], 1
+  .text:00000000015F02F4                 mov     [r12+848h], rax
+  .text:00000000015F02FC                 lea     rsi, aSndSoundmixer; "snd_soundmixer"
+  .text:00000000015F0303                 mov     rdi, rbx
+  .text:00000000015F0306                 mov     cs:s_pLocalPlayer, r12
+  .text:00000000015F030D                 call    sub_20D0B90
+  .text:00000000015F0312                 mov     rax, [rbp+var_18]
+  .text:00000000015F0316                 test    rax, rax
+  .text:00000000015F0319                 jz      short loc_15F032E
+  .text:00000000015F031B                 test    byte ptr [rax+31h], 4
+  .text:00000000015F031F                 jnz     short loc_15F032E
+  .text:00000000015F0321                 mov     esi, 0FFFFFFFFh
+  .text:00000000015F0326                 mov     rdi, rbx
+  .text:00000000015F0329                 call    sub_20D28F0
+  .text:00000000015F032E                 mov     rdi, rbx
+  .text:00000000015F0331                 call    nullsub_1836
+  .text:00000000015F0336                 mov     rdi, r12
+  .text:00000000015F0339                 call    sub_1099DE0
+  .text:00000000015F033E                 add     rsp, 10h
+  .text:00000000015F0342                 mov     rdi, r12
+  .text:00000000015F0345                 pop     rbx
+  .text:00000000015F0346                 pop     r12
+  .text:00000000015F0348                 pop     rbp
+  .text:00000000015F0349                 jmp     sub_15DA350
+  .text:00000000015F0350                 sub     ebx, 1
+  .text:00000000015F0353                 mov     rdi, r12
+  .text:00000000015F0356                 call    sub_2DCC8F0
+  .text:00000000015F035B                 cmp     eax, 0FFFFFFFFh
+  .text:00000000015F035E                 jnz     short loc_15F0378
+  .text:00000000015F0360                 cmp     eax, ebx
+  .text:00000000015F0362                 jz      loc_15F02D8
+  .text:00000000015F0368                 add     rsp, 10h
+  .text:00000000015F036C                 pop     rbx
+  .text:00000000015F036D                 pop     r12
+  .text:00000000015F036F                 pop     rbp
+  .text:00000000015F0370                 retn
+  .text:00000000015F0378                 sub     eax, 1
+  .text:00000000015F037B                 jmp     short loc_15F0360
+procedure: |-
+  __int64 __fastcall CBasePlayerController_CheckForLocalPlayer(__int64 a1, int a2)
+  {
+    int v2; // ebx
+    __int64 result; // rax
+    _BYTE v4[8]; // [rsp+0h] [rbp-20h] BYREF
+    __int64 v5; // [rsp+8h] [rbp-18h]
+
+    v2 = a2;
+    if ( a2 != -1 )
+      v2 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 272LL))(g_pEngineClient);
+    if ( !dword_47CC9B4 )
+    {
+  LABEL_11:
+      result = sub_2DCC8F0(a1);
+      if ( (_DWORD)result == -1 )
+        goto LABEL_12;
+      goto LABEL_14;
+    }
+    v2 = dword_47CC9B0;
+    if ( dword_47CC9B0 != -1 )
+    {
+      v2 = dword_47CC9B0 - 1;
+      goto LABEL_11;
+    }
+    LODWORD(result) = sub_2DCC8F0(a1);
+    if ( (_DWORD)result != -1 )
+    {
+  LABEL_14:
+      result = (unsigned int)(result - 1);
+  LABEL_12:
+      if ( (_DWORD)result != v2 )
+        return result;
+    }
+    *(_BYTE *)(a1 + 2312) = 1;
+    *(_QWORD *)(a1 + 2120) = 0xFFFFFFFF00000000LL;
+    s_pLocalPlayer = a1;
+    sub_20D0B90(v4, "snd_soundmixer", 9);
+    if ( v5 )
+    {
+      if ( (*(_BYTE *)(v5 + 49) & 4) == 0 )
+        sub_20D28F0(v4, 0xFFFFFFFFLL);
+    }
+    nullsub_1836(v4);
+    sub_1099DE0(a1);
+    return sub_15DA350(a1);
+  }

--- a/ida_preprocessor_scripts/references/client/CBasePlayerController_CheckForLocalPlayer.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CBasePlayerController_CheckForLocalPlayer.windows.yaml
@@ -1,0 +1,293 @@
+func_name: CBasePlayerController_CheckForLocalPlayer
+func_va: '0x1808f0b70'
+disasm_code: |-
+  .text:00000001808F0B70                 push    rbp
+  .text:00000001808F0B72                 push    rbx
+  .text:00000001808F0B73                 push    rdi
+  .text:00000001808F0B74                 push    r14
+  .text:00000001808F0B76                 push    r15
+  .text:00000001808F0B78                 mov     rbp, rsp
+  .text:00000001808F0B7B                 sub     rsp, 80h
+  .text:00000001808F0B82                 movsxd  rdi, edx
+  .text:00000001808F0B85                 mov     r14, rcx
+  .text:00000001808F0B88                 mov     r15d, 0FFFFFFFFh
+  .text:00000001808F0B8E                 cmp     edi, 0FFFFFFFFh
+  .text:00000001808F0B91                 jz      short loc_1808F0BAE
+  .text:00000001808F0B93                 mov     rcx, cs:g_pEngineClient
+  .text:00000001808F0B9A                 lea     rdx, [rbp+arg_8]
+  .text:00000001808F0B9E                 mov     r8d, edi
+  .text:00000001808F0BA1                 mov     rax, [rcx]
+  .text:00000001808F0BA4                 call    qword ptr [rax+110h]
+  .text:00000001808F0BAA                 mov     ebx, [rax]
+  .text:00000001808F0BAC                 jmp     short loc_1808F0BB1
+  .text:00000001808F0BAE                 mov     ebx, r15d
+  .text:00000001808F0BB1                 cmp     cs:dword_182380E0C, 0
+  .text:00000001808F0BB8                 jz      short loc_1808F0BCA
+  .text:00000001808F0BBA                 mov     eax, cs:dword_182380E10
+  .text:00000001808F0BC0                 cmp     eax, 0FFFFFFFFh
+  .text:00000001808F0BC3                 lea     ebx, [rax-1]
+  .text:00000001808F0BC6                 cmovz   ebx, r15d
+  .text:00000001808F0BCA                 lea     rdx, [rbp+arg_8]
+  .text:00000001808F0BCE                 mov     rcx, r14
+  .text:00000001808F0BD1                 call    sub_181510C50
+  .text:00000001808F0BD6                 mov     eax, [rbp+arg_8]
+  .text:00000001808F0BD9                 cmp     eax, 0FFFFFFFFh
+  .text:00000001808F0BDC                 jz      short loc_1808F0BE2
+  .text:00000001808F0BDE                 dec     eax
+  .text:00000001808F0BE0                 jmp     short loc_1808F0BE7
+  .text:00000001808F0BE2                 mov     eax, 0FFFFFFFFh
+  .text:00000001808F0BE7                 cmp     ebx, eax
+  .text:00000001808F0BE9                 jnz     loc_1808F0DCE
+  .text:00000001808F0BEF                 mov     [rsp+80h+arg_0], rsi
+  .text:00000001808F0BF7                 lea     rcx, s_pLocalPlayer
+  .text:00000001808F0BFE                 xor     esi, esi
+  .text:00000001808F0C00                 mov     [rcx+rdi*8], r14
+  .text:00000001808F0C04                 mov     byte ptr [r14+788h], 1
+  .text:00000001808F0C0C                 test    edi, edi
+  .text:00000001808F0C0E                 jz      short loc_1808F0C82
+  .text:00000001808F0C10                 mov     rax, cs:s_pLocalPlayer
+  .text:00000001808F0C17                 mov     [r14+6C8h], edi
+  .text:00000001808F0C1E                 test    rax, rax
+  .text:00000001808F0C21                 jz      short loc_1808F0C69
+  .text:00000001808F0C23                 mov     rcx, [rax+10h]
+  .text:00000001808F0C27                 test    rcx, rcx
+  .text:00000001808F0C2A                 jz      short loc_1808F0C69
+  .text:00000001808F0C2C                 mov     edx, [rcx+10h]
+  .text:00000001808F0C2F                 mov     r8d, edx
+  .text:00000001808F0C32                 mov     eax, [rcx+30h]
+  .text:00000001808F0C35                 mov     ecx, 7FFFh
+  .text:00000001808F0C3A                 and     eax, 1
+  .text:00000001808F0C3D                 shr     r8d, 0Fh
+  .text:00000001808F0C41                 sub     r8d, eax
+  .text:00000001808F0C44                 mov     eax, edx
+  .text:00000001808F0C46                 and     eax, ecx
+  .text:00000001808F0C48                 cmp     edx, r15d
+  .text:00000001808F0C4B                 mov     rdx, r14
+  .text:00000001808F0C4E                 cmovnz  ecx, eax
+  .text:00000001808F0C51                 shl     r8d, 0Fh
+  .text:00000001808F0C55                 or      ecx, r8d
+  .text:00000001808F0C58                 mov     [r14+6CCh], ecx
+  .text:00000001808F0C5F                 mov     rcx, r14
+  .text:00000001808F0C62                 call    sub_1808EC0B0
+  .text:00000001808F0C67                 jmp     short loc_1808F0CCE
+  .text:00000001808F0C69                 mov     [r14+6CCh], r15d
+  .text:00000001808F0C70                 test    rax, rax
+  .text:00000001808F0C73                 jz      short loc_1808F0CCE
+  .text:00000001808F0C75                 mov     rdx, r14
+  .text:00000001808F0C78                 mov     rcx, r14
+  .text:00000001808F0C7B                 call    sub_1808EC0B0
+  .text:00000001808F0C80                 jmp     short loc_1808F0CCE
+  .text:00000001808F0C82                 mov     [r14+6C8h], esi
+  .text:00000001808F0C89                 lea     rdx, aSndSoundmixer; "snd_soundmixer"
+  .text:00000001808F0C90                 mov     r8d, 9
+  .text:00000001808F0C96                 mov     [r14+6CCh], r15d
+  .text:00000001808F0C9D                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0CA1                 call    sub_181861600
+  .text:00000001808F0CA6                 mov     rax, [rbp+var_58]
+  .text:00000001808F0CAA                 test    rax, rax
+  .text:00000001808F0CAD                 jz      short loc_1808F0CC5
+  .text:00000001808F0CAF                 mov     eax, [rax+30h]
+  .text:00000001808F0CB2                 bt      rax, 0Ah
+  .text:00000001808F0CB7                 jb      short loc_1808F0CC5
+  .text:00000001808F0CB9                 mov     edx, r15d
+  .text:00000001808F0CBC                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0CC0                 call    sub_181862D90
+  .text:00000001808F0CC5                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0CC9                 call    nullsub_1038
+  .text:00000001808F0CCE                 mov     rcx, r14
+  .text:00000001808F0CD1                 call    sub_18049E8B0
+  .text:00000001808F0CD6                 lea     rdx, [rbp+arg_8]
+  .text:00000001808F0CDA                 mov     rcx, r14
+  .text:00000001808F0CDD                 call    sub_181510C50
+  .text:00000001808F0CE2                 mov     eax, [rbp+arg_8]
+  .text:00000001808F0CE5                 cmp     eax, 0FFFFFFFFh
+  .text:00000001808F0CE8                 jz      loc_1808F0DC6
+  .text:00000001808F0CEE                 dec     eax
+  .text:00000001808F0CF0                 cmp     eax, 0FFFFFFFFh
+  .text:00000001808F0CF3                 jz      loc_1808F0DC6
+  .text:00000001808F0CF9                 cmp     cs:dword_182080C00, esi
+  .text:00000001808F0CFF                 mov     eax, [r14+6C8h]
+  .text:00000001808F0D06                 mov     dword ptr [rbp+var_50], eax
+  .text:00000001808F0D09                 lea     rax, [rbp+arg_10]
+  .text:00000001808F0D0D                 mov     qword ptr [rbp+var_50+8], rax
+  .text:00000001808F0D11                 mov     [rbp+arg_10], rsi
+  .text:00000001808F0D15                 jz      loc_1808F0DC6
+  .text:00000001808F0D1B                 mov     rdi, rsi
+  .text:00000001808F0D1E                 lea     r15, ??_7?$_Func_impl_no_alloc@V_lambda_1_@?1??ProcessUserInfoConvarChangesForNewController@CBasePlayerController@@AEAAXXZ@_NP6AXPEAVConVarRefAbstract@@VCSplitScreenSlot@@PEBX2VConVarUserInfoSet_t@@PEAX@ZPEAX@std@@6B@; const std::_Func_impl_no_alloc<`CBasePlayerController::ProcessUserInfoConvarChangesForNewController(void)'::`2'::_lambda_1_,bool,void (*)(ConVarRefAbstract *,CSplitScreenSlot,void const *,void const *,ConVarUserInfoSet_t,void *),void *>::`vftable'
+  .text:00000001808F0D25                 mov     rbx, cs:qword_182080C08
+  .text:00000001808F0D2C                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0D30                 mov     r8d, 0FFFFFFFFh
+  .text:00000001808F0D36                 mov     rbx, [rdi+rbx]
+  .text:00000001808F0D3A                 mov     rdx, rbx
+  .text:00000001808F0D3D                 call    sub_181861690
+  .text:00000001808F0D42                 mov     edx, [r14+6C8h]
+  .text:00000001808F0D49                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0D4D                 call    sub_181862260
+  .text:00000001808F0D52                 mov     rdx, rax
+  .text:00000001808F0D55                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0D59                 call    sub_181862870
+  .text:00000001808F0D5E                 test    al, al
+  .text:00000001808F0D60                 jnz     short loc_1808F0DAB
+  .text:00000001808F0D62                 mov     rcx, cs:g_pVEngineCvar
+  .text:00000001808F0D69                 lea     rax, [rbp+var_60]
+  .text:00000001808F0D6D                 movups  xmm0, [rbp+var_50]
+  .text:00000001808F0D71                 mov     [rbp+arg_10], rax
+  .text:00000001808F0D75                 lea     rdx, [rbp+var_40]
+  .text:00000001808F0D79                 lea     r8, [rbp+var_40]
+  .text:00000001808F0D7D                 mov     rax, [rcx]
+  .text:00000001808F0D80                 mov     [rbp+var_8], rdx
+  .text:00000001808F0D84                 mov     rdx, rbx
+  .text:00000001808F0D87                 mov     [rbp+var_40], r15
+  .text:00000001808F0D8B                 movups  [rbp+var_38], xmm0
+  .text:00000001808F0D8F                 call    qword ptr [rax+78h]
+  .text:00000001808F0D92                 mov     rcx, [rbp+var_8]
+  .text:00000001808F0D96                 test    rcx, rcx
+  .text:00000001808F0D99                 jz      short loc_1808F0DAB
+  .text:00000001808F0D9B                 mov     rax, [rcx]
+  .text:00000001808F0D9E                 lea     rdx, [rbp+var_40]
+  .text:00000001808F0DA2                 cmp     rcx, rdx
+  .text:00000001808F0DA5                 setnz   dl
+  .text:00000001808F0DA8                 call    qword ptr [rax+20h]
+  .text:00000001808F0DAB                 lea     rcx, [rbp+var_60]
+  .text:00000001808F0DAF                 call    nullsub_1038
+  .text:00000001808F0DB4                 inc     esi
+  .text:00000001808F0DB6                 add     rdi, 8
+  .text:00000001808F0DBA                 cmp     esi, cs:dword_182080C00
+  .text:00000001808F0DC0                 jnz     loc_1808F0D25
+  .text:00000001808F0DC6                 mov     rsi, [rsp+80h+arg_0]
+  .text:00000001808F0DCE                 add     rsp, 80h
+  .text:00000001808F0DD5                 pop     r15
+  .text:00000001808F0DD7                 pop     r14
+  .text:00000001808F0DD9                 pop     rdi
+  .text:00000001808F0DDA                 pop     rbx
+  .text:00000001808F0DDB                 pop     rbp
+  .text:00000001808F0DDC                 retn
+procedure: |-
+  __int64 __fastcall CBasePlayerController_CheckForLocalPlayer(__int64 a1, int a2)
+  {
+    __int64 v2; // rdi
+    int v4; // ebx
+    __int64 result; // rax
+    int v6; // esi
+    __int64 *v7; // rax
+    __int64 v8; // rcx
+    unsigned int v9; // edx
+    int v10; // eax
+    int v11; // ecx
+    __int64 v12; // rdi
+    __int64 v13; // rbx
+    __int64 v14; // rax
+    __int64 v15; // rax
+    __int64 (__fastcall ***v16)(); // rdx
+    _BYTE v17[8]; // [rsp+20h] [rbp-60h] BYREF
+    __int64 v18; // [rsp+28h] [rbp-58h]
+    __int128 v19; // [rsp+30h] [rbp-50h]
+    __int64 (__fastcall **v20)(); // [rsp+40h] [rbp-40h] BYREF
+    __int128 v21; // [rsp+48h] [rbp-38h]
+    __int64 (__fastcall ***v22)(); // [rsp+78h] [rbp-8h]
+    unsigned int v23; // [rsp+B8h] [rbp+38h] BYREF
+    _BYTE *v24; // [rsp+C0h] [rbp+40h] BYREF
+
+    v2 = a2;
+    if ( a2 == -1 )
+      v4 = -1;
+    else
+      v4 = *(_DWORD *)(*(__int64 (__fastcall **)(__int64, unsigned int *, _QWORD))(*(_QWORD *)g_pEngineClient + 272LL))(
+                        g_pEngineClient,
+                        &v23,
+                        (unsigned int)a2);
+    if ( dword_182380E0C )
+    {
+      v4 = dword_182380E10 - 1;
+      if ( dword_182380E10 == -1 )
+        v4 = -1;
+    }
+    sub_181510C50(a1, (int *)&v23);
+    if ( v23 == -1 )
+      result = 0xFFFFFFFFLL;
+    else
+      result = v23 - 1;
+    if ( v4 == (_DWORD)result )
+    {
+      v6 = 0;
+      (&s_pLocalPlayer)[v2] = (__int64 *)a1;
+      *(_BYTE *)(a1 + 1928) = 1;
+      if ( (_DWORD)v2 )
+      {
+        v7 = s_pLocalPlayer;
+        *(_DWORD *)(a1 + 1736) = v2;
+        if ( v7 && (v8 = v7[2]) != 0 )
+        {
+          v9 = *(_DWORD *)(v8 + 16);
+          v10 = *(_DWORD *)(v8 + 48);
+          v11 = 0x7FFF;
+          if ( v9 != -1 )
+            v11 = v9 & 0x7FFF;
+          *(_DWORD *)(a1 + 1740) = (((v9 >> 15) - (v10 & 1)) << 15) | v11;
+          sub_1808EC0B0(a1, a1);
+        }
+        else
+        {
+          *(_DWORD *)(a1 + 1740) = -1;
+          if ( v7 )
+            sub_1808EC0B0(a1, a1);
+        }
+      }
+      else
+      {
+        *(_DWORD *)(a1 + 1736) = 0;
+        *(_DWORD *)(a1 + 1740) = -1;
+        sub_181861600(v17, "snd_soundmixer", 9);
+        if ( v18 && (*(_DWORD *)(v18 + 48) & 0x400LL) == 0 )
+          sub_181862D90(v17, 0xFFFFFFFFLL);
+        nullsub_1038(v17);
+      }
+      sub_18049E8B0(a1);
+      sub_181510C50(a1, (int *)&v23);
+      result = v23;
+      if ( v23 != -1 )
+      {
+        result = v23 - 1;
+        if ( v23 )
+        {
+          LODWORD(v19) = *(_DWORD *)(a1 + 1736);
+          result = (__int64)&v24;
+          *((_QWORD *)&v19 + 1) = &v24;
+          v24 = nullptr;
+          if ( dword_182080C00 )
+          {
+            v12 = 0;
+            do
+            {
+              v13 = *(_QWORD *)(v12 + qword_182080C08);
+              sub_181861690(v17, v13, 0xFFFFFFFFLL);
+              v14 = sub_181862260(v17, *(unsigned int *)(a1 + 1736));
+              if ( !(unsigned __int8)sub_181862870(v17, v14) )
+              {
+                v24 = v17;
+                v15 = *(_QWORD *)g_pVEngineCvar;
+                v22 = &v20;
+                v20 = std::ZPEAX::_Func_impl_no_alloc<`CBasePlayerController::ProcessUserInfoConvarChangesForNewController'::`2'::_lambda_1_,_NP6AXPEAVConVarRefAbstract::AXXZ &,CSplitScreenSlot,void const *,CSplitScreenSlot,ConVarUserInfoSet_t,void *>::`vftable';
+                v21 = v19;
+                (*(void (__fastcall **)(__int64, __int64, __int64 (__fastcall ***)()))(v15 + 120))(
+                  g_pVEngineCvar,
+                  v13,
+                  &v20);
+                if ( v22 )
+                {
+                  v16 = &v20;
+                  LOBYTE(v16) = v22 != &v20;
+                  ((void (__fastcall *)(__int64 (__fastcall ***)(), __int64 (__fastcall ***)()))(*v22)[4])(v22, v16);
+                }
+              }
+              result = nullsub_1038(v17);
+              ++v6;
+              v12 += 8;
+            }
+            while ( v6 != dword_182080C00 );
+          }
+        }
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2Client_Connect.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_Connect.linux.yaml
@@ -1,0 +1,630 @@
+func_name: CSource2Client_Connect
+func_va: '0x1895490'
+disasm_code: |-
+  .text:0000000001895490                 push    rbp
+  .text:0000000001895491                 mov     rbp, rsp
+  .text:0000000001895494                 push    r15
+  .text:0000000001895496                 push    r14
+  .text:0000000001895498                 lea     r15, [rbp+dest]
+  .text:000000000189549F                 push    r13
+  .text:00000000018954A1                 lea     r13, [rbp+var_430]
+  .text:00000000018954A8                 push    r12
+  .text:00000000018954AA                 mov     r12, rdi
+  .text:00000000018954AD                 push    rbx
+  .text:00000000018954AE                 mov     rbx, rsi
+  .text:00000000018954B1                 sub     rsp, 648h
+  .text:00000000018954B8                 call    sub_3F47C00
+  .text:00000000018954BD                 mov     [r12+50h], rbx
+  .text:00000000018954C2                 mov     dword ptr [r12+448h], 0BF800000h
+  .text:00000000018954CE                 call    sub_23188A0
+  .text:00000000018954D3                 mov     esi, 1
+  .text:00000000018954D8                 mov     rdi, r13
+  .text:00000000018954DB                 mov     [rbp+var_668], rbx
+  .text:00000000018954E2                 mov     [rbp+dest], rbx
+  .text:00000000018954E9                 mov     qword ptr [rbp+var_430], rbx
+  .text:00000000018954F0                 call    ConnectInterfaces
+  .text:00000000018954F5                 mov     esi, 1
+  .text:00000000018954FA                 mov     rdi, r15
+  .text:00000000018954FD                 call    sub_3F1E9E0
+  .text:0000000001895502                 mov     edx, 2
+  .text:0000000001895507                 mov     esi, 1
+  .text:000000000189550C                 add     dword ptr [r12+28h], 1
+  .text:0000000001895512                 lea     rdi, [rbp+var_668]
+  .text:0000000001895519                 call    sub_230CCE0
+  .text:000000000189551E                 lea     rax, qword_48B2C80
+  .text:0000000001895525                 mov     rdi, [rax]
+  .text:0000000001895528                 mov     rax, [rdi]
+  .text:000000000189552B                 call    qword ptr [rax+58h]
+  .text:000000000189552E                 lea     rdx, qword_48A20D0
+  .text:0000000001895535                 xor     esi, esi
+  .text:0000000001895537                 lea     rdi, aSource2enginet_0; "Source2EngineToClient001"
+  .text:000000000189553E                 mov     [rdx], rax
+  .text:0000000001895541                 call    rbx
+  .text:0000000001895543                 mov     cs:g_pEngineClient, rax
+  .text:000000000189554A                 test    rax, rax
+  .text:000000000189554D                 jz      loc_1895750
+  .text:0000000001895553                 lea     rax, g_pSource2EngineToClient
+  .text:000000000189555A                 lea     rdx, qword_48ADDB0
+  .text:0000000001895561                 mov     rax, [rax]
+  .text:0000000001895564                 mov     [rdx], rax
+  .text:0000000001895567                 test    rax, rax
+  .text:000000000189556A                 jz      loc_1895750
+  .text:0000000001895570                 lea     rdi, aSteamutils010; "SteamUtils010"
+  .text:0000000001895577                 ; _QWORD
+  .text:0000000001895577                 mov     rsi, r13; _QWORD
+  .text:000000000189557A                 call    _SteamInternal_SteamAPI_Init
+  .text:000000000189557F                 mov     r14d, eax
+  .text:0000000001895582                 test    eax, eax
+  .text:0000000001895584                 jnz     loc_1895768
+  .text:000000000189558A                 ; _QWORD
+  .text:000000000189558A                 xor     edi, edi; _QWORD
+  .text:000000000189558C                 mov     [rbp+var_430], 0
+  .text:0000000001895593                 call    _SteamAPI_SetTryCatchCallbacks
+  .text:0000000001895598                 call    _CommandLine
+  .text:000000000189559D                 mov     esi, 6B952A6h
+  .text:00000000018955A2                 mov     rdi, rax
+  .text:00000000018955A5                 mov     rax, [rax]
+  .text:00000000018955A8                 call    qword ptr [rax+20h]
+  .text:00000000018955AB                 test    al, al
+  .text:00000000018955AD                 jnz     loc_1895B95
+  .text:00000000018955B3                 ; _QWORD
+  .text:00000000018955B3                 lea     rdi, off_45324F0; _QWORD
+  .text:00000000018955BA                 call    _SteamInternal_ContextInit
+  .text:00000000018955BF                 cmp     qword ptr [rax], 0
+  .text:00000000018955C3                 jz      loc_1895B3F
+  .text:00000000018955C9                 ; _QWORD
+  .text:00000000018955C9                 lea     rdi, off_4501730; _QWORD
+  .text:00000000018955D0                 call    _SteamInternal_ContextInit
+  .text:00000000018955D5                 cmp     qword ptr [rax], 0
+  .text:00000000018955D9                 jz      loc_1895B3F
+  .text:00000000018955DF                 ; _QWORD
+  .text:00000000018955DF                 lea     rdi, off_4505000; _QWORD
+  .text:00000000018955E6                 call    _SteamInternal_ContextInit
+  .text:00000000018955EB                 cmp     qword ptr [rax], 0
+  .text:00000000018955EF                 jz      loc_1895B3F
+  .text:00000000018955F5                 ; _QWORD
+  .text:00000000018955F5                 lea     rdi, off_4569430; _QWORD
+  .text:00000000018955FC                 call    _SteamInternal_ContextInit
+  .text:0000000001895601                 cmp     qword ptr [rax], 0
+  .text:0000000001895605                 jz      loc_1895B3F
+  .text:000000000189560B                 ; _QWORD
+  .text:000000000189560B                 lea     rdi, off_454B800; _QWORD
+  .text:0000000001895612                 call    _SteamInternal_ContextInit
+  .text:0000000001895617                 cmp     qword ptr [rax], 0
+  .text:000000000189561B                 jz      loc_1895B3F
+  .text:0000000001895621                 ; _QWORD
+  .text:0000000001895621                 lea     rdi, off_4501730; _QWORD
+  .text:0000000001895628                 call    _SteamInternal_ContextInit
+  .text:000000000189562D                 mov     rdi, [rax]
+  .text:0000000001895630                 mov     rax, [rdi]
+  .text:0000000001895633                 call    qword ptr [rax+10h]
+  .text:0000000001895636                 mov     rdx, rax
+  .text:0000000001895639                 shr     rdx, 30h
+  .text:000000000189563D                 cmp     dl, 0Fh
+  .text:0000000001895640                 jbe     short loc_1895690
+  .text:0000000001895642                 mov     rcx, rax
+  .text:0000000001895645                 shr     rcx, 34h
+  .text:0000000001895649                 and     ecx, 0Fh
+  .text:000000000189564C                 cmp     cl, 0Ah
+  .text:000000000189564F                 ja      short loc_1895690
+  .text:0000000001895651                 mov     rcx, rax
+  .text:0000000001895654                 shr     rcx, 38h
+  .text:0000000001895658                 sub     ecx, 1
+  .text:000000000189565B                 cmp     cl, 3
+  .text:000000000189565E                 ja      short loc_1895690
+  .text:0000000001895660                 and     edx, 0FFFFFFF0h
+  .text:0000000001895663                 cmp     dl, 10h
+  .text:0000000001895666                 jz      loc_1895AD0
+  .text:000000000189566C                 cmp     dl, 70h ; 'p'
+  .text:000000000189566F                 jz      loc_1895A08
+  .text:0000000001895675                 cmp     dl, 30h ; '0'
+  .text:0000000001895678                 jnz     loc_18957B9
+  .text:000000000189567E                 test    eax, eax
+  .text:0000000001895680                 jnz     loc_18957B9
+  .text:0000000001895686                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000001895690                 ; _QWORD
+  .text:0000000001895690                 mov     edx, 400h; _QWORD
+  .text:0000000001895695                 ; _QWORD
+  .text:0000000001895695                 mov     rdi, r13; _QWORD
+  .text:0000000001895698                 mov     r14d, 2
+  .text:000000000189569E                 lea     rsi, aSteamidIsNotVa; "SteamID is not valid.  (Steam client ru"...
+  .text:00000000018956A5                 call    __V_strncpy
+  .text:00000000018956AA                 call    _CommandLine
+  .text:00000000018956AF                 mov     esi, 0CDBD1292h
+  .text:00000000018956B4                 lea     rbx, qword_B535F0
+  .text:00000000018956BB                 mov     rdi, rax
+  .text:00000000018956BE                 mov     rax, [rax]
+  .text:00000000018956C1                 call    qword ptr [rax+90h]
+  .text:00000000018956C7                 ; char *
+  .text:00000000018956C7                 lea     rsi, byte_BFB8D8; char *
+  .text:00000000018956CE                 test    al, al
+  .text:00000000018956D0                 jz      loc_1895A24
+  .text:00000000018956D6                 xor     eax, eax
+  .text:00000000018956D8                 ; this
+  .text:00000000018956D8                 mov     rdi, r15; this
+  .text:00000000018956DB                 mov     [rbp+dest], rax
+  .text:00000000018956E2                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:00000000018956E7                 cmp     [rbp+var_430], 0
+  .text:00000000018956EE                 jnz     loc_1895B5E
+  .text:00000000018956F4                 mov     rsi, [rbp+dest]
+  .text:00000000018956FB                 test    rsi, rsi
+  .text:00000000018956FE                 jz      loc_1895B7D
+  .text:0000000001895704                 lea     rdi, aS_65; "%s\n"
+  .text:000000000189570B                 xor     eax, eax
+  .text:000000000189570D                 call    _Warning
+  .text:0000000001895712                 lea     rax, g_pSource2EngineToClient
+  .text:0000000001895719                 mov     rdi, [rax]
+  .text:000000000189571C                 mov     rax, [rdi]
+  .text:000000000189571F                 call    qword ptr [rax+3C8h]
+  .text:0000000001895725                 ; _QWORD
+  .text:0000000001895725                 mov     rsi, [rbp+dest]; _QWORD
+  .text:000000000189572C                 ; _QWORD
+  .text:000000000189572C                 mov     rdx, rax; _QWORD
+  .text:000000000189572F                 test    rsi, rsi
+  .text:0000000001895732                 jz      loc_1895B89
+  .text:0000000001895738                 ; _QWORD
+  .text:0000000001895738                 mov     rdi, rbx; _QWORD
+  .text:000000000189573B                 call    _Plat_MessageBox
+  .text:0000000001895740                 ; _QWORD
+  .text:0000000001895740                 mov     edi, 64h ; 'd'; _QWORD
+  .text:0000000001895745                 call    _Plat_ExitProcess
+  .text:000000000189574A                 nop     word ptr [rax+rax+00h]
+  .text:0000000001895750                 xor     eax, eax
+  .text:0000000001895752                 add     rsp, 648h
+  .text:0000000001895759                 pop     rbx
+  .text:000000000189575A                 pop     r12
+  .text:000000000189575C                 pop     r13
+  .text:000000000189575E                 pop     r14
+  .text:0000000001895760                 pop     r15
+  .text:0000000001895762                 pop     rbp
+  .text:0000000001895763                 retn
+  .text:0000000001895768                 lea     rdi, aSteamapiInitFa; "SteamAPI_Init failed.  %s\n"
+  .text:000000000189576F                 mov     rsi, r13
+  .text:0000000001895772                 xor     eax, eax
+  .text:0000000001895774                 call    _Warning
+  .text:0000000001895779                 ; _QWORD
+  .text:0000000001895779                 xor     edi, edi; _QWORD
+  .text:000000000189577B                 call    _SteamAPI_SetTryCatchCallbacks
+  .text:0000000001895780                 call    _CommandLine
+  .text:0000000001895785                 mov     esi, 6B952A6h
+  .text:000000000189578A                 mov     rdi, rax
+  .text:000000000189578D                 mov     rax, [rax]
+  .text:0000000001895790                 call    qword ptr [rax+20h]
+  .text:0000000001895793                 test    al, al
+  .text:0000000001895795                 jz      loc_18956AA
+  .text:000000000189579B                 call    _CommandLine
+  .text:00000000018957A0                 mov     esi, 8F74045Fh
+  .text:00000000018957A5                 mov     rdi, rax
+  .text:00000000018957A8                 mov     rax, [rax]
+  .text:00000000018957AB                 call    qword ptr [rax+90h]
+  .text:00000000018957B1                 test    al, al
+  .text:00000000018957B3                 jz      loc_1895BA3
+  .text:00000000018957B9                 lea     rdi, aClientdllFacto; "ClientDLL factories - Start"
+  .text:00000000018957C0                 xor     eax, eax
+  .text:00000000018957C2                 call    _COM_TimestampedLog
+  .text:00000000018957C7                 lea     rdi, aGamemodelinfo0; "GameModelInfo001"
+  .text:00000000018957CE                 xor     esi, esi
+  .text:00000000018957D0                 call    rbx
+  .text:00000000018957D2                 mov     cs:qword_47F9B30, rax
+  .text:00000000018957D9                 test    rax, rax
+  .text:00000000018957DC                 jz      loc_1895750
+  .text:00000000018957E2                 lea     rdi, aSaverestoredat; "SaveRestoreDataVersion001"
+  .text:00000000018957E9                 xor     esi, esi
+  .text:00000000018957EB                 call    rbx
+  .text:00000000018957ED                 lea     rdx, qword_47E1370
+  .text:00000000018957F4                 mov     [rdx], rax
+  .text:00000000018957F7                 test    rax, rax
+  .text:00000000018957FA                 jz      loc_1895750
+  .text:0000000001895800                 lea     rdi, aVengineGameuif; "VENGINE_GAMEUIFUNCS_VERSION005"
+  .text:0000000001895807                 xor     esi, esi
+  .text:0000000001895809                 call    rbx
+  .text:000000000189580B                 mov     cs:qword_47F9A70, rax
+  .text:0000000001895812                 test    rax, rax
+  .text:0000000001895815                 jz      loc_1895750
+  .text:000000000189581B                 lea     rdi, aSource2enginet; "Source2EngineToClientStringTable001"
+  .text:0000000001895822                 xor     esi, esi
+  .text:0000000001895824                 call    rbx
+  .text:0000000001895826                 mov     cs:qword_47F9B20, rax
+  .text:000000000189582D                 test    rax, rax
+  .text:0000000001895830                 jz      loc_1895750
+  .text:0000000001895836                 lea     rdi, aVfilesystem017; "VFileSystem017"
+  .text:000000000189583D                 xor     esi, esi
+  .text:000000000189583F                 call    rbx
+  .text:0000000001895841                 mov     cs:qword_47F9B18, rax
+  .text:0000000001895848                 test    rax, rax
+  .text:000000000189584B                 jz      loc_1895750
+  .text:0000000001895851                 lea     rdi, aInputsystemver; "InputSystemVersion001"
+  .text:0000000001895858                 xor     esi, esi
+  .text:000000000189585A                 call    rbx
+  .text:000000000189585C                 mov     cs:qword_47F9A68, rax
+  .text:0000000001895863                 test    rax, rax
+  .text:0000000001895866                 jz      loc_1895750
+  .text:000000000189586C                 lea     rdi, aGameconfigclie; "GameConfigClientV001"
+  .text:0000000001895873                 xor     esi, esi
+  .text:0000000001895875                 call    rbx
+  .text:0000000001895877                 lea     rdx, qword_47DEE28
+  .text:000000000189587E                 mov     [rdx], rax
+  .text:0000000001895881                 test    rax, rax
+  .text:0000000001895884                 jz      loc_1895750
+  .text:000000000189588A                 lea     rdi, aScenefilecache; "SceneFileCache002"
+  .text:0000000001895891                 xor     esi, esi
+  .text:0000000001895893                 call    rbx
+  .text:0000000001895895                 mov     cs:qword_47F9A60, rax
+  .text:000000000189589C                 test    rax, rax
+  .text:000000000189589F                 jz      loc_1895750
+  .text:00000000018958A5                 lea     rdi, aResponserulesc; "ResponseRulesCache001"
+  .text:00000000018958AC                 xor     esi, esi
+  .text:00000000018958AE                 call    rbx
+  .text:00000000018958B0                 lea     rdx, unk_48B2C68
+  .text:00000000018958B7                 mov     [rdx], rax
+  .text:00000000018958BA                 test    rax, rax
+  .text:00000000018958BD                 jz      loc_1895750
+  .text:00000000018958C3                 lea     r13, g_pNetworkSystem
+  .text:00000000018958CA                 cmp     qword ptr [r13+0], 0
+  .text:00000000018958CF                 jz      loc_1895AB8
+  .text:00000000018958D5                 lea     r13, g_pSerializedEntities
+  .text:00000000018958DC                 cmp     qword ptr [r13+0], 0
+  .text:00000000018958E1                 jz      loc_1895AA0
+  .text:00000000018958E7                 lea     rax, g_pFlattenedSerializers
+  .text:00000000018958EE                 cmp     qword ptr [rax], 0
+  .text:00000000018958F2                 jz      loc_1895A80
+  .text:00000000018958F8                 lea     rax, g_pNetworkMessages
+  .text:00000000018958FF                 cmp     qword ptr [rax], 0
+  .text:0000000001895903                 jz      loc_1895A60
+  .text:0000000001895909                 lea     rdi, aGametypes001; "GameTypes001"
+  .text:0000000001895910                 xor     esi, esi
+  .text:0000000001895912                 call    rbx
+  .text:0000000001895914                 lea     rdx, qword_4688D00
+  .text:000000000189591B                 mov     [rdx], rax
+  .text:000000000189591E                 test    rax, rax
+  .text:0000000001895921                 jz      loc_1895750
+  .text:0000000001895927                 mov     rdi, [r13+0]
+  .text:000000000189592B                 mov     rax, [rdi]
+  .text:000000000189592E                 call    qword ptr [rax+70h]
+  .text:0000000001895931                 cmp     cs:qword_47F9A50, 0
+  .text:0000000001895939                 mov     cs:qword_47F9A58, rax
+  .text:0000000001895940                 jz      loc_1895B28
+  .text:0000000001895946                 lea     rdi, aImemanager001; "IMEManager001"
+  .text:000000000189594D                 xor     esi, esi
+  .text:000000000189594F                 call    rbx
+  .text:0000000001895951                 lea     rdx, unk_48ADEE8
+  .text:0000000001895958                 lea     rdi, aClientdllFacto_0; "ClientDLL factories - End"
+  .text:000000000189595F                 mov     [rdx], rax
+  .text:0000000001895962                 xor     eax, eax
+  .text:0000000001895964                 call    _COM_TimestampedLog
+  .text:0000000001895969                 call    _CommandLine
+  .text:000000000189596E                 xor     edx, edx
+  .text:0000000001895970                 mov     esi, 5AFDDFCDh
+  .text:0000000001895975                 mov     rdi, rax
+  .text:0000000001895978                 mov     rax, [rax]
+  .text:000000000189597B                 call    qword ptr [rax+18h]
+  .text:000000000189597E                 test    rax, rax
+  .text:0000000001895981                 jz      loc_1895B08
+  .text:0000000001895987                 lea     rdi, aLegacygameui00; "LegacyGameUI001"
+  .text:000000000189598E                 xor     esi, esi
+  .text:0000000001895990                 call    rbx
+  .text:0000000001895992                 lea     rdx, qword_48678F8
+  .text:0000000001895999                 mov     edi, 1
+  .text:000000000189599E                 mov     [rdx], rax
+  .text:00000000018959A1                 call    sub_2E09500
+  .text:00000000018959A6                 call    sub_2E011A0
+  .text:00000000018959AB                 lea     rsi, aClient; "client"
+  .text:00000000018959B2                 mov     rdi, rax
+  .text:00000000018959B5                 call    sub_2DC4920
+  .text:00000000018959BA                 test    r14d, r14d
+  .text:00000000018959BD                 jz      loc_1895AF0
+  .text:00000000018959C3                 ; src
+  .text:00000000018959C3                 lea     rsi, unk_9A2960; src
+  .text:00000000018959CA                 ; n
+  .text:00000000018959CA                 mov     edx, 226h; n
+  .text:00000000018959CF                 ; dest
+  .text:00000000018959CF                 mov     rdi, r15; dest
+  .text:00000000018959D2                 call    _memcpy
+  .text:00000000018959D7                 lea     rax, g_pFileSystem
+  .text:00000000018959DE                 mov     edx, 226h
+  .text:00000000018959E3                 mov     rsi, r15
+  .text:00000000018959E6                 lea     rcx, off_4568CD0
+  .text:00000000018959ED                 mov     rdi, [rax]
+  .text:00000000018959F0                 mov     rax, [rdi]
+  .text:00000000018959F3                 call    qword ptr [rax+390h]
+  .text:00000000018959F9                 mov     eax, 1
+  .text:00000000018959FE                 jmp     loc_1895752
+  .text:0000000001895A08                 test    eax, eax
+  .text:0000000001895A0A                 jz      loc_1895690
+  .text:0000000001895A10                 shr     rax, 20h
+  .text:0000000001895A14                 test    eax, 0FFFFFh
+  .text:0000000001895A19                 jz      loc_18957B9
+  .text:0000000001895A1F                 jmp     loc_1895690
+  .text:0000000001895A24                 lea     rbx, aLauncherError; "Launcher Error"
+  .text:0000000001895A2B                 lea     rsi, aFatalErrorFail; "FATAL ERROR: Failed to connect with loc"...
+  .text:0000000001895A32                 cmp     r14d, 2
+  .text:0000000001895A36                 jz      loc_18956D6
+  .text:0000000001895A3C                 lea     rsi, aFatalErrorFail_0; "FATAL ERROR: Failed to initialize the S"...
+  .text:0000000001895A43                 cmp     r14d, 3
+  .text:0000000001895A47                 jnz     loc_18956D6
+  .text:0000000001895A4D                 lea     rsi, aFatalErrorStea; "FATAL ERROR: Steam client version misma"...
+  .text:0000000001895A54                 jmp     loc_18956D6
+  .text:0000000001895A60                 lea     rdi, aNetworkmessage; "NetworkMessagesVersion001"
+  .text:0000000001895A67                 xor     esi, esi
+  .text:0000000001895A69                 call    rbx
+  .text:0000000001895A6B                 lea     rcx, g_pNetworkMessages
+  .text:0000000001895A72                 mov     [rcx], rax
+  .text:0000000001895A75                 jmp     loc_1895909
+  .text:0000000001895A80                 lea     rdi, aFlattenedseria; "FlattenedSerializersVersion001"
+  .text:0000000001895A87                 xor     esi, esi
+  .text:0000000001895A89                 call    rbx
+  .text:0000000001895A8B                 lea     rcx, g_pFlattenedSerializers
+  .text:0000000001895A92                 mov     [rcx], rax
+  .text:0000000001895A95                 jmp     loc_18958F8
+  .text:0000000001895AA0                 lea     rdi, aSerializedenti; "SerializedEntitiesVersion001"
+  .text:0000000001895AA7                 xor     esi, esi
+  .text:0000000001895AA9                 call    rbx
+  .text:0000000001895AAB                 mov     [r13+0], rax
+  .text:0000000001895AAF                 jmp     loc_18958E7
+  .text:0000000001895AB8                 lea     rdi, aNetworksystemv; "NetworkSystemVersion001"
+  .text:0000000001895ABF                 xor     esi, esi
+  .text:0000000001895AC1                 call    rbx
+  .text:0000000001895AC3                 mov     [r13+0], rax
+  .text:0000000001895AC7                 jmp     loc_18958D5
+  .text:0000000001895AD0                 test    eax, eax
+  .text:0000000001895AD2                 jz      loc_1895690
+  .text:0000000001895AD8                 shr     rax, 20h
+  .text:0000000001895ADC                 and     eax, 0FFFFFh
+  .text:0000000001895AE1                 cmp     eax, 1
+  .text:0000000001895AE4                 jnz     loc_1895690
+  .text:0000000001895AEA                 jmp     loc_18957B9
+  .text:0000000001895AF0                 call    sub_20AAB80
+  .text:0000000001895AF5                 mov     rdi, rax
+  .text:0000000001895AF8                 call    sub_20AAE00
+  .text:0000000001895AFD                 jmp     loc_18959C3
+  .text:0000000001895B08                 lea     rdi, aVscriptmanager; "VScriptManager010"
+  .text:0000000001895B0F                 xor     esi, esi
+  .text:0000000001895B11                 call    qword ptr [r12+50h]
+  .text:0000000001895B16                 lea     rdx, g_pScriptManager
+  .text:0000000001895B1D                 mov     [rdx], rax
+  .text:0000000001895B20                 jmp     loc_1895987
+  .text:0000000001895B28                 lea     rdi, aGameeventsyste_0; "GameEventSystemClientV001"
+  .text:0000000001895B2F                 xor     esi, esi
+  .text:0000000001895B31                 call    rbx
+  .text:0000000001895B33                 mov     cs:qword_47F9A50, rax
+  .text:0000000001895B3A                 jmp     loc_1895946
+  .text:0000000001895B3F                 ; _QWORD
+  .text:0000000001895B3F                 mov     edx, 400h; _QWORD
+  .text:0000000001895B44                 ; _QWORD
+  .text:0000000001895B44                 mov     rdi, r13; _QWORD
+  .text:0000000001895B47                 mov     r14d, 1
+  .text:0000000001895B4D                 lea     rsi, aMissingRequire; "Missing required interface"
+  .text:0000000001895B54                 call    __V_strncpy
+  .text:0000000001895B59                 jmp     loc_18956AA
+  .text:0000000001895B5E                 lea     rsi, asc_B7035B; "\n\n"
+  .text:0000000001895B65                 ; _QWORD
+  .text:0000000001895B65                 mov     rdi, r15; _QWORD
+  .text:0000000001895B68                 call    __ZN10CUtlStringpLEPKc; CUtlString::operator+=(char const*)
+  .text:0000000001895B6D                 ; _QWORD
+  .text:0000000001895B6D                 mov     rsi, r13; _QWORD
+  .text:0000000001895B70                 ; _QWORD
+  .text:0000000001895B70                 mov     rdi, r15; _QWORD
+  .text:0000000001895B73                 call    __ZN10CUtlStringpLEPKc; CUtlString::operator+=(char const*)
+  .text:0000000001895B78                 jmp     loc_18956F4
+  .text:0000000001895B7D                 lea     rsi, haystack
+  .text:0000000001895B84                 jmp     loc_1895704
+  .text:0000000001895B89                 lea     rsi, haystack
+  .text:0000000001895B90                 jmp     loc_1895738
+  .text:0000000001895B95                 lea     rdi, aApplicationRun; "Application running with '-nosteam' but"...
+  .text:0000000001895B9C                 xor     eax, eax
+  .text:0000000001895B9E                 call    _Plat_FatalError
+  .text:0000000001895BA3                 lea     rdi, aCommandLinePar; "Command line parameter '-nosteam' can o"...
+  .text:0000000001895BAA                 call    _Plat_FatalError
+  .text:0000000001895BAF                 ; Trap to Debugger
+  .text:0000000001895BAF                 int     3; Trap to Debugger
+procedure: |-
+  __int64 __fastcall CSource2Client_Connect(
+          __int64 a1,
+          __int64 (__fastcall *a2)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden this), _QWORD))
+  {
+    int v2; // r14d
+    __int64 v3; // rax
+    _QWORD *v4; // rax
+    unsigned __int64 v5; // rax
+    char v6; // dl
+    __int64 v7; // rax
+    const char *v8; // rbx
+    const char *v9; // rsi
+    const char *v10; // rsi
+    __int64 v11; // rax
+    char *v12; // rsi
+    __int64 v14; // rax
+    __int64 v15; // rax
+    __int64 v16; // rax
+    __int64 v17; // rax
+    __int64 v18; // rax
+    __int64 (__fastcall *v19)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD); // [rsp+8h] [rbp-668h] BYREF
+    _QWORD dest[70]; // [rsp+10h] [rbp-660h] BYREF
+    char v21[1072]; // [rsp+240h] [rbp-430h] BYREF
+
+    sub_3F47C00();
+    *(_QWORD *)(a1 + 80) = a2;
+    *(_DWORD *)(a1 + 1096) = -1082130432;
+    sub_23188A0();
+    v19 = a2;
+    dest[0] = a2;
+    *(_QWORD *)v21 = a2;
+    ConnectInterfaces(
+      (__int64 (__fastcall **)(void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden), _QWORD))v21,
+      1);
+    sub_3F1E9E0(dest, 1);
+    ++*(_DWORD *)(a1 + 40);
+    sub_230CCE0(&v19, 1, 2);
+    qword_48A20D0 = (*(__int64 (__fastcall **)(_QWORD *))(*qword_48B2C80 + 88LL))(qword_48B2C80);
+    g_pEngineClient = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"Source2EngineToClient001", 0);
+    if ( !g_pEngineClient )
+      return 0;
+    qword_48ADDB0 = g_pSource2EngineToClient;
+    if ( !g_pSource2EngineToClient )
+      return 0;
+    v2 = SteamInternal_SteamAPI_Init("SteamUtils010", v21);
+    if ( v2 )
+    {
+      Warning("SteamAPI_Init failed.  %s\n", v21);
+      SteamAPI_SetTryCatchCallbacks(0);
+      v14 = CommandLine();
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v14 + 32LL))(v14, 112808614) )
+        goto LABEL_18;
+      v15 = CommandLine();
+      if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v15 + 144LL))(v15, 2406745183LL) )
+        goto LABEL_29;
+  LABEL_65:
+      Plat_FatalError("Command line parameter '-nosteam' can only be used in insecure mode ('-insecure').");
+      __debugbreak();
+    }
+    v21[0] = 0;
+    SteamAPI_SetTryCatchCallbacks(0);
+    v3 = CommandLine();
+    if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v3 + 32LL))(v3, 112808614) )
+    {
+      Plat_FatalError("Application running with '-nosteam' but Steam is present.");
+      goto LABEL_65;
+    }
+    if ( !*(_QWORD *)SteamInternal_ContextInit(&off_45324F0)
+      || !*(_QWORD *)SteamInternal_ContextInit(&off_4501730)
+      || !*(_QWORD *)SteamInternal_ContextInit(&off_4505000)
+      || !*(_QWORD *)SteamInternal_ContextInit(&off_4569430)
+      || !*(_QWORD *)SteamInternal_ContextInit(&off_454B800) )
+    {
+      v2 = 1;
+      _V_strncpy(v21, "Missing required interface", 1024);
+  LABEL_18:
+      v7 = CommandLine();
+      v8 = (const char *)&qword_B535F0;
+      v9 = &byte_BFB8D8;
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v7 + 144LL))(v7, 3451720338LL) )
+      {
+        v8 = "Launcher Error";
+        v9 = "FATAL ERROR: Failed to connect with local Steam Client process!\n"
+             "\n"
+             "Please make sure that you are running latest version of the Steam Client and launch the game from Steam.\n";
+        if ( v2 != 2 )
+        {
+          v9 = "FATAL ERROR: Failed to initialize the Steamworks SDK.";
+          if ( v2 == 3 )
+            v9 = "FATAL ERROR: Steam client version mismatch.\n"
+                 "\n"
+                 "Please make sure that you are running latest version of the Steam Client and launch the game from Steam.\n"
+                 "You can check for Steam Client updates using Steam main menu:\n"
+                 "             Steam > Check for Steam Client Updates...";
+        }
+      }
+      dest[0] = 0;
+      CUtlString::Set((CUtlString *)dest, v9);
+      if ( v21[0] )
+      {
+        CUtlString::operator+=(dest, "\n\n");
+        CUtlString::operator+=(dest, v21);
+      }
+      v10 = (const char *)dest[0];
+      if ( !dest[0] )
+        v10 = &haystack;
+      Warning("%s\n", v10);
+      v11 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2EngineToClient + 968LL))(g_pSource2EngineToClient);
+      v12 = (char *)dest[0];
+      if ( !dest[0] )
+        v12 = &haystack;
+      Plat_MessageBox(v8, v12, v11);
+      Plat_ExitProcess(100);
+      return 0;
+    }
+    v4 = (_QWORD *)SteamInternal_ContextInit(&off_4501730);
+    v5 = (*(__int64 (__fastcall **)(_QWORD))(*(_QWORD *)*v4 + 16LL))(*v4);
+    if ( BYTE6(v5) <= 0xFu || ((v5 >> 52) & 0xF) > 0xA || (unsigned __int8)(HIBYTE(v5) - 1) > 3u )
+      goto LABEL_17;
+    v6 = BYTE6(v5) & 0xF0;
+    if ( (BYTE6(v5) & 0xF0) == 0x10 )
+    {
+      if ( !(_DWORD)v5 || (HIDWORD(v5) & 0xFFFFF) != 1 )
+        goto LABEL_17;
+    }
+    else if ( v6 == 112 )
+    {
+      if ( !(_DWORD)v5 || (v5 & 0xFFFFF00000000LL) != 0 )
+        goto LABEL_17;
+    }
+    else if ( v6 == 48 && !(_DWORD)v5 )
+    {
+  LABEL_17:
+      v2 = 2;
+      _V_strncpy(v21, "SteamID is not valid.  (Steam client running but no user logged on?)", 1024);
+      goto LABEL_18;
+    }
+  LABEL_29:
+    COM_TimestampedLog("ClientDLL factories - Start");
+    qword_47F9B30 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"GameModelInfo001", 0);
+    if ( !qword_47F9B30 )
+      return 0;
+    qword_47E1370 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"SaveRestoreDataVersion001", 0);
+    if ( !qword_47E1370 )
+      return 0;
+    qword_47F9A70 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"VENGINE_GAMEUIFUNCS_VERSION005", 0);
+    if ( !qword_47F9A70 )
+      return 0;
+    qword_47F9B20 = a2(
+                      (void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"Source2EngineToClientStringTable001",
+                      0);
+    if ( !qword_47F9B20 )
+      return 0;
+    qword_47F9B18 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"VFileSystem017", 0);
+    if ( !qword_47F9B18 )
+      return 0;
+    qword_47F9A68 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"InputSystemVersion001", 0);
+    if ( !qword_47F9A68 )
+      return 0;
+    qword_47DEE28 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"GameConfigClientV001", 0);
+    if ( !qword_47DEE28 )
+      return 0;
+    qword_47F9A60 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"SceneFileCache002", 0);
+    if ( !qword_47F9A60 )
+      return 0;
+    unk_48B2C68 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"ResponseRulesCache001", 0);
+    if ( !unk_48B2C68 )
+      return 0;
+    if ( !g_pNetworkSystem )
+      g_pNetworkSystem = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"NetworkSystemVersion001", 0);
+    if ( !g_pSerializedEntities )
+      g_pSerializedEntities = (_QWORD *)a2(
+                                          (void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"SerializedEntitiesVersion001",
+                                          0);
+    if ( !g_pFlattenedSerializers )
+      g_pFlattenedSerializers = (_QWORD *)a2(
+                                            (void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"FlattenedSerializersVersion001",
+                                            0);
+    if ( !g_pNetworkMessages )
+      g_pNetworkMessages = (_QWORD *)a2(
+                                       (void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"NetworkMessagesVersion001",
+                                       0);
+    qword_4688D00 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"GameTypes001", 0);
+    if ( !qword_4688D00 )
+      return 0;
+    qword_47F9A58 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSerializedEntities + 112LL))(g_pSerializedEntities);
+    if ( !qword_47F9A50 )
+      qword_47F9A50 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"GameEventSystemClientV001", 0);
+    unk_48ADEE8 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"IMEManager001", 0);
+    COM_TimestampedLog("ClientDLL factories - End");
+    v16 = CommandLine();
+    if ( !(*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v16 + 24LL))(v16, 1526587341, 0) )
+      g_pScriptManager = (*(__int64 (__fastcall **)(const char *, _QWORD))(a1 + 80))("VScriptManager010", 0);
+    qword_48678F8 = a2((void (__fastcall **)(__cxxabiv1::__class_type_info *__hidden))"LegacyGameUI001", 0);
+    sub_2E09500(1);
+    v17 = sub_2E011A0();
+    sub_2DC4920(v17, "client");
+    if ( !v2 )
+    {
+      v18 = sub_20AAB80();
+      sub_20AAE00(v18);
+    }
+    memcpy(dest, &unk_9A2960, 0x226u);
+    (*(void (__fastcall **)(_QWORD *, _QWORD *, __int64, __int64 (__fastcall ***)()))(*g_pFileSystem + 912LL))(
+      g_pFileSystem,
+      dest,
+      550,
+      &off_4568CD0);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2Client_Connect.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_Connect.windows.yaml
@@ -1,0 +1,592 @@
+func_name: CSource2Client_Connect
+func_va: '0x180b086f0'
+disasm_code: |-
+  .text:0000000180B086F0                 push    rbx
+  .text:0000000180B086F2                 push    rsi
+  .text:0000000180B086F3                 push    rdi
+  .text:0000000180B086F4                 sub     rsp, 650h
+  .text:0000000180B086FB                 mov     rbx, rdx
+  .text:0000000180B086FE                 mov     rsi, rcx
+  .text:0000000180B08701                 call    sub_181555650
+  .text:0000000180B08706                 mov     dword ptr [rsi+448h], 0BF800000h
+  .text:0000000180B08710                 mov     [rsi+50h], rbx
+  .text:0000000180B08714                 call    MathLib_Init
+  .text:0000000180B08719                 mov     edx, 1
+  .text:0000000180B0871E                 mov     [rsp+668h+arg_10], rbx
+  .text:0000000180B08726                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B0872E                 mov     [rsp+668h+arg_8], rbx
+  .text:0000000180B08736                 mov     [rsp+668h+arg_0], rbx
+  .text:0000000180B0873E                 call    ConnectInterfaces
+  .text:0000000180B08743                 mov     edx, 1
+  .text:0000000180B08748                 lea     rcx, [rsp+668h+arg_8]
+  .text:0000000180B08750                 call    ConnectTier2Libraries
+  .text:0000000180B08755                 inc     dword ptr [rsi+28h]
+  .text:0000000180B08758                 lea     rcx, [rsp+668h+arg_10]
+  .text:0000000180B08760                 mov     edx, 1
+  .text:0000000180B08765                 mov     r8d, 2
+  .text:0000000180B0876B                 call    ConnectGameInterfaces
+  .text:0000000180B08770                 mov     rcx, cs:qword_182553470
+  .text:0000000180B08777                 mov     rax, [rcx]
+  .text:0000000180B0877A                 call    qword ptr [rax+58h]
+  .text:0000000180B0877D                 xor     edx, edx
+  .text:0000000180B0877F                 lea     rcx, aSource2enginet; "Source2EngineToClient001"
+  .text:0000000180B08786                 mov     cs:qword_1824314A0, rax
+  .text:0000000180B0878D                 call    rbx
+  .text:0000000180B0878F                 mov     cs:g_pEngineClient, rax
+  .text:0000000180B08796                 test    rax, rax
+  .text:0000000180B08799                 jz      loc_180B08D4F
+  .text:0000000180B0879F                 mov     rax, cs:g_pSource2EngineToClient
+  .text:0000000180B087A6                 mov     cs:g_pSource2Engine, rax
+  .text:0000000180B087AD                 test    rax, rax
+  .text:0000000180B087B0                 jz      loc_180B08D4F
+  .text:0000000180B087B6                 lea     rdx, [rsp+668h+var_648]
+  .text:0000000180B087BB                 lea     rcx, aSteamutils010_0; "SteamUtils010"
+  .text:0000000180B087C2                 call    cs:SteamInternal_SteamAPI_Init
+  .text:0000000180B087C8                 mov     edi, eax
+  .text:0000000180B087CA                 test    eax, eax
+  .text:0000000180B087CC                 jz      short loc_180B087E2
+  .text:0000000180B087CE                 lea     rdx, [rsp+668h+var_648]
+  .text:0000000180B087D3                 lea     rcx, aSteamapiInitFa; "SteamAPI_Init failed.  %s\n"
+  .text:0000000180B087DA                 call    cs:Warning
+  .text:0000000180B087E0                 jmp     short loc_180B087E7
+  .text:0000000180B087E2                 mov     [rsp+668h+var_648], 0
+  .text:0000000180B087E7                 xor     ecx, ecx
+  .text:0000000180B087E9                 call    cs:SteamAPI_SetTryCatchCallbacks
+  .text:0000000180B087EF                 call    cs:CommandLine
+  .text:0000000180B087F5                 mov     edx, 6B952A6h
+  .text:0000000180B087FA                 mov     rcx, [rax]
+  .text:0000000180B087FD                 mov     r8, [rcx+20h]
+  .text:0000000180B08801                 mov     rcx, rax
+  .text:0000000180B08804                 call    r8
+  .text:0000000180B08807                 test    al, al
+  .text:0000000180B08809                 jz      short loc_180B0884E
+  .text:0000000180B0880B                 test    edi, edi
+  .text:0000000180B0880D                 jnz     short loc_180B0881D
+  .text:0000000180B0880F                 lea     rcx, aApplicationRun; "Application running with '-nosteam' but"...
+  .text:0000000180B08816                 call    cs:Plat_FatalError
+  .text:0000000180B0881C                 ; Trap to Debugger
+  .text:0000000180B0881C                 int     3; Trap to Debugger
+  .text:0000000180B0881D                 call    cs:CommandLine
+  .text:0000000180B08823                 mov     edx, 8F74045Fh
+  .text:0000000180B08828                 mov     rcx, [rax]
+  .text:0000000180B0882B                 mov     r8, [rcx+90h]
+  .text:0000000180B08832                 mov     rcx, rax
+  .text:0000000180B08835                 call    r8
+  .text:0000000180B08838                 test    al, al
+  .text:0000000180B0883A                 jnz     loc_180B08915
+  .text:0000000180B08840                 lea     rcx, aCommandLinePar; "Command line parameter '-nosteam' can o"...
+  .text:0000000180B08847                 call    cs:Plat_FatalError
+  .text:0000000180B0884D                 ; Trap to Debugger
+  .text:0000000180B0884D                 int     3; Trap to Debugger
+  .text:0000000180B0884E                 test    edi, edi
+  .text:0000000180B08850                 jnz     loc_180B08C5E
+  .text:0000000180B08856                 lea     rcx, off_18205AB18
+  .text:0000000180B0885D                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B08863                 cmp     qword ptr [rax], 0
+  .text:0000000180B08867                 jz      loc_180B08C41
+  .text:0000000180B0886D                 lea     rcx, off_18205A9A8
+  .text:0000000180B08874                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B0887A                 cmp     qword ptr [rax], 0
+  .text:0000000180B0887E                 jz      loc_180B08C41
+  .text:0000000180B08884                 lea     rcx, off_18200F7D0
+  .text:0000000180B0888B                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B08891                 cmp     qword ptr [rax], 0
+  .text:0000000180B08895                 jz      loc_180B08C41
+  .text:0000000180B0889B                 lea     rcx, off_182090DE8
+  .text:0000000180B088A2                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B088A8                 cmp     qword ptr [rax], 0
+  .text:0000000180B088AC                 jz      loc_180B08C41
+  .text:0000000180B088B2                 lea     rcx, off_1820717F0
+  .text:0000000180B088B9                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B088BF                 cmp     qword ptr [rax], 0
+  .text:0000000180B088C3                 jz      loc_180B08C41
+  .text:0000000180B088C9                 lea     rcx, off_18205A9A8
+  .text:0000000180B088D0                 call    cs:SteamInternal_ContextInit
+  .text:0000000180B088D6                 lea     rdx, [rsp+668h+arg_0]
+  .text:0000000180B088DE                 mov     rcx, [rax]
+  .text:0000000180B088E1                 mov     rax, [rcx]
+  .text:0000000180B088E4                 call    qword ptr [rax+10h]
+  .text:0000000180B088E7                 mov     rcx, rax
+  .text:0000000180B088EA                 call    sub_180B18BC0
+  .text:0000000180B088EF                 test    al, al
+  .text:0000000180B088F1                 jnz     short loc_180B08915
+  .text:0000000180B088F3                 mov     r8d, 400h
+  .text:0000000180B088F9                 lea     rdx, aSteamidIsNotVa; "SteamID is not valid.  (Steam client ru"...
+  .text:0000000180B08900                 lea     rcx, [rsp+668h+var_648]
+  .text:0000000180B08905                 call    cs:_V_strncpy
+  .text:0000000180B0890B                 mov     edi, 2
+  .text:0000000180B08910                 jmp     loc_180B08C5E
+  .text:0000000180B08915                 lea     rcx, aClientdllFacto; "ClientDLL factories - Start"
+  .text:0000000180B0891C                 call    cs:COM_TimestampedLog
+  .text:0000000180B08922                 xor     edx, edx
+  .text:0000000180B08924                 lea     rcx, aGamemodelinfo0; "GameModelInfo001"
+  .text:0000000180B0892B                 call    rbx
+  .text:0000000180B0892D                 mov     cs:qword_1823A07D8, rax
+  .text:0000000180B08934                 test    rax, rax
+  .text:0000000180B08937                 jz      loc_180B08D4F
+  .text:0000000180B0893D                 xor     edx, edx
+  .text:0000000180B0893F                 lea     rcx, aSaverestoredat; "SaveRestoreDataVersion001"
+  .text:0000000180B08946                 call    rbx
+  .text:0000000180B08948                 mov     cs:qword_18238D558, rax
+  .text:0000000180B0894F                 test    rax, rax
+  .text:0000000180B08952                 jz      loc_180B08D4F
+  .text:0000000180B08958                 xor     edx, edx
+  .text:0000000180B0895A                 lea     rcx, aVengineGameuif; "VENGINE_GAMEUIFUNCS_VERSION005"
+  .text:0000000180B08961                 call    rbx
+  .text:0000000180B08963                 mov     cs:qword_1823A07E0, rax
+  .text:0000000180B0896A                 test    rax, rax
+  .text:0000000180B0896D                 jz      loc_180B08D4F
+  .text:0000000180B08973                 xor     edx, edx
+  .text:0000000180B08975                 lea     rcx, aSource2enginet_0; "Source2EngineToClientStringTable001"
+  .text:0000000180B0897C                 call    rbx
+  .text:0000000180B0897E                 mov     cs:qword_1823A0850, rax
+  .text:0000000180B08985                 test    rax, rax
+  .text:0000000180B08988                 jz      loc_180B08D4F
+  .text:0000000180B0898E                 xor     edx, edx
+  .text:0000000180B08990                 lea     rcx, aVfilesystem017; "VFileSystem017"
+  .text:0000000180B08997                 call    rbx
+  .text:0000000180B08999                 mov     cs:qword_1823A07D0, rax
+  .text:0000000180B089A0                 test    rax, rax
+  .text:0000000180B089A3                 jz      loc_180B08D4F
+  .text:0000000180B089A9                 xor     edx, edx
+  .text:0000000180B089AB                 lea     rcx, aInputsystemver; "InputSystemVersion001"
+  .text:0000000180B089B2                 call    rbx
+  .text:0000000180B089B4                 mov     cs:qword_1823A07E8, rax
+  .text:0000000180B089BB                 test    rax, rax
+  .text:0000000180B089BE                 jz      loc_180B08D4F
+  .text:0000000180B089C4                 xor     edx, edx
+  .text:0000000180B089C6                 lea     rcx, aGameconfigclie; "GameConfigClientV001"
+  .text:0000000180B089CD                 call    rbx
+  .text:0000000180B089CF                 mov     cs:qword_18238D5A8, rax
+  .text:0000000180B089D6                 test    rax, rax
+  .text:0000000180B089D9                 jz      loc_180B08D4F
+  .text:0000000180B089DF                 xor     edx, edx
+  .text:0000000180B089E1                 lea     rcx, aVmediafoundati; "VMediaFoundation001"
+  .text:0000000180B089E8                 call    rbx
+  .text:0000000180B089EA                 xor     edx, edx
+  .text:0000000180B089EC                 mov     cs:g_pMediaFoundation, rax
+  .text:0000000180B089F3                 lea     rcx, aVavi001; "VAvi001"
+  .text:0000000180B089FA                 call    rbx
+  .text:0000000180B089FC                 xor     edx, edx
+  .text:0000000180B089FE                 mov     cs:g_pAVI, rax
+  .text:0000000180B08A05                 lea     rcx, aScenefilecache; "SceneFileCache002"
+  .text:0000000180B08A0C                 call    rbx
+  .text:0000000180B08A0E                 mov     cs:qword_1823A07F0, rax
+  .text:0000000180B08A15                 test    rax, rax
+  .text:0000000180B08A18                 jz      loc_180B08D4F
+  .text:0000000180B08A1E                 xor     edx, edx
+  .text:0000000180B08A20                 lea     rcx, aResponserulesc; "ResponseRulesCache001"
+  .text:0000000180B08A27                 call    rbx
+  .text:0000000180B08A29                 mov     cs:qword_182553488, rax
+  .text:0000000180B08A30                 test    rax, rax
+  .text:0000000180B08A33                 jz      loc_180B08D4F
+  .text:0000000180B08A39                 cmp     cs:g_pNetworkSystem, 0
+  .text:0000000180B08A41                 jnz     short loc_180B08A55
+  .text:0000000180B08A43                 xor     edx, edx
+  .text:0000000180B08A45                 lea     rcx, aNetworksystemv; "NetworkSystemVersion001"
+  .text:0000000180B08A4C                 call    rbx
+  .text:0000000180B08A4E                 mov     cs:g_pNetworkSystem, rax
+  .text:0000000180B08A55                 cmp     cs:g_pSerializedEntities, 0
+  .text:0000000180B08A5D                 jnz     short loc_180B08A71
+  .text:0000000180B08A5F                 xor     edx, edx
+  .text:0000000180B08A61                 lea     rcx, aSerializedenti; "SerializedEntitiesVersion001"
+  .text:0000000180B08A68                 call    rbx
+  .text:0000000180B08A6A                 mov     cs:g_pSerializedEntities, rax
+  .text:0000000180B08A71                 cmp     cs:g_pFlattenedSerializers, 0
+  .text:0000000180B08A79                 jnz     short loc_180B08A8D
+  .text:0000000180B08A7B                 xor     edx, edx
+  .text:0000000180B08A7D                 lea     rcx, aFlattenedseria; "FlattenedSerializersVersion001"
+  .text:0000000180B08A84                 call    rbx
+  .text:0000000180B08A86                 mov     cs:g_pFlattenedSerializers, rax
+  .text:0000000180B08A8D                 cmp     cs:g_pNetworkMessages, 0
+  .text:0000000180B08A95                 jnz     short loc_180B08AA9
+  .text:0000000180B08A97                 xor     edx, edx
+  .text:0000000180B08A99                 lea     rcx, aNetworkmessage; "NetworkMessagesVersion001"
+  .text:0000000180B08AA0                 call    rbx
+  .text:0000000180B08AA2                 mov     cs:g_pNetworkMessages, rax
+  .text:0000000180B08AA9                 xor     edx, edx
+  .text:0000000180B08AAB                 lea     rcx, aGametypes001; "GameTypes001"
+  .text:0000000180B08AB2                 call    rbx
+  .text:0000000180B08AB4                 mov     cs:qword_182315EF8, rax
+  .text:0000000180B08ABB                 test    rax, rax
+  .text:0000000180B08ABE                 jz      loc_180B08D4F
+  .text:0000000180B08AC4                 mov     rcx, cs:g_pSerializedEntities
+  .text:0000000180B08ACB                 mov     rax, [rcx]
+  .text:0000000180B08ACE                 call    qword ptr [rax+70h]
+  .text:0000000180B08AD1                 cmp     cs:qword_1823A0840, 0
+  .text:0000000180B08AD9                 mov     cs:qword_1823A0838, rax
+  .text:0000000180B08AE0                 jnz     short loc_180B08AF4
+  .text:0000000180B08AE2                 xor     edx, edx
+  .text:0000000180B08AE4                 lea     rcx, aGameeventsyste_0; "GameEventSystemClientV001"
+  .text:0000000180B08AEB                 call    rbx
+  .text:0000000180B08AED                 mov     cs:qword_1823A0840, rax
+  .text:0000000180B08AF4                 xor     edx, edx
+  .text:0000000180B08AF6                 lea     rcx, aImemanager001; "IMEManager001"
+  .text:0000000180B08AFD                 call    rbx
+  .text:0000000180B08AFF                 lea     rcx, aClientdllFacto_0; "ClientDLL factories - End"
+  .text:0000000180B08B06                 mov     cs:qword_1825C94A0, rax
+  .text:0000000180B08B0D                 call    cs:COM_TimestampedLog
+  .text:0000000180B08B13                 call    cs:CommandLine
+  .text:0000000180B08B19                 xor     r8d, r8d
+  .text:0000000180B08B1C                 mov     edx, 5AFDDFCDh
+  .text:0000000180B08B21                 mov     rcx, [rax]
+  .text:0000000180B08B24                 mov     r9, [rcx+18h]
+  .text:0000000180B08B28                 mov     rcx, rax
+  .text:0000000180B08B2B                 call    r9
+  .text:0000000180B08B2E                 test    rax, rax
+  .text:0000000180B08B31                 jnz     short loc_180B08B49
+  .text:0000000180B08B33                 mov     rax, [rsi+50h]
+  .text:0000000180B08B37                 lea     rcx, aVscriptmanager; "VScriptManager010"
+  .text:0000000180B08B3E                 xor     edx, edx
+  .text:0000000180B08B40                 call    rax
+  .text:0000000180B08B42                 mov     cs:g_pScriptManager, rax
+  .text:0000000180B08B49                 xor     edx, edx
+  .text:0000000180B08B4B                 lea     rcx, aLegacygameui00; "LegacyGameUI001"
+  .text:0000000180B08B52                 call    rbx
+  .text:0000000180B08B54                 mov     ecx, 1
+  .text:0000000180B08B59                 mov     cs:qword_1824056C8, rax
+  .text:0000000180B08B60                 call    sub_18150C960
+  .text:0000000180B08B65                 call    sub_181508EB0
+  .text:0000000180B08B6A                 mov     rcx, rax
+  .text:0000000180B08B6D                 lea     rdx, aClient_1; "client"
+  .text:0000000180B08B74                 call    sub_181501730
+  .text:0000000180B08B79                 test    edi, edi
+  .text:0000000180B08B7B                 jnz     short loc_180B08B8A
+  .text:0000000180B08B7D                 call    sub_181188D50
+  .text:0000000180B08B82                 mov     rcx, rax
+  .text:0000000180B08B85                 call    sub_181188C80
+  .text:0000000180B08B8A                 lea     rcx, [rsp+668h+var_248]
+  .text:0000000180B08B92                 mov     eax, 4
+  .text:0000000180B08B97                 lea     rdx, unk_181B03B70
+  .text:0000000180B08B9E                 xchg    ax, ax
+  .text:0000000180B08BA0                 lea     rcx, [rcx+80h]
+  .text:0000000180B08BA7                 movups  xmm0, xmmword ptr [rdx]
+  .text:0000000180B08BAA                 movups  xmm1, xmmword ptr [rdx+10h]
+  .text:0000000180B08BAE                 lea     rdx, [rdx+80h]
+  .text:0000000180B08BB5                 movups  xmmword ptr [rcx-80h], xmm0
+  .text:0000000180B08BB9                 movups  xmm0, xmmword ptr [rdx-60h]
+  .text:0000000180B08BBD                 movups  xmmword ptr [rcx-70h], xmm1
+  .text:0000000180B08BC1                 movups  xmm1, xmmword ptr [rdx-50h]
+  .text:0000000180B08BC5                 movups  xmmword ptr [rcx-60h], xmm0
+  .text:0000000180B08BC9                 movups  xmm0, xmmword ptr [rdx-40h]
+  .text:0000000180B08BCD                 movups  xmmword ptr [rcx-50h], xmm1
+  .text:0000000180B08BD1                 movups  xmm1, xmmword ptr [rdx-30h]
+  .text:0000000180B08BD5                 movups  xmmword ptr [rcx-40h], xmm0
+  .text:0000000180B08BD9                 movups  xmm0, xmmword ptr [rdx-20h]
+  .text:0000000180B08BDD                 movups  xmmword ptr [rcx-30h], xmm1
+  .text:0000000180B08BE1                 movups  xmm1, xmmword ptr [rdx-10h]
+  .text:0000000180B08BE5                 movups  xmmword ptr [rcx-20h], xmm0
+  .text:0000000180B08BE9                 movups  xmmword ptr [rcx-10h], xmm1
+  .text:0000000180B08BED                 sub     rax, 1
+  .text:0000000180B08BF1                 jnz     short loc_180B08BA0
+  .text:0000000180B08BF3                 mov     eax, [rdx+20h]
+  .text:0000000180B08BF6                 lea     r9, off_182091680
+  .text:0000000180B08BFD                 movups  xmm0, xmmword ptr [rdx]
+  .text:0000000180B08C00                 mov     r8d, 226h
+  .text:0000000180B08C06                 movups  xmm1, xmmword ptr [rdx+10h]
+  .text:0000000180B08C0A                 movups  xmmword ptr [rcx], xmm0
+  .text:0000000180B08C0D                 movups  xmmword ptr [rcx+10h], xmm1
+  .text:0000000180B08C11                 mov     [rcx+20h], eax
+  .text:0000000180B08C14                 movzx   eax, word ptr [rdx+24h]
+  .text:0000000180B08C18                 lea     rdx, [rsp+668h+var_248]
+  .text:0000000180B08C20                 mov     [rcx+24h], ax
+  .text:0000000180B08C24                 mov     rcx, cs:g_pFileSystem
+  .text:0000000180B08C2B                 mov     rax, [rcx]
+  .text:0000000180B08C2E                 call    qword ptr [rax+390h]
+  .text:0000000180B08C34                 mov     al, 1
+  .text:0000000180B08C36                 add     rsp, 650h
+  .text:0000000180B08C3D                 pop     rdi
+  .text:0000000180B08C3E                 pop     rsi
+  .text:0000000180B08C3F                 pop     rbx
+  .text:0000000180B08C40                 retn
+  .text:0000000180B08C41                 mov     r8d, 400h
+  .text:0000000180B08C47                 lea     rdx, aMissingRequire; "Missing required interface"
+  .text:0000000180B08C4E                 lea     rcx, [rsp+668h+var_648]
+  .text:0000000180B08C53                 call    cs:_V_strncpy
+  .text:0000000180B08C59                 mov     edi, 1
+  .text:0000000180B08C5E                 call    cs:CommandLine
+  .text:0000000180B08C64                 mov     edx, 0CDBD1292h
+  .text:0000000180B08C69                 mov     rcx, [rax]
+  .text:0000000180B08C6C                 mov     r8, [rcx+90h]
+  .text:0000000180B08C73                 mov     rcx, rax
+  .text:0000000180B08C76                 call    r8
+  .text:0000000180B08C79                 test    al, al
+  .text:0000000180B08C7B                 lea     rcx, unk_181B01958
+  .text:0000000180B08C82                 lea     rsi, aLauncherError; "Launcher Error"
+  .text:0000000180B08C89                 cmovnz  rsi, rcx
+  .text:0000000180B08C8D                 jz      short loc_180B08C98
+  .text:0000000180B08C8F                 lea     rdx, unk_181B01980
+  .text:0000000180B08C96                 jmp     short loc_180B08CBB
+  .text:0000000180B08C98                 cmp     edi, 2
+  .text:0000000180B08C9B                 jnz     short loc_180B08CA6
+  .text:0000000180B08C9D                 lea     rdx, aFatalErrorFail; "FATAL ERROR: Failed to connect with loc"...
+  .text:0000000180B08CA4                 jmp     short loc_180B08CBB
+  .text:0000000180B08CA6                 cmp     edi, 3
+  .text:0000000180B08CA9                 lea     rax, aFatalErrorStea; "FATAL ERROR: Steam client version misma"...
+  .text:0000000180B08CB0                 lea     rdx, aFatalErrorFail_0; "FATAL ERROR: Failed to initialize the S"...
+  .text:0000000180B08CB7                 cmovz   rdx, rax
+  .text:0000000180B08CBB                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B08CC3                 call    sub_180B000A0
+  .text:0000000180B08CC8                 cmp     [rsp+668h+var_648], 0
+  .text:0000000180B08CCD                 jz      short loc_180B08CF7
+  .text:0000000180B08CCF                 lea     rdx, asc_181B01CA8; "\n\n"
+  .text:0000000180B08CD6                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B08CDE                 call    cs:??YCUtlString@@QEAAAEAV0@PEBD@Z; CUtlString::operator+=(char const *)
+  .text:0000000180B08CE4                 lea     rdx, [rsp+668h+var_648]
+  .text:0000000180B08CE9                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B08CF1                 call    cs:??YCUtlString@@QEAAAEAV0@PEBD@Z; CUtlString::operator+=(char const *)
+  .text:0000000180B08CF7                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B08CFF                 call    sub_180171490
+  .text:0000000180B08D04                 mov     rdx, rax
+  .text:0000000180B08D07                 lea     rcx, aS_1; "%s\n"
+  .text:0000000180B08D0E                 call    cs:Warning
+  .text:0000000180B08D14                 mov     rcx, cs:g_pSource2EngineToClient
+  .text:0000000180B08D1B                 mov     rax, [rcx]
+  .text:0000000180B08D1E                 call    qword ptr [rax+3C8h]
+  .text:0000000180B08D24                 lea     rcx, [rsp+668h+arg_0]
+  .text:0000000180B08D2C                 mov     rbx, rax
+  .text:0000000180B08D2F                 call    sub_180171490
+  .text:0000000180B08D34                 mov     rdx, rax
+  .text:0000000180B08D37                 mov     r8, rbx
+  .text:0000000180B08D3A                 mov     rcx, rsi
+  .text:0000000180B08D3D                 call    cs:Plat_MessageBox
+  .text:0000000180B08D43                 mov     ecx, 64h ; 'd'
+  .text:0000000180B08D48                 call    cs:Plat_ExitProcess
+  .text:0000000180B08D4E                 ; Trap to Debugger
+  .text:0000000180B08D4E                 int     3; Trap to Debugger
+  .text:0000000180B08D4F                 xor     al, al
+  .text:0000000180B08D51                 add     rsp, 650h
+  .text:0000000180B08D58                 pop     rdi
+  .text:0000000180B08D59                 pop     rsi
+  .text:0000000180B08D5A                 pop     rbx
+  .text:0000000180B08D5B                 retn
+procedure: |-
+  char __fastcall sub_180B086F0(__int64 a1, __int64 (__fastcall *a2)(char *, _QWORD))
+  {
+    int v4; // edi
+    __int64 v5; // rax
+    __int64 v6; // rax
+    _QWORD *v7; // rax
+    __int64 v8; // rax
+    __int64 v9; // rax
+    __int64 v10; // rax
+    __int64 v11; // rax
+    _BYTE *v12; // rcx
+    __int64 v13; // rax
+    _OWORD *v14; // rdx
+    __int128 v15; // xmm0
+    __int128 v16; // xmm1
+    __int128 v17; // xmm0
+    __int128 v18; // xmm1
+    __int128 v19; // xmm0
+    __int128 v20; // xmm1
+    __int128 v21; // xmm0
+    __int128 v22; // xmm1
+    int v23; // eax
+    __int128 v24; // xmm1
+    __int64 v26; // rax
+    const char *v27; // rsi
+    const char *v28; // rdx
+    const char *v29; // rax
+    __int64 v30; // rbx
+    __int64 v31; // rax
+    char v32[1024]; // [rsp+20h] [rbp-648h] BYREF
+    _BYTE v33[584]; // [rsp+420h] [rbp-248h] BYREF
+    __int64 (__fastcall *v34)(char *, _QWORD); // [rsp+670h] [rbp+8h] BYREF
+    __int64 (__fastcall *v35)(char *, _QWORD); // [rsp+678h] [rbp+10h] BYREF
+    __int64 (__fastcall *v36)(char *, _QWORD); // [rsp+680h] [rbp+18h] BYREF
+
+    sub_181555650();
+    *(_DWORD *)(a1 + 1096) = -1082130432;
+    *(_QWORD *)(a1 + 80) = a2;
+    MathLib_Init();
+    v36 = a2;
+    v35 = a2;
+    v34 = a2;
+    ConnectInterfaces(&v34, 1);
+    ConnectTier2Libraries(&v35, 1);
+    ++*(_DWORD *)(a1 + 40);
+    ConnectGameInterfaces(&v36, 1, 2);
+    qword_1824314A0 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_182553470 + 88LL))(qword_182553470);
+    g_pEngineClient = a2("Source2EngineToClient001", 0);
+    if ( !g_pEngineClient )
+      return 0;
+    g_pSource2Engine = g_pSource2EngineToClient;
+    if ( !g_pSource2EngineToClient )
+      return 0;
+    v4 = SteamInternal_SteamAPI_Init("SteamUtils010", v32);
+    if ( v4 )
+      Warning("SteamAPI_Init failed.  %s\n", v32);
+    else
+      v32[0] = 0;
+    SteamAPI_SetTryCatchCallbacks(0);
+    v5 = CommandLine();
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v5 + 32LL))(v5, 112808614) )
+    {
+      if ( !v4 )
+      {
+        if ( *(_QWORD *)SteamInternal_ContextInit(&off_18205AB18)
+          && *(_QWORD *)SteamInternal_ContextInit(&off_18205A9A8)
+          && *(_QWORD *)SteamInternal_ContextInit(&off_18200F7D0)
+          && *(_QWORD *)SteamInternal_ContextInit(&off_182090DE8)
+          && *(_QWORD *)SteamInternal_ContextInit(&off_1820717F0) )
+        {
+          v7 = (_QWORD *)SteamInternal_ContextInit(&off_18205A9A8);
+          v8 = (*(__int64 (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v7 + 16LL))(*v7, &v34);
+          if ( (unsigned __int8)sub_180B18BC0(v8) )
+            goto LABEL_19;
+          V_strncpy(v32, "SteamID is not valid.  (Steam client running but no user logged on?)", 1024);
+          v4 = 2;
+        }
+        else
+        {
+          V_strncpy(v32, "Missing required interface", 1024);
+          v4 = 1;
+        }
+      }
+      v26 = CommandLine();
+      v27 = "Launcher Error";
+      if ( (*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v26 + 144LL))(v26, 3451720338LL) )
+      {
+        v27 = (const char *)&unk_181B01958;
+        v28 = (const char *)&unk_181B01980;
+      }
+      else if ( v4 == 2 )
+      {
+        v28 = "FATAL ERROR: Failed to connect with local Steam Client process!\n"
+              "\n"
+              "Please make sure that you are running latest version of the Steam Client and launch the game from Steam.\n";
+      }
+      else
+      {
+        v28 = "FATAL ERROR: Failed to initialize the Steamworks SDK.";
+        if ( v4 == 3 )
+          v28 = "FATAL ERROR: Steam client version mismatch.\n"
+                "\n"
+                "Please make sure that you are running latest version of the Steam Client and launch the game from Steam.\n"
+                "You can check for Steam Client updates using Steam main menu:\n"
+                "             Steam > Check for Steam Client Updates...";
+      }
+      sub_180B000A0(&v34, v28);
+      if ( v32[0] )
+      {
+        CUtlString::operator+=(&v34, "\n\n");
+        CUtlString::operator+=(&v34, v32);
+      }
+      v29 = (const char *)sub_180171490(&v34);
+      Warning("%s\n", v29);
+      v30 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2EngineToClient + 968LL))(g_pSource2EngineToClient);
+      v31 = sub_180171490(&v34);
+      Plat_MessageBox(v27, v31, v30);
+      Plat_ExitProcess(100);
+      __debugbreak();
+    }
+    if ( !v4 )
+    {
+      Plat_FatalError("Application running with '-nosteam' but Steam is present.");
+      __debugbreak();
+    }
+    v6 = CommandLine();
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v6 + 144LL))(v6, 2406745183LL) )
+    {
+      Plat_FatalError("Command line parameter '-nosteam' can only be used in insecure mode ('-insecure').");
+      __debugbreak();
+    }
+  LABEL_19:
+    COM_TimestampedLog("ClientDLL factories - Start");
+    qword_1823A07D8 = a2("GameModelInfo001", 0);
+    if ( !qword_1823A07D8 )
+      return 0;
+    qword_18238D558 = a2("SaveRestoreDataVersion001", 0);
+    if ( !qword_18238D558 )
+      return 0;
+    qword_1823A07E0 = a2("VENGINE_GAMEUIFUNCS_VERSION005", 0);
+    if ( !qword_1823A07E0 )
+      return 0;
+    qword_1823A0850 = a2("Source2EngineToClientStringTable001", 0);
+    if ( !qword_1823A0850 )
+      return 0;
+    qword_1823A07D0 = a2("VFileSystem017", 0);
+    if ( !qword_1823A07D0 )
+      return 0;
+    qword_1823A07E8 = a2("InputSystemVersion001", 0);
+    if ( !qword_1823A07E8 )
+      return 0;
+    qword_18238D5A8 = a2("GameConfigClientV001", 0);
+    if ( !qword_18238D5A8 )
+      return 0;
+    g_pMediaFoundation = a2("VMediaFoundation001", 0);
+    g_pAVI = a2("VAvi001", 0);
+    qword_1823A07F0 = a2("SceneFileCache002", 0);
+    if ( !qword_1823A07F0 )
+      return 0;
+    qword_182553488 = a2("ResponseRulesCache001", 0);
+    if ( !qword_182553488 )
+      return 0;
+    if ( !g_pNetworkSystem )
+      g_pNetworkSystem = a2("NetworkSystemVersion001", 0);
+    if ( !g_pSerializedEntities )
+      g_pSerializedEntities = a2("SerializedEntitiesVersion001", 0);
+    if ( !g_pFlattenedSerializers )
+      g_pFlattenedSerializers = a2("FlattenedSerializersVersion001", 0);
+    if ( !g_pNetworkMessages )
+      g_pNetworkMessages = a2("NetworkMessagesVersion001", 0);
+    qword_182315EF8 = a2("GameTypes001", 0);
+    if ( !qword_182315EF8 )
+      return 0;
+    qword_1823A0838 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSerializedEntities + 112LL))(g_pSerializedEntities);
+    if ( !qword_1823A0840 )
+      qword_1823A0840 = a2("GameEventSystemClientV001", 0);
+    qword_1825C94A0 = a2("IMEManager001", 0);
+    COM_TimestampedLog("ClientDLL factories - End");
+    v9 = CommandLine();
+    if ( !(*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v9 + 24LL))(v9, 1526587341, 0) )
+      g_pScriptManager = (*(__int64 (__fastcall **)(const char *, _QWORD))(a1 + 80))("VScriptManager010", 0);
+    qword_1824056C8 = a2("LegacyGameUI001", 0);
+    sub_18150C960(1);
+    v10 = sub_181508EB0();
+    sub_181501730(v10, "client");
+    if ( !v4 )
+    {
+      v11 = sub_181188D50();
+      sub_181188C80(v11);
+    }
+    v12 = v33;
+    v13 = 4;
+    v14 = &unk_181B03B70;
+    do
+    {
+      v12 += 128;
+      v15 = *v14;
+      v16 = v14[1];
+      v14 += 8;
+      *((_OWORD *)v12 - 8) = v15;
+      v17 = *(v14 - 6);
+      *((_OWORD *)v12 - 7) = v16;
+      v18 = *(v14 - 5);
+      *((_OWORD *)v12 - 6) = v17;
+      v19 = *(v14 - 4);
+      *((_OWORD *)v12 - 5) = v18;
+      v20 = *(v14 - 3);
+      *((_OWORD *)v12 - 4) = v19;
+      v21 = *(v14 - 2);
+      *((_OWORD *)v12 - 3) = v20;
+      v22 = *(v14 - 1);
+      *((_OWORD *)v12 - 2) = v21;
+      *((_OWORD *)v12 - 1) = v22;
+      --v13;
+    }
+    while ( v13 );
+    v23 = *((_DWORD *)v14 + 8);
+    v24 = v14[1];
+    *(_OWORD *)v12 = *v14;
+    *((_OWORD *)v12 + 1) = v24;
+    *((_DWORD *)v12 + 8) = v23;
+    *((_WORD *)v12 + 18) = *((_WORD *)v14 + 18);
+    (*(void (__fastcall **)(__int64, _BYTE *, __int64, __int64 (__fastcall ***)()))(*(_QWORD *)g_pFileSystem + 912LL))(
+      g_pFileSystem,
+      v33,
+      550,
+      &off_182091680);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.linux.yaml
@@ -38,8 +38,8 @@ disasm_code: |-
   .text:0000000001E7C426                 call    __ZN21CUtlScratchMemoryPool4InitEjjPvb; CUtlScratchMemoryPool::Init(uint,uint,void *,bool)
   .text:0000000001E7C42B                 lea     r14, qword_27C41A8
   .text:0000000001E7C432                 lea     rax, [rbx+10h]
-  .text:0000000001E7C436                 mov     cs:qword_256F1A8, rbx
-  .text:0000000001E7C43D                 mov     cs:qword_256F1A0, rax
+  .text:0000000001E7C436                 mov     cs:g_EntitySystem, rbx
+  .text:0000000001E7C43D                 mov     cs:g_pEntityList, rax
   .text:0000000001E7C444                 mov     r12, [r14]
   .text:0000000001E7C447                 test    r12, r12
   .text:0000000001E7C44A                 jz      short loc_1E7C4B9
@@ -649,8 +649,8 @@ procedure: |-
     v9 = a3 == 1 && g_pNetworkMessages != nullptr;
     *(_BYTE *)(a1 + 3034) = v9;
     CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3264), 0x400u, 0, nullptr, 0);// 0xCC0 = 3264LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
-    qword_256F1A8 = a1;
-    qword_256F1A0 = a1 + 16;
+    g_EntitySystem = a1;
+    g_pEntityList = a1 + 16;
     v10 = qword_27C41A8;
     if ( qword_27C41A8 )
     {

--- a/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CEntitySystem_Init.windows.yaml
@@ -36,10 +36,10 @@ disasm_code: |-
   .text:00000001811F82D8                 mov     rbx, cs:qword_1820B9438
   .text:00000001811F82DF                 lea     rax, [rsi+10h]
   .text:00000001811F82E3                 xor     r15d, r15d
-  .text:00000001811F82E6                 mov     cs:qword_181E1C888, rsi
+  .text:00000001811F82E6                 mov     cs:g_EntitySystem, rsi
   .text:00000001811F82ED                 test    rsi, rsi
   .text:00000001811F82F0                 cmovz   rax, r15
-  .text:00000001811F82F4                 mov     cs:qword_181D9D980, rax
+  .text:00000001811F82F4                 mov     cs:g_pEntityList, rax
   .text:00000001811F82FB                 test    rbx, rbx
   .text:00000001811F82FE                 jz      short loc_1811F834D
   .text:00000001811F8300                 test    byte ptr [rbx+68h], 2
@@ -516,10 +516,10 @@ procedure: |-
     CUtlScratchMemoryPool::Init((CUtlScratchMemoryPool *)(a1 + 3256), 0x400u, 0, nullptr, 0);// 0xCB8 = 3256LL = CEntitySystem::m_ComponentUnserializerInfoAllocator
     v11 = qword_1820B9438;
     v12 = a1 + 16;
-    qword_181E1C888 = a1;
+    g_EntitySystem = a1;
     if ( !a1 )
       v12 = 0;
-    qword_181D9D980 = v12;
+    g_pEntityList = v12;
     if ( qword_1820B9438 )
     {
       do


### PR DESCRIPTION
Adds \g_EntitySystem\ and \g_pEntityList\ discovery to the \ind-CEntitySystem_Init-decompiles\ preprocessor via LLM_DECOMPILE against the CEntitySystem_Init reference, plus expected_output/config entries and the 14172 gamesymbols snapshot update.

- Extend \ind-CEntitySystem_Init-decompiles.py\ with \TARGET_GLOBALVAR_NAMES\ and two \llm_decompile\ / \GENERATE_YAML_DESIRED_FIELDS\ entries.
- Update \CEntitySystem_Init.{linux,windows}.yaml\ references to label the stores as \g_EntitySystem\/\g_pEntityList\.
- Add both symbols to \configs/14172.yaml\ (skill expected_output + symbol list) and refresh \gamesymbols/14172.yaml\.
- Scope \post-change-update\ SKILL.md to a single resolved GAMEVER.