### PR TITLE
refactor(preprocessor): rename CModelState members to CSimulationState

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4158,17 +4158,17 @@ modules:
         expected_output:
           - CSkeletonInstance_m_modelState_m_hModel.{platform}.yaml
           - CSkeletonInstance_m_modelState_m_simulationState.{platform}.yaml
-          - CModelState_SetupJointState.{platform}.yaml
+          - CSimulationState_SetupJointState.{platform}.yaml
         expected_input:
           - CSkeletonInstance_PostDataUpdate.{platform}.yaml
-      - name: find-CModelState_SetupJointState-windows
+      - name: find-CSimulationState_SetupJointState-windows
         platform: windows
         expected_output:
           - CModelState_m_nTotalTransformCount.{platform}.yaml
           - CModelState_m_nBoneCount.{platform}.yaml
           - CModelState_m_nAttachmentCount.{platform}.yaml
         expected_input:
-          - CModelState_SetupJointState.{platform}.yaml
+          - CSimulationState_SetupJointState.{platform}.yaml
       - name: find-CUserMessage_ExtraUserData_vtable
         expected_output:
           - CUserMessage_ExtraUserData_vtable.{platform}.yaml
@@ -4970,13 +4970,13 @@ modules:
         member: m_modelState.m_hModel
         alias:
           - CSkeletonInstance::m_modelState.m_hModel
-      - name: CModelState
+      - name: CSimulationState
         category: struct
-      - name: CModelState_SetupJointState
+      - name: CSimulationState_SetupJointState
         category: func
         platform: windows
         alias:
-          - CModelState::SetupJointState
+          - CSimulationState::SetupJointState
       - name: CModelState_m_nTotalTransformCount
         category: structmember
         platform: windows

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4164,9 +4164,9 @@ modules:
       - name: find-CSimulationState_SetupJointState-windows
         platform: windows
         expected_output:
-          - CModelState_m_nTotalTransformCount.{platform}.yaml
-          - CModelState_m_nBoneCount.{platform}.yaml
-          - CModelState_m_nAttachmentCount.{platform}.yaml
+          - CSimulationState_m_nTotalTransformCount.{platform}.yaml
+          - CSimulationState_m_nBoneCount.{platform}.yaml
+          - CSimulationState_m_nAttachmentCount.{platform}.yaml
         expected_input:
           - CSimulationState_SetupJointState.{platform}.yaml
       - name: find-CUserMessage_ExtraUserData_vtable
@@ -4977,27 +4977,27 @@ modules:
         platform: windows
         alias:
           - CSimulationState::SetupJointState
-      - name: CModelState_m_nTotalTransformCount
+      - name: CSimulationState_m_nTotalTransformCount
         category: structmember
         platform: windows
-        struct: CModelState
+        struct: CSimulationState
         member: m_nTotalTransformCount
         alias:
-          - CModelState::m_nTotalTransformCount
-      - name: CModelState_m_nBoneCount
+          - CSimulationState::m_nTotalTransformCount
+      - name: CSimulationState_m_nBoneCount
         category: structmember
         platform: windows
-        struct: CModelState
+        struct: CSimulationState
         member: m_nBoneCount
         alias:
-          - CModelState::m_nBoneCount
-      - name: CModelState_m_nAttachmentCount
+          - CSimulationState::m_nBoneCount
+      - name: CSimulationState_m_nAttachmentCount
         category: structmember
         platform: windows
-        struct: CModelState
+        struct: CSimulationState
         member: m_nAttachmentCount
         alias:
-          - CModelState::m_nAttachmentCount
+          - CSimulationState::m_nAttachmentCount
       - name: CUserMessage_ExtraUserData_vtable
         category: vtable
       - name: SendViolationReport

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4157,7 +4157,7 @@ modules:
         platform: windows
         expected_output:
           - CSkeletonInstance_m_modelState_m_hModel.{platform}.yaml
-          - CSkeletonInstance_m_modelState.{platform}.yaml
+          - CSkeletonInstance_m_modelState_m_simulationState.{platform}.yaml
           - CModelState_SetupJointState.{platform}.yaml
         expected_input:
           - CSkeletonInstance_PostDataUpdate.{platform}.yaml

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -4956,13 +4956,13 @@ modules:
         category: vfunc
         alias:
           - CSkeletonInstance::PostDataUpdate
-      - name: CSkeletonInstance_m_modelState
+      - name: CSkeletonInstance_m_modelState_m_simulationState
         category: structmember
         platform: windows
         struct: CSkeletonInstance
-        member: m_modelState
+        member: m_modelState.m_simulationState
         alias:
-          - CSkeletonInstance::m_modelState
+          - CSkeletonInstance::m_modelState.m_simulationState
       - name: CSkeletonInstance_m_modelState_m_hModel
         category: structmember
         platform: windows

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -1328,7 +1328,7 @@ files:
     offset: '0x14'
     offset_sig: 48 89 7E ?? 48 8D 6E ??
     offset_sig_disp: 0
-    size: 8
+    size: 4
     struct_name: CSimulationState
   client/CSimulationState_m_nTotalTransformCount.windows.yaml:
     member_name: m_nTotalTransformCount
@@ -40420,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T13:22:50Z'
+last_publish_time: '2026-07-30T13:57:33Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -40420,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T13:57:33Z'
+last_publish_time: '2026-07-30T14:03:54Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,7 +73,7 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:47ddc5694615adc2ffab438fcaf22190d136d5001a80be45a9c5d7976003709d
+config_sha256: sha256:9b49b169515e2ec490ffc581b843ec9ab28325fefd2a1a86963ce95e1e0ce83a
 file_count: 3204
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -1154,27 +1154,6 @@ files:
     func_sig: 48 8B C4 48 89 70 ?? 57 48 81 EC ?? ?? ?? ?? 48 83 3D ?? ?? ?? ?? ??
     func_size: '0x370'
     func_va: '0x180bd1da0'
-  client/CModelState_m_nAttachmentCount.windows.yaml:
-    member_name: m_nAttachmentCount
-    offset: '0x18'
-    offset_sig: 89 46 ?? 89 56 ?? 0F 84 ?? ?? ?? ??
-    offset_sig_disp: 0
-    size: 4
-    struct_name: CModelState
-  client/CModelState_m_nBoneCount.windows.yaml:
-    member_name: m_nBoneCount
-    offset: '0x14'
-    offset_sig: 48 89 7E ?? 48 8D 6E ??
-    offset_sig_disp: 0
-    size: 8
-    struct_name: CModelState
-  client/CModelState_m_nTotalTransformCount.windows.yaml:
-    member_name: m_nTotalTransformCount
-    offset: '0x10'
-    offset_sig: 48 8D 6E ?? 89 7E ?? 48 85 DB
-    offset_sig_disp: 0
-    size: 4
-    struct_name: CModelState
   client/CNetworkGameClient_OnSource1Source1LegacyGameEvent.linux.yaml:
     func_name: CNetworkGameClient_OnSource1Source1LegacyGameEvent
     func_rva: '0x16d9d20'
@@ -1337,6 +1316,27 @@ files:
     func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC ?? 48 8B F1 33 FF
     func_size: '0x168'
     func_va: '0x180a59cc0'
+  client/CSimulationState_m_nAttachmentCount.windows.yaml:
+    member_name: m_nAttachmentCount
+    offset: '0x18'
+    offset_sig: 89 46 ?? 89 56 ?? 0F 84 ?? ?? ?? ??
+    offset_sig_disp: 0
+    size: 4
+    struct_name: CSimulationState
+  client/CSimulationState_m_nBoneCount.windows.yaml:
+    member_name: m_nBoneCount
+    offset: '0x14'
+    offset_sig: 48 89 7E ?? 48 8D 6E ??
+    offset_sig_disp: 0
+    size: 8
+    struct_name: CSimulationState
+  client/CSimulationState_m_nTotalTransformCount.windows.yaml:
+    member_name: m_nTotalTransformCount
+    offset: '0x10'
+    offset_sig: 48 8D 6E ?? 89 7E ?? 48 85 DB
+    offset_sig_disp: 0
+    size: 4
+    struct_name: CSimulationState
   client/CSkeletonInstance_PostDataUpdate.linux.yaml:
     func_name: CSkeletonInstance_PostDataUpdate
     func_rva: '0x17cfe30'
@@ -40420,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T12:40:23Z'
+last_publish_time: '2026-07-30T13:22:50Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,7 +73,7 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:66c12f67f77f120eaab5b38ecb6f444b806202078a1795c2ffb1b5f86a7feccd
+config_sha256: sha256:47ddc5694615adc2ffab438fcaf22190d136d5001a80be45a9c5d7976003709d
 file_count: 3204
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -1154,12 +1154,6 @@ files:
     func_sig: 48 8B C4 48 89 70 ?? 57 48 81 EC ?? ?? ?? ?? 48 83 3D ?? ?? ?? ?? ??
     func_size: '0x370'
     func_va: '0x180bd1da0'
-  client/CModelState_SetupJointState.windows.yaml:
-    func_name: CModelState_SetupJointState
-    func_rva: '0xa59cc0'
-    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC ?? 48 8B F1 33 FF
-    func_size: '0x168'
-    func_va: '0x180a59cc0'
   client/CModelState_m_nAttachmentCount.windows.yaml:
     member_name: m_nAttachmentCount
     offset: '0x18'
@@ -1337,6 +1331,12 @@ files:
     vtable_size: '0x100'
     vtable_symbol: ??_7CPrediction@@6B@
     vtable_va: '0x181b0e760'
+  client/CSimulationState_SetupJointState.windows.yaml:
+    func_name: CSimulationState_SetupJointState
+    func_rva: '0xa59cc0'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 56 48 83 EC ?? 48 8B F1 33 FF
+    func_size: '0x168'
+    func_va: '0x180a59cc0'
   client/CSkeletonInstance_PostDataUpdate.linux.yaml:
     func_name: CSkeletonInstance_PostDataUpdate
     func_rva: '0x17cfe30'
@@ -40420,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T12:30:56Z'
+last_publish_time: '2026-07-30T12:40:23Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,7 +73,7 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:cdbcd2f0009df537c164acef2a92aec529585dfaf35618294d08408beaa19ce6
+config_sha256: sha256:66c12f67f77f120eaab5b38ecb6f444b806202078a1795c2ffb1b5f86a7feccd
 file_count: 3204
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -1355,16 +1355,16 @@ files:
     vfunc_index: 25
     vfunc_offset: '0xc8'
     vtable_name: CSkeletonInstance
-  client/CSkeletonInstance_m_modelState.windows.yaml:
-    member_name: m_modelState
-    offset: '0x1c0'
-    struct_name: CSkeletonInstance
   client/CSkeletonInstance_m_modelState_m_hModel.windows.yaml:
     member_name: m_modelState.m_hModel
     offset: '0x1e0'
     offset_sig: 48 39 8E ?? ?? ?? ?? 75 ??
     offset_sig_disp: 0
     size: 8
+    struct_name: CSkeletonInstance
+  client/CSkeletonInstance_m_modelState_m_simulationState.windows.yaml:
+    member_name: m_modelState.m_simulationState
+    offset: '0x1c0'
     struct_name: CSkeletonInstance
   client/CSkeletonInstance_vtable.linux.yaml:
     vtable_class: CSkeletonInstance
@@ -40420,5 +40420,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T11:43:23Z'
+last_publish_time: '2026-07-30T12:30:56Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
+++ b/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
@@ -6,14 +6,14 @@ from ida_analyze_util import preprocess_common_skill
 TARGET_FUNCTION_NAMES = []
 
 TARGET_STRUCT_MEMBER_NAMES = [
-    "CModelState_m_nTotalTransformCount",
-    "CModelState_m_nBoneCount",
-    "CModelState_m_nAttachmentCount",
+    "CSimulationState_m_nTotalTransformCount",
+    "CSimulationState_m_nBoneCount",
+    "CSimulationState_m_nAttachmentCount",
 ]
 
 LLM_DECOMPILE = [
     {
-        "symbol_name": "CModelState_m_nTotalTransformCount",
+        "symbol_name": "CSimulationState_m_nTotalTransformCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
@@ -24,7 +24,7 @@ LLM_DECOMPILE = [
         },
     },
     {
-        "symbol_name": "CModelState_m_nBoneCount",
+        "symbol_name": "CSimulationState_m_nBoneCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
@@ -35,7 +35,7 @@ LLM_DECOMPILE = [
         },
     },
     {
-        "symbol_name": "CModelState_m_nAttachmentCount",
+        "symbol_name": "CSimulationState_m_nAttachmentCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
@@ -50,7 +50,7 @@ LLM_DECOMPILE = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CModelState_m_nTotalTransformCount",
+        "CSimulationState_m_nTotalTransformCount",
         [
             "struct_name",
             "member_name",
@@ -61,7 +61,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CModelState_m_nBoneCount",
+        "CSimulationState_m_nBoneCount",
         [
             "struct_name",
             "member_name",
@@ -72,7 +72,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CModelState_m_nAttachmentCount",
+        "CSimulationState_m_nAttachmentCount",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
+++ b/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CModelState_SetupJointState-windows skill."""
+"""Preprocess script for find-CSimulationState_SetupJointState-windows skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
@@ -16,33 +16,33 @@ LLM_DECOMPILE = [
         "symbol_name": "CModelState_m_nTotalTransformCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
-            "references/client/CModelState_SetupJointState.{platform}.yaml",
+            "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
         "dependency_policy": {
-            "CModelState_SetupJointState.{platform}.yaml": "required",
+            "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },
     },
     {
         "symbol_name": "CModelState_m_nBoneCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
-            "references/client/CModelState_SetupJointState.{platform}.yaml",
+            "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
         "dependency_policy": {
-            "CModelState_SetupJointState.{platform}.yaml": "required",
+            "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },
     },
     {
         "symbol_name": "CModelState_m_nAttachmentCount",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
-            "references/client/CModelState_SetupJointState.{platform}.yaml",
+            "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
         "dependency_policy": {
-            "CModelState_SetupJointState.{platform}.yaml": "required",
+            "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },
     },
 ]

--- a/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
+++ b/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
@@ -30,6 +30,7 @@ LLM_DECOMPILE = [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
+        "expected_size": 4,
         "dependency_policy": {
             "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },

--- a/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
+++ b/ida_preprocessor_scripts/find-CSimulationState_SetupJointState-windows.py
@@ -19,6 +19,7 @@ LLM_DECOMPILE = [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
+        "expected_size": 4,
         "dependency_policy": {
             "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },
@@ -42,6 +43,7 @@ LLM_DECOMPILE = [
             "references/client/CSimulationState_SetupJointState.{platform}.yaml",
         ],
         "expected_result_sections": ["found_struct_offset"],
+        "expected_size": 4,
         "dependency_policy": {
             "CSimulationState_SetupJointState.{platform}.yaml": "required",
         },

--- a/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate-windows.py
+++ b/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate-windows.py
@@ -4,7 +4,7 @@
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CModelState_SetupJointState",
+    "CSimulationState_SetupJointState",
 ]
 
 TARGET_STRUCT_MEMBER_NAMES = [
@@ -14,7 +14,7 @@ TARGET_STRUCT_MEMBER_NAMES = [
 
 LLM_DECOMPILE = [
     {
-        "symbol_name": "CModelState_SetupJointState",
+        "symbol_name": "CSimulationState_SetupJointState",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/client/CSkeletonInstance_PostDataUpdate.{platform}.yaml",
@@ -51,7 +51,7 @@ LLM_DECOMPILE = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CModelState_SetupJointState",
+        "CSimulationState_SetupJointState",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate-windows.py
+++ b/ida_preprocessor_scripts/find-CSkeletonInstance_PostDataUpdate-windows.py
@@ -9,7 +9,7 @@ TARGET_FUNCTION_NAMES = [
 
 TARGET_STRUCT_MEMBER_NAMES = [
     "CSkeletonInstance_m_modelState_m_hModel",
-    "CSkeletonInstance_m_modelState",
+    "CSkeletonInstance_m_modelState_m_simulationState",
 ]
 
 LLM_DECOMPILE = [
@@ -36,7 +36,7 @@ LLM_DECOMPILE = [
         },
     },
     {
-        "symbol_name": "CSkeletonInstance_m_modelState",
+        "symbol_name": "CSkeletonInstance_m_modelState_m_simulationState",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/client/CSkeletonInstance_PostDataUpdate.{platform}.yaml",
@@ -72,7 +72,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CSkeletonInstance_m_modelState",
+        "CSkeletonInstance_m_modelState_m_simulationState",
         [
             "struct_name",
             "member_name",

--- a/ida_preprocessor_scripts/references/client/CSimulationState_SetupJointState.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSimulationState_SetupJointState.windows.yaml
@@ -1,4 +1,4 @@
-func_name: CModelState_SetupJointState
+func_name: CSimulationState_SetupJointState
 func_va: '0x180a59820'
 disasm_code: |-
   .text:0000000180A59820                 mov     [rsp+arg_8], rbx
@@ -104,7 +104,7 @@ disasm_code: |-
   .text:0000000180A59986                 pop     rsi
   .text:0000000180A59987                 retn
 procedure: |-
-  void *__fastcall CModelState_SetupJointState(__int64 modelState, __int64 hModel)
+  void *__fastcall CSimulationState_SetupJointState(__int64 modelState, __int64 hModel)
   {
     int v3; // edi
     __int64 v4; // rcx

--- a/ida_preprocessor_scripts/references/client/CSimulationState_SetupJointState.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSimulationState_SetupJointState.windows.yaml
@@ -36,12 +36,12 @@ disasm_code: |-
   .text:0000000180A59881                 mov     rcx, rbx
   .text:0000000180A59884                 call    sub_181638B10
   .text:0000000180A59889                 mov     rcx, rbx
-  .text:0000000180A5988C                 mov     [rsi+14h], eax  ; 14h = CModelState::m_nBoneCount (structmember, struct=CModelState, member=m_nBoneCount)
+  .text:0000000180A5988C                 mov     [rsi+14h], eax  ; 14h = CSimulationState::m_nBoneCount (structmember, struct=CSimulationState, member=m_nBoneCount)
   .text:0000000180A5988F                 call    sub_18163BB00
   .text:0000000180A59894                 mov     edx, [rsi+14h]
   .text:0000000180A59897                 add     edx, eax
-  .text:0000000180A59899                 mov     [rsi+18h], eax  ; 18h = CModelState::m_nAttachmentCount (structmember, struct=CModelState, member=m_nAttachmentCount)
-  .text:0000000180A5989C                 mov     [rsi+10h], edx  ; 10h = CModelState::m_nTotalTransformCount (structmember, struct=CModelState, member=m_nTotalTransformCount)
+  .text:0000000180A59899                 mov     [rsi+18h], eax  ; 18h = CSimulationState::m_nAttachmentCount (structmember, struct=CSimulationState, member=m_nAttachmentCount)
+  .text:0000000180A5989C                 mov     [rsi+10h], edx  ; 10h = CSimulationState::m_nTotalTransformCount (structmember, struct=CSimulationState, member=m_nTotalTransformCount)
   .text:0000000180A5989F                 jz      loc_180A59975
   .text:0000000180A598A5                 movsxd  r14, edx
   .text:0000000180A598A8                 mov     eax, 20h ; ' '
@@ -143,13 +143,13 @@ procedure: |-
       v8 = *(_QWORD *)hModel;
     else
       v8 = 0;
-    *(_DWORD *)(modelState + 20) = sub_181638B10(v8, 0);// 20 = 0x14 = CModelState::m_nBoneCount (structmember, struct=CModelState, member=m_nBoneCount)
+    *(_DWORD *)(modelState + 20) = sub_181638B10(v8, 0);// 20 = 0x14 = CSimulationState::m_nBoneCount (structmember, struct=CSimulationState, member=m_nBoneCount)
     nAttachmentCount = (void *)sub_18163BB00(v8); // GetAttachmentCount
     nBoneCount = *(_DWORD *)(modelState + 20);
     v11 = (_DWORD)nAttachmentCount + nBoneCount == 0;
     nTotalTransformCount = (_DWORD)nAttachmentCount + nBoneCount;
-    *(_DWORD *)(modelState + 24) = (_DWORD)nAttachmentCount;// 24 = 0x18 = CModelState::m_nAttachmentCount (structmember, struct=CModelState, member=m_nAttachmentCount)
-    *(_DWORD *)(modelState + 16) = nTotalTransformCount;// 16 = 0x10 = CModelState::m_nTotalTransformCount (structmember, struct=CModelState, member=m_nTotalTransformCount)
+    *(_DWORD *)(modelState + 24) = (_DWORD)nAttachmentCount;// 24 = 0x18 = CSimulationState::m_nAttachmentCount (structmember, struct=CSimulationState, member=m_nAttachmentCount)
+    *(_DWORD *)(modelState + 16) = nTotalTransformCount;// 16 = 0x10 = CSimulationState::m_nTotalTransformCount (structmember, struct=CSimulationState, member=m_nTotalTransformCount)
     if ( !v11 )
     {
       v13 = nTotalTransformCount;

--- a/ida_preprocessor_scripts/references/client/CSkeletonInstance_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSkeletonInstance_PostDataUpdate.windows.yaml
@@ -171,7 +171,7 @@ disasm_code: |-
   .text:0000000180A65315                 lea     rcx, [rsi+180h]
   .text:0000000180A6531C                 call    sub_181642390
   .text:0000000180A65321                 mov     rdx, [rsi+1E0h]
-  .text:0000000180A65328                 lea     rcx, [rsi+1C0h]  ; 1C0h = CSkeletonInstance::m_modelState (structmember, struct=CSkeletonInstance, member=m_modelState)
+  .text:0000000180A65328                 lea     rcx, [rsi+1C0h]  ; 1C0h = CSkeletonInstance::m_modelState.m_simulationState (structmember, struct=CSkeletonInstance, member=m_modelState.m_simulationState)
   .text:0000000180A6532F                 call    CModelState_SetupJointState
   .text:0000000180A65334                 mov     rax, [rsi+1E0h]  ; 1E0h = CSkeletonInstance::m_modelState.m_hModel (structmember, struct=CSkeletonInstance, member=m_modelState.m_hModel)
   .text:0000000180A6533B                 test    rax, rax
@@ -973,7 +973,7 @@ procedure: |-
                   }
                   sub_181642390((__int64 **)(a1 + 336), *(_QWORD *)(a1 + 480));
                   sub_181642390((__int64 **)(a1 + 384), *(_QWORD *)(a1 + 480));
-                  CModelState_SetupJointState(a1 + 448, *(_QWORD *)(a1 + 480));// 448 = 0x1C0 = CSkeletonInstance::m_modelState (structmember, struct=CSkeletonInstance, member=m_modelState)
+                  CModelState_SetupJointState(a1 + 448, *(_QWORD *)(a1 + 480));// 448 = 0x1C0 = CSkeletonInstance::m_modelState.m_simulationState (structmember, struct=CSkeletonInstance, member=m_modelState.m_simulationState)
                   hModel_1 = *(_QWORD *)(a1 + 480);// 480 = 0x1E0 = CSkeletonInstance::m_modelState.m_hModel (structmember, struct=CSkeletonInstance, member=m_modelState.m_hModel)
                   if ( hModel_1 )
                     v25 = *(Concurrency::details::SchedulerBase **)hModel_1;

--- a/ida_preprocessor_scripts/references/client/CSkeletonInstance_PostDataUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/client/CSkeletonInstance_PostDataUpdate.windows.yaml
@@ -172,7 +172,7 @@ disasm_code: |-
   .text:0000000180A6531C                 call    sub_181642390
   .text:0000000180A65321                 mov     rdx, [rsi+1E0h]
   .text:0000000180A65328                 lea     rcx, [rsi+1C0h]  ; 1C0h = CSkeletonInstance::m_modelState.m_simulationState (structmember, struct=CSkeletonInstance, member=m_modelState.m_simulationState)
-  .text:0000000180A6532F                 call    CModelState_SetupJointState
+  .text:0000000180A6532F                 call    CSimulationState_SetupJointState
   .text:0000000180A65334                 mov     rax, [rsi+1E0h]  ; 1E0h = CSkeletonInstance::m_modelState.m_hModel (structmember, struct=CSkeletonInstance, member=m_modelState.m_hModel)
   .text:0000000180A6533B                 test    rax, rax
   .text:0000000180A6533E                 jz      short loc_180A65345
@@ -973,7 +973,7 @@ procedure: |-
                   }
                   sub_181642390((__int64 **)(a1 + 336), *(_QWORD *)(a1 + 480));
                   sub_181642390((__int64 **)(a1 + 384), *(_QWORD *)(a1 + 480));
-                  CModelState_SetupJointState(a1 + 448, *(_QWORD *)(a1 + 480));// 448 = 0x1C0 = CSkeletonInstance::m_modelState.m_simulationState (structmember, struct=CSkeletonInstance, member=m_modelState.m_simulationState)
+                  CSimulationState_SetupJointState(a1 + 448, *(_QWORD *)(a1 + 480));// 448 = 0x1C0 = CSkeletonInstance::m_modelState.m_simulationState (structmember, struct=CSkeletonInstance, member=m_modelState.m_simulationState)
                   hModel_1 = *(_QWORD *)(a1 + 480);// 480 = 0x1E0 = CSkeletonInstance::m_modelState.m_hModel (structmember, struct=CSkeletonInstance, member=m_modelState.m_hModel)
                   if ( hModel_1 )
                     v25 = *(Concurrency::details::SchedulerBase **)hModel_1;


### PR DESCRIPTION
## Summary
- Rename CModelState members and setup-joint-state finder assets to CSimulationState.
- Update the 14173 analysis config and canonical symbol snapshot to use the new names.

## Validation
- `uv run python format_repo_files.py --check`
- `uv run python tests/run_test_suite.py unit -b --durations 30`
- `uv run python tests/run_test_suite.py repository-contract -b --durations 30`