### PR TITLE
Add achievement manager preprocessors

### DIFF
--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -1350,6 +1350,11 @@ modules:
       - name: find-CEngineServer_vtable
         expected_output:
           - CEngineServer_vtable.{platform}.yaml
+      - name: find-CEngineServer_GetAchievementMgr
+        expected_output:
+          - CEngineServer_GetAchievementMgr.{platform}.yaml
+        expected_input:
+          - ../server/CBasePlayerController_SetConnectedState_Impl.{platform}.yaml
       - name: find-CMapListService_vtable
         expected_output:
           - CMapListService_vtable.{platform}.yaml
@@ -2764,6 +2769,10 @@ modules:
           - INetworkGameClient::SendStringCmd
       - name: CEngineServer_vtable
         category: vtable
+      - name: CEngineServer_GetAchievementMgr
+        category: vfunc
+        alias:
+          - CEngineServer::GetAchievementMgr
       - name: CMapListService_vtable
         category: vtable
       - name: CEngineServer_DumpNetStats
@@ -5883,6 +5892,11 @@ modules:
           - CBasePlayerController_GetPawn.{platform}.yaml
         expected_input:
           - CSource2GameClients_ClientDisconnect.{platform}.yaml
+      - name: find-CBasePlayerController_SetConnectedState_Impl
+        expected_output:
+          - CBasePlayerController_SetConnectedState_Impl.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_ClientDisconnect.{platform}.yaml
       - name: find-CBasePlayerController_SetPlayerName
         expected_output:
           - CBasePlayerController_SetPlayerName.{platform}.yaml
@@ -8871,6 +8885,10 @@ modules:
         category: func
         alias:
           - CBasePlayerController::GetPawn
+      - name: CBasePlayerController_SetConnectedState_Impl
+        category: func
+        alias:
+          - CBasePlayerController::SetConnectedState_Impl
       - name: CBasePlayerController_Connect
         category: vfunc
         alias:

--- a/configs/14172.yaml
+++ b/configs/14172.yaml
@@ -1350,11 +1350,6 @@ modules:
       - name: find-CEngineServer_vtable
         expected_output:
           - CEngineServer_vtable.{platform}.yaml
-      - name: find-CEngineServer_GetAchievementMgr
-        expected_output:
-          - CEngineServer_GetAchievementMgr.{platform}.yaml
-        expected_input:
-          - ../server/CBasePlayerController_SetConnectedState_Impl.{platform}.yaml
       - name: find-CMapListService_vtable
         expected_output:
           - CMapListService_vtable.{platform}.yaml
@@ -2769,10 +2764,6 @@ modules:
           - INetworkGameClient::SendStringCmd
       - name: CEngineServer_vtable
         category: vtable
-      - name: CEngineServer_GetAchievementMgr
-        category: vfunc
-        alias:
-          - CEngineServer::GetAchievementMgr
       - name: CMapListService_vtable
         category: vtable
       - name: CEngineServer_DumpNetStats
@@ -5897,6 +5888,11 @@ modules:
           - CBasePlayerController_SetConnectedState_Impl.{platform}.yaml
         expected_input:
           - CSource2GameClients_ClientDisconnect.{platform}.yaml
+      - name: find-CEngineServer_GetAchievementMgr
+        expected_output:
+          - CEngineServer_GetAchievementMgr.{platform}.yaml
+        expected_input:
+          - CBasePlayerController_SetConnectedState_Impl.{platform}.yaml
       - name: find-CBasePlayerController_SetPlayerName
         expected_output:
           - CBasePlayerController_SetPlayerName.{platform}.yaml
@@ -8889,6 +8885,10 @@ modules:
         category: func
         alias:
           - CBasePlayerController::SetConnectedState_Impl
+      - name: CEngineServer_GetAchievementMgr
+        category: vfunc
+        alias:
+          - CEngineServer::GetAchievementMgr
       - name: CBasePlayerController_Connect
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CBasePlayerController_SetConnectedState_Impl.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_SetConnectedState_Impl.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_SetConnectedState_Impl skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_SetConnectedState_Impl",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CBasePlayerController_SetConnectedState_Impl",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSource2GameClients_ClientDisconnect.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CSource2GameClients_ClientDisconnect.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_SetConnectedState_Impl",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEngineServer_GetAchievementMgr.py
+++ b/ida_preprocessor_scripts/find-CEngineServer_GetAchievementMgr.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEngineServer_GetAchievementMgr skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEngineServer_GetAchievementMgr",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CEngineServer_GetAchievementMgr",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CBasePlayerController_SetConnectedState_Impl.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CBasePlayerController_SetConnectedState_Impl.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # CEngineServer's concrete body is in engine2; the vfunc signature anchors
+    # to the callsite in CBasePlayerController_SetConnectedState_Impl (server).
+    ("CEngineServer_GetAchievementMgr", "CEngineServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEngineServer_GetAchievementMgr",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Find CEngineServer::GetAchievementMgr from its server-side vcall."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary\n- add LLM decompile preprocessor for CBasePlayerController_SetConnectedState_Impl\n- add CEngineServer_GetAchievementMgr vfunc preprocessor\n- register both symbols and their cross-module dependency in config 14172\n\n## Validation\n- uv run python -m unittest tests.test_analysis_config tests.test_llm_decompile_dependencies tests.test_script_desc_internal_preprocessor\n- uv run python -m py_compile ida_preprocessor_scripts/find-CBasePlayerController_SetConnectedState_Impl.py ida_preprocessor_scripts/find-CEngineServer_GetAchievementMgr.py