### PR TITLE
feat(preprocessor): add ServerVoice IsPlayingDemo finders

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -3,8 +3,8 @@ name: create-pr
 description: |
   Create a GitHub pull request from either staged task changes or an already-committed current branch. Use when the
   user asks to create or open a PR, including when there are no staged changes but the clean current branch is not
-  main and has commits ahead of origin/main. Staged changes use the full immutable candidate lifecycle before commit;
-  an already-committed branch is pushed and opened directly without rewriting its commits.
+  main and has commits ahead of origin/main. Both modes use the full immutable candidate lifecycle. An
+  already-committed branch receives a supplemental publication commit without rewriting its existing commits.
 ---
 
 # Create Pull Request
@@ -16,15 +16,15 @@ Create one pull request using exactly one delivery mode:
   paths this mode may stage are formatter updates to those same paths and validated
   `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` outputs.
 - `committed-branch` - when the index is empty, deliver the existing commits on a clean non-`main` current branch
-  that is ahead of `origin/main`. Treat the captured `origin/main...HEAD` diff as the authorized change set. Do not
-  format, stage, generate another commit, or rewrite existing commits in this mode.
+  that is ahead of `origin/main`. Treat the captured `origin/main...HEAD` diff as the authorized source change set.
+  Run the same candidate lifecycle, then commit only formatter changes to those captured paths and validated
+  `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` publication outputs. Never rewrite existing commits.
 
 Never mix the two modes in one invocation.
 
 ## Inputs
 
-- `gamever` - required only for `staged-delivery`. Use the caller-provided value; if omitted in that mode, read
-  `CS2VIBE_GAMEVER` from `.env`.
+- `gamever` - required in both modes. Use the caller-provided value; if omitted, read `CS2VIBE_GAMEVER` from `.env`.
 - `branch` - optional `dev*` branch name for `staged-delivery`. If omitted while on `main`, derive a concise
   `dev-<topic>` name from the staged change. Ignore this input in `committed-branch`; use the current branch exactly.
 - `commit_title` - optional Conventional Commit title for `staged-delivery`. If omitted, derive it from the staged
@@ -33,10 +33,8 @@ Never mix the two modes in one invocation.
   actual validation results.
 - `issue` - optional GitHub issue number. Add `Closes #<issue>` to the PR body when supplied.
 
-After selecting `staged-delivery`, resolve exactly one non-empty `GAMEVER`. Set
-`ANALYSIS_CONFIG="configs/$GAMEVER.yaml"` and stop if that file does not exist. Never fall back to another game
-version. `committed-branch` does not run the candidate lifecycle, so do not require or resolve a game version in that
-mode.
+After selecting either mode, resolve exactly one non-empty `GAMEVER`. Set `ANALYSIS_CONFIG="configs/$GAMEVER.yaml"`
+and stop if that file does not exist. Never fall back to another game version.
 
 ## Safety Rules
 
@@ -48,8 +46,8 @@ mode.
 - In `staged-delivery`, treat the initial staged path list as immutable authorization. Do not add other source,
   config, reference, test, or documentation paths after the gates run.
 - In `committed-branch`, require an empty index, a non-`main` attached branch, at least one commit ahead of
-  `origin/main`, and a non-empty `origin/main...HEAD` diff. Keep `HEAD`, the current branch, and the committed path
-  list unchanged until push.
+  `origin/main`, and a non-empty `origin/main...HEAD` diff. Preserve the captured `HEAD` as the parent of at most one
+  supplemental publication commit; preserve the current branch and captured committed path list until push.
 - Stop on the first failed/non-runnable gate. Do not repair or retry inside this skill, and do not commit, push, or
   create a PR after a gate failure.
 
@@ -126,33 +124,31 @@ duplicate PR.
 
 ## Step 2: Prepare the Immutable Candidate
 
-Run Steps 2 through 6 only in `staged-delivery`. In `committed-branch`, skip directly to Step 7 without running a
-formatter, candidate command, publication command, staging command, or commit command.
-
-In `staged-delivery`, **ALWAYS** Use SKILL `/prepare-post-change-candidate` with the resolved `gamever`.
+In both modes, **ALWAYS** Use SKILL `/prepare-post-change-candidate` with the resolved `gamever`.
 
 Retain the returned candidate path, candidate session path, gamedata session path, and candidate SHA-256. If the
 skill fails, stop the entire task.
 
 After preparation, inspect `git diff --name-only`. Formatting may have changed a path only when it belongs to
-`INITIAL_STAGED_PATHS`. If any other tracked path changed, stop and report it; do not stage it or continue.
+`INITIAL_STAGED_PATHS` in `staged-delivery`, or to `INITIAL_COMMITTED_PATHS` in `committed-branch`. If any other
+tracked path changed, stop and report it; do not stage it or continue.
 
 ## Step 3: Validate the Exact Candidate
 
-In `staged-delivery`, **ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and
-candidate session path returned by `/prepare-post-change-candidate`.
+In both modes, **ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and candidate
+session path returned by `/prepare-post-change-candidate`.
 
 Require explicit success, runnable C++ tests, and zero failure counters. If validation fails or is non-runnable,
 stop exactly as that skill requires. Do not publish, commit, push, or create a PR.
 
 ## Step 4: Publish the Validated Candidate
 
-Only after validation succeeds in `staged-delivery`, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the
-same `gamever`, candidate path, candidate session path, and gamedata session path.
+Only after validation succeeds in either mode, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the same
+`gamever`, candidate path, candidate session path, and gamedata session path.
 
 Require the published snapshot SHA-256 to equal the validated candidate SHA-256. Publication may modify only:
 
-- existing paths in `INITIAL_STAGED_PATHS` that were reformatted;
+- existing paths in `INITIAL_STAGED_PATHS` or `INITIAL_COMMITTED_PATHS` that were reformatted;
 - `gamesymbols/$GAMEVER.yaml`;
 - files under `gamedata/$GAMEVER/`.
 
@@ -161,14 +157,16 @@ a hard stop. Preserve pre-existing unrelated untracked files and leave them untr
 
 ## Step 5: Refresh the Authorized Index
 
-Refresh formatter changes only for existing files in `INITIAL_STAGED_PATHS`, passing every path explicitly:
+Refresh formatter changes only for existing files in the active mode's initial authorized path list, passing every
+path explicitly:
 
 ```bash
-git add -- <explicit-existing-initial-staged-paths>
+git add -- <explicit-existing-initial-authorized-paths>
 git add -- "gamesymbols/$GAMEVER.yaml" "gamedata/$GAMEVER"
 ```
 
-Already-staged deletions need no refresh. Never use a repository-wide add command.
+Already-staged deletions need no refresh. In `committed-branch`, the initially captured paths are already committed, so
+stage only those existing paths that the formatter changed. Never use a repository-wide add command.
 
 Then verify:
 
@@ -179,10 +177,12 @@ git diff --cached --name-only
 git diff --cached --stat
 ```
 
-Require zero unstaged tracked changes and a non-empty staged diff. Every final staged path must be either an initial
-staged path or an allowed current-version publication path. Review the final cached diff before committing.
+Require zero unstaged tracked changes. Every final staged path must be either an active mode initial authorized path or
+an allowed current-version publication path. Review the final cached diff before committing. In `staged-delivery`,
+require a non-empty staged diff. In `committed-branch`, an empty staged diff is permitted only when formatter and
+publication are both no-ops; record it and create no empty supplemental commit.
 
-## Step 6: Create the Commit on a Dev Branch
+## Step 6: Create the Required Commit
 
 If currently on `main`, create the validated branch now:
 
@@ -190,17 +190,21 @@ If currently on `main`, create the validated branch now:
 git switch -c <dev-branch>
 ```
 
-If already on the intended `dev*` branch, remain there. Derive or validate `commit_title` using the repository
-format `<type>(scope): <summary>`: start with a verb, keep it at most 100 characters, and omit the final period.
+If already on the intended branch, remain there. In `staged-delivery`, derive or validate `commit_title` using the
+repository format `<type>(scope): <summary>`: start with a verb, keep it at most 100 characters, and omit the final
+period. In `committed-branch`, use `chore(gamesymbols): publish <GAMEVER> snapshot` for the non-empty supplemental
+publication commit.
 
-Commit exactly the staged index:
+In `staged-delivery`, commit exactly the staged index. In `committed-branch`, commit exactly the non-empty staged
+publication index; when it is empty, skip this command and retain `INITIAL_HEAD`:
 
 ```bash
 git commit -m "<commit_title>" -m "Co-Authored-By: Codex"
 ```
 
-Verify the new commit's changed paths match the final staged path list and that no unstaged tracked changes remain.
-Do not amend if the verification fails; stop and report the mismatch.
+Verify any new commit's changed paths match the final staged path list and that no unstaged tracked changes remain.
+In `committed-branch`, require the supplemental commit's parent to equal `INITIAL_HEAD`, proving no existing commit
+was rewritten. Do not amend if verification fails; stop and report the mismatch.
 
 ## Step 7: Push and Create the Pull Request
 
@@ -208,16 +212,18 @@ In `committed-branch`, re-run the following immediately before push:
 
 ```bash
 git branch --show-current
-git rev-parse HEAD
+git merge-base --is-ancestor <INITIAL_HEAD> HEAD
 git diff --cached --quiet
 git diff --quiet
 git rev-list --count origin/main..HEAD
 git diff --name-only origin/main...HEAD
 ```
 
-Require the branch to equal `INITIAL_BRANCH`, `HEAD` to equal `INITIAL_HEAD`, both index and tracked worktree to be
-clean, the ahead count to remain greater than zero, and the committed path list to equal `INITIAL_COMMITTED_PATHS`.
-Stop if any captured state changed. This mode must not create a new commit.
+Require the branch to equal `INITIAL_BRANCH`, `INITIAL_HEAD` to remain an ancestor of `HEAD`, and both index and
+tracked worktree to be clean. Require the ahead count to remain greater than zero and the final committed path list to
+equal the union of `INITIAL_COMMITTED_PATHS` and the authorized formatter/publication paths. If a supplemental commit
+was made, require it to be the direct child of `INITIAL_HEAD`; otherwise require `HEAD` to equal `INITIAL_HEAD`.
+Stop if any condition fails.
 
 Push without force:
 
@@ -226,10 +232,11 @@ git push -u origin <PR_BRANCH>
 ```
 
 Build the PR title from `pr_title` when supplied. Otherwise, use the new commit title in `staged-delivery`; in
-`committed-branch`, derive a concise title from `git log --format=%s origin/main..HEAD` and the committed diff.
+`committed-branch`, derive a concise title from the captured initial committed diff and its pre-publication log so the
+supplemental publication commit does not become the PR title.
 
 Build the body from the delivered committed diff and actual results. Never claim a validation that this invocation
-did not run. Use this concise shape for `staged-delivery`:
+did not run. Use this concise shape in both modes:
 
 ```markdown
 ## Summary
@@ -245,12 +252,11 @@ did not run. Use this concise shape for `staged-delivery`:
 Closes #<issue>
 ```
 
-For `committed-branch`, replace the candidate lifecycle lines with truthful evidence for the existing commits:
+For `committed-branch`, retain the candidate lifecycle lines and add this truthful delivery evidence:
 
 ```markdown
-## Validation
-- implementation-specific tests: <commands/results supplied by the caller, or "not supplied">
-- existing committed branch: `<AHEAD_COUNT>` commit(s) ahead of `origin/main`; clean index and tracked worktree
+- existing committed branch: `<AHEAD_COUNT>` initial commit(s) ahead of `origin/main`; supplemental publication commit:
+  <created or not needed because publication was a no-op>
 ```
 
 Omit the issue line when no issue was supplied. Create the PR explicitly against `main`:
@@ -259,10 +265,10 @@ Omit the issue line when no issue was supplied. Create the PR explicitly against
 gh pr create --base main --head <PR_BRANCH> --title "<pr_title>" --body "<pr_body>"
 ```
 
-Report the branch, commit SHA, pushed remote, PR URL, game version, candidate SHA-256, and the final committed path
-list for `staged-delivery`. For `committed-branch`, report the branch, HEAD SHA, ahead count, pushed remote, PR URL,
-and `INITIAL_COMMITTED_PATHS`; omit game-version and candidate claims. If push succeeds but PR creation fails, report
-the remote branch and exact failure; do not delete the branch, force-push, or create another commit.
+Report the branch, commit SHA, pushed remote, PR URL, game version, candidate SHA-256, and final committed path list
+for both modes. In `committed-branch`, also report `INITIAL_HEAD`, the initial ahead count, and whether a supplemental
+publication commit was created. If push succeeds but PR creation fails, report the remote branch and exact failure;
+do not delete the branch, force-push, or create another commit.
 
 ## Checklist
 
@@ -270,6 +276,7 @@ the remote branch and exact failure; do not delete the branch, force-push, or cr
 - [ ] No unstaged tracked changes existed at invocation.
 - [ ] `staged-delivery`: initial cached diff is task-related; all candidate gates passed; final staged paths are
       authorized; commit is on a `dev*` branch and follows repository format.
-- [ ] `committed-branch`: index/worktree are clean; branch, HEAD, ahead count, and committed paths remain unchanged;
-      no formatter, candidate publication, staging, or commit command ran.
+- [ ] `committed-branch`: the full candidate lifecycle passed; formatter changes stay within captured committed paths;
+      publication outputs are staged and committed when non-empty; the original HEAD is preserved as the supplemental
+      commit parent; branch and worktree are clean before push.
 - [ ] No duplicate open PR existed; branch was pushed without force; exactly one PR was created against `main`.

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -2640,6 +2640,10 @@ modules:
         category: vfunc
         alias:
           - CEngineClient::ExecuteClientCmd
+      - name: CEngineClient_IsPlayingDemo
+        category: vfunc
+        alias:
+          - CEngineClient::IsPlayingDemo
       - name: CInputService_ProcessCommandBuffer
         category: func
         platform: windows
@@ -3659,6 +3663,14 @@ modules:
       - name: find-CMapAnNodeManager_FireGameEvent
         expected_output:
           - CMapAnNodeManager_FireGameEvent.{platform}.yaml
+      - name: find-C_ServerVoiceHandler_OnServerVoiceData
+        expected_output:
+          - C_ServerVoiceHandler_OnServerVoiceData.{platform}.yaml
+      - name: find-C_ServerVoiceHandler_OnServerVoiceData-decompiles
+        expected_output:
+          - IVEngineClient2_IsPlayingDemo.{platform}.yaml
+        expected_input:
+          - C_ServerVoiceHandler_OnServerVoiceData.{platform}.yaml
       - name: find-IVEngineClient2_ExecuteClientCmd
         expected_output:
           - IVEngineClient2_ExecuteClientCmd.{platform}.yaml
@@ -4420,6 +4432,14 @@ modules:
         category: func
         alias:
           - CMapAnNodeManager::FireGameEvent
+      - name: C_ServerVoiceHandler_OnServerVoiceData
+        category: func
+        alias:
+          - C_ServerVoiceHandler::OnServerVoiceData
+      - name: IVEngineClient2_IsPlayingDemo
+        category: vfunc
+        alias:
+          - IVEngineClient2::IsPlayingDemo
       - name: IVEngineClient2_ExecuteClientCmd
         category: vfunc
         alias:
@@ -11196,6 +11216,12 @@ modules:
         expected_input:
           - CEngineClient_vtable.{platform}.yaml
           - ../client/IVEngineClient2_ExecuteClientCmd.{platform}.yaml
+      - name: find-CEngineClient_IsPlayingDemo
+        expected_output:
+          - CEngineClient_IsPlayingDemo.{platform}.yaml
+        expected_input:
+          - CEngineClient_vtable.{platform}.yaml
+          - ../client/IVEngineClient2_IsPlayingDemo.{platform}.yaml
       - name: find-INetworkGameClient_SendStringCmd
         expected_output:
           - INetworkGameClient_SendStringCmd.{platform}.yaml

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:9e5a85b69afa06b0b603ac7d9c4c8af54fc040597c1b7c4dc39057f50722da64
-file_count: 3147
+config_sha256: sha256:93f4170f86434b1757379485c6b9c2c1478270b2bceed716de72619bd18ac4bb
+file_count: 3153
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -2543,6 +2543,18 @@ files:
     vtable_size: '0x248'
     vtable_symbol: ??_7C_MultiplayRules@@6B@
     vtable_va: '0x181a51550'
+  client/C_ServerVoiceHandler_OnServerVoiceData.linux.yaml:
+    func_name: C_ServerVoiceHandler_OnServerVoiceData
+    func_rva: '0x1863980'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 F3 48 81 EC ?? ?? ?? ?? 8B 46 ?? 48 89 BD ?? ?? ?? ??
+    func_size: '0x369'
+    func_va: '0x1863980'
+  client/C_ServerVoiceHandler_OnServerVoiceData.windows.yaml:
+    func_name: C_ServerVoiceHandler_OnServerVoiceData
+    func_rva: '0xaec370'
+    func_sig: 48 89 4C 24 ?? 53 55 56 57 41 54 41 55 41 57 48 81 EC ?? ?? ?? ??
+    func_size: '0x425'
+    func_va: '0x180aec370'
   client/ClientAntiTamperTest.windows.yaml:
     func_name: ClientAntiTamperTest
     func_rva: '0x1322c80'
@@ -4263,6 +4275,18 @@ files:
     vfunc_index: 41
     vfunc_offset: '0x148'
     vtable_name: IVEngineClient2
+  client/IVEngineClient2_IsPlayingDemo.linux.yaml:
+    func_name: IVEngineClient2_IsPlayingDemo
+    vfunc_index: 42
+    vfunc_offset: '0x150'
+    vfunc_sig: FF 90 50 01 00 00 84 C0 0F 85 ?? ?? ?? ?? E8 ?? ?? ?? ??
+    vtable_name: IVEngineClient2
+  client/IVEngineClient2_IsPlayingDemo.windows.yaml:
+    func_name: IVEngineClient2_IsPlayingDemo
+    vfunc_index: 42
+    vfunc_offset: '0x150'
+    vfunc_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
+    vtable_name: IVEngineClient2
   client/RegisterEventListener_Abstract.linux.yaml:
     func_name: RegisterEventListener_Abstract
     func_rva: '0x1664b60'
@@ -5674,6 +5698,22 @@ files:
     vfunc_index: 15
     vfunc_offset: '0x78'
     vtable_name: CEngineClient_vtable
+  engine/CEngineClient_IsPlayingDemo.linux.yaml:
+    func_name: CEngineClient_IsPlayingDemo
+    func_rva: '0x4e68c0'
+    func_size: '0x40'
+    func_va: '0x4e68c0'
+    vfunc_index: 42
+    vfunc_offset: '0x150'
+    vtable_name: CEngineClient
+  engine/CEngineClient_IsPlayingDemo.windows.yaml:
+    func_name: CEngineClient_IsPlayingDemo
+    func_rva: '0x75c60'
+    func_size: '0x1b'
+    func_va: '0x180075c60'
+    vfunc_index: 42
+    vfunc_offset: '0x150'
+    vtable_name: CEngineClient
   engine/CEngineClient_vtable.linux.yaml:
     vtable_class: CEngineClient
     vtable_entries:
@@ -39959,5 +39999,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-27T09:59:31Z'
+last_publish_time: '2026-07-27T10:53:00Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CEngineClient_IsPlayingDemo.py
+++ b/ida_preprocessor_scripts/find-CEngineClient_IsPlayingDemo.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineClient_IsPlayingDemo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # This function is a tiny implementation, so do not generate a func_sig.
+    (
+        "CEngineClient_IsPlayingDemo",
+        "CEngineClient",
+        "../client/IVEngineClient2_IsPlayingDemo",
+        False,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CEngineClient_IsPlayingDemo",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CEngineClient::IsPlayingDemo from the IVEngineClient2 slot."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-C_ServerVoiceHandler_OnServerVoiceData-decompiles.py
+++ b/ida_preprocessor_scripts/find-C_ServerVoiceHandler_OnServerVoiceData-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-C_ServerVoiceHandler_OnServerVoiceData-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IVEngineClient2_IsPlayingDemo",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IVEngineClient2_IsPlayingDemo",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/C_ServerVoiceHandler_OnServerVoiceData.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "C_ServerVoiceHandler_OnServerVoiceData.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # IVEngineClient2 is abstract; this relation supplies vtable metadata only.
+    ("IVEngineClient2_IsPlayingDemo", "IVEngineClient2"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IVEngineClient2_IsPlayingDemo",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve IVEngineClient2::IsPlayingDemo from ServerVoiceHandler's vcall."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-C_ServerVoiceHandler_OnServerVoiceData.py
+++ b/ida_preprocessor_scripts/find-C_ServerVoiceHandler_OnServerVoiceData.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-C_ServerVoiceHandler_OnServerVoiceData skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "C_ServerVoiceHandler_OnServerVoiceData",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "C_ServerVoiceHandler_OnServerVoiceData",
+        "xref_strings": [
+            "FULLMATCH:sounds/ServerVoice.vsnd",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "C_ServerVoiceHandler_OnServerVoiceData",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate ServerVoiceHandler::OnServerVoiceData from its sound asset."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/C_ServerVoiceHandler_OnServerVoiceData.linux.yaml
+++ b/ida_preprocessor_scripts/references/client/C_ServerVoiceHandler_OnServerVoiceData.linux.yaml
@@ -1,0 +1,363 @@
+func_name: C_ServerVoiceHandler_OnServerVoiceData
+func_va: '0x1863980'
+disasm_code: |-
+  .text:0000000001863980                 push    rbp
+  .text:0000000001863981                 mov     rbp, rsp
+  .text:0000000001863984                 push    r15
+  .text:0000000001863986                 push    r14
+  .text:0000000001863988                 push    r13
+  .text:000000000186398A                 push    r12
+  .text:000000000186398C                 push    rbx
+  .text:000000000186398D                 mov     rbx, rsi
+  .text:0000000001863990                 sub     rsp, 88h
+  .text:0000000001863997                 mov     eax, [rsi+40h]
+  .text:000000000186399A                 mov     [rbp+var_A8], rdi
+  .text:00000000018639A1                 test    al, 80h
+  .text:00000000018639A3                 jz      loc_1863A60
+  .text:00000000018639A9                 mov     r14d, [rsi+6Ch]
+  .text:00000000018639AD                 mov     edi, r14d
+  .text:00000000018639B0                 call    sub_1799EA0
+  .text:00000000018639B5                 test    al, al
+  .text:00000000018639B7                 jnz     loc_1863BC0
+  .text:00000000018639BD                 mov     r13d, 0FFFFFFFFh
+  .text:00000000018639C3                 lea     rdi, qword_47F26A0
+  .text:00000000018639CA                 mov     esi, 0FFFFFFFFh
+  .text:00000000018639CF                 mov     r15, [rbx+50h]
+  .text:00000000018639D3                 call    sub_20D1310
+  .text:00000000018639D8                 test    rax, rax
+  .text:00000000018639DB                 jz      loc_1863C00
+  .text:00000000018639E1                 lea     rdi, qword_47F2690
+  .text:00000000018639E8                 mov     esi, 0FFFFFFFFh
+  .text:00000000018639ED                 mov     r12d, [rax]
+  .text:00000000018639F0                 call    sub_20D1310
+  .text:00000000018639F5                 test    rax, rax
+  .text:00000000018639F8                 jz      loc_1863C10
+  .text:00000000018639FE                 mov     eax, [rax]
+  .text:0000000001863A00                 shl     rax, 20h
+  .text:0000000001863A04                 or      r12, rax
+  .text:0000000001863A07                 lea     rax, g_pSource2EngineToClient
+  .text:0000000001863A0E                 mov     rdi, [rax]
+  .text:0000000001863A11                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000001863A15                 jz      short loc_1863A80
+  .text:0000000001863A17                 lea     rdx, xmmword_47F25A0
+  .text:0000000001863A1E                 movsxd  rax, r13d
+  .text:0000000001863A21                 mov     byte ptr [rdx+rax], 1
+  .text:0000000001863A25                 mov     rax, [rdi]
+  .text:0000000001863A28                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000001863A2E                 test    al, al
+  .text:0000000001863A30                 jnz     loc_1863BF0
+  .text:0000000001863A36                 call    sub_19789D0
+  .text:0000000001863A3B                 mov     esi, r13d
+  .text:0000000001863A3E                 mov     [rbp+var_98], r13d
+  .text:0000000001863A45                 mov     rdi, rax
+  .text:0000000001863A48                 call    sub_19789E0
+  .text:0000000001863A4D                 test    al, al
+  .text:0000000001863A4F                 jz      short loc_1863A89
+  .text:0000000001863A51                 lea     rsp, [rbp-28h]
+  .text:0000000001863A55                 pop     rbx
+  .text:0000000001863A56                 pop     r12
+  .text:0000000001863A58                 pop     r13
+  .text:0000000001863A5A                 pop     r14
+  .text:0000000001863A5C                 pop     r15
+  .text:0000000001863A5E                 pop     rbp
+  .text:0000000001863A5F                 retn
+  .text:0000000001863A60                 test    al, 40h
+  .text:0000000001863A62                 jnz     loc_1863BD8
+  .text:0000000001863A68                 mov     r14d, 0FFFFFFFFh
+  .text:0000000001863A6E                 mov     edi, 0FFFFFFFFh
+  .text:0000000001863A73                 call    sub_1799EA0
+  .text:0000000001863A78                 jmp     loc_18639BD
+  .text:0000000001863A80                 mov     rax, [rdi]
+  .text:0000000001863A83                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000001863A89                 mov     [rbp+var_50], 0
+  .text:0000000001863A91                 mov     [rbp+var_48], 0
+  .text:0000000001863A98                 mov     [rbp+var_34], 0
+  .text:0000000001863A9F                 mov     [rbp+var_90], 0
+  .text:0000000001863AAA                 mov     [rbp+var_94], 0
+  .text:0000000001863AB4                 test    byte ptr [rbx+40h], 1
+  .text:0000000001863AB8                 jz      short loc_1863A51
+  .text:0000000001863ABA                 mov     rdi, [rbx+48h]
+  .text:0000000001863ABE                 test    rdi, rdi
+  .text:0000000001863AC1                 jz      loc_1863CA0
+  .text:0000000001863AC7                 lea     rbx, [rbp+var_60]
+  .text:0000000001863ACB                 lea     rcx, [rbp+var_94]
+  .text:0000000001863AD2                 mov     rsi, rbx
+  .text:0000000001863AD5                 lea     rdx, [rbp+var_90]
+  .text:0000000001863ADC                 call    sub_1863600
+  .text:0000000001863AE1                 test    al, al
+  .text:0000000001863AE3                 jz      loc_1863A51
+  .text:0000000001863AE9                 lea     rax, g_pSource2EngineToClient
+  .text:0000000001863AF0                 mov     rdi, [rax]
+  .text:0000000001863AF3                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000001863AF7                 jnz     loc_1863C20
+  .text:0000000001863AFD                 mov     rax, [rdi]
+  .text:0000000001863B00                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000001863B06                 test    al, al
+  .text:0000000001863B08                 jnz     loc_1863A51
+  .text:0000000001863B0E                 lea     rax, g_pSource2EngineToClient
+  .text:0000000001863B15                 mov     rdi, [rax]
+  .text:0000000001863B18                 mov     rax, [rdi]
+  .text:0000000001863B1B                 call    qword ptr [rax+480h]
+  .text:0000000001863B21                 test    eax, eax
+  .text:0000000001863B23                 jnz     loc_1863A51
+  .text:0000000001863B29                 lea     rax, aSoundsServervo; "sounds/ServerVoice.vsnd"
+  .text:0000000001863B30                 mov     rcx, rbx
+  .text:0000000001863B33                 mov     rsi, r15
+  .text:0000000001863B36                 mov     [rbp+var_50], rax
+  .text:0000000001863B3A                 lea     rax, g_pSoundService
+  .text:0000000001863B41                 lea     rdx, [rbp+var_80]
+  .text:0000000001863B45                 ; _QWORD
+  .text:0000000001863B45                 mov     rdi, [rax]; _QWORD
+  .text:0000000001863B48                 mov     rax, [rdi]
+  .text:0000000001863B4B                 push    rdx
+  .text:0000000001863B4C                 mov     edx, r14d
+  .text:0000000001863B4F                 push    0
+  .text:0000000001863B51                 mov     r9d, [rbp+var_94]
+  .text:0000000001863B58                 mov     r8, [rbp+var_90]
+  .text:0000000001863B5F                 call    qword ptr [rax+0C0h]
+  .text:0000000001863B65                 movss   xmm1, [rbp+var_70]
+  .text:0000000001863B6A                 pxor    xmm0, xmm0
+  .text:0000000001863B6E                 pop     rcx
+  .text:0000000001863B6F                 comiss  xmm0, xmm1
+  .text:0000000001863B72                 ; _QWORD
+  .text:0000000001863B72                 pop     rsi; _QWORD
+  .text:0000000001863B73                 jnb     loc_1863CB0
+  .text:0000000001863B79                 lea     rax, off_4568CF8
+  .text:0000000001863B80                 lea     rdx, [rbp+var_88]
+  .text:0000000001863B87                 mov     [rbp+var_98], r13d
+  .text:0000000001863B8E                 mov     rdi, [rbp+var_A8]
+  .text:0000000001863B95                 lea     rsi, [rbp+var_98]
+  .text:0000000001863B9C                 mov     rax, [rax]
+  .text:0000000001863B9F                 add     rdi, 38h ; '8'
+  .text:0000000001863BA3                 insertps xmm1, dword ptr [rax+30h], 10h
+  .text:0000000001863BAA                 movlps  [rbp+var_88], xmm1
+  .text:0000000001863BB1                 call    sub_185C2C0
+  .text:0000000001863BB6                 jmp     loc_1863A51
+  .text:0000000001863BC0                 cmp     r14d, 0FFFFFFFFh
+  .text:0000000001863BC4                 jz      loc_18639BD
+  .text:0000000001863BCA                 lea     r13d, [r14-1]
+  .text:0000000001863BCE                 jmp     loc_18639C3
+  .text:0000000001863BD8                 mov     r14d, [rsi+68h]
+  .text:0000000001863BDC                 cmp     r14d, 0FFFFFFFFh
+  .text:0000000001863BE0                 jz      loc_1863A6E
+  .text:0000000001863BE6                 add     r14d, 1
+  .text:0000000001863BEA                 jmp     loc_18639AD
+  .text:0000000001863BF0                 bt      r12, r13
+  .text:0000000001863BF4                 jb      loc_1863A36
+  .text:0000000001863BFA                 jmp     loc_1863A51
+  .text:0000000001863C00                 mov     rax, cs:qword_47F26A8
+  .text:0000000001863C07                 mov     rax, [rax+8]
+  .text:0000000001863C0B                 jmp     loc_18639E1
+  .text:0000000001863C10                 mov     rax, cs:qword_47F2698
+  .text:0000000001863C17                 mov     rax, [rax+8]
+  .text:0000000001863C1B                 jmp     loc_18639FE
+  .text:0000000001863C20                 lea     rdx, xmmword_47F2560
+  .text:0000000001863C27                 movsxd  rax, r13d
+  .text:0000000001863C2A                 mov     byte ptr [rdx+rax], 1
+  .text:0000000001863C2E                 mov     rax, [rdi]
+  .text:0000000001863C31                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000001863C37                 test    al, al
+  .text:0000000001863C39                 jnz     short loc_1863C56
+  .text:0000000001863C3B                 lea     rax, g_pSource2EngineToClient
+  .text:0000000001863C42                 mov     rdi, [rax]
+  .text:0000000001863C45                 mov     rax, [rdi]
+  .text:0000000001863C48                 call    qword ptr [rax+480h]
+  .text:0000000001863C4E                 test    eax, eax
+  .text:0000000001863C50                 jz      loc_1863B29
+  .text:0000000001863C56                 bt      r12, r13
+  .text:0000000001863C5A                 jnb     loc_1863A51
+  .text:0000000001863C60                 lea     rax, aSoundsServervo; "sounds/ServerVoice.vsnd"
+  .text:0000000001863C67                 mov     edx, r14d
+  .text:0000000001863C6A                 mov     rcx, rbx
+  .text:0000000001863C6D                 mov     [rbp+var_50], rax
+  .text:0000000001863C71                 lea     rax, g_pSoundService
+  .text:0000000001863C78                 mov     rsi, r15
+  .text:0000000001863C7B                 mov     rdi, [rax]
+  .text:0000000001863C7E                 mov     rax, [rdi]
+  .text:0000000001863C81                 push    0
+  .text:0000000001863C83                 push    1
+  .text:0000000001863C85                 mov     r9d, [rbp+var_94]
+  .text:0000000001863C8C                 mov     r8, [rbp+var_90]
+  .text:0000000001863C93                 call    qword ptr [rax+0C0h]
+  .text:0000000001863C99                 pop     rax
+  .text:0000000001863C9A                 pop     rdx
+  .text:0000000001863C9B                 jmp     loc_1863A51
+  .text:0000000001863CA0                 lea     rdi, off_453D580
+  .text:0000000001863CA7                 jmp     loc_1863AC7
+  .text:0000000001863CB0                 movss   xmm0, cs:dword_AFBC38
+  .text:0000000001863CB8                 comiss  xmm0, xmm1
+  .text:0000000001863CBB                 jnb     short loc_1863CE0
+  .text:0000000001863CBD                 ; float
+  .text:0000000001863CBD                 mulss   xmm1, cs:dword_AFC568; float
+  .text:0000000001863CC5                 ; float
+  .text:0000000001863CC5                 movss   xmm0, dword ptr cs:xmmword_AF89D0; float
+  .text:0000000001863CCD                 call    _V_powf
+  .text:0000000001863CD2                 movaps  xmm1, xmm0
+  .text:0000000001863CD5                 jmp     loc_1863B79
+  .text:0000000001863CE0                 pxor    xmm1, xmm1
+  .text:0000000001863CE4                 jmp     loc_1863B79
+procedure: |-
+  __int64 __fastcall C_ServerVoiceHandler_OnServerVoiceData(__int64 a1, __int64 a2)
+  {
+    int v2; // eax
+    unsigned int v3; // r14d
+    unsigned __int64 v4; // r13
+    __int64 v5; // r15
+    unsigned int *v6; // rax
+    __int64 v7; // r12
+    unsigned int *v8; // rax
+    unsigned __int64 v9; // r12
+    _QWORD *v10; // rdi
+    __int64 result; // rax
+    __int64 v12; // rax
+    _QWORD *v13; // rdi
+    _QWORD *v14; // rdi
+    _QWORD *v15; // rdi
+    __m128 v16; // xmm1
+    __m128 v17; // xmm0
+    __int64 v18; // [rsp-10h] [rbp-C0h]
+    __int64 v19; // [rsp-8h] [rbp-B8h]
+    int v21; // [rsp+18h] [rbp-98h] BYREF
+    unsigned int v22; // [rsp+1Ch] [rbp-94h] BYREF
+    __int64 v23; // [rsp+20h] [rbp-90h] BYREF
+    __int64 v24; // [rsp+28h] [rbp-88h] BYREF
+    _BYTE v25[16]; // [rsp+30h] [rbp-80h] BYREF
+    float v26; // [rsp+40h] [rbp-70h]
+    _BYTE v27[16]; // [rsp+50h] [rbp-60h] BYREF
+    const char *v28; // [rsp+60h] [rbp-50h]
+    int v29; // [rsp+68h] [rbp-48h]
+    int v30; // [rsp+7Ch] [rbp-34h]
+
+    v2 = *(_DWORD *)(a2 + 64);
+    if ( (v2 & 0x80u) == 0 )
+    {
+      if ( (v2 & 0x40) != 0 )
+      {
+        v3 = *(_DWORD *)(a2 + 104);
+        if ( v3 != -1 )
+        {
+          ++v3;
+          goto LABEL_3;
+        }
+      }
+      else
+      {
+        v3 = -1;
+      }
+      sub_1799EA0(0xFFFFFFFFLL);
+  LABEL_4:
+      v4 = 0xFFFFFFFFLL;
+      goto LABEL_5;
+    }
+    v3 = *(_DWORD *)(a2 + 108);
+  LABEL_3:
+    if ( !(unsigned __int8)sub_1799EA0(v3) || v3 == -1 )
+      goto LABEL_4;
+    v4 = v3 - 1;
+  LABEL_5:
+    v5 = *(_QWORD *)(a2 + 80);
+    v6 = (unsigned int *)sub_20D1310(&qword_47F26A0, 0xFFFFFFFFLL);
+    if ( !v6 )
+      v6 = *(unsigned int **)(qword_47F26A8 + 8);
+    v7 = *v6;
+    v8 = (unsigned int *)sub_20D1310(&qword_47F2690, 0xFFFFFFFFLL);
+    if ( !v8 )
+      v8 = *(unsigned int **)(qword_47F2698 + 8);
+    v9 = ((unsigned __int64)*v8 << 32) | v7;
+    v10 = g_pSource2EngineToClient;
+    if ( (_DWORD)v4 == -1 )
+    {
+      result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2EngineToClient + 336LL))(g_pSource2EngineToClient);  // 336LL = 0x150 = IVEngineClient2_IsPlayingDemo
+    }
+    else
+    {
+      *((_BYTE *)&xmmword_47F25A0 + (int)v4) = 1;
+      result = (*(__int64 (__fastcall **)(_QWORD *))(*v10 + 336LL))(v10);  // 336LL = 0x150 = IVEngineClient2_IsPlayingDemo
+      if ( (_BYTE)result && !_bittest64((const __int64 *)&v9, v4) )
+        return result;
+      v12 = sub_19789D0();
+      v21 = v4;
+      result = sub_19789E0(v12, (unsigned int)v4);
+      if ( (_BYTE)result )
+        return result;
+    }
+    v28 = nullptr;
+    v29 = 0;
+    v30 = 0;
+    v23 = 0;
+    v22 = 0;
+    if ( (*(_BYTE *)(a2 + 64) & 1) != 0 )
+    {
+      v13 = *(_QWORD **)(a2 + 72);
+      if ( !v13 )
+        v13 = &off_453D580;
+      result = sub_1863600(v13, v27, &v23, &v22);
+      if ( (_BYTE)result )
+      {
+        v14 = g_pSource2EngineToClient;
+        if ( (_DWORD)v4 == -1 )
+        {
+          result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2EngineToClient + 336LL))(g_pSource2EngineToClient);  // 336LL = 0x150 = IVEngineClient2_IsPlayingDemo
+          if ( (_BYTE)result )
+            return result;
+          result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2EngineToClient + 1152LL))(g_pSource2EngineToClient);
+          if ( (_DWORD)result )
+            return result;
+          goto LABEL_24;
+        }
+        *((_BYTE *)&xmmword_47F2560 + (int)v4) = 1;
+        result = (*(__int64 (__fastcall **)(_QWORD *))(*v14 + 336LL))(v14);  // 336LL = 0x150 = IVEngineClient2_IsPlayingDemo
+        if ( !(_BYTE)result )
+        {
+          result = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2EngineToClient + 1152LL))(g_pSource2EngineToClient);
+          if ( !(_DWORD)result )
+          {
+  LABEL_24:
+            v28 = "sounds/ServerVoice.vsnd";
+            v15 = g_pSoundService;
+            (*(void (__fastcall **)(_QWORD *, __int64, _QWORD, _BYTE *, __int64, _QWORD, _QWORD, _BYTE *))(*g_pSoundService + 192LL))(
+              g_pSoundService,
+              v5,
+              v3,
+              v27,
+              v23,
+              v22,
+              0,
+              v25);
+            v16 = (__m128)LODWORD(v26);
+            if ( v26 <= 0.0 )
+            {
+              if ( v26 <= -90.0 )
+              {
+                v16 = 0;
+              }
+              else
+              {
+                v17 = (__m128)0x41200000u;
+                *(double *)v17.m128_u64 = V_powf(v15, v19, 10.0, v26 * 0.050000001);
+                v16 = v17;
+              }
+            }
+            v21 = v4;
+            _mm_storel_ps((double *)&v24, _mm_insert_ps(v16, (__m128)*((unsigned int *)off_4568CF8 + 12), 16));
+            return sub_185C2C0(a1 + 56, &v21, &v24);
+          }
+        }
+        if ( _bittest64((const __int64 *)&v9, v4) )
+        {
+          v28 = "sounds/ServerVoice.vsnd";
+          (*(void (__fastcall **)(_QWORD *, __int64, _QWORD, _BYTE *, __int64, _QWORD, __int64, _QWORD))(*g_pSoundService + 192LL))(
+            g_pSoundService,
+            v5,
+            v3,
+            v27,
+            v23,
+            v22,
+            1,
+            0);
+          return v18;
+        }
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/client/C_ServerVoiceHandler_OnServerVoiceData.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/C_ServerVoiceHandler_OnServerVoiceData.windows.yaml
@@ -1,0 +1,503 @@
+func_name: C_ServerVoiceHandler_OnServerVoiceData
+func_va: '0x180aec370'
+disasm_code: |-
+  .text:0000000180AEC370                 mov     [rsp+arg_0], rcx
+  .text:0000000180AEC375                 push    rbx
+  .text:0000000180AEC376                 push    rbp
+  .text:0000000180AEC377                 push    rsi
+  .text:0000000180AEC378                 push    rdi
+  .text:0000000180AEC379                 push    r12
+  .text:0000000180AEC37B                 push    r13
+  .text:0000000180AEC37D                 push    r15
+  .text:0000000180AEC37F                 sub     rsp, 0C0h
+  .text:0000000180AEC386                 mov     r8d, [rdx+40h]
+  .text:0000000180AEC38A                 xor     edi, edi
+  .text:0000000180AEC38C                 mov     eax, r8d
+  .text:0000000180AEC38F                 mov     rbx, rdx
+  .text:0000000180AEC392                 shr     eax, 7
+  .text:0000000180AEC395                 mov     r12, rcx
+  .text:0000000180AEC398                 test    al, 1
+  .text:0000000180AEC39A                 jz      short loc_180AEC3A2
+  .text:0000000180AEC39C                 mov     r13d, [rdx+6Ch]
+  .text:0000000180AEC3A0                 jmp     short loc_180AEC3BE
+  .text:0000000180AEC3A2                 shr     r8d, 6
+  .text:0000000180AEC3A6                 test    r8b, 1
+  .text:0000000180AEC3AA                 jz      short loc_180AEC3B8
+  .text:0000000180AEC3AC                 mov     eax, [rdx+68h]
+  .text:0000000180AEC3AF                 lea     r13d, [rax+1]
+  .text:0000000180AEC3B3                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180AEC3B6                 jnz     short loc_180AEC3BE
+  .text:0000000180AEC3B8                 mov     r13d, 0FFFFFFFFh
+  .text:0000000180AEC3BE                 mov     ecx, r13d
+  .text:0000000180AEC3C1                 call    sub_180A5D340
+  .text:0000000180AEC3C6                 test    al, al
+  .text:0000000180AEC3C8                 jz      short loc_180AEC3D4
+  .text:0000000180AEC3CA                 lea     ebp, [r13-1]
+  .text:0000000180AEC3CE                 cmp     r13d, 0FFFFFFFFh
+  .text:0000000180AEC3D2                 jnz     short loc_180AEC3D9
+  .text:0000000180AEC3D4                 mov     ebp, 0FFFFFFFFh
+  .text:0000000180AEC3D9                 mov     rax, [rbx+50h]
+  .text:0000000180AEC3DD                 lea     rcx, unk_18239D618
+  .text:0000000180AEC3E4                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AEC3E9                 mov     [rsp+0F8h+var_B0], rax
+  .text:0000000180AEC3EE                 mov     [rsp+0F8h+arg_8], ebp
+  .text:0000000180AEC3F5                 call    sub_1818622D0
+  .text:0000000180AEC3FA                 test    rax, rax
+  .text:0000000180AEC3FD                 jnz     short loc_180AEC40A
+  .text:0000000180AEC3FF                 mov     rax, cs:qword_18239D620
+  .text:0000000180AEC406                 mov     rax, [rax+8]
+  .text:0000000180AEC40A                 mov     esi, [rax]
+  .text:0000000180AEC40C                 lea     rcx, unk_18239D628
+  .text:0000000180AEC413                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AEC418                 call    sub_1818622D0
+  .text:0000000180AEC41D                 test    rax, rax
+  .text:0000000180AEC420                 jnz     short loc_180AEC42D
+  .text:0000000180AEC422                 mov     rax, cs:qword_18239D630
+  .text:0000000180AEC429                 mov     rax, [rax+8]
+  .text:0000000180AEC42D                 mov     r15d, [rax]
+  .text:0000000180AEC430                 lea     rcx, cs:180000000h
+  .text:0000000180AEC437                 shl     r15, 20h
+  .text:0000000180AEC43B                 or      r15, rsi
+  .text:0000000180AEC43E                 mov     [rsp+0F8h+var_B8], r15
+  .text:0000000180AEC443                 cmp     ebp, 0FFFFFFFFh
+  .text:0000000180AEC446                 jz      short loc_180AEC453
+  .text:0000000180AEC448                 movsxd  rax, ebp
+  .text:0000000180AEC44B                 mov     byte ptr [rax+rcx+239DF80h], 1
+  .text:0000000180AEC453                 mov     rcx, cs:g_pSource2EngineToClient
+  .text:0000000180AEC45A                 mov     rax, [rcx]
+  .text:0000000180AEC45D                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000180AEC463                 test    al, al
+  .text:0000000180AEC465                 jz      short loc_180AEC478
+  .text:0000000180AEC467                 cmp     ebp, 0FFFFFFFFh
+  .text:0000000180AEC46A                 jz      short loc_180AEC494
+  .text:0000000180AEC46C                 mov     eax, ebp
+  .text:0000000180AEC46E                 bt      r15, rax
+  .text:0000000180AEC472                 jnb     loc_180AEC720
+  .text:0000000180AEC478                 cmp     ebp, 0FFFFFFFFh
+  .text:0000000180AEC47B                 jz      short loc_180AEC494
+  .text:0000000180AEC47D                 call    sub_180BA5FE0
+  .text:0000000180AEC482                 mov     edx, ebp
+  .text:0000000180AEC484                 mov     rcx, rax
+  .text:0000000180AEC487                 call    sub_180BAB270
+  .text:0000000180AEC48C                 test    al, al
+  .text:0000000180AEC48E                 jnz     loc_180AEC720
+  .text:0000000180AEC494                 test    byte ptr [rbx+40h], 1
+  .text:0000000180AEC498                 movaps  [rsp+0F8h+var_58], xmm7
+  .text:0000000180AEC4A0                 xorps   xmm7, xmm7
+  .text:0000000180AEC4A3                 mov     [rsp+0F8h+var_80], rdi
+  .text:0000000180AEC4A8                 mov     [rsp+0F8h+var_78], edi
+  .text:0000000180AEC4AF                 mov     [rsp+0F8h+var_64], edi
+  .text:0000000180AEC4B6                 jz      loc_180AEC718
+  .text:0000000180AEC4BC                 mov     rax, [rbx+48h]
+  .text:0000000180AEC4C0                 lea     rbx, off_182063A20
+  .text:0000000180AEC4C7                 test    rax, rax
+  .text:0000000180AEC4CA                 mov     [rsp+0F8h+arg_10], r14
+  .text:0000000180AEC4D2                 cmovnz  rbx, rax
+  .text:0000000180AEC4D6                 cmp     dword ptr [rbx+38h], 2
+  .text:0000000180AEC4DA                 jnz     short loc_180AEC558
+  .text:0000000180AEC4DC                 mov     rax, [rbx+30h]
+  .text:0000000180AEC4E0                 lea     rcx, [rbx+18h]
+  .text:0000000180AEC4E4                 mov     r14d, [rbx+4Ch]
+  .text:0000000180AEC4E8                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180AEC4EC                 mov     r12, [rax+10h]
+  .text:0000000180AEC4F0                 call    sub_181199C60
+  .text:0000000180AEC4F5                 movsxd  rcx, eax
+  .text:0000000180AEC4F8                 cmp     r14, rcx
+  .text:0000000180AEC4FB                 ja      loc_180AEC710
+  .text:0000000180AEC501                 cmp     r14, r12
+  .text:0000000180AEC504                 jnb     loc_180AEC710
+  .text:0000000180AEC50A                 cmp     r14, 4
+  .text:0000000180AEC50E                 ja      loc_180AEC710
+  .text:0000000180AEC514                 mov     r15, rdi
+  .text:0000000180AEC517                 mov     esi, edi
+  .text:0000000180AEC519                 test    r14, r14
+  .text:0000000180AEC51C                 jz      short loc_180AEC54B
+  .text:0000000180AEC51E                 xchg    ax, ax
+  .text:0000000180AEC520                 mov     edx, esi
+  .text:0000000180AEC522                 lea     rcx, [rbx+18h]
+  .text:0000000180AEC526                 call    sub_181198270
+  .text:0000000180AEC52B                 mov     ecx, [rax]
+  .text:0000000180AEC52D                 cmp     rcx, r15
+  .text:0000000180AEC530                 jb      loc_180AEC710
+  .text:0000000180AEC536                 mov     r15d, ecx
+  .text:0000000180AEC539                 cmp     rcx, r12
+  .text:0000000180AEC53C                 ja      loc_180AEC710
+  .text:0000000180AEC542                 inc     esi
+  .text:0000000180AEC544                 mov     eax, esi
+  .text:0000000180AEC546                 cmp     rax, r14
+  .text:0000000180AEC549                 jb      short loc_180AEC520
+  .text:0000000180AEC54B                 mov     r12, [rsp+0F8h+arg_0]
+  .text:0000000180AEC553                 mov     r15, [rsp+0F8h+var_B8]
+  .text:0000000180AEC558                 mov     eax, [rbx+38h]
+  .text:0000000180AEC55B                 test    eax, eax
+  .text:0000000180AEC55D                 jnz     short loc_180AEC57E
+  .text:0000000180AEC55F                 mov     [rsp+0F8h+var_90], edi
+  .text:0000000180AEC563                 mov     rax, [rbx+30h]
+  .text:0000000180AEC567                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180AEC56B                 mov     rsi, rax
+  .text:0000000180AEC56E                 cmp     qword ptr [rax+18h], 0Fh
+  .text:0000000180AEC573                 jbe     short loc_180AEC578
+  .text:0000000180AEC575                 mov     rsi, [rax]
+  .text:0000000180AEC578                 mov     r14d, [rax+10h]
+  .text:0000000180AEC57C                 jmp     short loc_180AEC5EC
+  .text:0000000180AEC57E                 cmp     eax, 2
+  .text:0000000180AEC581                 jnz     short loc_180AEC5E6
+  .text:0000000180AEC583                 mov     [rsp+0F8h+var_90], 1
+  .text:0000000180AEC58B                 mov     esi, edi
+  .text:0000000180AEC58D                 mov     eax, [rbx+4Ch]
+  .text:0000000180AEC590                 mov     [rsp+0F8h+var_78], eax
+  .text:0000000180AEC597                 cmp     [rbx+4Ch], edi
+  .text:0000000180AEC59A                 jbe     short loc_180AEC5BD
+  .text:0000000180AEC59C                 nop     dword ptr [rax+00h]
+  .text:0000000180AEC5A0                 mov     edx, esi
+  .text:0000000180AEC5A2                 lea     rcx, [rbx+18h]
+  .text:0000000180AEC5A6                 call    sub_181198270
+  .text:0000000180AEC5AB                 mov     ecx, esi
+  .text:0000000180AEC5AD                 inc     esi
+  .text:0000000180AEC5AF                 mov     eax, [rax]
+  .text:0000000180AEC5B1                 mov     [rsp+rcx*4+0F8h+var_74], eax
+  .text:0000000180AEC5B8                 cmp     esi, [rbx+4Ch]
+  .text:0000000180AEC5BB                 jb      short loc_180AEC5A0
+  .text:0000000180AEC5BD                 movss   xmm0, dword ptr [rbx+50h]
+  .text:0000000180AEC5C2                 movss   [rsp+0F8h+var_64], xmm0
+  .text:0000000180AEC5CB                 mov     r14, [rbx+30h]
+  .text:0000000180AEC5CF                 and     r14, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180AEC5D3                 mov     rsi, r14
+  .text:0000000180AEC5D6                 cmp     qword ptr [r14+18h], 0Fh
+  .text:0000000180AEC5DB                 jbe     short loc_180AEC5E0
+  .text:0000000180AEC5DD                 mov     rsi, [r14]
+  .text:0000000180AEC5E0                 mov     r14d, [r14+10h]
+  .text:0000000180AEC5E4                 jmp     short loc_180AEC5EC
+  .text:0000000180AEC5E6                 mov     rsi, rdi
+  .text:0000000180AEC5E9                 mov     r14d, edi
+  .text:0000000180AEC5EC                 mov     eax, [rbx+44h]
+  .text:0000000180AEC5EF                 mov     [rsp+0F8h+var_8C], eax
+  .text:0000000180AEC5F3                 mov     eax, [rbx+40h]
+  .text:0000000180AEC5F6                 mov     [rsp+0F8h+var_88], eax
+  .text:0000000180AEC5FA                 mov     eax, [rbx+3Ch]
+  .text:0000000180AEC5FD                 mov     [rsp+0F8h+var_84], eax
+  .text:0000000180AEC601                 test    rsi, rsi
+  .text:0000000180AEC604                 jz      loc_180AEC710
+  .text:0000000180AEC60A                 test    r14d, r14d
+  .text:0000000180AEC60D                 jz      loc_180AEC710
+  .text:0000000180AEC613                 cmp     ebp, 0FFFFFFFFh
+  .text:0000000180AEC616                 jz      short loc_180AEC62A
+  .text:0000000180AEC618                 movsxd  rax, ebp
+  .text:0000000180AEC61B                 lea     rcx, cs:180000000h
+  .text:0000000180AEC622                 mov     byte ptr [rax+rcx+239DFC0h], 1
+  .text:0000000180AEC62A                 mov     rcx, cs:g_pSource2EngineToClient
+  .text:0000000180AEC631                 mov     rax, [rcx]
+  .text:0000000180AEC634                 call    qword ptr [rax+150h]  ; 0x150 = IVEngineClient2_IsPlayingDemo
+  .text:0000000180AEC63A                 test    al, al
+  .text:0000000180AEC63C                 jnz     loc_180AEC746
+  .text:0000000180AEC642                 mov     rcx, cs:g_pSource2EngineToClient
+  .text:0000000180AEC649                 mov     rax, [rcx]
+  .text:0000000180AEC64C                 call    qword ptr [rax+480h]
+  .text:0000000180AEC652                 test    eax, eax
+  .text:0000000180AEC654                 jnz     loc_180AEC746
+  .text:0000000180AEC65A                 mov     rcx, cs:g_pSoundService
+  .text:0000000180AEC661                 lea     rax, aSoundsServervo; "sounds/ServerVoice.vsnd"
+  .text:0000000180AEC668                 mov     [rsp+0F8h+var_80], rax
+  .text:0000000180AEC66D                 lea     rdx, [rsp+0F8h+var_A8]
+  .text:0000000180AEC672                 mov     [rsp+0F8h+var_C0], rdx
+  .text:0000000180AEC677                 lea     r9, [rsp+0F8h+var_90]
+  .text:0000000180AEC67C                 mov     rdx, [rsp+0F8h+var_B0]
+  .text:0000000180AEC681                 mov     r8d, r13d
+  .text:0000000180AEC684                 mov     rax, [rcx]
+  .text:0000000180AEC687                 mov     [rsp+0F8h+var_C8], dil
+  .text:0000000180AEC68C                 mov     [rsp+0F8h+var_D0], r14d
+  .text:0000000180AEC691                 movaps  [rsp+0F8h+var_48], xmm6
+  .text:0000000180AEC699                 mov     [rsp+0F8h+var_D8], rsi
+  .text:0000000180AEC69E                 call    qword ptr [rax+0B8h]
+  .text:0000000180AEC6A4                 movss   xmm6, [rsp+0F8h+var_98]
+  .text:0000000180AEC6AA                 comiss  xmm7, xmm6
+  .text:0000000180AEC6AD                 jb      short loc_180AEC6BA
+  .text:0000000180AEC6AF                 movaps  xmm0, xmm6
+  .text:0000000180AEC6B2                 call    sub_180AF9980
+  .text:0000000180AEC6B7                 movaps  xmm6, xmm0
+  .text:0000000180AEC6BA                 mov     rax, cs:off_182090D60
+  .text:0000000180AEC6C1                 lea     rcx, [r12+38h]
+  .text:0000000180AEC6C6                 xor     r9d, r9d
+  .text:0000000180AEC6C9                 lea     r8, [rsp+0F8h+var_B8]
+  .text:0000000180AEC6CE                 lea     rdx, [rsp+0F8h+arg_8]
+  .text:0000000180AEC6D6                 movss   xmm7, dword ptr [rax+30h]
+  .text:0000000180AEC6DB                 call    sub_180AE8D30
+  .text:0000000180AEC6E0                 mov     ecx, [r12+64h]
+  .text:0000000180AEC6E5                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180AEC6E8                 jz      short loc_180AEC732
+  .text:0000000180AEC6EA                 test    ecx, 7FFFFFFFh
+  .text:0000000180AEC6F0                 jz      short loc_180AEC6F7
+  .text:0000000180AEC6F2                 mov     rdi, [r12+68h]
+  .text:0000000180AEC6F7                 cdqe
+  .text:0000000180AEC6F9                 add     rax, rax
+  .text:0000000180AEC6FC                 movss   dword ptr [rdi+rax*8+4], xmm6
+  .text:0000000180AEC702                 movaps  xmm6, [rsp+0F8h+var_48]
+  .text:0000000180AEC70A                 movss   dword ptr [rdi+rax*8+8], xmm7
+  .text:0000000180AEC710                 mov     r14, [rsp+0F8h+arg_10]
+  .text:0000000180AEC718                 movaps  xmm7, [rsp+0F8h+var_58]
+  .text:0000000180AEC720                 add     rsp, 0C0h
+  .text:0000000180AEC727                 pop     r15
+  .text:0000000180AEC729                 pop     r13
+  .text:0000000180AEC72B                 pop     r12
+  .text:0000000180AEC72D                 pop     rdi
+  .text:0000000180AEC72E                 pop     rsi
+  .text:0000000180AEC72F                 pop     rbp
+  .text:0000000180AEC730                 pop     rbx
+  .text:0000000180AEC731                 retn
+  .text:0000000180AEC732                 test    ecx, 7FFFFFFFh
+  .text:0000000180AEC738                 jz      short loc_180AEC73F
+  .text:0000000180AEC73A                 mov     rdi, [r12+68h]
+  .text:0000000180AEC73F                 movsxd  rax, dword ptr [rsp+0F8h+var_B8]
+  .text:0000000180AEC744                 jmp     short loc_180AEC6F9
+  .text:0000000180AEC746                 cmp     ebp, 0FFFFFFFFh
+  .text:0000000180AEC749                 jz      short loc_180AEC710
+  .text:0000000180AEC74B                 mov     eax, ebp
+  .text:0000000180AEC74D                 bt      r15, rax
+  .text:0000000180AEC751                 jnb     short loc_180AEC710
+  .text:0000000180AEC753                 mov     rcx, cs:g_pSoundService
+  .text:0000000180AEC75A                 lea     rax, aSoundsServervo; "sounds/ServerVoice.vsnd"
+  .text:0000000180AEC761                 mov     rdx, [rsp+0F8h+var_B0]
+  .text:0000000180AEC766                 lea     r9, [rsp+0F8h+var_90]
+  .text:0000000180AEC76B                 mov     [rsp+0F8h+var_C0], rdi
+  .text:0000000180AEC770                 mov     r8d, r13d
+  .text:0000000180AEC773                 mov     [rsp+0F8h+var_80], rax
+  .text:0000000180AEC778                 mov     rax, [rcx]
+  .text:0000000180AEC77B                 mov     [rsp+0F8h+var_C8], 1
+  .text:0000000180AEC780                 mov     [rsp+0F8h+var_D0], r14d
+  .text:0000000180AEC785                 mov     [rsp+0F8h+var_D8], rsi
+  .text:0000000180AEC78A                 call    qword ptr [rax+0B8h]
+  .text:0000000180AEC790                 jmp     loc_180AEC710
+procedure: |-
+  char __fastcall C_ServerVoiceHandler_OnSVCMsg_VoiceData(__int64 a1, __int64 a2)
+  {
+    int v2; // r8d
+    __int64 v3; // rdi
+    __int64 v5; // r12
+    unsigned int v6; // r13d
+    int v7; // eax
+    unsigned int v8; // ebp
+    unsigned int *v9; // rax
+    __int64 v10; // rsi
+    unsigned int *v11; // rax
+    unsigned __int64 v12; // r15
+    __int64 v13; // rax
+    __int64 v14; // rax
+    bool v15; // zf
+    void ***v16; // rax
+    void ***v17; // rbx
+    unsigned __int64 v18; // r14
+    unsigned __int64 v19; // r12
+    unsigned __int64 v20; // r15
+    unsigned int v21; // esi
+    unsigned __int64 v22; // rcx
+    int v23; // eax
+    unsigned __int64 v24; // rax
+    unsigned __int64 v25; // rsi
+    int v26; // r14d
+    unsigned int v27; // esi
+    _DWORD *v28; // rax
+    __int64 v29; // rcx
+    unsigned __int64 v30; // r14
+    __int64 v31; // rcx
+    float v32; // xmm6_4
+    double v33; // xmm0_8
+    int v34; // xmm7_4
+    __int64 v35; // rax
+    int v36; // ecx
+    unsigned __int64 v38; // [rsp+40h] [rbp-B8h] BYREF
+    __int64 v39; // [rsp+48h] [rbp-B0h]
+    char v40[16]; // [rsp+50h] [rbp-A8h] BYREF
+    float v41; // [rsp+60h] [rbp-98h]
+    _DWORD v42[4]; // [rsp+68h] [rbp-90h] BYREF
+    const char *v43; // [rsp+78h] [rbp-80h]
+    int i; // [rsp+80h] [rbp-78h]
+    _DWORD v45[4]; // [rsp+84h] [rbp-74h]
+    int v46; // [rsp+94h] [rbp-64h]
+    unsigned int v48; // [rsp+108h] [rbp+10h] BYREF
+
+    v2 = *(_DWORD *)(a2 + 64);
+    v3 = 0;
+    v5 = a1;
+    if ( (v2 & 0x80) != 0 )
+    {
+      v6 = *(_DWORD *)(a2 + 108);
+    }
+    else if ( (v2 & 0x40) == 0 || (v7 = *(_DWORD *)(a2 + 104), v6 = v7 + 1, v7 == -1) )
+    {
+      v6 = -1;
+    }
+    if ( !sub_180A5D340(v6) || (v8 = v6 - 1, v6 == -1) )
+      v8 = -1;
+    v39 = *(_QWORD *)(a2 + 80);
+    v48 = v8;
+    v9 = (unsigned int *)sub_1818622D0((__int64)&unk_18239D618, -1);
+    if ( !v9 )
+      v9 = *(unsigned int **)(qword_18239D620 + 8);
+    v10 = *v9;
+    v11 = (unsigned int *)sub_1818622D0((__int64)&unk_18239D628, -1);
+    if ( !v11 )
+      v11 = *(unsigned int **)(qword_18239D630 + 8);
+    v12 = v10 | ((unsigned __int64)*v11 << 32);
+    v38 = v12;
+    if ( v8 != -1 )
+      *((_BYTE *)&qword_18239DF80 + (int)v8) = 1;
+    LOBYTE(v13) = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2EngineToClient + 336LL))(g_pSource2EngineToClient);  // 336LL = 0x150 = IVEngineClient2_IsPlayingDemo
+    if ( (_BYTE)v13 )
+    {
+      if ( v8 == -1 )
+        goto LABEL_20;
+      LOBYTE(v13) = v8;
+      if ( !_bittest64((const __int64 *)&v12, v8) )
+        return v13;
+    }
+    if ( v8 != -1 )
+    {
+      v14 = sub_180BA5FE0();
+      LOBYTE(v13) = sub_180BAB270(v14, v8);
+      if ( (_BYTE)v13 )
+        return v13;
+    }
+  LABEL_20:
+    v15 = (*(_BYTE *)(a2 + 64) & 1) == 0;
+    v43 = nullptr;
+    i = 0;
+    v46 = 0;
+    if ( v15 )
+      return v13;
+    v16 = *(void ****)(a2 + 72);
+    v17 = &off_182063A20;
+    if ( v16 )
+      v17 = v16;
+    if ( *((_DWORD *)v17 + 14) != 2 )
+      goto LABEL_32;
+    v18 = *((unsigned int *)v17 + 19);
+    v19 = *(_QWORD *)(((unsigned __int64)v17[6] & 0xFFFFFFFFFFFFFFFCuLL) + 16);
+    LODWORD(v13) = sub_181199C60((unsigned int *)v17 + 6);
+    if ( v18 > (int)v13 || v18 >= v19 || v18 > 4 )
+      return v13;
+    v20 = 0;
+    v21 = 0;
+    if ( !v18 )
+    {
+  LABEL_31:
+      v5 = a1;
+      v12 = v38;
+  LABEL_32:
+      v23 = *((_DWORD *)v17 + 14);
+      if ( v23 )
+      {
+        if ( v23 == 2 )
+        {
+          v42[0] = 1;
+          v27 = 0;
+          for ( i = *((_DWORD *)v17 + 19); v27 < *((_DWORD *)v17 + 19); v45[v29] = *v28 )
+          {
+            v28 = (_DWORD *)sub_181198270(v17 + 3, v27);
+            v29 = v27++;
+          }
+          v46 = *((_DWORD *)v17 + 20);
+          v30 = (unsigned __int64)v17[6] & 0xFFFFFFFFFFFFFFFCuLL;
+          v25 = v30;
+          if ( *(_QWORD *)(v30 + 24) > 0xFu )
+            v25 = *(_QWORD *)v30;
+          v26 = *(_DWORD *)(v30 + 16);
+        }
+        else
+        {
+          v25 = 0;
+          v26 = 0;
+        }
+      }
+      else
+      {
+        v42[0] = 0;
+        v24 = (unsigned __int64)v17[6] & 0xFFFFFFFFFFFFFFFCuLL;
+        v25 = v24;
+        if ( *(_QWORD *)(v24 + 24) > 0xFu )
+          v25 = *(_QWORD *)v24;
+        v26 = *(_DWORD *)(v24 + 16);
+      }
+      v42[1] = *((_DWORD *)v17 + 17);
+      v42[2] = *((_DWORD *)v17 + 16);
+      LODWORD(v13) = *((_DWORD *)v17 + 15);
+      v42[3] = v13;
+      if ( v25 && v26 )
+      {
+        if ( v8 != -1 )
+          *((_BYTE *)&qword_18239DFC0 + (int)v8) = 1;
+        LOBYTE(v13) = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2EngineToClient + 336LL))(g_pSource2EngineToClient);// IVEngineClient2_IsPlayingDemo
+        if ( (_BYTE)v13
+          || (LODWORD(v13) = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2EngineToClient + 1152LL))(g_pSource2EngineToClient),
+              (_DWORD)v13) )
+        {
+          if ( v8 != -1 )
+          {
+            LOBYTE(v13) = v8;
+            if ( _bittest64((const __int64 *)&v12, v8) )
+            {
+              v43 = "sounds/ServerVoice.vsnd";
+              LOBYTE(v13) = (*(__int64 (__fastcall **)(__int64, __int64, _QWORD, _DWORD *, unsigned __int64, int, char, _QWORD))(*(_QWORD *)g_pSoundService + 184LL))(
+                              g_pSoundService,
+                              v39,
+                              v6,
+                              v42,
+                              v25,
+                              v26,
+                              1,
+                              0);
+            }
+          }
+        }
+        else
+        {
+          v43 = "sounds/ServerVoice.vsnd";
+          (*(void (__fastcall **)(__int64, __int64, _QWORD, _DWORD *, unsigned __int64, int, _BYTE, char *))(*(_QWORD *)g_pSoundService + 184LL))(
+            g_pSoundService,
+            v39,
+            v6,
+            v42,
+            v25,
+            v26,
+            0,
+            v40);
+          v32 = v41;
+          if ( v41 <= 0.0 )
+          {
+            v33 = sub_180AF9980(v31);
+            v32 = *(float *)&v33;
+          }
+          v34 = *((_DWORD *)off_182090D60 + 12);
+          LODWORD(v35) = sub_180AE8D30(v5 + 56, &v48, (int *)&v38, 0);
+          v36 = *(_DWORD *)(v5 + 100);
+          if ( (_DWORD)v35 == -1 )
+          {
+            if ( (v36 & 0x7FFFFFFF) != 0 )
+              v3 = *(_QWORD *)(v5 + 104);
+            v35 = (int)v38;
+          }
+          else
+          {
+            if ( (v36 & 0x7FFFFFFF) != 0 )
+              v3 = *(_QWORD *)(v5 + 104);
+            v35 = (int)v35;
+          }
+          v13 = 2 * v35;
+          *(float *)(v3 + 8 * v13 + 4) = v32;
+          *(_DWORD *)(v3 + 8 * v13 + 8) = v34;
+        }
+      }
+      return v13;
+    }
+    while ( 1 )
+    {
+      v13 = sub_181198270(v17 + 3, v21);
+      v22 = *(unsigned int *)v13;
+      if ( v22 < v20 )
+        return v13;
+      v20 = (unsigned int)v22;
+      if ( v22 > v19 )
+        return v13;
+      if ( ++v21 >= v18 )
+        goto LABEL_31;
+    }
+  }


### PR DESCRIPTION
## Summary
- Add the ServerVoice client finder and an LLM-based IVEngineClient2::IsPlayingDemo slot finder.
- Add the CEngineClient::IsPlayingDemo inherited-vfunc finder with dual-platform references.

## Validation
- implementation-specific tests: not supplied
- existing committed branch: `1` commit(s) ahead of `origin/main`; clean index and tracked worktree