### PR TITLE
feat(preprocessor): add CNetworkGameClient finders

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -1257,6 +1257,12 @@ modules:
           - CNetworkGameClient_OnPreserveEntity.{platform}.yaml
         expected_input:
           - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_OnPreserveEntity-decompiles
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_GetClientNetworkable.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_OnPreserveEntity.{platform}.yaml
       - name: find-CNetworkGameClient_CopyNewEntity
         platform: windows
         expected_output:
@@ -2384,6 +2390,11 @@ modules:
         platform: windows
         alias:
           - CNetworkGameClient::OnPreserveEntity
+      - name: CNetworkGameClient_GetClientNetworkable
+        category: func
+        platform: windows
+        alias:
+          - CNetworkGameClient::GetClientNetworkable
       - name: CNetworkGameClient_CopyNewEntity
         category: vfunc
         platform: windows

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -1239,6 +1239,49 @@ modules:
       - name: find-CNetworkGameClient_vtable
         expected_output:
           - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_SetSignonState
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_SetSignonState.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_ProcessReadPacketEntitiesWorkItems.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_OnPreserveEntity
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_OnPreserveEntity.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_CopyNewEntity
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_CopyNewEntity.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_CopyExistingEntity
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_CopyExistingEntity.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_OnReceivedUncompressedPacket
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_OnReceivedUncompressedPacket.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_ProcessPacketEntities.{platform}.yaml
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_Clear
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_Clear.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_vtable.{platform}.yaml
       - name: find-CNetworkGameClient_DisconnectGame
         expected_output:
           - CNetworkGameClient_DisconnectGame.{platform}.yaml
@@ -2326,6 +2369,41 @@ modules:
           - CMsgSource2NetworkFlowQuality::PrintStats
       - name: CNetworkGameClient_vtable
         category: vtable
+      - name: CNetworkGameClient_SetSignonState
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::SetSignonState
+      - name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::ProcessReadPacketEntitiesWorkItems
+      - name: CNetworkGameClient_OnPreserveEntity
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::OnPreserveEntity
+      - name: CNetworkGameClient_CopyNewEntity
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::CopyNewEntity
+      - name: CNetworkGameClient_CopyExistingEntity
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::CopyExistingEntity
+      - name: CNetworkGameClient_OnReceivedUncompressedPacket
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::OnReceivedUncompressedPacket
+      - name: CNetworkGameClient_Clear
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::Clear
       - name: CNetworkGameClient_DisconnectGame
         category: vfunc
         alias:

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:fc6b143a0bf200c3e04de64e37515f75aca5ee7881526132b439a71df2c08396
-file_count: 3155
+config_sha256: sha256:8b0a61d24775a516a7185ce252a923818101f1c41b8b32c3f09c0900a1b944f8
+file_count: 3162
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -9653,6 +9653,33 @@ files:
     vtable_size: '0x478'
     vtable_symbol: ??_7CNetworkGameClientBase@@6B@
     vtable_va: '0x18053a950'
+  engine/CNetworkGameClient_Clear.windows.yaml:
+    func_name: CNetworkGameClient_Clear
+    func_rva: '0x61450'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 41 56 48 83 EC ?? 0F B6 DA
+    func_size: '0x1a9'
+    func_va: '0x180061450'
+    vfunc_index: 130
+    vfunc_offset: '0x410'
+    vtable_name: CNetworkGameClient_vtable
+  engine/CNetworkGameClient_CopyExistingEntity.windows.yaml:
+    func_name: CNetworkGameClient_CopyExistingEntity
+    func_rva: '0x46da0'
+    func_sig: 48 8B C4 55 57 41 54 41 56
+    func_size: '0x311'
+    func_va: '0x180046da0'
+    vfunc_index: 140
+    vfunc_offset: '0x460'
+    vtable_name: CNetworkGameClient_vtable
+  engine/CNetworkGameClient_CopyNewEntity.windows.yaml:
+    func_name: CNetworkGameClient_CopyNewEntity
+    func_rva: '0x468b0'
+    func_sig: 48 89 5C 24 ?? 44 89 4C 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ??
+    func_size: '0x4e1'
+    func_va: '0x1800468b0'
+    vfunc_index: 139
+    vfunc_offset: '0x458'
+    vtable_name: CNetworkGameClient_vtable
   engine/CNetworkGameClient_DisconnectGame.linux.yaml:
     func_name: CNetworkGameClient_DisconnectGame
     func_rva: '0x4e3900'
@@ -9671,6 +9698,24 @@ files:
     vfunc_index: 13
     vfunc_offset: '0x68'
     vtable_name: CNetworkGameClient
+  engine/CNetworkGameClient_OnPreserveEntity.windows.yaml:
+    func_name: CNetworkGameClient_OnPreserveEntity
+    func_rva: '0x470c0'
+    func_sig: 48 89 5C 24 ?? 56 48 81 EC ?? ?? ?? ?? 48 8B DA
+    func_size: '0x1a0'
+    func_va: '0x1800470c0'
+    vfunc_index: 138
+    vfunc_offset: '0x450'
+    vtable_name: CNetworkGameClient_vtable
+  engine/CNetworkGameClient_OnReceivedUncompressedPacket.windows.yaml:
+    func_name: CNetworkGameClient_OnReceivedUncompressedPacket
+    func_rva: '0x6aa70'
+    func_sig: 40 53 48 83 EC ?? 48 8B D9 BA ?? ?? ?? ?? 8B 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 84 C0 74 ?? 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 85 C9 74 ?? 48 8B 01 33 D2 89 54 24 ?? 41 B8 ?? ?? ?? ?? 48 89 54 24 ?? 45 33 C9 BA ?? ?? ?? ?? FF 90 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 50 ?? 84 C0 74 ?? C7 83 ?? ?? ?? ?? ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??
+    func_size: '0x95'
+    func_va: '0x18006aa70'
+    vfunc_index: 141
+    vfunc_offset: '0x468'
+    vtable_name: CNetworkGameClient_vtable
   engine/CNetworkGameClient_PrintNetStats.linux.yaml:
     func_name: CNetworkGameClient_PrintNetStats
     func_rva: '0x4e4c20'
@@ -9701,6 +9746,15 @@ files:
     func_sig: 40 55 56 41 56 41 57 48 8D AC 24 ?? ?? ?? ??
     func_size: '0xaef'
     func_va: '0x180047cb0'
+  engine/CNetworkGameClient_ProcessReadPacketEntitiesWorkItems.windows.yaml:
+    func_name: CNetworkGameClient_ProcessReadPacketEntitiesWorkItems
+    func_rva: '0x464b0'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 57 48 83 EC ?? 48 8D 05 ?? ?? ?? ??
+    func_size: '0x19d'
+    func_va: '0x1800464b0'
+    vfunc_index: 137
+    vfunc_offset: '0x448'
+    vtable_name: CNetworkGameClient_vtable
   engine/CNetworkGameClient_RecordEntityBandwidth.linux.yaml:
     func_name: CNetworkGameClient_RecordEntityBandwidth
     func_rva: '0x498c40'
@@ -9737,6 +9791,15 @@ files:
     func_sig: 40 55 57 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 4C 8B F9
     func_size: '0x7a6'
     func_va: '0x1800648c0'
+  engine/CNetworkGameClient_SetSignonState.windows.yaml:
+    func_name: CNetworkGameClient_SetSignonState
+    func_rva: '0x60740'
+    func_sig: 44 89 44 24 ?? 89 54 24 ?? 55 53
+    func_size: '0x7e8'
+    func_va: '0x180060740'
+    vfunc_index: 132
+    vfunc_offset: '0x420'
+    vtable_name: CNetworkGameClient_vtable
   engine/CNetworkGameClient_vtable.linux.yaml:
     vtable_class: CNetworkGameClient
     vtable_entries:
@@ -40013,5 +40076,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-28T08:22:09Z'
+last_publish_time: '2026-07-28T12:41:38Z'
 schema_version: 4

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -40082,5 +40082,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-28T12:51:51Z'
+last_publish_time: '2026-07-28T13:41:03Z'
 schema_version: 4

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:8b0a61d24775a516a7185ce252a923818101f1c41b8b32c3f09c0900a1b944f8
-file_count: 3162
+config_sha256: sha256:0e843a49128d7b788844e0e1acb233e4a40423f9f7f269df7349070565b0cb3c
+file_count: 3163
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -9698,6 +9698,12 @@ files:
     vfunc_index: 13
     vfunc_offset: '0x68'
     vtable_name: CNetworkGameClient
+  engine/CNetworkGameClient_GetClientNetworkable.windows.yaml:
+    func_name: CNetworkGameClient_GetClientNetworkable
+    func_rva: '0x46650'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 54 41 55 41 56 41 57 48 83 EC ?? 48 8B F9 41 0F B6 F1
+    func_size: '0x15f'
+    func_va: '0x180046650'
   engine/CNetworkGameClient_OnPreserveEntity.windows.yaml:
     func_name: CNetworkGameClient_OnPreserveEntity
     func_rva: '0x470c0'
@@ -40076,5 +40082,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-28T12:41:38Z'
+last_publish_time: '2026-07-28T12:51:51Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_Clear.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_Clear.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_Clear skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_Clear",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_Clear",
+        "xref_strings": [
+            "CNetworkGameClient::Clear setting state to SIGNONSTATE_CONNECTED",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CNetworkGameClient_Clear", "CNetworkGameClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_Clear",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_CopyExistingEntity.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_CopyExistingEntity.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_CopyExistingEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_CopyExistingEntity",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_CopyExistingEntity",
+        "xref_strings": [
+            "CopyExistingEntity: missing client entity %d.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CNetworkGameClient_CopyExistingEntity", "CNetworkGameClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_CopyExistingEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_CopyNewEntity.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_CopyNewEntity.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_CopyNewEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_CopyNewEntity",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_CopyNewEntity",
+        "xref_strings": [
+            "CopyNewEntity:  Error creating entity %s(%i)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CNetworkGameClient_CopyNewEntity", "CNetworkGameClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_CopyNewEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_OnPreserveEntity-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_OnPreserveEntity-decompiles.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_OnPreserveEntity-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_GetClientNetworkable",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameClient_GetClientNetworkable",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameClient_OnPreserveEntity.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CNetworkGameClient_OnPreserveEntity.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_GetClientNetworkable",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CNetworkGameClient_GetClientNetworkable via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_OnPreserveEntity.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_OnPreserveEntity.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_OnPreserveEntity skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_OnPreserveEntity",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_OnPreserveEntity",
+        "xref_strings": [
+            "OnPreserveEntity: missing client entity %d.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CNetworkGameClient_OnPreserveEntity", "CNetworkGameClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_OnPreserveEntity",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_OnReceivedUncompressedPacket.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_OnReceivedUncompressedPacket.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_OnReceivedUncompressedPacket skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_OnReceivedUncompressedPacket",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_OnReceivedUncompressedPacket",
+        "xref_strings": [
+            "CNetworkGameClientBase::OnReceivedUncompressedPacket(), received full update",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        # ProcessPacketEntities also logs this message during a full update.
+        "exclude_funcs": ["CNetworkGameClient_ProcessPacketEntities"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    (
+        "CNetworkGameClient_OnReceivedUncompressedPacket",
+        "CNetworkGameClient_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_OnReceivedUncompressedPacket",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessReadPacketEntitiesWorkItems.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_ProcessReadPacketEntitiesWorkItems.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_ProcessReadPacketEntitiesWorkItems skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_ProcessReadPacketEntitiesWorkItems",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_ProcessReadPacketEntitiesWorkItems",
+        "xref_strings": [
+            "FULLMATCH:ProcessReadPacketEntitiesWorkItems",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    (
+        "CNetworkGameClient_ProcessReadPacketEntitiesWorkItems",
+        "CNetworkGameClient_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_ProcessReadPacketEntitiesWorkItems",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_SetSignonState.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_SetSignonState.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_SetSignonState skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_SetSignonState",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameClient_SetSignonState",
+        "xref_strings": [
+            "CNetworkGameClient::SetSignonState: start %i",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact_stem)
+    ("CNetworkGameClient_SetSignonState", "CNetworkGameClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameClient_SetSignonState",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameClient_OnPreserveEntity.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameClient_OnPreserveEntity.windows.yaml
@@ -1,0 +1,146 @@
+func_name: CNetworkGameClient_OnPreserveEntity
+func_va: '0x1800470c0'
+disasm_code: |-
+  .text:00000001800470C0                 mov     [rsp+arg_10], rbx
+  .text:00000001800470C5                 push    rsi
+  .text:00000001800470C6                 sub     rsp, 120h
+  .text:00000001800470CD                 mov     rbx, rdx
+  .text:00000001800470D0                 mov     rsi, rcx
+  .text:00000001800470D3                 mov     edx, 0FFFFFFFFh
+  .text:00000001800470D8                 lea     rcx, unk_18068DD58
+  .text:00000001800470DF                 call    sub_1803FEF60
+  .text:00000001800470E4                 test    rax, rax
+  .text:00000001800470E7                 jnz     short loc_1800470F4
+  .text:00000001800470E9                 mov     rax, qword ptr cs:unk_18068DD60
+  .text:00000001800470F0                 mov     rax, [rax+8]
+  .text:00000001800470F4                 movzx   eax, byte ptr [rax]
+  .text:00000001800470F7                 test    al, al
+  .text:00000001800470F9                 jz      loc_18004720F
+  .text:00000001800470FF                 mov     edx, [rbx+30h]
+  .text:0000000180047102                 lea     r8, [rsp+128h+var_C8]
+  .text:0000000180047107                 xorps   xmm0, xmm0
+  .text:000000018004710A                 mov     [rsp+128h+arg_0], rbp
+  .text:0000000180047112                 xorps   xmm1, xmm1
+  .text:0000000180047115                 mov     [rsp+128h+arg_8], rdi
+  .text:000000018004711D                 lea     rdi, [rbx+30h]
+  .text:0000000180047121                 movdqa  [rsp+128h+var_C8], xmm0
+  .text:0000000180047127                 xor     ebp, ebp
+  .text:0000000180047129                 movdqa  [rsp+128h+var_B8], xmm1
+  .text:000000018004712F                 mov     r9b, 1
+  .text:0000000180047132                 movdqa  [rsp+128h+var_A8], xmm0
+  .text:000000018004713B                 mov     rcx, rsi
+  .text:000000018004713E                 movdqa  [rsp+128h+var_98], xmm1
+  .text:0000000180047147                 movdqa  [rsp+128h+var_88], xmm0
+  .text:0000000180047150                 mov     [rsp+128h+var_78], ebp
+  .text:0000000180047157                 mov     [rsp+128h+var_74], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180047163                 call    CNetworkGameClient_GetClientNetworkable
+  .text:0000000180047168                 test    al, al
+  .text:000000018004716A                 jnz     short loc_1800471DB
+  .text:000000018004716C                 xor     r8d, r8d
+  .text:000000018004716F                 lea     rcx, [rsp+128h+var_E8]
+  .text:0000000180047174                 xor     edx, edx
+  .text:0000000180047176                 call    sub_18004C590
+  .text:000000018004717B                 mov     rbx, rax
+  .text:000000018004717E                 call    cs:GetDefaultMiniDumpTypeFlags
+  .text:0000000180047184                 mov     [rsp+128h+var_F8], rbp
+  .text:0000000180047189                 lea     rdx, aOnpreserveenti; "onpreserveentity"
+  .text:0000000180047190                 or      eax, 2
+  .text:0000000180047193                 mov     [rsp+128h+var_100], rbp
+  .text:0000000180047198                 mov     r8d, eax
+  .text:000000018004719B                 mov     [rsp+128h+var_108], rbp
+  .text:00000001800471A0                 mov     r9, rbx
+  .text:00000001800471A3                 lea     rcx, [rsp+128h+var_68]
+  .text:00000001800471AB                 call    sub_18004C5A0
+  .text:00000001800471B0                 xor     r8d, r8d
+  .text:00000001800471B3                 lea     rdx, [rsp+128h+var_68]
+  .text:00000001800471BB                 xor     ecx, ecx
+  .text:00000001800471BD                 call    cs:InvokeMiniDumpHandler
+  .text:00000001800471C3                 mov     rcx, rdi
+  .text:00000001800471C6                 call    sub_18004C710
+  .text:00000001800471CB                 mov     edx, eax
+  .text:00000001800471CD                 lea     rcx, aOnpreserveenti_0; "OnPreserveEntity: missing client entity"...
+  .text:00000001800471D4                 call    cs:Plat_FatalError
+  .text:00000001800471DA                 ; Trap to Debugger
+  .text:00000001800471DA                 int     3; Trap to Debugger
+  .text:00000001800471DB                 mov     rax, qword ptr [rsp+128h+var_C8]
+  .text:00000001800471E0                 test    rax, rax
+  .text:00000001800471E3                 jz      short loc_180047220
+  .text:00000001800471E5                 cmp     [rax+33h], bpl
+  .text:00000001800471E9                 jnz     short loc_1800471FF
+  .text:00000001800471EB                 mov     edx, [rdi]
+  .text:00000001800471ED                 lea     rcx, [rbx+0C0h]
+  .text:00000001800471F4                 mov     r8d, 4
+  .text:00000001800471FA                 call    sub_180044FB0
+  .text:00000001800471FF                 mov     rbp, [rsp+128h+arg_0]
+  .text:0000000180047207                 mov     rdi, [rsp+128h+arg_8]
+  .text:000000018004720F                 mov     rbx, [rsp+128h+arg_10]
+  .text:0000000180047217                 add     rsp, 120h
+  .text:000000018004721E                 pop     rsi
+  .text:000000018004721F                 retn
+  .text:0000000180047220                 lea     rax, aCBuildworkerCs_2; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180047227                 mov     [rsp+128h+var_D0], 3FCh
+  .text:000000018004722F                 mov     [rsp+128h+var_E8], rax
+  .text:0000000180047234                 lea     rcx, [rsp+128h+var_E8]
+  .text:0000000180047239                 lea     rax, aCnetworkgamecl_0; "CNetworkGameClient::OnPreserveEntity"
+  .text:0000000180047240                 mov     [rsp+128h+var_CC], 16h
+  .text:0000000180047248                 mov     [rsp+128h+var_E0], rax
+  .text:000000018004724D                 lea     rax, aPclass; "pClass"
+  .text:0000000180047254                 mov     [rsp+128h+var_D8], rax
+  .text:0000000180047259                 call    cs:?Assert_ConditionFailed_Fatal@@YAXAEBU_AssertCompileTimeConstantStruct_t@@@Z; Assert_ConditionFailed_Fatal(_AssertCompileTimeConstantStruct_t const &)
+procedure: |-
+  __int64 __fastcall CNetworkGameClient_OnPreserveEntity(__int64 a1, __int64 a2)
+  {
+    unsigned __int8 *v4; // rax
+    __int64 v5; // r9
+    __int64 result; // rax
+    __int64 v7; // rdx
+    unsigned int *v8; // rdi
+    int v9; // ebx
+    int DefaultMiniDumpTypeFlags; // eax
+    int v11; // eax
+    _QWORD v12[3]; // [rsp+40h] [rbp-E8h] BYREF
+    int v13; // [rsp+58h] [rbp-D0h]
+    int v14; // [rsp+5Ch] [rbp-CCh]
+    _OWORD v15[5]; // [rsp+60h] [rbp-C8h] BYREF
+    int v16; // [rsp+B0h] [rbp-78h]
+    __int64 v17; // [rsp+B4h] [rbp-74h]
+    _BYTE v18[104]; // [rsp+C0h] [rbp-68h] BYREF
+
+    v4 = (unsigned __int8 *)sub_1803FEF60(&unk_18068DD58, 0xFFFFFFFFLL);
+    if ( !v4 )
+      v4 = *(unsigned __int8 **)(unk_18068DD60 + 8);
+    result = *v4;
+    if ( (_BYTE)result )
+    {
+      v7 = *(unsigned int *)(a2 + 48);
+      v8 = (unsigned int *)(a2 + 48);
+      memset(v15, 0, sizeof(v15));
+      LOBYTE(v5) = 1;
+      v16 = 0;
+      v17 = -1;
+      if ( !(unsigned __int8)CNetworkGameClient_GetClientNetworkable(a1, v7, v15, v5) )
+      {
+        v9 = sub_18004C590(v12, 0, 0);
+        DefaultMiniDumpTypeFlags = GetDefaultMiniDumpTypeFlags();
+        sub_18004C5A0((unsigned int)v18, (unsigned int)"onpreserveentity", DefaultMiniDumpTypeFlags | 2, v9, 0, 0, 0);
+        InvokeMiniDumpHandler(0, v18, 0);
+        v11 = sub_18004C710(v8);
+        Plat_FatalError("OnPreserveEntity: missing client entity %d.\n", v11);
+        __debugbreak();
+      }
+      result = *(_QWORD *)&v15[0];
+      if ( !*(_QWORD *)&v15[0] )
+      {
+        v13 = 1020;
+        v12[0] = "C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\cl_ents_parse.cpp";
+        v14 = 22;
+        v12[1] = "CNetworkGameClient::OnPreserveEntity";
+        v12[2] = "pClass";
+        Assert_ConditionFailed_Fatal((const struct _AssertCompileTimeConstantStruct_t *)v12);
+        JUMPOUT(0x18004725FLL);
+      }
+      if ( !*(_BYTE *)(*(_QWORD *)&v15[0] + 51LL) )
+        return sub_180044FB0(a2 + 192, *v8, 4);
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary

- add Windows-only xref-string preprocessors for seven CNetworkGameClient vfuncs
- add an LLM decompile preprocessor that resolves CNetworkGameClient_GetClientNetworkable from OnPreserveEntity
- register the new symbols and publish the validated 14172 gamesymbol snapshot

## Validation

- formatter write/check completed with no tracked formatting changes
- seven vfunc finder IDA runs completed with Failed: 0
- GetClientNetworkable LLM decompile completed with Successful: 1, Failed: 0
- Python unittest suite: Ran 1048 tests, OK
- C++ post-change gate: 12 runnable tests, 0 compile failures, 0 invalid items, 0 vtable differences, 0 record-layout differences
- candidate and published snapshot SHA-256: 92ed2cece77a6c53f581e5ba5a116221615ba9b57ad9f4f44699d0f43069fd35