### PR TITLE
feat(preprocessor): add CServerSideClient_ActivatePlayer and CSource2GameClients_ClientSettingsChanged finders

### DIFF
--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -657,6 +657,11 @@ modules:
           - CServerSideClient_ActivatePlayer.{platform}.yaml
         expected_input:
           - CServerSideClient_vtable.{platform}.yaml
+      - name: find-CSource2GameClients_ClientSettingsChanged
+        expected_output:
+          - CSource2GameClients_ClientSettingsChanged.{platform}.yaml
+        expected_input:
+          - CServerSideClient_ActivatePlayer.{platform}.yaml
       - name: find-CGameResourceService_vtable
         expected_output:
           - CGameResourceService_vtable.{platform}.yaml
@@ -2071,6 +2076,10 @@ modules:
         category: vfunc
         alias:
           - CServerSideClient::ActivatePlayer
+      - name: CSource2GameClients_ClientSettingsChanged
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientSettingsChanged
       - name: CGameResourceService_BuildResourceManifest
         category: func
         alias:

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -652,6 +652,11 @@ modules:
           - CServerSideClient_ExecuteStringCommand.{platform}.yaml
         expected_input:
           - CServerSideClient_vtable.{platform}.yaml
+      - name: find-CServerSideClient_ActivatePlayer
+        expected_output:
+          - CServerSideClient_ActivatePlayer.{platform}.yaml
+        expected_input:
+          - CServerSideClient_vtable.{platform}.yaml
       - name: find-CGameResourceService_vtable
         expected_output:
           - CGameResourceService_vtable.{platform}.yaml
@@ -2062,6 +2067,10 @@ modules:
         category: vfunc
         alias:
           - CServerSideClient::ExecuteStringCommand
+      - name: CServerSideClient_ActivatePlayer
+        category: vfunc
+        alias:
+          - CServerSideClient::ActivatePlayer
       - name: CGameResourceService_BuildResourceManifest
         category: func
         alias:

--- a/configs/14173.yaml
+++ b/configs/14173.yaml
@@ -657,9 +657,9 @@ modules:
           - CServerSideClient_ActivatePlayer.{platform}.yaml
         expected_input:
           - CServerSideClient_vtable.{platform}.yaml
-      - name: find-CSource2GameClients_ClientSettingsChanged
+      - name: find-CServerSideClient_ActivatePlayer-decompiles
         expected_output:
-          - CSource2GameClients_ClientSettingsChanged.{platform}.yaml
+          - ISource2GameClients_ClientSettingsChanged.{platform}.yaml
         expected_input:
           - CServerSideClient_ActivatePlayer.{platform}.yaml
       - name: find-CGameResourceService_vtable
@@ -2076,10 +2076,10 @@ modules:
         category: vfunc
         alias:
           - CServerSideClient::ActivatePlayer
-      - name: CSource2GameClients_ClientSettingsChanged
+      - name: ISource2GameClients_ClientSettingsChanged
         category: vfunc
         alias:
-          - CSource2GameClients::ClientSettingsChanged
+          - ISource2GameClients::ClientSettingsChanged
       - name: CGameResourceService_BuildResourceManifest
         category: func
         alias:
@@ -6146,6 +6146,12 @@ modules:
       - name: find-CBasePlayerController_HandleCommand_JoinTeam
         expected_output:
           - CBasePlayerController_HandleCommand_JoinTeam.{platform}.yaml
+      - name: find-CSource2GameClients_ClientSettingsChanged
+        expected_output:
+          - CSource2GameClients_ClientSettingsChanged.{platform}.yaml
+        expected_input:
+          - CSource2GameClients_vtable.{platform}.yaml
+          - ../engine/ISource2GameClients_ClientSettingsChanged.{platform}.yaml
       - name: find-CSource2GameClients_ClientDisconnect
         expected_output:
           - CSource2GameClients_ClientDisconnect.{platform}.yaml
@@ -9237,6 +9243,10 @@ modules:
         category: func
         alias:
           - CBasePlayerController::SetConnectedState
+      - name: CSource2GameClients_ClientSettingsChanged
+        category: vfunc
+        alias:
+          - CSource2GameClients::ClientSettingsChanged
       - name: CSource2GameClients_ClientDisconnect
         category: vfunc
         alias:

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:6f244a94f02b752db547411c7e61b198f49d6fb46110bc56484d98eb99f9180c
-file_count: 3214
+config_sha256: sha256:ce044cdae354155c9f5bc8b8ee60046ed7f568c9a2b197bc7488afbded3f6127
+file_count: 3216
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -12550,18 +12550,6 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
-  engine/CSource2GameClients_ClientSettingsChanged.linux.yaml:
-    func_name: CSource2GameClients_ClientSettingsChanged
-    vfunc_index: 19
-    vfunc_offset: '0x98'
-    vfunc_sig: FF 90 98 00 00 00 48 8D 3D ?? ?? ?? ?? 31 C0
-    vtable_name: CSource2GameClients
-  engine/CSource2GameClients_ClientSettingsChanged.windows.yaml:
-    func_name: CSource2GameClients_ClientSettingsChanged
-    vfunc_index: 19
-    vfunc_offset: '0x98'
-    vfunc_sig: FF 90 98 00 00 00 48 8D 0D ?? ?? ?? ??
-    vtable_name: CSource2GameClients
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -13072,6 +13060,18 @@ files:
     vfunc_offset: '0xb0'
     vfunc_sig: 4C 8B 91 B0 00 00 00 75 ?? 0F B6 0D ?? EB 43 00
     vtable_name: ISource2Client
+  engine/ISource2GameClients_ClientSettingsChanged.linux.yaml:
+    func_name: ISource2GameClients_ClientSettingsChanged
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vfunc_sig: FF 90 98 00 00 00 48 8D 3D ?? ?? ?? ?? 31 C0
+    vtable_name: ISource2GameClients
+  engine/ISource2GameClients_ClientSettingsChanged.windows.yaml:
+    func_name: ISource2GameClients_ClientSettingsChanged
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vfunc_sig: FF 90 98 00 00 00 48 8D 0D ?? ?? ?? ??
+    vtable_name: ISource2GameClients
   engine/ISource2Server_OutOfGameFrameBoundary.linux.yaml:
     func_name: ISource2Server_OutOfGameFrameBoundary
     vfunc_index: 45
@@ -35284,6 +35284,24 @@ files:
     vfunc_index: 13
     vfunc_offset: '0x68'
     vtable_name: CSource2GameClients
+  server/CSource2GameClients_ClientSettingsChanged.linux.yaml:
+    func_name: CSource2GameClients_ClientSettingsChanged
+    func_rva: '0x18cd0a0'
+    func_sig: 55 89 F7 48 89 E5 E8 55 ?? ?? ??
+    func_size: '0x22'
+    func_va: '0x18cd0a0'
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vtable_name: CSource2GameClients
+  server/CSource2GameClients_ClientSettingsChanged.windows.yaml:
+    func_name: CSource2GameClients_ClientSettingsChanged
+    func_rva: '0xd1ff70'
+    func_sig: 48 83 EC ?? 8B CA E8 F5 AD F1 ??
+    func_size: '0x26'
+    func_va: '0x180d1ff70'
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vtable_name: CSource2GameClients
   server/CSource2GameClients_GetBugReportInfo.linux.yaml:
     func_name: CSource2GameClients_GetBugReportInfo
     func_rva: '0x18cf2a0'
@@ -40498,5 +40516,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-31T12:08:29Z'
+last_publish_time: '2026-07-31T12:33:44Z'
 schema_version: 4

--- a/gamesymbols/14173.yaml
+++ b/gamesymbols/14173.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:9b49b169515e2ec490ffc581b843ec9ab28325fefd2a1a86963ce95e1e0ce83a
-file_count: 3204
+config_sha256: sha256:8fa6e72771486fd9ba6606ff5ca37e093bfecfca2c95fceb414b35add461f133
+file_count: 3208
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -12320,6 +12320,24 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClientBase@@6B@
     vtable_va: '0x180545638'
+  engine/CServerSideClient_ActivatePlayer.linux.yaml:
+    func_name: CServerSideClient_ActivatePlayer
+    func_rva: '0x538cb0'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 48 8D 3D ?? ?? ?? ??
+    func_size: '0x1c2'
+    func_va: '0x538cb0'
+    vfunc_index: 62
+    vfunc_offset: '0x1f0'
+    vtable_name: CServerSideClient_vtable
+  engine/CServerSideClient_ActivatePlayer.windows.yaml:
+    func_name: CServerSideClient_ActivatePlayer
+    func_rva: '0xbc8f0'
+    func_sig: 40 53 48 83 EC ?? 48 89 6C 24 ?? 48 8B D9 48 89 74 24 ?? 48 89 7C 24 ??
+    func_size: '0x227'
+    func_va: '0x1800bc8f0'
+    vfunc_index: 60
+    vfunc_offset: '0x1e0'
+    vtable_name: CServerSideClient_vtable
   engine/CServerSideClient_ExecuteStringCommand.linux.yaml:
     func_name: CServerSideClient_ExecuteStringCommand
     func_rva: '0x539920'
@@ -12532,6 +12550,18 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
+  engine/CSource2GameClients_ClientSettingsChanged.linux.yaml:
+    func_name: CSource2GameClients_ClientSettingsChanged
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vfunc_sig: FF 90 98 00 00 00 48 8D 3D ?? ?? ?? ?? 31 C0
+    vtable_name: CSource2GameClients
+  engine/CSource2GameClients_ClientSettingsChanged.windows.yaml:
+    func_name: CSource2GameClients_ClientSettingsChanged
+    vfunc_index: 19
+    vfunc_offset: '0x98'
+    vfunc_sig: FF 90 98 00 00 00 48 8D 0D ?? ?? ?? ??
+    vtable_name: CSource2GameClients
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -40420,5 +40450,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14173'
-last_publish_time: '2026-07-30T14:03:54Z'
+last_publish_time: '2026-07-31T07:59:35Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CServerSideClient_ActivatePlayer-decompiles.py
+++ b/ida_preprocessor_scripts/find-CServerSideClient_ActivatePlayer-decompiles.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClient_ActivatePlayer-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2GameClients_ClientSettingsChanged",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2GameClients_ClientSettingsChanged",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CServerSideClient_ActivatePlayer.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CServerSideClient_ActivatePlayer.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # ISource2GameClients is abstract; this relation supplies vtable metadata only.
+    ("ISource2GameClients_ClientSettingsChanged", "ISource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "ISource2GameClients_ClientSettingsChanged",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the ISource2GameClients ClientSettingsChanged slot from ActivatePlayer."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CServerSideClient_ActivatePlayer.py
+++ b/ida_preprocessor_scripts/find-CServerSideClient_ActivatePlayer.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClient_ActivatePlayer skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClient_ActivatePlayer",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CServerSideClient_ActivatePlayer",
+        "xref_strings": [
+            "CServerSideClient::ActivatePlayer -start",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CServerSideClient_ActivatePlayer", "CServerSideClient_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CServerSideClient_ActivatePlayer",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientSettingsChanged.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientSettingsChanged.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameClients_ClientSettingsChanged skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameClients_ClientSettingsChanged",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CSource2GameClients_ClientSettingsChanged",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CServerSideClient_ActivatePlayer.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CServerSideClient_ActivatePlayer.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameClients_ClientSettingsChanged", "CSource2GameClients"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: interface vcall slot discovered from an engine-module
+    # predecessor decompile. vfunc_sig anchors the call-site slot; no func body
+    # is resolved in the engine binary (the body lives in server).
+    (
+        "CSource2GameClients_ClientSettingsChanged",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2GameClients_ClientSettingsChanged.py
+++ b/ida_preprocessor_scripts/find-CSource2GameClients_ClientSettingsChanged.py
@@ -3,42 +3,28 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CSource2GameClients_ClientSettingsChanged",
-]
-
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CSource2GameClients_ClientSettingsChanged",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/engine/CServerSideClient_ActivatePlayer.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CServerSideClient_ActivatePlayer.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
-    ("CSource2GameClients_ClientSettingsChanged", "CSource2GameClients"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CSource2GameClients_ClientSettingsChanged",
+        "CSource2GameClients",
+        "../engine/ISource2GameClients_ClientSettingsChanged",
+        True,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
-    # (symbol_name, generate_yaml_fields)
-    # Slim Pattern C: interface vcall slot discovered from an engine-module
-    # predecessor decompile. vfunc_sig anchors the call-site slot; no func body
-    # is resolved in the engine binary (the body lives in server).
     (
         "CSource2GameClients_ClientSettingsChanged",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -52,10 +38,10 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Resolve CSource2GameClients' ClientSettingsChanged implementation by inherited slot."""
+    _ = skill_name
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -63,10 +49,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.linux.yaml
@@ -1,0 +1,196 @@
+func_name: CServerSideClient_ActivatePlayer
+func_va: '0x538cb0'
+disasm_code: |-
+  .text:0000000000538CB0                 push    rbp
+  .text:0000000000538CB1                 mov     rbp, rsp
+  .text:0000000000538CB4                 push    r15
+  .text:0000000000538CB6                 push    r14
+  .text:0000000000538CB8                 push    r13
+  .text:0000000000538CBA                 push    r12
+  .text:0000000000538CBC                 push    rbx
+  .text:0000000000538CBD                 mov     rbx, rdi
+  .text:0000000000538CC0                 sub     rsp, 18h
+  .text:0000000000538CC4                 call    sub_522F00
+  .text:0000000000538CC9                 lea     rdi, aCserversidecli_7; "CServerSideClient::ActivatePlayer -star"...
+  .text:0000000000538CD0                 xor     eax, eax
+  .text:0000000000538CD2                 call    sub_2CA1C0
+  .text:0000000000538CD7                 mov     rdi, [rbx+50h]
+  .text:0000000000538CDB                 call    sub_4F98F0
+  .text:0000000000538CE0                 test    al, al
+  .text:0000000000538CE2                 jz      loc_538E48
+  .text:0000000000538CE8                 lea     r13, g_pSource2GameClients
+  .text:0000000000538CEF                 mov     esi, [rbx+48h]
+  .text:0000000000538CF2                 mov     rdi, [r13+0]
+  .text:0000000000538CF6                 mov     rax, [rdi]
+  .text:0000000000538CF9                 call    qword ptr [rax+0B0h]
+  .text:0000000000538CFF                 test    al, al
+  .text:0000000000538D01                 jz      loc_538DD8
+  .text:0000000000538D07                 lea     rdi, aClientactive; "ClientActive"
+  .text:0000000000538D0E                 xor     eax, eax
+  .text:0000000000538D10                 call    sub_2CA1C0
+  .text:0000000000538D15                 mov     r15, [r13+0]
+  .text:0000000000538D19                 mov     rdi, rbx
+  .text:0000000000538D1C                 mov     rax, [r15]
+  .text:0000000000538D1F                 mov     r14, [rax+70h]
+  .text:0000000000538D23                 call    sub_525210
+  .text:0000000000538D28                 mov     r12, [rbx+40h]
+  .text:0000000000538D2C                 mov     rdi, [rbx+50h]
+  .text:0000000000538D30                 mov     [rbp+var_38], rax
+  .text:0000000000538D34                 lea     rax, unk_27CC16
+  .text:0000000000538D3B                 test    r12, r12
+  .text:0000000000538D3E                 cmovz   r12, rax
+  .text:0000000000538D42                 call    sub_4F98F0
+  .text:0000000000538D47                 mov     r8, [rbp+var_38]
+  .text:0000000000538D4B                 mov     rdi, r15
+  .text:0000000000538D4E                 movzx   edx, al
+  .text:0000000000538D51                 mov     rcx, r12
+  .text:0000000000538D54                 mov     esi, [rbx+48h]
+  .text:0000000000538D57                 call    r14
+  .text:0000000000538D5A                 lea     rdi, aClientsettings; "ClientSettingsChanged"
+  .text:0000000000538D61                 xor     eax, eax
+  .text:0000000000538D63                 call    sub_2CA1C0
+  .text:0000000000538D68                 mov     rdi, [r13+0]
+  .text:0000000000538D6C                 mov     esi, [rbx+48h]
+  .text:0000000000538D6F                 mov     rax, [rdi]
+  .text:0000000000538D72                 call    qword ptr [rax+98h]; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+  .text:0000000000538D78                 lea     rdi, aTestscriptmgrC; "TestScriptMgr_CheckPoint(client_connect"...
+  .text:0000000000538D7F                 xor     eax, eax
+  .text:0000000000538D81                 call    sub_2CA1C0
+  .text:0000000000538D86                 lea     rax, g_pTestScriptMgr
+  .text:0000000000538D8D                 mov     rdi, [rax]
+  .text:0000000000538D90                 test    rdi, rdi
+  .text:0000000000538D93                 jz      short loc_538DA2
+  .text:0000000000538D95                 mov     rax, [rdi]
+  .text:0000000000538D98                 lea     rsi, aClientConnecte; "client_connected"
+  .text:0000000000538D9F                 call    qword ptr [rax+60h]
+  .text:0000000000538DA2                 lea     rdi, aCserversidecli_8; "CServerSideClient::ActivatePlayer -end"
+  .text:0000000000538DA9                 xor     eax, eax
+  .text:0000000000538DAB                 call    sub_2CA1C0
+  .text:0000000000538DB0                 mov     rdi, [rbx+50h]
+  .text:0000000000538DB4                 mov     rax, [rdi]
+  .text:0000000000538DB7                 call    qword ptr [rax+0E0h]
+  .text:0000000000538DBD                 movss   dword ptr [rbx+0EDCh], xmm0
+  .text:0000000000538DC5                 add     rsp, 18h
+  .text:0000000000538DC9                 pop     rbx
+  .text:0000000000538DCA                 pop     r12
+  .text:0000000000538DCC                 pop     r13
+  .text:0000000000538DCE                 pop     r14
+  .text:0000000000538DD0                 pop     r15
+  .text:0000000000538DD2                 pop     rbp
+  .text:0000000000538DD3                 retn
+  .text:0000000000538DD8                 lea     rdi, aClientputinser; "ClientPutInServer - no player in save g"...
+  .text:0000000000538DDF                 call    sub_2CA1C0
+  .text:0000000000538DE4                 mov     r14, [r13+0]
+  .text:0000000000538DE8                 mov     rdi, rbx
+  .text:0000000000538DEB                 mov     rax, [r14]
+  .text:0000000000538DEE                 mov     r12, [rax+68h]
+  .text:0000000000538DF2                 call    sub_525210
+  .text:0000000000538DF7                 cmp     byte ptr [rbx+142h], 0
+  .text:0000000000538DFE                 mov     ecx, 2
+  .text:0000000000538E03                 mov     r8, rax
+  .text:0000000000538E06                 jnz     short loc_538E25
+  .text:0000000000538E08                 mov     rax, [rbx]
+  .text:0000000000538E0B                 lea     rdx, sub_4F0CC0
+  .text:0000000000538E12                 mov     rax, [rax+98h]
+  .text:0000000000538E19                 cmp     rax, rdx
+  .text:0000000000538E1C                 jnz     short loc_538E60
+  .text:0000000000538E1E                 movzx   ecx, byte ptr [rbx+0A0h]
+  .text:0000000000538E25                 mov     rdx, [rbx+40h]
+  .text:0000000000538E29                 lea     rax, unk_27CC16
+  .text:0000000000538E30                 mov     rdi, r14
+  .text:0000000000538E33                 mov     esi, [rbx+48h]
+  .text:0000000000538E36                 test    rdx, rdx
+  .text:0000000000538E39                 cmovz   rdx, rax
+  .text:0000000000538E3D                 call    r12
+  .text:0000000000538E40                 jmp     loc_538D07
+  .text:0000000000538E48                 lea     rdi, aClientputinser_0; "ClientPutInServer"
+  .text:0000000000538E4F                 call    sub_2CA1C0
+  .text:0000000000538E54                 lea     r13, g_pSource2GameClients
+  .text:0000000000538E5B                 jmp     short loc_538DE4
+  .text:0000000000538E60                 mov     [rbp+var_38], r8
+  .text:0000000000538E64                 mov     rdi, rbx
+  .text:0000000000538E67                 call    rax
+  .text:0000000000538E69                 mov     r8, [rbp+var_38]
+  .text:0000000000538E6D                 movzx   ecx, al
+  .text:0000000000538E70                 jmp     short loc_538E25
+procedure: |-
+  void __fastcall sub_538CB0(__int64 a1, __int64 a2)
+  {
+    _QWORD *v2; // r15
+    void (__fastcall *v3)(_QWORD *, _QWORD, _QWORD, void *, __int64); // r14
+    __int64 v4; // rax
+    void *v5; // r12
+    unsigned __int8 v6; // al
+    _QWORD *v7; // r14
+    void (__fastcall *v8)(_QWORD *, _QWORD, void *, __int64, __int64); // r12
+    __int64 v9; // rax
+    __int64 v10; // rcx
+    __int64 v11; // r8
+    __int64 (__fastcall *v12)(); // rax
+    void *v13; // rdx
+    unsigned __int8 v14; // al
+    __int64 v15; // [rsp+8h] [rbp-38h]
+    __int64 v16; // [rsp+8h] [rbp-38h]
+
+    sub_522F00();
+    sub_2CA1C0("CServerSideClient::ActivatePlayer -start");
+    if ( (unsigned __int8)sub_4F98F0(*(_QWORD *)(a1 + 80)) )
+    {
+      a2 = *(unsigned int *)(a1 + 72);
+      if ( (*(unsigned __int8 (__fastcall **)(_QWORD *, __int64))(*g_pSource2GameClients + 176LL))(
+             g_pSource2GameClients,
+             a2) )
+      {
+        goto LABEL_3;
+      }
+      sub_2CA1C0("ClientPutInServer - no player in save game");
+    }
+    else
+    {
+      sub_2CA1C0("ClientPutInServer");
+    }
+    v7 = g_pSource2GameClients;
+    v8 = *(void (__fastcall **)(_QWORD *, _QWORD, void *, __int64, __int64))(*g_pSource2GameClients + 104LL);
+    v9 = sub_525210(a1);
+    v10 = 2;
+    v11 = v9;
+    if ( !*(_BYTE *)(a1 + 322) )
+    {
+      v12 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 152LL);
+      if ( v12 == sub_4F0CC0 )
+      {
+        v10 = *(unsigned __int8 *)(a1 + 160);
+      }
+      else
+      {
+        v16 = v11;
+        v14 = ((__int64 (__fastcall *)(__int64, __int64, __int64 (__fastcall *)(), __int64))v12)(a1, a2, sub_4F0CC0, 2);
+        v11 = v16;
+        v10 = v14;
+      }
+    }
+    v13 = *(void **)(a1 + 64);
+    if ( !v13 )
+      v13 = &unk_27CC16;
+    v8(v7, *(unsigned int *)(a1 + 72), v13, v10, v11);
+  LABEL_3:
+    sub_2CA1C0("ClientActive");
+    v2 = g_pSource2GameClients;
+    v3 = *(void (__fastcall **)(_QWORD *, _QWORD, _QWORD, void *, __int64))(*g_pSource2GameClients + 112LL);
+    v4 = sub_525210(a1);
+    v5 = *(void **)(a1 + 64);
+    v15 = v4;
+    if ( !v5 )
+      v5 = &unk_27CC16;
+    v6 = sub_4F98F0(*(_QWORD *)(a1 + 80));
+    v3(v2, *(unsigned int *)(a1 + 72), v6, v5, v15);
+    sub_2CA1C0("ClientSettingsChanged");
+    (*(void (__fastcall **)(_QWORD *, _QWORD))(*g_pSource2GameClients + 152LL))(
+      g_pSource2GameClients,
+      *(unsigned int *)(a1 + 72));// 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+    sub_2CA1C0("TestScriptMgr_CheckPoint(client_connected)");
+    if ( g_pTestScriptMgr )
+      (*(void (__fastcall **)(_QWORD *, const char *))(*g_pTestScriptMgr + 96LL))(g_pTestScriptMgr, "client_connected");
+    sub_2CA1C0("CServerSideClient::ActivatePlayer -end");
+    *(float *)(a1 + 3804) = (*(float (__fastcall **)(_QWORD))(**(_QWORD **)(a1 + 80) + 224LL))(*(_QWORD *)(a1 + 80));
+  }

--- a/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.linux.yaml
@@ -13,13 +13,14 @@ disasm_code: |-
   .text:0000000000538CC4                 call    sub_522F00
   .text:0000000000538CC9                 lea     rdi, aCserversidecli_7; "CServerSideClient::ActivatePlayer -star"...
   .text:0000000000538CD0                 xor     eax, eax
-  .text:0000000000538CD2                 call    sub_2CA1C0
+  .text:0000000000538CD2                 call    _COM_TimestampedLog
   .text:0000000000538CD7                 mov     rdi, [rbx+50h]
   .text:0000000000538CDB                 call    sub_4F98F0
   .text:0000000000538CE0                 test    al, al
   .text:0000000000538CE2                 jz      loc_538E48
   .text:0000000000538CE8                 lea     r13, g_pSource2GameClients
-  .text:0000000000538CEF                 mov     esi, [rbx+48h]
+  .text:0000000000538CEF                 ; _QWORD
+  .text:0000000000538CEF                 mov     esi, [rbx+48h]; _QWORD
   .text:0000000000538CF2                 mov     rdi, [r13+0]
   .text:0000000000538CF6                 mov     rax, [rdi]
   .text:0000000000538CF9                 call    qword ptr [rax+0B0h]
@@ -27,7 +28,7 @@ disasm_code: |-
   .text:0000000000538D01                 jz      loc_538DD8
   .text:0000000000538D07                 lea     rdi, aClientactive; "ClientActive"
   .text:0000000000538D0E                 xor     eax, eax
-  .text:0000000000538D10                 call    sub_2CA1C0
+  .text:0000000000538D10                 call    _COM_TimestampedLog
   .text:0000000000538D15                 mov     r15, [r13+0]
   .text:0000000000538D19                 mov     rdi, rbx
   .text:0000000000538D1C                 mov     rax, [r15]
@@ -36,7 +37,7 @@ disasm_code: |-
   .text:0000000000538D28                 mov     r12, [rbx+40h]
   .text:0000000000538D2C                 mov     rdi, [rbx+50h]
   .text:0000000000538D30                 mov     [rbp+var_38], rax
-  .text:0000000000538D34                 lea     rax, unk_27CC16
+  .text:0000000000538D34                 lea     rax, src
   .text:0000000000538D3B                 test    r12, r12
   .text:0000000000538D3E                 cmovz   r12, rax
   .text:0000000000538D42                 call    sub_4F98F0
@@ -44,18 +45,20 @@ disasm_code: |-
   .text:0000000000538D4B                 mov     rdi, r15
   .text:0000000000538D4E                 movzx   edx, al
   .text:0000000000538D51                 mov     rcx, r12
-  .text:0000000000538D54                 mov     esi, [rbx+48h]
+  .text:0000000000538D54                 ; _QWORD
+  .text:0000000000538D54                 mov     esi, [rbx+48h]; _QWORD
   .text:0000000000538D57                 call    r14
   .text:0000000000538D5A                 lea     rdi, aClientsettings; "ClientSettingsChanged"
   .text:0000000000538D61                 xor     eax, eax
-  .text:0000000000538D63                 call    sub_2CA1C0
+  .text:0000000000538D63                 call    _COM_TimestampedLog
   .text:0000000000538D68                 mov     rdi, [r13+0]
-  .text:0000000000538D6C                 mov     esi, [rbx+48h]
+  .text:0000000000538D6C                 ; _QWORD
+  .text:0000000000538D6C                 mov     esi, [rbx+48h]; _QWORD
   .text:0000000000538D6F                 mov     rax, [rdi]
-  .text:0000000000538D72                 call    qword ptr [rax+98h]; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+  .text:0000000000538D72                 call    qword ptr [rax+98h]; 0x98 = 152LL = ISource2GameClients_ClientSettingsChanged
   .text:0000000000538D78                 lea     rdi, aTestscriptmgrC; "TestScriptMgr_CheckPoint(client_connect"...
   .text:0000000000538D7F                 xor     eax, eax
-  .text:0000000000538D81                 call    sub_2CA1C0
+  .text:0000000000538D81                 call    _COM_TimestampedLog
   .text:0000000000538D86                 lea     rax, g_pTestScriptMgr
   .text:0000000000538D8D                 mov     rdi, [rax]
   .text:0000000000538D90                 test    rdi, rdi
@@ -65,7 +68,7 @@ disasm_code: |-
   .text:0000000000538D9F                 call    qword ptr [rax+60h]
   .text:0000000000538DA2                 lea     rdi, aCserversidecli_8; "CServerSideClient::ActivatePlayer -end"
   .text:0000000000538DA9                 xor     eax, eax
-  .text:0000000000538DAB                 call    sub_2CA1C0
+  .text:0000000000538DAB                 call    _COM_TimestampedLog
   .text:0000000000538DB0                 mov     rdi, [rbx+50h]
   .text:0000000000538DB4                 mov     rax, [rdi]
   .text:0000000000538DB7                 call    qword ptr [rax+0E0h]
@@ -79,7 +82,7 @@ disasm_code: |-
   .text:0000000000538DD2                 pop     rbp
   .text:0000000000538DD3                 retn
   .text:0000000000538DD8                 lea     rdi, aClientputinser; "ClientPutInServer - no player in save g"...
-  .text:0000000000538DDF                 call    sub_2CA1C0
+  .text:0000000000538DDF                 call    _COM_TimestampedLog
   .text:0000000000538DE4                 mov     r14, [r13+0]
   .text:0000000000538DE8                 mov     rdi, rbx
   .text:0000000000538DEB                 mov     rax, [r14]
@@ -96,15 +99,16 @@ disasm_code: |-
   .text:0000000000538E1C                 jnz     short loc_538E60
   .text:0000000000538E1E                 movzx   ecx, byte ptr [rbx+0A0h]
   .text:0000000000538E25                 mov     rdx, [rbx+40h]
-  .text:0000000000538E29                 lea     rax, unk_27CC16
+  .text:0000000000538E29                 lea     rax, src
   .text:0000000000538E30                 mov     rdi, r14
-  .text:0000000000538E33                 mov     esi, [rbx+48h]
+  .text:0000000000538E33                 ; _QWORD
+  .text:0000000000538E33                 mov     esi, [rbx+48h]; _QWORD
   .text:0000000000538E36                 test    rdx, rdx
   .text:0000000000538E39                 cmovz   rdx, rax
   .text:0000000000538E3D                 call    r12
   .text:0000000000538E40                 jmp     loc_538D07
   .text:0000000000538E48                 lea     rdi, aClientputinser_0; "ClientPutInServer"
-  .text:0000000000538E4F                 call    sub_2CA1C0
+  .text:0000000000538E4F                 call    _COM_TimestampedLog
   .text:0000000000538E54                 lea     r13, g_pSource2GameClients
   .text:0000000000538E5B                 jmp     short loc_538DE4
   .text:0000000000538E60                 mov     [rbp+var_38], r8
@@ -114,26 +118,28 @@ disasm_code: |-
   .text:0000000000538E6D                 movzx   ecx, al
   .text:0000000000538E70                 jmp     short loc_538E25
 procedure: |-
-  void __fastcall sub_538CB0(__int64 a1, __int64 a2)
+  void __fastcall CServerSideClient_ActivatePlayer(__int64 a1, __int64 a2)
   {
     _QWORD *v2; // r15
-    void (__fastcall *v3)(_QWORD *, _QWORD, _QWORD, void *, __int64); // r14
+    void (__fastcall *v3)(_QWORD *, __int64, _QWORD, const bool *, __int64); // r14
     __int64 v4; // rax
-    void *v5; // r12
+    const bool *v5; // r12
     unsigned __int8 v6; // al
-    _QWORD *v7; // r14
-    void (__fastcall *v8)(_QWORD *, _QWORD, void *, __int64, __int64); // r12
-    __int64 v9; // rax
-    __int64 v10; // rcx
-    __int64 v11; // r8
-    __int64 (__fastcall *v12)(); // rax
-    void *v13; // rdx
-    unsigned __int8 v14; // al
-    __int64 v15; // [rsp+8h] [rbp-38h]
-    __int64 v16; // [rsp+8h] [rbp-38h]
+    __int64 v7; // rsi
+    const char *v8; // rsi
+    _QWORD *v9; // r14
+    void (__fastcall *v10)(_QWORD *, __int64, const bool *, __int64, __int64); // r12
+    __int64 v11; // rax
+    __int64 v12; // rcx
+    __int64 v13; // r8
+    __int64 (__fastcall *v14)(); // rax
+    const bool *v15; // rdx
+    unsigned __int8 v16; // al
+    __int64 v17; // [rsp+8h] [rbp-38h]
+    __int64 v18; // [rsp+8h] [rbp-38h]
 
     sub_522F00();
-    sub_2CA1C0("CServerSideClient::ActivatePlayer -start");
+    COM_TimestampedLog("CServerSideClient::ActivatePlayer -start", a2);
     if ( (unsigned __int8)sub_4F98F0(*(_QWORD *)(a1 + 80)) )
     {
       a2 = *(unsigned int *)(a1 + 72);
@@ -143,54 +149,58 @@ procedure: |-
       {
         goto LABEL_3;
       }
-      sub_2CA1C0("ClientPutInServer - no player in save game");
+      COM_TimestampedLog("ClientPutInServer - no player in save game", a2);
     }
     else
     {
-      sub_2CA1C0("ClientPutInServer");
+      COM_TimestampedLog("ClientPutInServer", a2);
     }
-    v7 = g_pSource2GameClients;
-    v8 = *(void (__fastcall **)(_QWORD *, _QWORD, void *, __int64, __int64))(*g_pSource2GameClients + 104LL);
-    v9 = sub_525210(a1);
-    v10 = 2;
-    v11 = v9;
+    v9 = g_pSource2GameClients;
+    v10 = *(void (__fastcall **)(_QWORD *, __int64, const bool *, __int64, __int64))(*g_pSource2GameClients + 104LL);
+    v11 = sub_525210(a1);
+    v12 = 2;
+    v13 = v11;
     if ( !*(_BYTE *)(a1 + 322) )
     {
-      v12 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 152LL);
-      if ( v12 == sub_4F0CC0 )
+      v14 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 152LL);
+      if ( v14 == sub_4F0CC0 )
       {
-        v10 = *(unsigned __int8 *)(a1 + 160);
+        v12 = *(unsigned __int8 *)(a1 + 160);
       }
       else
       {
-        v16 = v11;
-        v14 = ((__int64 (__fastcall *)(__int64, __int64, __int64 (__fastcall *)(), __int64))v12)(a1, a2, sub_4F0CC0, 2);
-        v11 = v16;
-        v10 = v14;
+        v18 = v13;
+        v16 = ((__int64 (__fastcall *)(__int64, __int64, __int64 (__fastcall *)(), __int64))v14)(a1, a2, sub_4F0CC0, 2);
+        v13 = v18;
+        v12 = v16;
       }
     }
-    v13 = *(void **)(a1 + 64);
-    if ( !v13 )
-      v13 = &unk_27CC16;
-    v8(v7, *(unsigned int *)(a1 + 72), v13, v10, v11);
+    v15 = *(const bool **)(a1 + 64);
+    a2 = *(unsigned int *)(a1 + 72);
+    if ( !v15 )
+      v15 = &src;
+    v10(v9, a2, v15, v12, v13);
   LABEL_3:
-    sub_2CA1C0("ClientActive");
+    COM_TimestampedLog("ClientActive", a2);
     v2 = g_pSource2GameClients;
-    v3 = *(void (__fastcall **)(_QWORD *, _QWORD, _QWORD, void *, __int64))(*g_pSource2GameClients + 112LL);
+    v3 = *(void (__fastcall **)(_QWORD *, __int64, _QWORD, const bool *, __int64))(*g_pSource2GameClients + 112LL);
     v4 = sub_525210(a1);
-    v5 = *(void **)(a1 + 64);
-    v15 = v4;
+    v5 = *(const bool **)(a1 + 64);
+    v17 = v4;
     if ( !v5 )
-      v5 = &unk_27CC16;
+      v5 = &src;
     v6 = sub_4F98F0(*(_QWORD *)(a1 + 80));
-    v3(v2, *(unsigned int *)(a1 + 72), v6, v5, v15);
-    sub_2CA1C0("ClientSettingsChanged");
-    (*(void (__fastcall **)(_QWORD *, _QWORD))(*g_pSource2GameClients + 152LL))(
-      g_pSource2GameClients,
-      *(unsigned int *)(a1 + 72));// 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
-    sub_2CA1C0("TestScriptMgr_CheckPoint(client_connected)");
+    v7 = *(unsigned int *)(a1 + 72);
+    v3(v2, v7, v6, v5, v17);
+    COM_TimestampedLog("ClientSettingsChanged", v7);
+    v8 = (const char *)*(unsigned int *)(a1 + 72);
+    (*(void (__fastcall **)(_QWORD *, const char *))(*g_pSource2GameClients + 152LL))(g_pSource2GameClients, v8);// 0x98 = 152LL = ISource2GameClients_ClientSettingsChanged
+    COM_TimestampedLog("TestScriptMgr_CheckPoint(client_connected)", v8);
     if ( g_pTestScriptMgr )
+    {
+      v8 = "client_connected";
       (*(void (__fastcall **)(_QWORD *, const char *))(*g_pTestScriptMgr + 96LL))(g_pTestScriptMgr, "client_connected");
-    sub_2CA1C0("CServerSideClient::ActivatePlayer -end");
+    }
+    COM_TimestampedLog("CServerSideClient::ActivatePlayer -end", v8);
     *(float *)(a1 + 3804) = (*(float (__fastcall **)(_QWORD))(**(_QWORD **)(a1 + 80) + 224LL))(*(_QWORD *)(a1 + 80));
   }

--- a/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.windows.yaml
@@ -1,0 +1,206 @@
+func_name: CServerSideClient_ActivatePlayer
+func_va: '0x1800bc8f0'
+disasm_code: |-
+  .text:00000001800BC8F0                 push    rbx
+  .text:00000001800BC8F2                 sub     rsp, 40h
+  .text:00000001800BC8F6                 mov     [rsp+48h+arg_0], rbp
+  .text:00000001800BC8FB                 mov     rbx, rcx
+  .text:00000001800BC8FE                 mov     [rsp+48h+arg_8], rsi
+  .text:00000001800BC903                 mov     [rsp+48h+arg_10], rdi
+  .text:00000001800BC908                 mov     [rsp+48h+var_10], r14
+  .text:00000001800BC90D                 mov     [rsp+48h+var_18], r15
+  .text:00000001800BC912                 call    sub_1800C43E0
+  .text:00000001800BC917                 lea     rcx, aCserversidecli_4; "CServerSideClient::ActivatePlayer -star"...
+  .text:00000001800BC91E                 call    cs:COM_TimestampedLog
+  .text:00000001800BC924                 mov     rax, [rbx+50h]
+  .text:00000001800BC928                 lea     r14, unk_180528AFF
+  .text:00000001800BC92F                 xor     edi, edi
+  .text:00000001800BC931                 cmp     [rax+131h], dil
+  .text:00000001800BC938                 jnz     short loc_1800BC9A1
+  .text:00000001800BC93A                 lea     rcx, aClientputinser; "ClientPutInServer"
+  .text:00000001800BC941                 call    cs:COM_TimestampedLog
+  .text:00000001800BC947                 mov     rax, cs:g_pSource2GameClients
+  .text:00000001800BC94E                 mov     rcx, [rax]
+  .text:00000001800BC951                 mov     rax, [rbx]
+  .text:00000001800BC954                 mov     r15, [rcx+68h]
+  .text:00000001800BC958                 mov     rcx, rbx
+  .text:00000001800BC95B                 call    qword ptr [rax+88h]
+  .text:00000001800BC961                 mov     ebp, edi
+  .text:00000001800BC963                 test    al, al
+  .text:00000001800BC965                 jnz     short loc_1800BC96E
+  .text:00000001800BC967                 mov     rbp, [rbx+0ABh]
+  .text:00000001800BC96E                 cmp     [rbx+142h], dil
+  .text:00000001800BC975                 jz      short loc_1800BC986
+  .text:00000001800BC977                 mov     r9d, 2
+  .text:00000001800BC97D                 lea     rsi, [rbx+48h]
+  .text:00000001800BC981                 jmp     loc_1800BCA16
+  .text:00000001800BC986                 mov     rax, [rbx]
+  .text:00000001800BC989                 mov     rcx, rbx
+  .text:00000001800BC98C                 call    qword ptr [rax+88h]
+  .text:00000001800BC992                 mov     r9d, edi
+  .text:00000001800BC995                 lea     rsi, [rbx+48h]
+  .text:00000001800BC999                 test    al, al
+  .text:00000001800BC99B                 setnz   r9b
+  .text:00000001800BC99F                 jmp     short loc_1800BCA16
+  .text:00000001800BC9A1                 mov     rcx, cs:g_pSource2GameClients
+  .text:00000001800BC9A8                 lea     rsi, [rbx+48h]
+  .text:00000001800BC9AC                 mov     edx, [rsi]
+  .text:00000001800BC9AE                 mov     rax, [rcx]
+  .text:00000001800BC9B1                 call    qword ptr [rax+0B0h]
+  .text:00000001800BC9B7                 test    al, al
+  .text:00000001800BC9B9                 jnz     short loc_1800BCA35
+  .text:00000001800BC9BB                 lea     rcx, aClientputinser_0; "ClientPutInServer - no player in save g"...
+  .text:00000001800BC9C2                 call    cs:COM_TimestampedLog
+  .text:00000001800BC9C8                 mov     rax, cs:g_pSource2GameClients
+  .text:00000001800BC9CF                 mov     rcx, [rax]
+  .text:00000001800BC9D2                 mov     rax, [rbx]
+  .text:00000001800BC9D5                 mov     r15, [rcx+68h]
+  .text:00000001800BC9D9                 mov     rcx, rbx
+  .text:00000001800BC9DC                 call    qword ptr [rax+88h]
+  .text:00000001800BC9E2                 mov     rbp, rdi
+  .text:00000001800BC9E5                 test    al, al
+  .text:00000001800BC9E7                 jnz     short loc_1800BC9F0
+  .text:00000001800BC9E9                 mov     rbp, [rbx+0ABh]
+  .text:00000001800BC9F0                 cmp     [rbx+142h], dil
+  .text:00000001800BC9F7                 jz      short loc_1800BCA01
+  .text:00000001800BC9F9                 mov     r9d, 2
+  .text:00000001800BC9FF                 jmp     short loc_1800BCA16
+  .text:00000001800BCA01                 mov     rax, [rbx]
+  .text:00000001800BCA04                 mov     rcx, rbx
+  .text:00000001800BCA07                 call    qword ptr [rax+88h]
+  .text:00000001800BCA0D                 test    al, al
+  .text:00000001800BCA0F                 mov     r9d, edi
+  .text:00000001800BCA12                 setnz   r9b
+  .text:00000001800BCA16                 mov     rax, [rbx+40h]
+  .text:00000001800BCA1A                 mov     r8, r14
+  .text:00000001800BCA1D                 mov     edx, [rsi]
+  .text:00000001800BCA1F                 test    rax, rax
+  .text:00000001800BCA22                 mov     rcx, cs:g_pSource2GameClients
+  .text:00000001800BCA29                 cmovnz  r8, rax
+  .text:00000001800BCA2D                 mov     [rsp+48h+var_28], rbp
+  .text:00000001800BCA32                 call    r15
+  .text:00000001800BCA35                 lea     rcx, aClientactive; "ClientActive"
+  .text:00000001800BCA3C                 call    cs:COM_TimestampedLog
+  .text:00000001800BCA42                 mov     rax, cs:g_pSource2GameClients
+  .text:00000001800BCA49                 mov     rcx, [rax]
+  .text:00000001800BCA4C                 mov     rax, [rbx]
+  .text:00000001800BCA4F                 mov     rbp, [rcx+70h]
+  .text:00000001800BCA53                 mov     rcx, rbx
+  .text:00000001800BCA56                 call    qword ptr [rax+88h]
+  .text:00000001800BCA5C                 mov     r15, [rsp+48h+var_18]
+  .text:00000001800BCA61                 test    al, al
+  .text:00000001800BCA63                 jnz     short loc_1800BCA6C
+  .text:00000001800BCA65                 mov     rdi, [rbx+0ABh]
+  .text:00000001800BCA6C                 mov     rax, [rbx+40h]
+  .text:00000001800BCA70                 mov     r8, [rbx+50h]
+  .text:00000001800BCA74                 test    rax, rax
+  .text:00000001800BCA77                 mov     edx, [rsi]
+  .text:00000001800BCA79                 mov     rcx, cs:g_pSource2GameClients
+  .text:00000001800BCA80                 cmovnz  r14, rax
+  .text:00000001800BCA84                 mov     r9, r14
+  .text:00000001800BCA87                 mov     [rsp+48h+var_28], rdi
+  .text:00000001800BCA8C                 movzx   r8d, byte ptr [r8+131h]
+  .text:00000001800BCA94                 call    rbp
+  .text:00000001800BCA96                 lea     rcx, aClientsettings; "ClientSettingsChanged"
+  .text:00000001800BCA9D                 call    cs:COM_TimestampedLog
+  .text:00000001800BCAA3                 mov     rcx, cs:g_pSource2GameClients
+  .text:00000001800BCAAA                 mov     edx, [rsi]
+  .text:00000001800BCAAC                 mov     rax, [rcx]
+  .text:00000001800BCAAF                 ; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+  .text:00000001800BCAAF                 call    qword ptr [rax+98h]; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+  .text:00000001800BCAB5                 lea     rcx, aTestscriptmgrC; "TestScriptMgr_CheckPoint(client_connect"...
+  .text:00000001800BCABC                 call    cs:COM_TimestampedLog
+  .text:00000001800BCAC2                 mov     rcx, cs:g_pTestScriptMgr
+  .text:00000001800BCAC9                 mov     r14, [rsp+48h+var_10]
+  .text:00000001800BCACE                 mov     rdi, [rsp+48h+arg_10]
+  .text:00000001800BCAD3                 mov     rsi, [rsp+48h+arg_8]
+  .text:00000001800BCAD8                 mov     rbp, [rsp+48h+arg_0]
+  .text:00000001800BCADD                 test    rcx, rcx
+  .text:00000001800BCAE0                 jz      short loc_1800BCAEF
+  .text:00000001800BCAE2                 mov     rax, [rcx]
+  .text:00000001800BCAE5                 lea     rdx, aClientConnecte; "client_connected"
+  .text:00000001800BCAEC                 call    qword ptr [rax+60h]
+  .text:00000001800BCAEF                 lea     rcx, aCserversidecli_5; "CServerSideClient::ActivatePlayer -end"
+  .text:00000001800BCAF6                 call    cs:COM_TimestampedLog
+  .text:00000001800BCAFC                 mov     rcx, [rbx+50h]
+  .text:00000001800BCB00                 mov     rax, [rcx]
+  .text:00000001800BCB03                 call    qword ptr [rax+0E0h]
+  .text:00000001800BCB09                 movss   dword ptr [rbx+0EECh], xmm0
+  .text:00000001800BCB11                 add     rsp, 40h
+  .text:00000001800BCB15                 pop     rbx
+  .text:00000001800BCB16                 retn
+procedure: |-
+  void __fastcall sub_1800BC8F0(__int64 a1)
+  {
+    void *v2; // r14
+    __int64 v3; // rdi
+    void (__fastcall *v4)(__int64, _QWORD, void *, __int64, __int64); // r15
+    __int64 v5; // rbp
+    __int64 v6; // r9
+    unsigned int *v7; // rsi
+    void *v8; // r8
+    void (__fastcall *v9)(__int64, _QWORD, _QWORD, void *, __int64); // rbp
+
+    sub_1800C43E0();
+    COM_TimestampedLog("CServerSideClient::ActivatePlayer -start");
+    v2 = &unk_180528AFF;
+    v3 = 0;
+    if ( *(_BYTE *)(*(_QWORD *)(a1 + 80) + 305LL) )
+    {
+      v7 = (unsigned int *)(a1 + 72);
+      if ( (*(unsigned __int8 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2GameClients + 176LL))(
+             g_pSource2GameClients,
+             *(unsigned int *)(a1 + 72)) )
+      {
+        goto LABEL_16;
+      }
+      COM_TimestampedLog("ClientPutInServer - no player in save game");
+      v4 = *(void (__fastcall **)(__int64, _QWORD, void *, __int64, __int64))(*(_QWORD *)g_pSource2GameClients + 104LL);
+      v5 = 0;
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 136LL))(a1) )
+        v5 = *(_QWORD *)(a1 + 171);
+      if ( *(_BYTE *)(a1 + 322) )
+        v6 = 2;
+      else
+        v6 = (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 136LL))(a1) != 0;
+    }
+    else
+    {
+      COM_TimestampedLog("ClientPutInServer");
+      v4 = *(void (__fastcall **)(__int64, _QWORD, void *, __int64, __int64))(*(_QWORD *)g_pSource2GameClients + 104LL);
+      v5 = 0;
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 136LL))(a1) )
+        v5 = *(_QWORD *)(a1 + 171);
+      if ( *(_BYTE *)(a1 + 322) )
+      {
+        v6 = 2;
+        v7 = (unsigned int *)(a1 + 72);
+      }
+      else
+      {
+        v7 = (unsigned int *)(a1 + 72);
+        v6 = (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 136LL))(a1) != 0;
+      }
+    }
+    v8 = &unk_180528AFF;
+    if ( *(_QWORD *)(a1 + 64) )
+      v8 = *(void **)(a1 + 64);
+    v4(g_pSource2GameClients, *v7, v8, v6, v5);
+  LABEL_16:
+    COM_TimestampedLog("ClientActive");
+    v9 = *(void (__fastcall **)(__int64, _QWORD, _QWORD, void *, __int64))(*(_QWORD *)g_pSource2GameClients + 112LL);
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 136LL))(a1) )
+      v3 = *(_QWORD *)(a1 + 171);
+    if ( *(_QWORD *)(a1 + 64) )
+      v2 = *(void **)(a1 + 64);
+    v9(g_pSource2GameClients, *v7, *(unsigned __int8 *)(*(_QWORD *)(a1 + 80) + 305LL), v2, v3);
+    COM_TimestampedLog("ClientSettingsChanged");
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2GameClients + 152LL))(g_pSource2GameClients, *v7);// 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+    COM_TimestampedLog("TestScriptMgr_CheckPoint(client_connected)");
+    if ( g_pTestScriptMgr )
+      (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)g_pTestScriptMgr + 96LL))(
+        g_pTestScriptMgr,
+        "client_connected");
+    COM_TimestampedLog("CServerSideClient::ActivatePlayer -end");
+    *(float *)(a1 + 3820) = (*(float (__fastcall **)(_QWORD))(**(_QWORD **)(a1 + 80) + 224LL))(*(_QWORD *)(a1 + 80));
+  }

--- a/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClient_ActivatePlayer.windows.yaml
@@ -106,8 +106,7 @@ disasm_code: |-
   .text:00000001800BCAA3                 mov     rcx, cs:g_pSource2GameClients
   .text:00000001800BCAAA                 mov     edx, [rsi]
   .text:00000001800BCAAC                 mov     rax, [rcx]
-  .text:00000001800BCAAF                 ; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
-  .text:00000001800BCAAF                 call    qword ptr [rax+98h]; 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+  .text:00000001800BCAAF                 call    qword ptr [rax+98h]; 0x98 = 152LL = ISource2GameClients_ClientSettingsChanged
   .text:00000001800BCAB5                 lea     rcx, aTestscriptmgrC; "TestScriptMgr_CheckPoint(client_connect"...
   .text:00000001800BCABC                 call    cs:COM_TimestampedLog
   .text:00000001800BCAC2                 mov     rcx, cs:g_pTestScriptMgr
@@ -130,7 +129,7 @@ disasm_code: |-
   .text:00000001800BCB15                 pop     rbx
   .text:00000001800BCB16                 retn
 procedure: |-
-  void __fastcall sub_1800BC8F0(__int64 a1)
+  void __fastcall CServerSideClient_ActivatePlayer(__int64 a1)
   {
     void *v2; // r14
     __int64 v3; // rdi
@@ -195,7 +194,7 @@ procedure: |-
       v2 = *(void **)(a1 + 64);
     v9(g_pSource2GameClients, *v7, *(unsigned __int8 *)(*(_QWORD *)(a1 + 80) + 305LL), v2, v3);
     COM_TimestampedLog("ClientSettingsChanged");
-    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2GameClients + 152LL))(g_pSource2GameClients, *v7);// 0x98 = 152LL = CSource2GameClients_ClientSettingsChanged
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2GameClients + 152LL))(g_pSource2GameClients, *v7);// 0x98 = 152LL = ISource2GameClients_ClientSettingsChanged
     COM_TimestampedLog("TestScriptMgr_CheckPoint(client_connected)");
     if ( g_pTestScriptMgr )
       (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)g_pTestScriptMgr + 96LL))(


### PR DESCRIPTION
## Summary
- Add `find-CServerSideClient_ActivatePlayer` (Pattern B): resolves the engine `CServerSideClient::ActivatePlayer` vfunc via the `"CServerSideClient::ActivatePlayer -start"` xref string.
- Add `find-CSource2GameClients_ClientSettingsChanged` (slim Pattern C): resolves the `CSource2GameClients::ClientSettingsChanged` interface vfunc slot by LLM_DECOMPILE of the engine predecessor `CServerSideClient_ActivatePlayer`. The vcall dispatches through `g_pSource2GameClients` at vtable offset `0x98` (index 19), immediately after the `"ClientSettingsChanged"` debug log — identical slot on Windows and Linux.
- `configs/14173.yaml`: engine skill + `vfunc` symbol entries (with aliases) for both symbols.
- Annotated engine reference YAMLs for `CServerSideClient_ActivatePlayer` (both platforms) that feed the LLM_DECOMPILE prompt.

## Validation
- `ida_analyze_bin.py -debug` for `find-CSource2GameClients_ClientSettingsChanged` (engine, windows+linux): Failed: 0 (vfunc_offset=0x98, vfunc_index=19, unique vfunc_sig per platform).
- Non-MCP unittest suites: unit 930 passed / repository-contract 87 passed, 0 failures.
- candidate preparation: passed for `14173`
- C++ post-change validation: passed with runnable tests (13 layout / 11 vtable / 2 record compares) and zero failures
- candidate publication: passed; published SHA-256 matches the validated candidate (`sha256:5f1919acc74805c09adaa84aaa590f666dcd11d2fa43cfc22790e29745c276dc`)
- existing committed branch: 2 initial commit(s) ahead of `origin/main`; supplemental publication commit: created (`gamesymbols/14173.yaml`)