### PR TITLE
feat(preprocessor): add CDemoPlayer finders

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,31 +1,42 @@
 ---
 name: create-pr
-when_to_use: when user request to create a PR
 description: |
-  Deliver already-staged repository changes through the full post-change candidate lifecycle and open a GitHub
-  pull request. Use after implementation-specific tests pass and all task-related source/config/reference changes
-  are explicitly staged. Prepares, validates, and publishes the immutable candidate; refreshes only the original
-  staged paths plus current-version generated outputs; commits on a dev branch; pushes; and creates the PR.
+  Create a GitHub pull request from either staged task changes or an already-committed current branch. Use when the
+  user asks to create or open a PR, including when there are no staged changes but the clean current branch is not
+  main and has commits ahead of origin/main. Staged changes use the full immutable candidate lifecycle before commit;
+  an already-committed branch is pushed and opened directly without rewriting its commits.
 ---
 
 # Create Pull Request
 
-Create one pull request from the caller's staged changes. Treat the index at invocation time as the authorized
-change set. The only additional paths this workflow may stage are the formatter updates to those same paths and
-the validated `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` outputs produced by publication.
+Create one pull request using exactly one delivery mode:
+
+- `staged-delivery` - deliver the caller's staged changes through candidate preparation, validation, publication,
+  commit, push, and PR creation. Treat the index at invocation time as the authorized change set. The only additional
+  paths this mode may stage are formatter updates to those same paths and validated
+  `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` outputs.
+- `committed-branch` - when the index is empty, deliver the existing commits on a clean non-`main` current branch
+  that is ahead of `origin/main`. Treat the captured `origin/main...HEAD` diff as the authorized change set. Do not
+  format, stage, generate another commit, or rewrite existing commits in this mode.
+
+Never mix the two modes in one invocation.
 
 ## Inputs
 
-- `gamever` - use the caller-provided value. If omitted, read `CS2VIBE_GAMEVER` from `.env`.
-- `branch` - optional `dev*` branch name. If omitted while on `main`, derive a concise `dev-<topic>` name from the
-  staged change.
-- `commit_title` - optional Conventional Commit title. If omitted, derive it from the staged diff.
-- `pr_title` / `pr_body` - optional PR text. If omitted, derive it from the staged diff and actual validation
-  results.
+- `gamever` - required only for `staged-delivery`. Use the caller-provided value; if omitted in that mode, read
+  `CS2VIBE_GAMEVER` from `.env`.
+- `branch` - optional `dev*` branch name for `staged-delivery`. If omitted while on `main`, derive a concise
+  `dev-<topic>` name from the staged change. Ignore this input in `committed-branch`; use the current branch exactly.
+- `commit_title` - optional Conventional Commit title for `staged-delivery`. If omitted, derive it from the staged
+  diff.
+- `pr_title` / `pr_body` - optional PR text. If omitted, derive it from the delivered staged or committed diff and
+  actual validation results.
 - `issue` - optional GitHub issue number. Add `Closes #<issue>` to the PR body when supplied.
 
-Resolve exactly one non-empty `GAMEVER`. Set `ANALYSIS_CONFIG="configs/$GAMEVER.yaml"` and stop if that file does
-not exist. Never fall back to another game version.
+After selecting `staged-delivery`, resolve exactly one non-empty `GAMEVER`. Set
+`ANALYSIS_CONFIG="configs/$GAMEVER.yaml"` and stop if that file does not exist. Never fall back to another game
+version. `committed-branch` does not run the candidate lifecycle, so do not require or resolve a game version in that
+mode.
 
 ## Safety Rules
 
@@ -34,12 +45,15 @@ not exist. Never fall back to another game version.
 - Preserve unrelated untracked files and never stage them.
 - Require zero unstaged tracked changes at invocation. This forbids partially staged paths and prevents the
   formatter from absorbing unrelated work.
-- Treat the initial staged path list as immutable authorization. Do not add other source, config, reference, test,
-  or documentation paths after the gates run.
+- In `staged-delivery`, treat the initial staged path list as immutable authorization. Do not add other source,
+  config, reference, test, or documentation paths after the gates run.
+- In `committed-branch`, require an empty index, a non-`main` attached branch, at least one commit ahead of
+  `origin/main`, and a non-empty `origin/main...HEAD` diff. Keep `HEAD`, the current branch, and the committed path
+  list unchanged until push.
 - Stop on the first failed/non-runnable gate. Do not repair or retry inside this skill, and do not commit, push, or
   create a PR after a gate failure.
 
-## Step 1: Capture and Guard the Staged Change
+## Step 1: Select and Guard the Delivery Mode
 
 Record the current branch and complete status, then inspect the index:
 
@@ -57,21 +71,23 @@ gh auth status
 git fetch origin main --prune
 git rev-parse HEAD
 git rev-parse origin/main
+git rev-list --count origin/main..HEAD
+git diff --name-only origin/main...HEAD
+git diff --name-status origin/main...HEAD
+git diff --stat origin/main...HEAD
 ```
 
-`git diff --cached --quiet` must exit `1`, proving that staged changes exist. Exit `0` means there is nothing to
-deliver; stop with:
+`git diff --name-only` must be empty in both modes. If any unstaged tracked change exists, stop before formatting,
+candidate creation, push, or PR creation and report the paths. Untracked files may remain, but record them and never
+stage them.
 
-```text
-<skill_error>create-pr cannot run: no staged changes were provided.</skill_error>
-```
+Interpret `git diff --cached --quiet` as follows:
 
-Save the exact `git diff --cached --name-only` result as `INITIAL_STAGED_PATHS`, including staged additions,
-renames, and deletions. Read `git diff --cached` to understand the change, detect accidentally staged unrelated
-files or credentials, and derive the commit/PR summary.
+### Mode A - `staged-delivery`
 
-`git diff --name-only` must be empty. If any unstaged tracked change exists, stop before formatting or candidate
-creation and report the paths. Untracked files may remain, but record them and never stage them.
+Exit `1` proves staged changes exist. Save the exact `git diff --cached --name-only` result as
+`INITIAL_STAGED_PATHS`, including staged additions, renames, and deletions. Read `git diff --cached` to understand the
+change, detect accidentally staged unrelated files or credentials, and derive the commit/PR summary.
 
 Validate the intended branch before running expensive gates:
 
@@ -80,12 +96,40 @@ Validate the intended branch before running expensive gates:
 - On an existing `dev*` branch whose `HEAD` still equals `origin/main`, use that branch unless the caller explicitly
   supplied the same name.
 - On any other branch, stop and ask the caller to use `main` or a `dev*` branch.
-- Check `gh pr list --state open --head <dev-branch> --json url`. Stop if an open PR already exists for the
-  intended branch. Never create a duplicate PR.
+
+### Mode B - `committed-branch`
+
+Exit `0` means the index is empty. Allow this mode only when all of the following hold after fetching `origin/main`:
+
+- `git branch --show-current` returns a non-empty branch name other than `main`;
+- `git check-ref-format --branch <current-branch>` succeeds;
+- `git rev-list --count origin/main..HEAD` is greater than zero;
+- `git diff --quiet origin/main...HEAD` exits `1`, proving the PR would contain a non-empty committed diff.
+
+Otherwise stop with a specific error. Use these forms for the two common empty-index failures:
+
+```text
+<skill_error>create-pr cannot run: no staged changes and the current branch is main or detached.</skill_error>
+<skill_error>create-pr cannot run: no staged changes and the current branch has no committed changes ahead of origin/main.</skill_error>
+```
+
+Capture `INITIAL_BRANCH`, `INITIAL_HEAD`, `AHEAD_COUNT`, and the exact `git diff --name-only origin/main...HEAD` result
+as `INITIAL_COMMITTED_PATHS`. Read `git diff origin/main...HEAD` and `git log --format=fuller origin/main..HEAD` to
+understand the complete PR change, detect unrelated files or credentials, and derive the PR title/body. Ignore the
+optional `branch` input and use `INITIAL_BRANCH` as the PR head.
+
+Any exit code from `git diff --cached --quiet` other than `0` or `1` is a hard stop.
+
+For either mode, set `PR_BRANCH` to the intended dev branch or captured current branch. Check
+`gh pr list --state open --head <PR_BRANCH> --json url`. Stop if an open PR already exists for it. Never create a
+duplicate PR.
 
 ## Step 2: Prepare the Immutable Candidate
 
-**ALWAYS** Use SKILL `/prepare-post-change-candidate` with the resolved `gamever`.
+Run Steps 2 through 6 only in `staged-delivery`. In `committed-branch`, skip directly to Step 7 without running a
+formatter, candidate command, publication command, staging command, or commit command.
+
+In `staged-delivery`, **ALWAYS** Use SKILL `/prepare-post-change-candidate` with the resolved `gamever`.
 
 Retain the returned candidate path, candidate session path, gamedata session path, and candidate SHA-256. If the
 skill fails, stop the entire task.
@@ -95,16 +139,16 @@ After preparation, inspect `git diff --name-only`. Formatting may have changed a
 
 ## Step 3: Validate the Exact Candidate
 
-**ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and candidate session path
-returned by `/prepare-post-change-candidate`.
+In `staged-delivery`, **ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and
+candidate session path returned by `/prepare-post-change-candidate`.
 
 Require explicit success, runnable C++ tests, and zero failure counters. If validation fails or is non-runnable,
 stop exactly as that skill requires. Do not publish, commit, push, or create a PR.
 
 ## Step 4: Publish the Validated Candidate
 
-Only after validation succeeds, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the same `gamever`,
-candidate path, candidate session path, and gamedata session path.
+Only after validation succeeds in `staged-delivery`, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the
+same `gamever`, candidate path, candidate session path, and gamedata session path.
 
 Require the published snapshot SHA-256 to equal the validated candidate SHA-256. Publication may modify only:
 
@@ -160,14 +204,32 @@ Do not amend if the verification fails; stop and report the mismatch.
 
 ## Step 7: Push and Create the Pull Request
 
+In `committed-branch`, re-run the following immediately before push:
+
+```bash
+git branch --show-current
+git rev-parse HEAD
+git diff --cached --quiet
+git diff --quiet
+git rev-list --count origin/main..HEAD
+git diff --name-only origin/main...HEAD
+```
+
+Require the branch to equal `INITIAL_BRANCH`, `HEAD` to equal `INITIAL_HEAD`, both index and tracked worktree to be
+clean, the ahead count to remain greater than zero, and the committed path list to equal `INITIAL_COMMITTED_PATHS`.
+Stop if any captured state changed. This mode must not create a new commit.
+
 Push without force:
 
 ```bash
-git push -u origin <dev-branch>
+git push -u origin <PR_BRANCH>
 ```
 
-Build the PR title from `pr_title` or the commit title. Build the body from the committed staged diff and actual
-results, using this concise shape:
+Build the PR title from `pr_title` when supplied. Otherwise, use the new commit title in `staged-delivery`; in
+`committed-branch`, derive a concise title from `git log --format=%s origin/main..HEAD` and the committed diff.
+
+Build the body from the delivered committed diff and actual results. Never claim a validation that this invocation
+did not run. Use this concise shape for `staged-delivery`:
 
 ```markdown
 ## Summary
@@ -183,23 +245,31 @@ results, using this concise shape:
 Closes #<issue>
 ```
 
+For `committed-branch`, replace the candidate lifecycle lines with truthful evidence for the existing commits:
+
+```markdown
+## Validation
+- implementation-specific tests: <commands/results supplied by the caller, or "not supplied">
+- existing committed branch: `<AHEAD_COUNT>` commit(s) ahead of `origin/main`; clean index and tracked worktree
+```
+
 Omit the issue line when no issue was supplied. Create the PR explicitly against `main`:
 
 ```bash
-gh pr create --base main --head <dev-branch> --title "<pr_title>" --body "<pr_body>"
+gh pr create --base main --head <PR_BRANCH> --title "<pr_title>" --body "<pr_body>"
 ```
 
 Report the branch, commit SHA, pushed remote, PR URL, game version, candidate SHA-256, and the final committed path
-list. If push succeeds but PR creation fails, report the remote branch and exact failure; do not delete the branch,
-force-push, or create a second commit.
+list for `staged-delivery`. For `committed-branch`, report the branch, HEAD SHA, ahead count, pushed remote, PR URL,
+and `INITIAL_COMMITTED_PATHS`; omit game-version and candidate claims. If push succeeds but PR creation fails, report
+the remote branch and exact failure; do not delete the branch, force-push, or create another commit.
 
 ## Checklist
 
-- [ ] Initial cached diff is non-empty and contains only task-related changes.
-- [ ] No unstaged tracked changes existed before candidate preparation.
-- [ ] `/prepare-post-change-candidate` succeeded for the resolved game version.
-- [ ] `/post-change-validation` ran real C++ tests and succeeded for the exact candidate.
-- [ ] `/publish-post-change-candidate` published the same validated candidate.
-- [ ] Final staged paths are limited to initial staged paths plus current-version publication outputs.
-- [ ] Commit is on a `dev*` branch and follows the repository commit format.
-- [ ] Branch was pushed without force and exactly one PR was created against `main`.
+- [ ] Exactly one mode was selected: non-empty initial index, or clean non-`main` branch ahead of `origin/main`.
+- [ ] No unstaged tracked changes existed at invocation.
+- [ ] `staged-delivery`: initial cached diff is task-related; all candidate gates passed; final staged paths are
+      authorized; commit is on a `dev*` branch and follows repository format.
+- [ ] `committed-branch`: index/worktree are clean; branch, HEAD, ahead count, and committed paths remain unchanged;
+      no formatter, candidate publication, staging, or commit command ran.
+- [ ] No duplicate open PR existed; branch was pushed without force; exactly one PR was created against `main`.

--- a/.claude/skills/create-pr/agents/openai.yaml
+++ b/.claude/skills/create-pr/agents/openai.yaml
@@ -1,6 +1,6 @@
 interface:
   display_name: "Create Pull Request"
-  short_description: "Validate staged changes and open a pull request"
-  default_prompt: "Use $create-pr to validate my staged changes and create a pull request."
+  short_description: "Create a PR from staged changes or existing commits"
+  default_prompt: "Use $create-pr to create a pull request from my staged changes or current branch commits."
 policy:
   allow_implicit_invocation: false

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -879,6 +879,68 @@ modules:
           - INetworkMessages_Serialize.{platform}.yaml
         expected_input:
           - CNetworkGameClient_SendMovePacket.{platform}.yaml
+      - name: find-CDemoPlayer_vtable
+        expected_output:
+          - CDemoPlayer_vtable.{platform}.yaml
+      - name: find-CDemoPlayer_SkipToTick
+        platform: windows
+        expected_output:
+          - CDemoPlayer_SkipToTick.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_vtable.{platform}.yaml
+      - name: find-CDemoPlayer_PlayDemo
+        platform: windows
+        expected_output:
+          - CDemoPlayer_PlayDemo.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_vtable.{platform}.yaml
+      - name: find-CDemoPlayer_StopPlayback
+        platform: windows
+        expected_output:
+          - CDemoPlayer_StopPlayback.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_vtable.{platform}.yaml
+      - name: find-CDemoPlayer_StartPlayback
+        platform: windows
+        expected_output:
+          - CDemoPlayer_StartPlayback.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_vtable.{platform}.yaml
+          - CDemoPlayer_SkipToTick.{platform}.yaml
+      - name: find-CDemoPlayer_SetIgnorePacketsForResourceLoading
+        platform: windows
+        expected_output:
+          - CDemoPlayer_SetIgnorePacketsForResourceLoading.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_vtable.{platform}.yaml
+          - CDemoPlayer_InternalReadPacket.{platform}.yaml
+          - CDemoPlayer_StartPlayback.{platform}.yaml
+      - name: find-CDemoPlayer_InternalReadPacket
+        platform: windows
+        expected_output:
+          - CDemoPlayer_InternalReadPacket.{platform}.yaml
+      - name: find-Demo_PauseAtServerTick_CommandHandler
+        expected_output:
+          - Demo_PauseAtServerTick_CommandHandler.{platform}.yaml
+      - name: find-CDemoPlayer_StartPlayback-decompiles
+        platform: windows
+        expected_output:
+          - CDemoPlayer_m_bIsPlaying.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_StartPlayback.{platform}.yaml
+      - name: find-Demo_PauseAtServerTick_CommandHandler-decompiles
+        platform: windows
+        expected_output:
+          - CDemoPlayer_Pause.{platform}.yaml
+        expected_input:
+          - Demo_PauseAtServerTick_CommandHandler.{platform}.yaml
+          - CDemoPlayer_vtable.{platform}.yaml
+      - name: find-CDemoPlayer_Pause-decompiles
+        platform: windows
+        expected_output:
+          - CDemoPlayer_m_bIsPaused.{platform}.yaml
+        expected_input:
+          - CDemoPlayer_Pause.{platform}.yaml
       - name: find-CDemoRecorder_vtable
         expected_output:
           - CDemoRecorder_vtable.{platform}.yaml
@@ -2144,6 +2206,62 @@ modules:
         alias:
           - INetworkMessages::Serialize
         shared: true
+      - name: CDemoPlayer_vtable
+        category: vtable
+      - name: CDemoPlayer_SkipToTick
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::SkipToTick
+      - name: CDemoPlayer_PlayDemo
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::PlayDemo
+      - name: CDemoPlayer_StopPlayback
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::StopPlayback
+      - name: CDemoPlayer_StartPlayback
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::StartPlayback
+      - name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::SetIgnorePacketsForResourceLoading
+      - name: CDemoPlayer_InternalReadPacket
+        category: func
+        platform: windows
+        alias:
+          - CDemoPlayer::InternalReadPacket
+      - name: Demo_PauseAtServerTick_CommandHandler
+        category: func
+      - name: CDemoPlayer_Pause
+        category: vfunc
+        platform: windows
+        alias:
+          - CDemoPlayer::Pause
+      - name: CDemoPlayer
+        category: struct
+        platform: windows
+      - name: CDemoPlayer_m_bIsPlaying
+        category: structmember
+        platform: windows
+        struct: CDemoPlayer
+        member: m_bIsPlaying
+        alias:
+          - CDemoPlayer::m_bIsPlaying
+      - name: CDemoPlayer_m_bIsPaused
+        category: structmember
+        platform: windows
+        struct: CDemoPlayer
+        member: m_bIsPaused
+        alias:
+          - CDemoPlayer::m_bIsPaused
       - name: CDemoRecorder_vtable
         category: vtable
       - name: CDemoRecorder_ParseMessage

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:0c2801990dc194aeb17f99363e75c7825129b9a980e02425fd1e6c799fddafb9
-file_count: 3134
+config_sha256: sha256:9e5a85b69afa06b0b603ac7d9c4c8af54fc040597c1b7c4dc39057f50722da64
+file_count: 3147
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -5337,6 +5337,182 @@ files:
     vtable_size: '0x10'
     vtable_symbol: ??_7?$CDelayedCall2@VCServerSideClientBase@@V1@UUpdateAcknowledgedFramecountCall_t@1@Uempty_t@@@@6B@
     vtable_va: '0x180544f20'
+  engine/CDemoPlayer_InternalReadPacket.windows.yaml:
+    func_name: CDemoPlayer_InternalReadPacket
+    func_rva: '0x2aef0'
+    func_sig: 48 89 4C 24 ?? 53 55 56 57 41 54 41 55 41 56 41 57 48 83 EC ?? 45 33 FF
+    func_size: '0x922'
+    func_va: '0x18002aef0'
+  engine/CDemoPlayer_Pause.windows.yaml:
+    func_name: CDemoPlayer_Pause
+    func_rva: '0x354e0'
+    func_sig: 48 89 5C 24 ?? 57 48 81 EC ?? ?? ?? ?? 0F 29 74 24 ??
+    func_size: '0x12e'
+    func_va: '0x1800354e0'
+    vfunc_index: 18
+    vfunc_offset: '0x90'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_PlayDemo.windows.yaml:
+    func_name: CDemoPlayer_PlayDemo
+    func_rva: '0x30b40'
+    func_sig: 40 55 53 56 57 41 54 41 56 48 8D AC 24 ?? ?? ?? ??
+    func_size: '0x4d9'
+    func_va: '0x180030b40'
+    vfunc_index: 7
+    vfunc_offset: '0x38'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_SetIgnorePacketsForResourceLoading.windows.yaml:
+    func_name: CDemoPlayer_SetIgnorePacketsForResourceLoading
+    func_rva: '0x2e960'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 0F B6 DA 48 8B F9 3A 91 ?? 18 00 00
+    func_size: '0x6a'
+    func_va: '0x18002e960'
+    vfunc_index: 31
+    vfunc_offset: '0xf8'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_SkipToTick.windows.yaml:
+    func_name: CDemoPlayer_SkipToTick
+    func_rva: '0x29260'
+    func_sig: 40 55 53 57 41 55
+    func_size: '0x74a'
+    func_va: '0x180029260'
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_StartPlayback.windows.yaml:
+    func_name: CDemoPlayer_StartPlayback
+    func_rva: '0x33cc0'
+    func_sig: 48 8B C4 4C 89 48 ?? 55 53
+    func_size: '0x698'
+    func_va: '0x180033cc0'
+    vfunc_index: 8
+    vfunc_offset: '0x40'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_StopPlayback.windows.yaml:
+    func_name: CDemoPlayer_StopPlayback
+    func_rva: '0x28d90'
+    func_sig: 40 53 48 83 EC ?? 80 B9 ?? 12 00 00 ?? 48 8B D9 0F 84 ?? ?? ?? ??
+    func_size: '0x473'
+    func_va: '0x180028d90'
+    vfunc_index: 21
+    vfunc_offset: '0xa8'
+    vtable_name: CDemoPlayer_vtable
+  engine/CDemoPlayer_m_bIsPaused.windows.yaml:
+    member_name: m_bIsPaused
+    offset: '0x1231'
+    offset_sig: C6 81 ?? 12 00 00 ?? 0F 57 C0
+    offset_sig_disp: 0
+    size: 1
+    struct_name: CDemoPlayer
+  engine/CDemoPlayer_m_bIsPlaying.windows.yaml:
+    member_name: m_bIsPlaying
+    offset: '0x1230'
+    offset_sig: C6 87 ?? 12 00 00 ?? C6 87 ?? 12 00 00 ??
+    offset_sig_disp: 0
+    size: 1
+    struct_name: CDemoPlayer
+  engine/CDemoPlayer_vtable.linux.yaml:
+    vtable_class: CDemoPlayer
+    vtable_entries:
+      0: '0x47c590'
+      1: '0x47cb00'
+      10: '0x470950'
+      11: '0x470960'
+      12: '0x470930'
+      13: '0x472250'
+      14: '0x470910'
+      15: '0x4708b0'
+      16: '0x470820'
+      17: '0x470a20'
+      18: '0x470a10'
+      19: '0x48e260'
+      2: '0x470810'
+      20: '0x48e420'
+      21: '0x490330'
+      22: '0x47c550'
+      23: '0x4902a0'
+      24: '0x4708f0'
+      25: '0x47d5d0'
+      26: '0x470900'
+      27: '0x470a40'
+      28: '0x476660'
+      29: '0x470a30'
+      3: '0x4709a0'
+      30: '0x480000'
+      31: '0x47c570'
+      32: '0x4727f0'
+      33: '0x470940'
+      34: '0x48cfc0'
+      35: '0x470850'
+      36: '0x470830'
+      37: '0x470840'
+      38: '0x470970'
+      39: '0x470980'
+      4: '0x4709b0'
+      40: '0x470990'
+      41: '0x47fce0'
+      42: '0x47f880'
+      43: '0x472be0'
+      5: '0x4709e0'
+      6: '0x4708d0'
+      7: '0x470cf0'
+      8: '0x477060'
+      9: '0x486be0'
+    vtable_numvfunc: 44
+    vtable_rva: '0x9aacb8'
+    vtable_size: '0x160'
+    vtable_symbol: _ZTV11CDemoPlayer + 0x10
+    vtable_va: '0x9aacb8'
+  engine/CDemoPlayer_vtable.windows.yaml:
+    vtable_class: CDemoPlayer
+    vtable_entries:
+      0: '0x18002de90'
+      1: '0x1800247f0'
+      10: '0x18002e9f0'
+      11: '0x18002dc00'
+      12: '0x180035a50'
+      13: '0x18002dbe0'
+      14: '0x180029220'
+      15: '0x1800245d0'
+      16: '0x180035af0'
+      17: '0x180035ae0'
+      18: '0x1800354e0'
+      19: '0x180029260'
+      2: '0x180035a80'
+      20: '0x180035610'
+      21: '0x180028d90'
+      22: '0x18002b820'
+      23: '0x180021e70'
+      24: '0x18002cf40'
+      25: '0x1800245d0'
+      26: '0x180039130'
+      27: '0x180035b00'
+      28: '0x1800361c0'
+      29: '0x1800361d0'
+      3: '0x180035a90'
+      30: '0x180029210'
+      31: '0x18002e960'
+      32: '0x18002e9d0'
+      33: '0x18002aef0'
+      34: '0x180024820'
+      35: '0x180024800'
+      36: '0x180024810'
+      37: '0x180024440'
+      38: '0x1800354c0'
+      39: '0x1800354d0'
+      4: '0x180035a90'
+      40: '0x180034360'
+      41: '0x1800343c0'
+      5: '0x180029240'
+      6: '0x180035ac0'
+      7: '0x180030b40'
+      8: '0x180033cc0'
+      9: '0x18002e9e0'
+    vtable_numvfunc: 42
+    vtable_rva: '0x52db28'
+    vtable_size: '0x150'
+    vtable_symbol: ??_7CDemoPlayer@@6B@
+    vtable_va: '0x18052db28'
   engine/CDemoRecorder_ParseMessage.linux.yaml:
     func_name: CDemoRecorder_ParseMessage
     func_rva: '0x47db80'
@@ -12101,6 +12277,18 @@ files:
     func_sig: 41 57 48 83 EC ?? 8B 05 ?? ?? ?? ?? 4C 8B F9
     func_size: '0x1bc'
     func_va: '0x1803fe530'
+  engine/Demo_PauseAtServerTick_CommandHandler.linux.yaml:
+    func_name: Demo_PauseAtServerTick_CommandHandler
+    func_rva: '0x48e930'
+    func_sig: 55 48 89 E5 41 55 41 54 49 89 F4 53 48 83 EC ?? 48 8D 05 ?? ?? ?? ??
+    func_size: '0x1a5'
+    func_va: '0x48e930'
+  engine/Demo_PauseAtServerTick_CommandHandler.windows.yaml:
+    func_name: Demo_PauseAtServerTick_CommandHandler
+    func_rva: '0x38540'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 48 8D 35 ?? ?? ?? ??
+    func_size: '0x16e'
+    func_va: '0x180038540'
   engine/GetFrameTimeAmnesty.linux.yaml:
     func_name: GetFrameTimeAmnesty
     func_rva: '0x37b490'
@@ -39771,5 +39959,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-27T06:53:13Z'
+last_publish_time: '2026-07-27T09:59:31Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CDemoPlayer_InternalReadPacket.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_InternalReadPacket.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_InternalReadPacket skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_InternalReadPacket"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_InternalReadPacket",
+        "xref_strings": ["Unknown message in DemoSpawnGroups %d."],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_InternalReadPacket",
+        ["func_name", "func_sig", "func_va", "func_rva", "func_size"],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::InternalReadPacket and write its function YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_Pause-decompiles.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_Pause-decompiles.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_Pause-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = ["CDemoPlayer_m_bIsPaused"]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CDemoPlayer_m_bIsPaused",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CDemoPlayer_Pause.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_struct_offset"],
+        "dependency_policy": {
+            "CDemoPlayer_Pause.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_m_bIsPaused",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CDemoPlayer::m_bIsPaused via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_PlayDemo.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_PlayDemo.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_PlayDemo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_PlayDemo"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_PlayDemo",
+        "xref_strings": ["Demo filename is empty or invalid"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_PlayDemo", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_PlayDemo",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::PlayDemo and write its vfunc YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_SetIgnorePacketsForResourceLoading.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_SetIgnorePacketsForResourceLoading.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_SetIgnorePacketsForResourceLoading skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_SetIgnorePacketsForResourceLoading"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_SetIgnorePacketsForResourceLoading",
+        "xref_strings": ["CDemoPlayer::SetIgnorePacketsForResourceLoading(%s)"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [
+            "CDemoPlayer_InternalReadPacket",
+            "CDemoPlayer_StartPlayback",
+        ],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_SetIgnorePacketsForResourceLoading", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_SetIgnorePacketsForResourceLoading",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::SetIgnorePacketsForResourceLoading and write its vfunc YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_SkipToTick.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_SkipToTick.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_SkipToTick skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_SkipToTick"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_SkipToTick",
+        "xref_strings": [
+            "No available full packet to use to sync backwards.  Doing a full reload of the demo file",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_SkipToTick", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_SkipToTick",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::SkipToTick and write its vfunc YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_StartPlayback-decompiles.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_StartPlayback-decompiles.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_StartPlayback-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = ["CDemoPlayer_m_bIsPlaying"]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CDemoPlayer_m_bIsPlaying",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CDemoPlayer_StartPlayback.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_struct_offset"],
+        "dependency_policy": {
+            "CDemoPlayer_StartPlayback.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_m_bIsPlaying",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CDemoPlayer::m_bIsPlaying via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_StartPlayback.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_StartPlayback.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_StartPlayback skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_StartPlayback"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_StartPlayback",
+        "xref_strings": ["can't play back, no CNetworkGameClient for demo '%s'"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": ["CDemoPlayer_SkipToTick"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_StartPlayback", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_StartPlayback",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::StartPlayback and write its vfunc YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_StopPlayback.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_StopPlayback.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_StopPlayback skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_StopPlayback"]
+
+# The separately supplied "CDemoFile: %s handle packet :%d t=%d" anchor has
+# no CDemoPlayer vtable intersection on 14172, so it cannot identify this vfunc.
+FUNC_XREFS = [
+    {
+        "func_name": "CDemoPlayer_StopPlayback",
+        "xref_strings": [
+            "Demo playback finished ( %.1f seconds, %i render frames, %.2f fps).",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_StopPlayback", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_StopPlayback",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CDemoPlayer::StopPlayback and write its vfunc YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CDemoPlayer_vtable.py
+++ b/ida_preprocessor_scripts/find-CDemoPlayer_vtable.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CDemoPlayer_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CDemoPlayer"]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate CDemoPlayer vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-Demo_PauseAtServerTick_CommandHandler-decompiles.py
+++ b/ida_preprocessor_scripts/find-Demo_PauseAtServerTick_CommandHandler-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-Demo_PauseAtServerTick_CommandHandler-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CDemoPlayer_Pause"]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CDemoPlayer_Pause",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/Demo_PauseAtServerTick_CommandHandler.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "Demo_PauseAtServerTick_CommandHandler.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CDemoPlayer_Pause", "CDemoPlayer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CDemoPlayer_Pause",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CDemoPlayer::Pause via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-Demo_PauseAtServerTick_CommandHandler.py
+++ b/ida_preprocessor_scripts/find-Demo_PauseAtServerTick_CommandHandler.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-Demo_PauseAtServerTick_CommandHandler skill."""
+
+from ida_preprocessor_scripts._registerconcommand import (
+    preprocess_registerconcommand_skill,
+)
+
+TARGET_FUNCTION_NAMES = ["Demo_PauseAtServerTick_CommandHandler"]
+
+COMMAND_NAME = "demo_pauseatservertick"
+HELP_STRING = "Pauses when the 'render time' reaches the specified tick."
+SEARCH_WINDOW_BEFORE_CALL = 96
+SEARCH_WINDOW_AFTER_XREF = 96
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "Demo_PauseAtServerTick_CommandHandler",
+        ["func_name", "func_sig", "func_va", "func_rva", "func_size"],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    _ = skill_name, old_yaml_map
+    return await preprocess_registerconcommand_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        target_name=TARGET_FUNCTION_NAMES[0],
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        command_name=COMMAND_NAME,
+        help_string=HELP_STRING,
+        rename_to=TARGET_FUNCTION_NAMES[0],
+        search_window_before_call=SEARCH_WINDOW_BEFORE_CALL,
+        search_window_after_xref=SEARCH_WINDOW_AFTER_XREF,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CDemoPlayer_Pause.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CDemoPlayer_Pause.windows.yaml
@@ -1,0 +1,112 @@
+func_name: CDemoPlayer_Pause
+func_va: '0x1800354e0'
+disasm_code: |-
+  .text:00000001800354E0                 mov     [rsp+arg_10], rbx
+  .text:00000001800354E5                 push    rdi
+  .text:00000001800354E6                 sub     rsp, 80h
+  .text:00000001800354ED                 movaps  [rsp+88h+var_18], xmm6
+  .text:00000001800354F2                 xor     edi, edi
+  .text:00000001800354F4                 movaps  xmm6, xmm1
+  .text:00000001800354F7                 mov     byte ptr [rcx+1231h], 1 ; 1231h = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+  .text:00000001800354FE                 xorps   xmm0, xmm0
+  .text:0000000180035501                 mov     rbx, rcx
+  .text:0000000180035504                 comiss  xmm6, xmm0
+  .text:0000000180035507                 jbe     short loc_180035528
+  .text:0000000180035509                 call    cs:Plat_FloatTime
+  .text:000000018003550F                 xorps   xmm1, xmm1
+  .text:0000000180035512                 cvtss2sd xmm1, xmm6
+  .text:0000000180035516                 addsd   xmm0, xmm1
+  .text:000000018003551A                 cvtsd2ss xmm0, xmm0
+  .text:000000018003551E                 movss   dword ptr [rbx+210h], xmm0
+  .text:0000000180035526                 jmp     short loc_18003554F
+  .text:0000000180035528                 mov     [rcx+210h], edi
+  .text:000000018003552E                 cmp     [rcx+1232h], dil
+  .text:0000000180035535                 jz      short loc_18003554F
+  .text:0000000180035537                 mov     rax, cs:off_180612A40
+  .text:000000018003553E                 lea     rcx, off_180612A40
+  .text:0000000180035545                 call    qword ptr [rax+10h]
+  .text:0000000180035548                 mov     [rbx+1232h], dil
+  .text:000000018003554F                 cmp     [rbx+1230h], dil
+  .text:0000000180035556                 jz      loc_1800355F8
+  .text:000000018003555C                 mov     ecx, [rbx+10h]
+  .text:000000018003555F                 test    ecx, ecx
+  .text:0000000180035561                 jz      short loc_18003559E
+  .text:0000000180035563                 cmp     ecx, 1
+  .text:0000000180035566                 jnz     loc_1800355F8
+  .text:000000018003556C                 mov     rcx, cs:g_pSource2Client
+  .text:0000000180035573                 movzx   edx, byte ptr [rbx+1231h] ; 1231h = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+  .text:000000018003557A                 mov     rax, [rcx]
+  .text:000000018003557D                 call    qword ptr [rax+0D8h]
+  .text:0000000180035583                 cmp     [rbx+1231h], dil ; 1231h = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+  .text:000000018003558A                 jnz     short loc_1800355F8
+  .text:000000018003558C                 mov     rcx, cs:g_pSource2Client
+  .text:0000000180035593                 mov     rax, [rcx]
+  .text:0000000180035596                 call    qword ptr [rax+0E0h]
+  .text:000000018003559C                 jmp     short loc_1800355F8
+  .text:000000018003559E                 movzx   eax, byte ptr [rbx+1231h] ; 1231h = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+  .text:00000001800355A5                 mov     rcx, cs:g_pNetworkGameClient
+  .text:00000001800355AC                 mov     [rsp+88h+var_54], 0FFh
+  .text:00000001800355B1                 mov     [rsp+88h+var_50], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800355BA                 mov     [rsp+88h+var_48], 0BF800000h
+  .text:00000001800355C2                 mov     [rcx+29Dh], al
+  .text:00000001800355C8                 movzx   eax, dil
+  .text:00000001800355CC                 shr     al, 1
+  .text:00000001800355CE                 mov     [rsp+88h+var_40], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800355D7                 test    al, 1
+  .text:00000001800355D9                 jz      short loc_1800355F8
+  .text:00000001800355DB                 lea     rcx, [rdi-2]
+  .text:00000001800355DF                 call    sub_1802BF3F0
+  .text:00000001800355E4                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800355EB                 lea     rdx, [rdi-2]
+  .text:00000001800355EF                 mov     rcx, [rax]
+  .text:00000001800355F2                 mov     rax, [rcx]
+  .text:00000001800355F5                 call    qword ptr [rax+18h]
+  .text:00000001800355F8                 mov     rbx, [rsp+88h+arg_10]
+  .text:0000000180035600                 movaps  xmm6, [rsp+88h+var_18]
+  .text:0000000180035605                 add     rsp, 80h
+  .text:000000018003560C                 pop     rdi
+  .text:000000018003560D                 retn
+procedure: |-
+  void __fastcall CDemoPlayer_Pause(__int64 a1, __int64 a2)
+  {
+    float v2; // xmm1_4
+    float v4; // xmm0_4
+    int v5; // ecx
+
+    *(_BYTE *)(a1 + 4657) = 1;                    // 4657 = 0x1231 = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+    if ( v2 <= 0.0 )
+    {
+      *(_DWORD *)(a1 + 528) = 0;
+      if ( *(_BYTE *)(a1 + 4658) )
+      {
+        ((void (__fastcall *)(__int64 (__fastcall ***)(int, int, int, int, int, int, int, int, char, __int64, int, char), __int64))off_180612A40[2])(
+          &off_180612A40,
+          a2);
+        *(_BYTE *)(a1 + 4658) = 0;
+      }
+    }
+    else
+    {
+      v4 = Plat_FloatTime(a1, a2) + v2;
+      *(float *)(a1 + 528) = v4;
+    }
+    if ( *(_BYTE *)(a1 + 4656) )
+    {
+      v5 = *(_DWORD *)(a1 + 16);
+      if ( v5 )
+      {
+        if ( v5 == 1 )
+        {
+          (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 216LL))(
+            g_pSource2Client,
+            *(unsigned __int8 *)(a1 + 4657)); // 4657 = 0x1231 = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+          if ( !*(_BYTE *)(a1 + 4657) ) // 4657 = 0x1231 = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+            (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Client + 224LL))(g_pSource2Client);
+        }
+      }
+      else
+      {
+        *(_BYTE *)(g_pNetworkGameClient + 669) = *(_BYTE *)(a1 + 4657); // 4657 = 0x1231 = CDemoPlayer::m_bIsPaused (structmember, struct=CDemoPlayer, member=m_bIsPaused)
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CDemoPlayer_StartPlayback.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CDemoPlayer_StartPlayback.windows.yaml
@@ -1,0 +1,639 @@
+func_name: CDemoPlayer_StartPlayback
+func_va: '0x180033cc0'
+disasm_code: |-
+  .text:0000000180033CC0                 mov     rax, rsp
+  .text:0000000180033CC3                 mov     [rax+20h], r9
+  .text:0000000180033CC7                 push    rbp
+  .text:0000000180033CC8                 push    rbx
+  .text:0000000180033CC9                 lea     rbp, [rax-5Fh]
+  .text:0000000180033CCD                 sub     rsp, 0B8h
+  .text:0000000180033CD4                 movaps  xmmword ptr [rax-48h], xmm6
+  .text:0000000180033CD8                 mov     [rax+10h], rsi
+  .text:0000000180033CDC                 xor     esi, esi
+  .text:0000000180033CDE                 mov     [rax-18h], rdi
+  .text:0000000180033CE2                 mov     rdi, rcx
+  .text:0000000180033CE5                 mov     [rax-20h], r12
+  .text:0000000180033CE9                 movzx   r12d, r8b
+  .text:0000000180033CED                 mov     [rax-28h], r13
+  .text:0000000180033CF1                 mov     r13, r9
+  .text:0000000180033CF4                 mov     qword ptr [rbp+57h+var_70+8], rcx
+  .text:0000000180033CF8                 mov     [rax-38h], r15
+  .text:0000000180033CFC                 lea     rax, [rbp+57h+arg_0]
+  .text:0000000180033D00                 mov     qword ptr [rcx+1F8h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180033D0B                 lea     rcx, [rbp+57h+var_80]
+  .text:0000000180033D0F                 mov     qword ptr [rbp+57h+var_70], rax
+  .text:0000000180033D13                 movaps  xmm6, [rbp+57h+var_70]
+  .text:0000000180033D17                 mov     [rbp+57h+arg_0], 1
+  .text:0000000180033D1B                 mov     [rbp+57h+var_80], rsi
+  .text:0000000180033D1F                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180033D25                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033D2B                 mov     edx, 2
+  .text:0000000180033D30                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180033D36                 lea     r15, unk_180528AFF
+  .text:0000000180033D3D                 test    al, al
+  .text:0000000180033D3F                 jz      short loc_180033D81
+  .text:0000000180033D41                 mov     rax, [rbp+57h+var_80]
+  .text:0000000180033D45                 lea     r9, aDemo_0; "demo"
+  .text:0000000180033D4C                 test    rax, rax
+  .text:0000000180033D4F                 lea     r8, aPlayingSFromS; "playing %s from '%s'\n"
+  .text:0000000180033D56                 mov     rcx, r15
+  .text:0000000180033D59                 mov     edx, 2
+  .text:0000000180033D5E                 cmovnz  rcx, rax
+  .text:0000000180033D62                 test    r12b, r12b
+  .text:0000000180033D65                 lea     rax, aTimedemo; "timedemo"
+  .text:0000000180033D6C                 mov     qword ptr [rsp+0C0h+var_A0], rcx
+  .text:0000000180033D71                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033D77                 cmovnz  r9, rax
+  .text:0000000180033D7B                 call    cs:LoggingSystem_Log
+  .text:0000000180033D81                 test    r13, r13
+  .text:0000000180033D84                 jz      short loc_180033DEA
+  .text:0000000180033D86                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033D8C                 call    cs:LoggingSystem_GetChannelVerbosity
+  .text:0000000180033D92                 cmp     eax, 3
+  .text:0000000180033D95                 jl      short loc_180033DEA
+  .text:0000000180033D97                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033D9D                 mov     edx, 2
+  .text:0000000180033DA2                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180033DA8                 test    al, al
+  .text:0000000180033DAA                 jz      short loc_180033DC4
+  .text:0000000180033DAC                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033DB2                 lea     r8, aDemoPlaybackOp; "Demo playback options:\n"
+  .text:0000000180033DB9                 mov     edx, 2
+  .text:0000000180033DBE                 call    cs:LoggingSystem_Log
+  .text:0000000180033DC4                 mov     edx, cs:dword_18068C1F0
+  .text:0000000180033DCA                 lea     rcx, [rbp+57h+var_60]
+  .text:0000000180033DCE                 mov     r8d, 2
+  .text:0000000180033DD4                 call    cs:??0CKeyValuesDumpContextToLoggingChannel@@QEAA@HW4LoggingSeverity_t@@@Z; CKeyValuesDumpContextToLoggingChannel::CKeyValuesDumpContextToLoggingChannel(int,LoggingSeverity_t)
+  .text:0000000180033DDA                 xor     r8d, r8d
+  .text:0000000180033DDD                 lea     rdx, [rbp+57h+var_60]
+  .text:0000000180033DE1                 mov     rcx, r13
+  .text:0000000180033DE4                 call    cs:?Dump@KeyValues@@QEAA_NPEAVIKeyValuesDumpContext@@H@Z; KeyValues::Dump(IKeyValuesDumpContext *,int)
+  .text:0000000180033DEA                 mov     rbx, cs:g_pNetworkGameClient
+  .text:0000000180033DF1                 mov     [rsp+0C0h+var_28], r14
+  .text:0000000180033DF9                 test    rbx, rbx
+  .text:0000000180033DFC                 jz      loc_180034256
+  .text:0000000180033E02                 call    cs:VProfLite_Clear
+  .text:0000000180033E08                 mov     cl, 1
+  .text:0000000180033E0A                 call    cs:VProfLite_SetEnabled
+  .text:0000000180033E10                 lea     rdx, [rbp+57h+var_80]
+  .text:0000000180033E14                 call    sub_1800326A0
+  .text:0000000180033E19                 test    al, al
+  .text:0000000180033E1B                 jz      loc_1800342CF
+  .text:0000000180033E21                 lea     rdx, [rbp+57h+var_80]
+  .text:0000000180033E25                 mov     rcx, rdi
+  .text:0000000180033E28                 call    sub_180033720
+  .text:0000000180033E2D                 test    al, al
+  .text:0000000180033E2F                 jz      loc_1800342CF
+  .text:0000000180033E35                 mov     rcx, rdi
+  .text:0000000180033E38                 call    sub_180033460
+  .text:0000000180033E3D                 test    al, al
+  .text:0000000180033E3F                 jz      loc_1800342CF
+  .text:0000000180033E45                 mov     eax, [rdi+0D8h]
+  .text:0000000180033E4B                 mov     [rdi+200h], eax
+  .text:0000000180033E51                 test    r12b, r12b
+  .text:0000000180033E54                 jz      loc_180033F39
+  .text:0000000180033E5A                 mov     edx, 0FFFFFFFFh
+  .text:0000000180033E5F                 lea     rcx, unk_18068C238
+  .text:0000000180033E66                 call    sub_1803FEF60
+  .text:0000000180033E6B                 test    rax, rax
+  .text:0000000180033E6E                 jnz     short loc_180033E7B
+  .text:0000000180033E70                 mov     rax, cs:qword_18068C240
+  .text:0000000180033E77                 mov     rax, [rax+8]
+  .text:0000000180033E7B                 mov     rax, [rax]
+  .text:0000000180033E7E                 mov     rcx, r15
+  .text:0000000180033E81                 test    rax, rax
+  .text:0000000180033E84                 cmovnz  rcx, rax
+  .text:0000000180033E88                 xor     r9d, r9d
+  .text:0000000180033E8B                 xor     r8d, r8d
+  .text:0000000180033E8E                 xor     edx, edx
+  .text:0000000180033E90                 call    sub_180037770
+  .text:0000000180033E95                 mov     edx, 0FFFFFFFFh
+  .text:0000000180033E9A                 lea     rcx, unk_18068C248
+  .text:0000000180033EA1                 mov     r13d, eax
+  .text:0000000180033EA4                 call    sub_1803FEF60
+  .text:0000000180033EA9                 test    rax, rax
+  .text:0000000180033EAC                 jnz     short loc_180033EB9
+  .text:0000000180033EAE                 mov     rax, cs:qword_18068C250
+  .text:0000000180033EB5                 mov     rax, [rax+8]
+  .text:0000000180033EB9                 mov     rax, [rax]
+  .text:0000000180033EBC                 mov     r14, r15
+  .text:0000000180033EBF                 test    rax, rax
+  .text:0000000180033EC2                 cmovnz  r14, rax
+  .text:0000000180033EC6                 xor     r9d, r9d
+  .text:0000000180033EC9                 mov     rcx, r14
+  .text:0000000180033ECC                 xor     r8d, r8d
+  .text:0000000180033ECF                 xor     edx, edx
+  .text:0000000180033ED1                 call    sub_180037770
+  .text:0000000180033ED6                 mov     esi, eax
+  .text:0000000180033ED8                 test    eax, eax
+  .text:0000000180033EDA                 js      short loc_180033F02
+  .text:0000000180033EDC                 mov     edx, 2Bh ; '+'
+  .text:0000000180033EE1                 mov     rcx, r14
+  .text:0000000180033EE4                 call    sub_1804287E4
+  .text:0000000180033EE9                 test    rax, rax
+  .text:0000000180033EEC                 jz      short loc_180033F02
+  .text:0000000180033EEE                 xor     r9d, r9d
+  .text:0000000180033EF1                 xor     r8d, r8d
+  .text:0000000180033EF4                 xor     edx, edx
+  .text:0000000180033EF6                 mov     rcx, r14
+  .text:0000000180033EF9                 call    sub_180037770
+  .text:0000000180033EFE                 lea     esi, [rax+r13]
+  .text:0000000180033F02                 cmp     r13d, 64h ; 'd'
+  .text:0000000180033F06                 jl      short loc_180033F19
+  .text:0000000180033F08                 lea     eax, [r13-64h]
+  .text:0000000180033F0C                 mov     byte ptr [rdi+18A3h], 1
+  .text:0000000180033F13                 mov     [rdi+220h], eax
+  .text:0000000180033F19                 test    esi, esi
+  .text:0000000180033F1B                 jle     short loc_180033F2B
+  .text:0000000180033F1D                 cmp     esi, [rdi+220h]
+  .text:0000000180033F23                 jle     short loc_180033F2B
+  .text:0000000180033F25                 mov     [rdi+224h], esi
+  .text:0000000180033F2B                 xor     ecx, ecx
+  .text:0000000180033F2D                 call    cs:RandomSeed
+  .text:0000000180033F33                 mov     r13, [rbp+57h+arg_18]
+  .text:0000000180033F37                 xor     esi, esi
+  .text:0000000180033F39                 mov     rcx, cs:g_pNetworkClientService
+  .text:0000000180033F40                 mov     byte ptr [rdi+1230h], 1 ; 1230h = CDemoPlayer::m_bIsPlaying (structmember, struct=CDemoPlayer, member=m_bIsPlaying)
+  .text:0000000180033F47                 mov     byte ptr [rdi+1232h], 0
+  .text:0000000180033F4E                 mov     dword ptr [rbx+230h], 2
+  .text:0000000180033F58                 mov     rax, [rcx]
+  .text:0000000180033F5B                 call    qword ptr [rax+1C0h]
+  .text:0000000180033F61                 mov     rcx, cs:g_pNetworkSystem
+  .text:0000000180033F68                 lea     rdx, aDemo_1; "DEMO"
+  .text:0000000180033F6F                 mov     [rdi+204h], eax
+  .text:0000000180033F75                 xor     r9d, r9d
+  .text:0000000180033F78                 mov     dword ptr [rsp+30h], 1
+  .text:0000000180033F80                 xor     r8d, r8d
+  .text:0000000180033F83                 mov     [rsp+0C0h+var_98], 2
+  .text:0000000180033F8B                 mov     rax, [rcx]
+  .text:0000000180033F8E                 mov     qword ptr [rsp+0C0h+var_A0], rdx
+  .text:0000000180033F93                 mov     edx, cs:dword_18060EFC4
+  .text:0000000180033F99                 call    qword ptr [rax+0B0h]
+  .text:0000000180033F9F                 mov     [rbx+0F0h], rax
+  .text:0000000180033FA6                 test    rax, rax
+  .text:0000000180033FA9                 jnz     short loc_180033FD0
+  .text:0000000180033FAB                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180033FB1                 mov     edx, 3
+  .text:0000000180033FB6                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180033FBC                 test    al, al
+  .text:0000000180033FBE                 jz      loc_1800342CF
+  .text:0000000180033FC4                 lea     r8, aCdemoplayerSta_3; "CDemoPlayer::StartPlayback: failed to c"...
+  .text:0000000180033FCB                 jmp     loc_1800342B0
+  .text:0000000180033FD0                 movss   xmm1, cs:dword_180585200
+  .text:0000000180033FD8                 xor     r8d, r8d
+  .text:0000000180033FDB                 mov     [rbp+57h+arg_0], 0
+  .text:0000000180033FDF                 mov     rcx, [rbx+0F0h]
+  .text:0000000180033FE6                 mov     rax, [rcx]
+  .text:0000000180033FE9                 call    qword ptr [rax+1B8h]
+  .text:0000000180033FEF                 mov     eax, cs:dword_18060EFC4
+  .text:0000000180033FF5                 mov     rcx, rbx
+  .text:0000000180033FF8                 mov     [rbx+23Ch], eax
+  .text:0000000180033FFE                 mov     rdx, [rbx+0F0h]
+  .text:0000000180034005                 call    sub_18007CBE0
+  .text:000000018003400A                 mov     rcx, rbx
+  .text:000000018003400D                 call    CNetworkGameClientBase_DeferActivate
+  .text:0000000180034012                 mov     rcx, cs:g_pNetworkSystem
+  .text:0000000180034019                 mov     rax, [rcx]
+  .text:000000018003401C                 call    qword ptr [rax+0D8h]
+  .text:0000000180034022                 xorps   xmm1, xmm1
+  .text:0000000180034025                 lea     rdx, [rbp+57h+var_70]
+  .text:0000000180034029                 cvtsd2ss xmm1, xmm0
+  .text:000000018003402D                 lea     rcx, [rbp+57h+var_80]
+  .text:0000000180034031                 movss   dword ptr [rbx+250h], xmm1
+  .text:0000000180034039                 mov     [rdi+18A2h], r12b
+  .text:0000000180034040                 mov     dword ptr [rdi+228h], 0FFFFFFFFh
+  .text:000000018003404A                 mov     dword ptr [rdi+21Ch], 0FFFFFFFFh
+  .text:0000000180034054                 mov     [rdi+22Ch], esi
+  .text:000000018003405A                 mov     byte ptr [rdi+18A1h], 0
+  .text:0000000180034061                 mov     [rdi+210h], esi
+  .text:0000000180034067                 mov     dword ptr [rdi+214h], 3F800000h
+  .text:0000000180034071                 call    cs:?StripExtension@CUtlString@@QEBA?AV1@XZ; CUtlString::StripExtension(void)
+  .text:0000000180034077                 cmp     byte ptr [rdi+18A0h], 0
+  .text:000000018003407E                 jz      short loc_1800340BB
+  .text:0000000180034080                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180034086                 mov     edx, 2
+  .text:000000018003408B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180034091                 test    al, al
+  .text:0000000180034093                 jz      short loc_1800340B4
+  .text:0000000180034095                 mov     ecx, cs:dword_18068C1F0
+  .text:000000018003409B                 lea     r9, aFalse; "false"
+  .text:00000001800340A2                 lea     r8, aCdemoplayerSet; "CDemoPlayer::SetIgnorePacketsForResourc"...
+  .text:00000001800340A9                 mov     edx, 2
+  .text:00000001800340AE                 call    cs:LoggingSystem_Log
+  .text:00000001800340B4                 mov     byte ptr [rdi+18A0h], 0
+  .text:00000001800340BB                 mov     rcx, rdi
+  .text:00000001800340BE                 call    sub_180034410
+  .text:00000001800340C3                 mov     r8, r13
+  .text:00000001800340C6                 lea     rdx, [rbp+57h+var_70]
+  .text:00000001800340CA                 mov     rcx, rdi
+  .text:00000001800340CD                 call    sub_180033190
+  .text:00000001800340D2                 lea     r14, [rdi+1938h]
+  .text:00000001800340D9                 mov     eax, [r14]
+  .text:00000001800340DC                 mov     r12, r14
+  .text:00000001800340DF                 sub     eax, 1
+  .text:00000001800340E2                 movsxd  rsi, eax
+  .text:00000001800340E5                 js      short loc_180034112
+  .text:00000001800340E7                 nop     word ptr [rax+rax+00000000h]
+  .text:00000001800340F0                 mov     rax, [r14+8]
+  .text:00000001800340F4                 cmp     qword ptr [rax+rsi*8], 0
+  .text:00000001800340F9                 lea     rcx, [rax+rsi*8]
+  .text:00000001800340FD                 jz      short loc_180034105
+  .text:00000001800340FF                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180034105                 sub     rsi, 1
+  .text:0000000180034109                 jns     short loc_1800340F0
+  .text:000000018003410B                 lea     r12, [rdi+1938h]
+  .text:0000000180034112                 xor     esi, esi
+  .text:0000000180034114                 mov     [r14], esi
+  .text:0000000180034117                 test    dword ptr [r14+14h], 0C0000000h
+  .text:000000018003411F                 jnz     short loc_180034142
+  .text:0000000180034121                 mov     rdx, [r14+8]
+  .text:0000000180034125                 test    rdx, rdx
+  .text:0000000180034128                 jz      short loc_18003413E
+  .text:000000018003412A                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180034131                 mov     rcx, [rax]
+  .text:0000000180034134                 mov     rax, [rcx]
+  .text:0000000180034137                 call    qword ptr [rax+18h]
+  .text:000000018003413A                 mov     [r14+8], rsi
+  .text:000000018003413E                 mov     [r14+10h], esi
+  .text:0000000180034142                 mov     rcx, cs:g_pSource2Client
+  .text:0000000180034149                 mov     rdx, r15
+  .text:000000018003414C                 mov     r9, r13
+  .text:000000018003414F                 mov     r8, r12
+  .text:0000000180034152                 mov     rax, [rcx]
+  .text:0000000180034155                 mov     r10, [rax+1F0h]
+  .text:000000018003415C                 mov     rax, qword ptr [rbp+57h+var_70]
+  .text:0000000180034160                 test    rax, rax
+  .text:0000000180034163                 cmovnz  rdx, rax
+  .text:0000000180034167                 call    r10
+  .text:000000018003416A                 mov     rcx, rdi
+  .text:000000018003416D                 call    sub_18002F460
+  .text:0000000180034172                 mov     rcx, cs:g_pSource2Client
+  .text:0000000180034179                 mov     r9, r13
+  .text:000000018003417C                 mov     rax, [rcx]
+  .text:000000018003417F                 mov     r10, [rax+1F0h]
+  .text:0000000180034186                 mov     rax, qword ptr [rbp+57h+var_70]
+  .text:000000018003418A                 test    rax, rax
+  .text:000000018003418D                 cmovnz  r15, rax
+  .text:0000000180034191                 xor     r8d, r8d
+  .text:0000000180034194                 mov     rdx, r15
+  .text:0000000180034197                 call    r10
+  .text:000000018003419A                 mov     rcx, cs:g_pTestScriptMgr
+  .text:00000001800341A1                 test    rcx, rcx
+  .text:00000001800341A4                 jz      short loc_1800341B3
+  .text:00000001800341A6                 mov     rax, [rcx]
+  .text:00000001800341A9                 lea     rdx, aDemoplaybackst; "DemoPlaybackStarted"
+  .text:00000001800341B0                 call    qword ptr [rax+60h]
+  .text:00000001800341B3                 mov     edi, esi
+  .text:00000001800341B5                 cmp     [rbx+2CCF90h], esi
+  .text:00000001800341BB                 jle     short loc_1800341EA
+  .text:00000001800341BD                 nop     dword ptr [rax]
+  .text:00000001800341C0                 mov     rax, [rbx+2CCF98h]
+  .text:00000001800341C7                 mov     rcx, [rsi+rax]
+  .text:00000001800341CB                 test    rcx, rcx
+  .text:00000001800341CE                 jz      short loc_1800341DA
+  .text:00000001800341D0                 mov     rax, [rcx]
+  .text:00000001800341D3                 mov     edx, 1
+  .text:00000001800341D8                 call    qword ptr [rax]
+  .text:00000001800341DA                 inc     edi
+  .text:00000001800341DC                 add     rsi, 8
+  .text:00000001800341E0                 cmp     edi, [rbx+2CCF90h]
+  .text:00000001800341E6                 jl      short loc_1800341C0
+  .text:00000001800341E8                 xor     esi, esi
+  .text:00000001800341EA                 mov     [rbx+2CCF90h], esi
+  .text:00000001800341F0                 test    dword ptr [rbx+2CCFA4h], 0C0000000h
+  .text:00000001800341FA                 jnz     short loc_180034225
+  .text:00000001800341FC                 mov     rdx, [rbx+2CCF98h]
+  .text:0000000180034203                 test    rdx, rdx
+  .text:0000000180034206                 jz      short loc_18003421F
+  .text:0000000180034208                 mov     rax, cs:g_pMemAlloc
+  .text:000000018003420F                 mov     rcx, [rax]
+  .text:0000000180034212                 mov     rax, [rcx]
+  .text:0000000180034215                 call    qword ptr [rax+18h]
+  .text:0000000180034218                 mov     [rbx+2CCF98h], rsi
+  .text:000000018003421F                 mov     [rbx+2CCFA0h], esi
+  .text:0000000180034225                 mov     [rbx+2CD188h], rsi
+  .text:000000018003422C                 mov     [rbx+2CD190h], rsi
+  .text:0000000180034233                 mov     dword ptr [rbx+24Ch], 0FFFFFFFFh
+  .text:000000018003423D                 mov     bl, 1
+  .text:000000018003423F                 cmp     qword ptr [rbp+57h+var_70], 0
+  .text:0000000180034244                 jz      loc_1800342D1
+  .text:000000018003424A                 lea     rcx, [rbp+57h+var_70]
+  .text:000000018003424E                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180034254                 jmp     short loc_1800342D1
+  .text:0000000180034256                 lea     rax, aCBuildworkerCs_0; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:000000018003425D                 mov     dword ptr [rbp+57h+var_48], 0DDEh
+  .text:0000000180034264                 mov     [rbp+57h+var_60], rax
+  .text:0000000180034268                 lea     rcx, [rbp+57h+var_60]
+  .text:000000018003426C                 lea     rax, aCdemoplayerSta_4; "CDemoPlayer::StartPlayback"
+  .text:0000000180034273                 mov     dword ptr [rbp+57h+var_48+4], 14h
+  .text:000000018003427A                 mov     [rbp+57h+var_58], rax
+  .text:000000018003427E                 lea     rax, aPclient; "pClient"
+  .text:0000000180034285                 mov     [rbp+57h+var_50], rax
+  .text:0000000180034289                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@@Z; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &)
+  .text:000000018003428F                 test    al, al
+  .text:0000000180034291                 jz      short loc_180034294
+  .text:0000000180034293                 ; Trap to Debugger
+  .text:0000000180034293                 int     3; Trap to Debugger
+  .text:0000000180034294                 mov     ecx, cs:dword_18068C1F0
+  .text:000000018003429A                 mov     edx, 3
+  .text:000000018003429F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800342A5                 test    al, al
+  .text:00000001800342A7                 jz      short loc_1800342CF
+  .text:00000001800342A9                 lea     r8, aCanTPlayBackNo; "can't play back, no CNetworkGameClient "...
+  .text:00000001800342B0                 mov     rax, [rbp+57h+var_80]
+  .text:00000001800342B4                 mov     edx, 3
+  .text:00000001800342B9                 mov     ecx, cs:dword_18068C1F0
+  .text:00000001800342BF                 test    rax, rax
+  .text:00000001800342C2                 cmovnz  r15, rax
+  .text:00000001800342C6                 mov     r9, r15
+  .text:00000001800342C9                 call    cs:LoggingSystem_Log
+  .text:00000001800342CF                 xor     bl, bl
+  .text:00000001800342D1                 cmp     [rbp+57h+var_80], 0
+  .text:00000001800342D6                 mov     r15, [rsp+0C0h+var_30]
+  .text:00000001800342DE                 mov     r14, [rsp+0C0h+var_28]
+  .text:00000001800342E6                 mov     r13, [rsp+0C0h+var_20]
+  .text:00000001800342EE                 mov     r12, [rsp+0C0h+var_18]
+  .text:00000001800342F6                 mov     rdi, [rsp+0B0h]
+  .text:00000001800342FE                 mov     rsi, [rsp+0C0h+arg_8]
+  .text:0000000180034306                 jz      short loc_180034312
+  .text:0000000180034308                 lea     rcx, [rbp+57h+var_80]
+  .text:000000018003430C                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180034312                 movq    rcx, xmm6
+  .text:0000000180034317                 cmp     byte ptr [rcx], 0
+  .text:000000018003431A                 jz      short loc_180034343
+  .text:000000018003431C                 psrldq  xmm6, 8
+  .text:0000000180034321                 movq    rcx, xmm6
+  .text:0000000180034326                 add     rcx, 20h ; ' '
+  .text:000000018003432A                 mov     rdx, [rcx]
+  .text:000000018003432D                 call    qword ptr [rdx+10h]
+  .text:0000000180034330                 mov     r8, cs:off_180611758
+  .text:0000000180034337                 lea     rcx, off_180611758
+  .text:000000018003433E                 xor     edx, edx
+  .text:0000000180034340                 call    qword ptr [r8]
+  .text:0000000180034343                 movaps  xmm6, [rsp+0C0h+var_48+8]
+  .text:000000018003434B                 movzx   eax, bl
+  .text:000000018003434E                 add     rsp, 0B8h
+  .text:0000000180034355                 pop     rbx
+  .text:0000000180034356                 pop     rbp
+  .text:0000000180034357                 retn
+procedure: |-
+  __int64 __fastcall sub_180033CC0(__int64 a1, const char *a2, char a3, KeyValues *a4)
+  {
+    KeyValues *v6; // r13
+    __m128i v7; // xmm6
+    void *v8; // r15
+    const char *v9; // r9
+    void *v10; // rcx
+    __int64 v11; // rbx
+    __int64 v12; // rcx
+    __int64 v13; // rcx
+    void **v14; // rax
+    void *v15; // rax
+    void *v16; // rcx
+    int v17; // r13d
+    void **v18; // rax
+    void *v19; // rax
+    void *v20; // r14
+    int v21; // esi
+    __int64 v22; // rcx
+    int v23; // eax
+    __int64 v24; // rcx
+    __int64 v25; // rax
+    __int64 v26; // rdx
+    const char *v27; // r8
+    float v28; // xmm1_4
+    __int64 v29; // r12
+    int v30; // eax
+    __int64 v31; // rsi
+    CUtlString *v32; // rcx
+    __int64 v33; // rsi
+    void *v34; // rdx
+    int i; // edi
+    void (__fastcall ***v36)(_QWORD, __int64); // rcx
+    unsigned __int8 v37; // bl
+    unsigned __int64 v38; // rcx
+    _QWORD v40[2]; // [rsp+48h] [rbp-29h] BYREF
+    __m128i v41; // [rsp+58h] [rbp-19h] BYREF
+    _QWORD v42[5]; // [rsp+68h] [rbp-9h] BYREF
+    char v43; // [rsp+D8h] [rbp+67h] BYREF
+    KeyValues *v44; // [rsp+F0h] [rbp+7Fh]
+
+    v44 = a4;
+    v6 = a4;
+    v41.m128i_i64[1] = a1;
+    *(_QWORD *)(a1 + 504) = -1;
+    v41.m128i_i64[0] = (__int64)&v43;
+    v7 = v41;
+    v43 = 1;
+    v40[0] = 0;
+    CUtlString::Set((CUtlString *)v40, a2);
+    v8 = &unk_180528AFF;
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 2) )
+    {
+      v9 = "demo";
+      v10 = &unk_180528AFF;
+      if ( v40[0] )
+        v10 = (void *)v40[0];
+      if ( a3 )
+        v9 = "timedemo";
+      LoggingSystem_Log((unsigned int)dword_18068C1F0, 2, "playing %s from '%s'\n", v9, v10);
+    }
+    if ( v6 && (int)LoggingSystem_GetChannelVerbosity((unsigned int)dword_18068C1F0) >= 3 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 2) )
+        LoggingSystem_Log((unsigned int)dword_18068C1F0, 2, "Demo playback options:\n");
+      CKeyValuesDumpContextToLoggingChannel::CKeyValuesDumpContextToLoggingChannel(v42, (unsigned int)dword_18068C1F0, 2);
+      KeyValues::Dump(v6, (struct IKeyValuesDumpContext *)v42, 0);
+    }
+    v11 = g_pNetworkGameClient;
+    if ( !g_pNetworkGameClient )
+    {
+      v42[3] = 0x1400000DDELL;
+      v42[0] = "C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\cl_demo.cpp";
+      v42[1] = "CDemoPlayer::StartPlayback";
+      v42[2] = "pClient";
+      if ( Assert_ConditionFailed((const struct _AssertCompileTimeConstantStruct_t *)v42) )
+        __debugbreak();
+      if ( !(unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 3) )
+        goto LABEL_73;
+      v27 = "can't play back, no CNetworkGameClient for demo '%s'\n";
+      goto LABEL_70;
+    }
+    VProfLite_Clear();
+    LOBYTE(v12) = 1;
+    VProfLite_SetEnabled(v12);
+    if ( !(unsigned __int8)sub_1800326A0(v13, v40)
+      || !(unsigned __int8)sub_180033720(a1, v40)
+      || !(unsigned __int8)sub_180033460(a1) )
+    {
+  LABEL_73:
+      v37 = 0;
+      goto LABEL_74;
+    }
+    *(_DWORD *)(a1 + 512) = *(_DWORD *)(a1 + 216);
+    if ( a3 )
+    {
+      v14 = (void **)sub_1803FEF60(&unk_18068C238, 0xFFFFFFFFLL);
+      if ( !v14 )
+        v14 = *(void ***)(qword_18068C240 + 8);
+      v15 = *v14;
+      v16 = &unk_180528AFF;
+      if ( v15 )
+        v16 = v15;
+      v17 = sub_180037770(v16, 0, 0, 0);
+      v18 = (void **)sub_1803FEF60(&unk_18068C248, 0xFFFFFFFFLL);
+      if ( !v18 )
+        v18 = *(void ***)(qword_18068C250 + 8);
+      v19 = *v18;
+      v20 = &unk_180528AFF;
+      if ( v19 )
+        v20 = v19;
+      v21 = sub_180037770(v20, 0, 0, 0);
+      if ( v21 >= 0 && sub_1804287E4(v20, 43) )
+        v21 = sub_180037770(v20, 0, 0, 0) + v17;
+      if ( v17 >= 100 )
+      {
+        *(_BYTE *)(a1 + 6307) = 1;
+        *(_DWORD *)(a1 + 544) = v17 - 100;
+      }
+      if ( v21 > 0 && v21 > *(_DWORD *)(a1 + 544) )
+        *(_DWORD *)(a1 + 548) = v21;
+      RandomSeed(0);
+      v6 = v44;
+    }
+    v22 = g_pNetworkClientService;
+    *(_BYTE *)(a1 + 4656) = 1;                    // 4656 = 0x1230 = CDemoPlayer::m_bIsPlaying (structmember, struct=CDemoPlayer, member=m_bIsPlaying)
+    *(_BYTE *)(a1 + 4658) = 0;
+    *(_DWORD *)(v11 + 560) = 2;
+    v23 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v22 + 448LL))(v22);
+    v24 = g_pNetworkSystem;
+    *(_DWORD *)(a1 + 516) = v23;
+    v25 = (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD, _QWORD, const char *, int, int))(*(_QWORD *)v24 + 176LL))(
+            v24,
+            (unsigned int)dword_18060EFC4,
+            0,
+            0,
+            "DEMO",
+            2,
+            1);
+    *(_QWORD *)(v11 + 240) = v25;
+    if ( !v25 )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 3) )
+      {
+        v27 = "CDemoPlayer::StartPlayback: failed to create demo net channel for '%s'\n";
+  LABEL_70:
+        if ( v40[0] )
+          v8 = (void *)v40[0];
+        LoggingSystem_Log((unsigned int)dword_18068C1F0, 3, v27, v8);
+        goto LABEL_73;
+      }
+      goto LABEL_73;
+    }
+    v43 = 0;
+    (*(void (__fastcall **)(_QWORD, __int64, _QWORD))(**(_QWORD **)(v11 + 240) + 440LL))(*(_QWORD *)(v11 + 240), v26, 0);
+    *(_DWORD *)(v11 + 572) = dword_18060EFC4;
+    sub_18007CBE0(v11, *(_QWORD *)(v11 + 240));
+    CNetworkGameClientBase_DeferActivate((__int64 *)v11);
+    v28 = (*(double (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkSystem + 216LL))(g_pNetworkSystem);
+    *(float *)(v11 + 592) = v28;
+    *(_BYTE *)(a1 + 6306) = a3;
+    *(_DWORD *)(a1 + 552) = -1;
+    *(_DWORD *)(a1 + 540) = -1;
+    *(_DWORD *)(a1 + 556) = 0;
+    *(_BYTE *)(a1 + 6305) = 0;
+    *(_DWORD *)(a1 + 528) = 0;
+    *(_DWORD *)(a1 + 532) = 1065353216;
+    CUtlString::StripExtension(v40, &v41);
+    if ( *(_BYTE *)(a1 + 6304) )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 2) )
+        LoggingSystem_Log(
+          (unsigned int)dword_18068C1F0,
+          2,
+          "CDemoPlayer::SetIgnorePacketsForResourceLoading(%s)\n",
+          "false");
+      *(_BYTE *)(a1 + 6304) = 0;
+    }
+    sub_180034410(a1);
+    sub_180033190(a1, &v41, v6);
+    v29 = a1 + 6456;
+    v30 = *(_DWORD *)(a1 + 6456) - 1;
+    v31 = v30;
+    if ( v30 >= 0 )
+    {
+      do
+      {
+        v32 = (CUtlString *)(*(_QWORD *)(a1 + 6464) + 8 * v31);
+        if ( *(_QWORD *)v32 )
+          CUtlString::FreeMemoryBlock(v32);
+        --v31;
+      }
+      while ( v31 >= 0 );
+      v29 = a1 + 6456;
+    }
+    v33 = 0;
+    *(_DWORD *)(a1 + 6456) = 0;
+    if ( (*(_DWORD *)(a1 + 6476) & 0xC0000000) == 0 )
+    {
+      if ( *(_QWORD *)(a1 + 6464) )
+      {
+        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+        *(_QWORD *)(a1 + 6464) = 0;
+      }
+      *(_DWORD *)(a1 + 6472) = 0;
+    }
+    v34 = &unk_180528AFF;
+    if ( v41.m128i_i64[0] )
+      v34 = (void *)v41.m128i_i64[0];
+    (*(void (__fastcall **)(__int64, void *, __int64, KeyValues *))(*(_QWORD *)g_pSource2Client + 496LL))(
+      g_pSource2Client,
+      v34,
+      v29,
+      v6);
+    sub_18002F460(a1);
+    if ( v41.m128i_i64[0] )
+      v8 = (void *)v41.m128i_i64[0];
+    (*(void (__fastcall **)(__int64, void *, _QWORD, KeyValues *))(*(_QWORD *)g_pSource2Client + 496LL))(
+      g_pSource2Client,
+      v8,
+      0,
+      v6);
+    if ( g_pTestScriptMgr )
+      (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)g_pTestScriptMgr + 96LL))(
+        g_pTestScriptMgr,
+        "DemoPlaybackStarted");
+    for ( i = 0; i < *(_DWORD *)(v11 + 2936720); v33 += 8 )
+    {
+      v36 = *(void (__fastcall ****)(_QWORD, __int64))(v33 + *(_QWORD *)(v11 + 2936728));
+      if ( v36 )
+        (**v36)(v36, 1);
+      ++i;
+    }
+    *(_DWORD *)(v11 + 2936720) = 0;
+    if ( (*(_DWORD *)(v11 + 2936740) & 0xC0000000) == 0 )
+    {
+      if ( *(_QWORD *)(v11 + 2936728) )
+      {
+        (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+        *(_QWORD *)(v11 + 2936728) = 0;
+      }
+      *(_DWORD *)(v11 + 2936736) = 0;
+    }
+    *(_QWORD *)(v11 + 2937224) = 0;
+    *(_QWORD *)(v11 + 2937232) = 0;
+    *(_DWORD *)(v11 + 588) = -1;
+    v37 = 1;
+    if ( v41.m128i_i64[0] )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v41);
+  LABEL_74:
+    if ( v40[0] )
+      CUtlString::FreeMemoryBlock((CUtlString *)v40);
+    if ( *(_BYTE *)v7.m128i_i64[0] )
+    {
+      v38 = _mm_srli_si128(v7, 8).m128i_u64[0] + 32;
+      (*(void (__fastcall **)(unsigned __int64))(*(_QWORD *)v38 + 16LL))(v38);
+      ((void (__fastcall *)(__int64 (__fastcall ***)(), _QWORD))*off_180611758)(&off_180611758, 0);
+    }
+    return v37;
+  }

--- a/ida_preprocessor_scripts/references/engine/Demo_PauseAtServerTick_CommandHandler.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/Demo_PauseAtServerTick_CommandHandler.windows.yaml
@@ -1,0 +1,139 @@
+func_name: Demo_PauseAtServerTick_CommandHandler
+func_va: '0x180038540'
+disasm_code: |-
+  .text:0000000180038540                 mov     [rsp+arg_0], rbx
+  .text:0000000180038545                 mov     [rsp+arg_8], rsi
+  .text:000000018003854A                 push    rdi
+  .text:000000018003854B                 sub     rsp, 30h
+  .text:000000018003854F                 mov     rcx, cs:g_pDemoPlayer
+  .text:0000000180038556                 lea     rsi, g_DemoPlayer
+  .text:000000018003855D                 mov     rdi, cs:g_pNetworkGameClient
+  .text:0000000180038564                 mov     rbx, rdx
+  .text:0000000180038567                 cmp     rcx, rsi
+  .text:000000018003856A                 jnz     loc_180038671
+  .text:0000000180038570                 mov     rax, [rcx]
+  .text:0000000180038573                 call    qword ptr [rax+58h]
+  .text:0000000180038576                 test    al, al
+  .text:0000000180038578                 jz      loc_180038671
+  .text:000000018003857E                 test    rdi, rdi
+  .text:0000000180038581                 jz      loc_180038671
+  .text:0000000180038587                 cmp     byte ptr cs:qword_18068DB2C+1, 0
+  .text:000000018003858E                 jnz     loc_18003869E
+  .text:0000000180038594                 movss   xmm2, cs:dword_180585200
+  .text:000000018003859C                 mov     rcx, rbx
+  .text:000000018003859F                 call    sub_180043DA0
+  .text:00000001800385A4                 movaps  xmm2, xmm0
+  .text:00000001800385A7                 xorps   xmm0, xmm0
+  .text:00000001800385AA                 comiss  xmm0, xmm2
+  .text:00000001800385AD                 jbe     short loc_1800385D4
+  .text:00000001800385AF                 mov     ecx, cs:dword_18068C1F0
+  .text:00000001800385B5                 mov     edx, 3
+  .text:00000001800385BA                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800385C0                 test    al, al
+  .text:00000001800385C2                 jz      loc_18003869E
+  .text:00000001800385C8                 lea     r8, aMissingInvalid; "Missing/invalid pause tick number.\n"
+  .text:00000001800385CF                 jmp     loc_18003868D
+  .text:00000001800385D4                 cvttss2si ebx, xmm2
+  .text:00000001800385D8                 movd    xmm0, ebx
+  .text:00000001800385DC                 cvtdq2ps xmm0, xmm0
+  .text:00000001800385DF                 subss   xmm2, xmm0
+  .text:00000001800385E3                 cmp     ebx, [rdi+378h]
+  .text:00000001800385E9                 jg      short loc_180038649
+  .text:00000001800385EB                 movss   xmm1, cs:dword_180585200
+  .text:00000001800385F3                 mov     rcx, rsi
+  .text:00000001800385F6                 call    CDemoPlayer_Pause ; CDemoPlayer::Pause
+  .text:00000001800385FB                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180038601                 mov     edx, 3
+  .text:0000000180038606                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018003860C                 test    al, al
+  .text:000000018003860E                 jz      loc_18003869E
+  .text:0000000180038614                 mov     eax, [rdi+378h]
+  .text:000000018003861A                 lea     r8, aDesiredPauseTi; "Desired pause tick %d is not in the fut"...
+  .text:0000000180038621                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180038627                 mov     r9d, ebx
+  .text:000000018003862A                 mov     edx, 3
+  .text:000000018003862F                 mov     [rsp+38h+var_18], eax
+  .text:0000000180038633                 call    cs:LoggingSystem_Log
+  .text:0000000180038639                 mov     rbx, [rsp+38h+arg_0]
+  .text:000000018003863E                 mov     rsi, [rsp+38h+arg_8]
+  .text:0000000180038643                 add     rsp, 30h
+  .text:0000000180038647                 pop     rdi
+  .text:0000000180038648                 retn
+  .text:0000000180038649                 mov     edx, ebx
+  .text:000000018003864B                 lea     rcx, [rsp+38h+arg_10]
+  .text:0000000180038650                 call    sub_180311B60
+  .text:0000000180038655                 mov     rax, [rsp+38h+arg_10]
+  .text:000000018003865A                 mov     qword ptr cs:xmmword_18068C4B0+0Ch, rax
+  .text:0000000180038661                 mov     rbx, [rsp+38h+arg_0]
+  .text:0000000180038666                 mov     rsi, [rsp+38h+arg_8]
+  .text:000000018003866B                 add     rsp, 30h
+  .text:000000018003866F                 pop     rdi
+  .text:0000000180038670                 retn
+  .text:0000000180038671                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180038677                 mov     edx, 3
+  .text:000000018003867C                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180038682                 test    al, al
+  .text:0000000180038684                 jz      short loc_18003869E
+  .text:0000000180038686                 lea     r8, aErrorNotCurren; "Error - Not currently playing back a de"...
+  .text:000000018003868D                 mov     ecx, cs:dword_18068C1F0
+  .text:0000000180038693                 mov     edx, 3
+  .text:0000000180038698                 call    cs:LoggingSystem_Log
+  .text:000000018003869E                 mov     rbx, [rsp+38h+arg_0]
+  .text:00000001800386A3                 mov     rsi, [rsp+38h+arg_8]
+  .text:00000001800386A8                 add     rsp, 30h
+  .text:00000001800386AC                 pop     rdi
+  .text:00000001800386AD                 retn
+procedure: |-
+  double __fastcall Demo_PauseAtServerTick_CommandHandler(__int64 a1, __int64 a2)
+  {
+    __int64 v2; // rdi
+    __int64 v4; // rdx
+    double v5; // xmm0_8
+    float v6; // xmm2_4
+    double result; // xmm0_8
+    unsigned int v8; // ebx
+    __int64 v9; // [rsp+50h] [rbp+18h] BYREF
+
+    v2 = g_pNetworkGameClient;
+    if ( g_pDemoPlayer == &g_DemoPlayer
+      && (*(unsigned __int8 (__fastcall **)(__int64 *))(*g_pDemoPlayer + 88))(g_pDemoPlayer)
+      && v2 )
+    {
+      if ( !BYTE1(qword_18068DB2C) )
+      {
+        v5 = sub_180043DA0(a2);
+        v6 = *(float *)&v5;
+        result = 0.0;
+        if ( v6 >= 0.0 )
+        {
+          v8 = (int)v6;
+          *(_QWORD *)&result = COERCE_UNSIGNED_INT((float)(int)v6);
+          if ( (int)v6 > *(_DWORD *)(v2 + 888) )
+          {
+            sub_180311B60(&v9, v8);
+            *(_QWORD *)((char *)&xmmword_18068C4B0 + 12) = v9;
+          }
+          else
+          {
+            CDemoPlayer_Pause((__int64)&g_DemoPlayer, v4); // CDemoPlayer::Pause
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 3) )
+              return LoggingSystem_Log(
+                       (unsigned int)dword_18068C1F0,
+                       3,
+                       "Desired pause tick %d is not in the future.  The current tick is %d.  Pausing playback immediately.\n",
+                       v8,
+                       *(_DWORD *)(v2 + 888));
+          }
+        }
+        else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 3) )
+        {
+          return LoggingSystem_Log((unsigned int)dword_18068C1F0, 3, "Missing/invalid pause tick number.\n");
+        }
+      }
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_18068C1F0, 3) )
+    {
+      return LoggingSystem_Log((unsigned int)dword_18068C1F0, 3, "Error - Not currently playing back a demo.\n");
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary
- Add engine preprocessors for locating the `CDemoPlayer` vtable, playback functions, and the `demo_pauseatservertick` command handler.
- Add Windows decompile preprocessors and reference YAML for `m_bIsPlaying`, `CDemoPlayer_Pause`, and `m_bIsPaused`, with the corresponding `14172` configuration updates.

## Validation
- Engine analysis: `Failed: 0`
- Full repository `ida_analyze_bin.py -debug`: `Failed: 0`
- Non-MCP unit tests: `1048 tests OK`
- Ruff format/check: passed
- YamlFix, configuration parsing, and formatting gates: passed