### PR TITLE
feat(preprocessor): add MakeSpawnGroupActive finder

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -7360,6 +7360,11 @@ modules:
           - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
         expected_input:
           - CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
+      - name: find-CEngineServer_MakeSpawnGroupActive
+        expected_output:
+          - CEngineServer_MakeSpawnGroupActive.{platform}.yaml
+        expected_input:
+          - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
       - name: find-CSpawnGroupMgrGameSystem_UnloadSpawnGroup
         expected_output:
           - CSpawnGroupMgrGameSystem_UnloadSpawnGroup.{platform}.yaml
@@ -10409,6 +10414,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::UnloadSpawnGroup
+      - name: CEngineServer_MakeSpawnGroupActive
+        category: vfunc
+        alias:
+          - CEngineServer::MakeSpawnGroupActive
       - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
         category: func
         alias:

--- a/gamedata/14172/CS2Fixes/gamedata/cs2fixes.jsonc
+++ b/gamedata/14172/CS2Fixes/gamedata/cs2fixes.jsonc
@@ -395,6 +395,13 @@
 			"library": "server",
 			"windows": "48 8B C4 48 89 58 ? 57 48 81 EC ? ? ? ? 0F 29 70 ? 48 8B FA 0F 29 78 ? 48 8B D9",
 			"linux": "55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 89 FB 48 81 EC ? ? ? ? 66 0F 1F 44 00"
+		},
+		// Only called in an if statement by function with "DISALLOWED WORKSHOP CONVAR: %s" string
+		"IsCommandWhitelisted":
+		{
+			"library": "server",
+			"windows": "48 83 EC ? 4C 8B C2 48 8D 0D ? ? ? ? 48 8D 54 24 ? FF",
+			"linux": "55 48 89 F2 48 8D 35 ? ? ? ? 48 89 E5 48 83 EC"
 		}
 	},
 	"Offsets":

--- a/gamesymbol_snapshot_lib/pr_cli.py
+++ b/gamesymbol_snapshot_lib/pr_cli.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 from analysis_config import AnalysisConfigError, resolve_analysis_config
 from gamesymbol_snapshot_lib.errors import SnapshotConfigError, SnapshotMismatchError
-from gamesymbol_snapshot_lib.model import ChangedPath
+from gamesymbol_snapshot_lib.config import LATEST_CONFIG_DIGEST_VERSION, load_contract
+from gamesymbol_snapshot_lib.model import ChangedPath, SnapshotContext
 from gamesymbol_snapshot_lib.operations import load_snapshot_context
 from gamesymbol_snapshot_lib.paths import ensure_real_tree, path_from_key
 from gamesymbol_snapshot_lib.pr_validation import build_invalidation_plan
@@ -118,6 +119,16 @@ def _delete_paths(contract, paths: frozenset[str]) -> int:
             deleted += 1
     return deleted
 
+def _load_head_context(snapshot_path, config_path, game_version, bindir, base: SnapshotContext) -> SnapshotContext:
+    try:
+        return load_snapshot_context(snapshot_path, config_path, game_version, bindir)
+    except SnapshotMismatchError as exc:
+        if exc.reason != "config_digest_mismatch":
+            raise
+        print("Head snapshot config is stale; using the trusted base snapshot payload for invalidation")
+        contract = load_contract(config_path, game_version, bindir, LATEST_CONFIG_DIGEST_VERSION)
+        return SnapshotContext(base.document, base.raw_bytes, contract)
+
 
 def _run(args) -> None:
     repo_root = Path.cwd()
@@ -125,7 +136,7 @@ def _run(args) -> None:
     args.headconfigyaml = str(resolve_analysis_config(args.gamever, args.headconfigyaml))
     print(f"Head analysis config: {args.headconfigyaml}")
     base = load_snapshot_context(args.basesnapshot, args.baseconfigyaml, args.gamever, args.bindir)
-    head = load_snapshot_context(head_snapshot, args.headconfigyaml, args.gamever, args.bindir)
+    head = _load_head_context(head_snapshot, args.headconfigyaml, args.gamever, args.bindir, base)
     changes = _changed_paths(args.baseref, args.headref, repo_root)
     plan = build_invalidation_plan(
         base.contract,

--- a/gamesymbol_snapshot_lib/pr_cli.py
+++ b/gamesymbol_snapshot_lib/pr_cli.py
@@ -119,6 +119,7 @@ def _delete_paths(contract, paths: frozenset[str]) -> int:
             deleted += 1
     return deleted
 
+
 def _load_head_context(snapshot_path, config_path, game_version, bindir, base: SnapshotContext) -> SnapshotContext:
     try:
         return load_snapshot_context(snapshot_path, config_path, game_version, bindir)

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:0e843a49128d7b788844e0e1acb233e4a40423f9f7f269df7349070565b0cb3c
-file_count: 3163
+config_sha256: sha256:dd5c1c3903bc718e3625075647d51dba2af36bb2d2538603d8acfd5134aaaf34
+file_count: 3165
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -23731,6 +23731,18 @@ files:
     func_sig: 48 8B C4 55 53 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ??
     func_size: '0x688'
     func_va: '0x1801eff20'
+  server/CEngineServer_MakeSpawnGroupActive.linux.yaml:
+    func_name: CEngineServer_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: FF 90 00 02 00 00 89 5D ??
+    vtable_name: CEngineServer
+  server/CEngineServer_MakeSpawnGroupActive.windows.yaml:
+    func_name: CEngineServer_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: 4C 8B 82 00 02 00 00
+    vtable_name: CEngineServer
   server/CEngineServer_UnloadSpawnGroup.linux.yaml:
     func_name: CEngineServer_UnloadSpawnGroup
     vfunc_index: 60
@@ -40082,5 +40094,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-28T13:41:03Z'
+last_publish_time: '2026-07-29T02:09:58Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CEngineServer_MakeSpawnGroupActive.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_MakeSpawnGroupActive.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_MakeSpawnGroupActive skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_MakeSpawnGroupActive",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CEngineServer_MakeSpawnGroupActive",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # The concrete CEngineServer body is in engine2; the vfunc signature is
+    # anchored to its callsite in the server-side spawn-group manager.
+    ("CEngineServer_MakeSpawnGroupActive", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # Caller-anchored vfunc: do not emit a function-body signature.
+    (
+        "CEngineServer_MakeSpawnGroupActive",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Find CEngineServer::MakeSpawnGroupActive from SetActiveSpawnGroup's vcall."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
@@ -1,0 +1,1 @@
+func_name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
@@ -1,0 +1,1 @@
+func_name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup

--- a/tests/test_gamesymbol_pr_cli.py
+++ b/tests/test_gamesymbol_pr_cli.py
@@ -35,6 +35,7 @@ class TestGitChangeCollection(unittest.TestCase):
         with patch("gamesymbol_snapshot_lib.pr_cli.load_snapshot_context", side_effect=failure):
             with self.assertRaisesRegex(SnapshotMismatchError, "not canonical"):
                 _load_head_context("head.yaml", "head-config.yaml", "14172", "bin", base)
+
     def test_parse_name_status_preserves_status_rename_sides_and_spaces(self) -> None:
 
         raw = (

--- a/tests/test_gamesymbol_pr_cli.py
+++ b/tests/test_gamesymbol_pr_cli.py
@@ -2,12 +2,41 @@ import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import patch
 
-from gamesymbol_snapshot_lib.pr_cli import _parse_changed_paths, _revision_sources
+from gamesymbol_snapshot_lib.errors import SnapshotMismatchError
+from gamesymbol_snapshot_lib.model import SnapshotContext
+from gamesymbol_snapshot_lib.pr_cli import _load_head_context, _parse_changed_paths, _revision_sources
 
 
 class TestGitChangeCollection(unittest.TestCase):
+    def test_stale_head_config_uses_trusted_base_payload_for_invalidation(self) -> None:
+        base = SnapshotContext({"files": {"server/Stable.windows.yaml": {}}}, b"base", "base-contract")
+        head_contract = object()
+
+        with (
+            patch(
+                "gamesymbol_snapshot_lib.pr_cli.load_snapshot_context",
+                side_effect=SnapshotMismatchError("digest mismatch", reason="config_digest_mismatch"),
+            ),
+            patch("gamesymbol_snapshot_lib.pr_cli.load_contract", return_value=head_contract) as load_contract,
+        ):
+            head = _load_head_context("head.yaml", "head-config.yaml", "14172", "bin", base)
+
+        self.assertEqual(base.document, head.document)
+        self.assertEqual(base.raw_bytes, head.raw_bytes)
+        self.assertIs(head_contract, head.contract)
+        load_contract.assert_called_once_with("head-config.yaml", "14172", "bin", 2)
+
+    def test_head_snapshot_failures_other_than_config_digest_mismatch_propagate(self) -> None:
+        base = SnapshotContext({}, b"base", "base-contract")
+        failure = SnapshotMismatchError("snapshot is not canonical", reason="noncanonical_snapshot")
+
+        with patch("gamesymbol_snapshot_lib.pr_cli.load_snapshot_context", side_effect=failure):
+            with self.assertRaisesRegex(SnapshotMismatchError, "not canonical"):
+                _load_head_context("head.yaml", "head-config.yaml", "14172", "bin", base)
     def test_parse_name_status_preserves_status_rename_sides_and_spaces(self) -> None:
+
         raw = (
             b"A\0new file.py\0"
             b"M\0modified.py\0"


### PR DESCRIPTION
Summary:`n- add a preprocessor for CEngineServer::MakeSpawnGroupActive using the spawn-group manager callsite`n- register the finder and vfunc alias in the 14172 configuration`n- add platform-specific reference YAML inputs`n`nValidation:`n- git diff --check origin/main...HEAD