### PR TITLE
feat(preprocessor): add CLoopModeGame CreateLoopMode finder

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -7990,9 +7990,27 @@ modules:
       - name: find-CLoopModeGame_vtable
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeGame_ctor
+        expected_output:
+          - CLoopModeGame_ctor.{platform}.yaml
       - name: find-CLoopModeFactory_CLoopModeGame_vtable
         expected_output:
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline
+        optional_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeGame_ctor.{platform}.yaml
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+        skip_if_exists:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        prerequisite:
+          - find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline
       - name: find-CLoopModeGame_StaticInit
         expected_output:
           - CLoopModeGame_StaticInit.{platform}.yaml
@@ -11152,6 +11170,10 @@ modules:
         category: func
         alias:
           - CLoopModeGame::StaticInit
+      - name: CLoopModeGame_ctor
+        category: func
+        alias:
+          - CLoopModeGame::CLoopModeGame
       - name: CLoopModeGame_vtable
         category: vtable
       - name: CLoopModeFactory_CLoopModeGame_vtable
@@ -11160,6 +11182,10 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+      - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
       - name: CLoopModeFactory_CLoopModeGame_Shutdown
         category: vfunc
         alias:

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for the inlined CreateLoopMode finder."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "xref_strings": [
+            "%s:  CLoopModeGame constructed\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "CLoopModeFactory_CLoopModeGame_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the vfunc when CLoopModeGame_ctor is inlined into it."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for the de-inlined CreateLoopMode finder."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CLoopModeGame_ctor",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "CLoopModeFactory_CLoopModeGame_vtable",
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the vfunc from its de-inlined constructor call."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeGame_ctor.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_ctor.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeGame_ctor skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeGame_ctor",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeGame_ctor",
+        "xref_strings": [
+            "%s:  CLoopModeGame constructed\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CLoopModeGame_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- add a CLoopModeGame constructor finder
- resolve CreateLoopMode through noinline and inlined fallback paths
- register the symbols and workflow for game version 14173

## Validation
- uv run python format_repo_files.py --check
- Python compilation for all new preprocessors
- YAML parsing for configs/14173.yaml
- git diff --check