### PR TITLE
feat(preprocessor): add CreateMove discovery chain

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -75,6 +75,52 @@ git diff --name-status origin/main...HEAD
 git diff --stat origin/main...HEAD
 ```
 
+### PowerShell Native Command Execution
+
+On Windows PowerShell, use the following wrapper when recording the Step 1 native-command output and exit codes.
+Use `CommandArgs` rather than `Args`: PowerShell variable names are case-insensitive, and `$args` is an automatic
+variable. Pass the argument array through the named `-CommandArgs` parameter so it cannot be lost or ambiguously
+bound. Do not set `$ErrorActionPreference = 'Stop'` around these commands because native tools may write normal
+status messages to stderr. Interpret each command using its captured `$LASTEXITCODE` according to this skill.
+
+```powershell
+function Run-Native {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Name,
+
+        [Parameter(Mandatory)]
+        [string]$Executable,
+
+        [Parameter(Mandatory)]
+        [string[]]$CommandArgs
+    )
+
+    $output = & $Executable @CommandArgs 2>&1
+    $exitCode = $LASTEXITCODE
+
+    Write-Output "<<<$Name exit=$exitCode>>>"
+    if ($null -ne $output) {
+        $output | ForEach-Object { $_.ToString() }
+    }
+    Write-Output "<<<END $Name>>>"
+}
+
+Run-Native -Name 'branch' -Executable 'git' -CommandArgs @('branch', '--show-current')
+Run-Native -Name 'status_short' -Executable 'git' -CommandArgs @('status', '--short')
+Run-Native -Name 'cached_quiet' -Executable 'git' -CommandArgs @('diff', '--cached', '--quiet')
+```
+
+Use the same explicit form for every remaining command in Step 1, for example:
+
+```powershell
+Run-Native -Name 'fetch_main' -Executable 'git' -CommandArgs @('fetch', 'origin', 'main', '--prune')
+Run-Native -Name 'gh_auth' -Executable 'gh' -CommandArgs @('auth', 'status')
+Run-Native -Name 'committed_names' -Executable 'git' -CommandArgs @(
+    'diff', '--name-only', 'origin/main...HEAD'
+)
+```
+
 `git diff --name-only` must be empty in both modes. If any unstaged tracked change exists, stop before formatting,
 candidate creation, push, or PR creation and report the paths. Untracked files may remain, but record them and never
 stage them.

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4724,6 +4724,9 @@ modules:
         platform: windows
         alias:
           - CSource2Client::CreateMove
+      - name: CClientInput
+        category: struct
+        platform: windows
       - name: CClientInput_CreateMove
         category: vfunc
         platform: windows

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -1273,6 +1273,19 @@ modules:
       - name: find-CNetworkGameClient_vtable
         expected_output:
           - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkClientService_OnSimpleLoopFrameUpdate-decompiles
+        platform: windows
+        expected_output:
+          - CNetworkGameClient_CreateMove.{platform}.yaml
+        expected_input:
+          - CNetworkClientService_OnSimpleLoopFrameUpdate.{platform}.yaml
+          - CNetworkGameClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameClient_CreateMove-decompiles
+        platform: windows
+        expected_output:
+          - ISource2Client_CreateMove.{platform}.yaml
+        expected_input:
+          - CNetworkGameClient_CreateMove.{platform}.yaml
       - name: find-CNetworkGameClient_SetSignonState
         platform: windows
         expected_output:
@@ -2409,6 +2422,16 @@ modules:
           - CMsgSource2NetworkFlowQuality::PrintStats
       - name: CNetworkGameClient_vtable
         category: vtable
+      - name: CNetworkGameClient_CreateMove
+        category: vfunc
+        platform: windows
+        alias:
+          - CNetworkGameClient::CreateMove
+      - name: ISource2Client_CreateMove
+        category: vfunc
+        platform: windows
+        alias:
+          - ISource2Client::CreateMove
       - name: CNetworkGameClient_SetSignonState
         category: vfunc
         platform: windows
@@ -3814,6 +3837,25 @@ modules:
       - name: find-CSource2Client_vtable
         expected_output:
           - CSource2Client_vtable.{platform}.yaml
+      - name: find-CSource2Client_CreateMove
+        platform: windows
+        expected_output:
+          - CSource2Client_CreateMove.{platform}.yaml
+        expected_input:
+          - CSource2Client_vtable.{platform}.yaml
+          - ../engine/ISource2Client_CreateMove.{platform}.yaml
+      - name: find-CSource2Client_CreateMove-decompiles
+        platform: windows
+        expected_output:
+          - CClientInput_CreateMove.{platform}.yaml
+        expected_input:
+          - CSource2Client_CreateMove.{platform}.yaml
+      - name: find-CClientInput_CreateMove-decompiles
+        platform: windows
+        expected_output:
+          - CClientInput_m_viewangles.{platform}.yaml
+        expected_input:
+          - CClientInput_CreateMove.{platform}.yaml
       - name: find-CSource2Client_ProcessGameInput
         platform: windows
         expected_output:
@@ -4677,6 +4719,23 @@ modules:
           - IGameSystem::OnClientPreRenderAlt
       - name: CSource2Client_vtable
         category: vtable
+      - name: CSource2Client_CreateMove
+        category: vfunc
+        platform: windows
+        alias:
+          - CSource2Client::CreateMove
+      - name: CClientInput_CreateMove
+        category: vfunc
+        platform: windows
+        alias:
+          - CClientInput::CreateMove
+      - name: CClientInput_m_viewangles
+        category: structmember
+        platform: windows
+        struct: CClientInput
+        member: m_viewangles
+        alias:
+          - CClientInput::m_viewangles
       - name: CSource2Client_ProcessGameInput
         category: vfunc
         platform: windows

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:d6a8adf1004c67bd1d05edab4c12be496a4be730381321c4bc21590d40280666
-file_count: 3199
+config_sha256: sha256:cdbcd2f0009df537c164acef2a92aec529585dfaf35618294d08408beaa19ce6
+file_count: 3204
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -223,6 +223,23 @@ files:
     func_sig: 40 55 53 57 41 56 41 57 48 8B EC 48 81 EC ?? ?? ?? ??
     func_size: '0x26d'
     func_va: '0x1808f0b70'
+  client/CClientInput_CreateMove.windows.yaml:
+    func_name: CClientInput_CreateMove
+    func_rva: '0xb10270'
+    func_size: '0x109'
+    func_va: '0x180b10270'
+    vfunc_index: 8
+    vfunc_offset: '0x40'
+    vfunc_sig: 48 FF 60 40 CC CC 48 89 5C 24 ?? 48 89 7C 24 ??
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: CClientInput
+  client/CClientInput_m_viewangles.windows.yaml:
+    member_name: m_viewangles
+    offset: '0x688'
+    offset_sig: F2 0F 11 86 ?? ?? ?? ?? 89 86 ?? ?? ?? ?? C7 86 ?? ?? ?? ?? ?? ?? ?? ??
+    offset_sig_disp: 0
+    size: 8
+    struct_name: CClientInput
   client/CEntityInstance_PreDataUpdate.linux.yaml:
     func_name: CEntityInstance_PreDataUpdate
     vfunc_index: 19
@@ -1449,6 +1466,14 @@ files:
     vfunc_index: 0
     vfunc_offset: '0x0'
     vtable_name: CSource2Client_vtable
+  client/CSource2Client_CreateMove.windows.yaml:
+    func_name: CSource2Client_CreateMove
+    func_rva: '0xb10380'
+    func_size: '0xe'
+    func_va: '0x180b10380'
+    vfunc_index: 16
+    vfunc_offset: '0x80'
+    vtable_name: CSource2Client
   client/CSource2Client_FrameStageNotify.windows.yaml:
     func_name: CSource2Client_FrameStageNotify
     func_rva: '0xb10ff0'
@@ -9940,6 +9965,15 @@ files:
     vfunc_index: 139
     vfunc_offset: '0x458'
     vtable_name: CNetworkGameClient_vtable
+  engine/CNetworkGameClient_CreateMove.windows.yaml:
+    func_name: CNetworkGameClient_CreateMove
+    func_rva: '0x64500'
+    func_sig: 40 57 48 83 EC ?? 83 B9 ?? ?? ?? ?? ?? 48 8B F9
+    func_size: '0x1e4'
+    func_va: '0x180064500'
+    vfunc_index: 76
+    vfunc_offset: '0x260'
+    vtable_name: CNetworkGameClient
   engine/CNetworkGameClient_DisconnectGame.linux.yaml:
     func_name: CNetworkGameClient_DisconnectGame
     func_rva: '0x4e3900'
@@ -12996,6 +13030,12 @@ files:
     vfunc_offset: '0xf8'
     vfunc_sig: 48 8B 9A F8 00 00 00 E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? 0F B6 D0 FF D3 48 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B 01 FF 10 48 8B 0D ?? ?? ?? ?? 4C 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ??
     vtable_name: INetworkMessages
+  engine/ISource2Client_CreateMove.windows.yaml:
+    func_name: ISource2Client_CreateMove
+    vfunc_index: 16
+    vfunc_offset: '0x80'
+    vfunc_sig: FF 90 80 00 00 00 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 50 ?? 84 C0 74 ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: ISource2Client
   engine/ISource2Client_ProcessGameInput.windows.yaml:
     func_name: ISource2Client_ProcessGameInput
     vfunc_index: 22
@@ -40380,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T09:14:12Z'
+last_publish_time: '2026-07-30T11:43:23Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CClientInput_CreateMove-decompiles.py
+++ b/ida_preprocessor_scripts/find-CClientInput_CreateMove-decompiles.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CClientInput_CreateMove-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_STRUCT_MEMBER_NAMES = [
+    "CClientInput_m_viewangles",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CClientInput_m_viewangles",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CClientInput_CreateMove.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_struct_offset"],
+        "dependency_policy": {
+            "CClientInput_CreateMove.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CClientInput_m_viewangles",
+        [
+            "struct_name",
+            "member_name",
+            "offset",
+            "size",
+            "offset_sig",
+            "offset_sig_disp",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve CClientInput::m_viewangles from CClientInput::CreateMove."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        struct_member_names=TARGET_STRUCT_MEMBER_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkClientService_OnSimpleLoopFrameUpdate-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkClientService_OnSimpleLoopFrameUpdate-decompiles.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkClientService_OnSimpleLoopFrameUpdate-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameClient_CreateMove",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameClient_CreateMove",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkClientService_OnSimpleLoopFrameUpdate.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CNetworkClientService_OnSimpleLoopFrameUpdate.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CNetworkGameClient_CreateMove", "CNetworkGameClient"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameClient_CreateMove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve CNetworkGameClient::CreateMove from the simple-loop callback."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameClient_CreateMove-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameClient_CreateMove-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameClient_CreateMove-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2Client_CreateMove",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2Client_CreateMove",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameClient_CreateMove.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameClient_CreateMove.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # ISource2Client is abstract; this relation supplies vtable metadata only.
+    ("ISource2Client_CreateMove", "ISource2Client"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "ISource2Client_CreateMove",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the ISource2Client CreateMove slot from CNetworkGameClient."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_CreateMove-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_CreateMove-decompiles.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_CreateMove-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CClientInput_CreateMove",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CClientInput_CreateMove",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/client/CSource2Client_CreateMove.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSource2Client_CreateMove.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CClientInput_CreateMove", "CClientInput"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CClientInput_CreateMove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+            "vfunc_sig_allow_across_function_boundary:true",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve CClientInput::CreateMove from the CSource2Client thunk."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Client_CreateMove.py
+++ b/ida_preprocessor_scripts/find-CSource2Client_CreateMove.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Client_CreateMove skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    (
+        "CSource2Client_CreateMove",
+        "CSource2Client",
+        "../engine/ISource2Client_CreateMove",
+        False,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Client_CreateMove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve CSource2Client's CreateMove implementation without a func_sig."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/client/CClientInput_CreateMove.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CClientInput_CreateMove.windows.yaml
@@ -1,0 +1,112 @@
+func_name: CClientInput_CreateMove
+func_va: '0x180b10270'
+disasm_code: |-
+  .text:0000000180B10270                 test    edx, edx
+  .text:0000000180B10272                 jnz     locret_180B10378
+  .text:0000000180B10278                 mov     [rsp+arg_8], rbx
+  .text:0000000180B1027D                 push    rsi
+  .text:0000000180B1027E                 sub     rsp, 30h
+  .text:0000000180B10282                 mov     rsi, rcx
+  .text:0000000180B10285                 mov     [rsp+38h+arg_0], rdi
+  .text:0000000180B1028A                 mov     ecx, edx
+  .text:0000000180B1028C                 mov     ebx, edx
+  .text:0000000180B1028E                 call    sub_180926970
+  .text:0000000180B10293                 mov     rdi, rax
+  .text:0000000180B10296                 test    rax, rax
+  .text:0000000180B10299                 jz      loc_180B10369
+  .text:0000000180B1029F                 mov     rcx, rax
+  .text:0000000180B102A2                 call    sub_1808FE5A0
+  .text:0000000180B102A7                 mov     edx, eax
+  .text:0000000180B102A9                 mov     rcx, rdi
+  .text:0000000180B102AC                 call    sub_180901170
+  .text:0000000180B102B1                 mov     rdi, rax
+  .text:0000000180B102B4                 cmp     [rax+8Ch], bl
+  .text:0000000180B102BA                 jz      short loc_180B102DB
+  .text:0000000180B102BC                 mov     rcx, [rsi]
+  .text:0000000180B102BF                 mov     r8, rax
+  .text:0000000180B102C2                 mov     edx, ebx
+  .text:0000000180B102C4                 mov     r9, [rcx+0D8h]
+  .text:0000000180B102CB                 mov     rcx, rsi
+  .text:0000000180B102CE                 call    r9
+  .text:0000000180B102D1                 test    al, al
+  .text:0000000180B102D3                 jz      short loc_180B102DB
+  .text:0000000180B102D5                 mov     [rdi+8Ch], bl
+  .text:0000000180B102DB                 xor     eax, eax
+  .text:0000000180B102DD                 mov     dword ptr [rdi+94h], 1
+  .text:0000000180B102E7                 mov     [rsi+260h], rax
+  .text:0000000180B102EE                 mov     [rsi+268h], rax
+  .text:0000000180B102F5                 mov     rax, [rdi+60h]
+  .text:0000000180B102F9                 mov     [rsi+250h], rax
+  .text:0000000180B10300                 lea     rax, off_18205A890
+  .text:0000000180B10307                 mov     rcx, [rdi+40h]
+  .text:0000000180B1030B                 test    rcx, rcx
+  .text:0000000180B1030E                 cmovnz  rax, rcx
+  .text:0000000180B10312                 mov     rcx, [rax+40h]
+  .text:0000000180B10316                 lea     rax, off_182062B30
+  .text:0000000180B1031D                 test    rcx, rcx
+  .text:0000000180B10320                 cmovnz  rax, rcx
+  .text:0000000180B10324                 lea     rcx, [rsp+38h+pitchyaw]
+  .text:0000000180B10329                 movss   xmm3, dword ptr [rax+20h]
+  .text:0000000180B1032E                 movss   xmm2, dword ptr [rax+1Ch]
+  .text:0000000180B10333                 movss   xmm1, dword ptr [rax+18h]
+  .text:0000000180B10338                 call    sub_180189D60
+  .text:0000000180B1033D                 movsd   xmm0, [rsp+38h+pitchyaw]
+  .text:0000000180B10343                 mov     edx, ebx
+  .text:0000000180B10345                 mov     eax, [rsp+38h+var_10]
+  .text:0000000180B10349                 mov     rcx, rsi
+  .text:0000000180B1034C                 movsd   qword ptr [rsi+688h], xmm0  ; 688h = CClientInput::m_viewangles (structmember, struct=CClientInput, member=m_viewangles)
+  .text:0000000180B10354                 mov     [rsi+690h], eax  ; 690h = CClientInput::m_viewangles + 8 (structmember, struct=CClientInput, member=m_viewangles)
+  .text:0000000180B1035A                 mov     dword ptr [rsi+694h], 0FFFFFFFFh
+  .text:0000000180B10364                 call    sub_180B03940
+  .text:0000000180B10369                 mov     rdi, [rsp+38h+arg_0]
+  .text:0000000180B1036E                 mov     rbx, [rsp+38h+arg_8]
+  .text:0000000180B10373                 add     rsp, 30h
+  .text:0000000180B10377                 pop     rsi
+  .text:0000000180B10378                 retn
+procedure: |-
+  void __fastcall CClientInput_CreateMove(__int64 a1, int a2)
+  {
+    __int64 v3; // rdi
+    int v4; // eax
+    __int64 v5; // rax
+    __int64 v6; // rdi
+    void ***v7; // rax
+    float *v8; // rcx
+    float *v9; // rax
+    int yaw; // eax
+    __int64 pitchyaw; // [rsp+20h] [rbp-18h] BYREF
+    int v12; // [rsp+28h] [rbp-10h]
+
+    if ( !a2 )
+    {
+      v3 = sub_180926970(0);
+      if ( v3 )
+      {
+        v4 = sub_1808FE5A0();
+        v5 = sub_180901170(v3, v4);
+        v6 = v5;
+        if ( *(_BYTE *)(v5 + 140)
+          && (*(unsigned __int8 (__fastcall **)(__int64, _QWORD, __int64))(*(_QWORD *)a1 + 216LL))(a1, 0, v5) )
+        {
+          *(_BYTE *)(v6 + 140) = 0;
+        }
+        *(_DWORD *)(v6 + 148) = 1;
+        *(_QWORD *)(a1 + 608) = 0;
+        *(_QWORD *)(a1 + 616) = 0;
+        *(_QWORD *)(a1 + 592) = *(_QWORD *)(v6 + 96);
+        v7 = &off_18205A890;                      // CBaseUserCmdPB_vtable
+        if ( *(_QWORD *)(v6 + 64) )
+          v7 = *(void ****)(v6 + 64);
+        v8 = (float *)v7[8];
+        v9 = (float *)&off_182062B30;             // CMsgQAngle_vtable
+        if ( v8 )
+          v9 = v8;
+        sub_180189D60((float *)&pitchyaw, v9[6], v9[7], v9[8]);
+        yaw = v12;
+        *(_QWORD *)(a1 + 0x688) = pitchyaw;       // 1672 = 0x688 = CClientInput::m_viewangles (structmember, struct=CClientInput, member=m_viewangles)
+        *(_DWORD *)(a1 + 0x690) = yaw;             // 1680 = 0x690 = CClientInput::m_viewangles + 8 (structmember, struct=CClientInput, member=m_viewangles)
+        *(_DWORD *)(a1 + 0x694) = -1;
+        sub_180B03940(a1, 0);
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/client/CSource2Client_CreateMove.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSource2Client_CreateMove.windows.yaml
@@ -1,0 +1,11 @@
+func_name: CSource2Client_CreateMove
+func_va: '0x180b10380'
+disasm_code: |-
+  .text:0000000180B10380                 mov     rcx, cs:g_pCSGOInput
+  .text:0000000180B10387                 mov     rax, [rcx]
+  .text:0000000180B1038A                 jmp     qword ptr [rax+40h]  ; 40h = CClientInput_CreateMove
+procedure: |-
+  __int64 CSource2Client_CreateMove()
+  {
+    return (*(__int64 (__fastcall **)(__int64 *))(*g_pCSGOInput + 64))(g_pCSGOInput);// 64 = 0x40 = CClientInput_CreateMove
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkClientService_OnSimpleLoopFrameUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkClientService_OnSimpleLoopFrameUpdate.windows.yaml
@@ -1,0 +1,250 @@
+func_name: CNetworkClientService_OnSimpleLoopFrameUpdate
+func_va: '0x1801d3220'
+disasm_code: |-
+  .text:00000001801D3220                 mov     rax, rsp
+  .text:00000001801D3223                 push    rbx
+  .text:00000001801D3224                 sub     rsp, 0A0h
+  .text:00000001801D322B                 movaps  xmmword ptr [rax-18h], xmm6
+  .text:00000001801D322F                 xor     r9d, r9d
+  .text:00000001801D3232                 mov     [rax+18h], rdi
+  .text:00000001801D3236                 mov     rdi, rcx
+  .text:00000001801D3239                 mov     rax, [rcx+0A0h]
+  .text:00000001801D3240                 test    rax, rax
+  .text:00000001801D3243                 jz      short loc_1801D3254
+  .text:00000001801D3245                 mov     r8d, [rax+378h]
+  .text:00000001801D324C                 mov     ecx, [rax+37Ch]
+  .text:00000001801D3252                 jmp     short loc_1801D325A
+  .text:00000001801D3254                 mov     r8d, r9d
+  .text:00000001801D3257                 mov     ecx, r9d
+  .text:00000001801D325A                 movups  xmm0, xmmword ptr [rdx]
+  .text:00000001801D325D                 mov     [rsp+0A8h+var_28], ecx
+  .text:00000001801D3264                 sub     ecx, r8d
+  .text:00000001801D3267                 movups  xmm1, xmmword ptr [rdx+10h]
+  .text:00000001801D326B                 mov     [rsp+0A8h+var_20], ecx
+  .text:00000001801D3272                 mov     rcx, rdi
+  .text:00000001801D3275                 movups  [rsp+0A8h+var_58], xmm0
+  .text:00000001801D327A                 mov     [rsp+0A8h+var_30], 101h
+  .text:00000001801D3281                 movsd   xmm0, qword ptr [rdx+20h]
+  .text:00000001801D3286                 lea     rdx, [rsp+0A8h+var_58]
+  .text:00000001801D328B                 movsd   [rsp+0A8h+var_38], xmm0
+  .text:00000001801D3291                 movups  [rsp+0A8h+var_48], xmm1
+  .text:00000001801D3296                 mov     [rsp+0A8h+var_24], r9d
+  .text:00000001801D329E                 mov     [rsp+0A8h+var_1C], r9d
+  .text:00000001801D32A6                 call    CNetworkClientService_OnClientAdvanceTick
+  .text:00000001801D32AB                 mov     rcx, [rdi+0A0h]
+  .text:00000001801D32B2                 movss   xmm6, cs:dword_180584F90
+  .text:00000001801D32BA                 test    rcx, rcx
+  .text:00000001801D32BD                 jz      loc_1801D3415
+  .text:00000001801D32C3                 mov     [rsp+0A8h+arg_8], rsi
+  .text:00000001801D32CB                 call    CNetworkGameClient_CreateMove
+  .text:00000001801D32D0                 mov     rbx, [rdi+0A0h]
+  .text:00000001801D32D7                 mov     rcx, rbx
+  .text:00000001801D32DA                 call    CNetworkGameClient_SendMovePacket
+  .text:00000001801D32DF                 mov     rsi, [rbx+0F0h]
+  .text:00000001801D32E6                 test    rsi, rsi
+  .text:00000001801D32E9                 jz      short loc_1801D3307
+  .text:00000001801D32EB                 mov     rax, [rsi]
+  .text:00000001801D32EE                 mov     rcx, rsi
+  .text:00000001801D32F1                 call    qword ptr [rax+288h]
+  .text:00000001801D32F7                 test    al, al
+  .text:00000001801D32F9                 jnz     short loc_1801D3307
+  .text:00000001801D32FB                 mov     rax, [rsi]
+  .text:00000001801D32FE                 mov     rcx, rsi
+  .text:00000001801D3301                 call    qword ptr [rax+150h]
+  .text:00000001801D3307                 xorps   xmm1, xmm1
+  .text:00000001801D330A                 mov     rcx, rbx
+  .text:00000001801D330D                 call    CNetworkGameClient_SendMove
+  .text:00000001801D3312                 mov     edx, 0FFFFFFFFh
+  .text:00000001801D3317                 lea     rcx, unk_18068DF30
+  .text:00000001801D331E                 call    sub_1803FEF60
+  .text:00000001801D3323                 mov     rsi, [rsp+0A8h+arg_8]
+  .text:00000001801D332B                 test    rax, rax
+  .text:00000001801D332E                 jnz     short loc_1801D333B
+  .text:00000001801D3330                 mov     rax, cs:qword_18068DF38
+  .text:00000001801D3337                 mov     rax, [rax+8]
+  .text:00000001801D333B                 cmp     byte ptr [rax], 0
+  .text:00000001801D333E                 jz      loc_1801D33D2
+  .text:00000001801D3344                 mov     ecx, cs:dword_1808CDB6C
+  .text:00000001801D334A                 mov     edx, 2
+  .text:00000001801D334F                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001801D3355                 test    al, al
+  .text:00000001801D3357                 jz      short loc_1801D33D2
+  .text:00000001801D3359                 cmp     byte ptr [rbx+0D0h], 0
+  .text:00000001801D3360                 mov     eax, [rbx+378h]
+  .text:00000001801D3366                 mov     ecx, [rbx+2CCFA8h]
+  .text:00000001801D336C                 mov     edx, [rbx+2CCF6Ch]
+  .text:00000001801D3372                 mov     r8d, [rbx+2CCF68h]
+  .text:00000001801D3379                 movd    xmm1, eax
+  .text:00000001801D337D                 cvtdq2ps xmm1, xmm1
+  .text:00000001801D3380                 mulss   xmm1, xmm6
+  .text:00000001801D3384                 jnz     short loc_1801D3399
+  .text:00000001801D3386                 movss   xmm0, dword ptr [rbx+2C353Ch]
+  .text:00000001801D338E                 mulss   xmm0, xmm6
+  .text:00000001801D3392                 addss   xmm0, xmm1
+  .text:00000001801D3396                 movaps  xmm1, xmm0
+  .text:00000001801D3399                 mov     r9d, [rbx+37Ch]
+  .text:00000001801D33A0                 mov     [rsp+0A8h+var_68], ecx
+  .text:00000001801D33A4                 mov     ecx, cs:dword_1808CDB6C
+  .text:00000001801D33AA                 mov     [rsp+0A8h+var_70], edx
+  .text:00000001801D33AE                 mov     edx, 2
+  .text:00000001801D33B3                 mov     [rsp+0A8h+var_78], r8d
+  .text:00000001801D33B8                 lea     r8, aS5dC5dT63fSent; "[s%5d c%5d t%6.3f] SentTickSync   cmds "...
+  .text:00000001801D33BF                 cvtps2pd xmm0, xmm1
+  .text:00000001801D33C2                 movsd   [rsp+0A8h+var_80], xmm0
+  .text:00000001801D33C8                 mov     [rsp+0A8h+var_88], eax
+  .text:00000001801D33CC                 call    cs:LoggingSystem_Log
+  .text:00000001801D33D2                 mov     rcx, rbx
+  .text:00000001801D33D5                 call    sub_180065950
+  .text:00000001801D33DA                 mov     rcx, cs:off_180611750
+  .text:00000001801D33E1                 mov     rbx, [rdi+0A0h]
+  .text:00000001801D33E8                 mov     rax, [rcx]
+  .text:00000001801D33EB                 call    qword ptr [rax+58h]
+  .text:00000001801D33EE                 test    al, al
+  .text:00000001801D33F0                 jnz     short loc_1801D3415
+  .text:00000001801D33F2                 mov     rcx, cs:g_pSource2ClientPrediction
+  .text:00000001801D33F9                 test    rcx, rcx
+  .text:00000001801D33FC                 jz      short loc_1801D340B
+  .text:00000001801D33FE                 mov     rax, [rcx]
+  .text:00000001801D3401                 call    qword ptr [rax+0E0h]
+  .text:00000001801D3407                 test    al, al
+  .text:00000001801D3409                 jnz     short loc_1801D3415
+  .text:00000001801D340B                 xor     edx, edx
+  .text:00000001801D340D                 mov     rcx, rbx
+  .text:00000001801D3410                 call    sub_180065C50
+  .text:00000001801D3415                 mov     [rsp+0A8h+arg_0], 1
+  .text:00000001801D3420                 call    sub_180115300
+  .text:00000001801D3425                 mov     rcx, [rdi+0A0h]
+  .text:00000001801D342C                 test    rcx, rcx
+  .text:00000001801D342F                 jz      short loc_1801D343E
+  .text:00000001801D3431                 lea     rdx, [rsp+0A8h+arg_0]
+  .text:00000001801D3439                 call    sub_180065E30
+  .text:00000001801D343E                 lea     rdx, [rsp+0A8h+arg_0]
+  .text:00000001801D3446                 mov     rcx, rdi
+  .text:00000001801D3449                 call    CNetworkClientService_OnClientProcessNetworking
+  .text:00000001801D344E                 mov     rbx, [rdi+0A0h]
+  .text:00000001801D3455                 mov     rdi, [rsp+0A8h+arg_10]
+  .text:00000001801D345D                 test    rbx, rbx
+  .text:00000001801D3460                 jz      short loc_1801D34A8
+  .text:00000001801D3462                 mov     r9d, [rbx+378h]
+  .text:00000001801D3469                 lea     r8, [rbx+90h]
+  .text:00000001801D3470                 mov     dword ptr [rsp+0A8h+var_80], 1
+  .text:00000001801D3478                 lea     rdx, aCBuildworkerCs_9; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001801D347F                 lea     rcx, [rsp+0A8h+var_58]
+  .text:00000001801D3484                 movss   [rsp+0A8h+var_88], xmm6
+  .text:00000001801D348A                 call    sub_18005EBE0
+  .text:00000001801D348F                 lea     rdx, [rbx+3B8h]
+  .text:00000001801D3496                 mov     rcx, rbx
+  .text:00000001801D3499                 call    sub_180091260
+  .text:00000001801D349E                 lea     rcx, [rsp+0A8h+var_58]
+  .text:00000001801D34A3                 call    sub_18005EC80
+  .text:00000001801D34A8                 movaps  xmm6, [rsp+0A8h+var_18]
+  .text:00000001801D34B0                 add     rsp, 0A0h
+  .text:00000001801D34B7                 pop     rbx
+  .text:00000001801D34B8                 retn
+procedure: |-
+  __int64 __fastcall CNetworkClientService_OnSimpleLoopFrameUpdate(__int64 a1, __int128 *a2)
+  {
+    __int64 v3; // rax
+    int v4; // r8d
+    int v5; // ecx
+    __int128 v6; // xmm0
+    __int128 v7; // xmm1
+    __int64 v8; // rcx
+    __int64 v9; // rbx
+    __int64 v10; // rsi
+    _BYTE *v11; // rax
+    float v12; // xmm1_4
+    __int64 v13; // rbx
+    __int64 v14; // rcx
+    __int64 result; // rax
+    __int64 v16; // rbx
+    _OWORD v17[2]; // [rsp+50h] [rbp-58h] BYREF
+    __int64 v18; // [rsp+70h] [rbp-38h]
+    __int16 v19; // [rsp+78h] [rbp-30h]
+    int v20; // [rsp+80h] [rbp-28h]
+    int v21; // [rsp+84h] [rbp-24h]
+    int v22; // [rsp+88h] [rbp-20h]
+    int v23; // [rsp+8Ch] [rbp-1Ch]
+    int v24; // [rsp+B0h] [rbp+8h] BYREF
+
+    v3 = *(_QWORD *)(a1 + 160);
+    if ( v3 )
+    {
+      v4 = *(_DWORD *)(v3 + 888);
+      v5 = *(_DWORD *)(v3 + 892);
+    }
+    else
+    {
+      v4 = 0;
+      v5 = 0;
+    }
+    v6 = *a2;
+    v20 = v5;
+    v7 = a2[1];
+    v22 = v5 - v4;
+    v17[0] = v6;
+    v19 = 257;
+    v18 = *((_QWORD *)a2 + 4);
+    v17[1] = v7;
+    v21 = 0;
+    v23 = 0;
+    CNetworkClientService_OnClientAdvanceTick(a1, v17);
+    v8 = *(_QWORD *)(a1 + 160);
+    if ( v8 )
+    {
+      CNetworkGameClient_CreateMove(v8);
+      v9 = *(_QWORD *)(a1 + 160);
+      CNetworkGameClient_SendMovePacket(v9);
+      v10 = *(_QWORD *)(v9 + 240);
+      if ( v10 && !(*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)v10 + 648LL))(*(_QWORD *)(v9 + 240)) )
+        (*(void (__fastcall **)(__int64))(*(_QWORD *)v10 + 336LL))(v10);
+      CNetworkGameClient_SendMove(v9, 0.0);
+      v11 = (_BYTE *)sub_1803FEF60((__int64)&unk_18068DF30, -1);
+      if ( !v11 )
+        v11 = *(_BYTE **)(qword_18068DF38 + 8);
+      if ( *v11 && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CDB6C, 2) )
+      {
+        v12 = (float)*(int *)(v9 + 888) * 0.015625;
+        if ( !*(_BYTE *)(v9 + 208) )
+          v12 = (float)(*(float *)(v9 + 2897212) * 0.015625) + v12;
+        LoggingSystem_Log(
+          (unsigned int)dword_1808CDB6C,
+          2,
+          "[s%5d c%5d t%6.3f] SentTickSync   cmds %d...%d   seqnum %d\n",
+          *(_DWORD *)(v9 + 892),
+          *(_DWORD *)(v9 + 888),
+          v12,
+          *(_DWORD *)(v9 + 2936680),
+          *(_DWORD *)(v9 + 2936684),
+          *(_DWORD *)(v9 + 2936744));
+      }
+      sub_180065950(v9);
+      v13 = *(_QWORD *)(a1 + 160);
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64 *))(*off_180611750 + 88))(off_180611750)
+        && (!g_pSource2ClientPrediction
+         || !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2ClientPrediction + 224LL))(g_pSource2ClientPrediction)) )
+      {
+        sub_180065C50(v13, 0);
+      }
+    }
+    v24 = 1;
+    sub_180115300();
+    v14 = *(_QWORD *)(a1 + 160);
+    if ( v14 )
+      sub_180065E30(v14, &v24);
+    result = CNetworkClientService_OnClientProcessNetworking(a1, (__int64)&v24);
+    v16 = *(_QWORD *)(a1 + 160);
+    if ( v16 )
+    {
+      sub_18005EBE0(
+        (unsigned int)v17,
+        (unsigned int)"C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\networkgameclient.cpp:4593",
+        v16 + 144,
+        *(_DWORD *)(v16 + 888),
+        1015021568,
+        1);
+      sub_180091260(v16, (_WORD *)(v16 + 952));
+      return sub_18005EC80((__int64)v17);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameClient_CreateMove.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameClient_CreateMove.windows.yaml
@@ -1,0 +1,178 @@
+func_name: CNetworkGameClient_CreateMove
+func_va: '0x180064500'
+disasm_code: |-
+  .text:0000000180064500                 push    rdi
+  .text:0000000180064502                 sub     rsp, 30h
+  .text:0000000180064506                 cmp     dword ptr [rcx+230h], 6
+  .text:000000018006450D                 mov     rdi, rcx
+  .text:0000000180064510                 movss   xmm0, dword ptr [rcx+0ACh]
+  .text:0000000180064518                 cvtps2pd xmm0, xmm0
+  .text:000000018006451B                 addsd   xmm0, qword ptr [rcx+0B0h]
+  .text:0000000180064523                 movsd   qword ptr [rcx+0B0h], xmm0
+  .text:000000018006452B                 jl      loc_1800646DE
+  .text:0000000180064531                 cmp     byte ptr [rcx+2C141Fh], 0
+  .text:0000000180064538                 lea     rcx, off_180615950
+  .text:000000018006453F                 mov     rax, cs:off_180615950
+  .text:0000000180064546                 mov     [rsp+38h+var_10], rbx
+  .text:000000018006454B                 jnz     loc_180064602
+  .text:0000000180064551                 lea     rdx, [rsp+38h+arg_0]
+  .text:0000000180064556                 call    qword ptr [rax+0E8h]
+  .text:000000018006455C                 mov     eax, [rsp+38h+arg_0]
+  .text:0000000180064560                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180064563                 jz      loc_18006464F
+  .text:0000000180064569                 mov     rcx, cs:off_180615950
+  .text:0000000180064570                 mov     edx, eax
+  .text:0000000180064572                 mov     r8, [rcx+110h]
+  .text:0000000180064579                 lea     rcx, off_180615950
+  .text:0000000180064580                 call    r8
+  .text:0000000180064583                 test    al, al
+  .text:0000000180064585                 jnz     short loc_1800645D9
+  .text:0000000180064587                 mov     rcx, cs:g_pSource2Client
+  .text:000000018006458E                 mov     edx, [rsp+38h+arg_0]
+  .text:0000000180064592                 mov     rax, [rcx]
+  .text:0000000180064595                 call    qword ptr [rax+80h]  ; 80h = ISource2Client_CreateMove
+  .text:000000018006459B                 mov     rcx, cs:off_180611748
+  .text:00000001800645A2                 mov     rax, [rcx]
+  .text:00000001800645A5                 call    qword ptr [rax+48h]
+  .text:00000001800645A8                 test    al, al
+  .text:00000001800645AA                 jz      short loc_1800645D9
+  .text:00000001800645AC                 mov     rax, cs:off_180611748
+  .text:00000001800645B3                 mov     edx, [rsp+38h+arg_0]
+  .text:00000001800645B7                 mov     rcx, [rax]
+  .text:00000001800645BA                 mov     rbx, [rcx+60h]
+  .text:00000001800645BE                 mov     rcx, cs:g_pSource2Client
+  .text:00000001800645C5                 mov     rax, [rcx]
+  .text:00000001800645C8                 call    qword ptr [rax+98h]
+  .text:00000001800645CE                 mov     rcx, cs:off_180611748
+  .text:00000001800645D5                 mov     edx, eax
+  .text:00000001800645D7                 call    rbx
+  .text:00000001800645D9                 mov     rax, cs:off_180615950
+  .text:00000001800645E0                 lea     rdx, [rsp+38h+arg_10]
+  .text:00000001800645E5                 mov     r8d, [rsp+38h+arg_0]
+  .text:00000001800645EA                 lea     rcx, off_180615950
+  .text:00000001800645F1                 call    qword ptr [rax+0F0h]
+  .text:00000001800645F7                 mov     eax, [rax]
+  .text:00000001800645F9                 mov     [rsp+38h+arg_0], eax
+  .text:00000001800645FD                 jmp     loc_180064560
+  .text:0000000180064602                 lea     rdx, [rsp+38h+arg_8]
+  .text:0000000180064607                 call    qword ptr [rax+0E8h]
+  .text:000000018006460D                 mov     eax, [rsp+38h+arg_8]
+  .text:0000000180064611                 cmp     eax, 0FFFFFFFFh
+  .text:0000000180064614                 jz      short loc_18006464F
+  .text:0000000180064616                 mov     rcx, cs:g_pSource2Client
+  .text:000000018006461D                 mov     edx, eax
+  .text:000000018006461F                 mov     r8, [rcx]
+  .text:0000000180064622                 call    qword ptr [r8+88h]
+  .text:0000000180064629                 mov     rax, cs:off_180615950
+  .text:0000000180064630                 lea     rdx, [rsp+38h+arg_18]
+  .text:0000000180064635                 mov     r8d, [rsp+38h+arg_8]
+  .text:000000018006463A                 lea     rcx, off_180615950
+  .text:0000000180064641                 call    qword ptr [rax+0F0h]
+  .text:0000000180064647                 mov     eax, [rax]
+  .text:0000000180064649                 mov     [rsp+38h+arg_8], eax
+  .text:000000018006464D                 jmp     short loc_180064611
+  .text:000000018006464F                 mov     rcx, cs:g_pSource2Client
+  .text:0000000180064656                 xor     edx, edx
+  .text:0000000180064658                 mov     rax, [rcx]
+  .text:000000018006465B                 call    qword ptr [rax+98h]
+  .text:0000000180064661                 test    eax, eax
+  .text:0000000180064663                 jle     short loc_1800646D9
+  .text:0000000180064665                 movzx   edx, al
+  .text:0000000180064668                 imul    rcx, rdx, 38h ; '8'
+  .text:000000018006466C                 lea     rbx, [rcx+rdi]
+  .text:0000000180064670                 cmp     [rcx+rdi+2C3588h], eax
+  .text:0000000180064677                 jz      short loc_1800646BE
+  .text:0000000180064679                 mov     [rcx+rdi+2C3588h], eax
+  .text:0000000180064680                 xor     eax, eax
+  .text:0000000180064682                 mov     [rcx+rdi+2C3590h], rax
+  .text:000000018006468A                 mov     [rbx+2C3598h], rax
+  .text:0000000180064691                 mov     [rcx+rdi+2C35A0h], rax
+  .text:0000000180064699                 mov     [rcx+rdi+2C35ACh], eax
+  .text:00000001800646A0                 mov     [rcx+rdi+2C35B8h], al
+  .text:00000001800646A7                 mov     dword ptr [rcx+rdi+2C35A8h], 0BF800000h
+  .text:00000001800646B2                 mov     qword ptr [rcx+rdi+2C35B0h], 7F7FFFFFh
+  .text:00000001800646BE                 xorps   xmm0, xmm0
+  .text:00000001800646C1                 comisd  xmm0, qword ptr [rbx+2C3598h]
+  .text:00000001800646C9                 jb      short loc_1800646D9
+  .text:00000001800646CB                 call    cs:Plat_FloatTime
+  .text:00000001800646D1                 movsd   qword ptr [rbx+2C3598h], xmm0
+  .text:00000001800646D9                 mov     rbx, [rsp+38h+var_10]
+  .text:00000001800646DE                 add     rsp, 30h
+  .text:00000001800646E2                 pop     rdi
+  .text:00000001800646E3                 retn
+procedure: |-
+  void __fastcall CNetworkGameClient_CreateMove(__int64 a1)
+  {
+    bool v1; // cc
+    unsigned int j; // eax
+    __int64 (__fastcall *v4)(); // rbx
+    unsigned int v5; // eax
+    unsigned int i; // eax
+    int v7; // eax
+    __int64 v8; // rcx
+    __int64 v9; // rbx
+    unsigned int v10; // [rsp+40h] [rbp+8h] BYREF
+    unsigned int v11; // [rsp+48h] [rbp+10h] BYREF
+    char v12; // [rsp+50h] [rbp+18h] BYREF
+    char v13; // [rsp+58h] [rbp+20h] BYREF
+
+    v1 = *(_DWORD *)(a1 + 560) < 6;
+    *(double *)(a1 + 176) = *(float *)(a1 + 172) + *(double *)(a1 + 176);
+    if ( !v1 )
+    {
+      if ( *(_BYTE *)(a1 + 2888735) )
+      {
+        ((void (__fastcall *)(__int64 (__fastcall ***)(), unsigned int *))off_180615950[29])(&off_180615950, &v11);
+        for ( i = v11; i != -1; v11 = i )
+        {
+          (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 136LL))(g_pSource2Client, i);
+          i = *(_DWORD *)((__int64 (__fastcall *)(__int64 (__fastcall ***)(), char *, _QWORD))off_180615950[30])(
+                           &off_180615950,
+                           &v13,
+                           v11);
+        }
+      }
+      else
+      {
+        ((void (__fastcall *)(__int64 (__fastcall ***)(), unsigned int *))off_180615950[29])(&off_180615950, &v10);
+        for ( j = v10; j != -1; v10 = j )
+        {
+          if ( !((unsigned __int8 (__fastcall *)(__int64 (__fastcall ***)(), _QWORD))off_180615950[34])(&off_180615950, j) )
+          {
+            (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 128LL))(g_pSource2Client, v10);// 128LL = 0x80 = ISource2Client_CreateMove
+            if ( ((unsigned __int8 (__fastcall *)(__int64 (__fastcall ***)()))(*off_180611748)[9])(off_180611748) )
+            {
+              v4 = (*off_180611748)[12];
+              v5 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 152LL))(
+                     g_pSource2Client,
+                     v10);
+              ((void (__fastcall *)(__int64 (__fastcall ***)(), _QWORD))v4)(off_180611748, v5);
+            }
+          }
+          j = *(_DWORD *)((__int64 (__fastcall *)(__int64 (__fastcall ***)(), char *, _QWORD))off_180615950[30])(
+                           &off_180615950,
+                           &v12,
+                           v10);
+        }
+      }
+      v7 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Client + 152LL))(g_pSource2Client, 0);
+      if ( v7 > 0 )
+      {
+        v8 = 56LL * (unsigned __int8)v7;
+        v9 = v8 + a1;
+        if ( *(_DWORD *)(v8 + a1 + 2897288) != v7 )
+        {
+          *(_DWORD *)(v8 + a1 + 2897288) = v7;
+          *(_QWORD *)(v8 + a1 + 2897296) = 0;
+          *(_QWORD *)(v9 + 2897304) = 0;
+          *(_QWORD *)(v8 + a1 + 2897312) = 0;
+          *(_DWORD *)(v8 + a1 + 2897324) = 0;
+          *(_BYTE *)(v8 + a1 + 2897336) = 0;
+          *(_DWORD *)(v8 + a1 + 2897320) = -1082130432;
+          *(_QWORD *)(v8 + a1 + 2897328) = 2139095039;
+        }
+        if ( *(double *)(v9 + 2897304) <= 0.0 )
+          *(double *)(v9 + 2897304) = Plat_FloatTime(v8, (unsigned __int8)v7);
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- Add the Windows CreateMove discovery chain from CNetworkClientService through CNetworkGameClient and CSource2Client to CClientInput, including CClientInput::m_viewangles.
- Register the 14173 config/reference data, declare CClientInput struct metadata, harden create-pr PowerShell native argument handling, and publish the validated snapshot.

## Validation
- implementation-specific tests: `uv run ida_analyze_bin.py -debug` reported Failed: 0 / Skipped: 2044; non-MCP unit tests reported 1057 passed; `uv run python -m unittest tests.test_update_gamedata.TestGamedataConfigValidation` passed 4 tests
- candidate preparation: passed for `14173`
- C++ post-change validation: 12/12 tests runnable; zero compile failures, invalid test items, or layout differences
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: 3 initial commits ahead of `origin/main`; supplemental publication commit: created