### PR TITLE
feat(preprocessor): find CNetworkMessages GetNetMessageInfo

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -347,6 +347,12 @@ modules:
           - g_pLoggingChannel.{platform}.yaml
         expected_input:
           - CNetChan_ParseMessagesDemoInternal.{platform}.yaml
+      - name: find-CNetworkMessages_GetNetMessageInfo
+        expected_output:
+          - CNetworkMessages_GetNetMessageInfo.{platform}.yaml
+        expected_input:
+          - CNetworkMessages_vtable.{platform}.yaml
+          - CNetChan_ParseMessagesDemoInternal.{platform}.yaml
       - name: find-CNetworkMessages_FindNetworkMessagePartial
         expected_output:
           - CNetworkMessages_FindNetworkMessagePartial.{platform}.yaml
@@ -401,6 +407,11 @@ modules:
         category: vfunc
         alias:
           - CNetworkMessages::FindOrCreateNetMessage
+        shared: true
+      - name: CNetworkMessages_GetNetMessageInfo
+        category: vfunc
+        alias:
+          - CNetworkMessages::GetNetMessageInfo
         shared: true
       - name: CNetworkMessages_SerializeInternal
         category: func

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:57f14a5f9553dfcd2ba290a812f4920f2ccdf9bf025ceb352290ae6671831ed8
-file_count: 3173
+config_sha256: sha256:d7a463e7949aca6050b9fe1c02e69664fea2a5ca0e4a6127b11a181ce6e3b71d
+file_count: 3175
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -14563,6 +14563,18 @@ files:
     func_sig: 0F B6 81 ?? 05 00 00 C3 CC CC CC CC CC CC CC CC 48 89 4C 24 ??
     func_size: '0x8'
     func_va: '0x1800daa70'
+  networksystem/CNetworkMessages_GetNetMessageInfo.linux.yaml:
+    func_name: CNetworkMessages_GetNetMessageInfo
+    vfunc_index: 12
+    vfunc_offset: '0x60'
+    vfunc_sig: FF 50 60 49 89 C6
+    vtable_name: CNetworkMessages
+  networksystem/CNetworkMessages_GetNetMessageInfo.windows.yaml:
+    func_name: CNetworkMessages_GetNetMessageInfo
+    vfunc_index: 12
+    vfunc_offset: '0x60'
+    vfunc_sig: 4C 8B 42 60 48 8B D0 41 FF D0 41 8B 8D ?? ?? ?? ??
+    vtable_name: CNetworkMessages
   networksystem/CNetworkMessages_GetNetworkSerializationContextData.linux.yaml:
     func_name: CNetworkMessages_GetNetworkSerializationContextData
     func_rva: '0x2a4f70'
@@ -40155,5 +40167,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T03:34:48Z'
+last_publish_time: '2026-07-30T05:48:55Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CNetworkMessages_GetNetMessageInfo.py
+++ b/ida_preprocessor_scripts/find-CNetworkMessages_GetNetMessageInfo.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkMessages_GetNetMessageInfo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkMessages_GetNetMessageInfo",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkMessages_GetNetMessageInfo",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/networksystem/CNetChan_ParseMessagesDemoInternal.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetChan_ParseMessagesDemoInternal.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkMessages_GetNetMessageInfo", "CNetworkMessages"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkMessages_GetNetMessageInfo",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate the CNetworkMessages vfunc via the CNetChan demo parser."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- add an LLM decompile preprocessor for CNetworkMessages_GetNetMessageInfo
- use CNetChan_ParseMessagesDemoInternal as the required reference artifact
- register the vfunc and skill in the 14173 networksystem configuration

## Validation
- python -m unittest tests.test_llm_decompile_dependencies.TestRepositoryLlmDecompileDependencyPolicy.test_all_llm_specs_have_complete_policy_and_config_contract
- verified the 14173 configuration parses