### PR TITLE
feat(preprocessor): add client globals finders

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -3707,6 +3707,23 @@ modules:
       - name: find-CSource2Client_vtable
         expected_output:
           - CSource2Client_vtable.{platform}.yaml
+      - name: find-GlobalVarsWarningFunc
+        platform: windows
+        expected_output:
+          - GlobalVarsWarningFunc.{platform}.yaml
+      - name: find-CSource2Client_SetGlobals
+        platform: windows
+        expected_output:
+          - CSource2Client_SetGlobals.{platform}.yaml
+        expected_input:
+          - GlobalVarsWarningFunc.{platform}.yaml
+          - CSource2Client_vtable.{platform}.yaml
+      - name: find-CSource2Client_SetGlobals-decompiles
+        platform: windows
+        expected_output:
+          - gpGlobals.{platform}.yaml
+        expected_input:
+          - CSource2Client_SetGlobals.{platform}.yaml
       - name: find-CSource2Client_Connect
         expected_output:
           - CSource2Client_Connect.{platform}.yaml
@@ -4495,6 +4512,17 @@ modules:
           - IGameSystem::OnClientPreRenderAlt
       - name: CSource2Client_vtable
         category: vtable
+      - name: GlobalVarsWarningFunc
+        category: func
+        platform: windows
+      - name: CSource2Client_SetGlobals
+        category: vfunc
+        platform: windows
+        alias:
+          - CSource2Client::SetGlobals
+      - name: gpGlobals
+        category: gv
+        platform: windows
       - name: CSource2Client_Connect
         category: vfunc
         alias:

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:ae2149ab6edd368bbb21989bc14f66e437fdae9122a6733130a258b0ec4940a6
-file_count: 3170
+config_sha256: sha256:57f14a5f9553dfcd2ba290a812f4920f2ccdf9bf025ceb352290ae6671831ed8
+file_count: 3173
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -1467,6 +1467,15 @@ files:
     vfunc_index: 130
     vfunc_offset: '0x410'
     vtable_name: CSource2Client
+  client/CSource2Client_SetGlobals.windows.yaml:
+    func_name: CSource2Client_SetGlobals
+    func_rva: '0xb23e40'
+    func_sig: 48 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? 48 85 D2
+    func_size: '0x31'
+    func_va: '0x180b23e40'
+    vfunc_index: 11
+    vfunc_offset: '0x58'
+    vtable_name: CSource2Client_vtable
   client/CSource2Client_vtable.linux.yaml:
     vtable_class: CSource2Client
     vtable_entries:
@@ -3433,6 +3442,12 @@ files:
     func_sig_allow_across_function_boundary: true
     func_size: '0x238'
     func_va: '0x180f65110'
+  client/GlobalVarsWarningFunc.windows.yaml:
+    func_name: GlobalVarsWarningFunc
+    func_rva: '0xa59880'
+    func_sig: 40 53 48 83 EC ?? 8B 15 ?? ?? ?? ?? 8B D9
+    func_size: '0xb3'
+    func_va: '0x180a59880'
   client/IEngineServiceMgr_GetActiveLoopClientServerMode.linux.yaml:
     func_name: IEngineServiceMgr_GetActiveLoopClientServerMode
     vfunc_index: 31
@@ -5308,6 +5323,15 @@ files:
     gv_name: g_pWorldRendererMgr
     gv_rva: '0x25c9548'
     gv_va: '0x1825c9548'
+  client/gpGlobals.windows.yaml:
+    gv_inst_disp: 3
+    gv_inst_length: 7
+    gv_inst_offset: 0
+    gv_name: gpGlobals
+    gv_rva: '0x2090d60'
+    gv_sig: 48 89 15 ?? ?? ?? ?? 48 89 42 ??
+    gv_sig_va: '0x180b23e5c'
+    gv_va: '0x182090d60'
   client/s_pLocalPlayer.linux.yaml:
     gv_inst_disp: 3
     gv_inst_length: 7
@@ -40131,5 +40155,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-29T16:15:11Z'
+last_publish_time: '2026-07-30T03:34:48Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CSource2Client_SetGlobals-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_SetGlobals-decompiles.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_SetGlobals-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_GLOBALVAR_NAMES = [
+    "gpGlobals",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "gpGlobals",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CSource2Client_SetGlobals.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_gv"],
+        "dependency_policy": {
+            "CSource2Client_SetGlobals.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "gpGlobals",
+        [
+            "gv_name",
+            "gv_va",
+            "gv_rva",
+            "gv_sig",
+            "gv_sig_va",
+            "gv_inst_offset",
+            "gv_inst_length",
+            "gv_inst_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse the previous gv_sig or decompile SetGlobals to locate gpGlobals."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        gv_names=TARGET_GLOBALVAR_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_SetGlobals.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_SetGlobals.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_SetGlobals skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Client_SetGlobals",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_artifact)
+    ("CSource2Client_SetGlobals", "CSource2Client_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2Client_SetGlobals",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+def _read_func_va(yaml_path):
+    """Read func_va from a function YAML file, returning it as a string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("func_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the target vfunc from its warning callback data reference and vtable."""
+    warning_yaml_path = os.path.join(new_binary_dir, f"GlobalVarsWarningFunc.{platform}.yaml")
+    warning_func_va = _read_func_va(warning_yaml_path)
+    if not warning_func_va:
+        if debug:
+            print("    Preprocess: GlobalVarsWarningFunc func_va not found, cannot resolve xref_gvs")
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "CSource2Client_SetGlobals",
+            "xref_strings": [],
+            "xref_gvs": [str(warning_func_va)],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-GlobalVarsWarningFunc.py
+++ b/ida_preprocessor_scripts/find-GlobalVarsWarningFunc.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-GlobalVarsWarningFunc skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "GlobalVarsWarningFunc",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "GlobalVarsWarningFunc",
+        "xref_strings": [
+            "gpGlocals->curtime() called while IsInSimulation() is false",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "GlobalVarsWarningFunc",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse the previous func_sig or xref string to locate the target function."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CSource2Client_SetGlobals.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_SetGlobals.windows.yaml
@@ -1,0 +1,30 @@
+func_name: CSource2Client_SetGlobals
+func_va: '0x180b23e40'
+disasm_code: |-
+  .text:0000000180B23E40                 mov     rcx, cs:gpGlobals; read-only previous value, do not select for gpGlobals found_gv
+  .text:0000000180B23E47                 lea     r8, unk_182090D00
+  .text:0000000180B23E4E                 test    rdx, rdx
+  .text:0000000180B23E51                 lea     rax, GlobalVarsWarningFunc
+  .text:0000000180B23E58                 cmovz   rdx, r8
+  .text:0000000180B23E5C                 mov     cs:gpGlobals, rdx; target gpGlobals write, select this instruction for found_gv
+  .text:0000000180B23E63                 mov     [rdx+28h], rax
+  .text:0000000180B23E67                 xor     eax, eax
+  .text:0000000180B23E69                 cmp     rcx, r8
+  .text:0000000180B23E6C                 cmovnz  rax, rcx
+  .text:0000000180B23E70                 retn
+procedure: |-
+  void *__fastcall SetGlobals(__int64 a1, __int64 a2)
+  {
+    void *v2; // rcx
+    void *result; // rax
+
+    v2 = gpGlobals;                       // read-only previous value, do not select for gpGlobals
+    if ( !a2 )
+      a2 = (__int64)&unk_182090D00;
+    gpGlobals = (void *)a2;               // target gpGlobals write, select this assignment
+    *(_QWORD *)(a2 + 40) = GlobalVarsWarningFunc;
+    result = nullptr;
+    if ( v2 != &unk_182090D00 )
+      return v2;
+    return result;
+  }


### PR DESCRIPTION
## Summary
- add a Windows-only `GlobalVarsWarningFunc` finder using the `gpGlocals->curtime() called while IsInSimulation() is false` xref string
- resolve `CSource2Client_SetGlobals` from the warning callback data xref plus `CSource2Client_vtable`, then recover `gpGlobals` from the annotated store instruction
- publish the validated `14173` gamesymbol snapshot

## Validation
- targeted IDA preprocessing: all 3 new finders passed (`Successful: 1`, `Failed: 0` each)
- full `ida_analyze_bin.py -debug`: `Failed: 0`, `Skipped: 2006`
- non-MCP Python unittest suite: 1056 tests passed
- candidate preparation: passed for `14173`
- C++ post-change validation: passed with runnable tests and zero compile, invalid-item, vtable, and record-layout failures
- candidate publication: passed; published SHA-256 matches `44a3d215e9c88ef9982a682884a5ba942a401900316e0ea9cf22810c8f5bc502`