### PR TITLE
feat(ci): enforce ordinary PR gamedata consistency

### DIFF
--- a/.claude/skills/create-pr/agents/openai.yaml
+++ b/.claude/skills/create-pr/agents/openai.yaml
@@ -2,6 +2,5 @@ interface:
   display_name: "Create Pull Request"
   short_description: "Validate staged changes and open a pull request"
   default_prompt: "Use $create-pr to validate my staged changes and create a pull request."
-
 policy:
   allow_implicit_invocation: false

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -562,6 +562,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "candidate guard failed before gamedata" }
           $gamedataRoot = Join-Path $env:CANDIDATE_ROOT "gamedata-candidate"
           $gamedataSession = Join-Path $env:CANDIDATE_ROOT "$env:GAMEVER.gamedata.session.json"
+          $env:GAMEDATA_SESSION = $gamedataSession
           "GAMEDATA_SESSION=$gamedataSession" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           uv run gamedata_candidate.py build -gamever "$env:GAMEVER" `
             -build-id "${{ github.run_id }}-${{ github.run_attempt }}" `
@@ -570,6 +571,14 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "gamedata candidate build failed with exit code $LASTEXITCODE" }
           uv run gamedata_candidate.py guard -session "$gamedataSession"
           if ($LASTEXITCODE -ne 0) { throw "gamedata candidate guard failed" }
+          uv run gamedata_candidate.py verify-tracked `
+            -session "$env:GAMEDATA_SESSION" `
+            -gamever "$env:GAMEVER" `
+            -candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT" `
+            -configyaml "$env:HEAD_CONFIG" `
+            -repo-root "$env:WORKSPACE" `
+            -revision HEAD
+          if ($LASTEXITCODE -ne 0) { throw "tracked gamedata verification failed" }
           uv run gamesymbol_candidate.py guard -candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT" -session "$env:CANDIDATE_SESSION"
           if ($LASTEXITCODE -ne 0) { throw "candidate guard failed after gamedata" }
           uv run gamesymbol_candidate.py mark -candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT" -session "$env:CANDIDATE_SESSION" -step gamedata

--- a/README.md
+++ b/README.md
@@ -274,13 +274,14 @@ exit `0` means trusted, exit `3` reports a machine-readable untrusted reason, an
 errors remain hard failures. `migrate` explicitly upgrades a validated schema-1 snapshot without changing its `files`
 payload; it never runs implicitly during restore or verify.
 
-Pull requests that can affect analysis output must commit the matching `gamesymbols/<GAMEVER>.yaml` update. PR CI
-uses a trusted base snapshot for restore and targeted invalidation. A missing base snapshot bootstraps from clean YAML;
-an untrusted base snapshot emits a warning and takes the same clean full-rebuild path without restoring any baseline
-payload. The workflow then strict-packs an actual candidate and compares it with the PR head snapshot. Head snapshots,
-actual candidates, release promotion, and republish remain strict: none use the baseline warning fallback. The head
-snapshot is expected-only; both downstream consumers use the actual candidate, and the ordinary PR workflow never
-publishes or rewrites tracked bytes.
+Pull requests that can affect analysis or gamedata generator output must commit matching
+`gamesymbols/<GAMEVER>.yaml` and `gamedata/<GAMEVER>/` outputs when their bytes change. PR CI uses a trusted base
+snapshot for restore and targeted invalidation. A missing base snapshot bootstraps from clean YAML; an untrusted base
+snapshot emits a warning and takes the same clean full-rebuild path without restoring any baseline payload. The
+workflow then strict-packs an actual symbol candidate, compares it with the PR head snapshot, builds guarded gamedata
+from that actual candidate, and compares its inventory with raw gamedata blobs from the explicit PR head Git revision.
+Head outputs are expected-only; downstream validation uses the actual candidate transaction. The ordinary PR workflow
+never repairs, stages, commits, publishes, or rewrites missing tracked outputs.
 
 ### Currently supported gamedata
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -262,12 +262,13 @@ snapshot 隐含冻结的 config digest v1 并保持原字节稳定；新 writer 
 untrusted reason，CLI/config 或运行时错误仍硬失败。`migrate` 只显式升级已验证的 schema-1 snapshot，且不得改变
 `files` payload；restore/verify 不会隐式迁移。
 
-可能影响分析输出的 PR 必须同时提交对应的 `gamesymbols/<GAMEVER>.yaml` 更新。PR CI 只在 base snapshot 通过
-trust probe 后执行 restore 与 targeted invalidation；base snapshot 缺失时从 clean YAML bootstrap，不可信时输出
-warning，并在不恢复任何 baseline payload 的前提下走同一个 clean full rebuild。随后运行 analyzer、strict-pack
-actual candidate，再与 PR head snapshot 比较。HEAD snapshot、actual candidate、release promotion 与 republish
-仍保持 strict failure，不使用 baseline fallback。head snapshot 只表示 expected result；两个 downstream consumer
-都读取 actual candidate，普通 PR workflow 不会 publish 或改写 tracked snapshot。
+可能影响分析或 gamedata generator 输出的 PR，必须在实际 bytes 变化时同时提交匹配的
+`gamesymbols/<GAMEVER>.yaml` 与 `gamedata/<GAMEVER>/`。PR CI 只在 base snapshot 通过 trust probe 后执行 restore
+与 targeted invalidation；base snapshot 缺失时从 clean YAML bootstrap，不可信时输出 warning，并在不恢复任何
+baseline payload 的前提下走同一个 clean full rebuild。随后 strict-pack actual symbol candidate、与 PR head
+snapshot 比较，再从该 actual candidate 构建 guarded gamedata，并与显式 PR head Git revision 中的 raw gamedata
+blob inventory 比较。head outputs 只表示 expected result，downstream validation 使用 actual candidate transaction；
+普通 PR workflow 不会自动修复、stage、commit、publish 或改写遗漏的 tracked output。
 
 ### 当前支持的 gamedata
 

--- a/docs/plans/ordinary-pr-gamedata-consistency.md
+++ b/docs/plans/ordinary-pr-gamedata-consistency.md
@@ -1,0 +1,497 @@
+# Ordinary PR Gamedata Consistency Gate
+
+## Status
+
+本文记录普通开发 PR 同时提交 `gamesymbols/<GAMEVER>.yaml` 与 `gamedata/<GAMEVER>/`，并由 PR CI
+只读验证两类 tracked output 与同一 immutable candidate 一致的已确认设计。
+
+状态：已实施。
+
+本计划扩展 `track-gamesymbols-snapshot.md` 和 `candidate-snapshot-as-symbol-store.md` 的普通 PR expected-output
+契约，但不改变以下既有边界：
+
+- 普通 PR CI 不调用 `publish`，不改写 tracked files，也不 commit/push。
+- `publish-post-change-candidate` 只能发布同一 game version、candidate 和 session 中已经通过完整 C++ validation 的 symbol 与 gamedata candidate。
+- 新 game version 仍由 `build-on-self-runner.yml` 在 bump PR 合并后构建。
+- generated-output PR 仍是 release manifest、staged bin、tag 和 GitHub Release 的 acceptance/promotion boundary。
+
+## Decision Summary
+
+会影响 analysis output 或 gamedata generator output 的普通开发 PR 必须在同一个 PR 中提交：
+
+```text
+gamesymbols/<GAMEVER>.yaml
+gamedata/<GAMEVER>/
+```
+
+本地交付流程使用现有 transaction：
+
+```text
+prepare-post-change-candidate
+        -> post-change-validation
+        -> publish-post-change-candidate
+        -> explicitly stage snapshot + gamedata
+```
+
+普通 PR CI 使用另一条只读流程：
+
+```text
+actual symbol candidate
+        -> compare PR head snapshot
+        -> build guarded gamedata candidate
+        -> compare PR head gamedata inventory
+        -> C++ validation
+        -> complete without publish
+```
+
+核心不变量：
+
+```text
+PR head gamesymbols/<GAMEVER>.yaml == actual symbol candidate bytes
+
+PR head gamedata/<GAMEVER>/ inventory == guarded gamedata candidate inventory
+```
+
+其中 gamedata inventory 至少绑定每个 canonical path 的 raw-byte size 与 SHA-256，并绑定 generator contract、
+analysis config 和 symbol candidate identity。
+
+## Background
+
+当前普通 PR 已经对 symbol snapshot 建立了完整的 expected/actual 边界：
+
+1. 从可信 base snapshot restore deterministic baseline。
+2. 使用 PR head code/config 执行 invalidation 和 analysis。
+3. strict-pack actual symbol candidate。
+4. 将 actual candidate 与 PR head `gamesymbols/<GAMEVER>.yaml` 比较。
+5. 使用 actual candidate 构建 gamedata 并运行 C++ tests。
+
+本地 `/create-pr` 流程也已经要求按顺序调用：
+
+```text
+/prepare-post-change-candidate
+/post-change-validation
+/publish-post-change-candidate
+```
+
+`publish-post-change-candidate` 会把同一 validated symbol candidate 和 guarded gamedata candidate 分别发布到：
+
+```text
+gamesymbols/<GAMEVER>.yaml
+gamedata/<GAMEVER>/
+```
+
+但是普通 PR CI 当前只 guard 临时 gamedata candidate 自身，没有将其与 PR head 中 tracked
+`gamedata/<GAMEVER>/` 比较。结果是两类 expected output 的门禁不对称：
+
+| Tracked output | Local `/create-pr` publishes | Ordinary PR CI compares with actual candidate |
+| --- | --- | --- |
+| `gamesymbols/<GAMEVER>.yaml` | Yes | Yes |
+| `gamedata/<GAMEVER>/` | Yes | No |
+
+因此，下列错误当前可能绕过普通 PR CI：
+
+- symbol candidate 已变化，但提交者忘记更新 gamedata。
+- gamedata generator/config 已变化，但 PR 仍保留旧输出。
+- PR 删除或新增了错误的 gamedata 文件。
+- PR 手工修改 generated gamedata，使其不再对应本次 candidate。
+- PR 只提交匹配的 snapshot，却没有提交同一 validated transaction 产生的 gamedata。
+
+## Goals
+
+- 让普通开发 PR 原子审查 producer/config/source、symbol snapshot 和 gamedata output。
+- 保证默认分支上的 canonical snapshot 与 canonical gamedata 始终来自同一 validated candidate transaction。
+- 让普通 PR CI 对 snapshot 和 gamedata 使用对称的 expected/actual comparison。
+- 复用 `gamedata_candidate` session 中已有的 path、size、SHA-256、candidate、config 和 generator-contract identity。
+- 保持 CI `contents: read`，不增加自动 commit、push 或 PR mutation 权限。
+- 只验证当前 `VALIDATION_GAMEVER`，不 fan out 到历史或相邻版本。
+- mismatch 时提供 path-level added/missing/modified diagnostics，而不是输出完整 generated files。
+- 保持 generated-output PR 对正式 Release acceptance/promotion 的独占职责。
+
+## Non-Goals
+
+- 不让普通 PR CI 调用 `gamesymbol_candidate.py publish` 或 `gamedata_candidate.py publish`。
+- 不让 CI 自动修复、stage、commit 或 push 提交者遗漏的 gamedata。
+- 不把 PR head snapshot 或 PR head gamedata 作为 actual downstream input。
+- 不重新运行或重新序列化已经 guard 的 gamedata candidate。
+- 不在普通 bump PR 中提前生成尚未被接受的新 `PR_GAMEVER` output。
+- 不替代 generated-output PR 的 release manifest、pending staging、promotion、tag 或 Release validation。
+- 不允许人工编辑 gamedata 后通过降低 hash、path 或 generator-contract validation 来兼容。
+- 不要求与 analysis/gamedata 无关的 PR 制造无意义 generated-output diff。
+
+## Scope Policy
+
+### Output-Affecting Ordinary PR
+
+适用于可能改变当前 accepted game version 输出的修改，例如：
+
+- analysis config、preprocessor、Agent SKILL、reference 或 analyzer output logic。
+- `gamedata-generators/**`、gamedata mapping/config 或 shared generator helpers。
+- 会改变 candidate formal file set、symbol payload 或 downstream rendering 的代码。
+
+提交者必须运行完整 post-change transaction，并在实际 bytes 变化时提交 snapshot 与 gamedata。某一类输出最终
+没有变化是允许的；CI comparison 用于证明它确实没有变化。
+
+### Output-Neutral Ordinary PR
+
+纯文档、无关测试、frontend 或其他不能影响 analysis/gamedata output 的修改不需要人为重写 generated files。
+普通 PR CI 可以继续验证当前 tracked outputs 与实际 candidate 一致；如果 bytes 未变化，PR diff 中无需包含它们。
+
+### New Game Version Bump PR
+
+普通 PR self-runner 使用可信 base snapshot 的 `BASE_GAMEVER` 作为 `VALIDATION_GAMEVER`，不会提前构建 head
+`download.yaml` 引入的新 `PR_GAMEVER`。新版本 snapshot 和 gamedata 仍由 bump merge 后 dispatch 的
+`build-on-self-runner.yml` 生成，并通过 generated-output PR 接受。
+
+因此，新版本 bump PR 不因本计划而被要求提交尚未构建的：
+
+```text
+gamesymbols/<NEW_GAMEVER>.yaml
+gamedata/<NEW_GAMEVER>/
+```
+
+### Generated-Output PR
+
+`gamesymbols/build/<GAMEVER>/<BUILD_ID>` generated-output PR 不进入普通 PR 的重分析流程。它继续通过专用
+workflow 校验 output branch identity、tracked manifest、snapshot hash、gamedata inventory 和 staged state。
+
+如果 generated-output PR 打开后默认分支又合并了普通 output-affecting PR，则该 output PR 必须按其 immutable
+`SOURCE_SHA` freshness contract 判定为 stale 并重新构建。不得通过手工 conflict resolution 拼接两次不同
+candidate transaction 的 snapshot、gamedata 或 manifest。
+
+## Trust And Authority Model
+
+普通 PR 中存在五类不同对象：
+
+| Object | Source | Role | Trusted as actual output |
+| --- | --- | --- | --- |
+| Base snapshot | `pull_request.base.sha` history | Restore baseline only | No |
+| PR head snapshot | PR merge-ref Git object | Expected symbol output | No |
+| Actual symbol candidate | Current analysis transaction | Actual symbol output and downstream source | Yes |
+| Guarded gamedata candidate | Actual symbol candidate + head config/generators | Actual gamedata output | Yes |
+| PR head gamedata | PR merge-ref Git objects | Expected gamedata output | No |
+
+comparison 只能从 actual 指向 expected：
+
+```text
+actual symbol candidate -> compare -> PR head snapshot
+
+guarded gamedata candidate -> compare -> PR head gamedata
+```
+
+禁止反向使用 expected output 驱动 validation：
+
+```text
+PR head snapshot -> update_gamedata
+PR head gamedata -> candidate/session truth
+```
+
+### Git Object Boundary
+
+PR head expected gamedata 必须从 checkout 对应的 immutable Git revision 读取，不能信任在测试或 analyzer 执行后
+可能被修改的 working-tree files。即使 `.gitattributes` 已将 `gamedata/**` 标为 `-text`，comparison 仍应直接
+枚举并读取 PR merge-ref 的 Git blobs，或将这些 blob 原字节导出到 runner temp 后再比较。
+
+读取 Git tree 时只接受 exact root 下的 regular blobs：
+
+```text
+gamedata/<VALIDATION_GAMEVER>/
+```
+
+必须拒绝：
+
+- root 缺失或为空，但 candidate inventory 非空。
+- symlink、submodule 或非 regular-blob tree mode。
+- absolute path、`.`、`..`、empty component、backslash 或 root escape。
+- case-insensitive path collision。
+- 当前 game version 之外的 path 被纳入 comparison。
+
+## Developer Delivery Flow
+
+普通开发者或 `/create-pr` caller 保持现有顺序：
+
+1. `/prepare-post-change-candidate` 构建 immutable symbol candidate 和 gamedata candidate，并保留两个 session。
+2. `/post-change-validation` 对同一 candidate/session 运行完整 C++ validation。
+3. `/publish-post-change-candidate` guard 同一 candidate、candidate session 和 gamedata session。
+4. 原字节发布 symbol candidate 到 `gamesymbols/<GAMEVER>.yaml`。
+5. 原子发布 guarded gamedata candidate 到 `gamedata/<GAMEVER>/`。
+6. 检查 publish 后 snapshot SHA-256 等于 validated candidate SHA-256。
+7. 只显式 stage 当前 game version 的 snapshot 和 gamedata，以及调用者原先授权的修改。
+8. 在同一 PR 中 review producer changes 与 generated-output diff。
+
+任何 validation、guard 或 publication failure 都必须在 commit/push 前停止。不得从 tracked head snapshot、现有
+tracked gamedata、`bin` 或另一个 session fallback。
+
+## Ordinary PR CI Flow
+
+建议在 `pr-self-runner.yml` 中采用以下顺序：
+
+1. Checkout PR merge ref，并固定事件中的 base SHA。
+2. 选择 `VALIDATION_GAMEVER`，restore base，执行 invalidation 与 analysis。
+3. strict-build actual symbol candidate。
+4. 从 PR head Git object 读取 expected snapshot，并与 actual candidate 比较。
+5. 从 actual symbol candidate 构建 isolated gamedata candidate。
+6. guard gamedata session、symbol candidate、head config 和 generator contract identity。
+7. 从同一 PR head Git revision 枚举 `gamedata/<VALIDATION_GAMEVER>/` raw blobs。
+8. 将 head gamedata inventory 与 guarded candidate session inventory 精确比较。
+9. comparison 成功后才将 symbol candidate session 的 `gamedata` step 标记为完成。
+10. 对同一 actual symbol candidate 运行 C++ tests。
+11. cleanup runner-temp candidate/session；不 publish tracked files。
+
+流程图：
+
+```text
+current PR code + restored base
+              |
+              v
+      actual symbol candidate
+              |
+       +------+------+
+       |             |
+       v             v
+compare head      build guarded
+snapshot          gamedata candidate
+                       |
+                       v
+               compare head gamedata
+                       |
+              +--------+--------+
+              |                 |
+              v                 v
+           success            mismatch
+              |                 |
+              v                 v
+         C++ validation         fail
+              |
+              v
+    complete without publish
+```
+
+CI workflow 必须继续保持：
+
+- `permissions: contents: read`。
+- 不调用任何 publish subcommand。
+- 不执行 `git add`、`git commit`、`git push` 或 GitHub PR write API。
+- 不从 mutable working tree 获取 expected snapshot/gamedata identity。
+- cancellation/failure 时只清理 runner temp，不修改 tracked state 或 persisted accepted state。
+
+## CLI And Library Design
+
+### Shared Inventory Comparison
+
+将 `verify_published_gamedata()` 中的 inventory equality 逻辑提取为共享、只读 library boundary，例如：
+
+```python
+def compare_gamedata_inventory(
+    *,
+    session: Mapping[str, object],
+    expected_files: Sequence[Mapping[str, object]],
+) -> GamedataInventoryDiff: ...
+```
+
+`GamedataInventoryDiff` 至少报告：
+
+- `added`：只存在于 expected head gamedata。
+- `missing`：candidate 要求但 expected head 缺失。
+- `modified`：path 相同但 size 或 SHA-256 不同。
+
+comparison 前必须调用现有 `guard_candidate()`，并确认：
+
+- `session.gamever == VALIDATION_GAMEVER`。
+- session candidate SHA-256 等于 actual symbol candidate。
+- session analysis config SHA-256 等于 head analysis config。
+- 当前 generator contract SHA-256 等于 session identity。
+
+### Read-Only PR Command
+
+为 `gamedata_candidate.py` 增加明确的 read-only command，例如：
+
+```powershell
+uv run gamedata_candidate.py verify-tracked `
+  -session "$env:GAMEDATA_SESSION" `
+  -gamever "$env:GAMEVER" `
+  -candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT" `
+  -configyaml "$env:HEAD_CONFIG" `
+  -repo-root "$env:WORKSPACE" `
+  -revision HEAD
+```
+
+命令语义：
+
+1. `guard_candidate(session)`。
+2. 验证 game version、candidate 和 config identity。
+3. 从 `revision` 读取 exact `gamedata/<GAMEVER>/` Git tree/blob bytes。
+4. 使用与 candidate session 相同的 canonical path、size 和 SHA-256 inventory schema。
+5. 运行 exact comparison，并输出 bounded path-level diagnostics。
+6. mismatch 返回非零；不创建、修改或删除任何 repository file。
+
+`-revision` 在 CI 中必须显式传入，不接受隐式 working-tree fallback。revision 必须解析为当前 checkout 的 exact
+commit；branch name、remote ref 或不确定 symbolic fallback 不应在 command 内自行推断。
+
+现有 `verify_published_gamedata()` 继续服务 release staging/promotion 的 filesystem destination verification，
+但应复用同一个 pure inventory comparison helper，避免普通 PR 与 release 产生两套 equality 语义。
+
+## Failure Reporting
+
+日志应保持有界，并优先输出 canonical path：
+
+```text
+Tracked gamedata mismatch for 14170:
+  Added in PR head:
+    gamedata/14170/.../Unexpected.json
+
+  Missing from PR head:
+    gamedata/14170/.../Required.json
+
+  Modified:
+    gamedata/14170/.../GameData.json
+      expected size/sha256: 1234 / abc...
+      candidate size/sha256: 1240 / def...
+```
+
+不得输出整个大文件、candidate session 中的本地绝对路径、runner secrets 或完整环境变量。
+
+## Concurrency And Release Interaction
+
+普通开发 PR 与 generated-output PR 可能修改同一 `GAMEVER` 路径。设计规则：
+
+- 两类 PR 都不得 force-push 已进入 review 的 generated-output branch。
+- generated-output PR 的 bytes 必须来自其 manifest 绑定的 immutable `SOURCE_SHA`。
+- 默认分支在 output build 后推进时，output PR 必须按照 release freshness contract 重新验证或重建。
+- generated-output conflict 不得通过手工挑选 snapshot/gamedata files 解决；必须废弃旧 build 并从新的默认分支
+  SHA 重新生成完整 transaction。
+- 普通 PR 提交 tracked outputs 不授予其 release manifest、staged bin、tag 或 Release authority。
+
+本计划不改变 release promotion state machine，但依赖 `new-release-workflow.md` 中的 exact-source freshness
+不变量。实现时必须保证 workflow、promotion code 和 tests 对“exact source”或“ancestor source”采用同一个明确
+契约；不得让两套语义长期并存。
+
+## Required Changes
+
+- Modify: `gamedata_candidate.py`
+  - 提取共享 inventory comparison helper。
+  - 增加 read-only `verify-tracked` command。
+  - 从 exact Git revision 读取 versioned gamedata blob inventory。
+  - 保持现有 `publish` 的 atomic destination semantics 不变。
+- Modify: `.github/workflows/pr-self-runner.yml`
+  - 在 isolated gamedata candidate guard 后增加 head tracked-gamedata comparison。
+  - comparison 成功后再 mark `gamedata` validation step。
+  - 保持 read-only permissions 和 no-publish contract。
+- Modify: `tests/test_gamedata_candidate.py`
+  - 覆盖 exact/add/missing/modified inventory、identity mismatch、Git tree mode/path safety 和 no-working-tree fallback。
+- Modify: `tests/test_pr_self_runner_workflow.py`
+  - 强制 analyzer -> symbol compare -> gamedata build/guard -> tracked compare -> C++ ordering。
+  - 强制普通 PR 不调用 publish，不增加 write permissions。
+- Modify: `tests/test_symbol_store_architecture.py`
+  - 保留 `/create-pr` 对 prepare -> validation -> publish 的 ownership。
+  - 固化 snapshot 与 gamedata 都由同一 validated post-change transaction 发布。
+- Modify after implementation: `README.md` / `README_CN.md`
+  - 记录普通 output-affecting PR 必须提交匹配 snapshot 与 gamedata。
+  - 记录 CI 只读比较且不会自动修复遗漏。
+
+## Test Plan
+
+### Inventory Comparison Tests
+
+- candidate 与 Git head inventory 完全相同时成功。
+- added、missing、modified path 分别失败。
+- path 相同但 raw-byte size 不同失败。
+- path 和 size 相同但 SHA-256 不同失败。
+- inventory ordering 不影响 comparison 结果。
+- duplicate/case-colliding canonical path 被拒绝。
+- expected root 缺失或 candidate root 缺失时 fail closed。
+
+### Session Identity Tests
+
+- wrong `GAMEVER` 失败。
+- symbol candidate SHA-256 改变后失败。
+- head config SHA-256 与 session 不一致时失败。
+- generator contract 在 gamedata build 后改变时失败。
+- gamedata candidate bytes 在 build 后改变时失败。
+
+### Git Object Boundary Tests
+
+- command 从 explicit revision 读取 blobs，不读取 mutable working-tree expected files。
+- 修改 working-tree gamedata 不能改变 HEAD comparison 结果。
+- revision 中的 symlink、submodule 和 non-blob entries 被拒绝。
+- root escape、backslash、absolute path 和 invalid game version 被拒绝。
+- blob bytes 按原始内容 hash，不受 checkout line-ending 设置影响。
+
+### Workflow Contract Tests
+
+- PR workflow 在 actual symbol compare 后构建 gamedata candidate。
+- tracked gamedata comparison 发生在 gamedata guard 后、C++ tests 前。
+- comparison 使用 `ACTUAL_CANDIDATE_SNAPSHOT`、`GAMEDATA_SESSION`、`HEAD_CONFIG` 和 explicit `HEAD` revision。
+- comparison mismatch 阻止 `gamedata` mark 和 C++ validation。
+- workflow 权限仍精确为 `contents: read`。
+- workflow 中不存在 symbol/gamedata publish、git commit/push 或 PR mutation command。
+- bump-download 与 generated-output PR 保持现有 event partition。
+
+### End-To-End Tests
+
+- 本地 prepare/validate/publish 后，普通 PR comparison 对 snapshot 和 gamedata 同时通过。
+- 只回退一个 tracked gamedata 文件时 snapshot compare 仍通过，但 gamedata compare 必须失败。
+- 只修改 gamedata generator 且忘记发布 output 时必须失败。
+- output-neutral PR 在 tracked outputs 已一致时无需产生 generated diff。
+- new-version bump PR 继续验证 base `VALIDATION_GAMEVER`，不要求 head 新版本 output。
+
+## Rollout Plan
+
+1. 实现 pure inventory comparison 与 Git revision inventory reader，并完成 unit/path-safety tests。
+2. 增加 `verify-tracked` CLI，但暂不接入 required PR workflow。
+3. 对当前 accepted `GAMEVER` 在 clean checkout 上运行 read-only comparison，确认 tracked gamedata baseline 是否一致。
+4. 如 baseline 不一致，使用完整 prepare -> validation -> publish transaction 创建一次修复 PR；不得手工同步文件。
+5. 将 comparison 接入 `pr-self-runner.yml`，补 workflow contract tests。
+6. 更新 README/README_CN，并将新 check 设为 ordinary PR required gate。
+7. 观察同版本 ordinary PR 与 generated-output PR 的冲突；确认 release exact-source freshness gate 与文档一致。
+
+## Acceptance Criteria
+
+- output-affecting 普通 PR 在实际 symbol bytes 变化时必须提交匹配 snapshot。
+- output-affecting 普通 PR 在实际 gamedata bytes 变化时必须提交匹配 versioned gamedata。
+- PR head snapshot 与 actual symbol candidate 不一致时 CI 失败。
+- PR head gamedata inventory 与 guarded gamedata candidate 不一致时 CI 失败。
+- gamedata comparison 绑定同一 game version、symbol candidate、analysis config 和 generator contract。
+- expected gamedata 从 explicit PR head Git revision 读取，不依赖 mutable working tree。
+- 普通 PR CI 保持 read-only，不 publish、stage、commit、push 或修改 PR。
+- mismatch diagnostics 至少区分 added、missing 和 modified canonical paths。
+- output-neutral PR 在 bytes 不变时不需要 generated-output diff。
+- 新 game version bump 继续由 post-merge release build 负责。
+- generated-output PR 继续独占 release manifest、staging、promotion、tag 和 Release authority。
+- ordinary PR 与 generated-output PR 发生 source freshness 冲突时必须重建完整 output transaction，不手工拼接产物。
+
+## Final Architecture
+
+```text
+Developer transaction
+---------------------
+analysis
+  -> immutable symbol candidate
+  -> guarded gamedata candidate
+  -> C++ validation
+  -> publish same transaction
+       -> gamesymbols/<GAMEVER>.yaml
+       -> gamedata/<GAMEVER>/
+  -> commit code + expected outputs in one PR
+
+Ordinary PR verification
+------------------------
+PR code + trusted base
+  -> actual symbol candidate
+       -> compare PR head snapshot Git blob
+       -> build guarded gamedata candidate
+            -> compare PR head gamedata Git blobs
+       -> C++ validation
+  -> complete without publish
+
+Release transaction
+-------------------
+immutable SOURCE_SHA
+  -> full candidate validation
+  -> generated-output PR + manifest + staged bin
+  -> merge/promotion gate
+  -> tag and GitHub Release
+```
+
+最终语义：普通开发 PR 负责同时声明并证明当前 source 对应的 expected snapshot 与 expected gamedata；普通 PR
+CI 只重建和比较，不写入。generated-output PR 则继续负责将特定 immutable `SOURCE_SHA` 的完整 release
+transaction 接受并提升为正式发布状态。

--- a/gamedata_candidate.py
+++ b/gamedata_candidate.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
+import subprocess
 import uuid
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
 
 from gamedata_contract import (
@@ -15,7 +19,15 @@ from gamedata_contract import (
     validate_output_tree,
 )
 from gamesymbol_store import SymbolStoreError
-from release_workflow_lib.hashing import load_json_object, sha256_file, write_canonical_json
+from release_workflow_lib.errors import ReleaseWorkflowError
+from release_workflow_lib.hashing import (
+    REGULAR_GIT_MODES,
+    load_json_object,
+    normalized_relative_path,
+    sha256_bytes,
+    sha256_file,
+    write_canonical_json,
+)
 from update_gamedata import generate_gamedata
 
 SESSION_FIELDS = {
@@ -33,10 +45,53 @@ SESSION_FIELDS = {
     "gamedata_manifest_sha256",
     "files",
 }
+GAMEVER_RE = re.compile(r"^[0-9]{4,10}[a-z]?$", re.ASCII)
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.ASCII)
+MAX_DIAGNOSTIC_PATHS = 20
 
 
 class GamedataCandidateError(ValueError):
     pass
+
+
+@dataclass(frozen=True)
+class GamedataInventoryModification:
+    path: str
+    expected_size: int
+    expected_sha256: str
+    candidate_size: int
+    candidate_sha256: str
+
+
+@dataclass(frozen=True)
+class GamedataInventoryDiff:
+    added: tuple[str, ...]
+    missing: tuple[str, ...]
+    modified: tuple[GamedataInventoryModification, ...]
+
+    @property
+    def matches(self) -> bool:
+        return not (self.added or self.missing or self.modified)
+
+
+def _validated_gamever(gamever: str) -> str:
+    if not isinstance(gamever, str) or not GAMEVER_RE.fullmatch(gamever):
+        raise GamedataCandidateError(f"invalid GAMEVER: {gamever!r}")
+    return gamever
+
+
+def _canonical_inventory_path(value: object) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise GamedataCandidateError(f"path must be a non-empty POSIX relative path: {value!r}")
+    if value.startswith("/") or any(part in {"", ".", ".."} for part in value.split("/")):
+        raise GamedataCandidateError(f"unsafe relative path: {value!r}")
+    try:
+        normalized = normalized_relative_path(value)
+    except ReleaseWorkflowError as exc:
+        raise GamedataCandidateError(str(exc)) from exc
+    if normalized != value:
+        raise GamedataCandidateError(f"inventory path is not canonical: {value!r}")
+    return normalized
 
 
 def _absolute_file(path: str | Path, label: str) -> Path:
@@ -65,6 +120,7 @@ def build_candidate(
     platforms: list[str] | None = None,
     debug: bool = False,
 ) -> dict:
+    gamever = _validated_gamever(gamever)
     snapshot = _absolute_file(snapshot, "symbol candidate")
     analysis_config = _absolute_file(analysis_config, "analysis config")
     modules_dir = Path(modules_dir).resolve()
@@ -105,7 +161,9 @@ def build_candidate(
 
 def guard_candidate(session_path: str | Path) -> dict:
     session = _load_session(session_path)
-    gamever = session["gamever"]
+    gamever = _validated_gamever(session["gamever"])
+    if session["gamedata_path"] != f"gamedata/{gamever}":
+        raise GamedataCandidateError("gamedata candidate session has an invalid versioned output path")
     snapshot = _absolute_file(session["snapshot_path"], "symbol candidate")
     analysis_config = _absolute_file(session["analysis_config_path"], "analysis config")
     if sha256_file(snapshot) != session["candidate_sha256"]:
@@ -122,18 +180,237 @@ def guard_candidate(session_path: str | Path) -> dict:
     return session
 
 
+def _inventory_by_path(
+    files: Sequence[Mapping[str, object]], *, gamever: str, label: str
+) -> dict[str, dict[str, object]]:
+    if not isinstance(files, Sequence) or isinstance(files, (str, bytes)) or not files:
+        raise GamedataCandidateError(f"{label} is missing or empty")
+    prefix = f"gamedata/{gamever}/"
+    by_path: dict[str, dict[str, object]] = {}
+    casefolded_paths: dict[str, str] = {}
+    for item in files:
+        if not isinstance(item, Mapping) or set(item) != {"path", "size", "sha256"}:
+            raise GamedataCandidateError(f"{label} has an invalid inventory record")
+        path = _canonical_inventory_path(item["path"])
+        if not path.startswith(prefix):
+            raise GamedataCandidateError(f"{label} path is outside exact root {prefix}: {path}")
+        size = item["size"]
+        digest = item["sha256"]
+        if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+            raise GamedataCandidateError(f"{label} has an invalid size for {path}")
+        if not isinstance(digest, str) or not SHA256_RE.fullmatch(digest):
+            raise GamedataCandidateError(f"{label} has an invalid SHA-256 for {path}")
+        if path in by_path:
+            raise GamedataCandidateError(f"{label} has a duplicate path: {path}")
+        folded = path.casefold()
+        if folded in casefolded_paths:
+            raise GamedataCandidateError(
+                f"{label} has a case-insensitive path collision: {casefolded_paths[folded]} and {path}"
+            )
+        record = {"path": path, "size": size, "sha256": digest}
+        by_path[path] = record
+        casefolded_paths[folded] = path
+    return by_path
+
+
+def compare_gamedata_inventory(
+    *, session: Mapping[str, object], expected_files: Sequence[Mapping[str, object]]
+) -> GamedataInventoryDiff:
+    gamever = _validated_gamever(session.get("gamever"))
+    candidate_files = session.get("files")
+    candidate = _inventory_by_path(candidate_files, gamever=gamever, label="candidate gamedata inventory")
+    expected = _inventory_by_path(expected_files, gamever=gamever, label="expected gamedata inventory")
+    candidate_paths = set(candidate)
+    expected_paths = set(expected)
+    modified = []
+    for path in sorted(candidate_paths & expected_paths):
+        candidate_record = candidate[path]
+        expected_record = expected[path]
+        if (candidate_record["size"], candidate_record["sha256"]) != (
+            expected_record["size"],
+            expected_record["sha256"],
+        ):
+            modified.append(
+                GamedataInventoryModification(
+                    path=path,
+                    expected_size=expected_record["size"],
+                    expected_sha256=expected_record["sha256"],
+                    candidate_size=candidate_record["size"],
+                    candidate_sha256=candidate_record["sha256"],
+                )
+            )
+    return GamedataInventoryDiff(
+        added=tuple(sorted(expected_paths - candidate_paths)),
+        missing=tuple(sorted(candidate_paths - expected_paths)),
+        modified=tuple(modified),
+    )
+
+
+def _git_bytes(repo_root: Path, arguments: list[str]) -> bytes:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), *arguments],
+            capture_output=True,
+            check=False,
+        )
+    except OSError as exc:
+        raise GamedataCandidateError(f"unable to run git: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise GamedataCandidateError(detail or f"git {' '.join(arguments)} failed")
+    return result.stdout
+
+
+def _resolved_checkout_revision(repo_root: Path, revision: str) -> str:
+    if not isinstance(revision, str) or not revision or "\0" in revision:
+        raise GamedataCandidateError("an explicit Git revision is required")
+    if revision != "HEAD" and not re.fullmatch(r"[0-9a-fA-F]{40}", revision):
+        raise GamedataCandidateError("Git revision must be explicit HEAD or a full commit SHA")
+    resolved = (
+        _git_bytes(repo_root, ["rev-parse", "--verify", "--end-of-options", f"{revision}^{{commit}}"])
+        .decode("ascii", errors="strict")
+        .strip()
+    )
+    checkout = (
+        _git_bytes(repo_root, ["rev-parse", "--verify", "HEAD^{commit}"]).decode("ascii", errors="strict").strip()
+    )
+    if not re.fullmatch(r"[0-9a-fA-F]{40}", resolved) or not re.fullmatch(r"[0-9a-fA-F]{40}", checkout):
+        raise GamedataCandidateError("Git revision did not resolve to a full commit SHA")
+    if resolved.lower() != checkout.lower():
+        raise GamedataCandidateError("explicit Git revision does not match the current checkout commit")
+    return resolved.lower()
+
+
+def git_revision_gamedata_inventory(repo_root: str | Path, revision: str, gamever: str) -> list[dict]:
+    repo_root = Path(repo_root).resolve()
+    if not repo_root.is_dir():
+        raise GamedataCandidateError(f"repository root is missing: {repo_root}")
+    gamever = _validated_gamever(gamever)
+    resolved = _resolved_checkout_revision(repo_root, revision)
+    root = f"gamedata/{gamever}"
+    prefix = root + "/"
+    raw_entries = _git_bytes(repo_root, ["ls-tree", "-r", "-z", "--full-tree", resolved, "--", root])
+    objects: list[tuple[str, str]] = []
+    seen_paths: set[str] = set()
+    casefolded_paths: dict[str, str] = {}
+    for record in raw_entries.split(b"\0"):
+        if not record:
+            continue
+        try:
+            metadata, raw_path = record.split(b"\t", 1)
+            mode, object_type, object_id = metadata.decode("ascii").split()
+            path_text = raw_path.decode("utf-8")
+        except (UnicodeError, ValueError) as exc:
+            raise GamedataCandidateError("tracked gamedata has a malformed Git tree entry") from exc
+        if object_type != "blob":
+            raise GamedataCandidateError(f"tracked gamedata has a non-blob Git tree entry: {path_text}")
+        if mode not in REGULAR_GIT_MODES:
+            raise GamedataCandidateError(f"tracked gamedata has an unsupported Git tree entry: {path_text}")
+        if not re.fullmatch(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}", object_id):
+            raise GamedataCandidateError(f"tracked gamedata has an invalid Git object ID: {path_text}")
+        if not path_text.startswith(prefix):
+            raise GamedataCandidateError(f"tracked gamedata path is outside exact root {root}: {path_text}")
+        path = _canonical_inventory_path(path_text)
+        if path in seen_paths:
+            raise GamedataCandidateError(f"tracked gamedata has a duplicate path: {path}")
+        folded = path.casefold()
+        if folded in casefolded_paths:
+            raise GamedataCandidateError(
+                f"tracked gamedata has a case-insensitive path collision: {casefolded_paths[folded]} and {path}"
+            )
+        seen_paths.add(path)
+        casefolded_paths[folded] = path
+        objects.append((path, object_id))
+    if not objects:
+        raise GamedataCandidateError(f"tracked gamedata root is missing or empty at revision {resolved}: {root}")
+    inventory = []
+    for path, object_id in objects:
+        blob = _git_bytes(repo_root, ["cat-file", "blob", object_id])
+        inventory.append({"path": path, "size": len(blob), "sha256": sha256_bytes(blob)})
+    return sorted(inventory, key=lambda item: item["path"])
+
+
+def _guard_session_identity(
+    *, session_path: str | Path, gamever: str, candidate: str | Path, analysis_config: str | Path
+) -> dict:
+    gamever = _validated_gamever(gamever)
+    session = guard_candidate(session_path)
+    candidate = _absolute_file(candidate, "release candidate")
+    analysis_config = _absolute_file(analysis_config, "analysis config")
+    if session["gamever"] != gamever or session["candidate_sha256"] != sha256_file(candidate):
+        raise GamedataCandidateError("gamedata session does not match the release candidate")
+    if session["analysis_config_sha256"] != sha256_file(analysis_config):
+        raise GamedataCandidateError("gamedata session does not match the analysis config")
+    return session
+
+
+def _bounded_inventory_diagnostics(gamever: str, diff: GamedataInventoryDiff) -> str:
+    lines = [f"Tracked gamedata mismatch for {gamever}:"]
+
+    def add_paths(title: str, paths: tuple[str, ...]) -> None:
+        if not paths:
+            return
+        lines.append(f"  {title}:")
+        lines.extend(f"    {path}" for path in paths[:MAX_DIAGNOSTIC_PATHS])
+        if len(paths) > MAX_DIAGNOSTIC_PATHS:
+            lines.append(f"    ... {len(paths) - MAX_DIAGNOSTIC_PATHS} more")
+
+    add_paths("Added in PR head", diff.added)
+    add_paths("Missing from PR head", diff.missing)
+    if diff.modified:
+        lines.append("  Modified:")
+        for item in diff.modified[:MAX_DIAGNOSTIC_PATHS]:
+            lines.extend(
+                (
+                    f"    {item.path}",
+                    f"      expected size/sha256: {item.expected_size} / {item.expected_sha256}",
+                    f"      candidate size/sha256: {item.candidate_size} / {item.candidate_sha256}",
+                )
+            )
+        if len(diff.modified) > MAX_DIAGNOSTIC_PATHS:
+            lines.append(f"    ... {len(diff.modified) - MAX_DIAGNOSTIC_PATHS} more")
+    return "\n".join(lines)
+
+
 def verify_published_gamedata(
     *, session_path: str | Path, repo_root: str | Path, gamever: str, candidate: str | Path, analysis_config: str | Path
 ) -> dict:
-    session = guard_candidate(session_path)
-    if session["gamever"] != gamever or session["candidate_sha256"] != sha256_file(Path(candidate)):
-        raise GamedataCandidateError("gamedata session does not match the release candidate")
-    if session["analysis_config_sha256"] != sha256_file(Path(analysis_config)):
-        raise GamedataCandidateError("gamedata session does not match the analysis config")
+    session = _guard_session_identity(
+        session_path=session_path,
+        gamever=gamever,
+        candidate=candidate,
+        analysis_config=analysis_config,
+    )
     target = Path(repo_root) / "gamedata" / gamever
     files = prefixed_output_inventory(target, gamever)
-    if files != session["files"]:
+    if not compare_gamedata_inventory(session=session, expected_files=files).matches:
         raise GamedataCandidateError("published gamedata differs from the guarded candidate")
+    return {
+        "gamedata_path": session["gamedata_path"],
+        "gamedata_manifest_sha256": session["gamedata_manifest_sha256"],
+        "generator_contract_sha256": session["generator_contract_sha256"],
+    }
+
+
+def verify_tracked_gamedata(
+    *,
+    session_path: str | Path,
+    repo_root: str | Path,
+    revision: str,
+    gamever: str,
+    candidate: str | Path,
+    analysis_config: str | Path,
+) -> dict:
+    session = _guard_session_identity(
+        session_path=session_path,
+        gamever=gamever,
+        candidate=candidate,
+        analysis_config=analysis_config,
+    )
+    expected_files = git_revision_gamedata_inventory(repo_root, revision, gamever)
+    diff = compare_gamedata_inventory(session=session, expected_files=expected_files)
+    if not diff.matches:
+        raise GamedataCandidateError(_bounded_inventory_diagnostics(gamever, diff))
     return {
         "gamedata_path": session["gamedata_path"],
         "gamedata_manifest_sha256": session["gamedata_manifest_sha256"],
@@ -174,7 +451,7 @@ def publish_candidate(*, session_path: str | Path, output_dir: str | Path) -> di
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Build and publish immutable versioned gamedata candidates")
+    parser = argparse.ArgumentParser(description="Build, verify, and publish immutable versioned gamedata candidates")
     commands = parser.add_subparsers(dest="command", required=True)
     build = commands.add_parser("build")
     build.add_argument("-gamever", required=True)
@@ -188,6 +465,13 @@ def _parser() -> argparse.ArgumentParser:
     build.add_argument("-debug", action="store_true")
     guard = commands.add_parser("guard")
     guard.add_argument("-session", required=True)
+    verify_tracked = commands.add_parser("verify-tracked")
+    verify_tracked.add_argument("-session", required=True)
+    verify_tracked.add_argument("-gamever", required=True)
+    verify_tracked.add_argument("-candidate", required=True)
+    verify_tracked.add_argument("-configyaml", required=True)
+    verify_tracked.add_argument("-repo-root", required=True)
+    verify_tracked.add_argument("-revision", required=True)
     publish = commands.add_parser("publish")
     publish.add_argument("-session", required=True)
     publish.add_argument("-outputdir", required=True)
@@ -211,9 +495,25 @@ def main(argv=None) -> int:
             )
         elif args.command == "guard":
             guard_candidate(args.session)
+        elif args.command == "verify-tracked":
+            verify_tracked_gamedata(
+                session_path=args.session,
+                repo_root=args.repo_root,
+                revision=args.revision,
+                gamever=args.gamever,
+                candidate=args.candidate,
+                analysis_config=args.configyaml,
+            )
         else:
             publish_candidate(session_path=args.session, output_dir=args.outputdir)
-    except (GamedataCandidateError, GamedataContractError, SymbolStoreError, OSError, ValueError) as exc:
+    except (
+        GamedataCandidateError,
+        GamedataContractError,
+        ReleaseWorkflowError,
+        SymbolStoreError,
+        OSError,
+        ValueError,
+    ) as exc:
         print(f"Error: {exc}")
         return 1
     return 0

--- a/release_workflow_lib/promotion.py
+++ b/release_workflow_lib/promotion.py
@@ -62,16 +62,6 @@ def _git_output(arguments: list[str]) -> str:
     return result.stdout.strip()
 
 
-def _git_is_ancestor(ancestor: str, descendant: str) -> bool:
-    arguments = ["merge-base", "--is-ancestor", ancestor, descendant]
-    result = subprocess.run(["git", *arguments], capture_output=True, text=True, check=False)
-    if result.returncode == 0:
-        return True
-    if result.returncode == 1:
-        return False
-    raise ReleaseWorkflowError(result.stderr.strip() or f"git {' '.join(arguments)} failed")
-
-
 def verify_output_pr(
     *,
     repo_root: Path,
@@ -138,8 +128,8 @@ def verify_promotion(
     head_parents = _git_output(["rev-list", "--parents", "-n", "1", event_head_sha]).split()
     if len(head_parents) != 2 or head_parents[1] != pending["source_sha"]:
         raise ReleaseWorkflowError("generated-output commit is not directly based on SOURCE_SHA")
-    if not _git_is_ancestor(pending["source_sha"], base_parent_sha):
-        raise ReleaseWorkflowError("SOURCE_SHA is not an ancestor of the merge first parent")
+    if base_parent_sha != pending["source_sha"]:
+        raise ReleaseWorkflowError("merge first parent must exactly match SOURCE_SHA")
     paths = [
         line for line in _git_output(["diff", "--name-only", base_parent_sha, merge_sha, "--"]).splitlines() if line
     ]

--- a/tests/test_gamedata_candidate.py
+++ b/tests/test_gamedata_candidate.py
@@ -1,16 +1,23 @@
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from gamedata_candidate import (
     GamedataCandidateError,
     build_candidate,
+    compare_gamedata_inventory,
+    git_revision_gamedata_inventory,
     guard_candidate,
+    main,
     publish_candidate,
+    verify_tracked_gamedata,
 )
 from gamedata_contract import GamedataContractError, discover_generator_modules
 from gamesymbol_snapshot_lib.codec import build_snapshot_document, canonical_snapshot_bytes
 from gamesymbol_snapshot_lib.config import load_contract
+from release_workflow_lib.hashing import sha256_bytes
 
 
 GENERATOR_SOURCE = """
@@ -60,8 +67,105 @@ class GamedataCandidateFixture:
             session_path=self.session,
         )
 
+    def init_repo(self) -> Path:
+        repo = self.root / "repo"
+        repo.mkdir()
+        self.git(repo, "init", "-b", "main")
+        self.git(repo, "config", "user.email", "tests@example.com")
+        self.git(repo, "config", "user.name", "Tests")
+        return repo
+
+    def publish_and_commit(self, repo: Path) -> Path:
+        publish_candidate(
+            session_path=self.session,
+            output_dir=repo / "gamedata" / self.gamever,
+        )
+        self.git(repo, "add", "gamedata")
+        self.git(repo, "commit", "-m", "tracked gamedata")
+        return repo / "gamedata" / self.gamever / "fixture" / "payload" / "final.json"
+
+    @staticmethod
+    def git(repo: Path, *arguments: str) -> str:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def verify_tracked(
+        self,
+        repo: Path,
+        *,
+        gamever: str | None = None,
+        candidate: Path | None = None,
+        analysis_config: Path | None = None,
+    ) -> dict:
+        return verify_tracked_gamedata(
+            session_path=self.session,
+            repo_root=repo,
+            revision="HEAD",
+            gamever=gamever or self.gamever,
+            candidate=candidate or self.snapshot,
+            analysis_config=analysis_config or self.config,
+        )
+
 
 class TestGamedataCandidate(unittest.TestCase):
+    def test_inventory_comparison_is_order_independent_and_reports_path_level_diff(self) -> None:
+        candidate_files = [
+            {"path": "gamedata/14170/a.txt", "size": 1, "sha256": "a" * 64},
+            {"path": "gamedata/14170/b.txt", "size": 2, "sha256": "b" * 64},
+        ]
+        expected_files = [
+            {"path": "gamedata/14170/c.txt", "size": 3, "sha256": "c" * 64},
+            {"path": "gamedata/14170/b.txt", "size": 2, "sha256": "d" * 64},
+        ]
+
+        diff = compare_gamedata_inventory(
+            session={"gamever": "14170", "files": list(reversed(candidate_files))},
+            expected_files=list(reversed(expected_files)),
+        )
+
+        self.assertEqual(("gamedata/14170/c.txt",), diff.added)
+        self.assertEqual(("gamedata/14170/a.txt",), diff.missing)
+        self.assertEqual(("gamedata/14170/b.txt",), tuple(item.path for item in diff.modified))
+        self.assertFalse(diff.matches)
+        self.assertTrue(
+            compare_gamedata_inventory(
+                session={"gamever": "14170", "files": candidate_files},
+                expected_files=list(reversed(candidate_files)),
+            ).matches
+        )
+
+    def test_inventory_comparison_rejects_duplicate_case_colliding_and_unsafe_paths(self) -> None:
+        candidate = {"gamever": "14170", "files": [{"path": "gamedata/14170/a.txt", "size": 1, "sha256": "a" * 64}]}
+        invalid_expected = (
+            (
+                "duplicate",
+                [
+                    {"path": "gamedata/14170/a.txt", "size": 1, "sha256": "a" * 64},
+                    {"path": "gamedata/14170/a.txt", "size": 1, "sha256": "a" * 64},
+                ],
+            ),
+            (
+                "case-insensitive path collision",
+                [
+                    {"path": "gamedata/14170/A.txt", "size": 1, "sha256": "a" * 64},
+                    {"path": "gamedata/14170/a.txt", "size": 1, "sha256": "a" * 64},
+                ],
+            ),
+            ("unsafe relative path", [{"path": "gamedata/14170/../a.txt", "size": 1, "sha256": "a" * 64}]),
+            ("unsafe relative path", [{"path": "gamedata/14170//a.txt", "size": 1, "sha256": "a" * 64}]),
+        )
+
+        for expected_error, files in invalid_expected:
+            with self.subTest(expected_error=expected_error):
+                with self.assertRaisesRegex(GamedataCandidateError, expected_error):
+                    compare_gamedata_inventory(session=candidate, expected_files=files)
+
     def test_build_guard_and_publish_keep_versions_isolated(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             fixture = GamedataCandidateFixture(Path(tmp))
@@ -97,6 +201,166 @@ class TestGamedataCandidate(unittest.TestCase):
 
             with self.assertRaisesRegex(GamedataCandidateError, "bytes changed"):
                 guard_candidate(fixture.session)
+
+    def test_verify_tracked_reads_explicit_revision_instead_of_working_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GamedataCandidateFixture(Path(tmp))
+            fixture.build()
+            repo = fixture.init_repo()
+            tracked = fixture.publish_and_commit(repo)
+            tracked.write_text("mutable working tree\n", encoding="utf-8")
+
+            result = fixture.verify_tracked(repo)
+
+            self.assertEqual("gamedata/14170", result["gamedata_path"])
+            self.assertEqual(
+                0,
+                main(
+                    [
+                        "verify-tracked",
+                        "-session",
+                        str(fixture.session),
+                        "-gamever",
+                        fixture.gamever,
+                        "-candidate",
+                        str(fixture.snapshot),
+                        "-configyaml",
+                        str(fixture.config),
+                        "-repo-root",
+                        str(repo),
+                        "-revision",
+                        "HEAD",
+                    ]
+                ),
+            )
+
+    def test_verify_tracked_reports_added_missing_and_modified_paths(self) -> None:
+        cases = ("added", "missing", "modified-size", "modified-sha256")
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as tmp:
+                fixture = GamedataCandidateFixture(Path(tmp))
+                fixture.build()
+                repo = fixture.init_repo()
+                tracked = fixture.publish_and_commit(repo)
+                if case == "added":
+                    added = tracked.with_name("unexpected.txt")
+                    added.write_text("unexpected\n", encoding="utf-8")
+                    expected_error = "Added in PR head"
+                elif case == "missing":
+                    tracked.unlink()
+                    tracked.with_name("unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+                    expected_error = "Missing from PR head"
+                elif case == "modified-size":
+                    tracked.write_text("different length\n", encoding="utf-8")
+                    expected_error = "Modified"
+                else:
+                    original = tracked.read_bytes()
+                    tracked.write_bytes(b"x" * len(original))
+                    expected_error = "Modified"
+                fixture.git(repo, "add", "-A", "gamedata")
+                fixture.git(repo, "commit", "-m", case)
+
+                with self.assertRaisesRegex(GamedataCandidateError, expected_error):
+                    fixture.verify_tracked(repo)
+
+    def test_verify_tracked_rejects_session_identity_drift(self) -> None:
+        cases = ("gamever", "invalid-gamever", "candidate", "head-config", "session-candidate", "generator")
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as tmp:
+                fixture = GamedataCandidateFixture(Path(tmp))
+                fixture.build()
+                repo = fixture.init_repo()
+                fixture.publish_and_commit(repo)
+                gamever = fixture.gamever
+                candidate = fixture.snapshot
+                analysis_config = fixture.config
+                expected_error = "release candidate"
+                if case == "gamever":
+                    gamever = "14171"
+                elif case == "invalid-gamever":
+                    gamever = "../14170"
+                    expected_error = "invalid GAMEVER"
+                elif case == "candidate":
+                    candidate = fixture.root / "other-candidate.yaml"
+                    candidate.write_bytes(fixture.snapshot.read_bytes() + b"\n")
+                elif case == "head-config":
+                    analysis_config = fixture.root / "other-config.yaml"
+                    analysis_config.write_text("modules: [changed]\n", encoding="utf-8")
+                    expected_error = "does not match the analysis config"
+                elif case == "session-candidate":
+                    fixture.snapshot.write_bytes(fixture.snapshot.read_bytes() + b"\n")
+                    expected_error = "symbol candidate changed"
+                else:
+                    generator = fixture.modules / "fixture" / "gamedata.py"
+                    generator.write_text(generator.read_text(encoding="utf-8") + "\n# changed\n", encoding="utf-8")
+                    expected_error = "generator contract changed"
+
+                with self.assertRaisesRegex(GamedataCandidateError, expected_error):
+                    fixture.verify_tracked(
+                        repo,
+                        gamever=gamever,
+                        candidate=candidate,
+                        analysis_config=analysis_config,
+                    )
+
+    def test_git_revision_inventory_rejects_unsupported_modes_and_unsafe_paths(self) -> None:
+        object_id = b"a" * 40
+        cases = {
+            "unsupported Git tree entry": b"120000 blob " + object_id + b"\tgamedata/14170/link\0",
+            "non-blob Git tree entry": b"160000 commit " + object_id + b"\tgamedata/14170/submodule\0",
+            "non-empty POSIX relative path": b"100644 blob " + object_id + b"\tgamedata/14170/bad\\name.txt\0",
+            "unsafe relative path": b"100644 blob " + object_id + b"\tgamedata/14170/../escape.txt\0",
+            "outside exact root": b"100644 blob " + object_id + b"\t/gamedata/14170/file.txt\0",
+            "case-insensitive path collision": (
+                b"100644 blob " + object_id + b"\tgamedata/14170/A.txt\0"
+                b"100644 blob " + object_id + b"\tgamedata/14170/a.txt\0"
+            ),
+        }
+        commit = b"1" * 40 + b"\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            for expected_error, tree in cases.items():
+                with self.subTest(expected_error=expected_error):
+                    with patch("gamedata_candidate._git_bytes", side_effect=[commit, commit, tree]):
+                        with self.assertRaisesRegex(GamedataCandidateError, expected_error):
+                            git_revision_gamedata_inventory(repo, "HEAD", "14170")
+
+    def test_git_revision_inventory_requires_root_and_hashes_raw_blob_bytes(self) -> None:
+        commit = b"1" * 40 + b"\n"
+        object_id = b"a" * 40
+        tree = b"100644 blob " + object_id + b"\tgamedata/14170/file.txt\0"
+        blob = b"line one\r\nline two\r\n"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            with patch("gamedata_candidate._git_bytes", side_effect=[commit, commit, b""]):
+                with self.assertRaisesRegex(GamedataCandidateError, "missing or empty"):
+                    git_revision_gamedata_inventory(repo, "HEAD", "14170")
+            with patch("gamedata_candidate._git_bytes", side_effect=[commit, commit, tree, blob]):
+                inventory = git_revision_gamedata_inventory(repo, "HEAD", "14170")
+
+        self.assertEqual(
+            [{"path": "gamedata/14170/file.txt", "size": len(blob), "sha256": sha256_bytes(blob)}],
+            inventory,
+        )
+
+    def test_git_revision_inventory_requires_current_checkout_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            fixture = GamedataCandidateFixture(Path(tmp))
+            fixture.build()
+            repo = fixture.init_repo()
+            fixture.publish_and_commit(repo)
+            previous = fixture.git(repo, "rev-parse", "HEAD")
+            marker = repo / "marker.txt"
+            marker.write_text("advance checkout\n", encoding="utf-8")
+            fixture.git(repo, "add", "marker.txt")
+            fixture.git(repo, "commit", "-m", "advance checkout")
+
+            with self.assertRaisesRegex(GamedataCandidateError, "explicit HEAD or a full commit SHA"):
+                git_revision_gamedata_inventory(repo, "main", fixture.gamever)
+            with self.assertRaisesRegex(GamedataCandidateError, "does not match the current checkout"):
+                git_revision_gamedata_inventory(repo, previous, fixture.gamever)
 
     def test_contract_rejects_forbidden_and_undeclared_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_pr_self_runner_workflow.py
+++ b/tests/test_pr_self_runner_workflow.py
@@ -46,12 +46,31 @@ class TestPrSelfRunnerWorkflow(unittest.TestCase):
     def test_pr_validation_uses_one_candidate_and_never_publishes(self) -> None:
         self.assertIn("ACTUAL_CANDIDATE_SNAPSHOT=$candidate", self.steps["build-snapshot"]["run"])
         self.assertIn('-expected "$env:HEAD_SNAPSHOT"', self.steps["compare-snapshot"]["run"])
-        self.assertIn('-snapshot "$env:ACTUAL_CANDIDATE_SNAPSHOT"', self.steps["build-gamedata"]["run"])
+        gamedata = self.steps["build-gamedata"]["run"]
+        self.assertIn('-snapshot "$env:ACTUAL_CANDIDATE_SNAPSHOT"', gamedata)
+        self.assertIn("gamedata_candidate.py verify-tracked", gamedata)
+        self.assertIn('-session "$env:GAMEDATA_SESSION"', gamedata)
+        self.assertIn('-gamever "$env:GAMEVER"', gamedata)
+        self.assertIn('-candidate "$env:ACTUAL_CANDIDATE_SNAPSHOT"', gamedata)
+        self.assertIn('-configyaml "$env:HEAD_CONFIG"', gamedata)
+        self.assertIn('-repo-root "$env:WORKSPACE"', gamedata)
+        self.assertIn("-revision HEAD", gamedata)
+        self.assertIn("tracked gamedata verification failed", gamedata)
+        self.assertLess(
+            gamedata.index("gamedata_candidate.py guard"), gamedata.index("gamedata_candidate.py verify-tracked")
+        )
+        self.assertLess(
+            gamedata.index("gamedata_candidate.py verify-tracked"),
+            gamedata.index("gamesymbol_candidate.py mark"),
+        )
         self.assertIn('-snapshot "$env:ACTUAL_CANDIDATE_SNAPSHOT"', self.steps["cpp-tests"]["run"])
         commands = "\n".join(str(step.get("run", "")) for step in self.validate["steps"])
         self.assertNotIn("gamesymbol_candidate.py publish", commands)
         self.assertNotIn("gamedata_candidate.py publish", commands)
         self.assertNotIn("gh release", commands)
+        self.assertNotIn("git commit", commands)
+        self.assertNotIn("git push", commands)
+        self.assertNotIn("gh pr", commands)
 
     def test_baseline_bootstrap_has_explicit_contract_and_path_safety_gates(self) -> None:
         run = self.steps["restore-base"]["run"]

--- a/tests/test_release_workflow_guards.py
+++ b/tests/test_release_workflow_guards.py
@@ -332,13 +332,13 @@ class TestReleaseWorkflowGuards(unittest.TestCase):
                         head_sha=fixture.head_sha,
                     )
 
-    def test_promotion_allows_main_to_advance_after_output_build(self) -> None:
+    def test_promotion_requires_exact_source_as_merge_first_parent(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             fixture = ReleaseFixture(Path(tmp))
             fixture.stage()
             fixture.finalize_and_index()
             merge_sha = "4" * 40
-            base_parent_sha = "9" * 40
+            base_parent_sha = fixture.source_sha
             changed_paths = "\n".join(
                 [
                     f"gamesymbols/{fixture.gamever}.yaml",
@@ -346,16 +346,13 @@ class TestReleaseWorkflowGuards(unittest.TestCase):
                     f"release-manifests/{fixture.gamever}.json",
                 ]
             )
-            with (
-                patch(
-                    "release_workflow_lib.promotion._git_output",
-                    side_effect=[
-                        f"{merge_sha} {base_parent_sha} {fixture.head_sha}",
-                        f"{fixture.head_sha} {fixture.source_sha}",
-                        changed_paths,
-                    ],
-                ),
-                patch("release_workflow_lib.promotion._git_is_ancestor", return_value=True),
+            with patch(
+                "release_workflow_lib.promotion._git_output",
+                side_effect=[
+                    f"{merge_sha} {base_parent_sha} {fixture.head_sha}",
+                    f"{fixture.head_sha} {fixture.source_sha}",
+                    changed_paths,
+                ],
             ):
                 result = verify_promotion(
                     repo_root=fixture.repo,
@@ -373,24 +370,21 @@ class TestReleaseWorkflowGuards(unittest.TestCase):
 
             self.assertEqual(merge_sha, result["output_merge_sha"])
 
-    def test_promotion_rejects_source_outside_merge_base_history(self) -> None:
+    def test_promotion_rejects_default_branch_advancement_after_output_build(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             fixture = ReleaseFixture(Path(tmp))
             fixture.stage()
             fixture.finalize_and_index()
             merge_sha = "4" * 40
             base_parent_sha = "9" * 40
-            with (
-                patch(
-                    "release_workflow_lib.promotion._git_output",
-                    side_effect=[
-                        f"{merge_sha} {base_parent_sha} {fixture.head_sha}",
-                        f"{fixture.head_sha} {fixture.source_sha}",
-                    ],
-                ),
-                patch("release_workflow_lib.promotion._git_is_ancestor", return_value=False),
+            with patch(
+                "release_workflow_lib.promotion._git_output",
+                side_effect=[
+                    f"{merge_sha} {base_parent_sha} {fixture.head_sha}",
+                    f"{fixture.head_sha} {fixture.source_sha}",
+                ],
             ):
-                with self.assertRaisesRegex(ReleaseWorkflowError, "not an ancestor"):
+                with self.assertRaisesRegex(ReleaseWorkflowError, "exactly match SOURCE_SHA"):
                     verify_promotion(
                         repo_root=fixture.repo,
                         staging_root=fixture.staging,

--- a/tests/test_symbol_store_architecture.py
+++ b/tests/test_symbol_store_architecture.py
@@ -101,14 +101,22 @@ class TestSymbolStoreArchitecture(unittest.TestCase):
 
         self.assertIn("gamesymbol_candidate.py build", prepare)
         self.assertIn('gamedata_candidate.py build -gamever "$GAMEVER"', prepare)
+        self.assertIn('-snapshot "$CANDIDATE"', prepare)
+        self.assertIn('-session "$GAMEDATA_SESSION"', prepare)
         self.assertNotIn("gamesymbol_candidate.py publish", prepare)
         self.assertIn(
             'run_cpp_tests.py -gamever "$GAMEVER" -configyaml "$ANALYSIS_CONFIG" -snapshot "$CANDIDATE"',
             validation,
         )
-        self.assertIn("gamesymbol_candidate.py mark", validation)
+        self.assertIn(
+            'gamesymbol_candidate.py mark -candidate "$CANDIDATE" -session "$CANDIDATE_SESSION" -step cpp_tests',
+            validation,
+        )
         self.assertIn('gamedata_candidate.py publish -session "$GAMEDATA_SESSION"', publish)
-        self.assertIn("gamesymbol_candidate.py publish", publish)
+        self.assertIn(
+            'gamesymbol_candidate.py publish -candidate "$CANDIDATE" -session "$CANDIDATE_SESSION"',
+            publish,
+        )
         self.assertNotIn("gamesymbol_candidate.py build", publish)
         self.assertNotIn("gamesymbol_snapshot.py pack", publish)
 


### PR DESCRIPTION
## Summary
- add a read-only `verify-tracked` gamedata gate that compares the guarded candidate inventory with raw blobs from the explicit PR head Git revision
- enforce ordinary PR workflow ordering and exact `SOURCE_SHA` freshness during release promotion
- document the atomic snapshot/gamedata delivery contract and add Git object, identity, workflow, and architecture regression coverage

## Validation
- Python test suite: `1054/1054` passed with zero failures, errors, or skips
- formatter and Ruff checks: passed
- candidate preparation: passed for `14172` (`511c4e50dc0177d35af2d0bf95b848375c6ce250d53f4905a9cc4cb0e87f5cab`)
- tracked gamedata comparison: passed against explicit `HEAD`
- C++ post-change validation: 12 runnable tests, zero compile failures, invalid items, or layout differences
- candidate publication: passed; published snapshot SHA-256 matched the validated candidate and generated bytes were unchanged