### PR TITLE
feat(patch): record patch signature addresses

### DIFF
--- a/.claude/skills/find-CCSPlayer_MovementServices_CheckJumpButton_WaterPatch/SKILL.md
+++ b/.claude/skills/find-CCSPlayer_MovementServices_CheckJumpButton_WaterPatch/SKILL.md
@@ -110,7 +110,7 @@ Required parameters:
 ## IEEE 754 Float Reference
 
 - `100.0f` = `0x42C80000` = `1120403456` decimal
-- `145.0f` = `0x43110000` = `1125122048` decimal
+- `145.0f` = `0x43110000` = `1125187584` decimal
 
 ## Output YAML Files
 

--- a/.claude/skills/write-patch-as-yaml/SKILL.md
+++ b/.claude/skills/write-patch-as-yaml/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: write-patch-as-yaml
-description: Write patch analysis results as YAML file beside the binary using IDA Pro MCP. Use this skill after identifying a patch target and generating a signature for it to persist the results in a standardized YAML format.
+description: Write patch analysis results, including patch_sig match VA/RVA, as a YAML file beside the binary using IDA Pro MCP. Use this skill after identifying a patch target and generating a unique signature to persist patch_name, patch_va, patch_rva, patch_sig, optional patch_sig_disp, and patch_bytes in a standardized format.
 ---
 
 # Write Patch as YAML
 
-Persist a single patch analysis result to a YAML file beside the binary using IDA Pro MCP.
+Persist a single patch analysis result to a YAML file beside the binary using IDA Pro MCP. Resolve the unique
+`patch_sig` match in the current IDB and record its VA and RVA in the output.
 
 ## Prerequisites
 
@@ -21,17 +22,26 @@ Before using this skill, you should have:
 | `patch_sig` | Unique byte signature locating the instruction to patch | `0F 86 AF 00 00 00 0F 57 C0 0F 2E C2` |
 | `patch_bytes` | Replacement bytes to write at the patch location | `E9 B0 00 00 00 90` |
 
+The skill computes these required output fields automatically; callers do not provide them:
+
+| Output field | Description | Example |
+|--------------|-------------|---------|
+| `patch_va` | VA where `patch_sig` uniquely matches | `0x180A00E2F` |
+| `patch_rva` | RVA of the same signature match (`patch_va - image_base`) | `0xA00E2F` |
+
 ## Optional Parameters
 
 | Parameter | Description | Example |
 |-----------|-------------|---------|
-| `patch_sig_disp` | Byte displacement from signature start to the target instruction. `0` or `None` means signature starts at the target instruction. Non-zero means backward expansion was used by `/generate-signature-for-patch`. (use `None` to omit) | `5` |
+| `patch_sig_disp` | Byte displacement from signature start to the target instruction. `0` or `None` means signature starts at the target instruction. Non-zero values support legacy or externally generated displaced signatures. (use `None` to omit) | `5` |
 
 ## Method
 
 ```python
 mcp__ida-pro-mcp__py_eval code="""
 import idaapi
+import ida_bytes
+import ida_segment
 import os
 import yaml
 
@@ -44,6 +54,40 @@ patch_bytes = "<patch_bytes>"           # e.g., "E9 B0 00 00 00 90"
 # === OPTIONAL: Set to None to omit from output ===
 patch_sig_disp = <patch_sig_disp>       # e.g., 5 or None (0 also omitted)
 # =================================================
+
+# Find the unique patch_sig match in .text. patch_va/patch_rva always point to
+# the signature start; when patch_sig_disp is non-zero, the target instruction
+# is at patch_va + patch_sig_disp.
+tokens = patch_sig.split()
+if not tokens or any(token != '??' and (len(token) != 2 or any(c not in '0123456789abcdefABCDEF' for c in token)) for token in tokens):
+    raise ValueError(f"Invalid patch_sig: {patch_sig!r}")
+
+pattern = bytes(0 if token == '??' else int(token, 16) for token in tokens)
+mask = bytes(0x00 if token == '??' else 0xFF for token in tokens)
+
+def raw_bin_search(ea, max_ea, data, data_mask, flags=0):
+    if hasattr(ida_bytes, 'find_bytes'):
+        return ida_bytes.find_bytes(data, ea, range_end=max_ea, mask=data_mask, flags=flags)
+    return ida_bytes.bin_search(ea, max_ea, data, data_mask, len(data), flags)
+
+text_seg = ida_segment.get_segm_by_name('.text')
+if text_seg:
+    search_start, search_end = text_seg.start_ea, text_seg.end_ea
+else:
+    search_start, search_end = idaapi.cvar.inf.min_ea, idaapi.cvar.inf.max_ea
+
+flags = ida_bytes.BIN_SEARCH_FORWARD | ida_bytes.BIN_SEARCH_NOBREAK
+matches = []
+ea = raw_bin_search(search_start, search_end, pattern, mask, flags)
+while ea != idaapi.BADADDR and len(matches) < 2:
+    matches.append(ea)
+    ea = raw_bin_search(ea + 1, search_end, pattern, mask, flags)
+
+if len(matches) != 1:
+    raise RuntimeError(f"patch_sig must match exactly once in .text, found {len(matches)} matches")
+
+patch_va = matches[0]
+patch_rva = patch_va - idaapi.get_imagebase()
 
 # Get binary path and determine platform
 input_file = idaapi.get_input_file_path()
@@ -58,6 +102,8 @@ else:
 data = {}
 
 data['patch_name'] = patch_name
+data['patch_va'] = hex(patch_va)
+data['patch_rva'] = hex(patch_rva)
 data['patch_sig'] = patch_sig
 
 if patch_sig_disp is not None and patch_sig_disp > 0:
@@ -69,6 +115,7 @@ yaml_path = os.path.join(dir_path, f"{patch_name}.{platform}.yaml")
 with open(yaml_path, 'w', encoding='utf-8') as f:
     yaml.dump(data, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
 print(f"Written to: {yaml_path}")
+print(f"patch_va={hex(patch_va)}, patch_rva={hex(patch_rva)}")
 """
 ```
 
@@ -83,9 +130,11 @@ Examples:
 
 ## Output YAML Format
 
-Full output (with `patch_sig_disp` provided):
+Full output (with a displaced signature):
 ```yaml
 patch_name: ServerMovementUnlock
+patch_va: '0x180a00e2f'
+patch_rva: '0xa00e2f'
 patch_sig: 48 85 C0 74 ?? E8 ?? ?? ?? ?? 0F 86 AF 00 00 00
 patch_sig_disp: 5
 patch_bytes: E9 B0 00 00 00 90
@@ -94,14 +143,18 @@ patch_bytes: E9 B0 00 00 00 90
 Standard output (without backward expansion, `patch_sig_disp` is 0 or omitted):
 ```yaml
 patch_name: ServerMovementUnlock
+patch_va: '0x180a00e2f'
+patch_rva: '0xa00e2f'
 patch_sig: 0F 86 AF 00 00 00 0F 57 C0 0F 2E C2
 patch_bytes: E9 B0 00 00 00 90
 ```
 
 Each field:
 - `patch_name` - Descriptive name of the patch
+- `patch_va` - VA where `patch_sig` uniquely matches in the current binary
+- `patch_rva` - RVA of the same signature match (`patch_va - image_base`)
 - `patch_sig` - Unique byte signature locating the instruction to patch
-- `patch_sig_disp` (optional) - Byte displacement from signature start to the target instruction. Only present when non-zero (backward expansion was used). Runtime: scan for `patch_sig`, then add `patch_sig_disp` to get the target instruction address.
+- `patch_sig_disp` (optional) - Byte displacement from `patch_va` to the target instruction. Only present when non-zero. Runtime: scan for `patch_sig`, then add `patch_sig_disp` to get the target instruction address.
 - `patch_bytes` - Replacement bytes to write at the patch location
 
 ## Platform Detection
@@ -121,7 +174,7 @@ patch_bytes = "E9 B0 00 00 00 90"
 patch_sig_disp = None
 ```
 
-### Patch with backward-expanded signature
+### Legacy or externally generated displaced signature
 
 ```python
 patch_name = "DisableSteamBanCheck"
@@ -142,7 +195,9 @@ patch_sig_disp = None
 ## Notes
 
 - The YAML file is written to the same directory as the input binary
+- `patch_sig` must match exactly once in the current IDB `.text` segment; otherwise the skill stops without writing YAML
+- `patch_va` and `patch_rva` always identify the `patch_sig` match start, not the displaced target instruction
 - When `patch_sig_disp` is `None` or `0`, the `patch_sig_disp` field is omitted from the output entirely (signature starts at the target instruction)
 - `patch_sig` should be a signature generated by `/generate-signature-for-patch`
 - `patch_bytes` must have the same byte count as the original instruction being patched
-- `patch_sig_disp` is the byte displacement from signature start to the target instruction, only needed when backward expansion was used
+- `patch_sig_disp` is the byte displacement from signature start to the target instruction; the current `/generate-signature-for-patch` normally returns `0`

--- a/.serena/memories/symbol_yaml.md
+++ b/.serena/memories/symbol_yaml.md
@@ -13,7 +13,7 @@
 - Virtual function (fallback-signature style): may include `vfunc_sig` (and in one file, `vfunc_inst_offset`)
 - VTable dump: `vtable_class`, `vtable_va`, `vtable_rva`, `vtable_size`, `vtable_numvfunc`, `vtable_entries` (optional `vtable_symbol`)
 - Global variable signature: `gv_name`, `gv_va`, `gv_rva`, `gv_sig`, `gv_sig_va`, `gv_inst_offset`, `gv_inst_length`, `gv_inst_disp`
-- Patch: `patch_name`, `patch_sig`, `patch_bytes`
+- Patch: `patch_name`, `patch_va`, `patch_rva`, `patch_sig`, optional `patch_sig_disp`, `patch_bytes`
 - Struct member offset (new format): `struct_name`, `member_name`, `offset`, optional `size`, `offset_sig`
 - Legacy struct-member files (old format): top-level hex key only (example: `'0x68': HitGroupInfo 8`)
 
@@ -48,7 +48,10 @@
 - `gv_inst_disp`: Byte offset inside that instruction where the displacement begins.
 
 - `patch_name`: Logical patch identifier.
+- `patch_va`: Absolute virtual address where `patch_sig` matches in the current binary.
+- `patch_rva`: Relative virtual address of the same signature match (`patch_va - image_base`).
 - `patch_sig`: Signature used to locate the patch site.
+- `patch_sig_disp`: Optional byte displacement from the signature match to the target instruction.
 - `patch_bytes`: Replacement bytes to write at the located patch site.
 
 - `struct_name`: Struct/class name containing the member.

--- a/agent_runner.py
+++ b/agent_runner.py
@@ -249,7 +249,7 @@ def _agent_permission_args(agent_kind: str, *, claude_permission_mode: str = "")
     if agent_kind == "opencode":
         return ["--auto"]
     if agent_kind == "codex":
-        return ["--approval-mode", "full-auto"]
+        return []
     permission_mode = str(claude_permission_mode or "").strip() or "auto"
     return ["--permission-mode", permission_mode]
 

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -19872,11 +19872,15 @@ files:
   server/CCSBotManager_AddBot_BotNavIgnore.linux.yaml:
     patch_bytes: E9 12 00 00 00 90
     patch_name: CCSBotManager_AddBot_BotNavIgnore
+    patch_rva: '0xbf1531'
     patch_sig: 0F 84 B9 00 00 00 44 0F B6 B8 ?? 01 00 00
+    patch_va: '0xbf1531'
   server/CCSBotManager_AddBot_BotNavIgnore.windows.yaml:
     patch_bytes: E9 2C 00 00 00 90
     patch_name: CCSBotManager_AddBot_BotNavIgnore
+    patch_rva: '0x2a70fa'
     patch_sig: 0F 84 5E 04 00 00 80 B8 ?? 01 00 00 ??
+    patch_va: '0x1802a70fa'
   server/CCSBotManager_BotPlaceCommand.linux.yaml:
     func_name: CCSBotManager_BotPlaceCommand
     func_rva: '0xc08030'
@@ -23180,11 +23184,15 @@ files:
   server/CCSPlayer_MovementServices_CheckJumpButton_WaterPatch.linux.yaml:
     patch_bytes: 41 C7 45 40 00 00 11 43
     patch_name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    patch_rva: '0x15530f0'
     patch_sig: 41 C7 45 40 00 00 C8 42
+    patch_va: '0x15530f0'
   server/CCSPlayer_MovementServices_CheckJumpButton_WaterPatch.windows.yaml:
     patch_bytes: C7 46 40 00 00 11 43
     patch_name: CCSPlayer_MovementServices_CheckJumpButton_WaterPatch
+    patch_rva: '0xa5845c'
     patch_sig: C7 46 40 00 00 C8 42
+    patch_va: '0x180a5845c'
   server/CCSPlayer_MovementServices_CheckMovingGround.linux.yaml:
     func_name: CCSPlayer_MovementServices_CheckMovingGround
     func_rva: '0x1553880'
@@ -40117,5 +40125,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-29T13:40:11Z'
+last_publish_time: '2026-07-29T15:16:07Z'
 schema_version: 4

--- a/ida_analyze_util.py
+++ b/ida_analyze_util.py
@@ -824,7 +824,14 @@ VTABLE_YAML_ORDER = [
     "vtable_numvfunc",
     "vtable_entries",
 ]
-PATCH_YAML_ORDER = ["patch_name", "patch_sig", "patch_bytes"]
+PATCH_YAML_ORDER = [
+    "patch_name",
+    "patch_va",
+    "patch_rva",
+    "patch_sig",
+    "patch_sig_disp",
+    "patch_bytes",
+]
 STRUCT_MEMBER_YAML_ORDER = [
     "struct_name",
     "member_name",
@@ -4878,14 +4885,15 @@ async def preprocess_patch_via_mcp(session, new_path, old_path, image_base, new_
     Preprocess a patch output by reusing old-version patch metadata.
 
     Verifies that old ``patch_sig`` can be uniquely found in the new binary via
-    ``find_bytes``. On success, reuses ``patch_name``, ``patch_sig``, and
+    ``find_bytes``. On success, records the new signature-match VA/RVA and reuses
+    ``patch_name``, ``patch_sig``, optional ``patch_sig_disp``, and
     ``patch_bytes`` from old YAML.
 
     Args:
         session: Active MCP ClientSession
         new_path: Full path to expected output YAML
         old_path: Full path to old version YAML (may be None)
-        image_base: Binary image base address (reserved)
+        image_base: Binary image base address
         new_binary_dir: Directory for new version outputs (reserved)
         platform: "windows" or "linux" (reserved)
         debug: Enable debug output
@@ -4893,7 +4901,7 @@ async def preprocess_patch_via_mcp(session, new_path, old_path, image_base, new_
     Returns:
         Dict with patch YAML data, or None on failure
     """
-    _ = image_base, new_binary_dir, platform  # Reserved for future behavior.
+    _ = new_binary_dir, platform  # Reserved for future behavior.
 
     if yaml is None:
         if debug:
@@ -4952,16 +4960,37 @@ async def preprocess_patch_via_mcp(session, new_path, old_path, image_base, new_
     except Exception:
         match_count_int = len(matches)
 
-    if match_count_int != 1:
+    if match_count_int != 1 or len(matches) != 1:
         if debug:
             print(f"    Preprocess: patch_sig matched {match_count_int} (need 1) in {os.path.basename(old_path)}")
         return None
 
-    return {
+    try:
+        patch_va_int = int(matches[0], 0) if isinstance(matches[0], str) else int(matches[0])
+        image_base_int = int(image_base, 0) if isinstance(image_base, str) else int(image_base)
+    except (TypeError, ValueError):
+        if debug:
+            print(f"    Preprocess: invalid patch match/image base for {os.path.basename(old_path)}")
+        return None
+
+    result = {
         "patch_name": old_data.get("patch_name") or os.path.basename(new_path).rsplit(".", 2)[0],
+        "patch_va": hex(patch_va_int),
+        "patch_rva": hex(patch_va_int - image_base_int),
         "patch_sig": patch_sig,
         "patch_bytes": patch_bytes,
     }
+    patch_sig_disp = old_data.get("patch_sig_disp")
+    if patch_sig_disp is not None:
+        try:
+            patch_sig_disp_int = int(patch_sig_disp, 0) if isinstance(patch_sig_disp, str) else int(patch_sig_disp)
+        except (TypeError, ValueError):
+            if debug:
+                print(f"    Preprocess: invalid patch_sig_disp in {os.path.basename(old_path)}")
+            return None
+        if patch_sig_disp_int > 0:
+            result["patch_sig_disp"] = patch_sig_disp_int
+    return result
 
 
 async def preprocess_struct_offset_sig_via_mcp(

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -40,6 +40,8 @@ class TestSkillRunnerProjectPromptConfiguration(unittest.TestCase):
         self.assertNotIn("model_reasoning_effort=high", command.args)
         self.assertNotIn("model_reasoning_summary=none", command.args)
         self.assertNotIn("model_verbosity=low", command.args)
+        self.assertNotIn("--approval-mode", command.args)
+        self.assertNotIn("full-auto", command.args)
 
     def test_project_configs_define_skill_runner_prompt_and_runtime_settings(self) -> None:
         config_paths = [
@@ -72,14 +74,16 @@ class TestSkillRunnerProjectPromptConfiguration(unittest.TestCase):
         self.assertIn('model_reasoning_effort = "high"', codex_config)
         self.assertIn('model_reasoning_summary = "none"', codex_config)
         self.assertIn('model_verbosity = "low"', codex_config)
+        self.assertIn('approval_policy = "never"', codex_config)
+        self.assertIn('sandbox_mode    = "workspace-write"', codex_config)
         self.assertEqual([".claude/SKILL_RUNNER.md"], opencode_config["instructions"])
 
 
 class TestAgentPermissionArgs(unittest.TestCase):
-    def test_returns_full_auto_permission_args_for_each_agent_kind(self) -> None:
+    def test_returns_permission_args_for_each_agent_kind(self) -> None:
         expected_args = {
             "claude": ["--permission-mode", "auto"],
-            "codex": ["--approval-mode", "full-auto"],
+            "codex": [],
             "opencode": ["--auto"],
         }
 
@@ -93,10 +97,9 @@ class TestAgentPermissionArgs(unittest.TestCase):
             agent_runner._agent_permission_args("claude", claude_permission_mode="acceptEdits"),
         )
 
-    def test_skill_commands_enable_full_auto_permissions(self) -> None:
+    def test_skill_commands_use_cli_permission_args_when_required(self) -> None:
         expected_args = {
             "claude": ["--permission-mode", "auto"],
-            "codex": ["--approval-mode", "full-auto"],
             "opencode": ["--auto"],
         }
 
@@ -116,6 +119,18 @@ class TestAgentPermissionArgs(unittest.TestCase):
                     permission_args,
                     command.args[permission_index : permission_index + len(permission_args)],
                 )
+
+        codex_command = agent_runner._build_agent_command(
+            agent="codex",
+            agent_kind="codex",
+            skill_name="find-test",
+            session_id="session-id",
+            opencode_session_id=None,
+            developer_instructions='developer_instructions="test"',
+            is_retry=False,
+        )
+        self.assertNotIn("--approval-mode", codex_command.args)
+        self.assertNotIn("full-auto", codex_command.args)
 
 
 class TestAgentModelArgs(unittest.TestCase):

--- a/tests/test_ida_analyze_util.py
+++ b/tests/test_ida_analyze_util.py
@@ -73,6 +73,78 @@ def _write_yaml(path: Path, payload: dict[str, object]) -> None:
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
 
 
+class TestPatchYamlMetadata(unittest.IsolatedAsyncioTestCase):
+    def test_write_patch_yaml_preserves_address_fields_in_stable_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = Path(temp_dir) / "Patch.windows.yaml"
+
+            ida_analyze_util.write_patch_yaml(
+                output_path,
+                {
+                    "patch_bytes": "90 90",
+                    "patch_sig_disp": 5,
+                    "patch_sig": "AA BB",
+                    "patch_rva": "0x123456",
+                    "patch_va": "0x180123456",
+                    "patch_name": "Patch",
+                },
+            )
+
+            payload = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(
+            [
+                "patch_name",
+                "patch_va",
+                "patch_rva",
+                "patch_sig",
+                "patch_sig_disp",
+                "patch_bytes",
+            ],
+            list(payload),
+        )
+
+    async def test_preprocess_patch_recomputes_signature_match_va_and_rva(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            old_path = temp_path / "Patch.windows.yaml"
+            new_path = temp_path / "new" / "Patch.windows.yaml"
+            _write_yaml(
+                old_path,
+                {
+                    "patch_name": "Patch",
+                    "patch_va": "0x180000010",
+                    "patch_rva": "0x10",
+                    "patch_sig": "AA BB",
+                    "patch_sig_disp": 5,
+                    "patch_bytes": "90 90",
+                },
+            )
+            session = AsyncMock()
+            session.call_tool.return_value = _FakeCallToolResult([{"matches": ["0x180123456"], "n": 1}])
+
+            result = await ida_analyze_util.preprocess_patch_via_mcp(
+                session=session,
+                new_path=str(new_path),
+                old_path=str(old_path),
+                image_base=0x180000000,
+                new_binary_dir=str(new_path.parent),
+                platform="windows",
+            )
+
+        self.assertEqual(
+            {
+                "patch_name": "Patch",
+                "patch_va": "0x180123456",
+                "patch_rva": "0x123456",
+                "patch_sig": "AA BB",
+                "patch_sig_disp": 5,
+                "patch_bytes": "90 90",
+            },
+            result,
+        )
+
+
 class TestPreprocessIndexBasedVfuncViaMcp(unittest.IsolatedAsyncioTestCase):
     def test_inherited_vfunc_name_preserves_target_for_vtable_artifact(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
## Summary
- remove the obsolete Codex `--approval-mode full-auto` arguments and rely on the existing `skill_runner` profile permissions
- extend `write-patch-as-yaml` to resolve a unique `patch_sig` match and emit `patch_va`/`patch_rva`
- keep patch preprocessing, YAML ordering, tests, and symbol documentation consistent with the new fields
- rerun all patch tasks enabled for game version 14173 and publish their four platform artifacts into the symbol snapshot
- correct the WaterPatch `145.0f` decimal reference

## 14173 patch results
- WaterPatch Windows: VA `0x180a5845c`, RVA `0xa5845c`
- WaterPatch Linux: VA/RVA `0x15530f0`
- BotNavIgnore Windows: VA `0x1802a70fa`, RVA `0x2a70fa`
- BotNavIgnore Linux: VA/RVA `0xbf1531`

`FullWalkMove_SpeedClamp` remains excluded because its 14173 analysis task is explicitly commented out in the version config.

## Validation
- `uv run python -m unittest discover -s tests -b` (1078 tests, rerun after the Codex runner fix)
- 14173 patch skill runs: 4/4 platform tasks
- post-change candidate symbol/gamedata guards
- C++ post-change validation: 12 runnable tests, 0 compile failures, 0 invalid items, 0 layout differences
- published snapshot SHA-256 matches candidate: `eac1aa62b9180bc180f67eabae56f261ceb2661e38b2b01326db05aba06dc1ac`
- `git diff --check`