### PR TITLE
feat(preprocessor): add OnServerVoiceData IsPlayingDemo callee patch

### DIFF
--- a/.claude/skills/find-OnServerVoiceData_IsPlayingDemo_Callee/SKILL.md
+++ b/.claude/skills/find-OnServerVoiceData_IsPlayingDemo_Callee/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: find-OnServerVoiceData_IsPlayingDemo_Callee
+description: |
+  Generate the Windows-only OnServerVoiceData_IsPlayingDemo_Callee patch YAML from
+  IVEngineClient2_IsPlayingDemo.windows.yaml using a deterministic preprocessor script.
+  Use when locating the IVEngineClient2::IsPlayingDemo indirect call inside
+  C_ServerVoiceHandler::OnServerVoiceData without LLM decompilation.
+  Trigger: OnServerVoiceData IsPlayingDemo callee, voice demo call patch, IsPlayingDemo callsite
+disable-model-invocation: true
+---
+
+# OnServerVoiceData_IsPlayingDemo_Callee Patch Workflow
+
+## Overview
+
+This Windows-only patch finder converts the already-generated
+`IVEngineClient2_IsPlayingDemo.windows.yaml` vfunc metadata into
+`OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml`.
+
+The target call site is inside `C_ServerVoiceHandler::OnServerVoiceData`:
+
+```asm
+mov     rcx, cs:g_pSource2EngineToClient
+mov     rax, [rcx]
+call    qword ptr [rax+150h]    ; IVEngineClient2::IsPlayingDemo
+test    al, al
+jz      short loc_...
+```
+
+The patch address is the address of the indirect `call` instruction itself.
+
+## Prerequisite
+
+The following input YAML must already exist in the current client module output directory:
+
+```text
+IVEngineClient2_IsPlayingDemo.windows.yaml
+```
+
+Its required fields are:
+
+```yaml
+func_name: IVEngineClient2_IsPlayingDemo
+vtable_name: IVEngineClient2
+vfunc_offset: '0x150'
+vfunc_index: 42
+vfunc_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
+```
+
+## Deterministic Preprocessor
+
+Run through the configured `ida_analyze_bin.py` pipeline. The corresponding script is:
+
+```text
+ida_preprocessor_scripts/find-OnServerVoiceData_IsPlayingDemo_Callee.py
+```
+
+The script performs these checks without LLM invocation:
+
+1. Rejects every platform except Windows.
+2. Reads the input vfunc YAML from the current client output directory.
+3. Verifies the function name, vtable name, and `vfunc_offset / 8 == vfunc_index` relationship.
+4. Verifies that `vfunc_sig` starts with the concrete encoding of
+   `call qword ptr [rax+vfunc_offset]`.
+5. Calls IDA MCP `find_bytes` with the full `vfunc_sig` and requires exactly one match.
+6. Writes the match address as `patch_va`, derives `patch_rva` from the image base,
+   copies `vfunc_sig` to `patch_sig`, and writes `patch_sig_disp: 0`.
+
+## Output
+
+For game version `14173`, the expected output is:
+
+```yaml
+patch_name: OnServerVoiceData_IsPlayingDemo_Callee
+patch_va: '0x180aec45d'
+patch_rva: '0xaec45d'
+patch_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
+patch_sig_disp: 0
+```
+
+No `patch_bytes` field is generated because this skill identifies the callee call site;
+the downstream consumer decides how that call instruction is patched.
+
+## Failure Conditions
+
+Stop and report failure when any of the following occurs:
+
+- The input YAML is missing or malformed.
+- The vfunc offset and index disagree.
+- The signature does not begin at the expected indirect call.
+- The signature has zero or multiple matches.
+- The match address or image base is invalid.

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4533,7 +4533,6 @@ modules:
         category: vfunc
         alias:
           - IVEngineClient2::IsPlayingDemo
-          - OnServerVoiceData_IsPlayingDemo_Callee
       - name: IVEngineClient2_ExecuteClientCmd
         category: vfunc
         alias:

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -3764,6 +3764,12 @@ modules:
           - IVEngineClient2_IsPlayingDemo.{platform}.yaml
         expected_input:
           - C_ServerVoiceHandler_OnServerVoiceData.{platform}.yaml
+      - name: find-OnServerVoiceData_IsPlayingDemo_Callee
+        platform: windows
+        expected_output:
+          - OnServerVoiceData_IsPlayingDemo_Callee.{platform}.yaml
+        expected_input:
+          - IVEngineClient2_IsPlayingDemo.{platform}.yaml
       - name: find-IVEngineClient2_ExecuteClientCmd
         expected_output:
           - IVEngineClient2_ExecuteClientCmd.{platform}.yaml
@@ -4533,6 +4539,9 @@ modules:
         category: vfunc
         alias:
           - IVEngineClient2::IsPlayingDemo
+      - name: OnServerVoiceData_IsPlayingDemo_Callee
+        category: patch
+        platform: windows
       - name: IVEngineClient2_ExecuteClientCmd
         category: vfunc
         alias:

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:d515f6fce90e468930aa82d7d8f003ce7d775ccf657098f71ba16852d942339e
-file_count: 3169
+config_sha256: sha256:ae2149ab6edd368bbb21989bc14f66e437fdae9122a6733130a258b0ec4940a6
+file_count: 3170
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4288,6 +4288,12 @@ files:
     vfunc_offset: '0x150'
     vfunc_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
     vtable_name: IVEngineClient2
+  client/OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml:
+    patch_name: OnServerVoiceData_IsPlayingDemo_Callee
+    patch_rva: '0xaec45d'
+    patch_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
+    patch_sig_disp: 0
+    patch_va: '0x180aec45d'
   client/RegisterEventListener_Abstract.linux.yaml:
     func_name: RegisterEventListener_Abstract
     func_rva: '0x16646e0'
@@ -40125,5 +40131,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-29T15:16:07Z'
+last_publish_time: '2026-07-29T16:15:11Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-OnServerVoiceData_IsPlayingDemo_Callee.py
+++ b/ida_preprocessor_scripts/find-OnServerVoiceData_IsPlayingDemo_Callee.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Generate the OnServerVoiceData IsPlayingDemo call-site patch YAML on Windows."""
+
+import os
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import parse_mcp_result, write_patch_yaml
+
+
+SOURCE_VFUNC_NAME = "IVEngineClient2_IsPlayingDemo"
+SOURCE_VTABLE_NAME = "IVEngineClient2"
+TARGET_PATCH_NAME = "OnServerVoiceData_IsPlayingDemo_Callee"
+PATCH_SIG_DISP = 0
+VTABLE_ENTRY_SIZE = 8
+FIND_BYTES_LIMIT = 2
+
+_SIGNATURE_TOKEN_RE = re.compile(r"^(?:[0-9A-Fa-f]{2}|\?\?)$")
+
+
+def _debug(enabled, message):
+    if enabled:
+        print(f"    Preprocess: {message}")
+
+
+def _read_yaml(path, debug=False):
+    if yaml is None:
+        _debug(debug, "PyYAML is required")
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as yaml_file:
+            data = yaml.safe_load(yaml_file)
+    except Exception as exc:
+        _debug(debug, f"failed to read {os.path.basename(path)}: {exc}")
+        return None
+    if not isinstance(data, dict):
+        _debug(debug, f"invalid YAML payload in {os.path.basename(path)}")
+        return None
+    return data
+
+
+def _parse_int(value):
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(str(value).strip(), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_signature(value):
+    if not isinstance(value, str):
+        return None
+    tokens = value.split()
+    if not tokens or any(_SIGNATURE_TOKEN_RE.fullmatch(token) is None for token in tokens):
+        return None
+    return " ".join(token.upper() for token in tokens)
+
+
+def _expected_rax_vcall_prefix(vfunc_offset):
+    """Return the concrete bytes for ``call qword ptr [rax+vfunc_offset]``."""
+    if vfunc_offset < 0:
+        return None
+    if vfunc_offset == 0:
+        return ["FF", "10"]
+    if vfunc_offset <= 0x7F:
+        return ["FF", "50", f"{vfunc_offset:02X}"]
+    if vfunc_offset > 0x7FFF_FFFF:
+        return None
+    return ["FF", "90", *(f"{byte:02X}" for byte in vfunc_offset.to_bytes(4, "little"))]
+
+
+def _read_source_signature(source_path, debug=False):
+    data = _read_yaml(source_path, debug=debug)
+    if data is None:
+        return None
+
+    if data.get("func_name") != SOURCE_VFUNC_NAME:
+        _debug(debug, f"unexpected func_name in {os.path.basename(source_path)}")
+        return None
+    if data.get("vtable_name") != SOURCE_VTABLE_NAME:
+        _debug(debug, f"unexpected vtable_name in {os.path.basename(source_path)}")
+        return None
+
+    vfunc_offset = _parse_int(data.get("vfunc_offset"))
+    vfunc_index = _parse_int(data.get("vfunc_index"))
+    if vfunc_offset is None or vfunc_index is None:
+        _debug(debug, f"missing or invalid vfunc slot metadata in {os.path.basename(source_path)}")
+        return None
+    if vfunc_offset % VTABLE_ENTRY_SIZE != 0 or vfunc_index != vfunc_offset // VTABLE_ENTRY_SIZE:
+        _debug(debug, f"inconsistent vfunc_offset/vfunc_index in {os.path.basename(source_path)}")
+        return None
+
+    signature = _normalize_signature(data.get("vfunc_sig"))
+    if signature is None:
+        _debug(debug, f"missing or invalid vfunc_sig in {os.path.basename(source_path)}")
+        return None
+
+    expected_prefix = _expected_rax_vcall_prefix(vfunc_offset)
+    signature_tokens = signature.split()
+    if expected_prefix is None or signature_tokens[: len(expected_prefix)] != expected_prefix:
+        _debug(
+            debug,
+            f"vfunc_sig does not start with call [rax+0x{vfunc_offset:X}] in {os.path.basename(source_path)}",
+        )
+        return None
+    return signature
+
+
+def _match_output(expected_outputs, platform):
+    expected_filename = f"{TARGET_PATCH_NAME}.{platform}.yaml"
+    matches = [output_path for output_path in expected_outputs if Path(output_path).name == expected_filename]
+    return matches[0] if len(matches) == 1 else None
+
+
+async def _find_unique_signature_match(session, signature, debug=False):
+    try:
+        result = await session.call_tool(
+            name="find_bytes",
+            arguments={"patterns": [signature], "limit": FIND_BYTES_LIMIT},
+        )
+        data = parse_mcp_result(result)
+    except Exception as exc:
+        _debug(debug, f"find_bytes failed: {exc}")
+        return None
+
+    if not isinstance(data, list) or len(data) != 1 or not isinstance(data[0], dict):
+        _debug(debug, "find_bytes returned an invalid response")
+        return None
+
+    matches = data[0].get("matches", [])
+    fallback_count = len(matches) if isinstance(matches, list) else None
+    match_count = _parse_int(data[0].get("n", fallback_count))
+    if not isinstance(matches, list) or match_count != 1 or len(matches) != 1:
+        _debug(debug, f"vfunc_sig matched {match_count} location(s), expected exactly 1")
+        return None
+
+    try:
+        return int(matches[0], 0) if isinstance(matches[0], str) else int(matches[0])
+    except (TypeError, ValueError):
+        _debug(debug, "find_bytes returned an invalid match address")
+        return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Convert IVEngineClient2_IsPlayingDemo vfunc metadata into a call-site patch YAML."""
+    _ = skill_name, old_yaml_map
+
+    if platform != "windows":
+        _debug(debug, "OnServerVoiceData_IsPlayingDemo_Callee is Windows-only")
+        return False
+
+    output_path = _match_output(expected_outputs, platform)
+    if output_path is None:
+        _debug(debug, f"expected exactly one {TARGET_PATCH_NAME}.{platform}.yaml output")
+        return False
+
+    source_path = os.path.join(new_binary_dir, f"{SOURCE_VFUNC_NAME}.{platform}.yaml")
+    signature = _read_source_signature(source_path, debug=debug)
+    if signature is None:
+        return False
+
+    patch_va = await _find_unique_signature_match(session, signature, debug=debug)
+    image_base_int = _parse_int(image_base)
+    if patch_va is None or image_base_int is None or patch_va < image_base_int:
+        _debug(debug, "invalid patch match or image base")
+        return False
+
+    payload = {
+        "patch_name": TARGET_PATCH_NAME,
+        "patch_va": hex(patch_va),
+        "patch_rva": hex(patch_va - image_base_int),
+        "patch_sig": signature,
+        "patch_sig_disp": PATCH_SIG_DISP,
+    }
+    try:
+        write_patch_yaml(output_path, payload)
+    except Exception as exc:
+        _debug(debug, f"failed to write patch YAML: {exc}")
+        return False
+
+    _debug(debug, f"generated {TARGET_PATCH_NAME}.{platform}.yaml from {os.path.basename(source_path)}")
+    return True

--- a/tests/test_ida_preprocessor_contracts_misc.py
+++ b/tests/test_ida_preprocessor_contracts_misc.py
@@ -3,11 +3,32 @@ import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
-from tests.ida_preprocessor_test_support import load_module as _load_module, py_eval_payload as _py_eval_payload
+import yaml
+
+from tests.ida_preprocessor_test_support import (
+    FakeCallToolResult,
+    load_module as _load_module,
+    py_eval_payload as _py_eval_payload,
+)
 
 
 PROCESS_MOVEMENT_SCRIPT_PATH = Path("ida_preprocessor_scripts/find-CCSPlayer_MovementServices_ProcessMovement.py")
 INTERFACE_GLOBALS_PPGLOBAL_SCRIPT_PATH = Path("ida_preprocessor_scripts/find-g_pInterfaceGlobals_ppGlobal.py")
+ONSERVER_VOICE_IS_PLAYING_DEMO_CALLEE_SCRIPT_PATH = Path(
+    "ida_preprocessor_scripts/find-OnServerVoiceData_IsPlayingDemo_Callee.py"
+)
+
+
+def _write_is_playing_demo_source_yaml(path: Path, **overrides) -> None:
+    payload = {
+        "func_name": "IVEngineClient2_IsPlayingDemo",
+        "vtable_name": "IVEngineClient2",
+        "vfunc_offset": "0x150",
+        "vfunc_index": 42,
+        "vfunc_sig": "FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??",
+    }
+    payload.update(overrides)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
 
 
 class TestFindCBaseEntityCollisionRulesChanged(unittest.IsolatedAsyncioTestCase):
@@ -476,6 +497,115 @@ class TestCanonicalVtablePreprocessors(unittest.IsolatedAsyncioTestCase):
                     "CSource2Server_vtable2",
                     written_payload["vtable_symbol"],
                 )
+
+
+class TestFindOnServerVoiceDataIsPlayingDemoCallee(unittest.IsolatedAsyncioTestCase):
+    async def test_generates_patch_yaml_from_unique_vfunc_signature_match(self) -> None:
+        module = _load_module(
+            ONSERVER_VOICE_IS_PLAYING_DEMO_CALLEE_SCRIPT_PATH,
+            "find_OnServerVoiceData_IsPlayingDemo_Callee",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_dir = Path(temp_dir)
+            source_path = module_dir / "IVEngineClient2_IsPlayingDemo.windows.yaml"
+            output_path = module_dir / "OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml"
+            _write_is_playing_demo_source_yaml(source_path)
+
+            session = AsyncMock()
+            session.call_tool.return_value = FakeCallToolResult([{"matches": ["0x180aec45d"], "n": 1}])
+
+            result = await module.preprocess_skill(
+                session=session,
+                skill_name="find-OnServerVoiceData_IsPlayingDemo_Callee",
+                expected_outputs=[str(output_path)],
+                old_yaml_map={},
+                new_binary_dir=str(module_dir),
+                platform="windows",
+                image_base=0x180000000,
+                debug=True,
+            )
+
+            payload = yaml.safe_load(output_path.read_text(encoding="utf-8"))
+
+        self.assertTrue(result)
+        session.call_tool.assert_awaited_once_with(
+            name="find_bytes",
+            arguments={
+                "patterns": ["FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??"],
+                "limit": 2,
+            },
+        )
+        self.assertEqual(
+            {
+                "patch_name": "OnServerVoiceData_IsPlayingDemo_Callee",
+                "patch_va": "0x180aec45d",
+                "patch_rva": "0xaec45d",
+                "patch_sig": "FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??",
+                "patch_sig_disp": 0,
+            },
+            payload,
+        )
+
+    async def test_rejects_signature_that_does_not_start_at_the_vcall(self) -> None:
+        module = _load_module(
+            ONSERVER_VOICE_IS_PLAYING_DEMO_CALLEE_SCRIPT_PATH,
+            "find_OnServerVoiceData_IsPlayingDemo_Callee_bad_sig",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_dir = Path(temp_dir)
+            source_path = module_dir / "IVEngineClient2_IsPlayingDemo.windows.yaml"
+            output_path = module_dir / "OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml"
+            _write_is_playing_demo_source_yaml(
+                source_path,
+                vfunc_sig="48 8B 01 FF 90 50 01 00 00",
+            )
+
+            session = AsyncMock()
+            result = await module.preprocess_skill(
+                session=session,
+                skill_name="find-OnServerVoiceData_IsPlayingDemo_Callee",
+                expected_outputs=[str(output_path)],
+                old_yaml_map={},
+                new_binary_dir=str(module_dir),
+                platform="windows",
+                image_base=0x180000000,
+            )
+
+            self.assertFalse(output_path.exists())
+
+        self.assertFalse(result)
+        session.call_tool.assert_not_awaited()
+
+    async def test_rejects_non_unique_signature_match(self) -> None:
+        module = _load_module(
+            ONSERVER_VOICE_IS_PLAYING_DEMO_CALLEE_SCRIPT_PATH,
+            "find_OnServerVoiceData_IsPlayingDemo_Callee_multi",
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module_dir = Path(temp_dir)
+            source_path = module_dir / "IVEngineClient2_IsPlayingDemo.windows.yaml"
+            output_path = module_dir / "OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml"
+            _write_is_playing_demo_source_yaml(source_path)
+
+            session = AsyncMock()
+            session.call_tool.return_value = FakeCallToolResult([{"matches": ["0x180aec45d", "0x180bed000"], "n": 2}])
+
+            result = await module.preprocess_skill(
+                session=session,
+                skill_name="find-OnServerVoiceData_IsPlayingDemo_Callee",
+                expected_outputs=[str(output_path)],
+                old_yaml_map={},
+                new_binary_dir=str(module_dir),
+                platform="windows",
+                image_base=0x180000000,
+            )
+
+            self.assertFalse(output_path.exists())
+
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add a Windows-only deterministic preprocessor and skill that converts `IVEngineClient2_IsPlayingDemo` vfunc metadata into the `OnServerVoiceData_IsPlayingDemo_Callee` patch YAML, validates the indirect-call prefix, and requires a unique signature match.
- Register the patch symbol, remove its obsolete vfunc alias, add contract coverage, and publish the `14173` symbol snapshot.

## Validation
- implementation-specific tests: not rerun during this `create-pr` invocation
- candidate preparation: passed for `14173`
- C++ post-change validation: passed with 12 runnable tests, 0 compile failures, 0 invalid test items, and 0 layout differences
- candidate publication: passed; published SHA-256 `7009ca34caa38ebc290d13aaf0b30062b08fcbc5046caa33b008c70f77cd775c` matches the validated candidate
- existing committed branch: 2 initial commits ahead of `origin/main`; supplemental publication commit created as `fdf2d6f9`