### PR TITLE
feat(preprocessor): add CLoopModeFactory_CLoopModeGame_CreateLoopMode finders

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -8061,6 +8061,9 @@ modules:
       - name: find-CLoopModeGame_vtable
         expected_output:
           - CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeGame_ctor
+        expected_output:
+          - CLoopModeGame_ctor.{platform}.yaml
       - name: find-CLoopModeFactory_CLoopModeGame_vtable
         expected_output:
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
@@ -11223,6 +11226,10 @@ modules:
         category: func
         alias:
           - CLoopModeGame::StaticInit
+      - name: CLoopModeGame_ctor
+        category: func
+        alias:
+          - CLoopModeGame::CLoopModeGame
       - name: CLoopModeGame_vtable
         category: vtable
       - name: CLoopModeFactory_CLoopModeGame_vtable

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -8067,6 +8067,22 @@ modules:
       - name: find-CLoopModeFactory_CLoopModeGame_vtable
         expected_output:
           - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline
+        optional_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+        prerequisite:
+          - find-CLoopModeGame_ctor
+      - name: find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined
+        expected_output:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        expected_input:
+          - CLoopModeFactory_CLoopModeGame_vtable.{platform}.yaml
+        skip_if_exists:
+          - CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml
+        prerequisite:
+          - find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline
       - name: find-CLoopModeGame_StaticInit
         expected_output:
           - CLoopModeGame_StaticInit.{platform}.yaml
@@ -11238,6 +11254,10 @@ modules:
         category: vfunc
         alias:
           - CLoopModeFactory<CLoopModeGame>::Init
+      - name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+        category: vfunc
+        alias:
+          - CLoopModeFactory<CLoopModeGame>::CreateLoopMode
       - name: CLoopModeFactory_CLoopModeGame_Shutdown
         category: vfunc
         alias:

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -1333,7 +1333,7 @@ files:
   client/CSimulationState_m_nTotalTransformCount.windows.yaml:
     member_name: m_nTotalTransformCount
     offset: '0x10'
-    offset_sig: 89 7E ?? 48 85 DB 74 ??
+    offset_sig: 48 8D 6E ?? 89 7E ?? 48 85 DB
     offset_sig_disp: 0
     size: 4
     struct_name: CSimulationState
@@ -40450,5 +40450,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-31T02:57:22Z'
+last_publish_time: '2026-07-31T05:11:53Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:9b49b169515e2ec490ffc581b843ec9ab28325fefd2a1a86963ce95e1e0ce83a
-file_count: 3204
+config_sha256: sha256:645abaff12df3e838ebcc30f59c40131f9366d9cec0930f57f168d1c631b4360
+file_count: 3208
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -1333,7 +1333,7 @@ files:
   client/CSimulationState_m_nTotalTransformCount.windows.yaml:
     member_name: m_nTotalTransformCount
     offset: '0x10'
-    offset_sig: 48 8D 6E ?? 89 7E ?? 48 85 DB
+    offset_sig: 89 7E ?? 48 85 DB 74 ??
     offset_sig_disp: 0
     size: 4
     struct_name: CSimulationState
@@ -29930,6 +29930,24 @@ files:
     vtable_size: '0x88'
     vtable_symbol: ??_7CLoadingSpawnGroup@@6B@
     vtable_va: '0x181798e68'
+  server/CLoopModeFactory_CLoopModeGame_CreateLoopMode.linux.yaml:
+    func_name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    func_rva: '0x1711720'
+    func_sig: 55 BF 70 04 ?? ??
+    func_size: '0x27'
+    func_va: '0x1711720'
+    vfunc_index: 2
+    vfunc_offset: '0x10'
+    vtable_name: CLoopModeFactory_CLoopModeGame_vtable
+  server/CLoopModeFactory_CLoopModeGame_CreateLoopMode.windows.yaml:
+    func_name: CLoopModeFactory_CLoopModeGame_CreateLoopMode
+    func_rva: '0xbbf660'
+    func_sig: 48 89 74 24 ?? 57 48 83 EC ?? B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? 33 F6
+    func_size: '0x1c8'
+    func_va: '0x180bbf660'
+    vfunc_index: 2
+    vfunc_offset: '0x10'
+    vtable_name: CLoopModeFactory_CLoopModeGame_vtable
   server/CLoopModeFactory_CLoopModeGame_Init.linux.yaml:
     func_name: CLoopModeFactory_CLoopModeGame_Init
     func_rva: '0x172e5b0'
@@ -30248,6 +30266,18 @@ files:
     func_sig: 40 53 48 83 EC ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ?? FF 15 ?? ?? ?? ??
     func_size: '0xb5'
     func_va: '0x180bbf530'
+  server/CLoopModeGame_ctor.linux.yaml:
+    func_name: CLoopModeGame_ctor
+    func_rva: '0x17113b0'
+    func_sig: 55 48 8D 05 ?? ?? ?? ?? BA ?? ?? ?? ?? 41 B9 ?? ?? ?? ??
+    func_size: '0x370'
+    func_va: '0x17113b0'
+  server/CLoopModeGame_ctor.windows.yaml:
+    func_name: CLoopModeGame_ctor
+    func_rva: '0xbbf660'
+    func_sig: 48 89 74 24 ?? 57 48 83 EC ?? B9 ?? ?? ?? ?? E8 ?? ?? ?? ?? 33 F6
+    func_size: '0x1c8'
+    func_va: '0x180bbf660'
   server/CLoopModeGame_vtable.linux.yaml:
     vtable_class: CLoopModeGame
     vtable_entries:
@@ -40420,5 +40450,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T14:03:54Z'
+last_publish_time: '2026-07-31T02:57:22Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined skill.
+
+Resolves ``CLoopModeFactory_CLoopModeGame_CreateLoopMode`` (a vfunc of
+``CLoopModeFactory_CLoopModeGame_vtable``) directly from the
+``"%s:  CLoopModeGame constructed\n"`` debug string reference.  This applies when
+``CLoopModeGame_ctor`` is inlined into ``CreateLoopMode`` so the constructor's anchor
+string lives inside the factory method body.  The trailing newline is dropped from the
+xref pattern because IDA lists the string literal without it; substring matching still
+resolves the factory method.  It is the fallback for the
+``find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline`` path (which handles the
+de-inlined case) and is skipped whenever
+``CLoopModeFactory_CLoopModeGame_CreateLoopMode.{platform}.yaml`` already exists.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "xref_strings": [
+            "%s:  CLoopModeGame constructed",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CLoopModeFactory_CLoopModeGame_CreateLoopMode", "CLoopModeFactory_CLoopModeGame_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline.py
+++ b/ida_preprocessor_scripts/find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-noinline skill.
+
+Resolves ``CLoopModeFactory_CLoopModeGame_CreateLoopMode`` (a vfunc of
+``CLoopModeFactory_CLoopModeGame_vtable``) as the caller of the standalone
+``CLoopModeGame_ctor`` constructor.  This path applies when the constructor is NOT
+inlined into the factory method (e.g. server 14173, where ``CLoopModeGame_ctor`` is a
+de-inlined standalone function that ``CreateLoopMode`` calls after ``operator new``).
+The ``CLoopModeFactory_CLoopModeGame_vtable`` relation collapses the caller set to the
+single vtable member.  Its output is optional, so when the caller cannot be resolved
+(e.g. the constructor was inlined and produces no standalone body to xref) the
+``find-CLoopModeFactory_CLoopModeGame_CreateLoopMode-inlined`` fallback runs instead.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [
+            "CLoopModeGame_ctor",
+        ],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CLoopModeFactory_CLoopModeGame_CreateLoopMode", "CLoopModeFactory_CLoopModeGame_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeFactory_CLoopModeGame_CreateLoopMode",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CLoopModeGame_ctor.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_ctor.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CLoopModeGame_ctor skill.
+
+CLoopModeGame_ctor is the CLoopModeGame constructor, identified via the
+"%s:  CLoopModeGame constructed\n" debug string it references. The trailing
+newline is dropped from the xref pattern because IDA lists the string
+literal without it; substring matching still resolves the constructor.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CLoopModeGame_ctor",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CLoopModeGame_ctor",
+        "xref_strings": [
+            "%s:  CLoopModeGame constructed",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CLoopModeGame_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add preprocessor finders for `CLoopModeFactory<CLoopModeGame>::CreateLoopMode`, a vfunc (slot 2, offset `0x10`) of `CLoopModeFactory_CLoopModeGame_vtable`, resolved from the `CLoopModeGame` constructor via both the de-inlined path (`xref_funcs: CLoopModeGame_ctor`, `-noinline`) and the inlined-constructor fallback (`xref_strings: "%s:  CLoopModeGame constructed"`, `-inlined`).
- Add the supporting `find-CLoopModeGame_ctor` finder and the `configs/14173.yaml` skill + symbol entries wiring the noinline→inlined fallback chain (server, both platforms).

## Validation
- candidate preparation: passed for `14173`
- C++ post-change validation: passed with runnable tests and zero failures (13 layout / 11 vtable / 2 record compares, 0 differences)
- candidate publication: passed; published `gamesymbols/14173.yaml` SHA-256 matches the validated candidate (`sha256:3c54f1a2d4b9be819a039c851e5b7749ad3f7802bf381f498e6d46ea0fe08ec6`)
- existing committed branch: 2 initial commit(s) ahead of `origin/main`; supplemental publication commit: created (`chore(gamesymbols): publish 14173 snapshot`)
