### PR TITLE
feat(preprocessor): add Source2 client render finders

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -1011,6 +1011,12 @@ modules:
           - CNetworkClientService_OnServerBeginAsyncPostTickWork.{platform}.yaml
         expected_input:
           - CNetworkClientService_RegisterEventMapInternal.{platform}.yaml
+      - name: find-CNetworkClientService_OnClientProcessGameInput-decompiles
+        platform: windows
+        expected_output:
+          - ISource2Client_ProcessGameInput.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_OnClientProcessGameInput.{platform}.yaml
       - name: find-CNetworkClientService_ReceivedServerInfo
         expected_output:
           - CNetworkClientService_ReceivedServerInfo.{platform}.yaml
@@ -2513,6 +2519,11 @@ modules:
         platform: windows
         alias:
           - CNetworkClientService::OnClientProcessGameInput
+      - name: ISource2Client_ProcessGameInput
+        category: vfunc
+        platform: windows
+        alias:
+          - ISource2Client::ProcessGameInput
       - name: CNetworkClientService_OnClientPollNetworking
         category: func
         platform: windows
@@ -3803,6 +3814,58 @@ modules:
       - name: find-CSource2Client_vtable
         expected_output:
           - CSource2Client_vtable.{platform}.yaml
+      - name: find-CSource2Client_ProcessGameInput
+        platform: windows
+        expected_output:
+          - CSource2Client_ProcessGameInput.{platform}.yaml
+        expected_input:
+          - CSource2Client_vtable.{platform}.yaml
+          - ../engine/ISource2Client_ProcessGameInput.{platform}.yaml
+      - name: find-CSource2Client_ProcessGameInput-decompiles
+        platform: windows
+        expected_output:
+          - ISource2Client_FrameStageNotify.{platform}.yaml
+        expected_input:
+          - CSource2Client_ProcessGameInput.{platform}.yaml
+      - name: find-CSource2Client_FrameStageNotify
+        platform: windows
+        expected_output:
+          - CSource2Client_FrameStageNotify.{platform}.yaml
+        expected_input:
+          - CSource2Client_vtable.{platform}.yaml
+          - ISource2Client_FrameStageNotify.{platform}.yaml
+      - name: find-CSource2Client_FrameStageNotify-decompiles
+        platform: windows
+        expected_output:
+          - OnRenderStart.{platform}.yaml
+        expected_input:
+          - CSource2Client_FrameStageNotify.{platform}.yaml
+      - name: find-OnRenderStart-decompiles
+        platform: windows
+        expected_output:
+          - IViewRender_OnRenderStart.{platform}.yaml
+        expected_input:
+          - OnRenderStart.{platform}.yaml
+      - name: find-CViewRender_vtable
+        expected_output:
+          - CViewRender_vtable.{platform}.yaml
+      - name: find-CViewRender_OnRenderStart
+        platform: windows
+        expected_output:
+          - CViewRender_OnRenderStart.{platform}.yaml
+        expected_input:
+          - CViewRender_vtable.{platform}.yaml
+          - IViewRender_OnRenderStart.{platform}.yaml
+      - name: find-CViewRender_Render
+        platform: windows
+        expected_output:
+          - CViewRender_Render.{platform}.yaml
+        expected_input:
+          - CViewRender_vtable.{platform}.yaml
+      - name: find-C_BaseEntity_SetInterpolationPhase
+        platform: windows
+        expected_output:
+          - C_BaseEntity_SetInterpolationPhase.{platform}.yaml
       - name: find-GlobalVarsWarningFunc
         platform: windows
         expected_output:
@@ -4608,6 +4671,46 @@ modules:
           - IGameSystem::OnClientPreRenderAlt
       - name: CSource2Client_vtable
         category: vtable
+      - name: CSource2Client_ProcessGameInput
+        category: vfunc
+        platform: windows
+        alias:
+          - CSource2Client::ProcessGameInput
+      - name: ISource2Client_FrameStageNotify
+        category: vfunc
+        platform: windows
+        alias:
+          - ISource2Client::FrameStageNotify
+      - name: CSource2Client_FrameStageNotify
+        category: vfunc
+        platform: windows
+        alias:
+          - CSource2Client::FrameStageNotify
+      - name: OnRenderStart
+        category: func
+        platform: windows
+      - name: IViewRender_OnRenderStart
+        category: vfunc
+        platform: windows
+        alias:
+          - IViewRender::OnRenderStart
+      - name: CViewRender_vtable
+        category: vtable
+      - name: CViewRender_OnRenderStart
+        category: vfunc
+        platform: windows
+        alias:
+          - CViewRender::OnRenderStart
+      - name: CViewRender_Render
+        category: vfunc
+        platform: windows
+        alias:
+          - CViewRender::Render
+      - name: C_BaseEntity_SetInterpolationPhase
+        category: func
+        platform: windows
+        alias:
+          - C_BaseEntity::SetInterpolationPhase
       - name: GlobalVarsWarningFunc
         category: func
         platform: windows

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:e682b6e01ccaec5242e2d51a59295d507da324366159520465a4bad5258d4d2e
-file_count: 3187
+config_sha256: sha256:cd7a9c018c9dcfd0f844f66c26ca80dcc54bfb61f01793875c7cf1b8c0860af5
+file_count: 3198
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -1449,6 +1449,15 @@ files:
     vfunc_index: 0
     vfunc_offset: '0x0'
     vtable_name: CSource2Client_vtable
+  client/CSource2Client_FrameStageNotify.windows.yaml:
+    func_name: CSource2Client_FrameStageNotify
+    func_rva: '0xb10ff0'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 57 48 83 EC ?? 48 8B F9 33 ED
+    func_size: '0x5d8'
+    func_va: '0x180b10ff0'
+    vfunc_index: 36
+    vfunc_offset: '0x120'
+    vtable_name: CSource2Client
   client/CSource2Client_OnDisconnect.linux.yaml:
     func_name: CSource2Client_OnDisconnect
     func_rva: '0x1899260'
@@ -1466,6 +1475,15 @@ files:
     func_va: '0x180b1bd40'
     vfunc_index: 130
     vfunc_offset: '0x410'
+    vtable_name: CSource2Client
+  client/CSource2Client_ProcessGameInput.windows.yaml:
+    func_name: CSource2Client_ProcessGameInput
+    func_rva: '0xb200a0'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B 01 8B DA 0F 29 74 24 ??
+    func_size: '0xbc'
+    func_va: '0x180b200a0'
+    vfunc_index: 22
+    vfunc_offset: '0xb0'
     vtable_name: CSource2Client
   client/CSource2Client_SetGlobals.windows.yaml:
     func_name: CSource2Client_SetGlobals
@@ -2214,6 +2232,93 @@ files:
     vtable_size: '0xa8'
     vtable_symbol: ??_7CUserMessage_ExtraUserData@@6B@
     vtable_va: '0x181a3a950'
+  client/CViewRender_OnRenderStart.windows.yaml:
+    func_name: CViewRender_OnRenderStart
+    func_rva: '0xbada10'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 81 EC ?? ?? ?? ?? 4C 8B F1 48 8D 94 24 ?? ?? ?? ??
+    func_size: '0x1f9'
+    func_va: '0x180bada10'
+    vfunc_index: 4
+    vfunc_offset: '0x20'
+    vtable_name: CViewRender
+  client/CViewRender_Render.windows.yaml:
+    func_name: CViewRender_Render
+    func_rva: '0xbb09d0'
+    func_sig: 4C 8B DC 53 55 56 57 48 81 EC ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??
+    func_size: '0x353'
+    func_va: '0x180bb09d0'
+    vfunc_index: 5
+    vfunc_offset: '0x28'
+    vtable_name: CViewRender_vtable
+  client/CViewRender_vtable.linux.yaml:
+    vtable_class: CViewRender
+    vtable_entries:
+      0: '0x197bf40'
+      1: '0x196bba0'
+      10: '0x1993ee0'
+      11: '0x195f2c0'
+      12: '0x1981410'
+      13: '0x1981520'
+      14: '0x1968c50'
+      15: '0x196a4f0'
+      16: '0x1962000'
+      17: '0x195f2d0'
+      18: '0x197c000'
+      19: '0x197c880'
+      2: '0x195f130'
+      20: '0x195f260'
+      21: '0x195f270'
+      22: '0x195f280'
+      23: '0x195f290'
+      3: '0x195f2a0'
+      4: '0x1981250'
+      5: '0x19932f0'
+      6: '0x1961ff0'
+      7: '0x1965e60'
+      8: '0x1966ac0'
+      9: '0x195f2b0'
+    vtable_numvfunc: 24
+    vtable_rva: '0x43d11b8'
+    vtable_size: '0xc0'
+    vtable_symbol: _ZTV11CViewRender + 0x10
+    vtable_va: '0x43d11b8'
+  client/CViewRender_vtable.windows.yaml:
+    vtable_class: CViewRender
+    vtable_entries:
+      0: '0x180ba87e0'
+      1: '0x180bacd50'
+      10: '0x180bb0ed0'
+      11: '0x180ba26b0'
+      12: '0x180ba6960'
+      13: '0x180ba6860'
+      14: '0x180ba7bd0'
+      15: '0x180ba7a70'
+      16: '0x180ba6a00'
+      17: '0x180ba5fd0'
+      18: '0x180b9e8f0'
+      19: '0x180bb43a0'
+      2: '0x180bacdf0'
+      20: '0x180bae4a0'
+      21: '0x180bae310'
+      22: '0x180bad3f0'
+      3: '0x180bb43c0'
+      4: '0x180bada10'
+      5: '0x180bb09d0'
+      6: '0x180bb0d30'
+      7: '0x180ba6db0'
+      8: '0x180ba22d0'
+      9: '0x180ba7a30'
+    vtable_numvfunc: 23
+    vtable_rva: '0x1b194f0'
+    vtable_size: '0xb8'
+    vtable_symbol: ??_7CViewRender@@6B@
+    vtable_va: '0x181b194f0'
+  client/C_BaseEntity_SetInterpolationPhase.windows.yaml:
+    func_name: C_BaseEntity_SetInterpolationPhase
+    func_rva: '0xac0100'
+    func_sig: 48 8B C4 48 89 58 ?? 48 89 68 ?? 48 89 70 ?? 57 48 81 EC ?? ?? ?? ?? 8B 35 ?? ?? ?? ??
+    func_size: '0x257'
+    func_va: '0x180ac0100'
   client/C_GameRules_ctor.linux.yaml:
     func_name: C_GameRules_ctor
     func_rva: '0x18fae90'
@@ -4274,6 +4379,12 @@ files:
     vfunc_index: 1
     vfunc_offset: '0x8'
     vtable_name: INetworkClient
+  client/ISource2Client_FrameStageNotify.windows.yaml:
+    func_name: ISource2Client_FrameStageNotify
+    vfunc_index: 36
+    vfunc_offset: '0x120'
+    vfunc_sig: FF 90 20 01 00 00 E8 ?? ?? ?? ??
+    vtable_name: ISource2Client
   client/IVEngineClient2_ExecuteClientCmd.linux.yaml:
     func_name: IVEngineClient2_ExecuteClientCmd
     vfunc_index: 50
@@ -4303,6 +4414,18 @@ files:
     vfunc_offset: '0x150'
     vfunc_sig: FF 90 50 01 00 00 84 C0 74 ?? 83 FD ??
     vtable_name: IVEngineClient2
+  client/IViewRender_OnRenderStart.windows.yaml:
+    func_name: IViewRender_OnRenderStart
+    vfunc_index: 4
+    vfunc_offset: '0x20'
+    vfunc_sig: FF 50 20 E8 ?? ?? ?? ?? E8 ?? ?? ?? ??
+    vtable_name: IViewRender
+  client/OnRenderStart.windows.yaml:
+    func_name: OnRenderStart
+    func_rva: '0xb1cc20'
+    func_sig: 40 53 56 41 55 41 56 48 83 EC ?? 48 89 7C 24 ??
+    func_size: '0x3c8'
+    func_va: '0x180b1cc20'
   client/OnServerVoiceData_IsPlayingDemo_Callee.windows.yaml:
     patch_name: OnServerVoiceData_IsPlayingDemo_Callee
     patch_rva: '0xaec45d'
@@ -12864,6 +12987,12 @@ files:
     vfunc_offset: '0xf8'
     vfunc_sig: 48 8B 9A F8 00 00 00 E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 0F B6 D0 FF D3 48 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B 01 FF 10 48 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ??
     vtable_name: INetworkMessages
+  engine/ISource2Client_ProcessGameInput.windows.yaml:
+    func_name: ISource2Client_ProcessGameInput
+    vfunc_index: 22
+    vfunc_offset: '0xb0'
+    vfunc_sig: 4C 8B 91 B0 00 00 00 75 ?? 0F B6 0D ?? EB 43 00
+    vtable_name: ISource2Client
   engine/ISource2Server_OutOfGameFrameBoundary.linux.yaml:
     func_name: ISource2Server_OutOfGameFrameBoundary
     vfunc_index: 45
@@ -40242,5 +40371,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T06:29:38Z'
+last_publish_time: '2026-07-30T07:47:45Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CNetworkClientService_OnClientProcessGameInput-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_OnClientProcessGameInput-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_OnClientProcessGameInput-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2Client_ProcessGameInput",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2Client_ProcessGameInput",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkClientService_OnClientProcessGameInput.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkClientService_OnClientProcessGameInput.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # ISource2Client is abstract; this relation supplies vtable metadata only.
+    ("ISource2Client_ProcessGameInput", "ISource2Client"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "ISource2Client_ProcessGameInput",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the ISource2Client ProcessGameInput slot from the engine callback."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_FrameStageNotify-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_FrameStageNotify-decompiles.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_FrameStageNotify-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "OnRenderStart",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "OnRenderStart",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CSource2Client_FrameStageNotify.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CSource2Client_FrameStageNotify.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "OnRenderStart",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve OnRenderStart from CSource2Client::FrameStageNotify."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_FrameStageNotify.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_FrameStageNotify.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_FrameStageNotify skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CSource2Client_FrameStageNotify",
+        "CSource2Client",
+        "ISource2Client_FrameStageNotify",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Client_FrameStageNotify",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CSource2Client's FrameStageNotify implementation by inherited slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_ProcessGameInput-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_ProcessGameInput-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_ProcessGameInput-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2Client_FrameStageNotify",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2Client_FrameStageNotify",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CSource2Client_ProcessGameInput.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSource2Client_ProcessGameInput.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # ISource2Client is abstract; this relation supplies vtable metadata only.
+    ("ISource2Client_FrameStageNotify", "ISource2Client"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "ISource2Client_FrameStageNotify",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the ISource2Client FrameStageNotify slot from ProcessGameInput."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_ProcessGameInput.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_ProcessGameInput.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_ProcessGameInput skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CSource2Client_ProcessGameInput",
+        "CSource2Client",
+        "../engine/ISource2Client_ProcessGameInput",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Client_ProcessGameInput",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CSource2Client's ProcessGameInput implementation by inherited slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CViewRender_OnRenderStart.py
+++ b/ida_preprocessor_scripts/find-CViewRender_OnRenderStart.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CViewRender_OnRenderStart skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CViewRender_OnRenderStart",
+        "CViewRender",
+        "IViewRender_OnRenderStart",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CViewRender_OnRenderStart",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CViewRender's OnRenderStart implementation by inherited slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CViewRender_Render.py
+++ b/ida_preprocessor_scripts/find-CViewRender_Render.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CViewRender_Render skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CViewRender_Render",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CViewRender_Render",
+        "xref_strings": [
+            "FULLMATCH:CViewRender::Render",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CViewRender_Render", "CViewRender_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CViewRender_Render",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CViewRender::Render from its exact profiling string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CViewRender_vtable.py
+++ b/ida_preprocessor_scripts/find-CViewRender_vtable.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CViewRender_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_CLASS_NAMES = ["CViewRender"]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CViewRender",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate CViewRender vtable YAML by class-name lookup via MCP."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-C_BaseEntity_SetInterpolationPhase.py
+++ b/ida_preprocessor_scripts/find-C_BaseEntity_SetInterpolationPhase.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-C_BaseEntity_SetInterpolationPhase skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "C_BaseEntity_SetInterpolationPhase",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "C_BaseEntity_SetInterpolationPhase",
+        "xref_strings": [
+            "C_BaseEntity::SetInterpolationPhase ",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "C_BaseEntity_SetInterpolationPhase",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve C_BaseEntity::SetInterpolationPhase from its debug string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-OnRenderStart-decompiles.py
+++ b/ida_preprocessor_scripts/find-OnRenderStart-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-OnRenderStart-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IViewRender_OnRenderStart",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IViewRender_OnRenderStart",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/OnRenderStart.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "OnRenderStart.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # IViewRender is abstract; this relation supplies vtable metadata only.
+    ("IViewRender_OnRenderStart", "IViewRender"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IViewRender_OnRenderStart",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the IViewRender OnRenderStart slot from the render-start helper."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CSource2Client_FrameStageNotify.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_FrameStageNotify.windows.yaml
@@ -1,0 +1,523 @@
+func_name: CSource2Client_FrameStageNotify
+func_va: '0x180b10ff0'
+disasm_code: |-
+  .text:0000000180B10FF0                 mov     [rsp+arg_10], rbx
+  .text:0000000180B10FF5                 mov     [rsp+arg_18], rbp
+  .text:0000000180B10FFA                 push    rdi
+  .text:0000000180B10FFB                 sub     rsp, 40h
+  .text:0000000180B10FFF                 mov     rdi, rcx
+  .text:0000000180B11002                 xor     ebp, ebp
+  .text:0000000180B11004                 mov     rcx, [rcx+440h]
+  .text:0000000180B1100B                 mov     ebx, edx
+  .text:0000000180B1100D                 test    rcx, rcx
+  .text:0000000180B11010                 jz      short loc_180B11031
+  .text:0000000180B11012                 call    cs:?WaitOrImmediatelyExecute@CThreadedJob@@QEAAXXZ; CThreadedJob::WaitOrImmediatelyExecute(void)
+  .text:0000000180B11018                 mov     rcx, [rdi+440h]
+  .text:0000000180B1101F                 test    rcx, rcx
+  .text:0000000180B11022                 jz      short loc_180B11031
+  .text:0000000180B11024                 mov     rax, [rcx]
+  .text:0000000180B11027                 call    qword ptr [rax+10h]
+  .text:0000000180B1102A                 mov     [rdi+440h], rbp
+  .text:0000000180B11031                 cmp     cs:dword_182090D70, ebx
+  .text:0000000180B11037                 jz      short loc_180B1103F
+  .text:0000000180B11039                 mov     cs:dword_182090D70, ebx
+  .text:0000000180B1103F                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B11046                 mov     rax, [rcx]
+  .text:0000000180B11049                 call    qword ptr [rax+2B0h]
+  .text:0000000180B1104F                 ; switch 10 cases
+  .text:0000000180B1104F                 add     ebx, 0FFFFFFFDh; switch 10 cases
+  .text:0000000180B11052                 mov     cs:byte_1823A0830, al
+  .text:0000000180B11058                 cmp     ebx, 9
+  .text:0000000180B1105B                 ja      def_180B1107A; jumptable 0000000180B1107A default case
+  .text:0000000180B11061                 lea     rdx, cs:180000000h
+  .text:0000000180B11068                 movsxd  rax, ebx
+  .text:0000000180B1106B                 movaps  [rsp+48h+var_18], xmm6
+  .text:0000000180B11070                 mov     ecx, ds:(jpt_180B1107A - 180000000h)[rdx+rax*4]
+  .text:0000000180B11077                 add     rcx, rdx
+  .text:0000000180B1107A                 ; switch jump
+  .text:0000000180B1107A                 jmp     rcx; switch jump
+  .text:0000000180B1107C                 ; jumptable 0000000180B1107A case 12
+  .text:0000000180B1107C                 mov     ecx, 4; jumptable 0000000180B1107A case 12
+  .text:0000000180B11081                 call    sub_180AC0AC0
+  .text:0000000180B11086                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1108D                 lea     rdx, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B11094                 xor     r9d, r9d
+  .text:0000000180B11097                 mov     r8d, 0BB7h
+  .text:0000000180B1109D                 mov     rax, [rcx]
+  .text:0000000180B110A0                 call    qword ptr [rax+320h]
+  .text:0000000180B110A6                 call    OnRenderStart
+  .text:0000000180B110AB                 xor     ecx, ecx
+  .text:0000000180B110AD                 call    sub_180AC0AC0
+  .text:0000000180B110B2                 cmp     cs:byte_1823A0830, bpl
+  .text:0000000180B110B9                 jnz     short loc_180B110C8
+  .text:0000000180B110BB                 call    sub_1804EACA0
+  .text:0000000180B110C0                 mov     rcx, rax
+  .text:0000000180B110C3                 call    sub_1804EC880
+  .text:0000000180B110C8                 call    sub_1804EACA0
+  .text:0000000180B110CD                 mov     rcx, rax
+  .text:0000000180B110D0                 call    sub_1804ECB60
+  .text:0000000180B110D5                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B110DA                 ; jumptable 0000000180B1107A case 4
+  .text:0000000180B110DA                 mov     rax, cs:gpGlobals; jumptable 0000000180B1107A case 4
+  .text:0000000180B110E1                 mov     ecx, [rax+30h]
+  .text:0000000180B110E4                 mov     [rdi+448h], ecx
+  .text:0000000180B110EA                 mov     ecx, 1
+  .text:0000000180B110EF                 mov     rax, cs:gpGlobals
+  .text:0000000180B110F6                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180B110FB                 call    C_BaseEntity_SetInterpolationPhase
+  .text:0000000180B11100                 xor     ecx, ecx
+  .text:0000000180B11102                 call    sub_180A91F70
+  .text:0000000180B11107                 call    cs:ThreadInMainThread
+  .text:0000000180B1110D                 test    al, al
+  .text:0000000180B1110F                 jz      short loc_180B11118
+  .text:0000000180B11111                 mov     cs:byte_18208D450, bpl
+  .text:0000000180B11118                 mov     ecx, 1
+  .text:0000000180B1111D                 call    sub_180AC0AC0
+  .text:0000000180B11122                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B11129                 mov     edx, 1
+  .text:0000000180B1112E                 mov     rax, [rcx]
+  .text:0000000180B11131                 call    qword ptr [rax+60h]
+  .text:0000000180B11134                 xor     ecx, ecx
+  .text:0000000180B11136                 call    sub_180AC0AC0
+  .text:0000000180B1113B                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B11140                 ; jumptable 0000000180B1107A case 9
+  .text:0000000180B11140                 mov     rax, cs:gpGlobals; jumptable 0000000180B1107A case 9
+  .text:0000000180B11147                 mov     ecx, 1
+  .text:0000000180B1114C                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180B11151                 call    C_BaseEntity_SetInterpolationPhase
+  .text:0000000180B11156                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B1115B                 ; jumptable 0000000180B1107A case 10
+  .text:0000000180B1115B                 mov     edx, 0FFFFFFFFh; jumptable 0000000180B1107A case 10
+  .text:0000000180B11160                 lea     rcx, unk_18239F600
+  .text:0000000180B11167                 call    sub_181862110
+  .text:0000000180B1116C                 test    rax, rax
+  .text:0000000180B1116F                 jnz     short loc_180B1117C
+  .text:0000000180B11171                 mov     rax, cs:qword_18239F608
+  .text:0000000180B11178                 mov     rax, [rax+8]
+  .text:0000000180B1117C                 cmp     [rax], bpl
+  .text:0000000180B1117F                 jz      loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B11185                 mov     ecx, cs:dword_18202B898
+  .text:0000000180B1118B                 mov     [rsp+48h+arg_0], rsi
+  .text:0000000180B11190                 test    ecx, ecx
+  .text:0000000180B11192                 jns     short loc_180B11202
+  .text:0000000180B11194                 mov     ecx, cs:TlsIndex
+  .text:0000000180B1119A                 lea     rax, ??_7CDontUseThisGameSystem@@6B@; const CDontUseThisGameSystem::`vftable'
+  .text:0000000180B111A1                 mov     [rsp+48h+var_28], rax
+  .text:0000000180B111A6                 mov     rax, gs:58h
+  .text:0000000180B111AF                 mov     edx, 68h ; 'h'
+  .text:0000000180B111B4                 mov     [rsp+48h+var_20], rbp
+  .text:0000000180B111B9                 mov     rax, [rax+rcx*8]
+  .text:0000000180B111BD                 mov     eax, [rdx+rax]
+  .text:0000000180B111C0                 cmp     cs:dword_18221A358, eax
+  .text:0000000180B111C6                 jg      loc_180B11565
+  .text:0000000180B111CC                 mov     rax, cs:qword_18221A350
+  .text:0000000180B111D3                 lea     rcx, [rsp+48h+var_28]
+  .text:0000000180B111D8                 mov     rbx, [rsp+48h+var_28]
+  .text:0000000180B111DD                 mov     [rsp+48h+var_28], rax
+  .text:0000000180B111E2                 call    sub_18034647C
+  .text:0000000180B111E7                 lea     rcx, [rsp+48h+var_28]
+  .text:0000000180B111EC                 mov     [rsp+48h+var_28], rbx
+  .text:0000000180B111F1                 mov     cs:dword_18202B898, eax
+  .text:0000000180B111F7                 call    sub_180345AC0
+  .text:0000000180B111FC                 mov     ecx, cs:dword_18202B898
+  .text:0000000180B11202                 lea     r8, [rsp+48h+arg_8]
+  .text:0000000180B11207                 lea     rdx, sub_18034647C
+  .text:0000000180B1120E                 call    sub_180350550
+  .text:0000000180B11213                 mov     rcx, cs:g_pNetworkClientService
+  .text:0000000180B1121A                 mov     rax, [rcx]
+  .text:0000000180B1121D                 call    qword ptr [rax+0B8h]
+  .text:0000000180B11223                 mov     rcx, rax
+  .text:0000000180B11226                 mov     rdx, [rax]
+  .text:0000000180B11229                 call    qword ptr [rdx+40h]
+  .text:0000000180B1122C                 mov     ecx, 58h ; 'X'
+  .text:0000000180B11231                 movd    xmm0, eax
+  .text:0000000180B11235                 mov     rax, cs:g_pThreadPool
+  .text:0000000180B1123C                 cvtdq2ps xmm0, xmm0
+  .text:0000000180B1123F                 mov     rsi, [rax]
+  .text:0000000180B11242                 mulss   xmm0, cs:dword_1819713C8
+  .text:0000000180B1124A                 movaps  xmm6, xmm0
+  .text:0000000180B1124D                 call    sub_180BCB090
+  .text:0000000180B11252                 mov     rbx, rax
+  .text:0000000180B11255                 test    rax, rax
+  .text:0000000180B11258                 jz      short loc_180B112AD
+  .text:0000000180B1125A                 mov     dword ptr [rax+8], 1
+  .text:0000000180B11261                 lea     rcx, [rax+30h]
+  .text:0000000180B11265                 mov     dword ptr [rax+10h], 4
+  .text:0000000180B1126C                 lea     rdx, aClientRestoreS; "Client Restore Server State"
+  .text:0000000180B11273                 mov     [rax+20h], rbp
+  .text:0000000180B11277                 mov     r8d, 20h ; ' '
+  .text:0000000180B1127D                 mov     [rax+28h], rbp
+  .text:0000000180B11281                 mov     word ptr [rax+15h], 2
+  .text:0000000180B11287                 mov     [rax+18h], rbp
+  .text:0000000180B1128B                 lea     rax, ??_7CLambdaJob@?1???$QueueJobWithFlags@V_lambda_1_@?O@??FrameStageNotify@CSource2Client@@UEAAXW4ClientFrameStage_t@@@Z@@IThreadPool@@QEAA?AV?$CSmartPtr@VCThreadedJob@@VCRefCountAccessor@@@@PEBDW4JobPriority_t@@I$$QEAV_lambda_1_@?O@??FrameStageNotify@CSource2Client@@UEAAXW4ClientFrameStage_t@@@Z@@Z@6B@; const `IThreadPool::QueueJobWithFlags<`CSource2Client::FrameStageNotify(ClientFrameStage_t)'::`14'::_lambda_1_>(char const *,JobPriority_t,uint,`CSource2Client::FrameStageNotify(ClientFrameStage_t)'::`14'::_lambda_1_ &&)'::`2'::CLambdaJob::`vftable'
+  .text:0000000180B11292                 mov     [rcx], bpl
+  .text:0000000180B11295                 mov     [rbx], rax
+  .text:0000000180B11298                 movss   dword ptr [rbx+50h], xmm6
+  .text:0000000180B1129D                 mov     byte ptr [rbx+14h], 2
+  .text:0000000180B112A1                 call    cs:_V_strncpy
+  .text:0000000180B112A7                 mov     byte ptr [rbx+16h], 1
+  .text:0000000180B112AB                 jmp     short loc_180B112B0
+  .text:0000000180B112AD                 mov     rbx, rbp
+  .text:0000000180B112B0                 mov     [rbx+18h], rsi
+  .text:0000000180B112B4                 mov     rdx, rbx
+  .text:0000000180B112B7                 mov     rax, [rsi]
+  .text:0000000180B112BA                 mov     rcx, rsi
+  .text:0000000180B112BD                 call    qword ptr [rax+80h]
+  .text:0000000180B112C3                 mov     rcx, [rdi+440h]
+  .text:0000000180B112CA                 mov     rsi, [rsp+48h+arg_0]
+  .text:0000000180B112CF                 test    rcx, rcx
+  .text:0000000180B112D2                 jz      short loc_180B112DA
+  .text:0000000180B112D4                 mov     rax, [rcx]
+  .text:0000000180B112D7                 call    qword ptr [rax+10h]
+  .text:0000000180B112DA                 mov     [rdi+440h], rbx
+  .text:0000000180B112E1                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B112E6                 ; jumptable 0000000180B1107A case 5
+  .text:0000000180B112E6                 mov     r9, cs:gpGlobals; jumptable 0000000180B1107A case 5
+  .text:0000000180B112ED                 lea     rdx, aFramenetupdate; "FrameNetUpdate(%.3f %d)"
+  .text:0000000180B112F4                 mov     rcx, [rdi+430h]
+  .text:0000000180B112FB                 movss   xmm2, dword ptr [r9+30h]
+  .text:0000000180B11301                 mov     r9d, [r9+44h]
+  .text:0000000180B11305                 cvtps2pd xmm2, xmm2
+  .text:0000000180B11308                 movq    r8, xmm2
+  .text:0000000180B1130D                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
+  .text:0000000180B11313                 mov     rdx, [rdi+430h]
+  .text:0000000180B1131A                 mov     rcx, cs:off_18205ADB0
+  .text:0000000180B11321                 call    sub_18051A550
+  .text:0000000180B11326                 cmp     cs:qword_18238D530, rbp
+  .text:0000000180B1132D                 jz      short loc_180B1137A
+  .text:0000000180B1132F                 mov     edx, 0FFFFFFFFh
+  .text:0000000180B11334                 lea     rcx, unk_182397E20
+  .text:0000000180B1133B                 xorps   xmm6, xmm6
+  .text:0000000180B1133E                 call    sub_181862110
+  .text:0000000180B11343                 test    rax, rax
+  .text:0000000180B11346                 jnz     short loc_180B11353
+  .text:0000000180B11348                 mov     rax, cs:qword_182397E28
+  .text:0000000180B1134F                 mov     rax, [rax+8]
+  .text:0000000180B11353                 cmp     [rax], ebp
+  .text:0000000180B11355                 jle     short loc_180B1136B
+  .text:0000000180B11357                 mov     edx, 0FFFFFFFFh
+  .text:0000000180B1135C                 lea     rcx, unk_18239F658
+  .text:0000000180B11363                 call    sub_180165EE0
+  .text:0000000180B11368                 movaps  xmm6, xmm0
+  .text:0000000180B1136B                 mov     rcx, cs:qword_18238D530
+  .text:0000000180B11372                 movaps  xmm1, xmm6
+  .text:0000000180B11375                 call    sub_1814FA7F0
+  .text:0000000180B1137A                 mov     rcx, cs:g_pSource2ClientPrediction
+  .text:0000000180B11381                 mov     rax, [rcx]
+  .text:0000000180B11384                 call    qword ptr [rax+60h]
+  .text:0000000180B11387                 mov     rax, cs:gpGlobals
+  .text:0000000180B1138E                 mov     ecx, 1
+  .text:0000000180B11393                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180B11398                 call    C_BaseEntity_SetInterpolationPhase
+  .text:0000000180B1139D                 mov     ecx, 3
+  .text:0000000180B113A2                 call    sub_180AC0AC0
+  .text:0000000180B113A7                 mov     rcx, cs:g_pSource2ClientPrediction
+  .text:0000000180B113AE                 mov     ebx, eax
+  .text:0000000180B113B0                 mov     rdx, [rcx]
+  .text:0000000180B113B3                 call    qword ptr [rdx+68h]
+  .text:0000000180B113B6                 mov     ecx, ebx
+  .text:0000000180B113B8                 call    sub_180AC0AC0
+  .text:0000000180B113BD                 mov     rcx, rdi
+  .text:0000000180B113C0                 call    sub_180B207E0
+  .text:0000000180B113C5                 mov     rcx, cs:g_pEntitySystem
+  .text:0000000180B113CC                 call    sub_1814F6710
+  .text:0000000180B113D1                 mov     rcx, cs:qword_18238D530
+  .text:0000000180B113D8                 call    sub_180985030
+  .text:0000000180B113DD                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B113E4                 mov     rax, [rcx]
+  .text:0000000180B113E7                 call    qword ptr [rax+128h]
+  .text:0000000180B113ED                 mov     rcx, cs:qword_1822ACE48
+  .text:0000000180B113F4                 mov     edx, eax
+  .text:0000000180B113F6                 call    sub_1803C07F0
+  .text:0000000180B113FB                 xor     ecx, ecx
+  .text:0000000180B113FD                 call    sub_180A91F70
+  .text:0000000180B11402                 call    cs:ThreadInMainThread
+  .text:0000000180B11408                 test    al, al
+  .text:0000000180B1140A                 jz      short loc_180B11413
+  .text:0000000180B1140C                 mov     cs:byte_18208D450, bpl
+  .text:0000000180B11413                 mov     ecx, 1
+  .text:0000000180B11418                 call    sub_180AC0AC0
+  .text:0000000180B1141D                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B11422                 ; jumptable 0000000180B1107A case 8
+  .text:0000000180B11422                 mov     cl, 1; jumptable 0000000180B1107A case 8
+  .text:0000000180B11424                 call    sub_180A91F70
+  .text:0000000180B11429                 call    cs:ThreadInMainThread
+  .text:0000000180B1142F                 test    al, al
+  .text:0000000180B11431                 jz      short loc_180B1143A
+  .text:0000000180B11433                 mov     cs:byte_18208D450, 1
+  .text:0000000180B1143A                 mov     ecx, 2
+  .text:0000000180B1143F                 call    sub_180AC0AC0
+  .text:0000000180B11444                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1144B                 mov     rax, [rcx]
+  .text:0000000180B1144E                 call    qword ptr [rax+128h]
+  .text:0000000180B11454                 mov     rcx, cs:qword_1822ACE48
+  .text:0000000180B1145B                 mov     edx, eax
+  .text:0000000180B1145D                 call    sub_18039FF50
+  .text:0000000180B11462                 xor     ecx, ecx
+  .text:0000000180B11464                 call    sub_180AC0AC0
+  .text:0000000180B11469                 mov     rdx, [rdi+430h]
+  .text:0000000180B11470                 mov     rcx, cs:off_18205ADB0
+  .text:0000000180B11477                 call    sub_18050E9E0
+  .text:0000000180B1147C                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B11481                 ; jumptable 0000000180B1107A case 6
+  .text:0000000180B11481                 mov     r9, cs:gpGlobals; jumptable 0000000180B1107A case 6
+  .text:0000000180B11488                 lea     rdx, aFramepostdatau; "FramePostDataUpdate(%.3f %d)"
+  .text:0000000180B1148F                 mov     rcx, [rdi+438h]
+  .text:0000000180B11496                 movss   xmm2, dword ptr [r9+30h]
+  .text:0000000180B1149C                 mov     r9d, [r9+44h]
+  .text:0000000180B114A0                 cvtps2pd xmm2, xmm2
+  .text:0000000180B114A3                 movq    r8, xmm2
+  .text:0000000180B114A8                 call    cs:?Format@CUtlString@@QEAAHPEBDZZ; CUtlString::Format(char const *,...)
+  .text:0000000180B114AE                 mov     rdx, [rdi+438h]
+  .text:0000000180B114B5                 mov     rcx, cs:off_18205ADB0
+  .text:0000000180B114BC                 call    sub_18051A550
+  .text:0000000180B114C1                 jmp     loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B114C6                 ; jumptable 0000000180B1107A case 7
+  .text:0000000180B114C6                 call    sub_1804EACA0; jumptable 0000000180B1107A case 7
+  .text:0000000180B114CB                 mov     rcx, rax
+  .text:0000000180B114CE                 call    sub_1804EB840
+  .text:0000000180B114D3                 mov     rdx, [rdi+438h]
+  .text:0000000180B114DA                 mov     rcx, cs:off_18205ADB0
+  .text:0000000180B114E1                 call    sub_18050E9E0
+  .text:0000000180B114E6                 mov     rcx, cs:off_182097E28
+  .text:0000000180B114ED                 call    sub_180B842C0
+  .text:0000000180B114F2                 mov     rcx, cs:qword_182219A88
+  .text:0000000180B114F9                 call    sub_18036EB90
+  .text:0000000180B114FE                 mov     rcx, cs:qword_1823A0840
+  .text:0000000180B11505                 mov     rax, [rcx]
+  .text:0000000180B11508                 call    qword ptr [rax+90h]
+  .text:0000000180B1150E                 mov     ecx, 1
+  .text:0000000180B11513                 call    sub_180AA60C0
+  .text:0000000180B11518                 jmp     short loc_180B11550; jumptable 0000000180B1107A case 11
+  .text:0000000180B1151A                 ; jumptable 0000000180B1107A case 3
+  .text:0000000180B1151A                 mov     rax, cs:gpGlobals; jumptable 0000000180B1107A case 3
+  .text:0000000180B11521                 mov     ecx, 1
+  .text:0000000180B11526                 movss   xmm1, dword ptr [rax+30h]
+  .text:0000000180B1152B                 call    C_BaseEntity_SetInterpolationPhase
+  .text:0000000180B11530                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B11537                 lea     rdx, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1153E                 xor     r9d, r9d
+  .text:0000000180B11541                 mov     r8d, 0C57h
+  .text:0000000180B11547                 mov     rax, [rcx]
+  .text:0000000180B1154A                 call    qword ptr [rax+320h]
+  .text:0000000180B11550                 ; jumptable 0000000180B1107A case 11
+  .text:0000000180B11550                 movaps  xmm6, [rsp+48h+var_18]; jumptable 0000000180B1107A case 11
+  .text:0000000180B11555                 ; jumptable 0000000180B1107A default case
+  .text:0000000180B11555                 mov     rbx, [rsp+48h+arg_10]; jumptable 0000000180B1107A default case
+  .text:0000000180B1155A                 mov     rbp, [rsp+48h+arg_18]
+  .text:0000000180B1155F                 add     rsp, 40h
+  .text:0000000180B11563                 pop     rdi
+  .text:0000000180B11564                 retn
+  .text:0000000180B11565                 lea     rcx, dword_18221A358
+  .text:0000000180B1156C                 call    sub_1818ABC88
+  .text:0000000180B11571                 cmp     cs:dword_18221A358, 0FFFFFFFFh
+  .text:0000000180B11578                 jnz     loc_180B111CC
+  .text:0000000180B1157E                 mov     rax, cs:off_18202B998
+  .text:0000000180B11585                 lea     rcx, dword_18221A358
+  .text:0000000180B1158C                 mov     cs:qword_18221A350, rax
+  .text:0000000180B11593                 call    sub_1818ABC1C
+  .text:0000000180B11598                 jmp     loc_180B111CC
+procedure: |-
+  void __fastcall CSource2Client_FrameStageNotify(__int64 a1, int a2)
+  {
+    CThreadedJob *v3; // rcx
+    __int64 v5; // rcx
+    void ***v6; // rax
+    float *v7; // rax
+    __int64 v8; // rdx
+    __int64 v9; // r8
+    _BYTE *v10; // rax
+    __int64 v11; // rcx
+    _QWORD *ThreadLocalStoragePointer; // rax
+    __int64 v13; // rbx
+    int v14; // eax
+    __int64 v15; // rax
+    float v16; // xmm0_4
+    __int64 v17; // rax
+    __int64 v18; // rbx
+    __int64 v19; // rcx
+    int *v20; // rax
+    int v21; // ebx
+    unsigned int v22; // eax
+    unsigned int v23; // eax
+    void ***v24; // rax
+    _QWORD v25[2]; // [rsp+20h] [rbp-28h] BYREF
+    char v26; // [rsp+58h] [rbp+10h] BYREF
+
+    v3 = *(CThreadedJob **)(a1 + 1088);
+    if ( v3 )
+    {
+      CThreadedJob::WaitOrImmediatelyExecute(v3);
+      v5 = *(_QWORD *)(a1 + 1088);
+      if ( v5 )
+      {
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)v5 + 16LL))(v5);
+        *(_QWORD *)(a1 + 1088) = 0;
+      }
+    }
+    if ( dword_182090D70 != a2 )
+      dword_182090D70 = a2;
+    byte_1823A0830 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 688LL))(g_pEngineClient);
+    switch ( a2 )
+    {
+      case 3:
+        C_BaseEntity_SetInterpolationPhase(1u, *((float *)gpGlobals + 12));
+        (*(void (__fastcall **)(__int64, const char *, __int64, _QWORD))(*(_QWORD *)g_pEngineClient + 800LL))(
+          g_pEngineClient,
+          "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp",
+          3159,
+          0);
+        break;
+      case 4:
+        *(_DWORD *)(a1 + 1096) = *((_DWORD *)gpGlobals + 12);
+        C_BaseEntity_SetInterpolationPhase(1u, *((float *)gpGlobals + 12));
+        sub_180A91F70(0);
+        if ( (unsigned __int8)ThreadInMainThread() )
+          byte_18208D450 = 0;
+        sub_180AC0AC0(1);
+        (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pEntitySystem + 96LL))(g_pEntitySystem, 1);
+        sub_180AC0AC0(0);
+        break;
+      case 5:
+        CUtlString::Format(
+          *(CUtlString **)(a1 + 1072),
+          "FrameNetUpdate(%.3f %d)",
+          *((float *)gpGlobals + 12),
+          *((unsigned int *)gpGlobals + 17));
+        sub_18051A550(off_18205ADB0, *(_QWORD *)(a1 + 1072));
+        if ( qword_18238D530 )
+        {
+          v20 = (int *)sub_181862110(&unk_182397E20, 0xFFFFFFFFLL);
+          if ( !v20 )
+            v20 = *(int **)(qword_182397E28 + 8);
+          if ( *v20 > 0 )
+            sub_180165EE0(&unk_18239F658, 0xFFFFFFFFLL);
+          sub_1814FA7F0(qword_18238D530);
+        }
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2ClientPrediction + 96LL))(g_pSource2ClientPrediction);
+        C_BaseEntity_SetInterpolationPhase(1u, *((float *)gpGlobals + 12));
+        v21 = sub_180AC0AC0(3);
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2ClientPrediction + 104LL))(g_pSource2ClientPrediction);
+        sub_180AC0AC0(v21);
+        sub_180B207E0(a1);
+        sub_1814F6710(g_pEntitySystem);
+        sub_180985030(qword_18238D530);
+        v22 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 296LL))(g_pEngineClient);
+        sub_1803C07F0(qword_1822ACE48, v22);
+        sub_180A91F70(0);
+        if ( (unsigned __int8)ThreadInMainThread() )
+          byte_18208D450 = 0;
+        sub_180AC0AC0(1);
+        break;
+      case 6:
+        CUtlString::Format(
+          *(CUtlString **)(a1 + 1080),
+          "FramePostDataUpdate(%.3f %d)",
+          *((float *)gpGlobals + 12),
+          *((unsigned int *)gpGlobals + 17));
+        sub_18051A550(off_18205ADB0, *(_QWORD *)(a1 + 1080));
+        break;
+      case 7:
+        v24 = sub_1804EACA0();
+        sub_1804EB840(v24);
+        sub_18050E9E0(off_18205ADB0, *(_QWORD *)(a1 + 1080));
+        sub_180B842C0(off_182097E28);
+        sub_18036EB90(qword_182219A88);
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)qword_1823A0840 + 144LL))(qword_1823A0840);
+        sub_180AA60C0(1);
+        break;
+      case 8:
+        sub_180A91F70(1);
+        if ( (unsigned __int8)ThreadInMainThread() )
+          byte_18208D450 = 1;
+        sub_180AC0AC0(2);
+        v23 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 296LL))(g_pEngineClient);
+        sub_18039FF50(qword_1822ACE48, v23);
+        sub_180AC0AC0(0);
+        sub_18050E9E0(off_18205ADB0, *(_QWORD *)(a1 + 1072));
+        break;
+      case 9:
+        C_BaseEntity_SetInterpolationPhase(1u, *((float *)gpGlobals + 12));
+        break;
+      case 10:
+        v10 = (_BYTE *)sub_181862110(&unk_18239F600, 0xFFFFFFFFLL);
+        if ( !v10 )
+          v10 = *(_BYTE **)(qword_18239F608 + 8);
+        if ( *v10 )
+        {
+          v11 = (unsigned int)dword_18202B898;
+          if ( dword_18202B898 < 0 )
+          {
+            v25[0] = &CDontUseThisGameSystem::`vftable';
+            ThreadLocalStoragePointer = NtCurrentTeb()->ThreadLocalStoragePointer;
+            v25[1] = 0;
+            if ( dword_18221A358 > *(_DWORD *)(ThreadLocalStoragePointer[TlsIndex] + 104LL) )
+            {
+              sub_1818ABC88(&dword_18221A358);
+              if ( dword_18221A358 == -1 )
+              {
+                qword_18221A350 = (__int64)off_18202B998[0];
+                sub_1818ABC1C(&dword_18221A358);
+              }
+            }
+            v13 = v25[0];
+            v25[0] = qword_18221A350;
+            v14 = sub_18034647C(v25);
+            v25[0] = v13;
+            dword_18202B898 = v14;
+            sub_180345AC0(v25);
+            v11 = (unsigned int)dword_18202B898;
+          }
+          sub_180350550(v11, sub_18034647C, &v26);
+          v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkClientService + 184LL))(g_pNetworkClientService);
+          v16 = (float)(*(int (__fastcall **)(__int64))(*(_QWORD *)v15 + 64LL))(v15) * 0.015625;
+          v17 = sub_180BCB090(88);
+          v18 = v17;
+          if ( v17 )
+          {
+            *(_DWORD *)(v17 + 8) = 1;
+            *(_DWORD *)(v17 + 16) = 4;
+            *(_QWORD *)(v17 + 32) = 0;
+            *(_QWORD *)(v17 + 40) = 0;
+            *(_WORD *)(v17 + 21) = 2;
+            *(_QWORD *)(v17 + 24) = 0;
+            *(_BYTE *)(v17 + 48) = 0;
+            *(_QWORD *)v17 = &`Z::QueueJobWithFlags<`CSource2Client::FrameStageNotify'::`14'::_lambda_1_,EAAXW4ClientFrameStage_t>'::`2'::CLambdaJob::`vftable';
+            *(float *)(v17 + 80) = v16;
+            *(_BYTE *)(v17 + 20) = 2;
+            V_strncpy(v17 + 48, "Client Restore Server State", 32);
+            *(_BYTE *)(v18 + 22) = 1;
+          }
+          else
+          {
+            v18 = 0;
+          }
+          *(_QWORD *)(v18 + 24) = g_pThreadPool;
+          (*(void (__fastcall **)(_QWORD, __int64))(*g_pThreadPool + 128LL))(g_pThreadPool, v18);
+          v19 = *(_QWORD *)(a1 + 1088);
+          if ( v19 )
+            (*(void (__fastcall **)(__int64))(*(_QWORD *)v19 + 16LL))(v19);
+          *(_QWORD *)(a1 + 1088) = v18;
+        }
+        break;
+      case 12:
+        sub_180AC0AC0(4);
+        (*(void (__fastcall **)(__int64, const char *, __int64, _QWORD))(*(_QWORD *)g_pEngineClient + 800LL))(
+          g_pEngineClient,
+          "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp",
+          2999,
+          0);
+        OnRenderStart();
+        sub_180AC0AC0(0);
+        if ( !byte_1823A0830 )
+        {
+          v6 = sub_1804EACA0();
+          sub_1804EC880((__int64)v6);
+        }
+        v7 = (float *)sub_1804EACA0();
+        sub_1804ECB60(v7, v8, v9);
+        break;
+      default:
+        return;
+    }
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2Client_ProcessGameInput.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_ProcessGameInput.windows.yaml
@@ -1,0 +1,76 @@
+func_name: CSource2Client_ProcessGameInput
+func_va: '0x180b200a0'
+disasm_code: |-
+  .text:0000000180B200A0                 mov     [rsp+arg_0], rbx
+  .text:0000000180B200A5                 mov     [rsp+arg_8], rbp
+  .text:0000000180B200AA                 mov     [rsp+arg_10], rsi
+  .text:0000000180B200AF                 push    rdi
+  .text:0000000180B200B0                 sub     rsp, 30h
+  .text:0000000180B200B4                 mov     rax, [rcx]
+  .text:0000000180B200B7                 mov     ebx, edx
+  .text:0000000180B200B9                 movaps  [rsp+38h+var_18], xmm6
+  .text:0000000180B200BE                 xor     edx, edx
+  .text:0000000180B200C0                 movzx   esi, r9b
+  .text:0000000180B200C4                 movaps  xmm6, xmm2
+  .text:0000000180B200C7                 call    qword ptr [rax+120h] ; 120h = ISource2Client_FrameStageNotify
+  .text:0000000180B200CD                 call    sub_180AA5320
+  .text:0000000180B200D2                 mov     cl, 1
+  .text:0000000180B200D4                 movzx   ebp, al
+  .text:0000000180B200D7                 call    sub_180A91F70
+  .text:0000000180B200DC                 call    cs:ThreadInMainThread
+  .text:0000000180B200E2                 movzx   edi, cs:byte_18208D450
+  .text:0000000180B200E9                 mov     ecx, 1
+  .text:0000000180B200EE                 test    al, al
+  .text:0000000180B200F0                 cmovz   edi, ecx
+  .text:0000000180B200F3                 call    cs:ThreadInMainThread
+  .text:0000000180B200F9                 test    al, al
+  .text:0000000180B200FB                 jz      short loc_180B20104
+  .text:0000000180B200FD                 mov     cs:byte_18208D450, 1
+  .text:0000000180B20104                 mov     rcx, cs:g_pCSGOInput
+  .text:0000000180B2010B                 movzx   r9d, sil
+  .text:0000000180B2010F                 mov     cs:byte_1824361D8, 1
+  .text:0000000180B20116                 movaps  xmm2, xmm6
+  .text:0000000180B20119                 mov     edx, ebx
+  .text:0000000180B2011B                 mov     rax, [rcx]
+  .text:0000000180B2011E                 call    qword ptr [rax+20h]
+  .text:0000000180B20121                 movzx   ecx, bpl
+  .text:0000000180B20125                 call    sub_180A91F70
+  .text:0000000180B2012A                 mov     cs:byte_1824361D8, 0
+  .text:0000000180B20131                 call    cs:ThreadInMainThread
+  .text:0000000180B20137                 test    al, al
+  .text:0000000180B20139                 jz      short loc_180B20142
+  .text:0000000180B2013B                 mov     cs:byte_18208D450, dil
+  .text:0000000180B20142                 mov     rbx, [rsp+38h+arg_0]
+  .text:0000000180B20147                 mov     rbp, [rsp+38h+arg_8]
+  .text:0000000180B2014C                 mov     rsi, [rsp+38h+arg_10]
+  .text:0000000180B20151                 movaps  xmm6, [rsp+38h+var_18]
+  .text:0000000180B20156                 add     rsp, 30h
+  .text:0000000180B2015A                 pop     rdi
+  .text:0000000180B2015B                 retn
+procedure: |-
+  __int64 __fastcall CSource2Client_ProcessGameInput(__int64 a1, unsigned int a2, __int64 a3, unsigned __int8 a4)
+  {
+    char v6; // bp
+    char v7; // al
+    char v8; // di
+    __int64 v9; // r8
+    __int64 result; // rax
+
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 288LL))(a1, 0);// 288LL = 0x120 = ISource2Client_FrameStageNotify
+    v6 = sub_180AA5320();
+    sub_180A91F70(1);
+    v7 = ThreadInMainThread();
+    v8 = byte_18208D450;
+    if ( !v7 )
+      v8 = 1;
+    if ( (unsigned __int8)ThreadInMainThread() )
+      byte_18208D450 = 1;
+    byte_1824361D8 = 1;
+    (*(void (__fastcall **)(__int64 *, _QWORD, __int64, _QWORD))(*g_pCSGOInput + 32))(g_pCSGOInput, a2, v9, a4);
+    sub_180A91F70(v6);
+    byte_1824361D8 = 0;
+    result = ThreadInMainThread();
+    if ( (_BYTE)result )
+      byte_18208D450 = v8;
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/client/OnRenderStart.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/OnRenderStart.windows.yaml
@@ -1,0 +1,446 @@
+func_name: OnRenderStart
+func_va: '0x180b1cc20'
+disasm_code: |-
+  .text:0000000180B1CC20                 push    rbx
+  .text:0000000180B1CC22                 push    rsi
+  .text:0000000180B1CC23                 push    r13
+  .text:0000000180B1CC25                 push    r14
+  .text:0000000180B1CC27                 sub     rsp, 48h
+  .text:0000000180B1CC2B                 mov     [rsp+68h+var_30], rdi
+  .text:0000000180B1CC30                 mov     ecx, 3
+  .text:0000000180B1CC35                 mov     [rsp+68h+var_38], r12
+  .text:0000000180B1CC3A                 mov     [rsp+68h+var_40], r15
+  .text:0000000180B1CC3F                 call    sub_1809FB620
+  .text:0000000180B1CC44                 mov     ecx, 4
+  .text:0000000180B1CC49                 call    sub_1809FB620
+  .text:0000000180B1CC4E                 mov     ecx, 5
+  .text:0000000180B1CC53                 call    sub_1809FB620
+  .text:0000000180B1CC58                 mov     cl, 1
+  .text:0000000180B1CC5A                 call    sub_1803D9F90
+  .text:0000000180B1CC5F                 mov     byte ptr [rsp+68h+arg_0], al
+  .text:0000000180B1CC63                 call    cs:ThreadInMainThread
+  .text:0000000180B1CC69                 test    al, al
+  .text:0000000180B1CC6B                 jz      short loc_180B1CC74
+  .text:0000000180B1CC6D                 mov     cs:byte_18208D450, 0
+  .text:0000000180B1CC74                 mov     rcx, cs:gpGlobals
+  .text:0000000180B1CC7B                 movss   xmm1, dword ptr [rcx+30h]
+  .text:0000000180B1CC80                 mov     ecx, 0FFFFFFFFh
+  .text:0000000180B1CC85                 call    C_BaseEntity_SetInterpolationPhase
+  .text:0000000180B1CC8A                 call    cs:ThreadInMainThread
+  .text:0000000180B1CC90                 test    al, al
+  .text:0000000180B1CC92                 jz      short loc_180B1CC9B
+  .text:0000000180B1CC94                 mov     cs:byte_18208D450, 1
+  .text:0000000180B1CC9B                 mov     cl, 1
+  .text:0000000180B1CC9D                 call    sub_180A91F70
+  .text:0000000180B1CCA2                 call    sub_181187980
+  .text:0000000180B1CCA7                 mov     rcx, cs:qword_182219A88
+  .text:0000000180B1CCAE                 test    rcx, rcx
+  .text:0000000180B1CCB1                 jz      short loc_180B1CCB8
+  .text:0000000180B1CCB3                 call    sub_18034E060
+  .text:0000000180B1CCB8                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CCBF                 lea     rdx, [rsp+68h+arg_8]
+  .text:0000000180B1CCC4                 mov     [rsp+68h+var_28], rbp
+  .text:0000000180B1CCC9                 xor     ebx, ebx
+  .text:0000000180B1CCCB                 mov     rax, [rcx]
+  .text:0000000180B1CCCE                 call    qword ptr [rax+310h]
+  .text:0000000180B1CCD4                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CCDB                 cmp     [rax], ebx
+  .text:0000000180B1CCDD                 mov     rax, [rcx]
+  .text:0000000180B1CCE0                 jnz     short loc_180B1CD0A
+  .text:0000000180B1CCE2                 call    qword ptr [rax+328h]
+  .text:0000000180B1CCE8                 test    al, al
+  .text:0000000180B1CCEA                 jz      short loc_180B1CD00
+  .text:0000000180B1CCEC                 mov     rsi, [rsp+68h+arg_0]
+  .text:0000000180B1CCF1                 xor     dil, dil
+  .text:0000000180B1CCF4                 mov     ebp, dword ptr [rsp+68h+arg_0]
+  .text:0000000180B1CCF8                 movzx   r14d, byte ptr [rsp+68h+arg_0]
+  .text:0000000180B1CCFE                 jmp     short loc_180B1CD52
+  .text:0000000180B1CD00                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CD07                 mov     rax, [rcx]
+  .text:0000000180B1CD0A                 mov     r9, [rax+318h]
+  .text:0000000180B1CD11                 lea     rdx, [rsp+68h+arg_10]
+  .text:0000000180B1CD19                 xor     r8d, r8d
+  .text:0000000180B1CD1C                 lea     rsi, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CD23                 mov     ebp, 0B6Fh
+  .text:0000000180B1CD28                 mov     dil, 1
+  .text:0000000180B1CD2B                 call    r9
+  .text:0000000180B1CD2E                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CD35                 lea     rdx, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CD3C                 movzx   r9d, dil
+  .text:0000000180B1CD40                 mov     r8d, ebp
+  .text:0000000180B1CD43                 mov     ebx, [rax]
+  .text:0000000180B1CD45                 mov     rax, [rcx]
+  .text:0000000180B1CD48                 call    qword ptr [rax+320h]
+  .text:0000000180B1CD4E                 movzx   r14d, al
+  .text:0000000180B1CD52                 mov     rcx, cs:g_pCSGOInput
+  .text:0000000180B1CD59                 xor     edx, edx
+  .text:0000000180B1CD5B                 call    CCSGOInput_CAM_Think
+  .text:0000000180B1CD60                 test    dil, dil
+  .text:0000000180B1CD63                 jz      short loc_180B1CD98
+  .text:0000000180B1CD65                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CD6C                 lea     rdx, [rsp+68h+arg_8]
+  .text:0000000180B1CD71                 mov     r8d, ebx
+  .text:0000000180B1CD74                 mov     r9, [rcx]
+  .text:0000000180B1CD77                 call    qword ptr [r9+318h]
+  .text:0000000180B1CD7E                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CD85                 movzx   r9d, r14b
+  .text:0000000180B1CD89                 mov     r8d, ebp
+  .text:0000000180B1CD8C                 mov     rdx, rsi
+  .text:0000000180B1CD8F                 mov     rax, [rcx]
+  .text:0000000180B1CD92                 call    qword ptr [rax+320h]
+  .text:0000000180B1CD98                 mov     r15, [rsp+68h+arg_0]
+  .text:0000000180B1CD9D                 xor     edi, edi
+  .text:0000000180B1CD9F                 mov     r12d, dword ptr [rsp+68h+arg_0]
+  .text:0000000180B1CDA4                 xor     eax, eax
+  .text:0000000180B1CDA6                 movzx   r14d, byte ptr [rsp+68h+arg_0]
+  .text:0000000180B1CDAC                 xor     esi, esi
+  .text:0000000180B1CDAE                 mov     r13d, 1
+  .text:0000000180B1CDB4                 cmp     eax, r13d
+  .text:0000000180B1CDB7                 jz      loc_180B1CECB
+  .text:0000000180B1CDBD                 mov     ecx, esi
+  .text:0000000180B1CDBF                 call    sub_180C824F0
+  .text:0000000180B1CDC4                 test    rax, rax
+  .text:0000000180B1CDC7                 jz      loc_180B1CEBF
+  .text:0000000180B1CDCD                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CDD4                 lea     rdx, [rsp+68h+arg_8]
+  .text:0000000180B1CDD9                 xor     ebx, ebx
+  .text:0000000180B1CDDB                 mov     rax, [rcx]
+  .text:0000000180B1CDDE                 call    qword ptr [rax+310h]
+  .text:0000000180B1CDE4                 cmp     [rax], esi
+  .text:0000000180B1CDE6                 jnz     short loc_180B1CE01
+  .text:0000000180B1CDE8                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CDEF                 mov     rax, [rcx]
+  .text:0000000180B1CDF2                 call    qword ptr [rax+328h]
+  .text:0000000180B1CDF8                 test    al, al
+  .text:0000000180B1CDFA                 jz      short loc_180B1CE01
+  .text:0000000180B1CDFC                 xor     bpl, bpl
+  .text:0000000180B1CDFF                 jmp     short loc_180B1CE74
+  .text:0000000180B1CE01                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CE08                 movzx   ebp, r13b
+  .text:0000000180B1CE0C                 lea     r15, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CE13                 mov     r12d, 0B77h
+  .text:0000000180B1CE19                 mov     rax, [rcx]
+  .text:0000000180B1CE1C                 test    esi, esi
+  .text:0000000180B1CE1E                 jz      short loc_180B1CE27
+  .text:0000000180B1CE20                 jns     short loc_180B1CE27
+  .text:0000000180B1CE22                 xor     r8d, r8d
+  .text:0000000180B1CE25                 jmp     short loc_180B1CE2A
+  .text:0000000180B1CE27                 mov     r8d, esi
+  .text:0000000180B1CE2A                 lea     rdx, [rsp+68h+arg_10]
+  .text:0000000180B1CE32                 call    qword ptr [rax+318h]
+  .text:0000000180B1CE38                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CE3F                 mov     ebx, [rax]
+  .text:0000000180B1CE41                 mov     rax, [rcx]
+  .text:0000000180B1CE44                 test    esi, esi
+  .text:0000000180B1CE46                 jnz     short loc_180B1CE4D
+  .text:0000000180B1CE48                 xor     r9b, r9b
+  .text:0000000180B1CE4B                 jmp     short loc_180B1CE59
+  .text:0000000180B1CE4D                 test    esi, esi
+  .text:0000000180B1CE4F                 mov     r9d, 0FFh
+  .text:0000000180B1CE55                 cmovns  r9d, r13d
+  .text:0000000180B1CE59                 not     r9b
+  .text:0000000180B1CE5C                 lea     rdx, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CE63                 shr     r9b, 7
+  .text:0000000180B1CE67                 mov     r8d, r12d
+  .text:0000000180B1CE6A                 call    qword ptr [rax+320h]
+  .text:0000000180B1CE70                 movzx   r14d, al
+  .text:0000000180B1CE74                 mov     ecx, esi
+  .text:0000000180B1CE76                 call    sub_180C824F0
+  .text:0000000180B1CE7B                 mov     rcx, rax
+  .text:0000000180B1CE7E                 mov     rdx, [rax]
+  .text:0000000180B1CE81                 call    qword ptr [rdx+10h]
+  .text:0000000180B1CE84                 test    bpl, bpl
+  .text:0000000180B1CE87                 jz      short loc_180B1CEBF
+  .text:0000000180B1CE89                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CE90                 lea     rdx, [rsp+68h+arg_18]
+  .text:0000000180B1CE98                 mov     r8d, ebx
+  .text:0000000180B1CE9B                 mov     r9, [rcx]
+  .text:0000000180B1CE9E                 call    qword ptr [r9+318h]
+  .text:0000000180B1CEA5                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CEAC                 movzx   r9d, r14b
+  .text:0000000180B1CEB0                 mov     r8d, r12d
+  .text:0000000180B1CEB3                 mov     rdx, r15
+  .text:0000000180B1CEB6                 mov     rax, [rcx]
+  .text:0000000180B1CEB9                 call    qword ptr [rax+320h]
+  .text:0000000180B1CEBF                 lea     eax, [rdi+1]
+  .text:0000000180B1CEC2                 mov     edi, eax
+  .text:0000000180B1CEC4                 mov     esi, eax
+  .text:0000000180B1CEC6                 jmp     loc_180B1CDB4
+  .text:0000000180B1CECB                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CED2                 lea     rdx, [rsp+68h+arg_8]
+  .text:0000000180B1CED7                 xor     ebx, ebx
+  .text:0000000180B1CED9                 mov     rax, [rcx]
+  .text:0000000180B1CEDC                 call    qword ptr [rax+310h]
+  .text:0000000180B1CEE2                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CEE9                 mov     r15, [rsp+68h+var_40]
+  .text:0000000180B1CEEE                 mov     r12, [rsp+68h+var_38]
+  .text:0000000180B1CEF3                 cmp     [rax], ebx
+  .text:0000000180B1CEF5                 mov     rax, [rcx]
+  .text:0000000180B1CEF8                 jnz     short loc_180B1CF22
+  .text:0000000180B1CEFA                 call    qword ptr [rax+328h]
+  .text:0000000180B1CF00                 test    al, al
+  .text:0000000180B1CF02                 jz      short loc_180B1CF18
+  .text:0000000180B1CF04                 mov     rsi, [rsp+68h+arg_0]
+  .text:0000000180B1CF09                 xor     dil, dil
+  .text:0000000180B1CF0C                 mov     ebp, dword ptr [rsp+68h+arg_0]
+  .text:0000000180B1CF10                 movzx   r14d, byte ptr [rsp+68h+arg_0]
+  .text:0000000180B1CF16                 jmp     short loc_180B1CF6A
+  .text:0000000180B1CF18                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CF1F                 mov     rax, [rcx]
+  .text:0000000180B1CF22                 mov     r9, [rax+318h]
+  .text:0000000180B1CF29                 lea     rdx, [rsp+68h+arg_10]
+  .text:0000000180B1CF31                 xor     r8d, r8d
+  .text:0000000180B1CF34                 lea     rsi, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CF3B                 mov     ebp, 0B7Eh
+  .text:0000000180B1CF40                 mov     dil, 1
+  .text:0000000180B1CF43                 call    r9
+  .text:0000000180B1CF46                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CF4D                 lea     rdx, aCBuildworkerCs_56; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:0000000180B1CF54                 movzx   r9d, r13b
+  .text:0000000180B1CF58                 mov     r8d, ebp
+  .text:0000000180B1CF5B                 mov     ebx, [rax]
+  .text:0000000180B1CF5D                 mov     rax, [rcx]
+  .text:0000000180B1CF60                 call    qword ptr [rax+320h]
+  .text:0000000180B1CF66                 movzx   r14d, al
+  .text:0000000180B1CF6A                 xor     ecx, ecx
+  .text:0000000180B1CF6C                 call    sub_180AAF680
+  .text:0000000180B1CF71                 movzx   r13d, byte ptr [rsp+68h+arg_0]
+  .text:0000000180B1CF77                 test    dil, dil
+  .text:0000000180B1CF7A                 mov     rdi, [rsp+68h+var_30]
+  .text:0000000180B1CF7F                 jz      short loc_180B1CFB4
+  .text:0000000180B1CF81                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CF88                 lea     rdx, [rsp+68h+arg_0]
+  .text:0000000180B1CF8D                 mov     r8d, ebx
+  .text:0000000180B1CF90                 mov     r9, [rcx]
+  .text:0000000180B1CF93                 call    qword ptr [r9+318h]
+  .text:0000000180B1CF9A                 mov     rcx, cs:g_pEngineClient
+  .text:0000000180B1CFA1                 movzx   r9d, r14b
+  .text:0000000180B1CFA5                 mov     r8d, ebp
+  .text:0000000180B1CFA8                 mov     rdx, rsi
+  .text:0000000180B1CFAB                 mov     rax, [rcx]
+  .text:0000000180B1CFAE                 call    qword ptr [rax+320h]
+  .text:0000000180B1CFB4                 mov     rcx, cs:g_pViewRender
+  .text:0000000180B1CFBB                 mov     rax, [rcx]
+  .text:0000000180B1CFBE                 call    qword ptr [rax+20h] ; 20h = IViewRender_OnRenderStart
+  .text:0000000180B1CFC1                 call    sub_1810361A0
+  .text:0000000180B1CFC6                 call    sub_18102E970
+  .text:0000000180B1CFCB                 call    sub_180A94ED0
+  .text:0000000180B1CFD0                 movzx   ecx, r13b
+  .text:0000000180B1CFD4                 mov     rbp, [rsp+68h+var_28]
+  .text:0000000180B1CFD9                 add     rsp, 48h
+  .text:0000000180B1CFDD                 pop     r14
+  .text:0000000180B1CFDF                 pop     r13
+  .text:0000000180B1CFE1                 pop     rsi
+  .text:0000000180B1CFE2                 pop     rbx
+  .text:0000000180B1CFE3                 jmp     sub_1803D9F90
+procedure: |-
+  __int64 sub_180B1CC20()
+  {
+    __int64 v0; // rcx
+    __int64 v1; // rcx
+    unsigned int v2; // ebx
+    _DWORD *v3; // rax
+    __int64 v4; // rcx
+    bool v5; // zf
+    __int64 v6; // rax
+    const char *v7; // rsi
+    char v8; // di
+    unsigned int v9; // ebp
+    unsigned __int8 v10; // r14
+    const char *v11; // r15
+    int v12; // edi
+    unsigned int v13; // r12d
+    int v14; // eax
+    unsigned __int8 v15; // r14
+    int v16; // esi
+    unsigned int v17; // ebx
+    char v18; // bp
+    __int64 v19; // r8
+    __int64 v20; // r9
+    __int64 v21; // rax
+    unsigned int v22; // ebx
+    _DWORD *v23; // rax
+    __int64 v24; // rcx
+    __int64 v25; // rax
+    const char *v26; // rsi
+    char v27; // di
+    unsigned int v28; // ebp
+    unsigned __int8 v29; // r14
+    unsigned __int8 v30; // r13
+    const char *v32; // [rsp+70h] [rbp+8h] BYREF
+    char v33; // [rsp+78h] [rbp+10h] BYREF
+    char v34; // [rsp+80h] [rbp+18h] BYREF
+    char v35; // [rsp+88h] [rbp+20h] BYREF
+
+    sub_1809FB620(3);
+    sub_1809FB620(4);
+    sub_1809FB620(5);
+    LOBYTE(v0) = 1;
+    LOBYTE(v32) = sub_1803D9F90(v0);
+    if ( (unsigned __int8)ThreadInMainThread() )
+      byte_18208D450 = 0;
+    C_BaseEntity_SetInterpolationPhase(0xFFFFFFFFLL);
+    if ( (unsigned __int8)ThreadInMainThread() )
+      byte_18208D450 = 1;
+    LOBYTE(v1) = 1;
+    sub_180A91F70(v1);
+    sub_181187980();
+    if ( qword_182219A88 )
+      sub_18034E060();
+    v2 = 0;
+    v3 = (_DWORD *)(*(__int64 (__fastcall **)(__int64, char *))(*(_QWORD *)g_pEngineClient + 784LL))(
+                     g_pEngineClient,
+                     &v33);
+    v4 = g_pEngineClient;
+    v5 = *v3 == 0;
+    v6 = *(_QWORD *)g_pEngineClient;
+    if ( v5 )
+    {
+      if ( (*(unsigned __int8 (**)(void))(v6 + 808))() )
+      {
+        v7 = v32;
+        v8 = 0;
+        v9 = (unsigned int)v32;
+        v10 = (unsigned __int8)v32;
+        goto LABEL_12;
+      }
+      v4 = g_pEngineClient;
+      v6 = *(_QWORD *)g_pEngineClient;
+    }
+    v7 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp";
+    v9 = 2927;
+    v8 = 1;
+    v2 = *(_DWORD *)(*(__int64 (__fastcall **)(__int64, char *, _QWORD))(v6 + 792))(v4, &v34, 0);
+    v10 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, __int64))(*(_QWORD *)g_pEngineClient + 800LL))(
+            g_pEngineClient,
+            "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp",
+            2927,
+            1);
+  LABEL_12:
+    CCSGOInput_CAM_Think(g_pCSGOInput, 0);
+    if ( v8 )
+    {
+      (*(void (__fastcall **)(__int64, char *, _QWORD))(*(_QWORD *)g_pEngineClient + 792LL))(g_pEngineClient, &v33, v2);
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, _QWORD))(*(_QWORD *)g_pEngineClient + 800LL))(
+        g_pEngineClient,
+        v7,
+        v9,
+        v10);
+    }
+    v11 = v32;
+    v12 = 0;
+    v13 = (unsigned int)v32;
+    v14 = 0;
+    v15 = (unsigned __int8)v32;
+    v16 = 0;
+    while ( v14 != 1 )
+    {
+      if ( sub_180C824F0((unsigned int)v16) )
+      {
+        v17 = 0;
+        if ( *(_DWORD *)(*(__int64 (__fastcall **)(__int64, char *))(*(_QWORD *)g_pEngineClient + 784LL))(
+                          g_pEngineClient,
+                          &v33) == v16
+          && (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineClient + 808LL))(g_pEngineClient) )
+        {
+          v18 = 0;
+        }
+        else
+        {
+          v18 = 1;
+          v11 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp";
+          v13 = 2935;
+          if ( v16 >= 0 )
+            v19 = (unsigned int)v16;
+          else
+            v19 = 0;
+          v17 = *(_DWORD *)(*(__int64 (__fastcall **)(__int64, char *, __int64))(*(_QWORD *)g_pEngineClient + 792LL))(
+                             g_pEngineClient,
+                             &v34,
+                             v19);
+          if ( v16 )
+          {
+            v20 = 255;
+            if ( v16 >= 0 )
+              v20 = 1;
+          }
+          else
+          {
+            LOBYTE(v20) = 0;
+          }
+          LOBYTE(v20) = (unsigned __int8)~(_BYTE)v20 >> 7;
+          v15 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, __int64))(*(_QWORD *)g_pEngineClient + 800LL))(
+                  g_pEngineClient,
+                  "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp",
+                  2935,
+                  v20);
+        }
+        v21 = sub_180C824F0((unsigned int)v16);
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)v21 + 16LL))(v21);
+        if ( v18 )
+        {
+          (*(void (__fastcall **)(__int64, char *, _QWORD))(*(_QWORD *)g_pEngineClient + 792LL))(
+            g_pEngineClient,
+            &v35,
+            v17);
+          (*(void (__fastcall **)(__int64, const char *, _QWORD, _QWORD))(*(_QWORD *)g_pEngineClient + 800LL))(
+            g_pEngineClient,
+            v11,
+            v13,
+            v15);
+        }
+      }
+      v14 = v12 + 1;
+      v12 = v14;
+      v16 = v14;
+    }
+    v22 = 0;
+    v23 = (_DWORD *)(*(__int64 (__fastcall **)(__int64, char *))(*(_QWORD *)g_pEngineClient + 784LL))(
+                      g_pEngineClient,
+                      &v33);
+    v24 = g_pEngineClient;
+    v5 = *v23 == 0;
+    v25 = *(_QWORD *)g_pEngineClient;
+    if ( v5 )
+    {
+      if ( (*(unsigned __int8 (**)(void))(v25 + 808))() )
+      {
+        v26 = v32;
+        v27 = 0;
+        v28 = (unsigned int)v32;
+        v29 = (unsigned __int8)v32;
+        goto LABEL_36;
+      }
+      v24 = g_pEngineClient;
+      v25 = *(_QWORD *)g_pEngineClient;
+    }
+    v26 = "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp";
+    v28 = 2942;
+    v27 = 1;
+    v22 = *(_DWORD *)(*(__int64 (__fastcall **)(__int64, char *, _QWORD))(v25 + 792))(v24, &v34, 0);
+    v29 = (*(__int64 (__fastcall **)(__int64, const char *, __int64, __int64))(*(_QWORD *)g_pEngineClient + 800LL))(
+            g_pEngineClient,
+            "C:\\buildworker\\csgo_rel_win64\\build\\src\\game\\client\\cdll_client_int.cpp",
+            2942,
+            1);
+  LABEL_36:
+    sub_180AAF680(0);
+    v30 = (unsigned __int8)v32;
+    if ( v27 )
+    {
+      (*(void (__fastcall **)(__int64, const char **, _QWORD))(*(_QWORD *)g_pEngineClient + 792LL))(
+        g_pEngineClient,
+        &v32,
+        v22);
+      (*(void (__fastcall **)(__int64, const char *, _QWORD, _QWORD))(*(_QWORD *)g_pEngineClient + 800LL))(
+        g_pEngineClient,
+        v26,
+        v28,
+        v29);
+    }
+    (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pViewRender + 32LL))(g_pViewRender);// 32LL = 0x20 = IViewRender_OnRenderStart
+    sub_1810361A0();
+    sub_18102E970();
+    sub_180A94ED0();
+    return sub_1803D9F90(v30);
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkClientService_OnClientProcessGameInput.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkClientService_OnClientProcessGameInput.windows.yaml
@@ -1,0 +1,88 @@
+func_name: CNetworkClientService_OnClientProcessGameInput
+func_va: '0x1801d2ea0'
+disasm_code: |-
+  .text:00000001801D2EA0                 mov     [rsp+arg_8], rbx
+  .text:00000001801D2EA5                 push    rdi
+  .text:00000001801D2EA6                 sub     rsp, 20h
+  .text:00000001801D2EAA                 mov     rbx, [rcx+0A0h]
+  .text:00000001801D2EB1                 mov     rdi, rdx
+  .text:00000001801D2EB4                 test    rbx, rbx
+  .text:00000001801D2EB7                 jz      loc_1801D2F83
+  .text:00000001801D2EBD                 mov     rax, cs:off_180615950
+  .text:00000001801D2EC4                 lea     rdx, [rsp+28h+arg_0]
+  .text:00000001801D2EC9                 lea     rcx, off_180615950
+  .text:00000001801D2ED0                 call    qword ptr [rax+0E8h]
+  .text:00000001801D2ED6                 mov     eax, [rsp+28h+arg_0]
+  .text:00000001801D2EDA                 nop     word ptr [rax+rax+00h]
+  .text:00000001801D2EE0                 cmp     eax, 0FFFFFFFFh
+  .text:00000001801D2EE3                 jz      loc_1801D2F83
+  .text:00000001801D2EE9                 movsxd  rcx, eax
+  .text:00000001801D2EEC                 lea     rdx, [rcx+rcx*2]
+  .text:00000001801D2EF0                 cmp     qword ptr [rbx+rdx*8+0F0h], 0
+  .text:00000001801D2EF9                 jz      short loc_1801D2F58
+  .text:00000001801D2EFB                 cmp     dword ptr [rbx+230h], 6
+  .text:00000001801D2F02                 jl      short loc_1801D2F58
+  .text:00000001801D2F04                 cmp     byte ptr [rbx+29Dh], 0
+  .text:00000001801D2F0B                 mov     r8, cs:g_pSource2Client
+  .text:00000001801D2F12                 mov     rcx, [r8]
+  .text:00000001801D2F15                 mov     r10, [rcx+0B0h] ; 0B0h = ISource2Client_ProcessGameInput
+  .text:00000001801D2F1C                 jnz     short loc_1801D2F44
+  .text:00000001801D2F1E                 movzx   ecx, cs:byte_180611A84
+  .text:00000001801D2F25                 test    cl, cl
+  .text:00000001801D2F27                 jz      short loc_1801D2F3F
+  .text:00000001801D2F29                 cmp     dword ptr cs:qword_180611A70, 0FFFFFFFFh
+  .text:00000001801D2F30                 jnz     short loc_1801D2F3F
+  .text:00000001801D2F32                 test    cl, cl
+  .text:00000001801D2F34                 jz      short loc_1801D2F3F
+  .text:00000001801D2F36                 cmp     dword ptr cs:qword_180611A7C+4, 0FFFFFFFFh
+  .text:00000001801D2F3D                 jg      short loc_1801D2F44
+  .text:00000001801D2F3F                 xor     r9b, r9b
+  .text:00000001801D2F42                 jmp     short loc_1801D2F47
+  .text:00000001801D2F44                 mov     r9b, 1
+  .text:00000001801D2F47                 movss   xmm2, dword ptr [rdi+2Ch]
+  .text:00000001801D2F4C                 mov     edx, eax
+  .text:00000001801D2F4E                 mov     rcx, r8
+  .text:00000001801D2F51                 call    r10
+  .text:00000001801D2F54                 mov     eax, [rsp+28h+arg_0]
+  .text:00000001801D2F58                 mov     rcx, cs:off_180615950
+  .text:00000001801D2F5F                 lea     rdx, [rsp+28h+arg_10]
+  .text:00000001801D2F64                 mov     r8d, eax
+  .text:00000001801D2F67                 mov     r9, [rcx+0F0h]
+  .text:00000001801D2F6E                 lea     rcx, off_180615950
+  .text:00000001801D2F75                 call    r9
+  .text:00000001801D2F78                 mov     eax, [rax]
+  .text:00000001801D2F7A                 mov     [rsp+28h+arg_0], eax
+  .text:00000001801D2F7E                 jmp     loc_1801D2EE0
+  .text:00000001801D2F83                 mov     rbx, [rsp+28h+arg_8]
+  .text:00000001801D2F88                 add     rsp, 20h
+  .text:00000001801D2F8C                 pop     rdi
+  .text:00000001801D2F8D                 retn
+procedure: |-
+  void __fastcall CNetworkClientService_OnClientProcessGameInput(__int64 a1)
+  {
+    __int64 v1; // rbx
+    unsigned int i; // eax
+    unsigned int v3; // [rsp+30h] [rbp+8h] BYREF
+    char v4; // [rsp+40h] [rbp+18h] BYREF
+
+    v1 = *(_QWORD *)(a1 + 160);
+    if ( v1 )
+    {
+      ((void (__fastcall *)(__int64 (__fastcall ***)(), unsigned int *))off_180615950[29])(&off_180615950, &v3);
+      for ( i = v3; i != -1; v3 = i )
+      {
+        if ( *(_QWORD *)(v1 + 24LL * (int)i + 240) )
+        {
+          if ( *(int *)(v1 + 560) >= 6 )
+          {
+            (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 176LL))(g_pSource2Client, i);// 176LL = 0xB0 = ISource2Client_ProcessGameInput
+            i = v3;
+          }
+        }
+        i = *(_DWORD *)((__int64 (__fastcall *)(__int64 (__fastcall ***)(), char *, _QWORD))off_180615950[30])(
+                         &off_180615950,
+                         &v4,
+                         i);
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- Add the engine-to-client LLM decompile and inherited-vfunc chain for ISource2Client::ProcessGameInput, ISource2Client::FrameStageNotify, OnRenderStart, and IViewRender::OnRenderStart.
- Add CViewRender vtable, OnRenderStart, and Render finders plus the C_BaseEntity::SetInterpolationPhase xref finder and annotated reference YAMLs.
- Publish the validated 14173 gamesymbol snapshot.

## Validation
- uv run ida_analyze_bin.py -debug -oldgamever none: passed (Successful: 3, Failed: 0, Skipped: 2029)
- uv run python format_repo_files.py --check: passed
- non-MCP unittest suite: 1057 tests passed
- uv run python -m unittest discover -s tests -b: 1082 tests passed
- candidate preparation: passed for 14173
- C++ post-change validation: passed with 0 compile failures, 0 invalid items, and 0 layout/vtable/record differences
- candidate publication: passed; published SHA-256 matches a1056cdb6a74cfab69c4383ded0c71f94c09d3a57811f84d4581773852291db7