### PR TITLE
feat(preprocessor): add Steam and world session finders

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: create-pr
+when_to_use: when user request to create a PR
 description: |
   Deliver already-staged repository changes through the full post-change candidate lifecycle and open a GitHub
   pull request. Use after implementation-specific tests pass and all task-related source/config/reference changes
   are explicitly staged. Prepares, validates, and publishes the immutable candidate; refreshes only the original
-  staged paths plus current-version generated outputs; commits on a dev branch; pushes; and creates the PR. Should be triggered when user request to create a PR.
+  staged paths plus current-version generated outputs; commits on a dev branch; pushes; and creates the PR.
 ---
 
 # Create Pull Request

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -1192,8 +1192,47 @@ modules:
           - INetworkMessages_FindNetworkGroup.{platform}.yaml
         expected_input:
           - CNetworkGameClient_RecordEntityBandwidth.{platform}.yaml
+      - name: find-InitSteam
+        expected_output:
+          - InitSteam.{platform}.yaml
+      - name: find-InitSteam-decompiles
+        expected_output:
+          - g_nSteamAppId.{platform}.yaml
+          - g_nBreakpadAppId.{platform}.yaml
+        expected_input:
+          - InitSteam.{platform}.yaml
+      - name: find-CRenderingWorldSession_FindOrCreateWorldSession
+        platform: windows
+        expected_output:
+          - CRenderingWorldSession_FindOrCreateWorldSession.{platform}.yaml
+      - name: find-CRenderingWorldSession_GetEntityLumpForTemplate
+        platform: windows
+        expected_output:
+          - CRenderingWorldSession_GetEntityLumpForTemplate.{platform}.yaml
       - name: find-CEngineClient_vtable
         expected_output:
+          - CEngineClient_vtable.{platform}.yaml
+      - name: find-CEngineClient_GetEntityLumpForTemplate
+        platform: windows
+        expected_output:
+          - CEngineClient_GetEntityLumpForTemplate.{platform}.yaml
+        expected_input:
+          - CRenderingWorldSession_GetEntityLumpForTemplate.{platform}.yaml
+          - CEngineClient_vtable.{platform}.yaml
+      - name: find-CEngineClient_FindOrCreateWorldSession
+        platform: windows
+        expected_output:
+          - CEngineClient_FindOrCreateWorldSession.{platform}.yaml
+        expected_input:
+          - CRenderingWorldSession_FindOrCreateWorldSession.{platform}.yaml
+          - CRenderingWorldSession_GetEntityLumpForTemplate.{platform}.yaml
+          - CEngineClient_vtable.{platform}.yaml
+      - name: find-CEngineClient_GetStatsAppID
+        platform: windows
+        expected_output:
+          - CEngineClient_GetStatsAppID.{platform}.yaml
+        expected_input:
+          - g_nBreakpadAppId.{platform}.yaml
           - CEngineClient_vtable.{platform}.yaml
       - name: find-CEngineClient_DumpNetStats
         expected_output:
@@ -2400,8 +2439,39 @@ modules:
         alias:
           - INetworkMessages::SetIsForServer
         shared: true
+      - name: InitSteam
+        category: func
+      - name: g_nSteamAppId
+        category: gv
+      - name: g_nBreakpadAppId
+        category: gv
+      - name: CRenderingWorldSession_FindOrCreateWorldSession
+        category: func
+        platform: windows
+        alias:
+          - CRenderingWorldSession::FindOrCreateWorldSession
+      - name: CRenderingWorldSession_GetEntityLumpForTemplate
+        category: func
+        platform: windows
+        alias:
+          - CRenderingWorldSession::GetEntityLumpForTemplate
       - name: CEngineClient_vtable
         category: vtable
+      - name: CEngineClient_GetEntityLumpForTemplate
+        category: vfunc
+        platform: windows
+        alias:
+          - CEngineClient::GetEntityLumpForTemplate
+      - name: CEngineClient_FindOrCreateWorldSession
+        category: vfunc
+        platform: windows
+        alias:
+          - CEngineClient::FindOrCreateWorldSession
+      - name: CEngineClient_GetStatsAppID
+        category: vfunc
+        platform: windows
+        alias:
+          - CEngineClient::GetStatsAppID
       - name: CEngineClient_DumpNetStats
         category: vfunc
         alias:

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -1,7 +1,7 @@
 analysis_output_contract_version: 1
 config_digest_version: 2
-config_sha256: sha256:463f28f98242d9dcdaac16bf99cfb4976711ed7ca43f00f8f04fadd5567c89ee
-file_count: 3104
+config_sha256: sha256:c4965d001f822c8299dccafa28e4e680d950374b9651dc188032f86bbff79826
+file_count: 3115
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -5399,6 +5399,32 @@ files:
     vfunc_index: 50
     vfunc_offset: '0x190'
     vtable_name: CEngineClient
+  engine/CEngineClient_FindOrCreateWorldSession.windows.yaml:
+    func_name: CEngineClient_FindOrCreateWorldSession
+    func_rva: '0x75a20'
+    func_sig: 49 8B C0 48 8B CA 48 8B D0 4D 8B C1 E9 2F 65 1C 00
+    func_size: '0x11'
+    func_va: '0x180075a20'
+    vfunc_index: 13
+    vfunc_offset: '0x68'
+    vtable_name: CEngineClient_vtable
+  engine/CEngineClient_GetEntityLumpForTemplate.windows.yaml:
+    func_name: CEngineClient_GetEntityLumpForTemplate
+    func_rva: '0x75a40'
+    func_sig: 40 53 0F B6 44 24 ??
+    func_size: '0x27'
+    func_va: '0x180075a40'
+    vfunc_index: 14
+    vfunc_offset: '0x70'
+    vtable_name: CEngineClient_vtable
+  engine/CEngineClient_GetStatsAppID.windows.yaml:
+    func_name: CEngineClient_GetStatsAppID
+    func_rva: '0x75a70'
+    func_size: '0x7'
+    func_va: '0x180075a70'
+    vfunc_index: 15
+    vfunc_offset: '0x78'
+    vtable_name: CEngineClient_vtable
   engine/CEngineClient_vtable.linux.yaml:
     vtable_class: CEngineClient
     vtable_entries:
@@ -11029,6 +11055,18 @@ files:
     func_sig: 48 8B C4 41 56 41 57
     func_size: '0x132'
     func_va: '0x18009ee60'
+  engine/CRenderingWorldSession_FindOrCreateWorldSession.windows.yaml:
+    func_name: CRenderingWorldSession_FindOrCreateWorldSession
+    func_rva: '0x23bf60'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC ?? 4D 8B F0 48 8B EA
+    func_size: '0x14b'
+    func_va: '0x18023bf60'
+  engine/CRenderingWorldSession_GetEntityLumpForTemplate.windows.yaml:
+    func_name: CRenderingWorldSession_GetEntityLumpForTemplate
+    func_rva: '0x23c0b0'
+    func_sig: 40 55 56 57 41 56 48 8D 6C 24 ??
+    func_size: '0x214'
+    func_va: '0x18023c0b0'
   engine/CSVCMsg_PeerList_t_vtable.linux.yaml:
     vtable_class: CSVCMsg_PeerList_t
     vtable_entries:
@@ -12116,6 +12154,18 @@ files:
     vfunc_index: 15
     vfunc_offset: '0x78'
     vtable_name: ISource2Server
+  engine/InitSteam.linux.yaml:
+    func_name: InitSteam
+    func_rva: '0x3526a0'
+    func_sig: 55 31 D2 48 89 E5 41 55
+    func_size: '0x1fc'
+    func_va: '0x3526a0'
+  engine/InitSteam.windows.yaml:
+    func_name: InitSteam
+    func_rva: '0x203f40'
+    func_sig: 48 89 5C 24 ?? 56 57 41 56 48 81 EC ?? ?? ?? ?? 45 0F B6 F0
+    func_size: '0x3b1'
+    func_va: '0x180203f40'
   engine/IsMapValid.linux.yaml:
     func_name: IsMapValid
     func_rva: '0x3f1a60'
@@ -12164,6 +12214,42 @@ files:
     func_sig: 48 8B 06 55 48 89 E5
     func_size: '0xc8'
     func_va: '0x37c640'
+  engine/g_nBreakpadAppId.linux.yaml:
+    gv_inst_disp: 2
+    gv_inst_length: 6
+    gv_inst_offset: 0
+    gv_name: g_nBreakpadAppId
+    gv_rva: '0x9e209c'
+    gv_sig: 89 05 ?? ?? ?? ?? 45 84 E4
+    gv_sig_va: '0x3526f1'
+    gv_va: '0x9e209c'
+  engine/g_nBreakpadAppId.windows.yaml:
+    gv_inst_disp: 2
+    gv_inst_length: 6
+    gv_inst_offset: 0
+    gv_name: g_nBreakpadAppId
+    gv_rva: '0x911888'
+    gv_sig: 89 05 ?? ?? ?? ?? 45 84 F6
+    gv_sig_va: '0x180203ffd'
+    gv_va: '0x180911888'
+  engine/g_nSteamAppId.linux.yaml:
+    gv_inst_disp: 2
+    gv_inst_length: 6
+    gv_inst_offset: 0
+    gv_name: g_nSteamAppId
+    gv_rva: '0x9e20a0'
+    gv_sig: 8B 15 ?? ?? ?? ?? 4C 8D 2D ?? ?? ?? ??
+    gv_sig_va: '0x3526ca'
+    gv_va: '0x9e20a0'
+  engine/g_nSteamAppId.windows.yaml:
+    gv_inst_disp: 2
+    gv_inst_length: 6
+    gv_inst_offset: 0
+    gv_name: g_nSteamAppId
+    gv_rva: '0x911864'
+    gv_sig: 8B 05 ?? ?? ?? ?? 48 89 AC 24 ?? ?? ?? ?? 85 C0
+    gv_sig_va: '0x180203f80'
+    gv_va: '0x180911864'
   engine/g_pAVI.linux.yaml:
     gv_name: g_pAVI
     gv_rva: '0xc720a8'

--- a/ida_preprocessor_scripts/find-CEngineClient_FindOrCreateWorldSession.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_FindOrCreateWorldSession.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_FindOrCreateWorldSession skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineClient_FindOrCreateWorldSession",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineClient_FindOrCreateWorldSession",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CRenderingWorldSession_FindOrCreateWorldSession"],
+        "exclude_funcs": ["CRenderingWorldSession_GetEntityLumpForTemplate"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineClient_FindOrCreateWorldSession", "CEngineClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineClient_FindOrCreateWorldSession",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the CEngineClient vfunc from its rendering-session callee."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineClient_GetEntityLumpForTemplate.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_GetEntityLumpForTemplate.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_GetEntityLumpForTemplate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineClient_GetEntityLumpForTemplate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineClient_GetEntityLumpForTemplate",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CRenderingWorldSession_GetEntityLumpForTemplate"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineClient_GetEntityLumpForTemplate", "CEngineClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineClient_GetEntityLumpForTemplate",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the CEngineClient vfunc from its rendering-session callee."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineClient_GetStatsAppID.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_GetStatsAppID.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_GetStatsAppID skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineClient_GetStatsAppID",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CEngineClient_GetStatsAppID",
+        "xref_strings": [],
+        "xref_gvs": ["g_nBreakpadAppId"],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CEngineClient_GetStatsAppID", "CEngineClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineClient_GetStatsAppID",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the short GetStatsAppID vfunc without generating a signature."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CRenderingWorldSession_FindOrCreateWorldSession.py
+++ b/ida_preprocessor_scripts/find-CRenderingWorldSession_FindOrCreateWorldSession.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CRenderingWorldSession_FindOrCreateWorldSession skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CRenderingWorldSession_FindOrCreateWorldSession",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CRenderingWorldSession_FindOrCreateWorldSession",
+        "xref_strings": [
+            "FULLMATCH:FindOrCreateWorldSession",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CRenderingWorldSession_FindOrCreateWorldSession",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate FindOrCreateWorldSession via its exact debug string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CRenderingWorldSession_GetEntityLumpForTemplate.py
+++ b/ida_preprocessor_scripts/find-CRenderingWorldSession_GetEntityLumpForTemplate.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CRenderingWorldSession_GetEntityLumpForTemplate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CRenderingWorldSession_GetEntityLumpForTemplate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CRenderingWorldSession_GetEntityLumpForTemplate",
+        "xref_strings": [
+            "FULLMATCH:CEntityResourceManifest::GetEntityLumpForTemplate",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CRenderingWorldSession_GetEntityLumpForTemplate",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate GetEntityLumpForTemplate via its exact debug string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-InitSteam-decompiles.py
+++ b/ida_preprocessor_scripts/find-InitSteam-decompiles.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-InitSteam-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_GLOBALVAR_NAMES = [
+    "g_nSteamAppId",
+    "g_nBreakpadAppId",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "g_nSteamAppId",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/InitSteam.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "InitSteam.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "g_nBreakpadAppId",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/InitSteam.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "InitSteam.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "g_nSteamAppId",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+    (
+        "g_nBreakpadAppId",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate Steam application ID globals by decompiling InitSteam."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-InitSteam.py
+++ b/ida_preprocessor_scripts/find-InitSteam.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-InitSteam skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "InitSteam",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "InitSteam",
+        "xref_strings": [
+            "Game info file does not specify a steam app id!",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "InitSteam",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate InitSteam and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/InitSteam.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/InitSteam.linux.yaml
@@ -1,0 +1,205 @@
+func_name: InitSteam
+func_va: '0x3526a0'
+disasm_code: |-
+  .text:00000000003526A0                 push    rbp
+  .text:00000000003526A1                 ; bool
+  .text:00000000003526A1                 xor     edx, edx; bool
+  .text:00000000003526A3                 mov     rbp, rsp
+  .text:00000000003526A6                 push    r13
+  .text:00000000003526A8                 push    r12
+  .text:00000000003526AA                 mov     r12d, esi
+  .text:00000000003526AD                 push    rbx
+  .text:00000000003526AE                 lea     rsi, aFilesystem; "FileSystem"
+  .text:00000000003526B5                 sub     rsp, 1008h
+  .text:00000000003526BC                 call    __ZN9KeyValues7FindKeyEPKcb; KeyValues::FindKey(char const*,bool)
+  .text:00000000003526C1                 test    rax, rax
+  .text:00000000003526C4                 jz      loc_35288E
+  .text:00000000003526CA                 ; _QWORD
+  .text:00000000003526CA                 mov     edx, cs:g_nSteamAppId; _QWORD
+  .text:00000000003526D0                 lea     r13, aSteamappid; "SteamAppId"
+  .text:00000000003526D7                 mov     rbx, rax
+  .text:00000000003526DA                 test    edx, edx
+  .text:00000000003526DC                 jz      loc_352830
+  .text:00000000003526E2                 lea     rsi, aBreakpadappid; "BreakpadAppId"
+  .text:00000000003526E9                 ; _QWORD
+  .text:00000000003526E9                 mov     rdi, rbx; _QWORD
+  .text:00000000003526EC                 call    __ZNK9KeyValues6GetIntEPKci; KeyValues::GetInt(char const*,int)
+  .text:00000000003526F1                 mov     cs:g_nBreakpadAppId, eax
+  .text:00000000003526F7                 test    r12b, r12b
+  .text:00000000003526FA                 jnz     loc_352810
+  .text:0000000000352700                 mov     edx, cs:g_nSteamAppId
+  .text:0000000000352706                 lea     rbx, [rbp+var_1020]
+  .text:000000000035270D                 xor     eax, eax
+  .text:000000000035270F                 lea     rsi, aD_2; "%d"
+  .text:0000000000352716                 mov     rdi, rbx
+  .text:0000000000352719                 call    sub_352610
+  .text:000000000035271E                 ; _QWORD
+  .text:000000000035271E                 mov     rsi, rbx; _QWORD
+  .text:0000000000352721                 ; _QWORD
+  .text:0000000000352721                 mov     edx, 1; _QWORD
+  .text:0000000000352726                 ; _QWORD
+  .text:0000000000352726                 mov     rdi, r13; _QWORD
+  .text:0000000000352729                 call    _Plat_SetEnv
+  .text:000000000035272E                 ; _QWORD
+  .text:000000000035272E                 mov     rsi, rbx; _QWORD
+  .text:0000000000352731                 ; _QWORD
+  .text:0000000000352731                 mov     edx, 1; _QWORD
+  .text:0000000000352736                 lea     rdi, aSteamgameid; "SteamGameId"
+  .text:000000000035273D                 call    _Plat_SetEnv
+  .text:0000000000352742                 mov     ebx, cs:g_nSteamAppId
+  .text:0000000000352748                 mov     eax, cs:dword_9E2098
+  .text:000000000035274E                 cmp     ebx, eax
+  .text:0000000000352750                 jz      short loc_352772
+  .text:0000000000352752                 call    _CommandLine
+  .text:0000000000352757                 mov     esi, 6BD98EDDh
+  .text:000000000035275C                 mov     rdi, rax
+  .text:000000000035275F                 mov     rax, [rax]
+  .text:0000000000352762                 call    qword ptr [rax+90h]
+  .text:0000000000352768                 test    al, al
+  .text:000000000035276A                 jz      short loc_3527A8
+  .text:000000000035276C                 mov     eax, cs:g_nSteamAppId
+  .text:0000000000352772                 mov     rbx, cs:LOG_GENERAL_ptr
+  .text:0000000000352779                 ; _QWORD
+  .text:0000000000352779                 mov     esi, 2; _QWORD
+  .text:000000000035277E                 cmp     cs:g_nBreakpadAppId, eax
+  .text:0000000000352784                 ; _QWORD
+  .text:0000000000352784                 mov     edi, [rbx]; _QWORD
+  .text:0000000000352786                 jz      short loc_3527E0
+  .text:0000000000352788                 call    _LoggingSystem_IsChannelEnabled
+  .text:000000000035278D                 test    al, al
+  .text:000000000035278F                 jnz     short loc_3527B8
+  .text:0000000000352791                 add     rsp, 1008h
+  .text:0000000000352798                 mov     eax, 1
+  .text:000000000035279D                 pop     rbx
+  .text:000000000035279E                 pop     r12
+  .text:00000000003527A0                 pop     r13
+  .text:00000000003527A2                 pop     rbp
+  .text:00000000003527A3                 retn
+  .text:00000000003527A8                 mov     edi, ebx
+  .text:00000000003527AA                 call    sub_344190
+  .text:00000000003527AF                 jmp     short loc_35276C
+  .text:00000000003527B8                 ; _QWORD
+  .text:00000000003527B8                 mov     edi, [rbx]; _QWORD
+  .text:00000000003527BA                 lea     rdx, aSteamAppidDBre; "Steam AppId(%d), BreakpadId(%d)\n"
+  .text:00000000003527C1                 ; _QWORD
+  .text:00000000003527C1                 mov     esi, 2; _QWORD
+  .text:00000000003527C6                 xor     eax, eax
+  .text:00000000003527C8                 mov     r8d, cs:g_nBreakpadAppId
+  .text:00000000003527CF                 mov     ecx, cs:g_nSteamAppId
+  .text:00000000003527D5                 call    _LoggingSystem_Log
+  .text:00000000003527DA                 jmp     short loc_352791
+  .text:00000000003527E0                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000003527E5                 test    al, al
+  .text:00000000003527E7                 jz      short loc_352791
+  .text:00000000003527E9                 ; _QWORD
+  .text:00000000003527E9                 mov     edi, [rbx]; _QWORD
+  .text:00000000003527EB                 lea     rdx, aSteamAppidD; "Steam AppId(%d)\n"
+  .text:00000000003527F2                 ; _QWORD
+  .text:00000000003527F2                 mov     esi, 2; _QWORD
+  .text:00000000003527F7                 xor     eax, eax
+  .text:00000000003527F9                 mov     ecx, cs:g_nSteamAppId
+  .text:00000000003527FF                 call    _LoggingSystem_Log
+  .text:0000000000352804                 jmp     short loc_352791
+  .text:0000000000352810                 lea     rsi, aBreakpadappidT; "BreakpadAppId_Tools"
+  .text:0000000000352817                 ; _QWORD
+  .text:0000000000352817                 mov     edx, eax; _QWORD
+  .text:0000000000352819                 ; _QWORD
+  .text:0000000000352819                 mov     rdi, rbx; _QWORD
+  .text:000000000035281C                 call    __ZNK9KeyValues6GetIntEPKci; KeyValues::GetInt(char const*,int)
+  .text:0000000000352821                 mov     cs:g_nBreakpadAppId, eax
+  .text:0000000000352827                 jmp     loc_352700
+  .text:0000000000352830                 lea     rsi, aForcefixedappi; "ForceFixedAppIds"
+  .text:0000000000352837                 ; _QWORD
+  .text:0000000000352837                 xor     edx, edx; _QWORD
+  .text:0000000000352839                 ; _QWORD
+  .text:0000000000352839                 mov     rdi, rax; _QWORD
+  .text:000000000035283C                 call    __ZNK9KeyValues6GetIntEPKci; KeyValues::GetInt(char const*,int)
+  .text:0000000000352841                 lea     r13, aSteamappid; "SteamAppId"
+  .text:0000000000352848                 ; _QWORD
+  .text:0000000000352848                 mov     rsi, r13; _QWORD
+  .text:000000000035284B                 test    eax, eax
+  .text:000000000035284D                 jz      short loc_352870
+  .text:000000000035284F                 ; _QWORD
+  .text:000000000035284F                 xor     edx, edx; _QWORD
+  .text:0000000000352851                 ; _QWORD
+  .text:0000000000352851                 mov     rdi, rbx; _QWORD
+  .text:0000000000352854                 call    __ZNK9KeyValues6GetIntEPKci; KeyValues::GetInt(char const*,int)
+  .text:0000000000352859                 mov     edx, eax
+  .text:000000000035285B                 mov     cs:g_nSteamAppId, eax
+  .text:0000000000352861                 jmp     loc_3526E2
+  .text:0000000000352870                 call    _CommandLine
+  .text:0000000000352875                 mov     esi, 0C2EC365Ch
+  .text:000000000035287A                 mov     rdx, r13
+  .text:000000000035287D                 mov     rdi, rax
+  .text:0000000000352880                 mov     rax, [rax]
+  .text:0000000000352883                 call    qword ptr [rax+0A0h]
+  .text:0000000000352889                 mov     rsi, rax
+  .text:000000000035288C                 jmp     short loc_35284F
+  .text:000000000035288E                 lea     rdi, aGameInfoFileDo; "Game info file does not specify a steam"...
+  .text:0000000000352895                 xor     eax, eax
+  .text:0000000000352897                 call    _Plat_FatalError
+procedure: |-
+  __int64 __fastcall InitSteam(KeyValues *a1, char a2)
+  {
+    __int64 Key; // rax
+    __int64 v4; // rdx
+    __int64 v5; // rbx
+    unsigned int v6; // eax
+    unsigned int v7; // ebx
+    int v8; // eax
+    __int64 v9; // rax
+    const char *v11; // rsi
+    unsigned int Int; // eax
+    __int64 v13; // rax
+    _BYTE v14[4128]; // [rsp+0h] [rbp-1020h] BYREF
+
+    Key = KeyValues::FindKey(a1, "FileSystem", 0);
+    if ( !Key )
+    {
+      Plat_FatalError("Game info file does not specify a steam app id!\n");
+      JUMPOUT(0x35289C);
+    }
+    v4 = (unsigned int)g_nSteamAppId;
+    v5 = Key;
+    if ( !(_DWORD)g_nSteamAppId )
+    {
+      v11 = "SteamAppId";
+      if ( !(unsigned int)KeyValues::GetInt(Key, "ForceFixedAppIds", 0) )
+      {
+        v13 = CommandLine();
+        v11 = (const char *)(*(__int64 (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v13 + 160LL))(
+                              v13,
+                              3270260316LL,
+                              "SteamAppId");
+      }
+      Int = KeyValues::GetInt(v5, v11, 0);
+      v4 = Int;
+      LODWORD(g_nSteamAppId) = Int;
+    }
+    v6 = KeyValues::GetInt(v5, "BreakpadAppId", v4);
+    g_nBreakpadAppId = v6;
+    if ( a2 )
+      g_nBreakpadAppId = KeyValues::GetInt(v5, "BreakpadAppId_Tools", v6);
+    sub_352610(v14, "%d", g_nSteamAppId);
+    Plat_SetEnv("SteamAppId", v14, 1);
+    Plat_SetEnv("SteamGameId", v14, 1);
+    v7 = g_nSteamAppId;
+    v8 = dword_9E2098;
+    if ( (_DWORD)g_nSteamAppId != dword_9E2098 )
+    {
+      v9 = CommandLine();
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64))(*(_QWORD *)v9 + 144LL))(v9, 1809419997) )
+        sub_344190(v7);
+      v8 = g_nSteamAppId;
+    }
+    if ( g_nBreakpadAppId == v8 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        LoggingSystem_Log(LOG_GENERAL, 2, "Steam AppId(%d)\n", g_nSteamAppId);
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+    {
+      LoggingSystem_Log(LOG_GENERAL, 2, "Steam AppId(%d), BreakpadId(%d)\n", g_nSteamAppId, g_nBreakpadAppId);
+    }
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/engine/InitSteam.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/InitSteam.windows.yaml
@@ -1,0 +1,334 @@
+func_name: InitSteam
+func_va: '0x180203f40'
+disasm_code: |-
+  .text:0000000180203F40                 mov     [rsp+arg_10], rbx
+  .text:0000000180203F45                 push    rsi
+  .text:0000000180203F46                 push    rdi
+  .text:0000000180203F47                 push    r14
+  .text:0000000180203F49                 sub     rsp, 140h
+  .text:0000000180203F50                 movzx   r14d, r8b
+  .text:0000000180203F54                 movzx   esi, dl
+  .text:0000000180203F57                 xor     r8d, r8d
+  .text:0000000180203F5A                 lea     rdx, aFilesystem; "FileSystem"
+  .text:0000000180203F61                 mov     rdi, rcx
+  .text:0000000180203F64                 call    cs:?FindKey@KeyValues@@QEAAPEAV1@PEBD_N@Z; KeyValues::FindKey(char const *,bool)
+  .text:0000000180203F6A                 mov     rbx, rax
+  .text:0000000180203F6D                 test    rax, rax
+  .text:0000000180203F70                 jnz     short loc_180203F80
+  .text:0000000180203F72                 lea     rcx, aGameInfoFileDo; "Game info file does not specify a steam"...
+  .text:0000000180203F79                 call    cs:Plat_FatalError
+  .text:0000000180203F7F                 ; Trap to Debugger
+  .text:0000000180203F7F                 int     3; Trap to Debugger
+  .text:0000000180203F80                 mov     eax, cs:g_nSteamAppId
+  .text:0000000180203F86                 mov     [rsp+158h+arg_0], rbp
+  .text:0000000180203F8E                 test    eax, eax
+  .text:0000000180203F90                 jnz     short loc_180203FEA
+  .text:0000000180203F92                 xor     r8d, r8d
+  .text:0000000180203F95                 lea     rdx, aForcefixedappi; "ForceFixedAppIds"
+  .text:0000000180203F9C                 mov     rcx, rbx
+  .text:0000000180203F9F                 lea     rbp, aSteamappid; "SteamAppId"
+  .text:0000000180203FA6                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180203FAC                 test    eax, eax
+  .text:0000000180203FAE                 jnz     short loc_180203FD5
+  .text:0000000180203FB0                 call    cs:CommandLine
+  .text:0000000180203FB6                 lea     r8, aSteamappid; "SteamAppId"
+  .text:0000000180203FBD                 mov     edx, 0C2EC365Ch
+  .text:0000000180203FC2                 mov     rcx, [rax]
+  .text:0000000180203FC5                 mov     r9, [rcx+0B8h]
+  .text:0000000180203FCC                 mov     rcx, rax
+  .text:0000000180203FCF                 call    r9
+  .text:0000000180203FD2                 mov     rbp, rax
+  .text:0000000180203FD5                 xor     r8d, r8d
+  .text:0000000180203FD8                 mov     rdx, rbp
+  .text:0000000180203FDB                 mov     rcx, rbx
+  .text:0000000180203FDE                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180203FE4                 mov     cs:g_nSteamAppId, eax
+  .text:0000000180203FEA                 mov     r8d, eax
+  .text:0000000180203FED                 lea     rdx, aBreakpadappid; "BreakpadAppId"
+  .text:0000000180203FF4                 mov     rcx, rbx
+  .text:0000000180203FF7                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180203FFD                 mov     cs:g_nBreakpadAppId, eax
+  .text:0000000180204003                 test    r14b, r14b
+  .text:0000000180204006                 jz      short loc_180204021
+  .text:0000000180204008                 mov     r8d, eax
+  .text:000000018020400B                 lea     rdx, aBreakpadappidT; "BreakpadAppId_Tools"
+  .text:0000000180204012                 mov     rcx, rbx
+  .text:0000000180204015                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:000000018020401B                 mov     cs:g_nBreakpadAppId, eax
+  .text:0000000180204021                 mov     r8d, cs:g_nSteamAppId
+  .text:0000000180204028                 lea     rdx, aD_7; "%d"
+  .text:000000018020402F                 lea     rcx, [rsp+158h+var_128]
+  .text:0000000180204034                 call    sub_180102550
+  .text:0000000180204039                 mov     r8b, 1
+  .text:000000018020403C                 lea     rdx, [rsp+158h+var_128]
+  .text:0000000180204041                 lea     rcx, aSteamappid; "SteamAppId"
+  .text:0000000180204048                 call    cs:Plat_SetEnv
+  .text:000000018020404E                 mov     r8b, 1
+  .text:0000000180204051                 lea     rdx, [rsp+158h+var_128]
+  .text:0000000180204056                 lea     rcx, aSteamgameid; "SteamGameId"
+  .text:000000018020405D                 call    cs:Plat_SetEnv
+  .text:0000000180204063                 mov     ecx, cs:g_nSteamAppId
+  .text:0000000180204069                 call    sub_180203040
+  .text:000000018020406E                 mov     rcx, cs:LOG_GENERAL
+  .text:0000000180204075                 mov     edx, 2
+  .text:000000018020407A                 mov     eax, cs:g_nSteamAppId
+  .text:0000000180204080                 cmp     cs:g_nBreakpadAppId, eax
+  .text:0000000180204086                 mov     ecx, [rcx]
+  .text:0000000180204088                 jnz     short loc_1802040B8
+  .text:000000018020408A                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180204090                 test    al, al
+  .text:0000000180204092                 jz      short loc_1802040EE
+  .text:0000000180204094                 mov     rcx, cs:LOG_GENERAL
+  .text:000000018020409B                 lea     r8, aSteamAppidD; "Steam AppId(%d)\n"
+  .text:00000001802040A2                 mov     r9d, cs:g_nSteamAppId
+  .text:00000001802040A9                 mov     edx, 2
+  .text:00000001802040AE                 mov     ecx, [rcx]
+  .text:00000001802040B0                 call    cs:LoggingSystem_Log
+  .text:00000001802040B6                 jmp     short loc_1802040EE
+  .text:00000001802040B8                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001802040BE                 test    al, al
+  .text:00000001802040C0                 jz      short loc_1802040EE
+  .text:00000001802040C2                 mov     rcx, cs:LOG_GENERAL
+  .text:00000001802040C9                 lea     r8, aSteamAppidDBre; "Steam AppId(%d), BreakpadId(%d)\n"
+  .text:00000001802040D0                 mov     eax, cs:g_nBreakpadAppId
+  .text:00000001802040D6                 mov     edx, 2
+  .text:00000001802040DB                 mov     r9d, cs:g_nSteamAppId
+  .text:00000001802040E2                 mov     [rsp+158h+var_138], eax
+  .text:00000001802040E6                 mov     ecx, [rcx]
+  .text:00000001802040E8                 call    cs:LoggingSystem_Log
+  .text:00000001802040EE                 movzx   ecx, sil
+  .text:00000001802040F2                 call    sub_180203140
+  .text:00000001802040F7                 test    sil, sil
+  .text:00000001802040FA                 jnz     loc_1802042D5
+  .text:0000000180204100                 xor     r8d, r8d
+  .text:0000000180204103                 mov     [rsp+158h+arg_8], r15
+  .text:000000018020410B                 lea     rdx, aEngine2Initfil; "Engine2/InitFilterTextEarly"
+  .text:0000000180204112                 mov     rcx, rdi
+  .text:0000000180204115                 xor     bl, bl
+  .text:0000000180204117                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:000000018020411D                 lea     rbp, aSuccessfully; "successfully"
+  .text:0000000180204124                 lea     rsi, aWithError; "with error"
+  .text:000000018020412B                 lea     r15, aChina; "china"
+  .text:0000000180204132                 test    eax, eax
+  .text:0000000180204134                 jz      loc_1802041C6
+  .text:000000018020413A                 lea     rcx, off_18060E2F0
+  .text:0000000180204141                 call    cs:SteamInternal_ContextInit
+  .text:0000000180204147                 cmp     qword ptr [rax], 0
+  .text:000000018020414B                 jz      short loc_1802041C6
+  .text:000000018020414D                 lea     rcx, off_18060E2F0
+  .text:0000000180204154                 call    cs:SteamInternal_ContextInit
+  .text:000000018020415A                 mov     rcx, [rax]
+  .text:000000018020415D                 mov     rax, [rcx]
+  .text:0000000180204160                 call    qword ptr [rax+0F0h]
+  .text:0000000180204166                 test    al, al
+  .text:0000000180204168                 jnz     short loc_18020418C
+  .text:000000018020416A                 call    cs:CommandLine
+  .text:0000000180204170                 xor     r8d, r8d
+  .text:0000000180204173                 mov     edx, 0CDBD1292h
+  .text:0000000180204178                 mov     rcx, [rax]
+  .text:000000018020417B                 mov     r9, [rcx+98h]
+  .text:0000000180204182                 mov     rcx, rax
+  .text:0000000180204185                 call    r9
+  .text:0000000180204188                 test    eax, eax
+  .text:000000018020418A                 jz      short loc_1802041C6
+  .text:000000018020418C                 lea     rcx, off_18060E2F0
+  .text:0000000180204193                 call    cs:SteamInternal_ContextInit
+  .text:0000000180204199                 mov     edx, 80000000h
+  .text:000000018020419E                 mov     rcx, [rax]
+  .text:00000001802041A1                 mov     rax, [rcx]
+  .text:00000001802041A4                 call    qword ptr [rax+0F8h]
+  .text:00000001802041AA                 mov     r8, rsi
+  .text:00000001802041AD                 lea     rcx, aSteamTextFilte; "Steam text filtering initialized (prior"...
+  .text:00000001802041B4                 test    al, al
+  .text:00000001802041B6                 mov     rdx, r15
+  .text:00000001802041B9                 movzx   ebx, al
+  .text:00000001802041BC                 cmovnz  r8, rbp
+  .text:00000001802041C0                 call    cs:Msg
+  .text:00000001802041C6                 xor     r8d, r8d
+  .text:00000001802041C9                 lea     rdx, aEngine2Cnpw; "Engine2/CNPW"
+  .text:00000001802041D0                 mov     rcx, rdi
+  .text:00000001802041D3                 call    cs:?FindKey@KeyValues@@QEAAPEAV1@PEBD_N@Z; KeyValues::FindKey(char const *,bool)
+  .text:00000001802041D9                 test    rax, rax
+  .text:00000001802041DC                 jz      short loc_180204210
+  .text:00000001802041DE                 lea     rcx, off_18060E2F0
+  .text:00000001802041E5                 call    cs:SteamInternal_ContextInit
+  .text:00000001802041EB                 cmp     qword ptr [rax], 0
+  .text:00000001802041EF                 jz      short loc_180204210
+  .text:00000001802041F1                 lea     rcx, off_18060E308
+  .text:00000001802041F8                 call    cs:SteamInternal_ContextInit
+  .text:00000001802041FE                 cmp     qword ptr [rax], 0
+  .text:0000000180204202                 jz      short loc_180204210
+  .text:0000000180204204                 movzx   edx, r14b
+  .text:0000000180204208                 mov     rcx, rdi
+  .text:000000018020420B                 call    sub_180203D40
+  .text:0000000180204210                 xor     r8d, r8d
+  .text:0000000180204213                 lea     rdx, aEngine2Initfil; "Engine2/InitFilterTextEarly"
+  .text:000000018020421A                 mov     rcx, rdi
+  .text:000000018020421D                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180204223                 test    eax, eax
+  .text:0000000180204225                 jz      loc_1802042CD
+  .text:000000018020422B                 lea     rcx, off_18060E2F0
+  .text:0000000180204232                 call    cs:SteamInternal_ContextInit
+  .text:0000000180204238                 cmp     qword ptr [rax], 0
+  .text:000000018020423C                 jz      loc_1802042CD
+  .text:0000000180204242                 test    bl, bl
+  .text:0000000180204244                 jnz     loc_1802042CD
+  .text:000000018020424A                 lea     rcx, off_18060E2F0
+  .text:0000000180204251                 call    cs:SteamInternal_ContextInit
+  .text:0000000180204257                 mov     rcx, [rax]
+  .text:000000018020425A                 mov     rax, [rcx]
+  .text:000000018020425D                 call    qword ptr [rax+0F0h]
+  .text:0000000180204263                 test    al, al
+  .text:0000000180204265                 jnz     short loc_180204289
+  .text:0000000180204267                 call    cs:CommandLine
+  .text:000000018020426D                 xor     r8d, r8d
+  .text:0000000180204270                 mov     edx, 0CDBD1292h
+  .text:0000000180204275                 mov     rcx, [rax]
+  .text:0000000180204278                 mov     r9, [rcx+98h]
+  .text:000000018020427F                 mov     rcx, rax
+  .text:0000000180204282                 call    r9
+  .text:0000000180204285                 test    eax, eax
+  .text:0000000180204287                 jz      short loc_18020428B
+  .text:0000000180204289                 mov     bl, 1
+  .text:000000018020428B                 lea     rcx, off_18060E2F0
+  .text:0000000180204292                 call    cs:SteamInternal_ContextInit
+  .text:0000000180204298                 movzx   edx, bl
+  .text:000000018020429B                 shl     edx, 1Fh
+  .text:000000018020429E                 mov     rcx, [rax]
+  .text:00000001802042A1                 mov     rax, [rcx]
+  .text:00000001802042A4                 call    qword ptr [rax+0F8h]
+  .text:00000001802042AA                 test    al, al
+  .text:00000001802042AC                 lea     rdx, aWorldwide_0; "worldwide"
+  .text:00000001802042B3                 lea     rcx, aSteamTextFilte_0; "Steam text filtering initialized (prior"...
+  .text:00000001802042BA                 cmovnz  rsi, rbp
+  .text:00000001802042BE                 test    bl, bl
+  .text:00000001802042C0                 mov     r8, rsi
+  .text:00000001802042C3                 cmovnz  rdx, r15
+  .text:00000001802042C7                 call    cs:Msg
+  .text:00000001802042CD                 mov     r15, [rsp+158h+arg_8]
+  .text:00000001802042D5                 mov     rbp, [rsp+158h+arg_0]
+  .text:00000001802042DD                 mov     rbx, [rsp+158h+arg_10]
+  .text:00000001802042E5                 add     rsp, 140h
+  .text:00000001802042EC                 pop     r14
+  .text:00000001802042EE                 pop     rdi
+  .text:00000001802042EF                 pop     rsi
+  .text:00000001802042F0                 retn
+procedure: |-
+  void __fastcall sub_180203F40(KeyValues *a1, unsigned __int8 a2, unsigned __int8 a3)
+  {
+    KeyValues *Key; // rbx
+    int Int; // eax
+    const char *v8; // rbp
+    __int64 v9; // rcx
+    __int64 v10; // rax
+    int v11; // eax
+    __int64 v12; // r8
+    __int64 v13; // r8
+    unsigned __int8 v14; // bl
+    const char *v15; // rsi
+    _QWORD *v16; // rax
+    __int64 v17; // rcx
+    __int64 v18; // rax
+    _QWORD *v19; // rax
+    unsigned __int8 v20; // al
+    const char *v21; // r8
+    _QWORD *v22; // rax
+    __int64 v23; // rcx
+    __int64 v24; // rax
+    _QWORD *v25; // rax
+    char v26; // al
+    const char *v27; // rdx
+    _BYTE v28[296]; // [rsp+30h] [rbp-128h] BYREF
+
+    Key = KeyValues::FindKey(a1, "FileSystem", 0);
+    if ( !Key )
+    {
+      Plat_FatalError("Game info file does not specify a steam app id!\n");
+      __debugbreak();
+    }
+    Int = g_nSteamAppId;
+    if ( !g_nSteamAppId )
+    {
+      v8 = "SteamAppId";
+      if ( !KeyValues::GetInt(Key, "ForceFixedAppIds", 0) )
+      {
+        v10 = CommandLine(v9);
+        v8 = (const char *)(*(__int64 (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v10 + 184LL))(
+                             v10,
+                             3270260316LL,
+                             "SteamAppId");
+      }
+      Int = KeyValues::GetInt(Key, v8, 0);
+      g_nSteamAppId = Int;
+    }
+    v11 = KeyValues::GetInt(Key, "BreakpadAppId", Int);
+    g_nBreakpadAppId = v11;
+    if ( a3 )
+      g_nBreakpadAppId = KeyValues::GetInt(Key, "BreakpadAppId_Tools", v11);
+    sub_180102550(v28, "%d", (unsigned int)g_nSteamAppId);
+    LOBYTE(v12) = 1;
+    Plat_SetEnv("SteamAppId", v28, v12);
+    LOBYTE(v13) = 1;
+    Plat_SetEnv("SteamGameId", v28, v13);
+    sub_180203040((unsigned int)g_nSteamAppId);
+    if ( g_nBreakpadAppId == g_nSteamAppId )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+        LoggingSystem_Log(LOG_GENERAL, 2, "Steam AppId(%d)\n", g_nSteamAppId);
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(LOG_GENERAL, 2) )
+    {
+      LoggingSystem_Log(LOG_GENERAL, 2, "Steam AppId(%d), BreakpadId(%d)\n", g_nSteamAppId, g_nBreakpadAppId);
+    }
+    sub_180203140(a2);
+    if ( !a2 )
+    {
+      v14 = 0;
+      v15 = "with error";
+      if ( KeyValues::GetInt(a1, "Engine2/InitFilterTextEarly", 0) )
+      {
+        if ( *(_QWORD *)SteamInternal_ContextInit(&off_18060E2F0) )
+        {
+          v16 = (_QWORD *)SteamInternal_ContextInit(&off_18060E2F0);
+          if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v16 + 240LL))(*v16)
+            || (v18 = CommandLine(v17),
+                (*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v18 + 152LL))(v18, 3451720338LL, 0)) )
+          {
+            v19 = (_QWORD *)SteamInternal_ContextInit(&off_18060E2F0);
+            v20 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*(_QWORD *)*v19 + 248LL))(*v19, 0x80000000LL);
+            v21 = "with error";
+            v14 = v20;
+            if ( v20 )
+              v21 = "successfully";
+            Msg("Steam text filtering initialized (priority zero, %s) %s\n", "china", v21);
+          }
+        }
+      }
+      if ( KeyValues::FindKey(a1, "Engine2/CNPW", 0)
+        && *(_QWORD *)SteamInternal_ContextInit(&off_18060E2F0)
+        && *(_QWORD *)SteamInternal_ContextInit(&off_18060E308) )
+      {
+        sub_180203D40(a1, a3);
+      }
+      if ( KeyValues::GetInt(a1, "Engine2/InitFilterTextEarly", 0)
+        && *(_QWORD *)SteamInternal_ContextInit(&off_18060E2F0)
+        && !v14 )
+      {
+        v22 = (_QWORD *)SteamInternal_ContextInit(&off_18060E2F0);
+        if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v22 + 240LL))(*v22)
+          || (v24 = CommandLine(v23),
+              (*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v24 + 152LL))(v24, 3451720338LL, 0)) )
+        {
+          v14 = 1;
+        }
+        v25 = (_QWORD *)SteamInternal_ContextInit(&off_18060E2F0);
+        v26 = (*(__int64 (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v25 + 248LL))(*v25, v14 << 31);
+        v27 = "worldwide";
+        if ( v26 )
+          v15 = "successfully";
+        if ( v14 )
+          v27 = "china";
+        Msg("Steam text filtering initialized (priority one, %s) %s\n", v27, v15);
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- add InitSteam xref discovery and LLM decompile recovery for g_nSteamAppId and g_nBreakpadAppId
- add Windows-only rendering world session and CEngineClient vfunc finders
- register the new 14172 engine skills and symbols, with signature-free GetStatsAppID output
- publish the deterministic 14172 game-symbol snapshot and add create-pr trigger metadata

## Validation
- implementation-specific formatting and targeted IDA preprocessing: passed for all seven finders
- full ida_analyze_bin.py validation: Failed 0
- non-MCP unittest suite: 1018 tests passed
- candidate preparation: passed for 14172
- C++ post-change validation: 12/12 runnable tests passed; zero compile failures, invalid items, or layout differences
- candidate publication: passed; SHA-256 b47e57c6877894a6f89e2dee1f7881c00ac9bc07165f052acebad9e88827257a matches the validated candidate