### PR TITLE
Add CEngineServer unload spawn group analysis

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -2685,10 +2685,6 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
-      - name: CEngineServer_UnloadSpawnGroup
-        category: vfunc
-        alias:
-          - CEngineServer::UnloadSpawnGroup
       - name: CEngineServer_GetFrameTimeAmnesty
         category: vfunc
         alias:
@@ -7748,6 +7744,13 @@ modules:
           - CLoopModeGame_vtable.{platform}.yaml
         expected_input_linux:
           - CLoopModeGame_LoopInitInternal.{platform}.yaml
+      - name: find-CEngineServer_UnloadSpawnGroup
+        expected_output:
+          - CEngineServer_UnloadSpawnGroup.{platform}.yaml
+        expected_input_windows:
+          - CLoopModeGame_LoopInit.{platform}.yaml
+        expected_input_linux:
+          - CLoopModeGame_LoopInitInternal.{platform}.yaml
       - name: find-ILoopMode_LoopInit
         expected_output:
           - ILoopMode_LoopInit.{platform}.yaml
@@ -10313,6 +10316,10 @@ modules:
         category: vfunc
         alias:
           - IGameTypes::CreateWorkshopMapGroup
+      - name: CEngineServer_UnloadSpawnGroup
+        category: vfunc
+        alias:
+          - CEngineServer::UnloadSpawnGroup
       - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
         category: func
         alias:
@@ -11313,12 +11320,6 @@ modules:
         expected_input:
           - ../server/IAppSystem_Connect.{platform}.yaml
           - CNetSupportImpl_vtable.{platform}.yaml
-      - name: find-CEngineServer_UnloadSpawnGroup
-        expected_output:
-          - CEngineServer_UnloadSpawnGroup.{platform}.yaml
-        expected_input:
-          - CEngineServer_vtable.{platform}.yaml
-          - ../server/CLoopModeGame_LoopInit.{platform}.yaml
       - name: find-CEngineServer_IsDedicatedServer
         expected_output:
           - CEngineServer_IsDedicatedServer.{platform}.yaml

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -2685,6 +2685,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::ClientPrintf
+      - name: CEngineServer_UnloadSpawnGroup
+        category: vfunc
+        alias:
+          - CEngineServer::UnloadSpawnGroup
       - name: CEngineServer_GetFrameTimeAmnesty
         category: vfunc
         alias:
@@ -11309,6 +11313,12 @@ modules:
         expected_input:
           - ../server/IAppSystem_Connect.{platform}.yaml
           - CNetSupportImpl_vtable.{platform}.yaml
+      - name: find-CEngineServer_UnloadSpawnGroup
+        expected_output:
+          - CEngineServer_UnloadSpawnGroup.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+          - ../server/CLoopModeGame_LoopInit.{platform}.yaml
       - name: find-CEngineServer_IsDedicatedServer
         expected_output:
           - CEngineServer_IsDedicatedServer.{platform}.yaml

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:93f4170f86434b1757379485c6b9c2c1478270b2bceed716de72619bd18ac4bb
-file_count: 3153
+config_sha256: sha256:d365aacba258bec57f5914fbee75c257ed485493fc3f6c0c79a4368eeee6ded6
+file_count: 3155
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -6559,6 +6559,18 @@ files:
     vfunc_index: 28
     vfunc_offset: '0xe0'
     vtable_name: CEngineServer_vtable
+  engine/CEngineServer_UnloadSpawnGroup.linux.yaml:
+    func_name: CEngineServer_UnloadSpawnGroup
+    vfunc_index: 60
+    vfunc_offset: '0x1e0'
+    vfunc_sig: FF 90 E0 01 00 00 89 83 ?? ?? ?? ??
+    vtable_name: CEngineServer
+  engine/CEngineServer_UnloadSpawnGroup.windows.yaml:
+    func_name: CEngineServer_UnloadSpawnGroup
+    vfunc_index: 60
+    vfunc_offset: '0x1e0'
+    vfunc_sig: 4C 8B 80 E0 01 00 00 48 63 C3
+    vtable_name: CEngineServer
   engine/CEngineServer_vtable.linux.yaml:
     vtable_class: CEngineServer
     vtable_entries:
@@ -39999,5 +40011,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-27T10:53:00Z'
+last_publish_time: '2026-07-28T07:56:15Z'
 schema_version: 4

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,7 +73,7 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:d365aacba258bec57f5914fbee75c257ed485493fc3f6c0c79a4368eeee6ded6
+config_sha256: sha256:fc6b143a0bf200c3e04de64e37515f75aca5ee7881526132b439a71df2c08396
 file_count: 3155
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -6559,18 +6559,6 @@ files:
     vfunc_index: 28
     vfunc_offset: '0xe0'
     vtable_name: CEngineServer_vtable
-  engine/CEngineServer_UnloadSpawnGroup.linux.yaml:
-    func_name: CEngineServer_UnloadSpawnGroup
-    vfunc_index: 60
-    vfunc_offset: '0x1e0'
-    vfunc_sig: FF 90 E0 01 00 00 89 83 ?? ?? ?? ??
-    vtable_name: CEngineServer
-  engine/CEngineServer_UnloadSpawnGroup.windows.yaml:
-    func_name: CEngineServer_UnloadSpawnGroup
-    vfunc_index: 60
-    vfunc_offset: '0x1e0'
-    vfunc_sig: 4C 8B 80 E0 01 00 00 48 63 C3
-    vtable_name: CEngineServer
   engine/CEngineServer_vtable.linux.yaml:
     vtable_class: CEngineServer
     vtable_entries:
@@ -23674,6 +23662,20 @@ files:
     func_sig: 48 8B C4 55 53 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ??
     func_size: '0x688'
     func_va: '0x1801eff20'
+  server/CEngineServer_UnloadSpawnGroup.linux.yaml:
+    func_name: CEngineServer_UnloadSpawnGroup
+    vfunc_index: 60
+    vfunc_offset: '0x1e0'
+    vfunc_sig: FF 90 E0 01 00 00 89 83 ?? ?? ?? ??
+    vfunc_sig_max_match: 2
+    vtable_name: CEngineServer
+  server/CEngineServer_UnloadSpawnGroup.windows.yaml:
+    func_name: CEngineServer_UnloadSpawnGroup
+    vfunc_index: 60
+    vfunc_offset: '0x1e0'
+    vfunc_sig: 4C 8B 80 E0 01 00 00 48 63 C3
+    vfunc_sig_max_match: 2
+    vtable_name: CEngineServer
   server/CEngineServiceRegistry_UnregisterEngineServices.linux.yaml:
     func_name: CEngineServiceRegistry_UnregisterEngineServices
     func_rva: '0x2038f10'
@@ -40011,5 +40013,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-28T07:56:15Z'
+last_publish_time: '2026-07-28T08:22:09Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
@@ -83,9 +83,7 @@ async def preprocess_skill(
 ):
     """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the platform's LoopInit predecessor."""
     _ = skill_name
-    llm_decompile_specs = (
-        LLM_DECOMPILE_LINUX if platform == "linux" else LLM_DECOMPILE_WINDOWS
-    )
+    llm_decompile_specs = LLM_DECOMPILE_LINUX if platform == "linux" else LLM_DECOMPILE_WINDOWS
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,

--- a/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_UnloadSpawnGroup skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_UnloadSpawnGroup",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CEngineServer_UnloadSpawnGroup",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CLoopModeGame_LoopInit.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CLoopModeGame_LoopInit.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CEngineServer_UnloadSpawnGroup", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_UnloadSpawnGroup",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Find the CEngineServer vfunc called by CLoopModeGame_LoopInit."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_UnloadSpawnGroup.py
@@ -7,7 +7,13 @@ TARGET_FUNCTION_NAMES = [
     "CEngineServer_UnloadSpawnGroup",
 ]
 
-LLM_DECOMPILE = [
+# The vcall to CEngineServer::UnloadSpawnGroup lives in a different predecessor
+# per platform: on Windows CLoopModeGame_LoopInitInternal is inlined into
+# CLoopModeGame_LoopInit, so the vcall is in LoopInit; on Linux LoopInit is a
+# thin wrapper that tail-calls the separate CLoopModeGame_LoopInitInternal where
+# the vcall actually resides. The reference func_name drives which function is
+# decompiled in the new binary, so each platform points at its own predecessor.
+LLM_DECOMPILE_WINDOWS = [
     {
         "symbol_name": "CEngineServer_UnloadSpawnGroup",
         "prompt_path": "prompt/call_llm_decompile.md",
@@ -21,18 +27,41 @@ LLM_DECOMPILE = [
     },
 ]
 
+LLM_DECOMPILE_LINUX = [
+    {
+        "symbol_name": "CEngineServer_UnloadSpawnGroup",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CLoopModeGame_LoopInitInternal.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CLoopModeGame_LoopInitInternal.{platform}.yaml": "required",
+        },
+    },
+]
+
 FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
+    # (func_name, vtable_class) -- vtable_name is metadata only; CEngineServer's
+    # concrete body lives in engine2.dll, so no CEngineServer_vtable YAML is
+    # consumed here. The vfunc_sig anchors on the vcall instruction inside
+    # CLoopModeGame_LoopInit (server), matching the IGameTypes offset pattern.
     ("CEngineServer_UnloadSpawnGroup", "CEngineServer"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
+    # vfunc_sig is MANDATORY for Pattern C.
     (
         "CEngineServer_UnloadSpawnGroup",
         [
             "func_name",
             "vfunc_sig",
+            # Linux CLoopModeGame_LoopInitInternal calls this vfunc from two
+            # sites (0x1724CCD and 0x1724D0E), so the caller-anchored vfunc_sig
+            # matches 2 locations; allow up to 2 (Windows has 1 site <= 2).
+            "vfunc_sig_max_match:2",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",
@@ -52,7 +81,11 @@ async def preprocess_skill(
     llm_config=None,
     debug=False,
 ):
-    """Find the CEngineServer vfunc called by CLoopModeGame_LoopInit."""
+    """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the platform's LoopInit predecessor."""
+    _ = skill_name
+    llm_decompile_specs = (
+        LLM_DECOMPILE_LINUX if platform == "linux" else LLM_DECOMPILE_WINDOWS
+    )
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -62,7 +95,7 @@ async def preprocess_skill(
         image_base=image_base,
         func_names=TARGET_FUNCTION_NAMES,
         func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
+        llm_decompile_specs=llm_decompile_specs,
         llm_config=llm_config,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,

--- a/ida_preprocessor_scripts/references/server/CLoopModeGame_LoopInit.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CLoopModeGame_LoopInit.windows.yaml
@@ -1,0 +1,2151 @@
+func_name: CLoopModeGame_LoopInit
+func_va: '0x180bd9fa0'
+disasm_code: |-
+  .text:0000000180BD9FA0                 mov     [rsp-8+arg_10], r8
+  .text:0000000180BD9FA5                 mov     [rsp-8+arg_8], rdx
+  .text:0000000180BD9FAA                 mov     [rsp-8+arg_0], rcx
+  .text:0000000180BD9FAF                 push    rbp
+  .text:0000000180BD9FB0                 push    rbx
+  .text:0000000180BD9FB1                 push    rsi
+  .text:0000000180BD9FB2                 push    rdi
+  .text:0000000180BD9FB3                 push    r12
+  .text:0000000180BD9FB5                 push    r13
+  .text:0000000180BD9FB7                 push    r14
+  .text:0000000180BD9FB9                 push    r15
+  .text:0000000180BD9FBB                 lea     rbp, [rsp-0B8h]
+  .text:0000000180BD9FC3                 sub     rsp, 1B8h
+  .text:0000000180BD9FCA                 xor     r15d, r15d
+  .text:0000000180BD9FCD                 mov     rdi, rdx
+  .text:0000000180BD9FD0                 mov     [rbp+0F0h+var_130], r15d
+  .text:0000000180BD9FD4                 mov     r13, rcx
+  .text:0000000180BD9FD7                 mov     [rcx+6Eh], r15b
+  .text:0000000180BD9FDB                 test    rdx, rdx
+  .text:0000000180BD9FDE                 jz      loc_180BDAE6E
+  .text:0000000180BD9FE4                 lea     rdx, aMode; "mode"
+  .text:0000000180BD9FEB                 mov     rcx, rdi
+  .text:0000000180BD9FEE                 call    cs:?FindKey@KeyValues@@QEBAPEBV1@PEBD@Z; KeyValues::FindKey(char const *)
+  .text:0000000180BD9FF4                 lea     rsi, byte_1815DA9A0
+  .text:0000000180BD9FFB                 test    rax, rax
+  .text:0000000180BD9FFE                 jz      short loc_180BDA017
+  .text:0000000180BDA000                 xor     r9d, r9d
+  .text:0000000180BDA003                 xor     r8d, r8d
+  .text:0000000180BDA006                 mov     rdx, rsi
+  .text:0000000180BDA009                 mov     rcx, rax
+  .text:0000000180BDA00C                 call    cs:?Internal_GetString@CKeyValues_Data@@IEAAPEBDPEBDPEAD_K@Z; CKeyValues_Data::Internal_GetString(char const *,char *,unsigned __int64)
+  .text:0000000180BDA012                 mov     rbx, rax
+  .text:0000000180BDA015                 jmp     short loc_180BDA01A
+  .text:0000000180BDA017                 mov     rbx, rsi
+  .text:0000000180BDA01A                 lea     rdx, aListenserver; "listenserver"
+  .text:0000000180BDA021                 mov     rcx, rbx
+  .text:0000000180BDA024                 call    cs:V_stricmp_fast
+  .text:0000000180BDA02A                 test    eax, eax
+  .text:0000000180BDA02C                 jnz     short loc_180BDA038
+  .text:0000000180BDA02E                 mov     dword ptr [r13+68h], 3
+  .text:0000000180BDA036                 jmp     short loc_180BDA072
+  .text:0000000180BDA038                 lea     rdx, aDedicated; "dedicated"
+  .text:0000000180BDA03F                 mov     rcx, rbx
+  .text:0000000180BDA042                 call    cs:V_stricmp_fast
+  .text:0000000180BDA048                 test    eax, eax
+  .text:0000000180BDA04A                 jnz     short loc_180BDA056
+  .text:0000000180BDA04C                 mov     dword ptr [r13+68h], 1
+  .text:0000000180BDA054                 jmp     short loc_180BDA072
+  .text:0000000180BDA056                 lea     rdx, aRemoteclient; "remoteclient"
+  .text:0000000180BDA05D                 mov     rcx, rbx
+  .text:0000000180BDA060                 call    cs:V_stricmp_fast
+  .text:0000000180BDA066                 test    eax, eax
+  .text:0000000180BDA068                 jnz     short loc_180BDA072
+  .text:0000000180BDA06A                 mov     dword ptr [r13+68h], 2
+  .text:0000000180BDA072                 mov     eax, [r13+68h]
+  .text:0000000180BDA076                 movzx   ecx, al
+  .text:0000000180BDA079                 and     cl, 1
+  .text:0000000180BDA07C                 cmp     eax, 2
+  .text:0000000180BDA07F                 mov     byte ptr [rbp+0F0h+arg_18], cl
+  .text:0000000180BDA085                 setnz   cl
+  .text:0000000180BDA088                 call    sub_18050E7C0
+  .text:0000000180BDA08D                 lea     rdx, aLevelname; "levelname"
+  .text:0000000180BDA094                 mov     rcx, rdi
+  .text:0000000180BDA097                 call    cs:?FindKey@KeyValues@@QEBAPEBV1@PEBD@Z; KeyValues::FindKey(char const *)
+  .text:0000000180BDA09D                 test    rax, rax
+  .text:0000000180BDA0A0                 jz      short loc_180BDA0B6
+  .text:0000000180BDA0A2                 xor     r9d, r9d
+  .text:0000000180BDA0A5                 xor     r8d, r8d
+  .text:0000000180BDA0A8                 mov     rdx, rsi
+  .text:0000000180BDA0AB                 mov     rcx, rax
+  .text:0000000180BDA0AE                 call    cs:?Internal_GetString@CKeyValues_Data@@IEAAPEBDPEBDPEAD_K@Z; CKeyValues_Data::Internal_GetString(char const *,char *,unsigned __int64)
+  .text:0000000180BDA0B4                 jmp     short loc_180BDA0B9
+  .text:0000000180BDA0B6                 mov     rax, rsi
+  .text:0000000180BDA0B9                 mov     rdx, rax
+  .text:0000000180BDA0BC                 mov     [rsp+1F0h+var_1B0], r15
+  .text:0000000180BDA0C1                 lea     rcx, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA0C6                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDA0CC                 lea     rdx, aSavegame; "savegame"
+  .text:0000000180BDA0D3                 mov     rcx, rdi
+  .text:0000000180BDA0D6                 call    cs:?FindKey@KeyValues@@QEBAPEBV1@PEBD@Z; KeyValues::FindKey(char const *)
+  .text:0000000180BDA0DC                 test    rax, rax
+  .text:0000000180BDA0DF                 jz      short loc_180BDA0F5
+  .text:0000000180BDA0E1                 xor     r9d, r9d
+  .text:0000000180BDA0E4                 xor     r8d, r8d
+  .text:0000000180BDA0E7                 mov     rdx, rsi
+  .text:0000000180BDA0EA                 mov     rcx, rax
+  .text:0000000180BDA0ED                 call    cs:?Internal_GetString@CKeyValues_Data@@IEAAPEBDPEBDPEAD_K@Z; CKeyValues_Data::Internal_GetString(char const *,char *,unsigned __int64)
+  .text:0000000180BDA0F3                 jmp     short loc_180BDA0F8
+  .text:0000000180BDA0F5                 mov     rax, rsi
+  .text:0000000180BDA0F8                 mov     rdx, rax
+  .text:0000000180BDA0FB                 mov     [rsp+1F0h+var_1A0], r15
+  .text:0000000180BDA100                 lea     rcx, [rsp+1F0h+var_1A0]
+  .text:0000000180BDA105                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDA10B                 lea     rdx, aLandmarkname; "landmarkname"
+  .text:0000000180BDA112                 mov     rcx, rdi
+  .text:0000000180BDA115                 call    cs:?FindKey@KeyValues@@QEBAPEBV1@PEBD@Z; KeyValues::FindKey(char const *)
+  .text:0000000180BDA11B                 test    rax, rax
+  .text:0000000180BDA11E                 jz      short loc_180BDA134
+  .text:0000000180BDA120                 xor     r9d, r9d
+  .text:0000000180BDA123                 xor     r8d, r8d
+  .text:0000000180BDA126                 mov     rdx, rsi
+  .text:0000000180BDA129                 mov     rcx, rax
+  .text:0000000180BDA12C                 call    cs:?Internal_GetString@CKeyValues_Data@@IEAAPEBDPEBDPEAD_K@Z; CKeyValues_Data::Internal_GetString(char const *,char *,unsigned __int64)
+  .text:0000000180BDA132                 jmp     short loc_180BDA137
+  .text:0000000180BDA134                 mov     rax, rsi
+  .text:0000000180BDA137                 mov     rdx, rax
+  .text:0000000180BDA13A                 mov     [rsp+1F0h+var_190], r15
+  .text:0000000180BDA13F                 lea     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDA144                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDA14A                 lea     rdx, aPreviouslevel; "previouslevel"
+  .text:0000000180BDA151                 mov     rcx, rdi
+  .text:0000000180BDA154                 call    cs:?FindKey@KeyValues@@QEBAPEBV1@PEBD@Z; KeyValues::FindKey(char const *)
+  .text:0000000180BDA15A                 test    rax, rax
+  .text:0000000180BDA15D                 jz      short loc_180BDA173
+  .text:0000000180BDA15F                 xor     r9d, r9d
+  .text:0000000180BDA162                 xor     r8d, r8d
+  .text:0000000180BDA165                 mov     rdx, rsi
+  .text:0000000180BDA168                 mov     rcx, rax
+  .text:0000000180BDA16B                 call    cs:?Internal_GetString@CKeyValues_Data@@IEAAPEBDPEBDPEAD_K@Z; CKeyValues_Data::Internal_GetString(char const *,char *,unsigned __int64)
+  .text:0000000180BDA171                 jmp     short loc_180BDA176
+  .text:0000000180BDA173                 mov     rax, rsi
+  .text:0000000180BDA176                 mov     rdx, rax
+  .text:0000000180BDA179                 mov     [rsp+1F0h+var_180], r15
+  .text:0000000180BDA17E                 lea     rcx, [rsp+1F0h+var_180]
+  .text:0000000180BDA183                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDA189                 xor     r8d, r8d
+  .text:0000000180BDA18C                 lea     rdx, aLoadmap; "loadmap"
+  .text:0000000180BDA193                 mov     rcx, rdi
+  .text:0000000180BDA196                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180BDA19C                 xor     r8d, r8d
+  .text:0000000180BDA19F                 lea     rdx, aChangelevel_0; "changelevel"
+  .text:0000000180BDA1A6                 mov     rcx, rdi
+  .text:0000000180BDA1A9                 mov     ebx, eax
+  .text:0000000180BDA1AB                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:0000000180BDA1B1                 mov     rdx, [rsp+1F0h+var_180]
+  .text:0000000180BDA1B6                 test    eax, eax
+  .text:0000000180BDA1B8                 mov     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDA1BD                 mov     r9d, eax
+  .text:0000000180BDA1C0                 setnz   [rsp+1F0h+var_188]
+  .text:0000000180BDA1C5                 mov     dword ptr [rbp+0F0h+var_160], eax
+  .text:0000000180BDA1C8                 test    rdx, rdx
+  .text:0000000180BDA1CB                 jz      short loc_180BDA202
+  .text:0000000180BDA1CD                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA1D4                 inc     r8
+  .text:0000000180BDA1D7                 cmp     [rdx+r8], r15b
+  .text:0000000180BDA1DB                 jnz     short loc_180BDA1D4
+  .text:0000000180BDA1DD                 test    r8d, r8d
+  .text:0000000180BDA1E0                 jle     short loc_180BDA202
+  .text:0000000180BDA1E2                 test    rcx, rcx
+  .text:0000000180BDA1E5                 jz      short loc_180BDA202
+  .text:0000000180BDA1E7                 mov     rax, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA1EE                 xchg    ax, ax
+  .text:0000000180BDA1F0                 inc     rax
+  .text:0000000180BDA1F3                 cmp     [rcx+rax], r15b
+  .text:0000000180BDA1F7                 jnz     short loc_180BDA1F0
+  .text:0000000180BDA1F9                 test    eax, eax
+  .text:0000000180BDA1FB                 jle     short loc_180BDA202
+  .text:0000000180BDA1FD                 mov     r12b, 1
+  .text:0000000180BDA200                 jmp     short loc_180BDA205
+  .text:0000000180BDA202                 xor     r12b, r12b
+  .text:0000000180BDA205                 test    ebx, ebx
+  .text:0000000180BDA207                 mov     [rsp+1F0h+var_1A8], r12b
+  .text:0000000180BDA20C                 setz    al
+  .text:0000000180BDA20F                 mov     [r13+6Ch], al
+  .text:0000000180BDA213                 test    ebx, ebx
+  .text:0000000180BDA215                 jnz     short loc_180BDA258
+  .text:0000000180BDA217                 test    rdx, rdx
+  .text:0000000180BDA21A                 jz      short loc_180BDA22C
+  .text:0000000180BDA21C                 lea     rcx, [rsp+1F0h+var_180]
+  .text:0000000180BDA221                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA227                 mov     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDA22C                 test    rcx, rcx
+  .text:0000000180BDA22F                 jz      short loc_180BDA23C
+  .text:0000000180BDA231                 lea     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDA236                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA23C                 cmp     [rsp+1F0h+var_1A0], r15
+  .text:0000000180BDA241                 jz      short loc_180BDA24E
+  .text:0000000180BDA243                 lea     rcx, [rsp+1F0h+var_1A0]
+  .text:0000000180BDA248                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA24E                 cmp     [rsp+1F0h+var_1B0], r15
+  .text:0000000180BDA253                 jmp     loc_180BDB271
+  .text:0000000180BDA258                 cmp     dword ptr [r13+68h], 2
+  .text:0000000180BDA25D                 mov     r14, r15
+  .text:0000000180BDA260                 mov     [rbp+0F0h+var_140], r15
+  .text:0000000180BDA264                 mov     [rbp+0F0h+var_138], r15
+  .text:0000000180BDA268                 mov     [rbp+0F0h+var_148], r15d
+  .text:0000000180BDA26C                 mov     [rbp+0F0h+var_170], r15
+  .text:0000000180BDA270                 mov     [rbp+0F0h+var_168], r15
+  .text:0000000180BDA274                 mov     [rsp+1F0h+var_178], r15d
+  .text:0000000180BDA279                 mov     [rsp+1F0h+var_198], r15
+  .text:0000000180BDA27E                 jz      loc_180BDA691
+  .text:0000000180BDA284                 mov     rdx, [rsp+1F0h+var_1A0]
+  .text:0000000180BDA289                 test    rdx, rdx
+  .text:0000000180BDA28C                 jz      loc_180BDA61A
+  .text:0000000180BDA292                 mov     rax, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA299                 nop     dword ptr [rax+00000000h]
+  .text:0000000180BDA2A0                 inc     rax
+  .text:0000000180BDA2A3                 cmp     [rdx+rax], r14b
+  .text:0000000180BDA2A7                 jnz     short loc_180BDA2A0
+  .text:0000000180BDA2A9                 test    eax, eax
+  .text:0000000180BDA2AB                 jle     loc_180BDA61A
+  .text:0000000180BDA2B1                 test    r9d, r9d
+  .text:0000000180BDA2B4                 jnz     short loc_180BDA2E3
+  .text:0000000180BDA2B6                 mov     rcx, cs:g_pSource2Server
+  .text:0000000180BDA2BD                 lea     r8, [rsp+1F0h+var_198]
+  .text:0000000180BDA2C2                 movzx   r9d, byte ptr [rbp+0F0h+arg_18]
+  .text:0000000180BDA2CA                 mov     [rsp+1F0h+var_1C8], r8
+  .text:0000000180BDA2CF                 lea     r8, [rbp+0F0h+var_148]
+  .text:0000000180BDA2D3                 mov     dword ptr [rsp+1F0h+var_1D0], r14d
+  .text:0000000180BDA2D8                 mov     rax, [rcx]
+  .text:0000000180BDA2DB                 call    qword ptr [rax+1A0h]
+  .text:0000000180BDA2E1                 jmp     short loc_180BDA35B
+  .text:0000000180BDA2E3                 lea     rcx, [rbp+0F0h+var_148]
+  .text:0000000180BDA2E7                 call    sub_180B70C50
+  .text:0000000180BDA2EC                 mov     rcx, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA2F1                 mov     rbx, rax
+  .text:0000000180BDA2F4                 test    rcx, rcx
+  .text:0000000180BDA2F7                 jz      short loc_180BDA30B
+  .text:0000000180BDA2F9                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA300                 inc     r8
+  .text:0000000180BDA303                 cmp     [rcx+r8], r14b
+  .text:0000000180BDA307                 jnz     short loc_180BDA300
+  .text:0000000180BDA309                 jmp     short loc_180BDA30E
+  .text:0000000180BDA30B                 xor     r8d, r8d
+  .text:0000000180BDA30E                 test    rcx, rcx
+  .text:0000000180BDA311                 mov     rdx, rsi
+  .text:0000000180BDA314                 cmovnz  rdx, rcx
+  .text:0000000180BDA318                 lea     rcx, [rax+30h]
+  .text:0000000180BDA31C                 call    cs:?SetDirect@CUtlString@@QEAAXPEBDH@Z; CUtlString::SetDirect(char const *,int)
+  .text:0000000180BDA322                 mov     rax, [rsp+1F0h+var_1A0]
+  .text:0000000180BDA327                 lea     rcx, [rbx+40h]
+  .text:0000000180BDA32B                 test    rax, rax
+  .text:0000000180BDA32E                 jz      short loc_180BDA342
+  .text:0000000180BDA330                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA337                 inc     r8
+  .text:0000000180BDA33A                 cmp     [rax+r8], r14b
+  .text:0000000180BDA33E                 jnz     short loc_180BDA337
+  .text:0000000180BDA340                 jmp     short loc_180BDA345
+  .text:0000000180BDA342                 xor     r8d, r8d
+  .text:0000000180BDA345                 test    rax, rax
+  .text:0000000180BDA348                 mov     rdx, rsi
+  .text:0000000180BDA34B                 cmovnz  rdx, rax
+  .text:0000000180BDA34F                 call    cs:?SetDirect@CUtlString@@QEAAXPEBDH@Z; CUtlString::SetDirect(char const *,int)
+  .text:0000000180BDA355                 mov     word ptr [rbx+50h], 1
+  .text:0000000180BDA35B                 mov     eax, [rbp+0F0h+var_148]
+  .text:0000000180BDA35E                 test    eax, eax
+  .text:0000000180BDA360                 jnz     loc_180BDA424
+  .text:0000000180BDA366                 lea     rcx, [rsp+1F0h+var_178]
+  .text:0000000180BDA36B                 call    sub_180BCDDF0
+  .text:0000000180BDA370                 mov     r14, [rbp+0F0h+var_170]
+  .text:0000000180BDA374                 movsxd  rcx, eax
+  .text:0000000180BDA377                 lea     rdx, [rcx+rcx*4]
+  .text:0000000180BDA37B                 mov     rcx, rsi
+  .text:0000000180BDA37E                 shl     rdx, 5
+  .text:0000000180BDA382                 add     rdx, r14
+  .text:0000000180BDA385                 mov     byte ptr [rdx+90h], 1
+  .text:0000000180BDA38C                 mov     [rdx+98h], r12b
+  .text:0000000180BDA393                 mov     dword ptr [rdx+8Ch], 42B40000h
+  .text:0000000180BDA39D                 movaps  xmm0, cs:xmmword_181627920
+  .text:0000000180BDA3A4                 movups  xmmword ptr [rdx+40h], xmm0
+  .text:0000000180BDA3A8                 movaps  xmm1, cs:xmmword_181627930
+  .text:0000000180BDA3AF                 movups  xmmword ptr [rdx+50h], xmm1
+  .text:0000000180BDA3B3                 movaps  xmm0, cs:xmmword_181627940
+  .text:0000000180BDA3BA                 movups  xmmword ptr [rdx+60h], xmm0
+  .text:0000000180BDA3BE                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA3C3                 test    rax, rax
+  .text:0000000180BDA3C6                 cmovnz  rcx, rax
+  .text:0000000180BDA3CA                 lea     rax, aMapload; "mapload"
+  .text:0000000180BDA3D1                 mov     [rdx+18h], rax
+  .text:0000000180BDA3D5                 mov     [rdx], rcx
+  .text:0000000180BDA3D8                 mov     edx, 1
+  .text:0000000180BDA3DD                 mov     ecx, cs:dword_181F36C30
+  .text:0000000180BDA3E3                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180BDA3E9                 test    al, al
+  .text:0000000180BDA3EB                 jz      loc_180BDA68C
+  .text:0000000180BDA3F1                 mov     rax, [rsp+1F0h+var_1A0]
+  .text:0000000180BDA3F6                 lea     r8, aSaveFileSExpec; "save file '%s' expected to have a singl"...
+  .text:0000000180BDA3FD                 mov     ecx, cs:dword_181F36C30
+  .text:0000000180BDA403                 test    rax, rax
+  .text:0000000180BDA406                 mov     r9, rsi
+  .text:0000000180BDA409                 mov     edx, 1
+  .text:0000000180BDA40E                 cmovnz  r9, rax
+  .text:0000000180BDA412                 mov     eax, [rbp+0F0h+var_148]
+  .text:0000000180BDA415                 mov     dword ptr [rsp+1F0h+var_1D0], eax
+  .text:0000000180BDA419                 call    cs:LoggingSystem_Log
+  .text:0000000180BDA41F                 jmp     loc_180BDA68C
+  .text:0000000180BDA424                 xor     r12d, r12d
+  .text:0000000180BDA427                 test    eax, eax
+  .text:0000000180BDA429                 jle     loc_180BDA691
+  .text:0000000180BDA42F                 mov     r13, [rbp+0F0h+arg_8]
+  .text:0000000180BDA436                 xor     ebx, ebx
+  .text:0000000180BDA438                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000180BDA440                 mov     rdi, [rbp+0F0h+var_140]
+  .text:0000000180BDA444                 lea     rcx, [rsp+1F0h+var_178]
+  .text:0000000180BDA449                 call    sub_180BCDDF0
+  .text:0000000180BDA44E                 mov     r14, [rbp+0F0h+var_170]
+  .text:0000000180BDA452                 movsxd  rcx, eax
+  .text:0000000180BDA455                 movzx   eax, [rsp+1F0h+var_1A8]
+  .text:0000000180BDA45A                 lea     rdx, [rcx+rcx*4]
+  .text:0000000180BDA45E                 mov     rcx, rsi
+  .text:0000000180BDA461                 shl     rdx, 5
+  .text:0000000180BDA465                 add     rdx, r14
+  .text:0000000180BDA468                 mov     byte ptr [rdx+90h], 1
+  .text:0000000180BDA46F                 mov     [rdx+98h], al
+  .text:0000000180BDA475                 mov     dword ptr [rdx+8Ch], 42B40000h
+  .text:0000000180BDA47F                 movaps  xmm0, cs:xmmword_181627920
+  .text:0000000180BDA486                 movups  xmmword ptr [rdx+40h], xmm0
+  .text:0000000180BDA48A                 movaps  xmm1, cs:xmmword_181627930
+  .text:0000000180BDA491                 movups  xmmword ptr [rdx+50h], xmm1
+  .text:0000000180BDA495                 movaps  xmm0, cs:xmmword_181627940
+  .text:0000000180BDA49C                 movups  xmmword ptr [rdx+60h], xmm0
+  .text:0000000180BDA4A0                 mov     rax, [rdi+rbx+30h]
+  .text:0000000180BDA4A5                 test    rax, rax
+  .text:0000000180BDA4A8                 cmovnz  rcx, rax
+  .text:0000000180BDA4AC                 mov     [rdx], rcx
+  .text:0000000180BDA4AF                 mov     rcx, rsi
+  .text:0000000180BDA4B2                 mov     rax, [rdi+rbx+48h]
+  .text:0000000180BDA4B7                 test    rax, rax
+  .text:0000000180BDA4BA                 cmovnz  rcx, rax
+  .text:0000000180BDA4BE                 mov     [rdx+10h], rcx
+  .text:0000000180BDA4C2                 movups  xmm0, xmmword ptr [rdi+rbx]
+  .text:0000000180BDA4C6                 movups  xmmword ptr [rdx+40h], xmm0
+  .text:0000000180BDA4CA                 movups  xmm1, xmmword ptr [rdi+rbx+10h]
+  .text:0000000180BDA4CF                 movups  xmmword ptr [rdx+50h], xmm1
+  .text:0000000180BDA4D3                 movups  xmm0, xmmword ptr [rdi+rbx+20h]
+  .text:0000000180BDA4D8                 movups  xmmword ptr [rdx+60h], xmm0
+  .text:0000000180BDA4DC                 movzx   eax, byte ptr [rdi+rbx+52h]
+  .text:0000000180BDA4E1                 mov     [rdx+99h], al
+  .text:0000000180BDA4E7                 test    al, al
+  .text:0000000180BDA4E9                 jnz     loc_180BDA5F9
+  .text:0000000180BDA4EF                 lea     r15, [rdx+78h]
+  .text:0000000180BDA4F3                 mov     rdx, [rdi+rbx+40h]
+  .text:0000000180BDA4F8                 test    rdx, rdx
+  .text:0000000180BDA4FB                 jz      short loc_180BDA510
+  .text:0000000180BDA4FD                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA504                 inc     r8
+  .text:0000000180BDA507                 cmp     byte ptr [rdx+r8], 0
+  .text:0000000180BDA50C                 jnz     short loc_180BDA504
+  .text:0000000180BDA50E                 jmp     short loc_180BDA516
+  .text:0000000180BDA510                 xor     r8d, r8d
+  .text:0000000180BDA513                 mov     rdx, rsi
+  .text:0000000180BDA516                 mov     rcx, r15
+  .text:0000000180BDA519                 call    cs:?SetDirect@CUtlString@@QEAAXPEBDH@Z; CUtlString::SetDirect(char const *,int)
+  .text:0000000180BDA51F                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA524                 test    rax, rax
+  .text:0000000180BDA527                 jz      short loc_180BDA53D
+  .text:0000000180BDA529                 mov     rcx, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA530                 inc     rcx
+  .text:0000000180BDA533                 cmp     byte ptr [rax+rcx], 0
+  .text:0000000180BDA537                 jnz     short loc_180BDA530
+  .text:0000000180BDA539                 test    ecx, ecx
+  .text:0000000180BDA53B                 jnz     short loc_180BDA58C
+  .text:0000000180BDA53D                 mov     rdx, [rdi+rbx+30h]
+  .text:0000000180BDA542                 test    rdx, rdx
+  .text:0000000180BDA545                 jz      short loc_180BDA55C
+  .text:0000000180BDA547                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDA54E                 xchg    ax, ax
+  .text:0000000180BDA550                 inc     r8
+  .text:0000000180BDA553                 cmp     byte ptr [rdx+r8], 0
+  .text:0000000180BDA558                 jnz     short loc_180BDA550
+  .text:0000000180BDA55A                 jmp     short loc_180BDA562
+  .text:0000000180BDA55C                 xor     r8d, r8d
+  .text:0000000180BDA55F                 mov     rdx, rsi
+  .text:0000000180BDA562                 lea     rcx, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA567                 call    cs:?SetDirect@CUtlString@@QEAAXPEBDH@Z; CUtlString::SetDirect(char const *,int)
+  .text:0000000180BDA56D                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA572                 lea     rdx, aLevelname; "levelname"
+  .text:0000000180BDA579                 test    rax, rax
+  .text:0000000180BDA57C                 mov     r8, rsi
+  .text:0000000180BDA57F                 mov     rcx, r13
+  .text:0000000180BDA582                 cmovnz  r8, rax
+  .text:0000000180BDA586                 call    cs:?SetString@KeyValues@@QEAAXPEBD0@Z; KeyValues::SetString(char const *,char const *)
+  .text:0000000180BDA58C                 mov     ecx, cs:dword_181F36C30
+  .text:0000000180BDA592                 mov     edx, 1
+  .text:0000000180BDA597                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180BDA59D                 test    al, al
+  .text:0000000180BDA59F                 jz      short loc_180BDA5F9
+  .text:0000000180BDA5A1                 mov     rax, [r15]
+  .text:0000000180BDA5A4                 lea     r9, aLoading; "loading"
+  .text:0000000180BDA5AB                 test    rax, rax
+  .text:0000000180BDA5AE                 lea     r8, aSSHlSFromSaveF; "%s %s.HL%s from save file on %s\n"
+  .text:0000000180BDA5B5                 mov     rcx, rsi
+  .text:0000000180BDA5B8                 mov     edx, 1
+  .text:0000000180BDA5BD                 cmovnz  rcx, rax
+  .text:0000000180BDA5C1                 cmp     dword ptr [rbp+0F0h+var_160], 0
+  .text:0000000180BDA5C5                 lea     rax, aTransitioning; "transitioning"
+  .text:0000000180BDA5CC                 cmovnz  r9, rax
+  .text:0000000180BDA5D0                 lea     rax, aServer_3; "server"
+  .text:0000000180BDA5D7                 mov     [rsp+1F0h+var_1C0], rax
+  .text:0000000180BDA5DC                 lea     rax, a1_1; "1"
+  .text:0000000180BDA5E3                 mov     [rsp+1F0h+var_1C8], rax
+  .text:0000000180BDA5E8                 mov     [rsp+1F0h+var_1D0], rcx
+  .text:0000000180BDA5ED                 mov     ecx, cs:dword_181F36C30
+  .text:0000000180BDA5F3                 call    cs:LoggingSystem_Log
+  .text:0000000180BDA5F9                 inc     r12d
+  .text:0000000180BDA5FC                 add     rbx, 60h ; '`'
+  .text:0000000180BDA600                 cmp     r12d, [rbp+0F0h+var_148]
+  .text:0000000180BDA604                 jl      loc_180BDA440
+  .text:0000000180BDA60A                 mov     r13, [rbp+0F0h+arg_0]
+  .text:0000000180BDA611                 mov     rdi, [rbp+0F0h+arg_8]
+  .text:0000000180BDA618                 jmp     short loc_180BDA68C
+  .text:0000000180BDA61A                 lea     rcx, [rsp+1F0h+var_178]
+  .text:0000000180BDA61F                 call    sub_180BCDDF0
+  .text:0000000180BDA624                 mov     r14, [rbp+0F0h+var_170]
+  .text:0000000180BDA628                 movsxd  rcx, eax
+  .text:0000000180BDA62B                 lea     rdx, [rcx+rcx*4]
+  .text:0000000180BDA62F                 mov     rcx, rsi
+  .text:0000000180BDA632                 shl     rdx, 5
+  .text:0000000180BDA636                 add     rdx, r14
+  .text:0000000180BDA639                 mov     byte ptr [rdx+90h], 1
+  .text:0000000180BDA640                 mov     [rdx+98h], r12b
+  .text:0000000180BDA647                 mov     dword ptr [rdx+8Ch], 42B40000h
+  .text:0000000180BDA651                 movaps  xmm0, cs:xmmword_181627920
+  .text:0000000180BDA658                 movups  xmmword ptr [rdx+40h], xmm0
+  .text:0000000180BDA65C                 movaps  xmm1, cs:xmmword_181627930
+  .text:0000000180BDA663                 movups  xmmword ptr [rdx+50h], xmm1
+  .text:0000000180BDA667                 movaps  xmm0, cs:xmmword_181627940
+  .text:0000000180BDA66E                 movups  xmmword ptr [rdx+60h], xmm0
+  .text:0000000180BDA672                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA677                 test    rax, rax
+  .text:0000000180BDA67A                 cmovnz  rcx, rax
+  .text:0000000180BDA67E                 lea     rax, aMapload; "mapload"
+  .text:0000000180BDA685                 mov     [rdx+18h], rax
+  .text:0000000180BDA689                 mov     [rdx], rcx
+  .text:0000000180BDA68C                 mov     r15d, [rsp+1F0h+var_178]
+  .text:0000000180BDA691                 cmp     byte ptr [rbp+0F0h+arg_18], 0
+  .text:0000000180BDA698                 jz      loc_180BDA81B
+  .text:0000000180BDA69E                 mov     rcx, cs:g_pVApplication
+  .text:0000000180BDA6A5                 mov     rax, [rcx]
+  .text:0000000180BDA6A8                 call    qword ptr [rax+0B0h]
+  .text:0000000180BDA6AE                 test    al, al
+  .text:0000000180BDA6B0                 jnz     loc_180BDA81B
+  .text:0000000180BDA6B6                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA6BB                 lea     rdx, aError; "error"
+  .text:0000000180BDA6C2                 test    rax, rax
+  .text:0000000180BDA6C5                 mov     rcx, rsi
+  .text:0000000180BDA6C8                 cmovnz  rcx, rax
+  .text:0000000180BDA6CC                 call    cs:V_stricmp_fast
+  .text:0000000180BDA6D2                 test    eax, eax
+  .text:0000000180BDA6D4                 jnz     loc_180BDA81B
+  .text:0000000180BDA6DA                 mov     ecx, cs:dword_181FDF138
+  .text:0000000180BDA6E0                 mov     edx, 3
+  .text:0000000180BDA6E5                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180BDA6EB                 test    al, al
+  .text:0000000180BDA6ED                 jz      short loc_180BDA707
+  .text:0000000180BDA6EF                 mov     ecx, cs:dword_181FDF138
+  .text:0000000180BDA6F5                 lea     r8, aLoopinitInErro; "LoopInit:  in \"error\" map - disconnec"...
+  .text:0000000180BDA6FC                 mov     edx, 3
+  .text:0000000180BDA701                 call    cs:LoggingSystem_Log
+  .text:0000000180BDA707                 mov     rcx, cs:g_pNetworkClientService
+  .text:0000000180BDA70E                 mov     edx, 40h ; '@'
+  .text:0000000180BDA713                 mov     rax, [rcx]
+  .text:0000000180BDA716                 mov     r9, [rax+0E0h]
+  .text:0000000180BDA71D                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA722                 test    rax, rax
+  .text:0000000180BDA725                 cmovnz  rsi, rax
+  .text:0000000180BDA729                 mov     r8, rsi
+  .text:0000000180BDA72C                 call    r9
+  .text:0000000180BDA72F                 lea     rax, aCBuildworkerCs_47; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180BDA736                 mov     [rbp+0F0h+var_78], 28Ch
+  .text:0000000180BDA73D                 mov     [rbp+0F0h+var_90], rax
+  .text:0000000180BDA741                 lea     r12, aCloopmodegameL; "CLoopModeGame::LoopInit"
+  .text:0000000180BDA748                 lea     rax, aFalse; "false"
+  .text:0000000180BDA74F                 mov     [rbp+0F0h+var_88], r12
+  .text:0000000180BDA753                 lea     rdx, aErrorMap; "Error map!"
+  .text:0000000180BDA75A                 mov     [rbp+0F0h+var_80], rax
+  .text:0000000180BDA75E                 lea     rcx, [rbp+0F0h+var_90]
+  .text:0000000180BDA762                 mov     [rbp+0F0h+var_74], 14h
+  .text:0000000180BDA769                 call    cs:?Assert_ConditionFailed@@YA_NAEBU_AssertCompileTimeConstantStruct_t@@PEBDZZ; Assert_ConditionFailed(_AssertCompileTimeConstantStruct_t const &,char const *,...)
+  .text:0000000180BDA76F                 test    al, al
+  .text:0000000180BDA771                 jz      short loc_180BDA774
+  .text:0000000180BDA773                 ; Trap to Debugger
+  .text:0000000180BDA773                 int     3; Trap to Debugger
+  .text:0000000180BDA774                 cmp     [rsp+1F0h+var_198], 0
+  .text:0000000180BDA77A                 jz      short loc_180BDA787
+  .text:0000000180BDA77C                 lea     rcx, [rsp+1F0h+var_198]
+  .text:0000000180BDA781                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA787                 lea     eax, [r15-1]
+  .text:0000000180BDA78B                 movsxd  rdi, eax
+  .text:0000000180BDA78E                 test    eax, eax
+  .text:0000000180BDA790                 js      short loc_180BDA7CE
+  .text:0000000180BDA792                 lea     rbx, [rdi+rdi*4]
+  .text:0000000180BDA796                 shl     rbx, 5
+  .text:0000000180BDA79A                 add     rbx, 70h ; 'p'
+  .text:0000000180BDA79E                 add     rbx, r14
+  .text:0000000180BDA7A1                 cmp     qword ptr [rbx+8], 0
+  .text:0000000180BDA7A6                 lea     rcx, [rbx+8]
+  .text:0000000180BDA7AA                 jz      short loc_180BDA7B2
+  .text:0000000180BDA7AC                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA7B2                 cmp     qword ptr [rbx], 0
+  .text:0000000180BDA7B6                 jz      short loc_180BDA7C1
+  .text:0000000180BDA7B8                 mov     rcx, rbx
+  .text:0000000180BDA7BB                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA7C1                 sub     rbx, 0A0h
+  .text:0000000180BDA7C8                 sub     rdi, 1
+  .text:0000000180BDA7CC                 jns     short loc_180BDA7A1
+  .text:0000000180BDA7CE                 test    dword ptr [rbp+0F0h+var_168+4], 0C0000000h
+  .text:0000000180BDA7D5                 jnz     loc_180BDAE19
+  .text:0000000180BDA7DB                 test    r14, r14
+  .text:0000000180BDA7DE                 jz      loc_180BDAE19
+  .text:0000000180BDA7E4                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180BDA7EB                 mov     rdx, r14
+  .text:0000000180BDA7EE                 mov     rcx, [rax]
+  .text:0000000180BDA7F1                 mov     rax, [rcx]
+  .text:0000000180BDA7F4                 call    qword ptr [rax+18h]
+  .text:0000000180BDA7F7                 xor     r14d, r14d
+  .text:0000000180BDA7FA                 test    r14, r14
+  .text:0000000180BDA7FD                 jz      loc_180BDAE19
+  .text:0000000180BDA803                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180BDA80A                 mov     edx, r14d
+  .text:0000000180BDA80D                 mov     rcx, [rax]
+  .text:0000000180BDA810                 mov     rax, [rcx]
+  .text:0000000180BDA813                 call    qword ptr [rax+18h]
+  .text:0000000180BDA816                 jmp     loc_180BDAE19
+  .text:0000000180BDA81B                 mov     ecx, 28h ; '('
+  .text:0000000180BDA820                 call    sub_180EA7010
+  .text:0000000180BDA825                 mov     rcx, rax
+  .text:0000000180BDA828                 test    rax, rax
+  .text:0000000180BDA82B                 jz      short loc_180BDA85E
+  .text:0000000180BDA82D                 xor     edx, edx
+  .text:0000000180BDA82F                 mov     [rax+8], rdx
+  .text:0000000180BDA833                 mov     [rax+14h], rdx
+  .text:0000000180BDA837                 mov     [rax+1Ch], rdx
+  .text:0000000180BDA83B                 mov     [rax+24h], edx
+  .text:0000000180BDA83E                 lea     rax, ??_7CResourceManifestPrerequisite@@6B@; const CResourceManifestPrerequisite::`vftable'
+  .text:0000000180BDA845                 mov     r14, [rbp+0F0h+var_170]
+  .text:0000000180BDA849                 mov     r15d, [rsp+1F0h+var_178]
+  .text:0000000180BDA84E                 mov     [rcx], rax
+  .text:0000000180BDA851                 mov     [rcx+18h], rdx
+  .text:0000000180BDA855                 mov     [rcx+20h], rdx
+  .text:0000000180BDA859                 mov     [rcx+10h], edx
+  .text:0000000180BDA85C                 jmp     short loc_180BDA860
+  .text:0000000180BDA85E                 xor     ecx, ecx
+  .text:0000000180BDA860                 mov     [r13+8], rcx
+  .text:0000000180BDA864                 mov     rax, [rcx]
+  .text:0000000180BDA867                 call    qword ptr [rax+8]
+  .text:0000000180BDA86A                 mov     rcx, [rbp+0F0h+arg_10]
+  .text:0000000180BDA871                 mov     rdx, [r13+8]
+  .text:0000000180BDA875                 mov     rax, [rcx]
+  .text:0000000180BDA878                 call    qword ptr [rax]
+  .text:0000000180BDA87A                 mov     rcx, cs:g_pNetworkService
+  .text:0000000180BDA881                 mov     rax, [rcx]
+  .text:0000000180BDA884                 call    qword ptr [rax+0B8h]
+  .text:0000000180BDA88A                 cmp     byte ptr [rbp+0F0h+arg_18], 0
+  .text:0000000180BDA891                 lea     rbx, [r13+8]
+  .text:0000000180BDA895                 jz      loc_180BDAF66
+  .text:0000000180BDA89B                 mov     rcx, cs:qword_18219EC90
+  .text:0000000180BDA8A2                 lea     rdx, aDefaultsession; "defaultSession"
+  .text:0000000180BDA8A9                 mov     r9, [r13+8]
+  .text:0000000180BDA8AD                 mov     r8, rsi
+  .text:0000000180BDA8B0                 mov     rax, [rcx]
+  .text:0000000180BDA8B3                 mov     r10, [rax+68h]
+  .text:0000000180BDA8B7                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDA8BC                 test    rax, rax
+  .text:0000000180BDA8BF                 cmovnz  r8, rax
+  .text:0000000180BDA8C3                 call    r10
+  .text:0000000180BDA8C6                 mov     rcx, [r13+60h]
+  .text:0000000180BDA8CA                 mov     rbx, rax
+  .text:0000000180BDA8CD                 cmp     rax, rcx
+  .text:0000000180BDA8D0                 jz      short loc_180BDA915
+  .text:0000000180BDA8D2                 test    rcx, rcx
+  .text:0000000180BDA8D5                 jz      short loc_180BDA8E5
+  .text:0000000180BDA8D7                 mov     r8, [rcx]
+  .text:0000000180BDA8DA                 lea     rdx, aCloopmodegameS_1; "--CLoopModeGame::SetWorldSession"
+  .text:0000000180BDA8E1                 call    qword ptr [r8+8]
+  .text:0000000180BDA8E5                 mov     [r13+60h], rbx
+  .text:0000000180BDA8E9                 test    rbx, rbx
+  .text:0000000180BDA8EC                 jz      short loc_180BDA915
+  .text:0000000180BDA8EE                 mov     rax, [rbx]
+  .text:0000000180BDA8F1                 lea     rdx, aCloopmodegameS_2; "++CLoopModeGame::SetWorldSession"
+  .text:0000000180BDA8F8                 mov     rcx, rbx
+  .text:0000000180BDA8FB                 call    qword ptr [rax]
+  .text:0000000180BDA8FD                 call    sub_181529360
+  .text:0000000180BDA902                 test    al, al
+  .text:0000000180BDA904                 jnz     short loc_180BDA915
+  .text:0000000180BDA906                 mov     rcx, [r13+60h]
+  .text:0000000180BDA90A                 xor     edx, edx
+  .text:0000000180BDA90C                 mov     rax, [rcx]
+  .text:0000000180BDA90F                 call    qword ptr [rax+0F0h]
+  .text:0000000180BDA915                 mov     rax, [rbx]
+  .text:0000000180BDA918                 lea     rdx, aCloopmodegameL_0; "--CLoopModeGame::LoopInit"
+  .text:0000000180BDA91F                 mov     rcx, rbx
+  .text:0000000180BDA922                 call    qword ptr [rax+8]
+  .text:0000000180BDA925                 xor     r8d, r8d
+  .text:0000000180BDA928                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDA92C                 xor     edx, edx
+  .text:0000000180BDA92E                 call    sub_1807F3150
+  .text:0000000180BDA933                 or      [rbp+0F0h+var_110], 20h
+  .text:0000000180BDA937                 lea     rax, ??_7?$CBaseCmdKeyValues@VCSVCMsg_GameSessionConfiguration@@@@6B@; const CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable'
+  .text:0000000180BDA93E                 test    byte ptr [rbp+0F0h+var_118], 1
+  .text:0000000180BDA942                 mov     [rbp+0F0h+var_120], rax
+  .text:0000000180BDA946                 mov     [rbp+0F0h+var_B0], 0
+  .text:0000000180BDA94E                 jz      short loc_180BDA95D
+  .text:0000000180BDA950                 mov     rax, [rbp+0F0h+var_118]
+  .text:0000000180BDA954                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDA958                 mov     rdx, [rax]
+  .text:0000000180BDA95B                 jmp     short loc_180BDA965
+  .text:0000000180BDA95D                 mov     rdx, [rbp+0F0h+var_118]
+  .text:0000000180BDA961                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDA965                 lea     rcx, [rbp+0F0h+var_E0]
+  .text:0000000180BDA969                 call    sub_180FD7510
+  .text:0000000180BDA96E                 mov     qword ptr [rax+10h], 0
+  .text:0000000180BDA976                 cmp     qword ptr [rax+18h], 0Fh
+  .text:0000000180BDA97B                 jbe     short loc_180BDA980
+  .text:0000000180BDA97D                 mov     rax, [rax]
+  .text:0000000180BDA980                 mov     byte ptr [rax], 0
+  .text:0000000180BDA983                 lea     r8, [rbp+0F0h+var_120]
+  .text:0000000180BDA987                 mov     rcx, cs:qword_181FBDF10
+  .text:0000000180BDA98E                 lea     rax, ??_7GameSessionConfiguration_t@@6B@; const GameSessionConfiguration_t::`vftable'
+  .text:0000000180BDA995                 mov     [rbp+0F0h+var_120], rax
+  .text:0000000180BDA999                 mov     rdx, rdi
+  .text:0000000180BDA99C                 mov     rax, [rcx]
+  .text:0000000180BDA99F                 call    qword ptr [rax+0A8h]
+  .text:0000000180BDA9A5                 test    al, al
+  .text:0000000180BDA9A7                 jnz     loc_180BDAA47
+  .text:0000000180BDA9AD                 mov     rbx, [rbp+0F0h+var_B0]
+  .text:0000000180BDA9B1                 lea     rax, ??_7?$CBaseCmdKeyValues@VCSVCMsg_GameSessionConfiguration@@@@6B@; const CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable'
+  .text:0000000180BDA9B8                 mov     [rbp+0F0h+var_120], rax
+  .text:0000000180BDA9BC                 test    rbx, rbx
+  .text:0000000180BDA9BF                 jz      short loc_180BDA9DB
+  .text:0000000180BDA9C1                 mov     rcx, rbx
+  .text:0000000180BDA9C4                 call    cs:??1KeyValues@@QEAA@XZ; KeyValues::~KeyValues(void)
+  .text:0000000180BDA9CA                 mov     rcx, rbx
+  .text:0000000180BDA9CD                 call    cs:??3KeyValues@@SAXPEAX@Z; KeyValues::operator delete(void *)
+  .text:0000000180BDA9D3                 mov     [rbp+0F0h+var_B0], 0
+  .text:0000000180BDA9DB                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDA9DF                 call    sub_1807F3730
+  .text:0000000180BDA9E4                 cmp     [rsp+1F0h+var_198], 0
+  .text:0000000180BDA9EA                 jz      short loc_180BDA9F7
+  .text:0000000180BDA9EC                 lea     rcx, [rsp+1F0h+var_198]
+  .text:0000000180BDA9F1                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDA9F7                 lea     eax, [r15-1]
+  .text:0000000180BDA9FB                 movsxd  rdi, eax
+  .text:0000000180BDA9FE                 test    eax, eax
+  .text:0000000180BDAA00                 js      loc_180BDA7CE
+  .text:0000000180BDAA06                 lea     rbx, [rdi+rdi*4]
+  .text:0000000180BDAA0A                 shl     rbx, 5
+  .text:0000000180BDAA0E                 add     rbx, 70h ; 'p'
+  .text:0000000180BDAA12                 add     rbx, r14
+  .text:0000000180BDAA15                 cmp     qword ptr [rbx+8], 0
+  .text:0000000180BDAA1A                 lea     rcx, [rbx+8]
+  .text:0000000180BDAA1E                 jz      short loc_180BDAA26
+  .text:0000000180BDAA20                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAA26                 cmp     qword ptr [rbx], 0
+  .text:0000000180BDAA2A                 jz      short loc_180BDAA35
+  .text:0000000180BDAA2C                 mov     rcx, rbx
+  .text:0000000180BDAA2F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAA35                 sub     rbx, 0A0h
+  .text:0000000180BDAA3C                 sub     rdi, 1
+  .text:0000000180BDAA40                 jns     short loc_180BDAA15
+  .text:0000000180BDAA42                 jmp     loc_180BDA7CE
+  .text:0000000180BDAA47                 movzx   eax, [rbp+0F0h+var_C5]
+  .text:0000000180BDAA4B                 mov     rdx, [rbp+0F0h+var_D8]
+  .text:0000000180BDAA4F                 mov     [r13+6Dh], al
+  .text:0000000180BDAA53                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDAA57                 movzx   eax, [rbp+0F0h+var_C6]
+  .text:0000000180BDAA5B                 mov     [r13+6Fh], al
+  .text:0000000180BDAA5F                 movzx   eax, [rbp+0F0h+var_B2]
+  .text:0000000180BDAA63                 mov     [r13+70h], al
+  .text:0000000180BDAA67                 cmp     qword ptr [rdx+18h], 0Fh
+  .text:0000000180BDAA6C                 jbe     short loc_180BDAA71
+  .text:0000000180BDAA6E                 mov     rdx, [rdx]
+  .text:0000000180BDAA71                 lea     rcx, [r13+80h]
+  .text:0000000180BDAA78                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDAA7E                 mov     rdx, [rbp+0F0h+var_F8]
+  .text:0000000180BDAA82                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDAA86                 cmp     qword ptr [rdx+18h], 0Fh
+  .text:0000000180BDAA8B                 jbe     short loc_180BDAA90
+  .text:0000000180BDAA8D                 mov     rdx, [rdx]
+  .text:0000000180BDAA90                 lea     rcx, [r13+88h]
+  .text:0000000180BDAA97                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:0000000180BDAA9D                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180BDAAA4                 test    rcx, rcx
+  .text:0000000180BDAAA7                 jz      short loc_180BDAABA
+  .text:0000000180BDAAA9                 movzx   eax, [rbp+0F0h+var_C7]
+  .text:0000000180BDAAAD                 mov     [rcx+0BDDh], al
+  .text:0000000180BDAAB3                 mov     byte ptr [rcx+0BDEh], 0
+  .text:0000000180BDAABA                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180BDAAC1                 lea     rdx, [rbp+0F0h+var_120]
+  .text:0000000180BDAAC5                 mov     r9, rsi
+  .text:0000000180BDAAC8                 mov     r8, rbx
+  .text:0000000180BDAACB                 mov     rax, [rcx]
+  .text:0000000180BDAACE                 mov     r10, [rax+0D0h]
+  .text:0000000180BDAAD5                 mov     rax, [rsp+1F0h+var_1B0]
+  .text:0000000180BDAADA                 test    rax, rax
+  .text:0000000180BDAADD                 cmovnz  r9, rax
+  .text:0000000180BDAAE1                 call    r10
+  .text:0000000180BDAAE4                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180BDAAEB                 lea     rdx, [rbp+0F0h+var_50]
+  .text:0000000180BDAAF2                 mov     rax, [rcx]
+  .text:0000000180BDAAF5                 call    qword ptr [rax+100h]
+  .text:0000000180BDAAFB                 mov     rcx, rax
+  .text:0000000180BDAAFE                 xor     edx, edx
+  .text:0000000180BDAB00                 call    cs:?ToString@netadr_t@@QEBAPEBD_N@Z; netadr_t::ToString(bool)
+  .text:0000000180BDAB06                 or      [rbp+0F0h+var_110], 10h
+  .text:0000000180BDAB0A                 test    byte ptr [rbp+0F0h+var_118], 1
+  .text:0000000180BDAB0E                 jz      short loc_180BDAB1D
+  .text:0000000180BDAB10                 mov     rcx, [rbp+0F0h+var_118]
+  .text:0000000180BDAB14                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDAB18                 mov     rbx, [rcx]
+  .text:0000000180BDAB1B                 jmp     short loc_180BDAB25
+  .text:0000000180BDAB1D                 mov     rbx, [rbp+0F0h+var_118]
+  .text:0000000180BDAB21                 and     rbx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000180BDAB25                 xorps   xmm0, xmm0
+  .text:0000000180BDAB28                 xorps   xmm1, xmm1
+  .text:0000000180BDAB2B                 movups  [rbp+0F0h+var_70], xmm0
+  .text:0000000180BDAB32                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDAB39                 movdqu  [rbp+0F0h+var_60], xmm1
+  .text:0000000180BDAB41                 inc     r8
+  .text:0000000180BDAB44                 cmp     byte ptr [rax+r8], 0
+  .text:0000000180BDAB49                 jnz     short loc_180BDAB41
+  .text:0000000180BDAB4B                 mov     rdx, rax
+  .text:0000000180BDAB4E                 lea     rcx, [rbp+0F0h+var_70]
+  .text:0000000180BDAB55                 call    sub_18014A480
+  .text:0000000180BDAB5A                 mov     r8, rbx
+  .text:0000000180BDAB5D                 lea     rdx, [rbp+0F0h+var_70]
+  .text:0000000180BDAB64                 lea     rcx, [rbp+0F0h+var_E8]
+  .text:0000000180BDAB68                 call    sub_180FD76F0
+  .text:0000000180BDAB6D                 mov     rdx, qword ptr [rbp+0F0h+var_60+8]
+  .text:0000000180BDAB74                 cmp     rdx, 0Fh
+  .text:0000000180BDAB78                 jbe     short loc_180BDABAE
+  .text:0000000180BDAB7A                 mov     rcx, qword ptr [rbp+0F0h+var_70]
+  .text:0000000180BDAB81                 inc     rdx
+  .text:0000000180BDAB84                 mov     rax, rcx
+  .text:0000000180BDAB87                 cmp     rdx, 1000h
+  .text:0000000180BDAB8E                 jb      short loc_180BDABA9
+  .text:0000000180BDAB90                 mov     rcx, [rcx-8]
+  .text:0000000180BDAB94                 add     rdx, 27h ; '''
+  .text:0000000180BDAB98                 sub     rax, rcx
+  .text:0000000180BDAB9B                 add     rax, 0FFFFFFFFFFFFFFF8h
+  .text:0000000180BDAB9F                 cmp     rax, 1Fh
+  .text:0000000180BDABA3                 ja      loc_180BDB285
+  .text:0000000180BDABA9                 call    sub_180EA7070
+  .text:0000000180BDABAE                 mov     rax, [rsp+1F0h+var_198]
+  .text:0000000180BDABB3                 test    rax, rax
+  .text:0000000180BDABB6                 jz      loc_180BDAD2D
+  .text:0000000180BDABBC                 mov     rcx, 0FFFFFFFFFFFFFFFFh
+  .text:0000000180BDABC3                 inc     rcx
+  .text:0000000180BDABC6                 cmp     byte ptr [rax+rcx], 0
+  .text:0000000180BDABCA                 jnz     short loc_180BDABC3
+  .text:0000000180BDABCC                 test    ecx, ecx
+  .text:0000000180BDABCE                 jle     loc_180BDAD2D
+  .text:0000000180BDABD4                 xor     eax, eax
+  .text:0000000180BDABD6                 lea     rdx, [rbp+0F0h+var_A0]
+  .text:0000000180BDABDA                 lea     rcx, [rbp+0F0h+var_158]
+  .text:0000000180BDABDE                 mov     [rbp+0F0h+var_158], eax
+  .text:0000000180BDABE1                 mov     [rbp+0F0h+var_150], rax
+  .text:0000000180BDABE5                 call    sub_180BB6160
+  .text:0000000180BDABEA                 cmp     [rbp+0F0h+var_150], 0
+  .text:0000000180BDABEF                 mov     rbx, rax
+  .text:0000000180BDABF2                 mov     rdi, [rax]
+  .text:0000000180BDABF5                 jz      short loc_180BDAC01
+  .text:0000000180BDABF7                 lea     rcx, [rbp+0F0h+var_150]
+  .text:0000000180BDABFB                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAC01                 mov     [rbp+0F0h+var_150], rdi
+  .text:0000000180BDAC05                 mov     qword ptr [rbx], 0
+  .text:0000000180BDAC0C                 cmp     [rbp+0F0h+var_A0], 0
+  .text:0000000180BDAC11                 jz      short loc_180BDAC1D
+  .text:0000000180BDAC13                 lea     rcx, [rbp+0F0h+var_A0]
+  .text:0000000180BDAC17                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAC1D                 mov     rax, [rsp+1F0h+var_198]
+  .text:0000000180BDAC22                 lea     rcx, [rbp+0F0h+var_158]
+  .text:0000000180BDAC26                 test    rax, rax
+  .text:0000000180BDAC29                 mov     rdx, rsi
+  .text:0000000180BDAC2C                 cmovnz  rdx, rax
+  .text:0000000180BDAC30                 call    sub_180B8A000
+  .text:0000000180BDAC35                 test    al, al
+  .text:0000000180BDAC37                 jz      loc_180BDAD1C
+  .text:0000000180BDAC3D                 mov     rax, cs:g_pGameEntitySystem
+  .text:0000000180BDAC44                 lea     rdx, [rbp+0F0h+var_158]
+  .text:0000000180BDAC48                 mov     rcx, [rax+20D8h]
+  .text:0000000180BDAC4F                 mov     rax, [rcx]
+  .text:0000000180BDAC52                 call    qword ptr [rax+0F0h]
+  .text:0000000180BDAC58                 mov     rax, cs:g_pGameEntitySystem
+  .text:0000000180BDAC5F                 lea     r8, [rsp+1F0h+var_198]
+  .text:0000000180BDAC64                 lea     rdx, [rbp+0F0h+var_160]
+  .text:0000000180BDAC68                 mov     rcx, [rax+20D8h]
+  .text:0000000180BDAC6F                 mov     rax, [rcx]
+  .text:0000000180BDAC72                 call    qword ptr [rax+108h]
+  .text:0000000180BDAC78                 mov     ecx, cs:dword_181FBCED4
+  .text:0000000180BDAC7E                 mov     edx, 2
+  .text:0000000180BDAC83                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180BDAC89                 test    al, al
+  .text:0000000180BDAC8B                 jz      short loc_180BDACF3
+  .text:0000000180BDAC8D                 mov     rax, [rbp+0F0h+var_160]
+  .text:0000000180BDAC91                 lea     rdx, [rbp+0F0h+var_98]
+  .text:0000000180BDAC95                 test    rax, rax
+  .text:0000000180BDAC98                 lea     rcx, [rbp+0F0h+var_158]
+  .text:0000000180BDAC9C                 mov     rdi, rsi
+  .text:0000000180BDAC9F                 mov     rbx, rsi
+  .text:0000000180BDACA2                 cmovnz  rdi, rax
+  .text:0000000180BDACA6                 mov     rax, [rsp+1F0h+var_198]
+  .text:0000000180BDACAB                 test    rax, rax
+  .text:0000000180BDACAE                 cmovnz  rbx, rax
+  .text:0000000180BDACB2                 call    sub_180BB6160
+  .text:0000000180BDACB7                 mov     r9d, [rbp+0F0h+var_158]
+  .text:0000000180BDACBB                 lea     r8, aEtRestoringGam; "ET:  Restoring game at %u %s : '%s'\nET"...
+  .text:0000000180BDACC2                 mov     [rsp+1F0h+var_1C0], rdi
+  .text:0000000180BDACC7                 mov     edx, 2
+  .text:0000000180BDACCC                 mov     [rsp+1F0h+var_1C8], rbx
+  .text:0000000180BDACD1                 mov     rcx, [rax]
+  .text:0000000180BDACD4                 test    rcx, rcx
+  .text:0000000180BDACD7                 cmovnz  rsi, rcx
+  .text:0000000180BDACDB                 mov     ecx, cs:dword_181FBCED4
+  .text:0000000180BDACE1                 mov     [rsp+1F0h+var_1D0], rsi
+  .text:0000000180BDACE6                 call    cs:LoggingSystem_Log
+  .text:0000000180BDACEC                 mov     eax, 1
+  .text:0000000180BDACF1                 jmp     short loc_180BDACF6
+  .text:0000000180BDACF3                 mov     eax, [rbp+0F0h+var_130]
+  .text:0000000180BDACF6                 test    al, 1
+  .text:0000000180BDACF8                 jz      short loc_180BDAD0B
+  .text:0000000180BDACFA                 cmp     [rbp+0F0h+var_98], 0
+  .text:0000000180BDACFF                 jz      short loc_180BDAD0B
+  .text:0000000180BDAD01                 lea     rcx, [rbp+0F0h+var_98]
+  .text:0000000180BDAD05                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAD0B                 cmp     [rbp+0F0h+var_160], 0
+  .text:0000000180BDAD10                 jz      short loc_180BDAD1C
+  .text:0000000180BDAD12                 lea     rcx, [rbp+0F0h+var_160]
+  .text:0000000180BDAD16                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAD1C                 cmp     [rbp+0F0h+var_150], 0
+  .text:0000000180BDAD21                 jz      short loc_180BDAD2D
+  .text:0000000180BDAD23                 lea     rcx, [rbp+0F0h+var_150]
+  .text:0000000180BDAD27                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAD2D                 mov     edx, 1
+  .text:0000000180BDAD32                 mov     rcx, r13
+  .text:0000000180BDAD35                 call    CLoopModeGame_SetGameSystemState
+  .text:0000000180BDAD3A                 mov     rcx, r13
+  .text:0000000180BDAD3D                 call    sub_180BCDA10
+  .text:0000000180BDAD42                 mov     rcx, cs:qword_181FBDF10
+  .text:0000000180BDAD49                 lea     rdx, [rbp+0F0h+var_120]
+  .text:0000000180BDAD4D                 mov     rax, [rcx]
+  .text:0000000180BDAD50                 call    qword ptr [rax+0B0h]
+  .text:0000000180BDAD56                 test    al, al
+  .text:0000000180BDAD58                 jnz     short loc_180BDAD68
+  .text:0000000180BDAD5A                 lea     rcx, aLevelinitworld; "LevelInitWorld failed!\n"
+  .text:0000000180BDAD61                 call    cs:Plat_FatalError
+  .text:0000000180BDAD67                 ; Trap to Debugger
+  .text:0000000180BDAD67                 int     3; Trap to Debugger
+  .text:0000000180BDAD68                 lea     rcx, [rbp+0F0h+arg_0]
+  .text:0000000180BDAD6F                 call    sub_180C20420
+  .text:0000000180BDAD74                 mov     edx, 2
+  .text:0000000180BDAD79                 mov     rcx, r13
+  .text:0000000180BDAD7C                 call    CLoopModeGame_SetGameSystemState
+  .text:0000000180BDAD81                 mov     rdi, [rbp+0F0h+arg_10]
+  .text:0000000180BDAD88                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDAD8C                 mov     rdx, rdi
+  .text:0000000180BDAD8F                 call    IGameSystem_LoopInitAllSystems
+  .text:0000000180BDAD94                 test    al, al
+  .text:0000000180BDAD96                 jz      short loc_180BDADB9
+  .text:0000000180BDAD98                 mov     edx, 3
+  .text:0000000180BDAD9D                 mov     rcx, r13
+  .text:0000000180BDADA0                 call    CLoopModeGame_SetGameSystemState
+  .text:0000000180BDADA5                 mov     rdx, rdi
+  .text:0000000180BDADA8                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDADAC                 call    IGameSystem_LoopPostInitAllSystems
+  .text:0000000180BDADB1                 test    al, al
+  .text:0000000180BDADB3                 jnz     loc_180BDAE84
+  .text:0000000180BDADB9                 lea     rcx, [rbp+0F0h+arg_0]
+  .text:0000000180BDADC0                 call    sub_180C20FD0
+  .text:0000000180BDADC5                 mov     rbx, [rbp+0F0h+var_B0]
+  .text:0000000180BDADC9                 lea     rax, ??_7?$CBaseCmdKeyValues@VCSVCMsg_GameSessionConfiguration@@@@6B@; const CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable'
+  .text:0000000180BDADD0                 mov     [rbp+0F0h+var_120], rax
+  .text:0000000180BDADD4                 test    rbx, rbx
+  .text:0000000180BDADD7                 jz      short loc_180BDADF3
+  .text:0000000180BDADD9                 mov     rcx, rbx
+  .text:0000000180BDADDC                 call    cs:??1KeyValues@@QEAA@XZ; KeyValues::~KeyValues(void)
+  .text:0000000180BDADE2                 mov     rcx, rbx
+  .text:0000000180BDADE5                 call    cs:??3KeyValues@@SAXPEAX@Z; KeyValues::operator delete(void *)
+  .text:0000000180BDADEB                 mov     [rbp+0F0h+var_B0], 0
+  .text:0000000180BDADF3                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDADF7                 call    sub_1807F3730
+  .text:0000000180BDADFC                 cmp     [rsp+1F0h+var_198], 0
+  .text:0000000180BDAE02                 jz      short loc_180BDAE0F
+  .text:0000000180BDAE04                 lea     rcx, [rsp+1F0h+var_198]
+  .text:0000000180BDAE09                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAE0F                 lea     rcx, [rsp+1F0h+var_178]
+  .text:0000000180BDAE14                 call    sub_180BCC7B0
+  .text:0000000180BDAE19                 lea     rcx, [rbp+0F0h+var_148]
+  .text:0000000180BDAE1D                 call    sub_18053EE30
+  .text:0000000180BDAE22                 cmp     [rsp+1F0h+var_180], 0
+  .text:0000000180BDAE28                 jz      short loc_180BDAE35
+  .text:0000000180BDAE2A                 lea     rcx, [rsp+1F0h+var_180]
+  .text:0000000180BDAE2F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAE35                 cmp     [rsp+1F0h+var_190], 0
+  .text:0000000180BDAE3B                 jz      short loc_180BDAE48
+  .text:0000000180BDAE3D                 lea     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDAE42                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAE48                 cmp     [rsp+1F0h+var_1A0], 0
+  .text:0000000180BDAE4E                 jz      short loc_180BDAE5B
+  .text:0000000180BDAE50                 lea     rcx, [rsp+1F0h+var_1A0]
+  .text:0000000180BDAE55                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAE5B                 cmp     [rsp+1F0h+var_1B0], 0
+  .text:0000000180BDAE61                 jz      short loc_180BDAE6E
+  .text:0000000180BDAE63                 lea     rcx, [rsp+1F0h+var_1B0]
+  .text:0000000180BDAE68                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDAE6E                 xor     al, al
+  .text:0000000180BDAE70                 add     rsp, 1B8h
+  .text:0000000180BDAE77                 pop     r15
+  .text:0000000180BDAE79                 pop     r14
+  .text:0000000180BDAE7B                 pop     r13
+  .text:0000000180BDAE7D                 pop     r12
+  .text:0000000180BDAE7F                 pop     rdi
+  .text:0000000180BDAE80                 pop     rsi
+  .text:0000000180BDAE81                 pop     rbx
+  .text:0000000180BDAE82                 pop     rbp
+  .text:0000000180BDAE83                 retn
+  .text:0000000180BDAE84                 mov     rcx, cs:qword_181FBDF10
+  .text:0000000180BDAE8B                 lea     rdx, [rbp+0F0h+var_120]
+  .text:0000000180BDAE8F                 mov     r8, rdi
+  .text:0000000180BDAE92                 mov     rax, [rcx]
+  .text:0000000180BDAE95                 call    qword ptr [rax+0C8h]
+  .text:0000000180BDAE9B                 lea     rcx, [rbp+0F0h+arg_0]
+  .text:0000000180BDAEA2                 test    al, al
+  .text:0000000180BDAEA4                 jz      loc_180BDADC0
+  .text:0000000180BDAEAA                 call    sub_180C20FD0
+  .text:0000000180BDAEAF                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180BDAEB6                 mov     rdx, cs:qword_181ED26C0
+  .text:0000000180BDAEBD                 mov     rax, [rcx]
+  .text:0000000180BDAEC0                 call    qword ptr [rax+0D8h]
+  .text:0000000180BDAEC6                 xor     ebx, ebx
+  .text:0000000180BDAEC8                 test    r15d, r15d
+  .text:0000000180BDAECB                 jle     short loc_180BDAF04
+  .text:0000000180BDAECD                 nop     dword ptr [rax]
+  .text:0000000180BDAED0                 mov     rcx, cs:qword_181FDFC78 ; g_pEngineServer (IVEngineServer2* / CEngineServer*)
+  .text:0000000180BDAED7                 mov     rax, [rcx]
+  .text:0000000180BDAEDA                 ; 1E0h = 0x1E0 = CEngineServer_UnloadSpawnGroup (vfunc_index 60)
+  .text:0000000180BDAEDA                 mov     r8, [rax+1E0h]; 1E0h = 0x1E0 = CEngineServer_UnloadSpawnGroup
+  .text:0000000180BDAEE1                 movsxd  rax, ebx
+  .text:0000000180BDAEE4                 lea     rdx, [rax+rax*4]
+  .text:0000000180BDAEE8                 shl     rdx, 5
+  .text:0000000180BDAEEC                 add     rdx, r14
+  .text:0000000180BDAEEF                 call    r8              ; CEngineServer_UnloadSpawnGroup (via [rax+1E0h])
+  .text:0000000180BDAEF2                 test    ebx, ebx
+  .text:0000000180BDAEF4                 jnz     short loc_180BDAEFD
+  .text:0000000180BDAEF6                 mov     [r13+430h], eax
+  .text:0000000180BDAEFD                 inc     ebx
+  .text:0000000180BDAEFF                 cmp     ebx, r15d
+  .text:0000000180BDAF02                 jl      short loc_180BDAED0
+  .text:0000000180BDAF04                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180BDAF0B                 lea     r8, aGamesessionman_0; "GameSessionManifest"
+  .text:0000000180BDAF12                 movzx   edx, [rsp+1F0h+var_188]
+  .text:0000000180BDAF17                 mov     r9, rdi
+  .text:0000000180BDAF1A                 mov     byte ptr [rsp+1F0h+var_1D0], dl
+  .text:0000000180BDAF1E                 lea     rdx, [rbp+0F0h+var_120]
+  .text:0000000180BDAF22                 mov     rax, [rcx]
+  .text:0000000180BDAF25                 call    qword ptr [rax+0E0h]
+  .text:0000000180BDAF2B                 mov     rbx, [rbp+0F0h+var_B0]
+  .text:0000000180BDAF2F                 lea     rax, ??_7?$CBaseCmdKeyValues@VCSVCMsg_GameSessionConfiguration@@@@6B@; const CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable'
+  .text:0000000180BDAF36                 mov     [rbp+0F0h+var_120], rax
+  .text:0000000180BDAF3A                 test    rbx, rbx
+  .text:0000000180BDAF3D                 jz      short loc_180BDAF59
+  .text:0000000180BDAF3F                 mov     rcx, rbx
+  .text:0000000180BDAF42                 call    cs:??1KeyValues@@QEAA@XZ; KeyValues::~KeyValues(void)
+  .text:0000000180BDAF48                 mov     rcx, rbx
+  .text:0000000180BDAF4B                 call    cs:??3KeyValues@@SAXPEAX@Z; KeyValues::operator delete(void *)
+  .text:0000000180BDAF51                 mov     [rbp+0F0h+var_B0], 0
+  .text:0000000180BDAF59                 lea     rcx, [rbp+0F0h+var_120]
+  .text:0000000180BDAF5D                 call    sub_1807F3730
+  .text:0000000180BDAF62                 lea     rbx, [r13+8]
+  .text:0000000180BDAF66                 mov     rcx, cs:g_pResourceSystem
+  .text:0000000180BDAF6D                 lea     r12, aCloopmodegameL; "CLoopModeGame::LoopInit"
+  .text:0000000180BDAF74                 mov     rdi, [r13+8]
+  .text:0000000180BDAF78                 lea     rdx, aLoopmodegamest; "LoopModeGameStartup"
+  .text:0000000180BDAF7F                 mov     r9, r12
+  .text:0000000180BDAF82                 mov     byte ptr [rsp+1F0h+var_1D0], 0FFh
+  .text:0000000180BDAF87                 mov     r8b, 1
+  .text:0000000180BDAF8A                 mov     rax, [rcx]
+  .text:0000000180BDAF8D                 call    qword ptr [rax+0A0h]
+  .text:0000000180BDAF93                 mov     [rbp+0F0h+arg_18], rax
+  .text:0000000180BDAF9A                 test    rax, rax
+  .text:0000000180BDAF9D                 jz      loc_180BDB07D
+  .text:0000000180BDAFA3                 mov     ecx, [rdi+10h]
+  .text:0000000180BDAFA6                 mov     dword ptr [rbp+0F0h+arg_0], ecx
+  .text:0000000180BDAFAC                 cmp     ecx, [rdi+20h]
+  .text:0000000180BDAFAF                 jnz     loc_180BDB068
+  .text:0000000180BDAFB5                 mov     eax, [rdi+24h]
+  .text:0000000180BDAFB8                 and     eax, 0C0000000h
+  .text:0000000180BDAFBD                 jz      short loc_180BDAFCA
+  .text:0000000180BDAFBF                 cmp     eax, 80000000h
+  .text:0000000180BDAFC4                 jnz     loc_180BDB068
+  .text:0000000180BDAFCA                 mov     ecx, [rdi+20h]
+  .text:0000000180BDAFCD                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180BDAFD3                 jle     short loc_180BDAFE0
+  .text:0000000180BDAFD5                 mov     edx, 1
+  .text:0000000180BDAFDA                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180BDAFE0                 mov     ecx, [rdi+20h]
+  .text:0000000180BDAFE3                 mov     r9d, 8
+  .text:0000000180BDAFE9                 mov     edx, [rdi+24h]
+  .text:0000000180BDAFEC                 and     edx, 3FFFFFFFh
+  .text:0000000180BDAFF2                 lea     esi, [rcx+1]
+  .text:0000000180BDAFF5                 mov     r8d, esi
+  .text:0000000180BDAFF8                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180BDAFFE                 mov     ebx, eax
+  .text:0000000180BDB000                 cmp     eax, esi
+  .text:0000000180BDB002                 jge     short loc_180BDB022
+  .text:0000000180BDB004                 test    eax, eax
+  .text:0000000180BDB006                 jnz     short loc_180BDB014
+  .text:0000000180BDB008                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180BDB00B                 jg      short loc_180BDB014
+  .text:0000000180BDB00D                 mov     ebx, 0FFFFFFFFh
+  .text:0000000180BDB012                 jmp     short loc_180BDB022
+  .text:0000000180BDB014                 lea     eax, [rbx+rsi]
+  .text:0000000180BDB017                 cdq
+  .text:0000000180BDB018                 sub     eax, edx
+  .text:0000000180BDB01A                 sar     eax, 1
+  .text:0000000180BDB01C                 mov     ebx, eax
+  .text:0000000180BDB01E                 cmp     eax, esi
+  .text:0000000180BDB020                 jl      short loc_180BDB014
+  .text:0000000180BDB022                 movsxd  r9, dword ptr [rdi+20h]
+  .text:0000000180BDB026                 mov     rcx, [rdi+18h]
+  .text:0000000180BDB02A                 shl     r9, 3
+  .text:0000000180BDB02E                 test    dword ptr [rdi+24h], 0C0000000h
+  .text:0000000180BDB035                 movsxd  r8, ebx
+  .text:0000000180BDB038                 setz    dl
+  .text:0000000180BDB03B                 shl     r8, 3
+  .text:0000000180BDB03F                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180BDB045                 mov     [rdi+18h], rax
+  .text:0000000180BDB049                 mov     eax, [rdi+24h]
+  .text:0000000180BDB04C                 test    eax, 0C0000000h
+  .text:0000000180BDB051                 jz      short loc_180BDB05B
+  .text:0000000180BDB053                 and     eax, 3FFFFFFFh
+  .text:0000000180BDB058                 mov     [rdi+24h], eax
+  .text:0000000180BDB05B                 mov     ecx, dword ptr [rbp+0F0h+arg_0]
+  .text:0000000180BDB061                 mov     [rdi+20h], ebx
+  .text:0000000180BDB064                 lea     rbx, [r13+8]
+  .text:0000000180BDB068                 inc     dword ptr [rdi+10h]
+  .text:0000000180BDB06B                 mov     rax, [rdi+18h]
+  .text:0000000180BDB06F                 mov     rdx, [rbp+0F0h+arg_18]
+  .text:0000000180BDB076                 movsxd  rcx, ecx
+  .text:0000000180BDB079                 mov     [rax+rcx*8], rdx
+  .text:0000000180BDB07D                 mov     rcx, cs:g_pResourceSystem
+  .text:0000000180BDB084                 lea     rdx, aLoopmodegameSe; "LoopModeGame_server"
+  .text:0000000180BDB08B                 mov     rdi, [rbx]
+  .text:0000000180BDB08E                 mov     r9, r12
+  .text:0000000180BDB091                 mov     r8b, 1
+  .text:0000000180BDB094                 mov     byte ptr [rsp+1F0h+var_1D0], 0FFh
+  .text:0000000180BDB099                 mov     rax, [rcx]
+  .text:0000000180BDB09C                 call    qword ptr [rax+0A8h]
+  .text:0000000180BDB0A2                 mov     r13, rax
+  .text:0000000180BDB0A5                 test    rax, rax
+  .text:0000000180BDB0A8                 jz      loc_180BDB168
+  .text:0000000180BDB0AE                 movsxd  r12, dword ptr [rdi+10h]
+  .text:0000000180BDB0B2                 cmp     r12d, [rdi+20h]
+  .text:0000000180BDB0B6                 jnz     loc_180BDB15D
+  .text:0000000180BDB0BC                 test    dword ptr [rdi+24h], 40000000h
+  .text:0000000180BDB0C3                 jnz     loc_180BDB15D
+  .text:0000000180BDB0C9                 mov     ecx, [rdi+20h]
+  .text:0000000180BDB0CC                 cmp     ecx, 7FFFFFFEh
+  .text:0000000180BDB0D2                 jle     short loc_180BDB0DF
+  .text:0000000180BDB0D4                 mov     edx, 1
+  .text:0000000180BDB0D9                 call    cs:UtlVectorMemory_FailedAllocation
+  .text:0000000180BDB0DF                 mov     ecx, [rdi+20h]
+  .text:0000000180BDB0E2                 mov     r9d, 8
+  .text:0000000180BDB0E8                 mov     edx, [rdi+24h]
+  .text:0000000180BDB0EB                 and     edx, 3FFFFFFFh
+  .text:0000000180BDB0F1                 lea     esi, [rcx+1]
+  .text:0000000180BDB0F4                 mov     r8d, esi
+  .text:0000000180BDB0F7                 call    cs:UtlVectorMemory_CalcNewAllocationCount
+  .text:0000000180BDB0FD                 mov     ebx, eax
+  .text:0000000180BDB0FF                 cmp     eax, esi
+  .text:0000000180BDB101                 jge     short loc_180BDB121
+  .text:0000000180BDB103                 test    eax, eax
+  .text:0000000180BDB105                 jnz     short loc_180BDB113
+  .text:0000000180BDB107                 cmp     esi, 0FFFFFFFFh
+  .text:0000000180BDB10A                 jg      short loc_180BDB113
+  .text:0000000180BDB10C                 mov     ebx, 0FFFFFFFFh
+  .text:0000000180BDB111                 jmp     short loc_180BDB121
+  .text:0000000180BDB113                 lea     eax, [rbx+rsi]
+  .text:0000000180BDB116                 cdq
+  .text:0000000180BDB117                 sub     eax, edx
+  .text:0000000180BDB119                 sar     eax, 1
+  .text:0000000180BDB11B                 mov     ebx, eax
+  .text:0000000180BDB11D                 cmp     eax, esi
+  .text:0000000180BDB11F                 jl      short loc_180BDB113
+  .text:0000000180BDB121                 movsxd  r9, dword ptr [rdi+20h]
+  .text:0000000180BDB125                 mov     rcx, [rdi+18h]
+  .text:0000000180BDB129                 shl     r9, 3
+  .text:0000000180BDB12D                 test    dword ptr [rdi+24h], 0C0000000h
+  .text:0000000180BDB134                 movsxd  r8, ebx
+  .text:0000000180BDB137                 setz    dl
+  .text:0000000180BDB13A                 shl     r8, 3
+  .text:0000000180BDB13E                 call    cs:UtlVectorMemory_Alloc
+  .text:0000000180BDB144                 mov     [rdi+18h], rax
+  .text:0000000180BDB148                 mov     eax, [rdi+24h]
+  .text:0000000180BDB14B                 test    eax, 0C0000000h
+  .text:0000000180BDB150                 jz      short loc_180BDB15A
+  .text:0000000180BDB152                 and     eax, 3FFFFFFFh
+  .text:0000000180BDB157                 mov     [rdi+24h], eax
+  .text:0000000180BDB15A                 mov     [rdi+20h], ebx
+  .text:0000000180BDB15D                 inc     dword ptr [rdi+10h]
+  .text:0000000180BDB160                 mov     rax, [rdi+18h]
+  .text:0000000180BDB164                 mov     [rax+r12*8], r13
+  .text:0000000180BDB168                 mov     rcx, cs:qword_181FBDF10
+  .text:0000000180BDB16F                 test    rcx, rcx
+  .text:0000000180BDB172                 jz      short loc_180BDB18B
+  .text:0000000180BDB174                 mov     rax, [rcx]
+  .text:0000000180BDB177                 mov     r8, [rbp+0F0h+arg_10]
+  .text:0000000180BDB17E                 mov     rdx, [rbp+0F0h+arg_8]
+  .text:0000000180BDB185                 call    qword ptr [rax+90h]
+  .text:0000000180BDB18B                 cmp     [rsp+1F0h+var_198], 0
+  .text:0000000180BDB191                 jz      short loc_180BDB19E
+  .text:0000000180BDB193                 lea     rcx, [rsp+1F0h+var_198]
+  .text:0000000180BDB198                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB19E                 lea     eax, [r15-1]
+  .text:0000000180BDB1A2                 movsxd  rdi, eax
+  .text:0000000180BDB1A5                 test    eax, eax
+  .text:0000000180BDB1A7                 js      short loc_180BDB1ED
+  .text:0000000180BDB1A9                 lea     rbx, [rdi+rdi*4]
+  .text:0000000180BDB1AD                 shl     rbx, 5
+  .text:0000000180BDB1B1                 add     rbx, 70h ; 'p'
+  .text:0000000180BDB1B5                 add     rbx, r14
+  .text:0000000180BDB1B8                 nop     dword ptr [rax+rax+00000000h]
+  .text:0000000180BDB1C0                 cmp     qword ptr [rbx+8], 0
+  .text:0000000180BDB1C5                 lea     rcx, [rbx+8]
+  .text:0000000180BDB1C9                 jz      short loc_180BDB1D1
+  .text:0000000180BDB1CB                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB1D1                 cmp     qword ptr [rbx], 0
+  .text:0000000180BDB1D5                 jz      short loc_180BDB1E0
+  .text:0000000180BDB1D7                 mov     rcx, rbx
+  .text:0000000180BDB1DA                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB1E0                 sub     rbx, 0A0h
+  .text:0000000180BDB1E7                 sub     rdi, 1
+  .text:0000000180BDB1EB                 jns     short loc_180BDB1C0
+  .text:0000000180BDB1ED                 test    dword ptr [rbp+0F0h+var_168+4], 0C0000000h
+  .text:0000000180BDB1F4                 jnz     short loc_180BDB229
+  .text:0000000180BDB1F6                 test    r14, r14
+  .text:0000000180BDB1F9                 jz      short loc_180BDB229
+  .text:0000000180BDB1FB                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180BDB202                 mov     rdx, r14
+  .text:0000000180BDB205                 mov     rcx, [rax]
+  .text:0000000180BDB208                 mov     rax, [rcx]
+  .text:0000000180BDB20B                 call    qword ptr [rax+18h]
+  .text:0000000180BDB20E                 xor     r14d, r14d
+  .text:0000000180BDB211                 test    r14, r14
+  .text:0000000180BDB214                 jz      short loc_180BDB229
+  .text:0000000180BDB216                 mov     rax, cs:g_pMemAlloc
+  .text:0000000180BDB21D                 mov     edx, r14d
+  .text:0000000180BDB220                 mov     rcx, [rax]
+  .text:0000000180BDB223                 mov     rax, [rcx]
+  .text:0000000180BDB226                 call    qword ptr [rax+18h]
+  .text:0000000180BDB229                 lea     rcx, [rbp+0F0h+var_148]
+  .text:0000000180BDB22D                 call    sub_18053EE30
+  .text:0000000180BDB232                 cmp     [rsp+1F0h+var_180], 0
+  .text:0000000180BDB238                 jz      short loc_180BDB245
+  .text:0000000180BDB23A                 lea     rcx, [rsp+1F0h+var_180]
+  .text:0000000180BDB23F                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB245                 cmp     [rsp+1F0h+var_190], 0
+  .text:0000000180BDB24B                 jz      short loc_180BDB258
+  .text:0000000180BDB24D                 lea     rcx, [rsp+1F0h+var_190]
+  .text:0000000180BDB252                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB258                 cmp     [rsp+1F0h+var_1A0], 0
+  .text:0000000180BDB25E                 jz      short loc_180BDB26B
+  .text:0000000180BDB260                 lea     rcx, [rsp+1F0h+var_1A0]
+  .text:0000000180BDB265                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB26B                 cmp     [rsp+1F0h+var_1B0], 0
+  .text:0000000180BDB271                 jz      short loc_180BDB27E
+  .text:0000000180BDB273                 lea     rcx, [rsp+1F0h+var_1B0]
+  .text:0000000180BDB278                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:0000000180BDB27E                 mov     al, 1
+  .text:0000000180BDB280                 jmp     loc_180BDAE70
+  .text:0000000180BDB285                 call    _invalid_parameter_noinfo_noreturn
+procedure: |-
+  char __fastcall CLoopModeGame_LoopInit(__int64 a1, KeyValues *a2, void (__fastcall ***a3)(_QWORD, _QWORD))
+  {
+    int v3; // r15d
+    KeyValues *v4; // rdi
+    __int64 v5; // r13
+    CKeyValues_Data *Key; // rax
+    __int64 v7; // r8
+    char *v8; // rsi
+    char *String; // rbx
+    __int64 v10; // r8
+    __int64 v11; // r8
+    int v12; // eax
+    CKeyValues_Data *v13; // rax
+    const char *v14; // rax
+    CKeyValues_Data *v15; // rax
+    const char *v16; // rax
+    CKeyValues_Data *v17; // rax
+    const char *v18; // rax
+    CKeyValues_Data *v19; // rax
+    const char *v20; // rax
+    int Int; // ebx
+    unsigned int v22; // eax
+    __int64 v23; // r8
+    __int64 v24; // rdx
+    __int64 v25; // rcx
+    __int64 v26; // r9
+    __int64 v27; // rax
+    char v28; // r12
+    bool v29; // zf
+    __int64 v30; // r14
+    __int64 v31; // rax
+    __int64 v32; // rax
+    __int64 v33; // rbx
+    __int64 v34; // r8
+    const char *v35; // rdx
+    __int64 v36; // r8
+    const char *v37; // rdx
+    int v38; // eax
+    char *v39; // rcx
+    __int64 v40; // rdx
+    char *v41; // r9
+    int v42; // r12d
+    KeyValues *v43; // r13
+    __int64 v44; // rbx
+    __int64 v45; // rdi
+    int v46; // eax
+    __int64 v47; // rcx
+    __int64 v48; // rdx
+    char *v49; // rcx
+    char *v50; // rcx
+    char v51; // al
+    CUtlString *v52; // r15
+    const char *v53; // rdx
+    __int64 v54; // r8
+    __int64 v55; // rcx
+    const char *v56; // rdx
+    __int64 v57; // r8
+    const char *v58; // r8
+    const char *v59; // r9
+    char *v60; // rcx
+    int v61; // eax
+    char *v62; // rcx
+    __int64 v63; // r8
+    char *v64; // rcx
+    __int64 v65; // rdi
+    __int64 v66; // rbx
+    __int64 v67; // rax
+    __int64 v68; // rcx
+    __int64 v69; // r8
+    __int64 *v70; // rbx
+    char *v71; // r8
+    __int64 v72; // rax
+    __int64 v73; // rcx
+    __int64 v74; // rbx
+    unsigned __int64 v75; // rdx
+    _QWORD *v76; // rax
+    KeyValues *v77; // rbx
+    __int64 v78; // rdi
+    __int64 v79; // rbx
+    __int64 v80; // rdx
+    unsigned __int64 v81; // rdx
+    const char *v82; // rdx
+    char *v83; // r9
+    netadr_t *v84; // rax
+    const char *v85; // rax
+    unsigned __int64 v86; // rbx
+    __int64 v87; // r8
+    __int64 v88; // rcx
+    __int64 v89; // rdx
+    __int64 v90; // rcx
+    __int64 *v91; // rbx
+    __int64 v92; // rdi
+    char *v93; // rdx
+    char *v94; // rdi
+    char *v95; // rbx
+    char **v96; // rax
+    char v97; // al
+    void (__fastcall ***v98)(_QWORD, _QWORD); // rdi
+    KeyValues *v99; // rbx
+    int i; // ebx
+    int v102; // eax
+    KeyValues *v103; // rbx
+    __int64 v104; // rdi
+    __int64 v105; // r8
+    int v106; // ecx
+    __int64 v107; // rcx
+    __int64 v108; // rcx
+    int v109; // esi
+    int v110; // eax
+    __int64 v111; // rdx
+    int v112; // ebx
+    int v113; // eax
+    __int64 v114; // rdi
+    __int64 v115; // r13
+    __int64 v116; // r12
+    __int64 v117; // rcx
+    __int64 v118; // rcx
+    int v119; // esi
+    int v120; // eax
+    __int64 v121; // rdx
+    int v122; // ebx
+    int v123; // eax
+    __int64 v124; // rdi
+    __int64 v125; // rbx
+    __int64 v126; // [rsp+20h] [rbp-E0h]
+    int v127; // [rsp+20h] [rbp-E0h]
+    char *v128; // [rsp+40h] [rbp-C0h] BYREF
+    char v129; // [rsp+48h] [rbp-B8h]
+    char *v130; // [rsp+50h] [rbp-B0h] BYREF
+    char *v131; // [rsp+58h] [rbp-A8h] BYREF
+    __int64 v132; // [rsp+60h] [rbp-A0h] BYREF
+    bool v133; // [rsp+68h] [rbp-98h]
+    __int64 v134; // [rsp+70h] [rbp-90h] BYREF
+    int v135; // [rsp+78h] [rbp-88h] BYREF
+    __int64 v136; // [rsp+80h] [rbp-80h]
+    __int64 v137; // [rsp+88h] [rbp-78h]
+    char *v138; // [rsp+90h] [rbp-70h] BYREF
+    unsigned int v139; // [rsp+98h] [rbp-68h] BYREF
+    __int64 v140; // [rsp+A0h] [rbp-60h] BYREF
+    int v141; // [rsp+A8h] [rbp-58h] BYREF
+    __int64 v142; // [rsp+B0h] [rbp-50h]
+    __int64 v143; // [rsp+B8h] [rbp-48h]
+    int v144; // [rsp+C0h] [rbp-40h]
+    void **v145; // [rsp+D0h] [rbp-30h] BYREF
+    __int64 v146; // [rsp+D8h] [rbp-28h]
+    int v147; // [rsp+E0h] [rbp-20h]
+    __int64 v148; // [rsp+F8h] [rbp-8h]
+    _BYTE v149[8]; // [rsp+108h] [rbp+8h] BYREF
+    _BYTE v150[8]; // [rsp+110h] [rbp+10h] BYREF
+    __int64 v151; // [rsp+118h] [rbp+18h]
+    unsigned __int8 v152; // [rsp+129h] [rbp+29h]
+    char v153; // [rsp+12Ah] [rbp+2Ah]
+    char v154; // [rsp+12Bh] [rbp+2Bh]
+    char v155; // [rsp+13Eh] [rbp+3Eh]
+    KeyValues *v156; // [rsp+140h] [rbp+40h]
+    __int64 v157; // [rsp+150h] [rbp+50h] BYREF
+    __int64 v158; // [rsp+158h] [rbp+58h] BYREF
+    _QWORD v159[3]; // [rsp+160h] [rbp+60h] BYREF
+    int v160; // [rsp+178h] [rbp+78h]
+    int v161; // [rsp+17Ch] [rbp+7Ch]
+    __int128 v162; // [rsp+180h] [rbp+80h] BYREF
+    __int128 v163; // [rsp+190h] [rbp+90h]
+    _BYTE v164[80]; // [rsp+1A0h] [rbp+A0h] BYREF
+    __int64 v165; // [rsp+200h] [rbp+100h] BYREF
+    KeyValues *v166; // [rsp+208h] [rbp+108h]
+    void (__fastcall ***v167)(_QWORD, _QWORD); // [rsp+210h] [rbp+110h]
+    __int64 v168; // [rsp+218h] [rbp+118h]
+
+    v167 = a3;
+    v166 = a2;
+    v165 = a1;
+    v3 = 0;
+    v4 = a2;
+    v144 = 0;
+    v5 = a1;
+    *(_BYTE *)(a1 + 110) = 0;
+    if ( !a2 )
+      return 0;
+    Key = KeyValues::FindKey(a2, "mode");
+    v8 = byte_1815DA9A0;
+    if ( Key )
+      String = (char *)CKeyValues_Data::Internal_GetString(Key, byte_1815DA9A0, nullptr, 0);
+    else
+      String = byte_1815DA9A0;
+    if ( (unsigned int)V_stricmp_fast(String, "listenserver", v7) )
+    {
+      if ( (unsigned int)V_stricmp_fast(String, "dedicated", v10) )
+      {
+        if ( !(unsigned int)V_stricmp_fast(String, "remoteclient", v11) )
+          *(_DWORD *)(v5 + 104) = 2;
+      }
+      else
+      {
+        *(_DWORD *)(v5 + 104) = 1;
+      }
+    }
+    else
+    {
+      *(_DWORD *)(v5 + 104) = 3;
+    }
+    v12 = *(_DWORD *)(v5 + 104);
+    LOBYTE(v168) = v12 & 1;
+    sub_18050E7C0(v12 != 2);
+    v13 = KeyValues::FindKey(v4, "levelname");
+    if ( v13 )
+      v14 = CKeyValues_Data::Internal_GetString(v13, byte_1815DA9A0, nullptr, 0);
+    else
+      v14 = byte_1815DA9A0;
+    v128 = nullptr;
+    CUtlString::Set((CUtlString *)&v128, v14);
+    v15 = KeyValues::FindKey(v4, "savegame");
+    if ( v15 )
+      v16 = CKeyValues_Data::Internal_GetString(v15, byte_1815DA9A0, nullptr, 0);
+    else
+      v16 = byte_1815DA9A0;
+    v130 = nullptr;
+    CUtlString::Set((CUtlString *)&v130, v16);
+    v17 = KeyValues::FindKey(v4, "landmarkname");
+    if ( v17 )
+      v18 = CKeyValues_Data::Internal_GetString(v17, byte_1815DA9A0, nullptr, 0);
+    else
+      v18 = byte_1815DA9A0;
+    v132 = 0;
+    CUtlString::Set((CUtlString *)&v132, v18);
+    v19 = KeyValues::FindKey(v4, "previouslevel");
+    if ( v19 )
+      v20 = CKeyValues_Data::Internal_GetString(v19, byte_1815DA9A0, nullptr, 0);
+    else
+      v20 = byte_1815DA9A0;
+    v134 = 0;
+    CUtlString::Set((CUtlString *)&v134, v20);
+    Int = KeyValues::GetInt(v4, "loadmap", 0);
+    v22 = KeyValues::GetInt(v4, "changelevel", 0);
+    v24 = v134;
+    v25 = v132;
+    v26 = v22;
+    v133 = v22 != 0;
+    LODWORD(v138) = v22;
+    if ( !v134 )
+      goto LABEL_32;
+    v23 = -1;
+    do
+      ++v23;
+    while ( *(_BYTE *)(v134 + v23) );
+    if ( (int)v23 <= 0 )
+      goto LABEL_32;
+    if ( !v132 )
+      goto LABEL_32;
+    v27 = -1;
+    do
+      ++v27;
+    while ( *(_BYTE *)(v132 + v27) );
+    if ( (int)v27 > 0 )
+      v28 = 1;
+    else
+  LABEL_32:
+      v28 = 0;
+    v129 = v28;
+    *(_BYTE *)(v5 + 108) = Int == 0;
+    if ( Int )
+    {
+      v29 = *(_DWORD *)(v5 + 104) == 2;
+      v30 = 0;
+      v142 = 0;
+      v143 = 0;
+      v141 = 0;
+      v136 = 0;
+      v137 = 0;
+      v135 = 0;
+      v131 = nullptr;
+      if ( v29 )
+        goto LABEL_106;
+      if ( !v130 )
+        goto LABEL_102;
+      v31 = -1;
+      do
+        ++v31;
+      while ( v130[v31] );
+      if ( (int)v31 > 0 )
+      {
+        if ( (_DWORD)v26 )
+        {
+          v32 = sub_180B70C50(&v141);
+          v33 = v32;
+          if ( v128 )
+          {
+            v34 = -1;
+            do
+              ++v34;
+            while ( v128[v34] );
+          }
+          else
+          {
+            LODWORD(v34) = 0;
+          }
+          v35 = byte_1815DA9A0;
+          if ( v128 )
+            v35 = v128;
+          CUtlString::SetDirect((CUtlString *)(v32 + 48), v35, v34);
+          if ( v130 )
+          {
+            v36 = -1;
+            do
+              ++v36;
+            while ( v130[v36] );
+          }
+          else
+          {
+            LODWORD(v36) = 0;
+          }
+          v37 = byte_1815DA9A0;
+          if ( v130 )
+            v37 = v130;
+          CUtlString::SetDirect((CUtlString *)(v33 + 64), v37, v36);
+          *(_WORD *)(v33 + 80) = 1;
+        }
+        else
+        {
+          (*(void (__fastcall **)(__int64, char *, int *, _QWORD, _DWORD, char **))(*(_QWORD *)g_pSource2Server + 416LL))(
+            g_pSource2Server,
+            v130,
+            &v141,
+            (unsigned __int8)v168,
+            0,
+            &v131);
+        }
+        if ( v141 )
+        {
+          v42 = 0;
+          if ( v141 <= 0 )
+            goto LABEL_106;
+          v43 = v166;
+          v44 = 0;
+          do
+          {
+            v45 = v142;
+            v46 = sub_180BCDDF0(&v135, v24, v23, v26);
+            v30 = v136;
+            v47 = v46;
+            LOBYTE(v46) = v129;
+            v48 = 5 * v47;
+            v49 = byte_1815DA9A0;
+            v24 = v136 + 32 * v48;
+            *(_BYTE *)(v24 + 144) = 1;
+            *(_BYTE *)(v24 + 152) = v46;
+            *(_DWORD *)(v24 + 140) = 1119092736;
+            *(_OWORD *)(v24 + 64) = xmmword_181627920;
+            *(_OWORD *)(v24 + 80) = xmmword_181627930;
+            *(_OWORD *)(v24 + 96) = xmmword_181627940;
+            if ( *(_QWORD *)(v45 + v44 + 48) )
+              v49 = *(char **)(v45 + v44 + 48);
+            *(_QWORD *)v24 = v49;
+            v50 = byte_1815DA9A0;
+            if ( *(_QWORD *)(v45 + v44 + 72) )
+              v50 = *(char **)(v45 + v44 + 72);
+            *(_QWORD *)(v24 + 16) = v50;
+            *(_OWORD *)(v24 + 64) = *(_OWORD *)(v45 + v44);
+            *(_OWORD *)(v24 + 80) = *(_OWORD *)(v45 + v44 + 16);
+            *(_OWORD *)(v24 + 96) = *(_OWORD *)(v45 + v44 + 32);
+            v51 = *(_BYTE *)(v45 + v44 + 82);
+            *(_BYTE *)(v24 + 153) = v51;
+            if ( !v51 )
+            {
+              v52 = (CUtlString *)(v24 + 120);
+              v53 = *(const char **)(v45 + v44 + 64);
+              if ( v53 )
+              {
+                v54 = -1;
+                do
+                  ++v54;
+                while ( v53[v54] );
+              }
+              else
+              {
+                LODWORD(v54) = 0;
+                v53 = byte_1815DA9A0;
+              }
+              CUtlString::SetDirect(v52, v53, v54);
+              if ( !v128 )
+                goto LABEL_86;
+              v55 = -1;
+              do
+                ++v55;
+              while ( v128[v55] );
+              if ( !(_DWORD)v55 )
+              {
+  LABEL_86:
+                v56 = *(const char **)(v45 + v44 + 48);
+                if ( v56 )
+                {
+                  v57 = -1;
+                  do
+                    ++v57;
+                  while ( v56[v57] );
+                }
+                else
+                {
+                  LODWORD(v57) = 0;
+                  v56 = byte_1815DA9A0;
+                }
+                CUtlString::SetDirect((CUtlString *)&v128, v56, v57);
+                v58 = byte_1815DA9A0;
+                if ( v128 )
+                  v58 = v128;
+                KeyValues::SetString(v43, "levelname", v58);
+              }
+              if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F36C30, 1) )
+              {
+                v59 = "loading";
+                v60 = byte_1815DA9A0;
+                if ( *(_QWORD *)v52 )
+                  v60 = *(char **)v52;
+                if ( (_DWORD)v138 )
+                  v59 = "transitioning";
+                LoggingSystem_Log(
+                  (unsigned int)dword_181F36C30,
+                  1,
+                  "%s %s.HL%s from save file on %s\n",
+                  v59,
+                  v60,
+                  "1",
+                  "server");
+              }
+            }
+            ++v42;
+            v44 += 96;
+          }
+          while ( v42 < v141 );
+          v5 = v165;
+          v4 = v166;
+        }
+        else
+        {
+          v38 = sub_180BCDDF0(&v135, v24, v23, v26);
+          v30 = v136;
+          v39 = byte_1815DA9A0;
+          v40 = v136 + 160LL * v38;
+          *(_BYTE *)(v40 + 144) = 1;
+          *(_BYTE *)(v40 + 152) = v28;
+          *(_DWORD *)(v40 + 140) = 1119092736;
+          *(_OWORD *)(v40 + 64) = xmmword_181627920;
+          *(_OWORD *)(v40 + 80) = xmmword_181627930;
+          *(_OWORD *)(v40 + 96) = xmmword_181627940;
+          if ( v128 )
+            v39 = v128;
+          *(_QWORD *)(v40 + 24) = "mapload";
+          *(_QWORD *)v40 = v39;
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181F36C30, 1) )
+          {
+            v41 = byte_1815DA9A0;
+            if ( v130 )
+              v41 = v130;
+            LODWORD(v126) = v141;
+            LoggingSystem_Log(
+              (unsigned int)dword_181F36C30,
+              1,
+              "save file '%s' expected to have a single entry [%d]. Loading base level.",
+              v41,
+              v126);
+          }
+        }
+      }
+      else
+      {
+  LABEL_102:
+        v61 = sub_180BCDDF0(&v135, v130, v23, v26);
+        v30 = v136;
+        v62 = byte_1815DA9A0;
+        v24 = v136 + 160LL * v61;
+        *(_BYTE *)(v24 + 144) = 1;
+        *(_BYTE *)(v24 + 152) = v28;
+        *(_DWORD *)(v24 + 140) = 1119092736;
+        *(_OWORD *)(v24 + 64) = xmmword_181627920;
+        *(_OWORD *)(v24 + 80) = xmmword_181627930;
+        *(_OWORD *)(v24 + 96) = xmmword_181627940;
+        if ( v128 )
+          v62 = v128;
+        *(_QWORD *)(v24 + 24) = "mapload";
+        *(_QWORD *)v24 = v62;
+      }
+      v3 = v135;
+  LABEL_106:
+      if ( (_BYTE)v168
+        && !(*(unsigned __int8 (__fastcall **)(__int64, __int64, __int64, __int64))(*(_QWORD *)g_pVApplication + 176LL))(
+              g_pVApplication,
+              v24,
+              v23,
+              v26) )
+      {
+        v64 = byte_1815DA9A0;
+        if ( v128 )
+          v64 = v128;
+        if ( !(unsigned int)V_stricmp_fast(v64, "error", v63) )
+        {
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181FDF138, 3) )
+            LoggingSystem_Log((unsigned int)dword_181FDF138, 3, "LoopInit:  in \"error\" map - disconnecting...\n");
+          if ( v128 )
+            v8 = v128;
+          (*(void (__fastcall **)(__int64, __int64, char *))(*(_QWORD *)g_pNetworkClientService + 224LL))(
+            g_pNetworkClientService,
+            64,
+            v8);
+          v160 = 652;
+          v159[0] = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\shared\\loopmodegame.cpp";
+          v159[1] = "CLoopModeGame::LoopInit";
+          v159[2] = "false";
+          v161 = 20;
+          if ( Assert_ConditionFailed((const struct _AssertCompileTimeConstantStruct_t *)v159, "Error map!") )
+            __debugbreak();
+          if ( v131 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v131);
+          v65 = v3 - 1;
+          if ( v3 - 1 >= 0 )
+          {
+            v66 = v30 + 160LL * (v3 - 1) + 112;
+            do
+            {
+              if ( *(_QWORD *)(v66 + 8) )
+                CUtlString::FreeMemoryBlock((CUtlString *)(v66 + 8));
+              if ( *(_QWORD *)v66 )
+                CUtlString::FreeMemoryBlock((CUtlString *)v66);
+              v66 -= 160;
+              --v65;
+            }
+            while ( v65 >= 0 );
+          }
+  LABEL_126:
+          if ( (v137 & 0xC000000000000000uLL) == 0 && v30 )
+            (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v30);
+  LABEL_212:
+          sub_18053EE30(&v141);
+          if ( v134 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v134);
+          if ( v132 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v132);
+          if ( v130 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v130);
+          if ( v128 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v128);
+          return 0;
+        }
+      }
+      v67 = sub_180EA7010(40);
+      v68 = v67;
+      if ( v67 )
+      {
+        *(_QWORD *)(v67 + 8) = 0;
+        *(_QWORD *)(v67 + 20) = 0;
+        *(_QWORD *)(v67 + 28) = 0;
+        *(_DWORD *)(v67 + 36) = 0;
+        v30 = v136;
+        v3 = v135;
+        *(_QWORD *)v67 = &CResourceManifestPrerequisite::`vftable';
+        *(_QWORD *)(v67 + 24) = 0;
+        *(_QWORD *)(v67 + 32) = 0;
+        *(_DWORD *)(v67 + 16) = 0;
+      }
+      else
+      {
+        v68 = 0;
+      }
+      *(_QWORD *)(v5 + 8) = v68;
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)v68 + 8LL))(v68);
+      (**v167)(v167, *(_QWORD *)(v5 + 8));
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkService + 184LL))(g_pNetworkService);
+      v70 = (__int64 *)(v5 + 8);
+      if ( (_BYTE)v168 )
+      {
+        v71 = byte_1815DA9A0;
+        if ( v128 )
+          v71 = v128;
+        v72 = (*(__int64 (__fastcall **)(__int64, const char *, char *, _QWORD))(*(_QWORD *)qword_18219EC90 + 104LL))(
+                qword_18219EC90,
+                "defaultSession",
+                v71,
+                *(_QWORD *)(v5 + 8));
+        v73 = *(_QWORD *)(v5 + 96);
+        v74 = v72;
+        if ( v72 != v73 )
+        {
+          if ( v73 )
+            (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)v73 + 8LL))(
+              v73,
+              "--CLoopModeGame::SetWorldSession");
+          *(_QWORD *)(v5 + 96) = v74;
+          if ( v74 )
+          {
+            (**(void (__fastcall ***)(__int64, const char *))v74)(v74, "++CLoopModeGame::SetWorldSession");
+            if ( !(unsigned __int8)sub_181529360() )
+              (*(void (__fastcall **)(_QWORD, _QWORD))(**(_QWORD **)(v5 + 96) + 240LL))(*(_QWORD *)(v5 + 96), 0);
+          }
+        }
+        (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)v74 + 8LL))(v74, "--CLoopModeGame::LoopInit");
+        sub_1807F3150(&v145, 0, 0);
+        v147 |= 0x20u;
+        v145 = &CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable';
+        v156 = nullptr;
+        if ( (v146 & 1) != 0 )
+          v75 = *(_QWORD *)(v146 & 0xFFFFFFFFFFFFFFFCuLL);
+        else
+          v75 = v146 & 0xFFFFFFFFFFFFFFFCuLL;
+        v76 = (_QWORD *)sub_180FD7510(v150, v75);
+        v76[2] = 0;
+        if ( v76[3] > 0xFu )
+          v76 = (_QWORD *)*v76;
+        *(_BYTE *)v76 = 0;
+        v145 = &GameSessionConfiguration_t::`vftable';
+        if ( !(*(unsigned __int8 (__fastcall **)(__int64, KeyValues *, void ***))(*(_QWORD *)qword_181FBDF10 + 168LL))(
+                qword_181FBDF10,
+                v4,
+                &v145) )
+        {
+          v77 = v156;
+          v145 = &CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable';
+          if ( v156 )
+          {
+            KeyValues::~KeyValues(v156);
+            KeyValues::operator delete(v77);
+            v156 = nullptr;
+          }
+          sub_1807F3730(&v145);
+          if ( v131 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v131);
+          v78 = v3 - 1;
+          if ( v3 - 1 >= 0 )
+          {
+            v79 = v30 + 160LL * (v3 - 1) + 112;
+            do
+            {
+              if ( *(_QWORD *)(v79 + 8) )
+                CUtlString::FreeMemoryBlock((CUtlString *)(v79 + 8));
+              if ( *(_QWORD *)v79 )
+                CUtlString::FreeMemoryBlock((CUtlString *)v79);
+              v79 -= 160;
+              --v78;
+            }
+            while ( v78 >= 0 );
+          }
+          goto LABEL_126;
+        }
+        v80 = v151;
+        *(_BYTE *)(v5 + 109) = v154;
+        v81 = v80 & 0xFFFFFFFFFFFFFFFCuLL;
+        *(_BYTE *)(v5 + 111) = v153;
+        *(_BYTE *)(v5 + 112) = v155;
+        if ( *(_QWORD *)(v81 + 24) > 0xFu )
+          v81 = *(_QWORD *)v81;
+        CUtlString::Set((CUtlString *)(v5 + 128), (const char *)v81);
+        v82 = (const char *)(v148 & 0xFFFFFFFFFFFFFFFCuLL);
+        if ( *(_QWORD *)((v148 & 0xFFFFFFFFFFFFFFFCuLL) + 24) > 0xFu )
+          v82 = *(const char **)v82;
+        CUtlString::Set((CUtlString *)(v5 + 136), v82);
+        if ( g_pEntitySystem )
+          *(_WORD *)(g_pEntitySystem + 3037) = v152;
+        v83 = byte_1815DA9A0;
+        if ( v128 )
+          v83 = v128;
+        (*(void (__fastcall **)(__int64, void ***, __int64, char *))(*(_QWORD *)g_pNetworkServerService + 208LL))(
+          g_pNetworkServerService,
+          &v145,
+          v74,
+          v83);
+        v84 = (netadr_t *)(*(__int64 (__fastcall **)(__int64, _BYTE *))(*(_QWORD *)g_pNetworkServerService + 256LL))(
+                            g_pNetworkServerService,
+                            v164);
+        v85 = netadr_t::ToString(v84, 0);
+        v147 |= 0x10u;
+        if ( (v146 & 1) != 0 )
+          v86 = *(_QWORD *)(v146 & 0xFFFFFFFFFFFFFFFCuLL);
+        else
+          v86 = v146 & 0xFFFFFFFFFFFFFFFCuLL;
+        v162 = 0;
+        v87 = -1;
+        v163 = 0;
+        do
+          ++v87;
+        while ( v85[v87] );
+        sub_18014A480(&v162, v85);
+        sub_180FD76F0(v149, &v162, v86);
+        if ( *((_QWORD *)&v163 + 1) > 0xFu )
+        {
+          v88 = v162;
+          v89 = *((_QWORD *)&v163 + 1) + 1LL;
+          if ( (unsigned __int64)(*((_QWORD *)&v163 + 1) + 1LL) >= 0x1000 )
+          {
+            v88 = *(_QWORD *)(v162 - 8);
+            v89 = *((_QWORD *)&v163 + 1) + 40LL;
+            if ( (unsigned __int64)(v162 - v88 - 8) > 0x1F )
+              invalid_parameter_noinfo_noreturn();
+          }
+          sub_180EA7070(v88, v89);
+        }
+        if ( v131 )
+        {
+          v90 = -1;
+          do
+            ++v90;
+          while ( v131[v90] );
+          if ( (int)v90 > 0 )
+          {
+            v139 = 0;
+            v140 = 0;
+            v91 = (__int64 *)sub_180BB6160(&v139, &v157);
+            v92 = *v91;
+            if ( v140 )
+              CUtlString::FreeMemoryBlock((CUtlString *)&v140);
+            v140 = v92;
+            *v91 = 0;
+            if ( v157 )
+              CUtlString::FreeMemoryBlock((CUtlString *)&v157);
+            v93 = byte_1815DA9A0;
+            if ( v131 )
+              v93 = v131;
+            if ( (unsigned __int8)sub_180B8A000(&v139, v93) )
+            {
+              (*(void (__fastcall **)(_QWORD, unsigned int *))(**(_QWORD **)(g_pGameEntitySystem + 8408) + 240LL))(
+                *(_QWORD *)(g_pGameEntitySystem + 8408),
+                &v139);
+              (*(void (__fastcall **)(_QWORD, char **, char **))(**(_QWORD **)(g_pGameEntitySystem + 8408) + 264LL))(
+                *(_QWORD *)(g_pGameEntitySystem + 8408),
+                &v138,
+                &v131);
+              if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181FBCED4, 2) )
+              {
+                v94 = byte_1815DA9A0;
+                v95 = byte_1815DA9A0;
+                if ( v138 )
+                  v94 = v138;
+                if ( v131 )
+                  v95 = v131;
+                v96 = (char **)sub_180BB6160(&v139, &v158);
+                if ( *v96 )
+                  v8 = *v96;
+                LoggingSystem_Log(
+                  (unsigned int)dword_181FBCED4,
+                  2,
+                  "ET:  Restoring game at %u %s : '%s'\nET:  '%s'\n",
+                  v139,
+                  v8,
+                  v95,
+                  v94);
+                v97 = 1;
+              }
+              else
+              {
+                v97 = v144;
+              }
+              if ( (v97 & 1) != 0 && v158 )
+                CUtlString::FreeMemoryBlock((CUtlString *)&v158);
+              if ( v138 )
+                CUtlString::FreeMemoryBlock((CUtlString *)&v138);
+            }
+            if ( v140 )
+              CUtlString::FreeMemoryBlock((CUtlString *)&v140);
+          }
+        }
+        CLoopModeGame_SetGameSystemState(v5, 1);
+        sub_180BCDA10(v5);
+        if ( !(*(unsigned __int8 (__fastcall **)(__int64, void ***))(*(_QWORD *)qword_181FBDF10 + 176LL))(
+                qword_181FBDF10,
+                &v145) )
+        {
+          Plat_FatalError("LevelInitWorld failed!\n");
+          __debugbreak();
+        }
+        sub_180C20420(&v165);
+        CLoopModeGame_SetGameSystemState(v5, 2);
+        v98 = v167;
+        if ( !IGameSystem_LoopInitAllSystems((__int64)&v145, (__int64)v167)
+          || (CLoopModeGame_SetGameSystemState(v5, 3), !IGameSystem_LoopPostInitAllSystems((__int64)&v145, (__int64)v98))
+          || !(*(unsigned __int8 (__fastcall **)(__int64, void ***, void (__fastcall ***)(_QWORD, _QWORD)))(*(_QWORD *)qword_181FBDF10 + 200LL))(
+                qword_181FBDF10,
+                &v145,
+                v98) )
+        {
+          sub_180C20FD0(&v165);
+          v99 = v156;
+          v145 = &CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable';
+          if ( v156 )
+          {
+            KeyValues::~KeyValues(v156);
+            KeyValues::operator delete(v99);
+            v156 = nullptr;
+          }
+          sub_1807F3730(&v145);
+          if ( v131 )
+            CUtlString::FreeMemoryBlock((CUtlString *)&v131);
+          sub_180BCC7B0(&v135);
+          goto LABEL_212;
+        }
+        sub_180C20FD0(&v165);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pNetworkServerService + 216LL))(
+          g_pNetworkServerService,
+          qword_181ED26C0);
+        for ( i = 0; i < v3; ++i )
+        {
+          v102 = (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_181FDFC78 + 480LL))(// 480LL = 0x1E0 = CEngineServer_UnloadSpawnGroup (qword_181FDFC78 = g_pEngineServer, vfunc_index 60)
+                   qword_181FDFC78,
+                   v30 + 160LL * i);              // 480LL = 0x1E0 = CEngineServer_UnloadSpawnGroup
+          if ( !i )
+            *(_DWORD *)(v5 + 1072) = v102;
+        }
+        LOBYTE(v126) = v133;
+        (*(void (__fastcall **)(__int64, void ***, const char *, void (__fastcall ***)(_QWORD, _QWORD), _DWORD))(*(_QWORD *)g_pNetworkServerService + 224LL))(
+          g_pNetworkServerService,
+          &v145,
+          "GameSessionManifest",
+          v98,
+          v126);
+        v103 = v156;
+        v145 = &CBaseCmdKeyValues<CSVCMsg_GameSessionConfiguration>::`vftable';
+        if ( v156 )
+        {
+          KeyValues::~KeyValues(v156);
+          KeyValues::operator delete(v103);
+          v156 = nullptr;
+        }
+        sub_1807F3730(&v145);
+        v70 = (__int64 *)(v5 + 8);
+      }
+      v104 = *(_QWORD *)(v5 + 8);
+      LOBYTE(v126) = -1;
+      LOBYTE(v69) = 1;
+      v168 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, const char *, _DWORD))(*(_QWORD *)g_pResourceSystem
+                                                                                             + 160LL))(
+               g_pResourceSystem,
+               "LoopModeGameStartup",
+               v69,
+               "CLoopModeGame::LoopInit",
+               v126);
+      if ( v168 )
+      {
+        v106 = *(_DWORD *)(v104 + 16);
+        LODWORD(v165) = v106;
+        if ( v106 == *(_DWORD *)(v104 + 32)
+          && ((*(_DWORD *)(v104 + 36) & 0xC0000000) == 0 || (*(_DWORD *)(v104 + 36) & 0xC0000000) == 0x80000000) )
+        {
+          v107 = *(unsigned int *)(v104 + 32);
+          if ( (_DWORD)v107 == 0x7FFFFFFF )
+            UtlVectorMemory_FailedAllocation(v107, 1);
+          v108 = *(unsigned int *)(v104 + 32);
+          v109 = v108 + 1;
+          v110 = UtlVectorMemory_CalcNewAllocationCount(
+                   v108,
+                   *(_DWORD *)(v104 + 36) & 0x3FFFFFFF,
+                   (unsigned int)(v108 + 1),
+                   8);
+          v112 = v110;
+          if ( v110 < v109 )
+          {
+            if ( v110 || v109 > -1 )
+            {
+              do
+              {
+                v111 = (unsigned int)((v112 + v109) >> 31);
+                v112 = (v112 + v109) / 2;
+              }
+              while ( v112 < v109 );
+            }
+            else
+            {
+              v112 = -1;
+            }
+          }
+          LOBYTE(v111) = (*(_DWORD *)(v104 + 36) & 0xC0000000) == 0;
+          *(_QWORD *)(v104 + 24) = UtlVectorMemory_Alloc(
+                                     *(_QWORD *)(v104 + 24),
+                                     v111,
+                                     8LL * v112,
+                                     8LL * *(int *)(v104 + 32));
+          v113 = *(_DWORD *)(v104 + 36);
+          if ( (v113 & 0xC0000000) != 0 )
+            *(_DWORD *)(v104 + 36) = v113 & 0x3FFFFFFF;
+          v106 = v165;
+          *(_DWORD *)(v104 + 32) = v112;
+          v70 = (__int64 *)(v5 + 8);
+        }
+        ++*(_DWORD *)(v104 + 16);
+        *(_QWORD *)(*(_QWORD *)(v104 + 24) + 8LL * v106) = v168;
+      }
+      v114 = *v70;
+      LOBYTE(v105) = 1;
+      LOBYTE(v127) = -1;
+      v115 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, const char *, int))(*(_QWORD *)g_pResourceSystem
+                                                                                          + 168LL))(
+               g_pResourceSystem,
+               "LoopModeGame_server",
+               v105,
+               "CLoopModeGame::LoopInit",
+               v127);
+      if ( v115 )
+      {
+        v116 = *(int *)(v114 + 16);
+        if ( (_DWORD)v116 == *(_DWORD *)(v114 + 32) && (*(_DWORD *)(v114 + 36) & 0x40000000) == 0 )
+        {
+          v117 = *(unsigned int *)(v114 + 32);
+          if ( (_DWORD)v117 == 0x7FFFFFFF )
+            UtlVectorMemory_FailedAllocation(v117, 1);
+          v118 = *(unsigned int *)(v114 + 32);
+          v119 = v118 + 1;
+          v120 = UtlVectorMemory_CalcNewAllocationCount(
+                   v118,
+                   *(_DWORD *)(v114 + 36) & 0x3FFFFFFF,
+                   (unsigned int)(v118 + 1),
+                   8);
+          v122 = v120;
+          if ( v120 < v119 )
+          {
+            if ( v120 || v119 > -1 )
+            {
+              do
+              {
+                v121 = (unsigned int)((v122 + v119) >> 31);
+                v122 = (v122 + v119) / 2;
+              }
+              while ( v122 < v119 );
+            }
+            else
+            {
+              v122 = -1;
+            }
+          }
+          LOBYTE(v121) = (*(_DWORD *)(v114 + 36) & 0xC0000000) == 0;
+          *(_QWORD *)(v114 + 24) = UtlVectorMemory_Alloc(
+                                     *(_QWORD *)(v114 + 24),
+                                     v121,
+                                     8LL * v122,
+                                     8LL * *(int *)(v114 + 32));
+          v123 = *(_DWORD *)(v114 + 36);
+          if ( (v123 & 0xC0000000) != 0 )
+            *(_DWORD *)(v114 + 36) = v123 & 0x3FFFFFFF;
+          *(_DWORD *)(v114 + 32) = v122;
+        }
+        ++*(_DWORD *)(v114 + 16);
+        *(_QWORD *)(*(_QWORD *)(v114 + 24) + 8 * v116) = v115;
+      }
+      if ( qword_181FBDF10 )
+        (*(void (__fastcall **)(__int64, KeyValues *, void (__fastcall ***)(_QWORD, _QWORD)))(*(_QWORD *)qword_181FBDF10
+                                                                                            + 144LL))(
+          qword_181FBDF10,
+          v166,
+          v167);
+      if ( v131 )
+        CUtlString::FreeMemoryBlock((CUtlString *)&v131);
+      v124 = v3 - 1;
+      if ( v3 - 1 >= 0 )
+      {
+        v125 = v30 + 160LL * (v3 - 1) + 112;
+        do
+        {
+          if ( *(_QWORD *)(v125 + 8) )
+            CUtlString::FreeMemoryBlock((CUtlString *)(v125 + 8));
+          if ( *(_QWORD *)v125 )
+            CUtlString::FreeMemoryBlock((CUtlString *)v125);
+          v125 -= 160;
+          --v124;
+        }
+        while ( v124 >= 0 );
+      }
+      if ( (v137 & 0xC000000000000000uLL) == 0 && v30 )
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v30);
+      sub_18053EE30(&v141);
+      if ( v134 )
+        CUtlString::FreeMemoryBlock((CUtlString *)&v134);
+      if ( v132 )
+        CUtlString::FreeMemoryBlock((CUtlString *)&v132);
+      if ( v130 )
+        CUtlString::FreeMemoryBlock((CUtlString *)&v130);
+      v29 = v128 == nullptr;
+      goto LABEL_279;
+    }
+    if ( v24 )
+    {
+      CUtlString::FreeMemoryBlock((CUtlString *)&v134);
+      v25 = v132;
+    }
+    if ( v25 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v132);
+    if ( v130 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v130);
+    v29 = v128 == nullptr;
+  LABEL_279:
+    if ( !v29 )
+      CUtlString::FreeMemoryBlock((CUtlString *)&v128);
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CLoopModeGame_LoopInitInternal.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CLoopModeGame_LoopInitInternal.linux.yaml
@@ -1,0 +1,2037 @@
+func_name: CLoopModeGame_LoopInitInternal
+func_va: '0x1723c50'
+disasm_code: |-
+  .text:0000000001723C36                 lea     rdi, aBasicStringSCo; "basic_string::_S_construct null not val"...
+  .text:0000000001723C3D                 call    sub_9EB370
+  .text:0000000001723C42                 lea     rdi, aBasicStringSCr; "basic_string::_S_create"
+  .text:0000000001723C49                 call    sub_9EB380
+  .text:0000000001723C50                 push    rbp
+  .text:0000000001723C51                 mov     rbp, rsp
+  .text:0000000001723C54                 push    r15
+  .text:0000000001723C56                 push    r14
+  .text:0000000001723C58                 push    r13
+  .text:0000000001723C5A                 push    r12
+  .text:0000000001723C5C                 lea     r12, byte_93BAEA
+  .text:0000000001723C63                 push    rbx
+  .text:0000000001723C64                 mov     rbx, rdi
+  .text:0000000001723C67                 mov     rdi, rsi
+  .text:0000000001723C6A                 mov     r13, r12
+  .text:0000000001723C6D                 sub     rsp, 198h
+  .text:0000000001723C74                 mov     [rbp+var_148], rsi
+  .text:0000000001723C7B                 lea     rsi, aMode; "mode"
+  .text:0000000001723C82                 mov     [rbp+var_150], rdx
+  .text:0000000001723C89                 call    sub_9EF5C0
+  .text:0000000001723C8E                 test    rax, rax
+  .text:0000000001723C91                 jz      short loc_1723CA5
+  .text:0000000001723C93                 xor     ecx, ecx
+  .text:0000000001723C95                 xor     edx, edx
+  .text:0000000001723C97                 mov     rsi, r12
+  .text:0000000001723C9A                 mov     rdi, rax
+  .text:0000000001723C9D                 call    sub_9F1070
+  .text:0000000001723CA2                 mov     r13, rax
+  .text:0000000001723CA5                 lea     rsi, aListenserver; "listenserver"
+  .text:0000000001723CAC                 mov     rdi, r13
+  .text:0000000001723CAF                 call    sub_9EFFD0
+  .text:0000000001723CB4                 test    eax, eax
+  .text:0000000001723CB6                 jnz     loc_1724230
+  .text:0000000001723CBC                 mov     eax, 3
+  .text:0000000001723CC1                 mov     [rbx+68h], eax
+  .text:0000000001723CC4                 mov     edi, 1
+  .text:0000000001723CC9                 mov     dword ptr [rbp+var_160], 1
+  .text:0000000001723CD3                 call    sub_EC67A0
+  .text:0000000001723CD8                 mov     rdi, [rbp+var_148]
+  .text:0000000001723CDF                 lea     rsi, aLevelname; "levelname"
+  .text:0000000001723CE6                 call    sub_9EF5C0
+  .text:0000000001723CEB                 lea     rsi, byte_93BAEA
+  .text:0000000001723CF2                 test    rax, rax
+  .text:0000000001723CF5                 jz      short loc_1723D09
+  .text:0000000001723CF7                 mov     rsi, r12
+  .text:0000000001723CFA                 xor     ecx, ecx
+  .text:0000000001723CFC                 xor     edx, edx
+  .text:0000000001723CFE                 mov     rdi, rax
+  .text:0000000001723D01                 call    sub_9F1070
+  .text:0000000001723D06                 mov     rsi, rax
+  .text:0000000001723D09                 lea     rax, [rbp+var_138]
+  .text:0000000001723D10                 mov     [rbp+var_138], 0
+  .text:0000000001723D1B                 mov     rdi, rax
+  .text:0000000001723D1E                 mov     [rbp+var_158], rax
+  .text:0000000001723D25                 call    sub_9F0420
+  .text:0000000001723D2A                 mov     rdi, [rbp+var_148]
+  .text:0000000001723D31                 lea     rsi, aSavegame; "savegame"
+  .text:0000000001723D38                 call    sub_9EF5C0
+  .text:0000000001723D3D                 lea     rsi, byte_93BAEA
+  .text:0000000001723D44                 test    rax, rax
+  .text:0000000001723D47                 jz      short loc_1723D5B
+  .text:0000000001723D49                 mov     rsi, r12
+  .text:0000000001723D4C                 xor     ecx, ecx
+  .text:0000000001723D4E                 xor     edx, edx
+  .text:0000000001723D50                 mov     rdi, rax
+  .text:0000000001723D53                 call    sub_9F1070
+  .text:0000000001723D58                 mov     rsi, rax
+  .text:0000000001723D5B                 lea     rax, [rbp+var_130]
+  .text:0000000001723D62                 mov     [rbp+var_130], 0
+  .text:0000000001723D6D                 mov     rdi, rax
+  .text:0000000001723D70                 mov     [rbp+var_168], rax
+  .text:0000000001723D77                 call    sub_9F0420
+  .text:0000000001723D7C                 mov     rdi, [rbp+var_148]
+  .text:0000000001723D83                 lea     rsi, aLandmarkname; "landmarkname"
+  .text:0000000001723D8A                 call    sub_9EF5C0
+  .text:0000000001723D8F                 lea     rsi, byte_93BAEA
+  .text:0000000001723D96                 test    rax, rax
+  .text:0000000001723D99                 jz      short loc_1723DAD
+  .text:0000000001723D9B                 mov     rsi, r12
+  .text:0000000001723D9E                 xor     ecx, ecx
+  .text:0000000001723DA0                 xor     edx, edx
+  .text:0000000001723DA2                 mov     rdi, rax
+  .text:0000000001723DA5                 call    sub_9F1070
+  .text:0000000001723DAA                 mov     rsi, rax
+  .text:0000000001723DAD                 lea     rax, [rbp+var_128]
+  .text:0000000001723DB4                 mov     [rbp+var_128], 0
+  .text:0000000001723DBF                 mov     rdi, rax
+  .text:0000000001723DC2                 mov     [rbp+var_170], rax
+  .text:0000000001723DC9                 call    sub_9F0420
+  .text:0000000001723DCE                 mov     rdi, [rbp+var_148]
+  .text:0000000001723DD5                 lea     rsi, aPreviouslevel; "previouslevel"
+  .text:0000000001723DDC                 call    sub_9EF5C0
+  .text:0000000001723DE1                 lea     rsi, byte_93BAEA
+  .text:0000000001723DE8                 test    rax, rax
+  .text:0000000001723DEB                 jz      short loc_1723DFF
+  .text:0000000001723DED                 mov     rsi, r12
+  .text:0000000001723DF0                 xor     ecx, ecx
+  .text:0000000001723DF2                 xor     edx, edx
+  .text:0000000001723DF4                 mov     rdi, rax
+  .text:0000000001723DF7                 call    sub_9F1070
+  .text:0000000001723DFC                 mov     rsi, rax
+  .text:0000000001723DFF                 lea     rax, [rbp+var_120]
+  .text:0000000001723E06                 mov     [rbp+var_120], 0
+  .text:0000000001723E11                 mov     rdi, rax
+  .text:0000000001723E14                 mov     [rbp+var_178], rax
+  .text:0000000001723E1B                 call    sub_9F0420
+  .text:0000000001723E20                 mov     r14, [rbp+var_148]
+  .text:0000000001723E27                 xor     edx, edx
+  .text:0000000001723E29                 lea     rsi, aLoadmap; "loadmap"
+  .text:0000000001723E30                 mov     rdi, r14
+  .text:0000000001723E33                 call    sub_9F1130
+  .text:0000000001723E38                 xor     edx, edx
+  .text:0000000001723E3A                 mov     rdi, r14
+  .text:0000000001723E3D                 lea     rsi, aChangelevel_0; "changelevel"
+  .text:0000000001723E44                 mov     r12d, eax
+  .text:0000000001723E47                 call    sub_9F1130
+  .text:0000000001723E4C                 mov     rdi, [rbp+var_120]
+  .text:0000000001723E53                 test    r12d, r12d
+  .text:0000000001723E56                 mov     r13d, eax
+  .text:0000000001723E59                 setz    r15b
+  .text:0000000001723E5D                 test    rdi, rdi
+  .text:0000000001723E60                 jz      loc_1723F00
+  .text:0000000001723E66                 call    sub_9F1BA0
+  .text:0000000001723E6B                 xor     r14d, r14d
+  .text:0000000001723E6E                 test    eax, eax
+  .text:0000000001723E70                 jle     short loc_1723E89
+  .text:0000000001723E72                 mov     rdi, [rbp+var_128]
+  .text:0000000001723E79                 test    rdi, rdi
+  .text:0000000001723E7C                 jz      short loc_1723E89
+  .text:0000000001723E7E                 call    sub_9F1BA0
+  .text:0000000001723E83                 test    eax, eax
+  .text:0000000001723E85                 setnle  r14b
+  .text:0000000001723E89                 mov     [rbx+6Ch], r15b
+  .text:0000000001723E8D                 mov     r15d, 1
+  .text:0000000001723E93                 test    r12d, r12d
+  .text:0000000001723E96                 jnz     short loc_1723F12
+  .text:0000000001723E98                 mov     rdi, [rbp+var_178]
+  .text:0000000001723E9F                 call    sub_9EF5F0
+  .text:0000000001723EA4                 cmp     [rbp+var_128], 0
+  .text:0000000001723EAC                 jz      short loc_1723EBA
+  .text:0000000001723EAE                 mov     rdi, [rbp+var_170]
+  .text:0000000001723EB5                 call    sub_9EF5F0
+  .text:0000000001723EBA                 cmp     [rbp+var_130], 0
+  .text:0000000001723EC2                 jz      short loc_1723ED0
+  .text:0000000001723EC4                 mov     rdi, [rbp+var_168]
+  .text:0000000001723ECB                 call    sub_9EF5F0
+  .text:0000000001723ED0                 cmp     [rbp+var_138], 0
+  .text:0000000001723ED8                 jz      short loc_1723EE6
+  .text:0000000001723EDA                 mov     rdi, [rbp+var_158]
+  .text:0000000001723EE1                 call    sub_9EF5F0
+  .text:0000000001723EE6                 lea     rsp, [rbp-28h]
+  .text:0000000001723EEA                 mov     eax, r15d
+  .text:0000000001723EED                 pop     rbx
+  .text:0000000001723EEE                 pop     r12
+  .text:0000000001723EF0                 pop     r13
+  .text:0000000001723EF2                 pop     r14
+  .text:0000000001723EF4                 pop     r15
+  .text:0000000001723EF6                 pop     rbp
+  .text:0000000001723EF7                 retn
+  .text:0000000001723F00                 mov     [rbx+6Ch], r15b
+  .text:0000000001723F04                 xor     r14d, r14d
+  .text:0000000001723F07                 mov     r15d, 1
+  .text:0000000001723F0D                 test    r12d, r12d
+  .text:0000000001723F10                 jz      short loc_1723EA4
+  .text:0000000001723F12                 mov     [rbp+var_F0], 0
+  .text:0000000001723F1D                 test    r13d, r13d
+  .text:0000000001723F20                 setnz   byte ptr [rbp+var_194]
+  .text:0000000001723F27                 cmp     dword ptr [rbx+68h], 2
+  .text:0000000001723F2B                 mov     [rbp+var_E8], 0
+  .text:0000000001723F36                 mov     [rbp+var_E0], 0
+  .text:0000000001723F41                 mov     [rbp+var_118], 0
+  .text:0000000001723F4C                 jz      loc_1724A78
+  .text:0000000001723F52                 mov     r12, [rbp+var_130]
+  .text:0000000001723F59                 test    r12, r12
+  .text:0000000001723F5C                 jz      loc_1724290
+  .text:0000000001723F62                 mov     rdi, r12
+  .text:0000000001723F65                 call    sub_9F1BA0
+  .text:0000000001723F6A                 test    eax, eax
+  .text:0000000001723F6C                 jle     loc_1724290
+  .text:0000000001723F72                 test    r13d, r13d
+  .text:0000000001723F75                 jnz     loc_1725150
+  .text:0000000001723F7B                 lea     rax, g_pSource2Server
+  .text:0000000001723F82                 xor     r8d, r8d
+  .text:0000000001723F85                 mov     rsi, r12
+  .text:0000000001723F88                 mov     ecx, dword ptr [rbp+var_160]
+  .text:0000000001723F8E                 lea     rdx, [rbp+var_F0]
+  .text:0000000001723F95                 lea     r9, [rbp+var_118]
+  .text:0000000001723F9C                 mov     rdi, [rax]
+  .text:0000000001723F9F                 mov     rax, [rdi]
+  .text:0000000001723FA2                 call    qword ptr [rax+1A0h]
+  .text:0000000001723FA8                 mov     eax, dword ptr [rbp+var_F0]
+  .text:0000000001723FAE                 test    eax, eax
+  .text:0000000001723FB0                 jz      loc_1724DA0
+  .text:0000000001723FB6                 jle     loc_1724A78
+  .text:0000000001723FBC                 cmp     byte ptr [rbp+var_194], 0
+  .text:0000000001723FC3                 lea     rdx, aTransitioning; "transitioning"
+  .text:0000000001723FCA                 mov     dword ptr [rbp+var_188+4], 0
+  .text:0000000001723FD4                 mov     dword ptr [rbp+var_188], 0
+  .text:0000000001723FDE                 lea     rax, aLoading; "loading"
+  .text:0000000001723FE5                 mov     byte ptr [rbp+var_190], r14b
+  .text:0000000001723FEC                 lea     r13, byte_93BAEA
+  .text:0000000001723FF3                 mov     [rbp+var_1B8], rbx
+  .text:0000000001723FFA                 cmovnz  rax, rdx
+  .text:0000000001723FFE                 xor     r12d, r12d
+  .text:0000000001724001                 xor     r15d, r15d
+  .text:0000000001724004                 mov     [rbp+var_180], r12
+  .text:000000000172400B                 mov     [rbp+var_1B0], rax
+  .text:0000000001724012                 xor     eax, eax
+  .text:0000000001724014                 jmp     short loc_1724034
+  .text:0000000001724020                 add     r15, 1
+  .text:0000000001724024                 cmp     dword ptr [rbp+var_F0], r15d
+  .text:000000000172402B                 jle     loc_1724C58
+  .text:0000000001724031                 movsxd  rax, r14d
+  .text:0000000001724034                 lea     rdx, [r15+r15*2]
+  .text:0000000001724038                 mov     ebx, eax
+  .text:000000000172403A                 shl     rdx, 5
+  .text:000000000172403E                 add     rdx, [rbp+var_E8]
+  .text:0000000001724045                 cmp     dword ptr [rbp+var_188], eax
+  .text:000000000172404B                 jz      loc_1724BC8
+  .text:0000000001724051                 movaps  xmm3, cs:xmmword_8CABE0
+  .text:0000000001724058                 movss   xmm2, dword ptr cs:xmmword_8CD150
+  .text:0000000001724060                 pxor    xmm0, xmm0
+  .text:0000000001724064                 lea     rcx, [rax+rax*4]
+  .text:0000000001724068                 mov     rax, [rbp+var_180]
+  .text:000000000172406F                 movaps  xmm4, xmmword ptr cs:dbl_8CCEB0
+  .text:0000000001724076                 lea     r14d, [rbx+1]
+  .text:000000000172407A                 shl     rcx, 5
+  .text:000000000172407E                 lea     r12, [rax+rcx]
+  .text:0000000001724082                 mov     rax, 0FFFFFFFE00000000h
+  .text:000000000172408C                 mov     [r12+80h], rax
+  .text:0000000001724094                 xor     eax, eax
+  .text:0000000001724096                 mov     [r12+99h], ax
+  .text:000000000172409F                 mov     rax, cs:qword_8CEBF8
+  .text:00000000017240A6                 movaps  xmmword ptr [r12], xmm0
+  .text:00000000017240AB                 movaps  xmmword ptr [r12+10h], xmm0
+  .text:00000000017240B1                 movaps  xmmword ptr [r12+40h], xmm2
+  .text:00000000017240B7                 mov     [r12+90h], rax
+  .text:00000000017240BF                 movzx   eax, byte ptr [rbp+var_190]
+  .text:00000000017240C6                 movaps  xmmword ptr [r12+50h], xmm3
+  .text:00000000017240CC                 movaps  xmmword ptr [r12+60h], xmm4
+  .text:00000000017240D2                 movaps  xmmword ptr [r12+20h], xmm0
+  .text:00000000017240D8                 movaps  xmmword ptr [r12+30h], xmm0
+  .text:00000000017240DE                 movaps  xmmword ptr [r12+70h], xmm0
+  .text:00000000017240E4                 mov     byte ptr [r12+88h], 0FFh
+  .text:00000000017240ED                 mov     [r12+98h], al
+  .text:00000000017240F5                 mov     dword ptr [r12+8Ch], 42B40000h
+  .text:0000000001724101                 mov     rax, [rdx+30h]
+  .text:0000000001724105                 test    rax, rax
+  .text:0000000001724108                 cmovz   rax, r13
+  .text:000000000172410C                 mov     [r12], rax
+  .text:0000000001724110                 mov     rax, [rdx+48h]
+  .text:0000000001724114                 test    rax, rax
+  .text:0000000001724117                 cmovz   rax, r13
+  .text:000000000172411B                 mov     [r12+10h], rax
+  .text:0000000001724120                 movdqa  xmm0, xmmword ptr [rdx]
+  .text:0000000001724124                 movaps  xmmword ptr [r12+40h], xmm0
+  .text:000000000172412A                 movdqa  xmm0, xmmword ptr [rdx+10h]
+  .text:000000000172412F                 movaps  xmmword ptr [r12+50h], xmm0
+  .text:0000000001724135                 movdqa  xmm0, xmmword ptr [rdx+20h]
+  .text:000000000172413A                 movaps  xmmword ptr [r12+60h], xmm0
+  .text:0000000001724140                 movzx   eax, byte ptr [rdx+52h]
+  .text:0000000001724144                 mov     [r12+99h], al
+  .text:000000000172414C                 test    al, al
+  .text:000000000172414E                 jnz     loc_1724020
+  .text:0000000001724154                 mov     rsi, [rdx+40h]
+  .text:0000000001724158                 lea     rdi, [r12+78h]
+  .text:000000000172415D                 mov     [rbp+var_1A0], rdx
+  .text:0000000001724164                 call    sub_170CD50
+  .text:0000000001724169                 mov     rdi, [rbp+var_138]
+  .text:0000000001724170                 mov     rdx, [rbp+var_1A0]
+  .text:0000000001724177                 test    rdi, rdi
+  .text:000000000172417A                 jz      short loc_172418C
+  .text:000000000172417C                 call    sub_9F1BA0
+  .text:0000000001724181                 mov     rdx, [rbp+var_1A0]
+  .text:0000000001724188                 test    eax, eax
+  .text:000000000172418A                 jnz     short loc_17241BD
+  .text:000000000172418C                 mov     rsi, [rdx+30h]
+  .text:0000000001724190                 mov     rdi, [rbp+var_158]
+  .text:0000000001724197                 call    sub_170CD50
+  .text:000000000172419C                 mov     rdx, [rbp+var_138]
+  .text:00000000017241A3                 lea     rsi, aLevelname; "levelname"
+  .text:00000000017241AA                 mov     rdi, [rbp+var_148]
+  .text:00000000017241B1                 test    rdx, rdx
+  .text:00000000017241B4                 cmovz   rdx, r13
+  .text:00000000017241B8                 call    sub_9F0BE0
+  .text:00000000017241BD                 lea     rdx, dword_27BC7B0
+  .text:00000000017241C4                 mov     esi, 1
+  .text:00000000017241C9                 mov     edi, [rdx]
+  .text:00000000017241CB                 mov     [rbp+var_1A0], rdx
+  .text:00000000017241D2                 call    sub_9F0CA0
+  .text:00000000017241D7                 test    al, al
+  .text:00000000017241D9                 jz      loc_1724020
+  .text:00000000017241DF                 mov     r8, [r12+78h]
+  .text:00000000017241E4                 lea     rax, aServer; "server"
+  .text:00000000017241EB                 mov     esi, 1
+  .text:00000000017241F0                 mov     rdx, [rbp+var_1A0]
+  .text:00000000017241F7                 lea     r9, a1; "1"
+  .text:00000000017241FE                 test    r8, r8
+  .text:0000000001724201                 cmovz   r8, r13
+  .text:0000000001724205                 sub     rsp, 8
+  .text:0000000001724209                 mov     edi, [rdx]
+  .text:000000000172420B                 push    rax
+  .text:000000000172420C                 mov     rcx, [rbp+var_1B0]
+  .text:0000000001724213                 xor     eax, eax
+  .text:0000000001724215                 lea     rdx, aSSHlSFromSaveF; "%s %s.HL%s from save file on %s\n"
+  .text:000000000172421C                 call    sub_9F0170
+  .text:0000000001724221                 pop     r11
+  .text:0000000001724223                 pop     r12
+  .text:0000000001724225                 jmp     loc_1724020
+  .text:0000000001724230                 lea     rsi, aDedicated; "dedicated"
+  .text:0000000001724237                 mov     rdi, r13
+  .text:000000000172423A                 call    sub_9EFFD0
+  .text:000000000172423F                 mov     edx, eax
+  .text:0000000001724241                 mov     eax, 1
+  .text:0000000001724246                 test    edx, edx
+  .text:0000000001724248                 jz      loc_1723CC1
+  .text:000000000172424E                 lea     rsi, aRemoteclient; "remoteclient"
+  .text:0000000001724255                 mov     rdi, r13
+  .text:0000000001724258                 call    sub_9EFFD0
+  .text:000000000172425D                 mov     dword ptr [rbp+var_160], eax
+  .text:0000000001724263                 test    eax, eax
+  .text:0000000001724265                 jz      loc_1724C80
+  .text:000000000172426B                 mov     eax, [rbx+68h]
+  .text:000000000172426E                 xor     edi, edi
+  .text:0000000001724270                 mov     ecx, eax
+  .text:0000000001724272                 and     ecx, 1
+  .text:0000000001724275                 cmp     eax, 2
+  .text:0000000001724278                 mov     dword ptr [rbp+var_160], ecx
+  .text:000000000172427E                 setnz   dil
+  .text:0000000001724282                 jmp     loc_1723CD3
+  .text:0000000001724290                 lea     rdi, [rbp+var_C8]
+  .text:0000000001724297                 mov     esi, 1
+  .text:000000000172429C                 mov     [rbp+var_D0], 0
+  .text:00000000017242A6                 mov     [rbp+var_C8], 0
+  .text:00000000017242B1                 mov     [rbp+var_C0], 0
+  .text:00000000017242BC                 call    sub_1723B20
+  .text:00000000017242C1                 mov     eax, [rbp+var_D0]
+  .text:00000000017242C7                 xor     r10d, r10d
+  .text:00000000017242CA                 pxor    xmm0, xmm0
+  .text:00000000017242CE                 mov     r12, [rbp+var_C8]
+  .text:00000000017242D5                 movss   xmm1, dword ptr cs:xmmword_8CD150
+  .text:00000000017242DD                 mov     ecx, dword ptr [rbp+var_C0+4]
+  .text:00000000017242E3                 lea     rdx, byte_93BAEA
+  .text:00000000017242EA                 mov     dword ptr [rbp+var_180], eax
+  .text:00000000017242F0                 add     eax, 1
+  .text:00000000017242F3                 mov     dword ptr [rbp+var_188], eax
+  .text:00000000017242F9                 mov     rax, 0FFFFFFFE00000000h
+  .text:0000000001724303                 mov     [r12+80h], rax
+  .text:000000000172430B                 mov     rax, cs:qword_8CEBF8
+  .text:0000000001724312                 movaps  xmmword ptr [r12+40h], xmm1
+  .text:0000000001724318                 movaps  xmm1, cs:xmmword_8CABE0
+  .text:000000000172431F                 movaps  xmmword ptr [r12], xmm0
+  .text:0000000001724324                 movaps  xmmword ptr [r12+50h], xmm1
+  .text:000000000172432A                 movaps  xmm1, xmmword ptr cs:dbl_8CCEB0
+  .text:0000000001724331                 mov     [r12+90h], rax
+  .text:0000000001724339                 mov     rax, [rbp+var_138]
+  .text:0000000001724340                 mov     dword ptr [rbp+var_188+4], ecx
+  .text:0000000001724346                 mov     qword ptr [r12+10h], 0
+  .text:000000000172434F                 movaps  xmmword ptr [r12+20h], xmm0
+  .text:0000000001724355                 test    rax, rax
+  .text:0000000001724358                 movaps  xmmword ptr [r12+30h], xmm0
+  .text:000000000172435E                 cmovz   rax, rdx
+  .text:0000000001724362                 movaps  xmmword ptr [r12+60h], xmm1
+  .text:0000000001724368                 movaps  xmmword ptr [r12+70h], xmm0
+  .text:000000000172436E                 mov     [r12], rax
+  .text:0000000001724372                 lea     rax, aMapload; "mapload"
+  .text:0000000001724379                 mov     byte ptr [r12+88h], 0FFh
+  .text:0000000001724382                 mov     [r12+99h], r10w
+  .text:000000000172438B                 mov     [r12+98h], r14b
+  .text:0000000001724393                 mov     dword ptr [r12+8Ch], 42B40000h
+  .text:000000000172439F                 mov     [r12+18h], rax
+  .text:00000000017243A4                 mov     r9d, dword ptr [rbp+var_160]
+  .text:00000000017243AB                 test    r9d, r9d
+  .text:00000000017243AE                 jz      short loc_17243F0
+  .text:00000000017243B0                 lea     rax, g_pVApplication
+  .text:00000000017243B7                 mov     rdi, [rax]
+  .text:00000000017243BA                 mov     rax, [rdi]
+  .text:00000000017243BD                 call    qword ptr [rax+0B8h]
+  .text:00000000017243C3                 test    al, al
+  .text:00000000017243C5                 jnz     short loc_17243F0
+  .text:00000000017243C7                 mov     rdi, [rbp+var_138]
+  .text:00000000017243CE                 lea     rax, byte_93BAEA
+  .text:00000000017243D5                 lea     rsi, aError; "error"
+  .text:00000000017243DC                 test    rdi, rdi
+  .text:00000000017243DF                 cmovz   rdi, rax
+  .text:00000000017243E3                 call    sub_9EFFD0
+  .text:00000000017243E8                 test    eax, eax
+  .text:00000000017243EA                 jz      loc_1725236
+  .text:00000000017243F0                 mov     edi, 28h ; '('
+  .text:00000000017243F5                 call    sub_9E60E0
+  .text:00000000017243FA                 mov     rdi, [rbp+var_150]
+  .text:0000000001724401                 mov     rsi, rax
+  .text:0000000001724404                 lea     rax, off_23C0FB8
+  .text:000000000172440B                 mov     [rbx+8], rsi
+  .text:000000000172440F                 mov     [rsi], rax
+  .text:0000000001724412                 mov     rax, [rdi]
+  .text:0000000001724415                 mov     qword ptr [rsi+10h], 0
+  .text:000000000172441D                 mov     qword ptr [rsi+18h], 0
+  .text:0000000001724425                 mov     qword ptr [rsi+20h], 0
+  .text:000000000172442D                 mov     dword ptr [rsi+8], 1
+  .text:0000000001724434                 call    qword ptr [rax]
+  .text:0000000001724436                 lea     rax, g_pNetworkService
+  .text:000000000172443D                 mov     rdi, [rax]
+  .text:0000000001724440                 mov     rax, [rdi]
+  .text:0000000001724443                 call    qword ptr [rax+0C0h]
+  .text:0000000001724449                 mov     r8d, dword ptr [rbp+var_160]
+  .text:0000000001724450                 test    r8d, r8d
+  .text:0000000001724453                 jz      loc_1724AD0
+  .text:0000000001724459                 lea     rax, qword_28BAE70
+  .text:0000000001724460                 lea     rcx, byte_93BAEA
+  .text:0000000001724467                 mov     rdx, [rbp+var_138]
+  .text:000000000172446E                 lea     rsi, aDefaultsession; "defaultSession"
+  .text:0000000001724475                 mov     rdi, [rax]
+  .text:0000000001724478                 test    rdx, rdx
+  .text:000000000172447B                 cmovz   rdx, rcx
+  .text:000000000172447F                 mov     rcx, [rbx+8]
+  .text:0000000001724483                 mov     rax, [rdi]
+  .text:0000000001724486                 call    qword ptr [rax+68h]
+  .text:0000000001724489                 mov     rdi, rbx
+  .text:000000000172448C                 mov     r13, rax
+  .text:000000000172448F                 mov     rsi, rax
+  .text:0000000001724492                 call    CLoopModeGame_SetWorldSession
+  .text:0000000001724497                 mov     rax, [r13+0]
+  .text:000000000172449B                 lea     rsi, aCloopmodegameL; "--CLoopModeGame::LoopInit"
+  .text:00000000017244A2                 mov     rdi, r13
+  .text:00000000017244A5                 call    qword ptr [rax+8]
+  .text:00000000017244A8                 lea     rax, [rbp+var_B0]
+  .text:00000000017244AF                 xor     esi, esi
+  .text:00000000017244B1                 xor     edx, edx
+  .text:00000000017244B3                 mov     rdi, rax
+  .text:00000000017244B6                 mov     [rbp+var_160], rax
+  .text:00000000017244BD                 call    sub_12193A0
+  .text:00000000017244C2                 lea     rax, off_24A0B88
+  .text:00000000017244C9                 mov     [rbp+var_40], 0
+  .text:00000000017244D1                 or      dword ptr [rbp+var_A0], 20h
+  .text:00000000017244D8                 mov     qword ptr [rbp+var_B0], rax
+  .text:00000000017244DF                 mov     rax, qword ptr [rbp+var_B0+8]
+  .text:00000000017244E6                 mov     rsi, rax
+  .text:00000000017244E9                 and     rsi, 0FFFFFFFFFFFFFFFCh
+  .text:00000000017244ED                 test    al, 1
+  .text:00000000017244EF                 jnz     loc_17250A9
+  .text:00000000017244F5                 lea     rdi, [rbp+var_70]
+  .text:00000000017244F9                 call    sub_1C73016
+  .text:00000000017244FE                 cmp     cs:__pthread_key_create_ptr, 0
+  .text:0000000001724506                 mov     rdx, [rax]
+  .text:0000000001724509                 jz      loc_1724BB8
+  .text:000000000172450F                 mov     edx, [rdx-8]
+  .text:0000000001724512                 test    edx, edx
+  .text:0000000001724514                 mov     rdx, [rax]
+  .text:0000000001724517                 setnle  cl
+  .text:000000000172451A                 lea     rdi, [rdx-18h]
+  .text:000000000172451E                 test    cl, cl
+  .text:0000000001724520                 jz      loc_1724AA0
+  .text:0000000001724526                 mov     r14, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:000000000172452D                 cmp     rdi, r14
+  .text:0000000001724530                 jnz     loc_172510F
+  .text:0000000001724536                 lea     rdx, [r14+18h]
+  .text:000000000172453A                 mov     [rax], rdx
+  .text:000000000172453D                 lea     r15, qword_2841E20
+  .text:0000000001724544                 lea     rax, off_24A0C28
+  .text:000000000172454B                 mov     qword ptr [rbp+var_B0], rax
+  .text:0000000001724552                 mov     rdx, [rbp+var_160]
+  .text:0000000001724559                 mov     rsi, [rbp+var_148]
+  .text:0000000001724560                 mov     rdi, [r15]
+  .text:0000000001724563                 mov     rax, [rdi]
+  .text:0000000001724566                 call    qword ptr [rax+0A8h]
+  .text:000000000172456C                 test    al, al
+  .text:000000000172456E                 jz      loc_17248A3
+  .text:0000000001724574                 movzx   eax, [rbp+var_55]
+  .text:0000000001724578                 lea     rdi, [rbx+80h]
+  .text:000000000172457F                 mov     [rbx+6Dh], al
+  .text:0000000001724582                 movzx   eax, [rbp+var_56]
+  .text:0000000001724586                 mov     ah, [rbp+var_42]
+  .text:0000000001724589                 mov     [rbx+6Fh], ax
+  .text:000000000172458D                 mov     rax, [rbp+var_68]
+  .text:0000000001724591                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:0000000001724595                 mov     rsi, [rax]
+  .text:0000000001724598                 call    sub_9F0420
+  .text:000000000172459D                 mov     rax, [rbp+var_88]
+  .text:00000000017245A4                 lea     rdi, [rbx+88h]
+  .text:00000000017245AB                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:00000000017245AF                 mov     rsi, [rax]
+  .text:00000000017245B2                 call    sub_9F0420
+  .text:00000000017245B7                 lea     rax, g_pEntitySystem
+  .text:00000000017245BE                 mov     rax, [rax]
+  .text:00000000017245C1                 test    rax, rax
+  .text:00000000017245C4                 jz      short loc_17245D7
+  .text:00000000017245C6                 movzx   edx, [rbp+var_57]
+  .text:00000000017245CA                 mov     byte ptr [rax+0BDEh], 0
+  .text:00000000017245D1                 mov     [rax+0BDDh], dl
+  .text:00000000017245D7                 lea     rax, g_pNetworkServerService
+  .text:00000000017245DE                 lea     rdx, byte_93BAEA
+  .text:00000000017245E5                 mov     rcx, [rbp+var_138]
+  .text:00000000017245EC                 mov     rsi, [rbp+var_160]
+  .text:00000000017245F3                 mov     rdi, [rax]
+  .text:00000000017245F6                 test    rcx, rcx
+  .text:00000000017245F9                 cmovz   rcx, rdx
+  .text:00000000017245FD                 mov     rdx, r13
+  .text:0000000001724600                 mov     rax, [rdi]
+  .text:0000000001724603                 lea     r13, [rbp+var_100]
+  .text:000000000172460A                 call    qword ptr [rax+0D8h]
+  .text:0000000001724610                 lea     rax, g_pNetworkServerService
+  .text:0000000001724617                 mov     rdi, [rax]
+  .text:000000000172461A                 mov     rax, [rdi]
+  .text:000000000172461D                 call    qword ptr [rax+108h]
+  .text:0000000001724623                 xor     esi, esi
+  .text:0000000001724625                 mov     rdi, r13
+  .text:0000000001724628                 mov     [rbp+var_100], rax
+  .text:000000000172462F                 mov     dword ptr [rbp+var_F8], edx
+  .text:0000000001724635                 call    sub_9EF9E0
+  .text:000000000172463A                 or      dword ptr [rbp+var_A0], 10h
+  .text:0000000001724641                 mov     rsi, rax
+  .text:0000000001724644                 mov     rax, qword ptr [rbp+var_B0+8]
+  .text:000000000172464B                 mov     rcx, rax
+  .text:000000000172464E                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000001724652                 mov     [rbp+var_190], rcx
+  .text:0000000001724659                 test    al, 1
+  .text:000000000172465B                 jnz     loc_1725127
+  .text:0000000001724661                 test    rsi, rsi
+  .text:0000000001724664                 jz      loc_1723C36
+  .text:000000000172466A                 mov     rdi, rsi
+  .text:000000000172466D                 mov     [rbp+var_1A0], rsi
+  .text:0000000001724674                 call    sub_9F1BA0
+  .text:0000000001724679                 mov     rsi, [rbp+var_1A0]
+  .text:0000000001724680                 test    rax, rax
+  .text:0000000001724683                 mov     rdx, rax
+  .text:0000000001724686                 jz      loc_1724D90
+  .text:000000000172468C                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:0000000001724696                 cmp     rax, rdx
+  .text:0000000001724699                 jb      loc_1723C42
+  .text:000000000172469F                 lea     rax, [rdx+39h]
+  .text:00000000017246A3                 cmp     rax, 1000h
+  .text:00000000017246A9                 ja      short loc_17246F8
+  .text:00000000017246AB                 lea     rdi, [rdx+19h]
+  .text:00000000017246AF                 mov     [rbp+var_1A8], rsi
+  .text:00000000017246B6                 mov     [rbp+var_1A0], rdx
+  .text:00000000017246BD                 call    sub_9E60E0
+  .text:00000000017246C2                 mov     rdx, [rbp+var_1A0]
+  .text:00000000017246C9                 mov     rsi, [rbp+var_1A8]
+  .text:00000000017246D0                 mov     rcx, rax
+  .text:00000000017246D3                 mov     dword ptr [rax+10h], 0
+  .text:00000000017246DA                 lea     rdi, [rax+18h]
+  .text:00000000017246DE                 cmp     rdx, 1
+  .text:00000000017246E2                 mov     [rax+8], rdx
+  .text:00000000017246E6                 jnz     short loc_172475D
+  .text:00000000017246E8                 movzx   eax, byte ptr [rsi]
+  .text:00000000017246EB                 mov     [rcx+18h], al
+  .text:00000000017246EE                 jmp     loc_1724781
+  .text:00000000017246F8                 lea     r8, [rdx+1000h]
+  .text:00000000017246FF                 and     eax, 0FFFh
+  .text:0000000001724704                 mov     [rbp+var_1B0], rsi
+  .text:000000000172470B                 sub     r8, rax
+  .text:000000000172470E                 mov     [rbp+var_1A8], rdx
+  .text:0000000001724715                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:000000000172471F                 cmp     r8, rax
+  .text:0000000001724722                 cmova   r8, rax
+  .text:0000000001724726                 lea     rdi, [r8+19h]
+  .text:000000000172472A                 mov     [rbp+var_1A0], r8
+  .text:0000000001724731                 call    sub_9E60E0
+  .text:0000000001724736                 mov     r8, [rbp+var_1A0]
+  .text:000000000172473D                 mov     rdx, [rbp+var_1A8]
+  .text:0000000001724744                 lea     rdi, [rax+18h]
+  .text:0000000001724748                 mov     rcx, rax
+  .text:000000000172474B                 mov     dword ptr [rax+10h], 0
+  .text:0000000001724752                 mov     rsi, [rbp+var_1B0]
+  .text:0000000001724759                 mov     [rax+8], r8
+  .text:000000000172475D                 mov     [rbp+var_1A8], rcx
+  .text:0000000001724764                 mov     [rbp+var_1A0], rdx
+  .text:000000000172476B                 call    sub_9F1D30
+  .text:0000000001724770                 mov     rcx, [rbp+var_1A8]
+  .text:0000000001724777                 mov     rdx, [rbp+var_1A0]
+  .text:000000000172477E                 mov     rdi, rax
+  .text:0000000001724781                 cmp     rcx, r14
+  .text:0000000001724784                 jnz     loc_1725140
+  .text:000000000172478A                 mov     rdx, [rbp+var_190]
+  .text:0000000001724791                 lea     rax, [rbp+var_108]
+  .text:0000000001724798                 mov     [rbp+var_108], rdi
+  .text:000000000172479F                 lea     rdi, [rbp+var_78]
+  .text:00000000017247A3                 mov     rsi, rax
+  .text:00000000017247A6                 mov     [rbp+var_1A0], rax
+  .text:00000000017247AD                 call    sub_1C72D4E
+  .text:00000000017247B2                 mov     rax, [rbp+var_108]
+  .text:00000000017247B9                 lea     rdi, [rax-18h]
+  .text:00000000017247BD                 cmp     rdi, r14
+  .text:00000000017247C0                 jnz     loc_1725136
+  .text:00000000017247C6                 mov     rdi, [rbp+var_118]
+  .text:00000000017247CD                 test    rdi, rdi
+  .text:00000000017247D0                 jz      short loc_17247DF
+  .text:00000000017247D2                 call    sub_9F1BA0
+  .text:00000000017247D7                 test    eax, eax
+  .text:00000000017247D9                 jg      loc_1724F08
+  .text:00000000017247DF                 cmp     dword ptr [rbx+468h], 1
+  .text:00000000017247E6                 jz      short loc_17247F5
+  .text:00000000017247E8                 mov     esi, 1
+  .text:00000000017247ED                 mov     rdi, rbx
+  .text:00000000017247F0                 call    CLoopModeGame_SetGameSystemState
+  .text:00000000017247F5                 mov     rdi, rbx
+  .text:00000000017247F8                 call    sub_1711C90
+  .text:00000000017247FD                 mov     rdi, [r15]
+  .text:0000000001724800                 mov     rsi, [rbp+var_160]
+  .text:0000000001724807                 mov     rax, [rdi]
+  .text:000000000172480A                 call    qword ptr [rax+0B0h]
+  .text:0000000001724810                 test    al, al
+  .text:0000000001724812                 jz      loc_172522A
+  .text:0000000001724818                 mov     rdi, r13
+  .text:000000000172481B                 call    sub_17851A0
+  .text:0000000001724820                 cmp     dword ptr [rbx+468h], 2
+  .text:0000000001724827                 jz      short loc_1724836
+  .text:0000000001724829                 mov     esi, 2
+  .text:000000000172482E                 mov     rdi, rbx
+  .text:0000000001724831                 call    CLoopModeGame_SetGameSystemState
+  .text:0000000001724836                 mov     rsi, [rbp+var_150]
+  .text:000000000172483D                 mov     rdi, [rbp+var_160]
+  .text:0000000001724844                 call    IGameSystem_LoopInitAllSystems
+  .text:0000000001724849                 test    al, al
+  .text:000000000172484B                 jz      short loc_172489B
+  .text:000000000172484D                 cmp     dword ptr [rbx+468h], 3
+  .text:0000000001724854                 jz      short loc_1724863
+  .text:0000000001724856                 mov     esi, 3
+  .text:000000000172485B                 mov     rdi, rbx
+  .text:000000000172485E                 call    CLoopModeGame_SetGameSystemState
+  .text:0000000001724863                 mov     r14, [rbp+var_160]
+  .text:000000000172486A                 mov     rsi, [rbp+var_150]
+  .text:0000000001724871                 mov     rdi, r14
+  .text:0000000001724874                 call    IGameSystem_LoopPostInitAllSystems
+  .text:0000000001724879                 test    al, al
+  .text:000000000172487B                 jz      short loc_172489B
+  .text:000000000172487D                 mov     rdi, [r15]
+  .text:0000000001724880                 mov     rsi, r14
+  .text:0000000001724883                 mov     rdx, [rbp+var_150]
+  .text:000000000172488A                 mov     rax, [rdi]
+  .text:000000000172488D                 call    qword ptr [rax+0C8h]
+  .text:0000000001724893                 test    al, al
+  .text:0000000001724895                 jnz     loc_1724C8E
+  .text:000000000172489B                 mov     rdi, r13
+  .text:000000000172489E                 call    sub_17851D0
+  .text:00000000017248A3                 mov     rbx, [rbp+var_40]
+  .text:00000000017248A7                 lea     rax, off_24A0B88
+  .text:00000000017248AE                 mov     qword ptr [rbp+var_B0], rax
+  .text:00000000017248B5                 test    rbx, rbx
+  .text:00000000017248B8                 jz      short loc_17248D2
+  .text:00000000017248BA                 mov     rdi, rbx
+  .text:00000000017248BD                 call    sub_9EF8E0
+  .text:00000000017248C2                 mov     rdi, rbx
+  .text:00000000017248C5                 call    sub_9F0250
+  .text:00000000017248CA                 mov     [rbp+var_40], 0
+  .text:00000000017248D2                 mov     rdi, [rbp+var_160]
+  .text:00000000017248D9                 call    sub_12372B0
+  .text:00000000017248DE                 xor     r15d, r15d
+  .text:00000000017248E1                 nop     dword ptr [rax+00000000h]
+  .text:00000000017248E8                 cmp     [rbp+var_118], 0
+  .text:00000000017248F0                 jz      short loc_17248FE
+  .text:00000000017248F2                 lea     rdi, [rbp+var_118]
+  .text:00000000017248F9                 call    sub_9EF5F0
+  .text:00000000017248FE                 mov     eax, dword ptr [rbp+var_180]
+  .text:0000000001724904                 test    eax, eax
+  .text:0000000001724906                 js      short loc_1724957
+  .text:0000000001724908                 movsxd  rax, dword ptr [rbp+var_180]
+  .text:000000000172490F                 lea     rbx, [r12-30h]
+  .text:0000000001724914                 lea     rax, [rax+rax*4]
+  .text:0000000001724918                 shl     rax, 5
+  .text:000000000172491C                 lea     r13, [r12+rax+70h]
+  .text:0000000001724921                 nop     dword ptr [rax+00000000h]
+  .text:0000000001724928                 cmp     qword ptr [r13+8], 0
+  .text:000000000172492D                 jz      short loc_1724938
+  .text:000000000172492F                 lea     rdi, [r13+8]
+  .text:0000000001724933                 call    sub_9EF5F0
+  .text:0000000001724938                 cmp     qword ptr [r13+0], 0
+  .text:000000000172493D                 jz      loc_1724A60
+  .text:0000000001724943                 mov     rdi, r13
+  .text:0000000001724946                 sub     r13, 0A0h
+  .text:000000000172494D                 call    sub_9EF5F0
+  .text:0000000001724952                 cmp     rbx, r13
+  .text:0000000001724955                 jnz     short loc_1724928
+  .text:0000000001724957                 cmp     dword ptr [rbp+var_188+4], 3FFFFFFFh
+  .text:0000000001724961                 ja      short loc_172497B
+  .text:0000000001724963                 test    r12, r12
+  .text:0000000001724966                 jz      short loc_172497B
+  .text:0000000001724968                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:000000000172496F                 mov     rsi, r12
+  .text:0000000001724972                 mov     rdi, [rax]
+  .text:0000000001724975                 mov     rax, [rdi]
+  .text:0000000001724978                 call    qword ptr [rax+20h]
+  .text:000000000172497B                 movsxd  rax, dword ptr [rbp+var_F0]
+  .text:0000000001724982                 mov     edx, eax
+  .text:0000000001724984                 sub     edx, 1
+  .text:0000000001724987                 js      short loc_1724A03
+  .text:0000000001724989                 movsxd  rcx, edx
+  .text:000000000172498C                 mov     edx, edx
+  .text:000000000172498E                 lea     rbx, [rcx+rcx*2]
+  .text:0000000001724992                 sub     rax, rdx
+  .text:0000000001724995                 lea     r12, [rax+rax*2]
+  .text:0000000001724999                 shl     rbx, 5
+  .text:000000000172499D                 shl     r12, 5
+  .text:00000000017249A1                 sub     r12, 0C0h
+  .text:00000000017249A8                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000000017249B0                 mov     r13, [rbp+var_E8]
+  .text:00000000017249B7                 add     r13, rbx
+  .text:00000000017249BA                 cmp     qword ptr [r13+48h], 0
+  .text:00000000017249BF                 jz      short loc_17249CA
+  .text:00000000017249C1                 lea     rdi, [r13+48h]
+  .text:00000000017249C5                 call    sub_9EF5F0
+  .text:00000000017249CA                 cmp     qword ptr [r13+40h], 0
+  .text:00000000017249CF                 jz      short loc_17249DA
+  .text:00000000017249D1                 lea     rdi, [r13+40h]
+  .text:00000000017249D5                 call    sub_9EF5F0
+  .text:00000000017249DA                 cmp     qword ptr [r13+38h], 0
+  .text:00000000017249DF                 jz      short loc_17249EA
+  .text:00000000017249E1                 lea     rdi, [r13+38h]
+  .text:00000000017249E5                 call    sub_9EF5F0
+  .text:00000000017249EA                 cmp     qword ptr [r13+30h], 0
+  .text:00000000017249EF                 jz      short loc_1724A50
+  .text:00000000017249F1                 lea     rdi, [r13+30h]
+  .text:00000000017249F5                 sub     rbx, 60h ; '`'
+  .text:00000000017249F9                 call    sub_9EF5F0
+  .text:00000000017249FE                 cmp     r12, rbx
+  .text:0000000001724A01                 jnz     short loc_17249B0
+  .text:0000000001724A03                 cmp     dword ptr [rbp+var_E0+4], 3FFFFFFFh
+  .text:0000000001724A0D                 mov     dword ptr [rbp+var_F0], 0
+  .text:0000000001724A17                 ja      short loc_1724A35
+  .text:0000000001724A19                 mov     rsi, [rbp+var_E8]
+  .text:0000000001724A20                 test    rsi, rsi
+  .text:0000000001724A23                 jz      short loc_1724A35
+  .text:0000000001724A25                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:0000000001724A2C                 mov     rdi, [rax]
+  .text:0000000001724A2F                 mov     rax, [rdi]
+  .text:0000000001724A32                 call    qword ptr [rax+20h]
+  .text:0000000001724A35                 cmp     [rbp+var_120], 0
+  .text:0000000001724A3D                 jz      loc_1723EA4
+  .text:0000000001724A43                 jmp     loc_1723E98
+  .text:0000000001724A50                 sub     rbx, 60h ; '`'
+  .text:0000000001724A54                 cmp     rbx, r12
+  .text:0000000001724A57                 jnz     loc_17249B0
+  .text:0000000001724A5D                 jmp     short loc_1724A03
+  .text:0000000001724A60                 sub     r13, 0A0h
+  .text:0000000001724A67                 cmp     r13, rbx
+  .text:0000000001724A6A                 jnz     loc_1724928
+  .text:0000000001724A70                 jmp     loc_1724957
+  .text:0000000001724A78                 mov     dword ptr [rbp+var_180], 0FFFFFFFFh
+  .text:0000000001724A82                 xor     r12d, r12d
+  .text:0000000001724A85                 mov     dword ptr [rbp+var_188+4], 0
+  .text:0000000001724A8F                 mov     dword ptr [rbp+var_188], 0
+  .text:0000000001724A99                 jmp     loc_17243A4
+  .text:0000000001724AA0                 mov     r14, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:0000000001724AA7                 cmp     rdi, r14
+  .text:0000000001724AAA                 jz      loc_172453D
+  .text:0000000001724AB0                 mov     dword ptr [rdx-8], 0
+  .text:0000000001724AB7                 mov     qword ptr [rdx-18h], 0
+  .text:0000000001724ABF                 mov     byte ptr [rdx], 0
+  .text:0000000001724AC2                 jmp     loc_172453D
+  .text:0000000001724AD0                 lea     r15, qword_2841E20
+  .text:0000000001724AD7                 lea     r13, aCloopmodegameL_0; "CLoopModeGame::LoopInit"
+  .text:0000000001724ADE                 lea     rax, g_pResourceSystem
+  .text:0000000001724AE5                 mov     r8d, 0FFFFFFFFh
+  .text:0000000001724AEB                 mov     edx, 1
+  .text:0000000001724AF0                 mov     r14, [rbx+8]
+  .text:0000000001724AF4                 lea     rsi, aLoopmodegamest; "LoopModeGameStartup"
+  .text:0000000001724AFB                 mov     rcx, r13
+  .text:0000000001724AFE                 mov     rdi, [rax]
+  .text:0000000001724B01                 mov     rax, [rdi]
+  .text:0000000001724B04                 call    qword ptr [rax+0A0h]
+  .text:0000000001724B0A                 mov     r8, rax
+  .text:0000000001724B0D                 test    rax, rax
+  .text:0000000001724B10                 jz      short loc_1724B31
+  .text:0000000001724B12                 movsxd  rax, dword ptr [r14+10h]
+  .text:0000000001724B16                 mov     edx, eax
+  .text:0000000001724B18                 cmp     eax, [r14+20h]
+  .text:0000000001724B1C                 jz      loc_17250DD
+  .text:0000000001724B22                 add     edx, 1
+  .text:0000000001724B25                 mov     [r14+10h], edx
+  .text:0000000001724B29                 mov     rdx, [r14+18h]
+  .text:0000000001724B2D                 mov     [rdx+rax*8], r8
+  .text:0000000001724B31                 lea     rax, g_pResourceSystem
+  .text:0000000001724B38                 mov     r8d, 0FFFFFFFFh
+  .text:0000000001724B3E                 mov     rcx, r13
+  .text:0000000001724B41                 mov     edx, 1
+  .text:0000000001724B46                 mov     r14, [rbx+8]
+  .text:0000000001724B4A                 lea     rsi, aLoopmodegameSe; "LoopModeGame_server"
+  .text:0000000001724B51                 mov     rdi, [rax]
+  .text:0000000001724B54                 mov     rax, [rdi]
+  .text:0000000001724B57                 call    qword ptr [rax+0A8h]
+  .text:0000000001724B5D                 mov     rbx, rax
+  .text:0000000001724B60                 test    rax, rax
+  .text:0000000001724B63                 jz      short loc_1724B85
+  .text:0000000001724B65                 movsxd  r13, dword ptr [r14+10h]
+  .text:0000000001724B69                 mov     eax, r13d
+  .text:0000000001724B6C                 cmp     r13d, [r14+20h]
+  .text:0000000001724B70                 jz      loc_17250C6
+  .text:0000000001724B76                 add     eax, 1
+  .text:0000000001724B79                 mov     [r14+10h], eax
+  .text:0000000001724B7D                 mov     rax, [r14+18h]
+  .text:0000000001724B81                 mov     [rax+r13*8], rbx
+  .text:0000000001724B85                 mov     rdi, [r15]
+  .text:0000000001724B88                 test    rdi, rdi
+  .text:0000000001724B8B                 jz      short loc_1724BA7
+  .text:0000000001724B8D                 mov     rax, [rdi]
+  .text:0000000001724B90                 lea     rdx, nullsub_982
+  .text:0000000001724B97                 mov     rax, [rax+90h]
+  .text:0000000001724B9E                 cmp     rax, rdx
+  .text:0000000001724BA1                 jnz     loc_17250B1
+  .text:0000000001724BA7                 mov     r15d, 1
+  .text:0000000001724BAD                 jmp     loc_17248E8
+  .text:0000000001724BB8                 mov     edi, [rdx-8]
+  .text:0000000001724BBB                 test    edi, edi
+  .text:0000000001724BBD                 setnle  cl
+  .text:0000000001724BC0                 jmp     loc_172451A
+  .text:0000000001724BC8                 mov     dword ptr [rbp+var_1A8], eax
+  .text:0000000001724BCE                 mov     eax, dword ptr [rbp+var_188]
+  .text:0000000001724BD4                 mov     esi, 1
+  .text:0000000001724BD9                 mov     rcx, [rbp+var_180]
+  .text:0000000001724BE0                 lea     rdi, [rbp+var_C8]
+  .text:0000000001724BE7                 mov     [rbp+var_1A0], rdx
+  .text:0000000001724BEE                 mov     [rbp+var_D0], eax
+  .text:0000000001724BF4                 mov     dword ptr [rbp+var_C0], eax
+  .text:0000000001724BFA                 mov     eax, dword ptr [rbp+var_188+4]
+  .text:0000000001724C00                 mov     [rbp+var_C8], rcx
+  .text:0000000001724C07                 mov     dword ptr [rbp+var_C0+4], eax
+  .text:0000000001724C0D                 call    sub_1723B20
+  .text:0000000001724C12                 mov     rax, [rbp+var_C8]
+  .text:0000000001724C19                 mov     ebx, [rbp+var_D0]
+  .text:0000000001724C1F                 mov     rdx, [rbp+var_1A0]
+  .text:0000000001724C26                 mov     [rbp+var_180], rax
+  .text:0000000001724C2D                 mov     eax, dword ptr [rbp+var_C0]
+  .text:0000000001724C33                 mov     dword ptr [rbp+var_188], eax
+  .text:0000000001724C39                 mov     eax, dword ptr [rbp+var_C0+4]
+  .text:0000000001724C3F                 mov     dword ptr [rbp+var_188+4], eax
+  .text:0000000001724C45                 movsxd  rax, dword ptr [rbp+var_1A8]
+  .text:0000000001724C4C                 jmp     loc_1724051
+  .text:0000000001724C58                 mov     r12, [rbp+var_180]
+  .text:0000000001724C5F                 mov     dword ptr [rbp+var_188], r14d
+  .text:0000000001724C66                 mov     dword ptr [rbp+var_180], ebx
+  .text:0000000001724C6C                 mov     rbx, [rbp+var_1B8]
+  .text:0000000001724C73                 jmp     loc_17243A4
+  .text:0000000001724C80                 mov     dword ptr [rbx+68h], 2
+  .text:0000000001724C87                 xor     edi, edi
+  .text:0000000001724C89                 jmp     loc_1723CD3
+  .text:0000000001724C8E                 mov     rdi, r13
+  .text:0000000001724C91                 call    sub_17851D0
+  .text:0000000001724C96                 lea     rax, g_pNetworkServerService
+  .text:0000000001724C9D                 mov     rdi, [rax]
+  .text:0000000001724CA0                 lea     rax, qword_272E140
+  .text:0000000001724CA7                 mov     rsi, [rax]
+  .text:0000000001724CAA                 mov     rax, [rdi]
+  .text:0000000001724CAD                 call    qword ptr [rax+0E0h]
+  .text:0000000001724CB3                 mov     edx, dword ptr [rbp+var_188]
+  .text:0000000001724CB9                 test    edx, edx
+  .text:0000000001724CBB                 jle     short loc_1724D19
+  .text:0000000001724CBD                 lea     rax, qword_2868848 ; g_pEngineServer (IVEngineServer2* / CEngineServer*)
+  .text:0000000001724CC4                 mov     rsi, r12
+  .text:0000000001724CC7                 mov     rdi, [rax]
+  .text:0000000001724CCA                 mov     rax, [rdi]
+  .text:0000000001724CCD                 call    qword ptr [rax+1E0h] ; 1E0h = 0x1E0 = CEngineServer_UnloadSpawnGroup (vfunc_index 60)
+  .text:0000000001724CD3                 mov     [rbx+430h], eax
+  .text:0000000001724CD9                 mov     eax, dword ptr [rbp+var_188]
+  .text:0000000001724CDF                 cmp     eax, 1
+  .text:0000000001724CE2                 jz      short loc_1724D19
+  .text:0000000001724CE4                 lea     r13, [rax+rax*4]
+  .text:0000000001724CE8                 lea     r14, [r12+0A0h]
+  .text:0000000001724CF0                 shl     r13, 5
+  .text:0000000001724CF4                 add     r13, r12
+  .text:0000000001724CF7                 lea     rax, qword_2868848 ; g_pEngineServer (IVEngineServer2* / CEngineServer*)
+  .text:0000000001724CFE                 mov     rsi, r14
+  .text:0000000001724D01                 add     r14, 0A0h
+  .text:0000000001724D08                 mov     rdi, [rax]
+  .text:0000000001724D0B                 mov     rax, [rdi]
+  .text:0000000001724D0E                 call    qword ptr [rax+1E0h] ; 1E0h = 0x1E0 = CEngineServer_UnloadSpawnGroup (vfunc_index 60)
+  .text:0000000001724D14                 cmp     r14, r13
+  .text:0000000001724D17                 jnz     short loc_1724CF7
+  .text:0000000001724D19                 lea     rax, g_pNetworkServerService
+  .text:0000000001724D20                 lea     rdx, aGamesessionman_0; "GameSessionManifest"
+  .text:0000000001724D27                 mov     r8d, [rbp+var_194]
+  .text:0000000001724D2E                 mov     rcx, [rbp+var_150]
+  .text:0000000001724D35                 mov     rsi, [rbp+var_160]
+  .text:0000000001724D3C                 mov     rdi, [rax]
+  .text:0000000001724D3F                 and     r8d, 1
+  .text:0000000001724D43                 mov     rax, [rdi]
+  .text:0000000001724D46                 call    qword ptr [rax+0E8h]
+  .text:0000000001724D4C                 mov     r13, [rbp+var_40]
+  .text:0000000001724D50                 lea     rax, off_24A0B88
+  .text:0000000001724D57                 mov     qword ptr [rbp+var_B0], rax
+  .text:0000000001724D5E                 test    r13, r13
+  .text:0000000001724D61                 jz      short loc_1724D7B
+  .text:0000000001724D63                 mov     rdi, r13
+  .text:0000000001724D66                 call    sub_9EF8E0
+  .text:0000000001724D6B                 mov     rdi, r13
+  .text:0000000001724D6E                 call    sub_9F0250
+  .text:0000000001724D73                 mov     [rbp+var_40], 0
+  .text:0000000001724D7B                 mov     rdi, [rbp+var_160]
+  .text:0000000001724D82                 call    sub_12372B0
+  .text:0000000001724D87                 jmp     loc_1724AD7
+  .text:0000000001724D90                 lea     rdi, [r14+18h]
+  .text:0000000001724D94                 jmp     loc_172478A
+  .text:0000000001724DA0                 lea     rdi, [rbp+var_C8]
+  .text:0000000001724DA7                 mov     esi, 1
+  .text:0000000001724DAC                 mov     [rbp+var_D0], 0
+  .text:0000000001724DB6                 mov     [rbp+var_C8], 0
+  .text:0000000001724DC1                 mov     [rbp+var_C0], 0
+  .text:0000000001724DCC                 call    sub_1723B20
+  .text:0000000001724DD1                 mov     eax, [rbp+var_D0]
+  .text:0000000001724DD7                 movss   xmm1, dword ptr cs:xmmword_8CD150
+  .text:0000000001724DDF                 pxor    xmm0, xmm0
+  .text:0000000001724DE3                 mov     r12, [rbp+var_C8]
+  .text:0000000001724DEA                 mov     esi, 1
+  .text:0000000001724DEF                 lea     r13, dword_27BC7B0
+  .text:0000000001724DF6                 mov     dword ptr [rbp+var_180], eax
+  .text:0000000001724DFC                 mov     eax, dword ptr [rbp+var_C0+4]
+  .text:0000000001724E02                 movaps  xmmword ptr [r12+40h], xmm1
+  .text:0000000001724E08                 movaps  xmm1, cs:xmmword_8CABE0
+  .text:0000000001724E0F                 mov     [r12+98h], r14b
+  .text:0000000001724E17                 lea     r14, byte_93BAEA
+  .text:0000000001724E1E                 mov     edi, [r13+0]
+  .text:0000000001724E22                 movaps  xmmword ptr [r12+50h], xmm1
+  .text:0000000001724E28                 movaps  xmm1, xmmword ptr cs:dbl_8CCEB0
+  .text:0000000001724E2F                 mov     dword ptr [rbp+var_188+4], eax
+  .text:0000000001724E35                 mov     rax, 0FFFFFFFE00000000h
+  .text:0000000001724E3F                 mov     [r12+80h], rax
+  .text:0000000001724E47                 xor     eax, eax
+  .text:0000000001724E49                 mov     [r12+99h], ax
+  .text:0000000001724E52                 mov     rax, cs:qword_8CEBF8
+  .text:0000000001724E59                 movaps  xmmword ptr [r12], xmm0
+  .text:0000000001724E5E                 mov     qword ptr [r12+10h], 0
+  .text:0000000001724E67                 movaps  xmmword ptr [r12+20h], xmm0
+  .text:0000000001724E6D                 mov     [r12+90h], rax
+  .text:0000000001724E75                 mov     rax, [rbp+var_138]
+  .text:0000000001724E7C                 movaps  xmmword ptr [r12+30h], xmm0
+  .text:0000000001724E82                 movaps  xmmword ptr [r12+60h], xmm1
+  .text:0000000001724E88                 movaps  xmmword ptr [r12+70h], xmm0
+  .text:0000000001724E8E                 mov     byte ptr [r12+88h], 0FFh
+  .text:0000000001724E97                 test    rax, rax
+  .text:0000000001724E9A                 cmovz   rax, r14
+  .text:0000000001724E9E                 mov     dword ptr [r12+8Ch], 42B40000h
+  .text:0000000001724EAA                 mov     [r12], rax
+  .text:0000000001724EAE                 lea     rax, aMapload; "mapload"
+  .text:0000000001724EB5                 mov     [r12+18h], rax
+  .text:0000000001724EBA                 call    sub_9F0CA0
+  .text:0000000001724EBF                 test    al, al
+  .text:0000000001724EC1                 jz      short loc_1724EEF
+  .text:0000000001724EC3                 mov     edi, [r13+0]
+  .text:0000000001724EC7                 lea     rdx, aSaveFileSExpec; "save file '%s' expected to have a singl"...
+  .text:0000000001724ECE                 mov     esi, 1
+  .text:0000000001724ED3                 mov     rcx, [rbp+var_130]
+  .text:0000000001724EDA                 mov     r8d, dword ptr [rbp+var_F0]
+  .text:0000000001724EE1                 test    rcx, rcx
+  .text:0000000001724EE4                 cmovz   rcx, r14
+  .text:0000000001724EE8                 xor     eax, eax
+  .text:0000000001724EEA                 call    sub_9F0170
+  .text:0000000001724EEF                 mov     eax, dword ptr [rbp+var_180]
+  .text:0000000001724EF5                 add     eax, 1
+  .text:0000000001724EF8                 mov     dword ptr [rbp+var_188], eax
+  .text:0000000001724EFE                 jmp     loc_17243A4
+  .text:0000000001724F08                 mov     rdi, [rbp+var_1A0]
+  .text:0000000001724F0F                 mov     rsi, r13
+  .text:0000000001724F12                 mov     [rbp+var_100], 0
+  .text:0000000001724F1D                 mov     [rbp+var_F8], 0
+  .text:0000000001724F28                 call    sub_169A890
+  .text:0000000001724F2D                 cmp     [rbp+var_F8], 0
+  .text:0000000001724F35                 mov     r14, [rbp+var_108]
+  .text:0000000001724F3C                 jz      short loc_1724F4A
+  .text:0000000001724F3E                 lea     rdi, [rbp+var_F8]
+  .text:0000000001724F45                 call    sub_9EF5F0
+  .text:0000000001724F4A                 mov     rsi, [rbp+var_118]
+  .text:0000000001724F51                 mov     [rbp+var_F8], r14
+  .text:0000000001724F58                 mov     rdi, r13
+  .text:0000000001724F5B                 lea     r14, byte_93BAEA
+  .text:0000000001724F62                 test    rsi, rsi
+  .text:0000000001724F65                 cmovz   rsi, r14
+  .text:0000000001724F69                 call    sub_169A900
+  .text:0000000001724F6E                 test    al, al
+  .text:0000000001724F70                 jz      loc_172508A
+  .text:0000000001724F76                 lea     rax, g_pGameEntitySystem
+  .text:0000000001724F7D                 mov     rsi, r13
+  .text:0000000001724F80                 mov     rax, [rax]
+  .text:0000000001724F83                 mov     rdi, [rax+20E8h]
+  .text:0000000001724F8A                 mov     rax, [rdi]
+  .text:0000000001724F8D                 call    qword ptr [rax+0F0h]
+  .text:0000000001724F93                 lea     rax, g_pGameEntitySystem
+  .text:0000000001724F9A                 lea     rdx, [rbp+var_118]
+  .text:0000000001724FA1                 mov     rax, [rax]
+  .text:0000000001724FA4                 mov     rsi, [rax+20E8h]
+  .text:0000000001724FAB                 lea     rax, [rbp+var_110]
+  .text:0000000001724FB2                 mov     rdi, rax
+  .text:0000000001724FB5                 mov     [rbp+var_190], rax
+  .text:0000000001724FBC                 mov     rax, [rsi]
+  .text:0000000001724FBF                 call    qword ptr [rax+108h]
+  .text:0000000001724FC5                 lea     rax, dword_2844428
+  .text:0000000001724FCC                 mov     esi, 2
+  .text:0000000001724FD1                 mov     edi, [rax]
+  .text:0000000001724FD3                 call    sub_9F0CA0
+  .text:0000000001724FD8                 test    al, al
+  .text:0000000001724FDA                 jz      loc_1725074
+  .text:0000000001724FE0                 mov     rax, [rbp+var_110]
+  .text:0000000001724FE7                 mov     rsi, r13
+  .text:0000000001724FEA                 mov     r9, [rbp+var_118]
+  .text:0000000001724FF1                 mov     rdi, [rbp+var_1A0]
+  .text:0000000001724FF8                 test    rax, rax
+  .text:0000000001724FFB                 cmovz   rax, r14
+  .text:0000000001724FFF                 test    r9, r9
+  .text:0000000001725002                 cmovz   r9, r14
+  .text:0000000001725006                 mov     [rbp+var_1B0], rax
+  .text:000000000172500D                 mov     [rbp+var_1A8], r9
+  .text:0000000001725014                 call    sub_169A890
+  .text:0000000001725019                 lea     rax, dword_2844428
+  .text:0000000001725020                 mov     esi, 2
+  .text:0000000001725025                 mov     r8, [rbp+var_108]
+  .text:000000000172502C                 lea     rdx, aEtRestoringGam; "ET:  Restoring game at %u %s : '%s'\nET"...
+  .text:0000000001725033                 mov     edi, [rax]
+  .text:0000000001725035                 mov     rax, [rbp+var_1B0]
+  .text:000000000172503C                 test    r8, r8
+  .text:000000000172503F                 cmovz   r8, r14
+  .text:0000000001725043                 sub     rsp, 8
+  .text:0000000001725047                 push    rax
+  .text:0000000001725048                 mov     ecx, dword ptr [rbp+var_100]
+  .text:000000000172504E                 xor     eax, eax
+  .text:0000000001725050                 mov     r9, [rbp+var_1A8]
+  .text:0000000001725057                 call    sub_9F0170
+  .text:000000000172505C                 cmp     [rbp+var_108], 0
+  .text:0000000001725064                 pop     rcx
+  .text:0000000001725065                 pop     rsi
+  .text:0000000001725066                 jz      short loc_1725074
+  .text:0000000001725068                 mov     rdi, [rbp+var_1A0]
+  .text:000000000172506F                 call    sub_9EF5F0
+  .text:0000000001725074                 cmp     [rbp+var_110], 0
+  .text:000000000172507C                 jz      short loc_172508A
+  .text:000000000172507E                 mov     rdi, [rbp+var_190]
+  .text:0000000001725085                 call    sub_9EF5F0
+  .text:000000000172508A                 cmp     [rbp+var_F8], 0
+  .text:0000000001725092                 jz      loc_17247DF
+  .text:0000000001725098                 lea     rdi, [rbp+var_F8]
+  .text:000000000172509F                 call    sub_9EF5F0
+  .text:00000000017250A4                 jmp     loc_17247DF
+  .text:00000000017250A9                 mov     rsi, [rsi]
+  .text:00000000017250AC                 jmp     loc_17244F5
+  .text:00000000017250B1                 mov     rdx, [rbp+var_150]
+  .text:00000000017250B8                 mov     rsi, [rbp+var_148]
+  .text:00000000017250BF                 call    rax
+  .text:00000000017250C1                 jmp     loc_1724BA7
+  .text:00000000017250C6                 lea     rdi, [r14+18h]
+  .text:00000000017250CA                 mov     esi, 1
+  .text:00000000017250CF                 call    sub_ECF100
+  .text:00000000017250D4                 mov     eax, [r14+10h]
+  .text:00000000017250D8                 jmp     loc_1724B76
+  .text:00000000017250DD                 lea     rdi, [r14+18h]
+  .text:00000000017250E1                 mov     esi, 1
+  .text:00000000017250E6                 mov     dword ptr [rbp+var_188], eax
+  .text:00000000017250EC                 mov     [rbp+var_160], r8
+  .text:00000000017250F3                 call    sub_ECF100
+  .text:00000000017250F8                 mov     edx, [r14+10h]
+  .text:00000000017250FC                 movsxd  rax, dword ptr [rbp+var_188]
+  .text:0000000001725103                 mov     r8, [rbp+var_160]
+  .text:000000000172510A                 jmp     loc_1724B22
+  .text:000000000172510F                 mov     [rbp+var_190], rax
+  .text:0000000001725116                 call    sub_170BBB0
+  .text:000000000172511B                 mov     rax, [rbp+var_190]
+  .text:0000000001725122                 jmp     loc_1724536
+  .text:0000000001725127                 mov     rax, [rcx]
+  .text:000000000172512A                 mov     [rbp+var_190], rax
+  .text:0000000001725131                 jmp     loc_1724661
+  .text:0000000001725136                 call    sub_170BBB0
+  .text:000000000172513B                 jmp     loc_17247C6
+  .text:0000000001725140                 mov     [rcx], rdx
+  .text:0000000001725143                 mov     byte ptr [rcx+rdx+18h], 0
+  .text:0000000001725148                 jmp     loc_172478A
+  .text:0000000001725150                 mov     ecx, 60h ; '`'
+  .text:0000000001725155                 mov     edx, 1
+  .text:000000000172515A                 xor     esi, esi
+  .text:000000000172515C                 xor     edi, edi
+  .text:000000000172515E                 call    sub_9F0E30
+  .text:0000000001725163                 mov     r12d, eax
+  .text:0000000001725166                 test    eax, eax
+  .text:0000000001725168                 jle     loc_1725228
+  .text:000000000172516E                 movsxd  rax, dword ptr [rbp+var_E0]
+  .text:0000000001725175                 xor     esi, esi
+  .text:0000000001725177                 mov     rdi, [rbp+var_E8]
+  .text:000000000172517E                 lea     rcx, [rax+rax*2]
+  .text:0000000001725182                 movsxd  rax, r12d
+  .text:0000000001725185                 lea     rdx, [rax+rax*2]
+  .text:0000000001725189                 shl     rcx, 5
+  .text:000000000172518D                 shl     rdx, 5
+  .text:0000000001725191                 cmp     dword ptr [rbp+var_E0+4], 3FFFFFFFh
+  .text:000000000172519B                 setbe   sil
+  .text:000000000172519F                 call    sub_9F1010
+  .text:00000000017251A4                 mov     rdi, rax
+  .text:00000000017251A7                 mov     [rbp+var_E8], rax
+  .text:00000000017251AE                 mov     eax, dword ptr [rbp+var_E0+4]
+  .text:00000000017251B4                 cmp     eax, 3FFFFFFFh
+  .text:00000000017251B9                 jbe     short loc_17251C6
+  .text:00000000017251BB                 and     eax, 3FFFFFFFh
+  .text:00000000017251C0                 mov     dword ptr [rbp+var_E0+4], eax
+  .text:00000000017251C6                 xor     eax, eax
+  .text:00000000017251C8                 pxor    xmm0, xmm0
+  .text:00000000017251CC                 mov     byte ptr [rdi+52h], 0
+  .text:00000000017251D0                 mov     [rdi+50h], ax
+  .text:00000000017251D4                 add     dword ptr [rbp+var_F0], 1
+  .text:00000000017251DB                 movaps  xmmword ptr [rdi+30h], xmm0
+  .text:00000000017251DF                 movaps  xmmword ptr [rdi+40h], xmm0
+  .text:00000000017251E3                 mov     dword ptr [rbp+var_E0], r12d
+  .text:00000000017251EA                 call    sub_1D1CD20
+  .text:00000000017251EF                 mov     r12, [rbp+var_E8]
+  .text:00000000017251F6                 mov     rsi, [rbp+var_138]
+  .text:00000000017251FD                 lea     rdi, [r12+30h]
+  .text:0000000001725202                 call    sub_170CD50
+  .text:0000000001725207                 mov     rsi, [rbp+var_130]
+  .text:000000000172520E                 lea     rdi, [r12+40h]
+  .text:0000000001725213                 call    sub_170CD50
+  .text:0000000001725218                 mov     eax, 1
+  .text:000000000172521D                 mov     [r12+50h], ax
+  .text:0000000001725223                 jmp     loc_1723FA8
+  .text:0000000001725228                 jmp     short loc_1725228
+  .text:000000000172522A                 lea     rdi, aLevelinitworld; "LevelInitWorld failed!\n"
+  .text:0000000001725231                 call    sub_9EF870
+  .text:0000000001725236                 lea     rbx, dword_2868900
+  .text:000000000172523D                 mov     esi, 3
+  .text:0000000001725242                 mov     edi, [rbx]
+  .text:0000000001725244                 call    sub_9F0CA0
+  .text:0000000001725249                 test    al, al
+  .text:000000000172524B                 jnz     loc_17252E7
+  .text:0000000001725251                 lea     rax, g_pNetworkClientService
+  .text:0000000001725258                 mov     rdx, [rbp+var_138]
+  .text:000000000172525F                 mov     rdi, [rax]
+  .text:0000000001725262                 mov     rax, [rdi]
+  .text:0000000001725265                 mov     rax, [rax+0E8h]
+  .text:000000000172526C                 test    rdx, rdx
+  .text:000000000172526F                 jz      loc_1725301
+  .text:0000000001725275                 mov     esi, 40h ; '@'
+  .text:000000000172527A                 call    rax
+  .text:000000000172527C                 lea     rax, aLoopinit; "LoopInit"
+  .text:0000000001725283                 movq    xmm0, cs:off_24A2900; "../../game/shared/loopmodegame.cpp"
+  .text:000000000172528B                 mov     [rbp+var_98], 28Ch
+  .text:0000000001725295                 lea     rdi, [rbp+var_B0]
+  .text:000000000172529C                 pinsrq  xmm0, rax, 1
+  .text:00000000017252A3                 lea     rax, aFalse; "false"
+  .text:00000000017252AA                 movaps  [rbp+var_B0], xmm0
+  .text:00000000017252B1                 mov     [rbp+var_A0], rax
+  .text:00000000017252B8                 movzx   eax, [rbp+var_94]
+  .text:00000000017252BF                 lea     rsi, aErrorMap; "Error map!"
+  .text:00000000017252C6                 and     eax, 0FFFFFF80h
+  .text:00000000017252C9                 or      eax, 14h
+  .text:00000000017252CC                 mov     [rbp+var_94], al
+  .text:00000000017252D2                 xor     eax, eax
+  .text:00000000017252D4                 call    sub_9F0D10
+  .text:00000000017252D9                 test    al, al
+  .text:00000000017252DB                 jz      loc_17248DE
+  .text:00000000017252E1                 ; Trap to Debugger
+  .text:00000000017252E1                 int     3; Trap to Debugger
+  .text:00000000017252E2                 jmp     loc_17248DE
+  .text:00000000017252E7                 mov     edi, [rbx]
+  .text:00000000017252E9                 lea     rdx, aLoopinitInErro; "LoopInit:  in \"error\" map - disconnec"...
+  .text:00000000017252F0                 mov     esi, 3
+  .text:00000000017252F5                 xor     eax, eax
+  .text:00000000017252F7                 call    sub_9F0170
+  .text:00000000017252FC                 jmp     loc_1725251
+  .text:0000000001725301                 lea     rdx, byte_93BAEA
+  .text:0000000001725308                 jmp     loc_1725275
+procedure: |-
+  __int64 __fastcall CLoopModeGame_LoopInitInternal(__int64 a1, __m128i *a2, __m128i *a3, __m128 si128, double a5)
+  {
+    __int64 v5; // rbx
+    const char *v6; // r13
+    __int64 v7; // rax
+    int v8; // eax
+    _BOOL8 v9; // rdi
+    __int64 v10; // rax
+    __int64 v11; // rax
+    __int64 v12; // rax
+    __int64 v13; // rax
+    __m128i *v14; // rsi
+    int v15; // r12d
+    int v16; // r13d
+    bool v17; // r15
+    bool v18; // r14
+    unsigned int v19; // r15d
+    bool v21; // zf
+    const char *v22; // r12
+    const char *v23; // rax
+    __int64 v24; // r15
+    __int64 i; // rax
+    int v26; // ebx
+    const __m128i *v27; // rdx
+    __int64 v28; // r12
+    const char *v29; // rax
+    const char *v30; // rax
+    __int8 v31; // al
+    const __m128i *v32; // rdx
+    int v33; // eax
+    const char *v34; // rdx
+    const char *v35; // r8
+    int v36; // edx
+    __int64 v37; // r12
+    int v38; // ecx
+    const char *v39; // rax
+    const char *v40; // rdi
+    __int64 v41; // rsi
+    void (__fastcall **v42)(__m128i *, double, double); // rax
+    const char *v43; // rdx
+    void (__fastcall ***v44)(_QWORD, const char *); // r13
+    _QWORD *v45; // rsi
+    _BYTE **v46; // rax
+    _BYTE *v47; // rdx
+    int v48; // edx
+    bool v49; // sf
+    bool v50; // cl
+    _BYTE *v51; // rdi
+    __int16 v52; // ax
+    const char *v53; // rcx
+    int v54; // edx
+    __int64 v55; // rax
+    _BYTE *v56; // rsi
+    unsigned __int64 v57; // rdx
+    __int64 v58; // rax
+    unsigned __int64 v59; // rdx
+    _BYTE *v60; // rcx
+    const char *v61; // rdi
+    unsigned __int64 v62; // r8
+    __int64 v63; // rax
+    __int64 v64; // rax
+    __int64 v65; // rbx
+    _QWORD *v66; // rbx
+    _QWORD *v67; // r13
+    _QWORD *v68; // rdi
+    __int64 v69; // rdx
+    __int64 v70; // rbx
+    unsigned __int64 v71; // r12
+    __m128i *v72; // r13
+    __int64 v73; // r14
+    __int64 v74; // r8
+    __int64 v75; // rax
+    int v76; // edx
+    __int64 v77; // r14
+    __int64 v78; // rdx
+    __int64 v79; // rbx
+    __int64 v80; // r13
+    int v81; // eax
+    __int64 (__fastcall *v82)(); // rax
+    __int64 v83; // r14
+    __int64 v84; // rsi
+    __int64 v85; // r13
+    int v86; // eax
+    __int64 v87; // rdi
+    const char *v88; // rax
+    const char *v89; // rcx
+    const char *v90; // r14
+    const char *v91; // rsi
+    const char *v92; // rax
+    const char *v93; // r9
+    const char *v94; // r8
+    int v95; // eax
+    int v96; // r12d
+    __int64 v97; // rdi
+    __m128i *v98; // r12
+    const char *v99; // [rsp-8h] [rbp-1C8h]
+    __int64 v100; // [rsp+8h] [rbp-1B8h]
+    const char *v101; // [rsp+10h] [rbp-1B0h]
+    const char *v102; // [rsp+10h] [rbp-1B0h]
+    unsigned __int64 v103; // [rsp+18h] [rbp-1A8h]
+    _BYTE *v104; // [rsp+18h] [rbp-1A8h]
+    int v105; // [rsp+18h] [rbp-1A8h]
+    const char *v106; // [rsp+18h] [rbp-1A8h]
+    const __m128i *v107; // [rsp+20h] [rbp-1A0h]
+    unsigned __int64 v108; // [rsp+20h] [rbp-1A0h]
+    unsigned __int64 v109; // [rsp+20h] [rbp-1A0h]
+    unsigned __int64 v110; // [rsp+20h] [rbp-1A0h]
+    const __m128i *v111; // [rsp+20h] [rbp-1A0h]
+    bool v112; // [rsp+2Ch] [rbp-194h]
+    unsigned __int64 v113; // [rsp+30h] [rbp-190h]
+    _BYTE **v114; // [rsp+30h] [rbp-190h]
+    __int64 v115; // [rsp+38h] [rbp-188h]
+    int v116; // [rsp+38h] [rbp-188h]
+    __int64 v117; // [rsp+40h] [rbp-180h]
+    int v118; // [rsp+40h] [rbp-180h]
+    unsigned int v119; // [rsp+60h] [rbp-160h]
+    __int64 v120; // [rsp+60h] [rbp-160h]
+    const char *v123; // [rsp+88h] [rbp-138h] BYREF
+    const char *v124; // [rsp+90h] [rbp-130h] BYREF
+    __int64 v125; // [rsp+98h] [rbp-128h] BYREF
+    __int64 v126; // [rsp+A0h] [rbp-120h] BYREF
+    const char *v127; // [rsp+A8h] [rbp-118h] BYREF
+    const char *v128; // [rsp+B0h] [rbp-110h] BYREF
+    const char *v129; // [rsp+B8h] [rbp-108h] BYREF
+    __int64 v130; // [rsp+C0h] [rbp-100h] BYREF
+    const char *v131; // [rsp+C8h] [rbp-F8h] BYREF
+    __int64 v132; // [rsp+D0h] [rbp-F0h] BYREF
+    __m128i *v133; // [rsp+D8h] [rbp-E8h]
+    __int64 v134; // [rsp+E0h] [rbp-E0h]
+    int v135; // [rsp+F0h] [rbp-D0h]
+    __int64 v136; // [rsp+F8h] [rbp-C8h] BYREF
+    __int64 v137; // [rsp+100h] [rbp-C0h]
+    __m128 v138; // [rsp+110h] [rbp-B0h] BYREF
+    const char *v139; // [rsp+120h] [rbp-A0h]
+    int v140; // [rsp+128h] [rbp-98h]
+    char v141; // [rsp+12Ch] [rbp-94h]
+    char v142[8]; // [rsp+148h] [rbp-78h] BYREF
+    _BYTE v143[48]; // [rsp+150h] [rbp-70h] BYREF
+    __int64 v144; // [rsp+180h] [rbp-40h]
+
+    v5 = a1;
+    v6 = &byte_93BAEA;
+    v7 = sub_9EF5C0(a2, "mode");
+    if ( v7 )
+      v6 = (const char *)sub_9F1070(v7, &byte_93BAEA, 0, 0);
+    if ( !(unsigned int)sub_9EFFD0(v6, "listenserver") )
+    {
+      v8 = 3;
+  LABEL_5:
+      *(_DWORD *)(a1 + 104) = v8;
+      v9 = 1;
+      v119 = 1;
+      goto LABEL_6;
+    }
+    v36 = sub_9EFFD0(v6, "dedicated");
+    v8 = 1;
+    if ( !v36 )
+      goto LABEL_5;
+    v119 = sub_9EFFD0(v6, "remoteclient");
+    if ( v119 )
+    {
+      v119 = *(_DWORD *)(a1 + 104) & 1;
+      v9 = *(_DWORD *)(a1 + 104) != 2;
+    }
+    else
+    {
+      *(_DWORD *)(a1 + 104) = 2;
+      v9 = 0;
+    }
+  LABEL_6:
+    sub_EC67A0(v9);
+    v10 = sub_9EF5C0(a2, "levelname");
+    if ( v10 )
+      sub_9F1070(v10, &byte_93BAEA, 0, 0);
+    v123 = nullptr;
+    sub_9F0420(&v123);
+    v11 = sub_9EF5C0(a2, "savegame");
+    if ( v11 )
+      sub_9F1070(v11, &byte_93BAEA, 0, 0);
+    v124 = nullptr;
+    sub_9F0420(&v124);
+    v12 = sub_9EF5C0(a2, "landmarkname");
+    if ( v12 )
+      sub_9F1070(v12, &byte_93BAEA, 0, 0);
+    v125 = 0;
+    sub_9F0420(&v125);
+    v13 = sub_9EF5C0(a2, "previouslevel");
+    if ( v13 )
+      sub_9F1070(v13, &byte_93BAEA, 0, 0);
+    v126 = 0;
+    sub_9F0420(&v126);
+    v14 = (__m128i *)"changelevel";
+    v15 = sub_9F1130(a2, "loadmap", 0);
+    v16 = sub_9F1130(a2, "changelevel", 0);
+    v17 = v15 == 0;
+    if ( v126 )
+    {
+      v18 = 0;
+      if ( (int)sub_9F1BA0(v126) > 0 && v125 )
+        v18 = (int)sub_9F1BA0(v125) > 0;
+      *(_BYTE *)(v5 + 108) = v17;
+      v19 = 1;
+      if ( !v15 )
+      {
+  LABEL_19:
+        sub_9EF5F0(&v126, v14->m128i_i8, *(double *)si128.m128_u64, a5);
+        goto LABEL_20;
+      }
+    }
+    else
+    {
+      *(_BYTE *)(v5 + 108) = v17;
+      v18 = 0;
+      v19 = 1;
+      if ( !v15 )
+        goto LABEL_20;
+    }
+    v132 = 0;
+    v112 = v16 != 0;
+    v21 = *(_DWORD *)(v5 + 104) == 2;
+    v133 = nullptr;
+    v134 = 0;
+    v127 = nullptr;
+    if ( v21 )
+      goto LABEL_146;
+    v22 = v124;
+    if ( v124 && (int)sub_9F1BA0(v124) > 0 )
+    {
+      if ( v16 )
+      {
+        v95 = sub_9F0E30(0, 0, 1, 96);
+        v96 = v95;
+        if ( v95 <= 0 )
+        {
+          while ( 1 )
+            ;
+        }
+        v97 = sub_9F1010(v133, HIDWORD(v134) <= 0x3FFFFFFF, 96LL * v95, 96LL * (int)v134);
+        v133 = (__m128i *)v97;
+        if ( HIDWORD(v134) > 0x3FFFFFFF )
+          HIDWORD(v134) &= 0x3FFFFFFFu;
+        si128.m128_u64[0] = 0;
+        *(_BYTE *)(v97 + 82) = 0;
+        *(_WORD *)(v97 + 80) = 0;
+        LODWORD(v132) = v132 + 1;
+        *(_OWORD *)(v97 + 48) = 0;
+        *(_OWORD *)(v97 + 64) = 0;
+        LODWORD(v134) = v96;
+        sub_1D1CD20(v97);
+        v98 = v133;
+        sub_170CD50(&v133[3], v123);
+        sub_170CD50(&v98[4], v124);
+        v98[5].m128i_i16[0] = 1;
+      }
+      else
+      {
+        (*(void (__fastcall **)(_QWORD *, const char *, __int64 *, _QWORD, _QWORD, const char **, double, double))(*g_pSource2Server + 416LL))(
+          g_pSource2Server,
+          v22,
+          &v132,
+          v119,
+          0,
+          &v127,
+          *(double *)si128.m128_u64,
+          a5);
+      }
+      if ( (_DWORD)v132 )
+      {
+        if ( (int)v132 > 0 )
+        {
+          v115 = 0;
+          v23 = "loading";
+          v100 = v5;
+          if ( v16 )
+            v23 = "transitioning";
+          v24 = 0;
+          v117 = 0;
+          v101 = v23;
+          for ( i = 0; ; i = v26 + 1 )
+          {
+            v26 = i;
+            v27 = &v133[6 * v24];
+            if ( (_DWORD)v115 == (_DWORD)i )
+            {
+              v105 = i;
+              v111 = &v133[6 * v24];
+              v135 = v115;
+              v137 = v115;
+              v136 = v117;
+              sub_1723B20(&v136, 1);
+              v26 = v135;
+              v27 = v111;
+              v117 = v136;
+              v115 = v137;
+              i = v105;
+            }
+            v28 = v117 + 160 * i;
+            *(_QWORD *)(v28 + 128) = 0xFFFFFFFE00000000LL;
+            *(_WORD *)(v28 + 153) = 0;
+            *(_OWORD *)v28 = 0;
+            *(_OWORD *)(v28 + 16) = 0;
+            *(_OWORD *)(v28 + 64) = 0x3F800000u;
+            *(_QWORD *)(v28 + 144) = 0x100000001000001LL;
+            *(_OWORD *)(v28 + 80) = xmmword_8CABE0;
+            *(_OWORD *)(v28 + 96) = *(_OWORD *)&dbl_8CCEB0;
+            *(_OWORD *)(v28 + 32) = 0;
+            *(_OWORD *)(v28 + 48) = 0;
+            *(_OWORD *)(v28 + 112) = 0;
+            *(_BYTE *)(v28 + 136) = -1;
+            *(_BYTE *)(v28 + 152) = v18;
+            *(_DWORD *)(v28 + 140) = 1119092736;
+            v29 = (const char *)v27[3].m128i_i64[0];
+            if ( !v29 )
+              v29 = &byte_93BAEA;
+            *(_QWORD *)v28 = v29;
+            v30 = (const char *)v27[4].m128i_i64[1];
+            if ( !v30 )
+              v30 = &byte_93BAEA;
+            *(_QWORD *)(v28 + 16) = v30;
+            *(__m128i *)(v28 + 64) = _mm_load_si128(v27);
+            *(__m128i *)(v28 + 80) = _mm_load_si128(v27 + 1);
+            si128 = (__m128)_mm_load_si128(v27 + 2);
+            *(__m128 *)(v28 + 96) = si128;
+            v31 = v27[5].m128i_i8[2];
+            *(_BYTE *)(v28 + 153) = v31;
+            if ( !v31 )
+            {
+              v107 = v27;
+              sub_170CD50(v28 + 120, v27[4].m128i_i64[0]);
+              v32 = v107;
+              if ( !v123 || (v33 = sub_9F1BA0(v123), v32 = v107, !v33) )
+              {
+                sub_170CD50(&v123, v32[3].m128i_i64[0]);
+                v34 = v123;
+                if ( !v123 )
+                  v34 = &byte_93BAEA;
+                sub_9F0BE0(a2, "levelname", v34);
+              }
+              if ( (unsigned __int8)sub_9F0CA0((unsigned int)dword_27BC7B0, 1) )
+              {
+                v35 = *(const char **)(v28 + 120);
+                if ( !v35 )
+                  v35 = &byte_93BAEA;
+                sub_9F0170((unsigned int)dword_27BC7B0, 1, "%s %s.HL%s from save file on %s\n", v101, v35, "1", "server");
+              }
+            }
+            if ( (int)v132 <= (int)++v24 )
+              break;
+          }
+          v37 = v117;
+          LODWORD(v115) = v26 + 1;
+          v118 = v26;
+          v5 = v100;
+          goto LABEL_62;
+        }
+  LABEL_146:
+        v118 = -1;
+        v37 = 0;
+        v115 = 0;
+        goto LABEL_62;
+      }
+      v135 = 0;
+      v136 = 0;
+      v137 = 0;
+      sub_1723B20(&v136, 1);
+      si128.m128_u64[0] = 0;
+      v37 = v136;
+      v118 = v135;
+      v86 = HIDWORD(v137);
+      *(_OWORD *)(v136 + 64) = 0x3F800000u;
+      *(_BYTE *)(v37 + 152) = v18;
+      v87 = (unsigned int)dword_27BC7B0;
+      *(_OWORD *)(v37 + 80) = xmmword_8CABE0;
+      a5 = 0.0;
+      HIDWORD(v115) = v86;
+      *(_QWORD *)(v37 + 128) = 0xFFFFFFFE00000000LL;
+      *(_WORD *)(v37 + 153) = 0;
+      *(_OWORD *)v37 = 0;
+      *(_QWORD *)(v37 + 16) = 0;
+      *(_OWORD *)(v37 + 32) = 0;
+      *(_QWORD *)(v37 + 144) = 0x100000001000001LL;
+      v88 = v123;
+      *(_OWORD *)(v37 + 48) = 0;
+      *(_OWORD *)(v37 + 96) = *(_OWORD *)&dbl_8CCEB0;
+      *(_OWORD *)(v37 + 112) = 0;
+      *(_BYTE *)(v37 + 136) = -1;
+      if ( !v88 )
+        v88 = &byte_93BAEA;
+      *(_DWORD *)(v37 + 140) = 1119092736;
+      *(_QWORD *)v37 = v88;
+      *(_QWORD *)(v37 + 24) = "mapload";
+      if ( (unsigned __int8)sub_9F0CA0(v87, 1) )
+      {
+        v89 = v124;
+        if ( !v124 )
+          v89 = &byte_93BAEA;
+        sub_9F0170(
+          (unsigned int)dword_27BC7B0,
+          1,
+          "save file '%s' expected to have a single entry [%d]. Loading base level.",
+          v89,
+          (unsigned int)v132);
+      }
+      LODWORD(v115) = v118 + 1;
+    }
+    else
+    {
+      v135 = 0;
+      v136 = 0;
+      v137 = 0;
+      sub_1723B20(&v136, 1);
+      si128.m128_u64[0] = 0;
+      v37 = v136;
+      v38 = HIDWORD(v137);
+      v118 = v135;
+      LODWORD(v115) = v135 + 1;
+      *(_QWORD *)(v136 + 128) = 0xFFFFFFFE00000000LL;
+      *(_OWORD *)(v37 + 64) = 0x3F800000u;
+      *(_OWORD *)v37 = 0;
+      *(_OWORD *)(v37 + 80) = xmmword_8CABE0;
+      a5 = 0.0;
+      *(_QWORD *)(v37 + 144) = 0x100000001000001LL;
+      v39 = v123;
+      HIDWORD(v115) = v38;
+      *(_QWORD *)(v37 + 16) = 0;
+      *(_OWORD *)(v37 + 32) = 0;
+      *(_OWORD *)(v37 + 48) = 0;
+      if ( !v39 )
+        v39 = &byte_93BAEA;
+      *(_OWORD *)(v37 + 96) = *(_OWORD *)&dbl_8CCEB0;
+      *(_OWORD *)(v37 + 112) = 0;
+      *(_QWORD *)v37 = v39;
+      *(_BYTE *)(v37 + 136) = -1;
+      *(_WORD *)(v37 + 153) = 0;
+      *(_BYTE *)(v37 + 152) = v18;
+      *(_DWORD *)(v37 + 140) = 1119092736;
+      *(_QWORD *)(v37 + 24) = "mapload";
+    }
+  LABEL_62:
+    if ( v119
+      && !(*(unsigned __int8 (__fastcall **)(_QWORD *, double, double))(*g_pVApplication + 184LL))(
+            g_pVApplication,
+            *(double *)si128.m128_u64,
+            a5) )
+    {
+      v40 = v123;
+      if ( !v123 )
+        v40 = &byte_93BAEA;
+      if ( !(unsigned int)sub_9EFFD0(v40, "error") )
+        goto LABEL_203;
+    }
+    v41 = sub_9E60E0(40);
+    *(_QWORD *)(v5 + 8) = v41;
+    *(_QWORD *)v41 = off_23C0FB8;
+    v42 = (void (__fastcall **)(__m128i *, double, double))a3->m128i_i64[0];
+    *(_QWORD *)(v41 + 16) = 0;
+    *(_QWORD *)(v41 + 24) = 0;
+    *(_QWORD *)(v41 + 32) = 0;
+    *(_DWORD *)(v41 + 8) = 1;
+    (*v42)(a3, *(double *)si128.m128_u64, a5);
+    (*(void (__fastcall **)(_QWORD *))(*g_pNetworkService + 192LL))(g_pNetworkService);
+    if ( !v119 )
+      goto LABEL_149;
+    v43 = v123;
+    if ( !v123 )
+      v43 = &byte_93BAEA;
+    v44 = (void (__fastcall ***)(_QWORD, const char *))(*(__int64 (__fastcall **)(_QWORD *, const char *, const char *, _QWORD))(*qword_28BAE70 + 104LL))(
+                                                         qword_28BAE70,
+                                                         "defaultSession",
+                                                         v43,
+                                                         *(_QWORD *)(v5 + 8));
+    CLoopModeGame_SetWorldSession(v5, v44);
+    (*v44)[1](v44, "--CLoopModeGame::LoopInit");
+    sub_12193A0(&v138, 0, 0);
+    v144 = 0;
+    LODWORD(v139) = (unsigned int)v139 | 0x20;
+    v138.m128_u64[0] = (unsigned __int64)off_24A0B88;
+    v45 = (_QWORD *)(v138.m128_u64[1] & 0xFFFFFFFFFFFFFFFCLL);
+    if ( (v138.m128_i8[8] & 1) != 0 )
+      v45 = (_QWORD *)*v45;
+    v46 = (_BYTE **)sub_1C73016(v143, v45);
+    v47 = *v46;
+    if ( &_pthread_key_create )
+    {
+      v48 = *((_DWORD *)v47 - 2);
+      v21 = v48 == 0;
+      v49 = v48 < 0;
+      v47 = *v46;
+      v50 = !v49 && !v21;
+    }
+    else
+    {
+      v50 = *((_DWORD *)v47 - 2) > 0;
+    }
+    v51 = v47 - 24;
+    if ( v50 )
+    {
+      if ( v51 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+      {
+        v114 = v46;
+        sub_170BBB0();
+        v46 = v114;
+      }
+      *v46 = &unk_29F3178;
+    }
+    else if ( v51 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+    {
+      *((_DWORD *)v47 - 2) = 0;
+      *((_QWORD *)v47 - 3) = 0;
+      *v47 = 0;
+    }
+    v138.m128_u64[0] = (unsigned __int64)off_24A0C28;
+    v14 = a2;
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __m128i *, __m128 *))(*(_QWORD *)qword_2841E20 + 168LL))(
+            qword_2841E20,
+            a2,
+            &v138) )
+      goto LABEL_112;
+    *(_BYTE *)(v5 + 109) = v143[27];
+    LOBYTE(v52) = v143[26];
+    HIBYTE(v52) = v143[46];
+    *(_WORD *)(v5 + 111) = v52;
+    sub_9F0420(v5 + 128);
+    sub_9F0420(v5 + 136);
+    if ( g_pEntitySystem )
+      *(_WORD *)(g_pEntitySystem + 3037) = v143[25];
+    v53 = v123;
+    if ( !v123 )
+      v53 = &byte_93BAEA;
+    (*(void (__fastcall **)(_QWORD *, __m128 *, void (__fastcall ***)(_QWORD, const char *), const char *))(*g_pNetworkServerService + 216LL))(
+      g_pNetworkServerService,
+      &v138,
+      v44,
+      v53);
+    v130 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 264LL))(g_pNetworkServerService);
+    LODWORD(v131) = v54;
+    v55 = sub_9EF9E0(&v130, 0);
+    LODWORD(v139) = (unsigned int)v139 | 0x10;
+    v56 = (_BYTE *)v55;
+    v113 = v138.m128_u64[1] & 0xFFFFFFFFFFFFFFFCLL;
+    if ( (v138.m128_i8[8] & 1) != 0 )
+      v113 = *(_QWORD *)(v138.m128_u64[1] & 0xFFFFFFFFFFFFFFFCLL);
+    if ( !v55 )
+    {
+      sub_9EB370("basic_string::_S_construct null not valid");
+      goto LABEL_208;
+    }
+    v57 = sub_9F1BA0(v55);
+    if ( !v57 )
+    {
+      v61 = (const char *)&unk_29F3178;
+      goto LABEL_97;
+    }
+    if ( v57 > 0x3FFFFFFFFFFFFFF9LL )
+    {
+  LABEL_208:
+      sub_9EB380("basic_string::_S_create", v56, v57);
+      JUMPOUT(0x1723C4E);
+    }
+    if ( v57 + 57 > 0x1000 )
+    {
+      v62 = v57 + 4096 - (((_WORD)v57 + 57) & 0xFFF);
+      v103 = v57;
+      if ( v62 > 0x3FFFFFFFFFFFFFF9LL )
+        v62 = 0x3FFFFFFFFFFFFFF9LL;
+      v109 = v62;
+      v63 = sub_9E60E0(v62 + 25);
+      v59 = v103;
+      v61 = (const char *)(v63 + 24);
+      v60 = (_BYTE *)v63;
+      *(_DWORD *)(v63 + 16) = 0;
+      *(_QWORD *)(v63 + 8) = v109;
+    }
+    else
+    {
+      v108 = v57;
+      v58 = sub_9E60E0(v57 + 25);
+      v59 = v108;
+      v60 = (_BYTE *)v58;
+      *(_DWORD *)(v58 + 16) = 0;
+      v61 = (const char *)(v58 + 24);
+      *(_QWORD *)(v58 + 8) = v108;
+      if ( v108 == 1 )
+      {
+        *(_BYTE *)(v58 + 24) = *v56;
+        goto LABEL_95;
+      }
+    }
+    v104 = v60;
+    v110 = v59;
+    v64 = sub_9F1D30(v61, v56, v59);
+    v60 = v104;
+    v59 = v110;
+    v61 = (const char *)v64;
+  LABEL_95:
+    if ( v60 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+    {
+      *(_QWORD *)v60 = v59;
+      v60[v59 + 24] = 0;
+    }
+  LABEL_97:
+    v129 = v61;
+    sub_1C72D4E(v142, &v129, v113);
+    if ( v129 - 24 != (const char *)&std::string::_Rep::_S_empty_rep_storage )
+      sub_170BBB0();
+    if ( v127 && (int)sub_9F1BA0(v127) > 0 )
+    {
+      v130 = 0;
+      v131 = nullptr;
+      sub_169A890(&v129, &v130);
+      v90 = v129;
+      if ( v131 )
+        sub_9EF5F0(&v131, (const char *)&v130);
+      v91 = v127;
+      v131 = v90;
+      if ( !v127 )
+        v91 = &byte_93BAEA;
+      if ( (unsigned __int8)sub_169A900(&v130, v91) )
+      {
+        (*(void (__fastcall **)(_QWORD, __int64 *))(**(_QWORD **)(g_pGameEntitySystem + 8424) + 240LL))(
+          *(_QWORD *)(g_pGameEntitySystem + 8424),
+          &v130);
+        (*(void (__fastcall **)(const char **, _QWORD, const char **))(**(_QWORD **)(g_pGameEntitySystem + 8424) + 264LL))(
+          &v128,
+          *(_QWORD *)(g_pGameEntitySystem + 8424),
+          &v127);
+        v91 = (_BYTE *)(dword_0 + 2);
+        if ( (unsigned __int8)sub_9F0CA0((unsigned int)dword_2844428, 2) )
+        {
+          v92 = v128;
+          v93 = v127;
+          if ( !v128 )
+            v92 = &byte_93BAEA;
+          if ( !v127 )
+            v93 = &byte_93BAEA;
+          v102 = v92;
+          v106 = v93;
+          sub_169A890(&v129, &v130);
+          v94 = v129;
+          if ( !v129 )
+            v94 = &byte_93BAEA;
+          sub_9F0170(
+            (unsigned int)dword_2844428,
+            2,
+            "ET:  Restoring game at %u %s : '%s'\nET:  '%s'\n",
+            (unsigned int)v130,
+            v94,
+            v106,
+            v102);
+          v91 = v99;
+          if ( v129 )
+            sub_9EF5F0(&v129, v99);
+        }
+        if ( v128 )
+          sub_9EF5F0(&v128, v91);
+      }
+      if ( v131 )
+        sub_9EF5F0(&v131, v91);
+    }
+    if ( *(_DWORD *)(v5 + 1128) != 1 )
+      CLoopModeGame_SetGameSystemState(v5, 1);
+    sub_1711C90(v5);
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __m128 *))(*(_QWORD *)qword_2841E20 + 176LL))(qword_2841E20, &v138) )
+    {
+      sub_9EF870("LevelInitWorld failed!\n");
+  LABEL_203:
+      if ( (unsigned __int8)sub_9F0CA0((unsigned int)dword_2868900, 3) )
+        sub_9F0170((unsigned int)dword_2868900, 3, "LoopInit:  in \"error\" map - disconnecting...\n");
+      (*(void (__fastcall **)(_QWORD *, __int64))(*g_pNetworkClientService + 232LL))(g_pNetworkClientService, 64);
+      v140 = 652;
+      si128 = (__m128)_mm_insert_epi64(_mm_loadl_epi64((const __m128i *)off_24A2900), (signed __int64)"LoopInit", 1);
+      v138 = si128;
+      v139 = "false";
+      v14 = (__m128i *)"Error map!";
+      v141 = v141 & 0x80 | 0x14;
+      if ( (unsigned __int8)sub_9F0D10(&v138, "Error map!") )
+        __debugbreak();
+      goto LABEL_115;
+    }
+    sub_17851A0(&v130);
+    if ( *(_DWORD *)(v5 + 1128) != 2 )
+      CLoopModeGame_SetGameSystemState(v5, 2);
+    v14 = a3;
+    if ( !(unsigned __int8)IGameSystem_LoopInitAllSystems((unsigned __int64)&v138, (signed __int64)a3) )
+      goto LABEL_111;
+    if ( *(_DWORD *)(v5 + 1128) != 3 )
+      CLoopModeGame_SetGameSystemState(v5, 3);
+    v14 = a3;
+    if ( !(unsigned __int8)IGameSystem_LoopPostInitAllSystems((unsigned __int64)&v138, (signed __int64)a3)
+      || (v14 = (__m128i *)&v138,
+          !(*(unsigned __int8 (__fastcall **)(__int64, __m128 *, __m128i *))(*(_QWORD *)qword_2841E20 + 200LL))(
+             qword_2841E20,
+             &v138,
+             a3)) )
+    {
+  LABEL_111:
+      sub_17851D0(&v130);
+  LABEL_112:
+      v65 = v144;
+      v138.m128_u64[0] = (unsigned __int64)off_24A0B88;
+      if ( v144 )
+      {
+        sub_9EF8E0(v144);
+        sub_9F0250(v65);
+        v144 = 0;
+      }
+      sub_12372B0(&v138);
+  LABEL_115:
+      v19 = 0;
+      goto LABEL_116;
+    }
+    sub_17851D0(&v130);
+    (*(void (__fastcall **)(_QWORD *, __int64))(*g_pNetworkServerService + 224LL))(g_pNetworkServerService, qword_272E140);
+    if ( (int)v115 > 0 )
+    {
+      // 480LL = 0x1E0 = CEngineServer_UnloadSpawnGroup (qword_2868848 = g_pEngineServer, vfunc_index 60)
+      *(_DWORD *)(v5 + 1072) = (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_2868848 + 480LL))(
+                                 qword_2868848,
+                                 v37);
+      if ( (_DWORD)v115 != 1 )
+      {
+        v83 = v37 + 160;
+        do
+        {
+          v84 = v83;
+          v83 += 160;
+          // 480LL = 0x1E0 = CEngineServer_UnloadSpawnGroup (qword_2868848 = g_pEngineServer, vfunc_index 60)
+          (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)qword_2868848 + 480LL))(qword_2868848, v84);
+        }
+        while ( v83 != v37 + 160LL * (unsigned int)v115 );
+      }
+    }
+    (*(void (__fastcall **)(_QWORD *, __m128 *, const char *, __m128i *, bool))(*g_pNetworkServerService + 232LL))(
+      g_pNetworkServerService,
+      &v138,
+      "GameSessionManifest",
+      a3,
+      v112);
+    v85 = v144;
+    v138.m128_u64[0] = (unsigned __int64)off_24A0B88;
+    if ( v144 )
+    {
+      sub_9EF8E0(v144);
+      sub_9F0250(v85);
+      v144 = 0;
+    }
+    sub_12372B0(&v138);
+  LABEL_149:
+    v73 = *(_QWORD *)(v5 + 8);
+    v74 = (*(__int64 (__fastcall **)(_QWORD *, const char *, __int64, const char *, __int64))(*g_pResourceSystem + 160LL))(
+            g_pResourceSystem,
+            "LoopModeGameStartup",
+            1,
+            "CLoopModeGame::LoopInit",
+            0xFFFFFFFFLL);
+    if ( v74 )
+    {
+      v75 = *(int *)(v73 + 16);
+      v76 = v75;
+      if ( (_DWORD)v75 == *(_DWORD *)(v73 + 32) )
+      {
+        v116 = *(_DWORD *)(v73 + 16);
+        v120 = v74;
+        sub_ECF100(v73 + 24, 1, (unsigned int)v75);
+        v76 = *(_DWORD *)(v73 + 16);
+        v75 = v116;
+        v74 = v120;
+      }
+      *(_DWORD *)(v73 + 16) = v76 + 1;
+      *(_QWORD *)(*(_QWORD *)(v73 + 24) + 8 * v75) = v74;
+    }
+    v77 = *(_QWORD *)(v5 + 8);
+    v14 = (__m128i *)"LoopModeGame_server";
+    v79 = (*(__int64 (__fastcall **)(_QWORD *, const char *, __int64, const char *, __int64))(*g_pResourceSystem + 168LL))(
+            g_pResourceSystem,
+            "LoopModeGame_server",
+            1,
+            "CLoopModeGame::LoopInit",
+            0xFFFFFFFFLL);
+    if ( v79 )
+    {
+      v80 = *(int *)(v77 + 16);
+      v81 = v80;
+      if ( (_DWORD)v80 == *(_DWORD *)(v77 + 32) )
+      {
+        v14 = (__m128i *)(dword_0 + 1);
+        sub_ECF100(v77 + 24, 1, v78);
+        v81 = *(_DWORD *)(v77 + 16);
+      }
+      *(_DWORD *)(v77 + 16) = v81 + 1;
+      *(_QWORD *)(*(_QWORD *)(v77 + 24) + 8 * v80) = v79;
+    }
+    if ( qword_2841E20 )
+    {
+      v82 = *(__int64 (__fastcall **)())(*(_QWORD *)qword_2841E20 + 144LL);
+      if ( v82 != nullsub_982 )
+      {
+        v14 = a2;
+        ((void (__fastcall *)(__int64, __m128i *, __m128i *))v82)(qword_2841E20, a2, a3);
+      }
+    }
+    v19 = 1;
+  LABEL_116:
+    if ( v127 )
+      sub_9EF5F0(&v127, v14->m128i_i8);
+    if ( v118 >= 0 )
+    {
+      v66 = (_QWORD *)(v37 - 48);
+      v67 = (_QWORD *)(v37 + 160LL * v118 + 112);
+      do
+      {
+        while ( 1 )
+        {
+          if ( v67[1] )
+            sub_9EF5F0(v67 + 1, v14->m128i_i8);
+          if ( !*v67 )
+            break;
+          v68 = v67;
+          v67 -= 20;
+          sub_9EF5F0(v68, v14->m128i_i8);
+          if ( v66 == v67 )
+            goto LABEL_124;
+        }
+        v67 -= 20;
+      }
+      while ( v67 != v66 );
+    }
+  LABEL_124:
+    if ( HIDWORD(v115) <= 0x3FFFFFFF && v37 )
+    {
+      v14 = (__m128i *)v37;
+      (*(void (__fastcall **)(_QWORD *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v37);
+    }
+    v69 = (unsigned int)(v132 - 1);
+    if ( (int)v132 - 1 >= 0 )
+    {
+      v69 = (unsigned int)v69;
+      v70 = 96LL * (int)v69;
+      v71 = 96 * ((int)v132 - (unsigned __int64)(unsigned int)v69) - 192;
+      do
+      {
+        while ( 1 )
+        {
+          v72 = &v133[(unsigned __int64)v70 / 0x10];
+          if ( v133[(unsigned __int64)v70 / 0x10 + 4].m128i_i64[1] )
+            sub_9EF5F0(&v72[4].m128i_u64[1], v14->m128i_i8);
+          if ( v72[4].m128i_i64[0] )
+            sub_9EF5F0(&v72[4], v14->m128i_i8);
+          if ( v72[3].m128i_i64[1] )
+            sub_9EF5F0(&v72[3].m128i_u64[1], v14->m128i_i8);
+          if ( !v72[3].m128i_i64[0] )
+            break;
+          v70 -= 96;
+          sub_9EF5F0(&v72[3], v14->m128i_i8);
+          if ( v71 == v70 )
+            goto LABEL_137;
+        }
+        v70 -= 96;
+      }
+      while ( v70 != v71 );
+    }
+  LABEL_137:
+    LODWORD(v132) = 0;
+    if ( HIDWORD(v134) <= 0x3FFFFFFF )
+    {
+      v14 = v133;
+      if ( v133 )
+        (*(void (__fastcall **)(_QWORD *, __m128i *, __int64))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v133, v69);
+    }
+    if ( v126 )
+      goto LABEL_19;
+  LABEL_20:
+    if ( v125 )
+      sub_9EF5F0(&v125, v14->m128i_i8);
+    if ( v124 )
+      sub_9EF5F0(&v124, v14->m128i_i8);
+    if ( v123 )
+      sub_9EF5F0(&v123, v14->m128i_i8);
+    return v19;
+  }


### PR DESCRIPTION
## Summary
- add an LLM_DECOMPILE preprocessor for CEngineServer::UnloadSpawnGroup
- derive the vfunc from the server-side CLoopModeGame::LoopInit call
- register the late engine analysis skill and vfunc metadata for 14172

## Validation
- uv run python -m unittest tests.test_config_scheduling_dependencies tests.test_llm_decompile_dependencies