### PR TITLE
feat(preprocessor): add CreateLoopMode finder

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -3468,6 +3468,11 @@ modules:
         expected_input:
           - CLoopModeGame_StaticInit.{platform}.yaml
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
       - name: find-CEntityInstance_vtable
         expected_output:
           - CEntityInstance_vtable.{platform}.yaml
@@ -4329,6 +4334,10 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+      - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
       - name: CLoopModeFactory_CLoopModeGame_Shutdown
         category: vfunc
         alias:
@@ -7803,6 +7812,11 @@ modules:
         expected_input:
           - CLoopModeGame_StaticInit.{platform}.yaml
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
       - name: find-CLoopModeGame_OnLoopActivate
         expected_output:
           - CLoopModeGame_OnLoopActivate.{platform}.yaml
@@ -10961,6 +10975,10 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+      - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
       - name: CLoopModeFactory_CLoopModeGame_Shutdown
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_CreateLoopMode skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "xref_strings": ["Show status of all spawn groups."],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "CLoopModeFactory_CLoopModeGame_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the CreateLoopMode vfunc through its spawn-group status string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- add a string-xref finder for CLoopModeFactory_CLoopModeGame_CreateLoopMode
- bind the resolved function to CLoopModeFactory_CLoopModeGame_vtable
- schedule and declare the vfunc in both client sections of configs/14173.yaml

## Validation
- uv run python -m py_compile ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode.py
- uv run python -m unittest tests.test_ida_preprocessor_contracts_gamesystems -v
- uv run python -m unittest tests.test_config_scheduling_dependencies -v