### PR TITLE
fix(preprocessor): resolve MakeSpawnGroupActive via IVEngineServer2

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -2764,6 +2764,10 @@ modules:
           - INetworkGameClient::SendStringCmd
       - name: CEngineServer_vtable
         category: vtable
+      - name: CEngineServer_MakeSpawnGroupActive
+        category: vfunc
+        alias:
+          - CEngineServer::MakeSpawnGroupActive
       - name: CMapListService_vtable
         category: vtable
       - name: CEngineServer_DumpNetStats
@@ -7360,9 +7364,9 @@ modules:
           - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
         expected_input:
           - CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
-      - name: find-CEngineServer_MakeSpawnGroupActive
+      - name: find-CSpawnGroupMgrGameSystem_SetActiveSpawnGroup-decompiles
         expected_output:
-          - CEngineServer_MakeSpawnGroupActive.{platform}.yaml
+          - IVEngineServer2_MakeSpawnGroupActive.{platform}.yaml
         expected_input:
           - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
       - name: find-CSpawnGroupMgrGameSystem_UnloadSpawnGroup
@@ -10414,10 +10418,10 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::UnloadSpawnGroup
-      - name: CEngineServer_MakeSpawnGroupActive
+      - name: IVEngineServer2_MakeSpawnGroupActive
         category: vfunc
         alias:
-          - CEngineServer::MakeSpawnGroupActive
+          - IVEngineServer2::MakeSpawnGroupActive
       - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
         category: func
         alias:
@@ -11442,6 +11446,12 @@ modules:
         expected_input:
           - CEngineServer_vtable.{platform}.yaml
           - ../server/IVEngineServer2_ServerCommand.{platform}.yaml
+      - name: find-CEngineServer_MakeSpawnGroupActive
+        expected_output:
+          - CEngineServer_MakeSpawnGroupActive.{platform}.yaml
+        expected_input:
+          - CEngineServer_vtable.{platform}.yaml
+          - ../server/IVEngineServer2_MakeSpawnGroupActive.{platform}.yaml
       - name: find-ConnectInterfaces
         expected_output:
           - ConnectInterfaces.{platform}.yaml

--- a/gamesymbols/14172.yaml
+++ b/gamesymbols/14172.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 8bb3c48086c6e053300d2db6a019a56d2d1dfdb231c3556ff0dd7e77bc170995
 config_digest_version: 2
-config_sha256: sha256:dd5c1c3903bc718e3625075647d51dba2af36bb2d2538603d8acfd5134aaaf34
-file_count: 3165
+config_sha256: sha256:981483d8272f4c39e9c66f0b3e76b4846b6ed6d07e8bfa656538822fe162ec22
+file_count: 3167
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -6469,6 +6469,24 @@ files:
     vfunc_index: 54
     vfunc_offset: '0x1b0'
     vtable_name: CEngineServer_vtable
+  engine/CEngineServer_MakeSpawnGroupActive.linux.yaml:
+    func_name: CEngineServer_MakeSpawnGroupActive
+    func_rva: '0x5158a0'
+    func_sig: 55 48 89 E5 53 89 F3 48 83 EC ?? 48 8D 05 FE 22 ?? ??
+    func_size: '0x3e'
+    func_va: '0x5158a0'
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vtable_name: CEngineServer
+  engine/CEngineServer_MakeSpawnGroupActive.windows.yaml:
+    func_name: CEngineServer_MakeSpawnGroupActive
+    func_rva: '0xa0180'
+    func_sig: 48 8B 0D C9 D8 86 ??
+    func_size: '0x17'
+    func_va: '0x1800a0180'
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vtable_name: CEngineServer
   engine/CEngineServer_PrecacheGeneric.linux.yaml:
     func_name: CEngineServer_PrecacheGeneric
     func_rva: '0x5168c0'
@@ -23731,18 +23749,6 @@ files:
     func_sig: 48 8B C4 55 53 48 8D A8 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 83 B9 ?? ?? ?? ?? ??
     func_size: '0x688'
     func_va: '0x1801eff20'
-  server/CEngineServer_MakeSpawnGroupActive.linux.yaml:
-    func_name: CEngineServer_MakeSpawnGroupActive
-    vfunc_index: 64
-    vfunc_offset: '0x200'
-    vfunc_sig: FF 90 00 02 00 00 89 5D ??
-    vtable_name: CEngineServer
-  server/CEngineServer_MakeSpawnGroupActive.windows.yaml:
-    func_name: CEngineServer_MakeSpawnGroupActive
-    vfunc_index: 64
-    vfunc_offset: '0x200'
-    vfunc_sig: 4C 8B 82 00 02 00 00
-    vtable_name: CEngineServer
   server/CEngineServer_UnloadSpawnGroup.linux.yaml:
     func_name: CEngineServer_UnloadSpawnGroup
     vfunc_index: 60
@@ -38094,6 +38100,18 @@ files:
     vfunc_offset: '0x1b8'
     vfunc_sig: FF 90 B8 01 00 00 48 8B 35 ?? ?? ?? ??
     vtable_name: IVEngineServer2
+  server/IVEngineServer2_MakeSpawnGroupActive.linux.yaml:
+    func_name: IVEngineServer2_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: FF 90 00 02 00 00 89 5D ??
+    vtable_name: IVEngineServer2
+  server/IVEngineServer2_MakeSpawnGroupActive.windows.yaml:
+    func_name: IVEngineServer2_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: 4C 8B 82 00 02 00 00
+    vtable_name: IVEngineServer2
   server/IVEngineServer2_ServerCommand.linux.yaml:
     func_name: IVEngineServer2_ServerCommand
     vfunc_index: 45
@@ -40094,5 +40112,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14172'
-last_publish_time: '2026-07-29T02:09:58Z'
+last_publish_time: '2026-07-29T07:09:39Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CEngineServer_MakeSpawnGroupActive.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_MakeSpawnGroupActive.py
@@ -3,40 +3,28 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CEngineServer_MakeSpawnGroupActive",
-]
-
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CEngineServer_MakeSpawnGroupActive",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # The concrete CEngineServer body is in engine2; the vfunc signature is
-    # anchored to its callsite in the server-side spawn-group manager.
-    ("CEngineServer_MakeSpawnGroupActive", "CEngineServer"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CEngineServer_MakeSpawnGroupActive",
+        "CEngineServer",
+        "../server/IVEngineServer2_MakeSpawnGroupActive",
+        True,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
-    # Caller-anchored vfunc: do not emit a function-body signature.
     (
         "CEngineServer_MakeSpawnGroupActive",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -50,10 +38,9 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Find CEngineServer::MakeSpawnGroupActive from SetActiveSpawnGroup's vcall."""
+    """Inherit the MakeSpawnGroupActive slot from IVEngineServer2."""
     _ = skill_name
     return await preprocess_common_skill(
         session=session,
@@ -62,10 +49,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-CSpawnGroupMgrGameSystem_SetActiveSpawnGroup-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSpawnGroupMgrGameSystem_SetActiveSpawnGroup-decompiles.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSpawnGroupMgrGameSystem_SetActiveSpawnGroup-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IVEngineServer2_MakeSpawnGroupActive",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IVEngineServer2_MakeSpawnGroupActive",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # IVEngineServer2 is abstract; this relation supplies vtable metadata only.
+    ("IVEngineServer2_MakeSpawnGroupActive", "IVEngineServer2"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IVEngineServer2_MakeSpawnGroupActive",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the IVEngineServer2 MakeSpawnGroupActive slot from SetActiveSpawnGroup."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
@@ -1,1 +1,264 @@
 func_name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+func_va: '0xf28550'
+disasm_code: |-
+  .text:0000000000F28550                 push    rbp
+  .text:0000000000F28551                 mov     rbp, rsp
+  .text:0000000000F28554                 push    r14
+  .text:0000000000F28556                 push    r13
+  .text:0000000000F28558                 push    r12
+  .text:0000000000F2855A                 push    rbx
+  .text:0000000000F2855B                 mov     ebx, esi
+  .text:0000000000F2855D                 sub     rsp, 30h
+  .text:0000000000F28561                 call    sub_F279C0
+  .text:0000000000F28566                 test    rax, rax
+  .text:0000000000F28569                 jz      loc_F286D8
+  .text:0000000000F2856F                 mov     rdi, [rax]
+  .text:0000000000F28572                 lea     rdx, sub_EFB940
+  .text:0000000000F28579                 mov     rax, [rdi]
+  .text:0000000000F2857C                 mov     rax, [rax]
+  .text:0000000000F2857F                 cmp     rax, rdx
+  .text:0000000000F28582                 jnz     loc_F286C8
+  .text:0000000000F28588                 mov     r12, [rdi+8]
+  .text:0000000000F2858C                 lea     rax, haystack
+  .text:0000000000F28593                 test    r12, r12
+  .text:0000000000F28596                 cmovz   r12, rax
+  .text:0000000000F2859A                 lea     r14, g_pEntitySystem
+  .text:0000000000F285A1                 mov     rdi, [r14]
+  .text:0000000000F285A4                 call    sub_2115E60
+  .text:0000000000F285A9                 mov     r13d, eax
+  .text:0000000000F285AC                 cmp     ebx, eax
+  .text:0000000000F285AE                 jz      short loc_F2862A
+  .text:0000000000F285B0                 mov     rdi, [r14]
+  .text:0000000000F285B3                 mov     esi, ebx
+  .text:0000000000F285B5                 call    sub_2115E50
+  .text:0000000000F285BA                 lea     rax, g_engine
+  .text:0000000000F285C1                 mov     esi, ebx
+  .text:0000000000F285C3                 mov     rdi, [rax]
+  .text:0000000000F285C6                 mov     rax, [rdi]
+  .text:0000000000F285C9                 call    qword ptr [rax+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive
+  .text:0000000000F285CF                 mov     dword ptr [rbp+var_40], ebx
+  .text:0000000000F285D2                 lea     rbx, [rbp+var_38]
+  .text:0000000000F285D6                 ; char *
+  .text:0000000000F285D6                 mov     rsi, r12; char *
+  .text:0000000000F285D9                 ; this
+  .text:0000000000F285D9                 mov     rdi, rbx; this
+  .text:0000000000F285DC                 mov     [rbp+var_38], 0
+  .text:0000000000F285E4                 mov     [rbp+var_30], r13d
+  .text:0000000000F285E8                 call    __ZN10CUtlString3SetEPKc; CUtlString::Set(char const*)
+  .text:0000000000F285ED                 ; _QWORD
+  .text:0000000000F285ED                 mov     edi, cs:dword_272E148; _QWORD
+  .text:0000000000F285F3                 ; _QWORD
+  .text:0000000000F285F3                 mov     esi, 1; _QWORD
+  .text:0000000000F285F8                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000000F285FD                 test    al, al
+  .text:0000000000F285FF                 jnz     short loc_F28640
+  .text:0000000000F28601                 mov     edi, cs:dword_25B4524
+  .text:0000000000F28607                 test    edi, edi
+  .text:0000000000F28609                 js      short loc_F2866D
+  .text:0000000000F2860B                 lea     rcx, [rbp+var_40]
+  .text:0000000000F2860F                 xor     edx, edx
+  .text:0000000000F28611                 mov     esi, 99h
+  .text:0000000000F28616                 call    sub_EC6CF0
+  .text:0000000000F2861B                 cmp     [rbp+var_38], 0
+  .text:0000000000F28620                 jz      short loc_F2862A
+  .text:0000000000F28622                 ; this
+  .text:0000000000F28622                 mov     rdi, rbx; this
+  .text:0000000000F28625                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:0000000000F2862A                 add     rsp, 30h
+  .text:0000000000F2862E                 pop     rbx
+  .text:0000000000F2862F                 pop     r12
+  .text:0000000000F28631                 pop     r13
+  .text:0000000000F28633                 pop     r14
+  .text:0000000000F28635                 pop     rbp
+  .text:0000000000F28636                 retn
+  .text:0000000000F28640                 ; _QWORD
+  .text:0000000000F28640                 mov     edi, cs:dword_272E148; _QWORD
+  .text:0000000000F28646                 mov     r8, r12
+  .text:0000000000F28649                 ; _QWORD
+  .text:0000000000F28649                 mov     esi, 1; _QWORD
+  .text:0000000000F2864E                 xor     eax, eax
+  .text:0000000000F28650                 lea     rcx, aSv_0; "SV"
+  .text:0000000000F28657                 lea     rdx, aSCspawngroupmg; "%s:  CSpawnGroupMgrGameSystem::PerformA"...
+  .text:0000000000F2865E                 call    _LoggingSystem_Log
+  .text:0000000000F28663                 mov     edi, cs:dword_25B4524
+  .text:0000000000F28669                 test    edi, edi
+  .text:0000000000F2866B                 jns     short loc_F2860B
+  .text:0000000000F2866D                 lea     r13, off_23C1238
+  .text:0000000000F28674                 mov     [rbp+var_48], 0
+  .text:0000000000F2867C                 mov     [rbp+var_50], r13
+  .text:0000000000F28680                 movzx   eax, cs:byte_2727750
+  .text:0000000000F28687                 test    al, al
+  .text:0000000000F28689                 jz      loc_F28768
+  .text:0000000000F2868F                 mov     rax, cs:qword_2727758
+  .text:0000000000F28696                 lea     r12, [rbp+var_50]
+  .text:0000000000F2869A                 mov     rdi, r12
+  .text:0000000000F2869D                 mov     [rbp+var_50], rax
+  .text:0000000000F286A1                 call    qword ptr [rax+98h]
+  .text:0000000000F286A7                 mov     rdi, r12
+  .text:0000000000F286AA                 mov     [rbp+var_50], r13
+  .text:0000000000F286AE                 mov     cs:dword_25B4524, eax
+  .text:0000000000F286B4                 call    nullsub_653
+  .text:0000000000F286B9                 mov     edi, cs:dword_25B4524
+  .text:0000000000F286BF                 jmp     loc_F2860B
+  .text:0000000000F286C8                 call    rax
+  .text:0000000000F286CA                 mov     r12, rax
+  .text:0000000000F286CD                 jmp     loc_F2859A
+  .text:0000000000F286D8                 ; _QWORD
+  .text:0000000000F286D8                 mov     edi, cs:dword_272E148; _QWORD
+  .text:0000000000F286DE                 ; _QWORD
+  .text:0000000000F286DE                 mov     esi, 1; _QWORD
+  .text:0000000000F286E3                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000000F286E8                 test    al, al
+  .text:0000000000F286EA                 jz      loc_F2862A
+  .text:0000000000F286F0                 lea     edx, [rbx-80000000h]
+  .text:0000000000F286F6                 mov     [rbp+var_40], 0
+  .text:0000000000F286FE                 lea     r12, [rbp+var_40]
+  .text:0000000000F28702                 cmp     edx, 7FFFFFFEh
+  .text:0000000000F28708                 ja      loc_F287A0
+  .text:0000000000F2870E                 lea     rsi, aCoU; "CO-%u"
+  .text:0000000000F28715                 ; this
+  .text:0000000000F28715                 mov     rdi, r12; this
+  .text:0000000000F28718                 xor     eax, eax
+  .text:0000000000F2871A                 call    __ZN10CUtlString6FormatEPKcz; CUtlString::Format(char const*,...)
+  .text:0000000000F2871F                 mov     rcx, [rbp+var_40]
+  .text:0000000000F28723                 lea     rax, haystack
+  .text:0000000000F2872A                 ; _QWORD
+  .text:0000000000F2872A                 mov     esi, 1; _QWORD
+  .text:0000000000F2872F                 ; _QWORD
+  .text:0000000000F2872F                 mov     edi, cs:dword_272E148; _QWORD
+  .text:0000000000F28735                 lea     rdx, aSCspawngroupmg_0; "%s:  CSpawnGroupMgrGameSystem::Activate"...
+  .text:0000000000F2873C                 test    rcx, rcx
+  .text:0000000000F2873F                 cmovz   rcx, rax
+  .text:0000000000F28743                 xor     eax, eax
+  .text:0000000000F28745                 call    _LoggingSystem_Log
+  .text:0000000000F2874A                 cmp     [rbp+var_40], 0
+  .text:0000000000F2874F                 jz      loc_F2862A
+  .text:0000000000F28755                 ; this
+  .text:0000000000F28755                 mov     rdi, r12; this
+  .text:0000000000F28758                 call    __ZN10CUtlString15FreeMemoryBlockEv; CUtlString::FreeMemoryBlock(void)
+  .text:0000000000F2875D                 jmp     loc_F2862A
+  .text:0000000000F28768                 lea     r12, byte_2727750
+  .text:0000000000F2876F                 ; _QWORD
+  .text:0000000000F2876F                 mov     rdi, r12; _QWORD
+  .text:0000000000F28772                 call    ___cxa_guard_acquire
+  .text:0000000000F28777                 test    eax, eax
+  .text:0000000000F28779                 jz      loc_F2868F
+  .text:0000000000F2877F                 mov     rax, cs:off_25B3F18
+  .text:0000000000F28786                 ; _QWORD
+  .text:0000000000F28786                 mov     rdi, r12; _QWORD
+  .text:0000000000F28789                 mov     cs:qword_2727758, rax
+  .text:0000000000F28790                 call    ___cxa_guard_release
+  .text:0000000000F28795                 jmp     loc_F2868F
+  .text:0000000000F287A0                 mov     edx, ebx
+  .text:0000000000F287A2                 ; this
+  .text:0000000000F287A2                 mov     rdi, r12; this
+  .text:0000000000F287A5                 xor     eax, eax
+  .text:0000000000F287A7                 lea     rsi, aU_0; "%u"
+  .text:0000000000F287AE                 call    __ZN10CUtlString6FormatEPKcz; CUtlString::Format(char const*,...)
+  .text:0000000000F287B3                 jmp     loc_F2871F
+procedure: |-
+  __int64 __fastcall CSpawnGroupMgrGameSystem_SetActiveSpawnGroup(__int64 a1, __int64 a2)
+  {
+    __int64 (****v2)(void); // rax
+    __int64 (***v3)(void); // rdi
+    __int64 (*v4)(void); // rax
+    const char *v5; // r12
+    __int64 result; // rax
+    int v7; // r13d
+    __int64 v8; // rdi
+    int v9; // eax
+    const bool *v10; // rcx
+    _QWORD v11[2]; // [rsp+0h] [rbp-50h] BYREF
+    const bool *v12; // [rsp+10h] [rbp-40h] BYREF
+    __int64 v13; // [rsp+18h] [rbp-38h] BYREF
+    int v14; // [rsp+20h] [rbp-30h]
+
+    v2 = (__int64 (****)(void))sub_F279C0(a1, a2);
+    if ( v2 )
+    {
+      v3 = *v2;
+      v4 = ***v2;
+      if ( v4 == sub_EFB940 )
+      {
+        v5 = (const char *)v3[1];
+        if ( !v5 )
+          v5 = (const char *)&haystack;
+      }
+      else
+      {
+        v5 = (const char *)v4();
+      }
+      result = sub_2115E60(g_pEntitySystem);
+      v7 = result;
+      if ( (_DWORD)a2 != (_DWORD)result )
+      {
+        sub_2115E50(g_pEntitySystem, (unsigned int)a2);
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, (unsigned int)a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive
+        LODWORD(v12) = a2;
+        v13 = 0;
+        v14 = v7;
+        CUtlString::Set((CUtlString *)&v13, v5);
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_272E148, 1) )
+        {
+          LoggingSystem_Log(
+            (unsigned int)dword_272E148,
+            1,
+            "%s:  CSpawnGroupMgrGameSystem::PerformActivateSpawnGroup(%s)\n",
+            "SV",
+            v5);
+          v8 = (unsigned int)dword_25B4524;
+          if ( dword_25B4524 >= 0 )
+          {
+  LABEL_8:
+            result = sub_EC6CF0(v8, 153, 0, &v12);
+            if ( v13 )
+              return CUtlString::FreeMemoryBlock((CUtlString *)&v13);
+            return result;
+          }
+        }
+        else
+        {
+          v8 = (unsigned int)dword_25B4524;
+          if ( dword_25B4524 >= 0 )
+            goto LABEL_8;
+        }
+        v11[1] = 0;
+        v11[0] = off_23C1238;
+        if ( !(_BYTE)byte_2727750 && (unsigned int)__cxa_guard_acquire(&byte_2727750) )
+        {
+          qword_2727758 = (__int64)off_25B3F18[0];
+          __cxa_guard_release(&byte_2727750);
+        }
+        v11[0] = qword_2727758;
+        v9 = (*(__int64 (__fastcall **)(_QWORD *))(qword_2727758 + 152))(v11);
+        v11[0] = off_23C1238;
+        dword_25B4524 = v9;
+        nullsub_653(v11);
+        v8 = (unsigned int)dword_25B4524;
+        goto LABEL_8;
+      }
+    }
+    else
+    {
+      result = LoggingSystem_IsChannelEnabled((unsigned int)dword_272E148, 1);
+      if ( (_BYTE)result )
+      {
+        v12 = nullptr;
+        if ( (unsigned int)a2 + 0x80000000 > 0x7FFFFFFE )
+          CUtlString::Format((CUtlString *)&v12, "%u", a2);
+        else
+          CUtlString::Format((CUtlString *)&v12, "CO-%u", a2 + 0x80000000);
+        v10 = v12;
+        if ( !v12 )
+          v10 = &haystack;
+        result = LoggingSystem_Log(
+                   (unsigned int)dword_272E148,
+                   1,
+                   "%s:  CSpawnGroupMgrGameSystem::ActivateSpawnGroup:  no such group\n",
+                   v10);
+        if ( v12 )
+          return CUtlString::FreeMemoryBlock((CUtlString *)&v12);
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
@@ -1,1 +1,222 @@
 func_name: CSpawnGroupMgrGameSystem_SetActiveSpawnGroup
+func_va: '0x18058b000'
+disasm_code: |-
+  .text:000000018058B000                 mov     [rsp+arg_18], rbx
+  .text:000000018058B005                 push    rdi
+  .text:000000018058B006                 sub     rsp, 60h
+  .text:000000018058B00A                 xor     edi, edi
+  .text:000000018058B00C                 mov     ebx, edx
+  .text:000000018058B00E                 mov     dword ptr [rsp+68h+arg_10], edi
+  .text:000000018058B015                 call    sub_180559F90
+  .text:000000018058B01A                 test    rax, rax
+  .text:000000018058B01D                 jnz     loc_18058B0DD
+  .text:000000018058B023                 mov     ecx, cs:dword_181E42170
+  .text:000000018058B029                 mov     edx, 1
+  .text:000000018058B02E                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018058B034                 test    al, al
+  .text:000000018058B036                 jz      short loc_18058B0A8
+  .text:000000018058B038                 lea     eax, [rbx-80000000h]
+  .text:000000018058B03E                 mov     [rsp+68h+arg_10], rdi
+  .text:000000018058B046                 lea     rcx, [rsp+68h+arg_10]
+  .text:000000018058B04E                 cmp     eax, 7FFFFFFEh
+  .text:000000018058B053                 ja      short loc_18058B065
+  .text:000000018058B055                 lea     r8d, [rbx-80000000h]
+  .text:000000018058B05C                 lea     rdx, aCoU; "CO-%u"
+  .text:000000018058B063                 jmp     short loc_18058B06F
+  .text:000000018058B065                 mov     r8d, ebx
+  .text:000000018058B068                 lea     rdx, aU; "%u"
+  .text:000000018058B06F                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
+  .text:000000018058B075                 mov     rax, [rsp+68h+arg_10]
+  .text:000000018058B07D                 lea     r9, byte_1815DA9A0
+  .text:000000018058B084                 mov     ecx, cs:dword_181E42170
+  .text:000000018058B08A                 lea     r8, aSCspawngroupmg_1; "%s:  CSpawnGroupMgrGameSystem::Activate"...
+  .text:000000018058B091                 test    rax, rax
+  .text:000000018058B094                 mov     edx, 1
+  .text:000000018058B099                 cmovnz  r9, rax
+  .text:000000018058B09D                 call    cs:LoggingSystem_Log
+  .text:000000018058B0A3                 mov     edi, 1
+  .text:000000018058B0A8                 test    dil, 1
+  .text:000000018058B0AC                 jz      loc_18058B221
+  .text:000000018058B0B2                 cmp     [rsp+68h+arg_10], 0
+  .text:000000018058B0BB                 jz      loc_18058B221
+  .text:000000018058B0C1                 lea     rcx, [rsp+68h+arg_10]
+  .text:000000018058B0C9                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018058B0CF                 mov     rbx, [rsp+68h+arg_18]
+  .text:000000018058B0D7                 add     rsp, 60h
+  .text:000000018058B0DB                 pop     rdi
+  .text:000000018058B0DC                 retn
+  .text:000000018058B0DD                 mov     rcx, [rax]
+  .text:000000018058B0E0                 mov     [rsp+68h+arg_0], rbp
+  .text:000000018058B0E5                 mov     [rsp+68h+arg_8], rsi
+  .text:000000018058B0EA                 mov     rax, [rcx]
+  .text:000000018058B0ED                 call    qword ptr [rax]
+  .text:000000018058B0EF                 mov     rcx, cs:g_pEntitySystem
+  .text:000000018058B0F6                 mov     rsi, rax
+  .text:000000018058B0F9                 call    sub_1812227E0
+  .text:000000018058B0FE                 mov     ebp, eax
+  .text:000000018058B100                 cmp     eax, ebx
+  .text:000000018058B102                 jz      loc_18058B217
+  .text:000000018058B108                 mov     rcx, cs:g_pEntitySystem
+  .text:000000018058B10F                 mov     edx, ebx
+  .text:000000018058B111                 call    sub_18122C680
+  .text:000000018058B116                 mov     rcx, cs:g_engine
+  .text:000000018058B11D                 mov     rdx, [rcx]
+  .text:000000018058B120                 mov     r8, [rdx+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive
+  .text:000000018058B127                 mov     edx, ebx
+  .text:000000018058B129                 call    r8
+  .text:000000018058B12C                 mov     rdx, rsi
+  .text:000000018058B12F                 mov     [rsp+68h+var_20], rdi
+  .text:000000018058B134                 lea     rcx, [rsp+68h+var_20]
+  .text:000000018058B139                 mov     [rsp+68h+var_28], ebx
+  .text:000000018058B13D                 mov     [rsp+68h+var_18], ebp
+  .text:000000018058B141                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018058B147                 mov     ecx, cs:dword_181E42170
+  .text:000000018058B14D                 mov     edx, 1
+  .text:000000018058B152                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018058B158                 test    al, al
+  .text:000000018058B15A                 jz      short loc_18058B180
+  .text:000000018058B15C                 mov     ecx, cs:dword_181E42170
+  .text:000000018058B162                 lea     r9, aSv; "SV"
+  .text:000000018058B169                 lea     r8, aSCspawngroupmg_2; "%s:  CSpawnGroupMgrGameSystem::PerformA"...
+  .text:000000018058B170                 mov     [rsp+68h+var_48], rsi
+  .text:000000018058B175                 mov     edx, 1
+  .text:000000018058B17A                 call    cs:LoggingSystem_Log
+  .text:000000018058B180                 mov     ecx, cs:dword_181BE64D8
+  .text:000000018058B186                 test    ecx, ecx
+  .text:000000018058B188                 jns     short loc_18058B1F4
+  .text:000000018058B18A                 mov     ecx, cs:TlsIndex
+  .text:000000018058B190                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:000000018058B197                 mov     [rsp+68h+var_38], rax
+  .text:000000018058B19C                 mov     rax, gs:58h
+  .text:000000018058B1A5                 mov     edx, 238h
+  .text:000000018058B1AA                 mov     [rsp+68h+var_30], rdi
+  .text:000000018058B1AF                 mov     rax, [rax+rcx*8]
+  .text:000000018058B1B3                 mov     eax, [rdx+rax]
+  .text:000000018058B1B6                 cmp     cs:dword_181E3F3D8, eax
+  .text:000000018058B1BC                 jg      short loc_18058B22F
+  .text:000000018058B1BE                 mov     rax, cs:qword_181E3F3D0
+  .text:000000018058B1C5                 lea     rcx, [rsp+68h+var_38]
+  .text:000000018058B1CA                 mov     rbx, [rsp+68h+var_38]
+  .text:000000018058B1CF                 mov     [rsp+68h+var_38], rax
+  .text:000000018058B1D4                 call    sub_180500EB4
+  .text:000000018058B1D9                 lea     rcx, [rsp+68h+var_38]
+  .text:000000018058B1DE                 mov     [rsp+68h+var_38], rbx
+  .text:000000018058B1E3                 mov     cs:dword_181BE64D8, eax
+  .text:000000018058B1E9                 call    sub_1805006A0
+  .text:000000018058B1EE                 mov     ecx, cs:dword_181BE64D8
+  .text:000000018058B1F4                 lea     r8, [rsp+68h+var_28]
+  .text:000000018058B1F9                 lea     rdx, sub_180500EB4
+  .text:000000018058B200                 call    sub_180509290
+  .text:000000018058B205                 cmp     [rsp+68h+var_20], rdi
+  .text:000000018058B20A                 jz      short loc_18058B217
+  .text:000000018058B20C                 lea     rcx, [rsp+68h+var_20]
+  .text:000000018058B211                 call    cs:?FreeMemoryBlock@CUtlString@@AEAAXXZ; CUtlString::FreeMemoryBlock(void)
+  .text:000000018058B217                 mov     rbp, [rsp+68h+arg_0]
+  .text:000000018058B21C                 mov     rsi, [rsp+68h+arg_8]
+  .text:000000018058B221                 mov     rbx, [rsp+68h+arg_18]
+  .text:000000018058B229                 add     rsp, 60h
+  .text:000000018058B22D                 pop     rdi
+  .text:000000018058B22E                 retn
+  .text:000000018058B22F                 lea     rcx, dword_181E3F3D8
+  .text:000000018058B236                 call    sub_18152F5F4
+  .text:000000018058B23B                 cmp     cs:dword_181E3F3D8, 0FFFFFFFFh
+  .text:000000018058B242                 jnz     loc_18058B1BE
+  .text:000000018058B248                 mov     rax, cs:off_181BE6600
+  .text:000000018058B24F                 lea     rcx, dword_181E3F3D8
+  .text:000000018058B256                 mov     cs:qword_181E3F3D0, rax
+  .text:000000018058B25D                 call    sub_18152F588
+  .text:000000018058B262                 jmp     loc_18058B1BE
+procedure: |-
+  void __fastcall CSpawnGroupMgrGameSystem_SetActiveSpawnGroup(__int64 a1, unsigned int a2)
+  {
+    char v2; // di
+    _QWORD *v4; // rax
+    char *v5; // r9
+    const char *v6; // rsi
+    int v7; // ebp
+    __int64 v8; // rcx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v10; // rbx
+    int v11; // eax
+    _QWORD v12[2]; // [rsp+30h] [rbp-38h] BYREF
+    unsigned int v13; // [rsp+40h] [rbp-28h] BYREF
+    __int64 v14; // [rsp+48h] [rbp-20h] BYREF
+    int v15; // [rsp+50h] [rbp-18h]
+    char *v16; // [rsp+80h] [rbp+18h] BYREF
+
+    v2 = 0;
+    LODWORD(v16) = 0;
+    v4 = (_QWORD *)sub_180559F90(a1);
+    if ( v4 )
+    {
+      v6 = (const char *)(**(__int64 (__fastcall ***)(_QWORD))*v4)(*v4);
+      v7 = sub_1812227E0(g_pEntitySystem);
+      if ( v7 != a2 )
+      {
+        sub_18122C680(g_pEntitySystem, a2);
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive
+        v14 = 0;
+        v13 = a2;
+        v15 = v7;
+        CUtlString::Set((CUtlString *)&v14, v6);
+        if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181E42170, 1) )
+          LoggingSystem_Log(
+            (unsigned int)dword_181E42170,
+            1,
+            "%s:  CSpawnGroupMgrGameSystem::PerformActivateSpawnGroup(%s)\n",
+            "SV",
+            v6);
+        v8 = (unsigned int)dword_181BE64D8;
+        if ( dword_181BE64D8 < 0 )
+        {
+          v12[0] = &CDontUseThisGameSystem::`vftable';
+          ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+          v12[1] = 0;
+          if ( dword_181E3F3D8 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 568LL) )
+          {
+            sub_18152F5F4(&dword_181E3F3D8);
+            if ( dword_181E3F3D8 == -1 )
+            {
+              qword_181E3F3D0 = (__int64)off_181BE6600[0];
+              sub_18152F588(&dword_181E3F3D8);
+            }
+          }
+          v10 = v12[0];
+          v12[0] = qword_181E3F3D0;
+          v11 = sub_180500EB4(v12);
+          v12[0] = v10;
+          dword_181BE64D8 = v11;
+          sub_1805006A0(v12);
+          v8 = (unsigned int)dword_181BE64D8;
+        }
+        sub_180509290(v8, sub_180500EB4, &v13);
+        if ( v14 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v14);
+      }
+    }
+    else
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181E42170, 1) )
+      {
+        v16 = nullptr;
+        if ( a2 + 0x80000000 > 0x7FFFFFFE )
+          CUtlString::Format((CUtlString *)&v16, "%u", a2);
+        else
+          CUtlString::Format((CUtlString *)&v16, "CO-%u", a2 + 0x80000000);
+        v5 = byte_1815DA9A0;
+        if ( v16 )
+          v5 = v16;
+        LoggingSystem_Log(
+          (unsigned int)dword_181E42170,
+          1,
+          "%s:  CSpawnGroupMgrGameSystem::ActivateSpawnGroup:  no such group\n",
+          v5);
+        v2 = 1;
+      }
+      if ( (v2 & 1) != 0 )
+      {
+        if ( v16 )
+          CUtlString::FreeMemoryBlock((CUtlString *)&v16);
+      }
+    }
+  }

--- a/tests/test_trusted_yaml.py
+++ b/tests/test_trusted_yaml.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import yaml
 
+import generate_reference_yaml
 import trusted_yaml
 
 
@@ -57,6 +58,20 @@ class TestRepositoryYamlCompatibility(unittest.TestCase):
             with self.subTest(fixture=fixture_path):
                 raw = fixture_path.read_bytes()
                 self.assertEqual(yaml.load(raw, Loader=yaml.SafeLoader), trusted_yaml.load_yaml(raw))
+
+    def test_reference_yamls_match_generation_contract(self) -> None:
+        reference_root = Path("ida_preprocessor_scripts/references")
+        reference_paths = sorted(reference_root.rglob("*.yaml"))
+        self.assertTrue(reference_paths, f"no reference YAML files found under {reference_root}")
+
+        for reference_path in reference_paths:
+            with self.subTest(reference=reference_path):
+                payload = trusted_yaml.load_yaml_file(reference_path)
+                self.assertIsInstance(payload, dict)
+                try:
+                    generate_reference_yaml._validate_reference_yaml_payload(payload)
+                except generate_reference_yaml.ReferenceGenerationError as exc:
+                    self.fail(f"{reference_path}: {exc}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- recover `IVEngineServer2_MakeSpawnGroupActive` from the spawn-group manager callsite with complete Windows and Linux reference YAMLs
- derive `CEngineServer_MakeSpawnGroupActive` through the verified interface vfunc relationship
- validate every checked-in reference YAML against the generation contract so `func_name`-only placeholders fail repository validation

## Validation

- `uv run python -m unittest tests.test_trusted_yaml -b`
- `uv run python tests/run_test_suite.py repository-contract -b`
- `uv run python format_repo_files.py --check`
- `git diff --check`