### PR TITLE
feat(preprocessor): add decal placement finder chain

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -41,6 +41,7 @@ and stop if that file does not exist. Never fall back to another game version.
 - Run from the repository root and require an `origin` remote plus successful `gh auth status`.
 - Never commit directly to `main`, force-push, amend an existing commit, or use `git add -A` / `git add .`.
 - Preserve unrelated untracked files and never stage them.
+- **Never impose a 64-second execution timeout** on candidate preparation, C++ validation, or candidate publication. When a command may outlive the interactive timeout, start it as a background task and poll its log and exit status until it finishes.
 - Require zero unstaged tracked changes at invocation. This forbids partially staged paths and prevents the
   formatter from absorbing unrelated work.
 - In `staged-delivery`, treat the initial staged path list as immutable authorization. Do not add other source,

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -6007,9 +6007,15 @@ modules:
           - CBasePlayerPawn_OnTakeDamage_Alive.{platform}.yaml
           - CBasePlayerPawn_OnTakeDamage_Dying.{platform}.yaml
           - CBasePlayerPawn_OnTakeDamage_Dead.{platform}.yaml
+          - DecalPlacementInfo_ctor.{platform}.yaml
         expected_input:
           - CBasePlayerPawn_OnTakeDamage.{platform}.yaml
           - CBasePlayerPawn_vtable.{platform}.yaml
+      - name: find-DecalPlacementInfo_ctor-decompiles
+        expected_output:
+          - CBaseModelEntity_GetBoneTransform.{platform}.yaml
+        expected_input:
+          - DecalPlacementInfo_ctor.{platform}.yaml
       - name: find-CCSPlayerPawn_OnTakeDamage
         expected_output:
           - CCSPlayerPawn_OnTakeDamage.{platform}.yaml
@@ -9096,6 +9102,14 @@ modules:
         category: vfunc
         alias:
           - CBasePlayerPawn::OnTakeDamage_Dead
+      - name: DecalPlacementInfo_ctor
+        category: func
+        alias:
+          - DecalPlacementInfo::DecalPlacementInfo
+      - name: CBaseModelEntity_GetBoneTransform
+        category: func
+        alias:
+          - CBaseModelEntity::GetBoneTransform
       - name: CBasePlayerPawn_OnTakeDamage
         category: vfunc
         alias:

--- a/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
+++ b/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
@@ -102,8 +102,8 @@
         },
         "CBaseModelEntity::GetBoneTransform": {
             "library": "server",
-            "linux": "55 48 89 E5 41 56 49 89 F6 41 55 41 54 41 89 D4 53 48 89 FB 48 8B BE",
-            "windows": "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B E9 41 8B F8 48 8B 89"
+            "linux": "55 48 89 E5 41 56 49 89 F6 41 55 41 54 41 89 D4 53 48 89 FB 48 8B BE ? ? ? ?",
+            "windows": "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B E9 41 8B F8 48 8B 89 ? ? ? ?"
         },
         "CBaseModelEntity::LookupBone": {
             "library": "server",

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -73,8 +73,8 @@ binaries:
       path: game/bin/win64/vphysics2.dll
       sha256: 6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80
 config_digest_version: 2
-config_sha256: sha256:274af0c32334b4d5f388c91961d43c1a70693026576a7e21da96e73934355c8c
-file_count: 3241
+config_sha256: sha256:92cbabf2892d5f952f944855c56bf68345868b06c982b7b4a6ec4e69f5db86d4
+file_count: 3245
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -17587,6 +17587,18 @@ files:
     func_sig: 40 53 48 83 EC ?? 48 8B 89 ?? ?? ?? ?? 48 8B DA 48 8B 01 FF 50 ?? 48 8B C8
     func_size: '0x26'
     func_va: '0x180afdbe0'
+  server/CBaseModelEntity_GetBoneTransform.linux.yaml:
+    func_name: CBaseModelEntity_GetBoneTransform
+    func_rva: '0x15dd0b0'
+    func_sig: 55 48 89 E5 41 56 49 89 F6 41 55 41 54 41 89 D4 53 48 89 FB 48 8B BE ?? ?? ?? ??
+    func_size: '0x84'
+    func_va: '0x15dd0b0'
+  server/CBaseModelEntity_GetBoneTransform.windows.yaml:
+    func_name: CBaseModelEntity_GetBoneTransform
+    func_rva: '0xaef140'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B E9 41 8B F8 48 8B 89 ?? ?? ?? ??
+    func_size: '0x80'
+    func_va: '0x180aef140'
   server/CBaseModelEntity_GetModelScale.linux.yaml:
     func_name: CBaseModelEntity_GetModelScale
     func_rva: '0x15dce10'
@@ -38220,6 +38232,18 @@ files:
     func_sig: 48 89 5C 24 ?? 44 89 44 24 ?? 89 54 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ??
     func_size: '0x9a4'
     func_va: '0x180b7ec80'
+  server/DecalPlacementInfo_ctor.linux.yaml:
+    func_name: DecalPlacementInfo_ctor
+    func_rva: '0xec3630'
+    func_sig: 48 B8 ?? ?? ?? ?? ?? ?? ?? ?? 55 66 0F EF C0 48 89 E5 41 57 41 56 4D 89 CE
+    func_size: '0x535'
+    func_va: '0xec3630'
+  server/DecalPlacementInfo_ctor.windows.yaml:
+    func_name: DecalPlacementInfo_ctor
+    func_rva: '0x502c10'
+    func_sig: 48 8B C4 48 89 58 ?? 48 89 68 ?? 48 89 70 ?? 57 41 54 41 55 41 56 41 57 48 81 EC ?? ?? ?? ?? 44 8B B4 24 ?? ?? ?? ??
+    func_size: '0x5f9'
+    func_va: '0x180502c10'
   server/DispatchParticleEffect.linux.yaml:
     func_name: DispatchParticleEffect
     func_rva: '0x1724e00'
@@ -41383,5 +41407,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-04T08:34:12Z'
+last_publish_time: '2026-08-04T09:33:24Z'
 schema_version: 4

--- a/ida_preprocessor_scripts/find-CBasePlayerPawn_OnTakeDamage-decompiles.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerPawn_OnTakeDamage-decompiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CBaseEntity_OnTakeDamage_Alive-AND-Dying-AND-Dead skill."""
+"""Preprocess script for find-CBasePlayerPawn_OnTakeDamage-decompiles skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
@@ -7,6 +7,7 @@ TARGET_FUNCTION_NAMES = [
     "CBasePlayerPawn_OnTakeDamage_Alive",
     "CBasePlayerPawn_OnTakeDamage_Dying",
     "CBasePlayerPawn_OnTakeDamage_Dead",
+    "DecalPlacementInfo_ctor",
 ]
 
 LLM_DECOMPILE = [
@@ -39,6 +40,17 @@ LLM_DECOMPILE = [
             "references/server/CBasePlayerPawn_OnTakeDamage.{platform}.yaml",
         ],
         "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CBasePlayerPawn_OnTakeDamage.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "DecalPlacementInfo_ctor",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CBasePlayerPawn_OnTakeDamage.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
         "dependency_policy": {
             "CBasePlayerPawn_OnTakeDamage.{platform}.yaml": "required",
         },
@@ -85,6 +97,16 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "vfunc_index",
             "vtable_name",
             "vfunc_sig_allow_across_function_boundary:true",
+        ],
+    ),
+    (
+        "DecalPlacementInfo_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
         ],
     ),
 ]

--- a/ida_preprocessor_scripts/find-DecalPlacementInfo_ctor-decompiles.py
+++ b/ida_preprocessor_scripts/find-DecalPlacementInfo_ctor-decompiles.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-DecalPlacementInfo_ctor-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseModelEntity_GetBoneTransform",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CBaseModelEntity_GetBoneTransform",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/DecalPlacementInfo_ctor.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "DecalPlacementInfo_ctor.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CBaseModelEntity_GetBoneTransform",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate the target function and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBasePlayerPawn_OnTakeDamage.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerPawn_OnTakeDamage.linux.yaml
@@ -87,7 +87,7 @@ disasm_code: |-
   .text:0000000001434324                 xorps   xmm1, xmm2
   .text:0000000001434327                 movss   [rbp+var_88], xmm0
   .text:000000000143432F                 movlps  [rbp+var_90], xmm1
-  .text:0000000001434336                 call    sub_DCBF30
+  .text:0000000001434336                 call    DecalPlacementInfo_ctor
   .text:000000000143433B                 mov     rax, [r12]
   .text:000000000143433F                 lea     rdi, aImpactRtwound; "Impact.RtWound"
   .text:0000000001434346                 movzx   eax, byte ptr [rax+84h]
@@ -137,7 +137,7 @@ procedure: |-
           v9 = v7 + 20;
           v12 = -*(float *)(v9 + 32);
           _mm_storel_ps((double *)&v11, _mm_xor_ps(v8, (__m128)_mm_loadl_epi64((const __m128i *)&qword_86F920)));
-          sub_DCBF30(v13, a1, v9, &v11, 0xFFFFFFFFLL, 0);
+          DecalPlacementInfo_ctor(v13, a1, v9, &v11, 0xFFFFFFFFLL, 0);
           v13[64] = *(_BYTE *)(*(_QWORD *)a2 + 132LL) ^ 1;
           v10 = unk_24DA260;
           v11 = sub_97FAA0("Impact.RtWound");

--- a/ida_preprocessor_scripts/references/server/CBasePlayerPawn_OnTakeDamage.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerPawn_OnTakeDamage.windows.yaml
@@ -46,7 +46,7 @@ disasm_code: |-
   .text:0000000180A8A6EB                 movss   [rsp+98h+var_64], xmm1
   .text:0000000180A8A6F1                 movss   [rsp+98h+var_68], xmm0
   .text:0000000180A8A6F7                 mov     [rsp+98h+var_78], 0FFFFFFFFh
-  .text:0000000180A8A6FF                 call    sub_1804DF350
+  .text:0000000180A8A6FF                 call    DecalPlacementInfo_ctor
   .text:0000000180A8A704                 mov     rax, [rdi]
   .text:0000000180A8A707                 lea     rcx, aImpactRtwound; "Impact.RtWound"
   .text:0000000180A8A70E                 cmp     byte ptr [rax+84h], 0
@@ -115,7 +115,7 @@ procedure: |-
           v12[2] = -v5[13];
           v12[1] = v7;
           v12[0] = -v6;
-          sub_1804DF350((unsigned int)v13, (_DWORD)a1, (_DWORD)v5 + 20, (unsigned int)v12, -1, 0);
+          DecalPlacementInfo_ctor((unsigned int)v13, (_DWORD)a1, (_DWORD)v5 + 20, (unsigned int)v12, -1, 0);
           v13[64] = *(_BYTE *)(*(_QWORD *)a2 + 132LL) == 0;
           GlobalSymbol = MakeGlobalSymbol("Impact.RtWound");
           sub_1804E52C0(qword_181D8C058, nullptr, &GlobalSymbol, (__int64)v13);

--- a/ida_preprocessor_scripts/references/server/DecalPlacementInfo_ctor.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/DecalPlacementInfo_ctor.linux.yaml
@@ -1,0 +1,563 @@
+func_name: DecalPlacementInfo_ctor
+func_va: '0xec3630'
+disasm_code: |-
+  .text:0000000000EC3630                 mov     rax, 0FFFFFFFF00000000h
+  .text:0000000000EC363A                 push    rbp
+  .text:0000000000EC363B                 pxor    xmm0, xmm0
+  .text:0000000000EC363F                 mov     rbp, rsp
+  .text:0000000000EC3642                 push    r15
+  .text:0000000000EC3644                 push    r14
+  .text:0000000000EC3646                 mov     r14, r9
+  .text:0000000000EC3649                 push    r13
+  .text:0000000000EC364B                 mov     r13, rcx
+  .text:0000000000EC364E                 push    r12
+  .text:0000000000EC3650                 mov     r12, rdx
+  .text:0000000000EC3653                 push    rbx
+  .text:0000000000EC3654                 mov     rbx, rdi
+  .text:0000000000EC3657                 sub     rsp, 38h
+  .text:0000000000EC365B                 mov     [rdi+28h], rax
+  .text:0000000000EC365F                 mov     eax, 0BF800000h
+  .text:0000000000EC3664                 mov     qword ptr [rdi], 0
+  .text:0000000000EC366B                 movups  xmmword ptr [rdi+8], xmm0
+  .text:0000000000EC366F                 movups  xmmword ptr [rdi+18h], xmm0
+  .text:0000000000EC3673                 mov     qword ptr [rdi+30h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000EC367B                 mov     [rdi+38h], rax
+  .text:0000000000EC367F                 mov     qword ptr [rdi+40h], 0
+  .text:0000000000EC3687                 mov     qword ptr [rdi+48h], 0
+  .text:0000000000EC368F                 mov     qword ptr [rdi+50h], 0
+  .text:0000000000EC3697                 mov     dword ptr [rdi+58h], 0
+  .text:0000000000EC369E                 mov     rdi, rsi
+  .text:0000000000EC36A1                 test    rsi, rsi
+  .text:0000000000EC36A4                 jz      loc_EC3B50
+  .text:0000000000EC36AA                 mov     [rbx], rdi
+  .text:0000000000EC36AD                 mov     [rbx+30h], r8d
+  .text:0000000000EC36B1                 mov     rax, [rdi]
+  .text:0000000000EC36B4                 call    qword ptr [rax+1A8h]
+  .text:0000000000EC36BA                 mov     rdi, [rbx]
+  .text:0000000000EC36BD                 lea     rdx, sub_A27CE0
+  .text:0000000000EC36C4                 mov     r15, rax
+  .text:0000000000EC36C7                 mov     rax, [rdi]
+  .text:0000000000EC36CA                 mov     rax, [rax+558h]
+  .text:0000000000EC36D1                 cmp     rax, rdx
+  .text:0000000000EC36D4                 jnz     loc_EC3A68
+  .text:0000000000EC36DA                 ; a3
+  .text:0000000000EC36DA                 mov     edx, [rbx+30h]; a3
+  .text:0000000000EC36DD                 test    edx, edx
+  .text:0000000000EC36DF                 js      loc_EC3A72
+  .text:0000000000EC36E5                 test    r15, r15
+  .text:0000000000EC36E8                 jz      loc_EC3A72
+  .text:0000000000EC36EE                 ; a1
+  .text:0000000000EC36EE                 lea     rdi, [rbp+a1]; a1
+  .text:0000000000EC36F2                 ; a2
+  .text:0000000000EC36F2                 mov     rsi, r15; a2
+  .text:0000000000EC36F5                 call    CBaseModelEntity_GetBoneTransform
+  .text:0000000000EC36FA                 movss   xmm2, dword ptr [rbp+a1]
+  .text:0000000000EC36FF                 movss   xmm10, dword ptr [rbp+a1+4]
+  .text:0000000000EC3705                 movss   xmm9, dword ptr [rbp+a1+8]
+  .text:0000000000EC370B                 movss   xmm7, dword ptr [rbp+a1+0Ch]
+  .text:0000000000EC3710                 movaps  xmm1, [rbp+var_40]
+  .text:0000000000EC3714                 lea     rax, unk_863D40
+  .text:0000000000EC371B                 pxor    xmm4, xmm4
+  .text:0000000000EC371F                 movaps  xmm8, xmm2
+  .text:0000000000EC3723                 pxor    xmm13, xmm13
+  .text:0000000000EC3728                 unpcklps xmm8, xmm2
+  .text:0000000000EC372C                 movaps  xmm3, xmmword ptr [rax]
+  .text:0000000000EC372F                 lea     rax, unk_863D70
+  .text:0000000000EC3736                 mulps   xmm3, xmm1
+  .text:0000000000EC3739                 movaps  xmm0, xmm3
+  .text:0000000000EC373C                 dpps    xmm0, xmm3, 0FFh
+  .text:0000000000EC3742                 sqrtps  xmm0, xmm0
+  .text:0000000000EC3745                 cmpeqps xmm4, xmm0
+  .text:0000000000EC3749                 andps   xmm4, xmmword ptr [rax]
+  .text:0000000000EC374C                 orps    xmm0, xmm4
+  .text:0000000000EC374F                 divps   xmm3, xmm0
+  .text:0000000000EC3752                 movaps  xmm4, xmm10
+  .text:0000000000EC3756                 movaps  xmm0, xmm9
+  .text:0000000000EC375A                 unpcklps xmm4, xmm2
+  .text:0000000000EC375D                 unpcklps xmm0, xmm2
+  .text:0000000000EC3760                 movlhps xmm0, xmm4
+  .text:0000000000EC3763                 movaps  xmm4, xmm10
+  .text:0000000000EC3767                 unpcklps xmm4, xmm9
+  .text:0000000000EC376B                 movlhps xmm4, xmm8
+  .text:0000000000EC376F                 unpcklps xmm9, xmm13
+  .text:0000000000EC3773                 unpcklps xmm2, xmm10
+  .text:0000000000EC3777                 movlhps xmm2, xmm9
+  .text:0000000000EC377B                 movaps  xmm6, xmm3
+  .text:0000000000EC377E                 movaps  xmm5, xmm3
+  .text:0000000000EC3781                 shufps  xmm6, xmm3, 9
+  .text:0000000000EC3785                 shufps  xmm5, xmm3, 12h
+  .text:0000000000EC3789                 mulps   xmm0, xmm6
+  .text:0000000000EC378C                 shufps  xmm3, xmm3, 0FFh
+  .text:0000000000EC3790                 mulps   xmm4, xmm5
+  .text:0000000000EC3793                 subps   xmm0, xmm4
+  .text:0000000000EC3796                 addps   xmm0, xmm0
+  .text:0000000000EC3799                 movaps  xmm4, xmm0
+  .text:0000000000EC379C                 movaps  xmm8, xmm0
+  .text:0000000000EC37A0                 shufps  xmm4, xmm0, 12h
+  .text:0000000000EC37A4                 shufps  xmm8, xmm0, 9
+  .text:0000000000EC37A9                 mulps   xmm0, xmm3
+  .text:0000000000EC37AC                 mulps   xmm8, xmm5
+  .text:0000000000EC37B0                 mulps   xmm4, xmm6
+  .text:0000000000EC37B3                 addps   xmm0, xmm2
+  .text:0000000000EC37B6                 movss   xmm2, dword ptr cs:qword_8CCD78
+  .text:0000000000EC37BE                 subps   xmm4, xmm8
+  .text:0000000000EC37C2                 pxor    xmm8, xmm8
+  .text:0000000000EC37C7                 ucomiss xmm7, xmm2
+  .text:0000000000EC37CA                 addps   xmm0, xmm4
+  .text:0000000000EC37CD                 jp      loc_EC3AA0
+  .text:0000000000EC37D3                 jnz     loc_EC3AA0
+  .text:0000000000EC37D9                 movaps  xmm2, xmm0
+  .text:0000000000EC37DC                 movaps  xmm12, xmm8
+  .text:0000000000EC37E0                 movaps  xmm10, xmm8
+  .text:0000000000EC37E4                 shufps  xmm2, xmm0, 55h ; 'U'
+  .text:0000000000EC37E8                 subss   xmm12, xmm2
+  .text:0000000000EC37ED                 movaps  xmm2, xmm8
+  .text:0000000000EC37F1                 movss   xmm8, dword ptr cs:qword_8CCD78
+  .text:0000000000EC37FA                 subss   xmm10, xmm0
+  .text:0000000000EC37FF                 unpckhps xmm0, xmm0
+  .text:0000000000EC3802                 subss   xmm2, xmm0
+  .text:0000000000EC3806                 shufps  xmm8, xmm8, 0
+  .text:0000000000EC380B                 movss   xmm11, dword ptr [r12+4]
+  .text:0000000000EC3812                 movss   xmm4, dword ptr [r12]
+  .text:0000000000EC3818                 movss   xmm9, dword ptr [r12+8]
+  .text:0000000000EC381F                 insertps xmm10, xmm10, 0Eh
+  .text:0000000000EC3826                 movlhps xmm4, xmm11
+  .text:0000000000EC382A                 movaps  xmm11, xmm9
+  .text:0000000000EC382E                 insertps xmm2, xmm2, 0Eh
+  .text:0000000000EC3834                 lea     rax, unk_863D30
+  .text:0000000000EC383B                 movaps  xmm0, xmm4
+  .text:0000000000EC383E                 shufps  xmm11, xmm4, 0A0h
+  .text:0000000000EC3843                 shufps  xmm11, xmm4, 2
+  .text:0000000000EC3848                 insertps xmm7, xmm7, 0Eh
+  .text:0000000000EC384E                 mulps   xmm11, xmm5
+  .text:0000000000EC3852                 shufps  xmm0, xmm4, 20h ; ' '
+  .text:0000000000EC3856                 shufps  xmm4, xmm9, 88h
+  .text:0000000000EC385B                 pinsrd  xmm0, dword ptr [r12+8], 0
+  .text:0000000000EC3864                 mulps   xmm0, xmm6
+  .text:0000000000EC3867                 pxor    xmm14, xmm14
+  .text:0000000000EC386C                 xorps   xmm1, xmmword ptr [rax]
+  .text:0000000000EC386F                 subps   xmm0, xmm11
+  .text:0000000000EC3873                 insertps xmm11, xmm12, 0Eh
+  .text:0000000000EC387A                 movlhps xmm10, xmm11
+  .text:0000000000EC387E                 shufps  xmm10, xmm2, 88h
+  .text:0000000000EC3883                 insertps xmm10, xmm7, 30h ; '0'
+  .text:0000000000EC388A                 addps   xmm0, xmm0
+  .text:0000000000EC388D                 movaps  xmm2, xmm0
+  .text:0000000000EC3890                 shufps  xmm2, xmm0, 12h
+  .text:0000000000EC3894                 mulps   xmm2, xmm6
+  .text:0000000000EC3897                 movaps  xmm6, xmm0
+  .text:0000000000EC389A                 shufps  xmm6, xmm0, 9
+  .text:0000000000EC389E                 mulps   xmm0, xmm3
+  .text:0000000000EC38A1                 movss   xmm3, dword ptr [r13+8]
+  .text:0000000000EC38A7                 mulps   xmm5, xmm6
+  .text:0000000000EC38AA                 addps   xmm0, xmm4
+  .text:0000000000EC38AD                 movaps  xmm4, xmm1
+  .text:0000000000EC38B0                 dpps    xmm4, xmm1, 0FFh
+  .text:0000000000EC38B6                 subps   xmm2, xmm5
+  .text:0000000000EC38B9                 movss   xmm5, dword ptr [r13+4]
+  .text:0000000000EC38BF                 movaps  xmm7, xmm5
+  .text:0000000000EC38C2                 addps   xmm0, xmm2
+  .text:0000000000EC38C5                 movss   xmm2, dword ptr [r13+0]
+  .text:0000000000EC38CB                 sqrtps  xmm4, xmm4
+  .text:0000000000EC38CE                 unpcklps xmm7, xmm2
+  .text:0000000000EC38D1                 mulps   xmm0, xmm8
+  .text:0000000000EC38D5                 movaps  xmm8, xmm2
+  .text:0000000000EC38D9                 unpcklps xmm8, xmm2
+  .text:0000000000EC38DD                 divps   xmm1, xmm4
+  .text:0000000000EC38E0                 addps   xmm0, xmm10
+  .text:0000000000EC38E4                 movss   dword ptr [rbx+8], xmm0
+  .text:0000000000EC38E9                 extractps dword ptr [rbx+0Ch], xmm0, 1
+  .text:0000000000EC38F0                 extractps dword ptr [rbx+10h], xmm0, 2
+  .text:0000000000EC38F7                 pxor    xmm0, xmm0
+  .text:0000000000EC38FB                 cmpeqps xmm0, xmm4
+  .text:0000000000EC38FF                 blendvps xmm1, cs:xmmword_267CF00
+  .text:0000000000EC3908                 movaps  xmm0, xmm3
+  .text:0000000000EC390B                 unpcklps xmm0, xmm2
+  .text:0000000000EC390E                 movlhps xmm0, xmm7
+  .text:0000000000EC3911                 movaps  xmm7, xmm5
+  .text:0000000000EC3914                 movaps  xmm6, xmm1
+  .text:0000000000EC3917                 movaps  xmm4, xmm1
+  .text:0000000000EC391A                 unpcklps xmm7, xmm3
+  .text:0000000000EC391D                 movlhps xmm7, xmm8
+  .text:0000000000EC3921                 shufps  xmm6, xmm1, 9
+  .text:0000000000EC3925                 shufps  xmm4, xmm1, 12h
+  .text:0000000000EC3929                 mulps   xmm0, xmm6
+  .text:0000000000EC392C                 shufps  xmm1, xmm1, 0FFh
+  .text:0000000000EC3930                 unpcklps xmm3, xmm14
+  .text:0000000000EC3934                 mulps   xmm7, xmm4
+  .text:0000000000EC3937                 unpcklps xmm2, xmm5
+  .text:0000000000EC393A                 movlhps xmm2, xmm3
+  .text:0000000000EC393D                 subps   xmm0, xmm7
+  .text:0000000000EC3940                 addps   xmm0, xmm0
+  .text:0000000000EC3943                 movaps  xmm7, xmm0
+  .text:0000000000EC3946                 movaps  xmm8, xmm0
+  .text:0000000000EC394A                 shufps  xmm7, xmm0, 12h
+  .text:0000000000EC394E                 shufps  xmm8, xmm0, 9
+  .text:0000000000EC3953                 mulps   xmm7, xmm6
+  .text:0000000000EC3956                 mulps   xmm8, xmm4
+  .text:0000000000EC395A                 mulps   xmm0, xmm1
+  .text:0000000000EC395D                 subps   xmm7, xmm8
+  .text:0000000000EC3961                 addps   xmm0, xmm2
+  .text:0000000000EC3964                 addps   xmm0, xmm7
+  .text:0000000000EC3967                 movss   dword ptr [rbx+14h], xmm0
+  .text:0000000000EC396C                 shufps  xmm0, xmm0, 0E9h
+  .text:0000000000EC3970                 movq    qword ptr [rbx+18h], xmm0
+  .text:0000000000EC3975                 test    r14, r14
+  .text:0000000000EC3978                 jz      loc_EC3AF0
+  .text:0000000000EC397E                 movss   xmm7, dword ptr [r14+4]
+  .text:0000000000EC3984                 lea     rdi, [rbx+14h]
+  .text:0000000000EC3988                 movss   xmm5, dword ptr [r14+8]
+  .text:0000000000EC398E                 movss   xmm2, dword ptr [r14]
+  .text:0000000000EC3993                 movaps  xmm3, xmm7
+  .text:0000000000EC3996                 movaps  xmm0, xmm5
+  .text:0000000000EC3999                 unpcklps xmm3, xmm2
+  .text:0000000000EC399C                 movaps  xmm8, xmm2
+  .text:0000000000EC39A0                 unpcklps xmm0, xmm2
+  .text:0000000000EC39A3                 movlhps xmm0, xmm3
+  .text:0000000000EC39A6                 unpcklps xmm8, xmm2
+  .text:0000000000EC39AA                 mulps   xmm0, xmm6
+  .text:0000000000EC39AD                 movaps  xmm3, xmm7
+  .text:0000000000EC39B0                 unpcklps xmm2, xmm7
+  .text:0000000000EC39B3                 unpcklps xmm3, xmm5
+  .text:0000000000EC39B6                 movlhps xmm3, xmm8
+  .text:0000000000EC39BA                 unpcklps xmm5, xmm14
+  .text:0000000000EC39BE                 movlhps xmm2, xmm5
+  .text:0000000000EC39C1                 mulps   xmm3, xmm4
+  .text:0000000000EC39C4                 subps   xmm0, xmm3
+  .text:0000000000EC39C7                 addps   xmm0, xmm0
+  .text:0000000000EC39CA                 mulps   xmm1, xmm0
+  .text:0000000000EC39CD                 movaps  xmm3, xmm0
+  .text:0000000000EC39D0                 shufps  xmm3, xmm0, 12h
+  .text:0000000000EC39D4                 mulps   xmm3, xmm6
+  .text:0000000000EC39D7                 movaps  xmm6, xmm0
+  .text:0000000000EC39DA                 shufps  xmm6, xmm0, 9
+  .text:0000000000EC39DE                 mulps   xmm4, xmm6
+  .text:0000000000EC39E1                 addps   xmm1, xmm2
+  .text:0000000000EC39E4                 subps   xmm3, xmm4
+  .text:0000000000EC39E7                 addps   xmm1, xmm3
+  .text:0000000000EC39EA                 movq    qword ptr [rbx+20h], xmm1
+  .text:0000000000EC39EF                 extractps dword ptr [rbx+28h], xmm1, 2
+  .text:0000000000EC39F6                 call    sub_1D1F830
+  .text:0000000000EC39FB                 pxor    xmm5, xmm5
+  .text:0000000000EC39FF                 ucomiss xmm0, xmm5
+  .text:0000000000EC3A02                 jp      short loc_EC3A1A
+  .text:0000000000EC3A04                 jnz     short loc_EC3A1A
+  .text:0000000000EC3A06                 mov     rax, cs:qword_7B5148
+  .text:0000000000EC3A0D                 mov     [rbx+14h], rax
+  .text:0000000000EC3A11                 mov     eax, cs:dword_7B5150
+  .text:0000000000EC3A17                 mov     [rbx+1Ch], eax
+  .text:0000000000EC3A1A                 lea     rdi, [rbx+20h]
+  .text:0000000000EC3A1E                 call    sub_1D1F830
+  .text:0000000000EC3A23                 movaps  xmm1, xmm0
+  .text:0000000000EC3A26                 pxor    xmm0, xmm0
+  .text:0000000000EC3A2A                 ucomiss xmm1, xmm0
+  .text:0000000000EC3A2D                 jp      short loc_EC3A45
+  .text:0000000000EC3A2F                 jnz     short loc_EC3A45
+  .text:0000000000EC3A31                 mov     rax, cs:qword_7B5148
+  .text:0000000000EC3A38                 mov     [rbx+20h], rax
+  .text:0000000000EC3A3C                 mov     eax, cs:dword_7B5150
+  .text:0000000000EC3A42                 mov     [rbx+28h], eax
+  .text:0000000000EC3A45                 add     rsp, 38h
+  .text:0000000000EC3A49                 mov     rcx, rbx
+  .text:0000000000EC3A4C                 mov     rdx, r13
+  .text:0000000000EC3A4F                 pop     rbx
+  .text:0000000000EC3A50                 mov     rsi, r12
+  .text:0000000000EC3A53                 mov     rdi, r15
+  .text:0000000000EC3A56                 pop     r12
+  .text:0000000000EC3A58                 pop     r13
+  .text:0000000000EC3A5A                 pop     r14
+  .text:0000000000EC3A5C                 pop     r15
+  .text:0000000000EC3A5E                 pop     rbp
+  .text:0000000000EC3A5F                 jmp     sub_EC2FF0
+  .text:0000000000EC3A68                 call    rax
+  .text:0000000000EC3A6A                 test    al, al
+  .text:0000000000EC3A6C                 jz      loc_EC36DA
+  .text:0000000000EC3A72                 mov     rdi, [rbx]
+  .text:0000000000EC3A75                 call    sub_D341C0
+  .text:0000000000EC3A7A                 movss   xmm2, dword ptr [rax]
+  .text:0000000000EC3A7E                 movss   xmm10, dword ptr [rax+4]
+  .text:0000000000EC3A84                 movss   xmm9, dword ptr [rax+8]
+  .text:0000000000EC3A8A                 movss   xmm7, dword ptr [rax+0Ch]
+  .text:0000000000EC3A8F                 movaps  xmm1, xmmword ptr [rax+10h]
+  .text:0000000000EC3A93                 mov     dword ptr [rbx+30h], 0FFFFFFFFh
+  .text:0000000000EC3A9A                 jmp     loc_EC3714
+  .text:0000000000EC3AA0                 pxor    xmm4, xmm4
+  .text:0000000000EC3AA4                 ucomiss xmm7, xmm4
+  .text:0000000000EC3AA7                 jp      short loc_EC3AAF
+  .text:0000000000EC3AA9                 jz      loc_EC3B40
+  .text:0000000000EC3AAF                 divss   xmm2, xmm7
+  .text:0000000000EC3AB3                 movaps  xmm7, xmm2
+  .text:0000000000EC3AB6                 movaps  xmm8, xmm7
+  .text:0000000000EC3ABA                 pxor    xmm2, xmm2
+  .text:0000000000EC3ABE                 movaps  xmm10, xmm2
+  .text:0000000000EC3AC2                 movaps  xmm12, xmm2
+  .text:0000000000EC3AC6                 shufps  xmm8, xmm8, 0
+  .text:0000000000EC3ACB                 mulps   xmm0, xmm8
+  .text:0000000000EC3ACF                 movaps  xmm4, xmm0
+  .text:0000000000EC3AD2                 subss   xmm10, xmm0
+  .text:0000000000EC3AD7                 shufps  xmm4, xmm0, 55h ; 'U'
+  .text:0000000000EC3ADB                 unpckhps xmm0, xmm0
+  .text:0000000000EC3ADE                 subss   xmm12, xmm4
+  .text:0000000000EC3AE3                 subss   xmm2, xmm0
+  .text:0000000000EC3AE7                 jmp     loc_EC380B
+  .text:0000000000EC3AF0                 mov     rax, cs:qword_8CF4E0
+  .text:0000000000EC3AF7                 mov     dword ptr [rbx+28h], 7F7FFFFFh
+  .text:0000000000EC3AFE                 lea     rdi, [rbx+14h]
+  .text:0000000000EC3B02                 mov     [rbx+20h], rax
+  .text:0000000000EC3B06                 call    sub_1D1F830
+  .text:0000000000EC3B0B                 pxor    xmm5, xmm5
+  .text:0000000000EC3B0F                 ucomiss xmm0, xmm5
+  .text:0000000000EC3B12                 jp      loc_EC3A45
+  .text:0000000000EC3B18                 jnz     loc_EC3A45
+  .text:0000000000EC3B1E                 mov     rax, cs:qword_7B5148
+  .text:0000000000EC3B25                 mov     [rbx+14h], rax
+  .text:0000000000EC3B29                 mov     eax, cs:dword_7B5150
+  .text:0000000000EC3B2F                 mov     [rbx+1Ch], eax
+  .text:0000000000EC3B32                 jmp     loc_EC3A45
+  .text:0000000000EC3B40                 movss   xmm7, cs:dword_8CDAB0
+  .text:0000000000EC3B48                 jmp     loc_EC3AB6
+  .text:0000000000EC3B50                 mov     [rbp+var_54], r8d
+  .text:0000000000EC3B54                 call    sub_178CAC0
+  .text:0000000000EC3B59                 mov     r8d, [rbp+var_54]
+  .text:0000000000EC3B5D                 mov     rdi, rax
+  .text:0000000000EC3B60                 jmp     loc_EC36AA
+procedure: |-
+  __int64 __fastcall DecalPlacementInfo_ctor(
+          __int64 *a1,
+          __int64 a2,
+          unsigned int *a3,
+          unsigned int *a4,
+          int a5,
+          unsigned int *a6)
+  {
+    __int64 v10; // rdi
+    __int64 v11; // r15
+    __int64 (__fastcall *v12)(); // rax
+    int v13; // edx
+    __m128 v14; // xmm2
+    __m128 v15; // xmm10
+    __m128 v16; // xmm9
+    __m128 v17; // xmm7
+    __m128 v18; // xmm1
+    __m128 v19; // xmm3
+    __m128 v20; // xmm0
+    __m128 v21; // xmm3
+    __m128 v22; // xmm6
+    __m128 v23; // xmm5
+    __m128 v24; // xmm3
+    __m128 v25; // xmm0
+    __m128 v26; // xmm0
+    __m128 v27; // xmm4
+    __m128 v28; // xmm8
+    __m128 v29; // xmm0
+    __m128 v30; // xmm2
+    __m128 v31; // xmm0
+    __m128 v32; // xmm12
+    __m128 v33; // xmm10
+    __m128 v34; // xmm2
+    __m128 v35; // xmm8
+    __m128 v36; // xmm4
+    __m128 v37; // xmm11
+    __m128 v38; // xmm1
+    __m128 v39; // xmm0
+    __m128 inserted; // xmm10
+    __m128 v41; // xmm0
+    __m128 v42; // xmm2
+    __m128 v43; // xmm6
+    __m128 v44; // xmm0
+    __m128 v45; // xmm3
+    __m128 v46; // xmm2
+    __m128 v47; // xmm5
+    __m128 v48; // xmm0
+    __m128 v49; // xmm2
+    __m128 v50; // xmm4
+    __m128 v51; // xmm0
+    __m128 v52; // xmm1
+    __m128 v53; // xmm6
+    __m128 v54; // xmm4
+    __m128 v55; // xmm1
+    __m128 v56; // xmm0
+    __m128 v57; // xmm0
+    __m128 v58; // xmm0
+    __int64 v59; // xmm0_8
+    __m128 v60; // xmm7
+    __m128 v61; // xmm5
+    __m128 v62; // xmm2
+    __m128 v63; // xmm0
+    __m128 v64; // xmm0
+    __m128 v65; // xmm1
+    float v66; // xmm1_4
+    __m128 *v68; // rax
+    __m128 v69; // xmm0
+    __int64 v70; // rax
+    int v71; // [rsp+Ch] [rbp-54h]
+    __m128i a1a; // [rsp+10h] [rbp-50h] BYREF
+    __m128 v73; // [rsp+20h] [rbp-40h]
+
+    a1[5] = 0xFFFFFFFF00000000LL;
+    *a1 = 0;
+    *(_OWORD *)(a1 + 1) = 0;
+    *(_OWORD *)(a1 + 3) = 0;
+    a1[6] = -1;
+    a1[7] = 3212836864LL;
+    a1[8] = 0;
+    a1[9] = 0;
+    a1[10] = 0;
+    *((_DWORD *)a1 + 22) = 0;
+    v10 = a2;
+    if ( !a2 )
+    {
+      v71 = a5;
+      v70 = sub_178CAC0();
+      a5 = v71;
+      v10 = v70;
+    }
+    *a1 = v10;
+    *((_DWORD *)a1 + 12) = a5;
+    v11 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v10 + 424LL))(v10);
+    v12 = *(__int64 (__fastcall **)())(*(_QWORD *)*a1 + 1368LL);
+    if ( (v12 == sub_A27CE0 || !(unsigned __int8)v12()) && (v13 = *((_DWORD *)a1 + 12), v13 >= 0) && v11 )
+    {
+      CBaseModelEntity_GetBoneTransform(&a1a, v11, v13);
+      v14 = (__m128)a1a.m128i_u32[0];
+      v15 = (__m128)a1a.m128i_u32[1];
+      v16 = (__m128)a1a.m128i_u32[2];
+      v17 = (__m128)a1a.m128i_u32[3];
+      v18 = v73;
+    }
+    else
+    {
+      v68 = (__m128 *)sub_D341C0(*a1);
+      v14 = (__m128)v68->m128_u32[0];
+      v15 = (__m128)v68->m128_u32[1];
+      v16 = (__m128)v68->m128_u32[2];
+      v17 = (__m128)v68->m128_u32[3];
+      v18 = v68[1];
+      *((_DWORD *)a1 + 12) = -1;
+    }
+    v19 = _mm_mul_ps(unk_863D40, v18);
+    v20 = _mm_sqrt_ps(_mm_dp_ps(v19, v19, 255));
+    v21 = _mm_div_ps(v19, _mm_or_ps(v20, _mm_and_ps(_mm_cmpeq_ps((__m128)0LL, v20), unk_863D70)));
+    v22 = _mm_shuffle_ps(v21, v21, 9);
+    v23 = _mm_shuffle_ps(v21, v21, 18);
+    v24 = _mm_shuffle_ps(v21, v21, 255);
+    v25 = _mm_sub_ps(
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v16, v14), _mm_unpacklo_ps(v15, v14)), v22),
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v15, v16), _mm_unpacklo_ps(v14, v14)), v23));
+    v26 = _mm_add_ps(v25, v25);
+    v27 = _mm_shuffle_ps(v26, v26, 18);
+    v28 = _mm_shuffle_ps(v26, v26, 9);
+    v29 = _mm_add_ps(_mm_mul_ps(v26, v24), _mm_movelh_ps(_mm_unpacklo_ps(v14, v15), _mm_unpacklo_ps(v16, (__m128)0LL)));
+    v30 = (__m128)0x3F800000u;
+    v31 = _mm_add_ps(v29, _mm_sub_ps(_mm_mul_ps(v27, v22), _mm_mul_ps(v28, v23)));
+    if ( v17.m128_f32[0] == 1.0 )
+    {
+      v32 = 0;
+      v33 = 0;
+      v32.m128_f32[0] = 0.0 - _mm_shuffle_ps(v31, v31, 85).m128_f32[0];
+      v34 = 0;
+      v33.m128_f32[0] = 0.0 - v31.m128_f32[0];
+      v34.m128_f32[0] = 0.0 - _mm_unpackhi_ps(v31, v31).m128_f32[0];
+      v35 = _mm_shuffle_ps((__m128)0x3F800000u, (__m128)0x3F800000u, 0);
+    }
+    else
+    {
+      if ( v17.m128_f32[0] == 0.0 )
+      {
+        v17 = (__m128)0x4B000000u;
+      }
+      else
+      {
+        v30.m128_f32[0] = 1.0 / v17.m128_f32[0];
+        v17 = v30;
+      }
+      v34 = 0;
+      v33 = 0;
+      v32 = 0;
+      v35 = _mm_shuffle_ps(v17, v17, 0);
+      v69 = _mm_mul_ps(v31, v35);
+      v33.m128_f32[0] = 0.0 - v69.m128_f32[0];
+      v32.m128_f32[0] = 0.0 - _mm_shuffle_ps(v69, v69, 85).m128_f32[0];
+      v34.m128_f32[0] = 0.0 - _mm_unpackhi_ps(v69, v69).m128_f32[0];
+    }
+    v36 = _mm_movelh_ps((__m128)*a3, (__m128)a3[1]);
+    v37 = _mm_mul_ps(_mm_shuffle_ps(_mm_shuffle_ps((__m128)a3[2], v36, 160), v36, 2), v23);
+    v38 = _mm_xor_ps(v18, unk_863D30);
+    v39 = _mm_sub_ps(_mm_mul_ps((__m128)_mm_insert_epi32((__m128i)_mm_shuffle_ps(v36, v36, 32), a3[2], 0), v22), v37);
+    inserted = _mm_insert_ps(
+                 _mm_shuffle_ps(
+                   _mm_movelh_ps(_mm_insert_ps(v33, v33, 14), _mm_insert_ps(v37, v32, 14)),
+                   _mm_insert_ps(v34, v34, 14),
+                   136),
+                 _mm_insert_ps(v17, v17, 14),
+                 48);
+    v41 = _mm_add_ps(v39, v39);
+    v42 = _mm_mul_ps(_mm_shuffle_ps(v41, v41, 18), v22);
+    v43 = _mm_shuffle_ps(v41, v41, 9);
+    v44 = _mm_mul_ps(v41, v24);
+    v45 = (__m128)a4[2];
+    v46 = _mm_sub_ps(v42, _mm_mul_ps(v23, v43));
+    v47 = (__m128)a4[1];
+    v48 = _mm_add_ps(_mm_add_ps(v44, _mm_shuffle_ps(v36, (__m128)a3[2], 136)), v46);
+    v49 = (__m128)*a4;
+    v50 = _mm_sqrt_ps(_mm_dp_ps(v38, v38, 255));
+    v51 = _mm_add_ps(_mm_mul_ps(v48, v35), inserted);
+    *((_DWORD *)a1 + 2) = v51.m128_i32[0];
+    *((_DWORD *)a1 + 3) = _mm_extract_ps(v51, 1);
+    *((_DWORD *)a1 + 4) = _mm_extract_ps(v51, 2);
+    v52 = _mm_blendv_ps(_mm_div_ps(v38, v50), (__m128)xmmword_267CF00, _mm_cmpeq_ps((__m128)0LL, v50));
+    v53 = _mm_shuffle_ps(v52, v52, 9);
+    v54 = _mm_shuffle_ps(v52, v52, 18);
+    v55 = _mm_shuffle_ps(v52, v52, 255);
+    v56 = _mm_sub_ps(
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v45, v49), _mm_unpacklo_ps(v47, v49)), v53),
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v47, v45), _mm_unpacklo_ps(v49, v49)), v54));
+    v57 = _mm_add_ps(v56, v56);
+    v58 = _mm_add_ps(
+            _mm_add_ps(_mm_mul_ps(v57, v55), _mm_movelh_ps(_mm_unpacklo_ps(v49, v47), _mm_unpacklo_ps(v45, (__m128)0LL))),
+            _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v57, v57, 18), v53), _mm_mul_ps(_mm_shuffle_ps(v57, v57, 9), v54)));
+    *((_DWORD *)a1 + 5) = v58.m128_i32[0];
+    v59 = _mm_shuffle_ps(v58, v58, 233).m128_u64[0];
+    a1[3] = v59;
+    if ( a6 )
+    {
+      v60 = (__m128)a6[1];
+      v61 = (__m128)a6[2];
+      v62 = (__m128)*a6;
+      v63 = _mm_sub_ps(
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v61, v62), _mm_unpacklo_ps(v60, v62)), v53),
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v60, v61), _mm_unpacklo_ps(v62, v62)), v54));
+      v64 = _mm_add_ps(v63, v63);
+      v65 = _mm_add_ps(
+              _mm_add_ps(
+                _mm_mul_ps(v55, v64),
+                _mm_movelh_ps(_mm_unpacklo_ps(v62, v60), _mm_unpacklo_ps(v61, (__m128)0LL))),
+              _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v64, v64, 18), v53), _mm_mul_ps(v54, _mm_shuffle_ps(v64, v64, 9))));
+      a1[4] = v65.m128_u64[0];
+      *((_DWORD *)a1 + 10) = _mm_extract_ps(v65, 2);
+      if ( sub_1D1F830((char *)a1 + 20) == 0.0 )
+      {
+        *(__int64 *)((char *)a1 + 20) = 0;
+        *((_DWORD *)a1 + 7) = 0;
+      }
+      v66 = sub_1D1F830(a1 + 4);
+      v59 = 0;
+      if ( v66 == 0.0 )
+      {
+        a1[4] = 0;
+        *((_DWORD *)a1 + 10) = 0;
+      }
+    }
+    else
+    {
+      *((_DWORD *)a1 + 10) = 2139095039;
+      a1[4] = 0x7F7FFFFF7F7FFFFFLL;
+      *(float *)&v59 = sub_1D1F830((char *)a1 + 20);
+      if ( *(float *)&v59 == 0.0 )
+      {
+        *(__int64 *)((char *)a1 + 20) = 0;
+        *((_DWORD *)a1 + 7) = 0;
+      }
+    }
+    return sub_EC2FF0(v11, a3, a4, a1, *(double *)&v59);
+  }

--- a/ida_preprocessor_scripts/references/server/DecalPlacementInfo_ctor.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/DecalPlacementInfo_ctor.windows.yaml
@@ -1,0 +1,596 @@
+func_name: DecalPlacementInfo_ctor
+func_va: '0x180502c10'
+disasm_code: |-
+  .text:0000000180502C10                 mov     rax, rsp
+  .text:0000000180502C13                 mov     [rax+8], rbx
+  .text:0000000180502C17                 mov     [rax+10h], rbp
+  .text:0000000180502C1B                 mov     [rax+18h], rsi
+  .text:0000000180502C1F                 push    rdi
+  .text:0000000180502C20                 push    r12
+  .text:0000000180502C22                 push    r13
+  .text:0000000180502C24                 push    r14
+  .text:0000000180502C26                 push    r15
+  .text:0000000180502C28                 sub     rsp, 110h
+  .text:0000000180502C2F                 mov     r14d, [rsp+138h+arg_20]
+  .text:0000000180502C37                 xor     esi, esi
+  .text:0000000180502C39                 movaps  xmmword ptr [rax-38h], xmm6
+  .text:0000000180502C3D                 mov     r12, r9
+  .text:0000000180502C40                 movaps  xmmword ptr [rax-48h], xmm7
+  .text:0000000180502C44                 mov     r13, r8
+  .text:0000000180502C47                 movaps  xmmword ptr [rax-58h], xmm8
+  .text:0000000180502C4C                 mov     rbx, rcx
+  .text:0000000180502C4F                 movaps  xmmword ptr [rax-68h], xmm9
+  .text:0000000180502C54                 mov     [rcx], rsi
+  .text:0000000180502C57                 movsd   xmm0, cs:qword_1815E09F8
+  .text:0000000180502C5F                 movsd   qword ptr [rcx+8], xmm0
+  .text:0000000180502C64                 movaps  xmmword ptr [rax-78h], xmm10
+  .text:0000000180502C69                 movaps  xmmword ptr [rax-88h], xmm11
+  .text:0000000180502C71                 movaps  xmmword ptr [rax-98h], xmm12
+  .text:0000000180502C79                 movaps  xmmword ptr [rax-0A8h], xmm13
+  .text:0000000180502C81                 movaps  xmmword ptr [rax-0B8h], xmm14
+  .text:0000000180502C89                 mov     eax, cs:dword_1815E0A00
+  .text:0000000180502C8F                 mov     [rcx+10h], eax
+  .text:0000000180502C92                 movsd   xmm0, cs:qword_1815E09F8
+  .text:0000000180502C9A                 movsd   qword ptr [rcx+14h], xmm0
+  .text:0000000180502C9F                 mov     eax, cs:dword_1815E0A00
+  .text:0000000180502CA5                 movaps  [rsp+138h+var_C8], xmm15
+  .text:0000000180502CAB                 mov     [rcx+1Ch], eax
+  .text:0000000180502CAE                 movsd   xmm0, cs:qword_1815E09F8
+  .text:0000000180502CB6                 movsd   qword ptr [rcx+20h], xmm0
+  .text:0000000180502CBB                 mov     eax, cs:dword_1815E0A00
+  .text:0000000180502CC1                 mov     [rcx+28h], eax
+  .text:0000000180502CC4                 mov     dword ptr [rcx+2Ch], 0FFFFFFFFh
+  .text:0000000180502CCB                 mov     qword ptr [rcx+30h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180502CD3                 mov     dword ptr [rcx+38h], 0BF800000h
+  .text:0000000180502CDA                 mov     [rcx+3Ch], esi
+  .text:0000000180502CDD                 mov     [rcx+40h], sil
+  .text:0000000180502CE1                 movsd   xmm0, cs:qword_1815E09F8
+  .text:0000000180502CE9                 movsd   qword ptr [rcx+44h], xmm0
+  .text:0000000180502CEE                 mov     eax, cs:dword_1815E0A00
+  .text:0000000180502CF4                 mov     [rcx+4Ch], eax
+  .text:0000000180502CF7                 movsd   xmm0, cs:qword_1815E09F8
+  .text:0000000180502CFF                 movsd   qword ptr [rcx+50h], xmm0
+  .text:0000000180502D04                 mov     eax, cs:dword_1815E0A00
+  .text:0000000180502D0A                 mov     [rcx+58h], eax
+  .text:0000000180502D0D                 test    rdx, rdx
+  .text:0000000180502D10                 jz      short loc_180502D1B
+  .text:0000000180502D12                 mov     [rcx], rdx
+  .text:0000000180502D15                 mov     [rcx+30h], r14d
+  .text:0000000180502D19                 jmp     short loc_180502D2F
+  .text:0000000180502D1B                 call    sub_180C332F0
+  .text:0000000180502D20                 mov     [rbx], rax
+  .text:0000000180502D23                 mov     rdx, rax
+  .text:0000000180502D26                 mov     [rbx+30h], r14d
+  .text:0000000180502D2A                 test    rax, rax
+  .text:0000000180502D2D                 jz      short loc_180502D3E
+  .text:0000000180502D2F                 mov     rax, [rdx]
+  .text:0000000180502D32                 mov     rcx, rdx
+  .text:0000000180502D35                 call    qword ptr [rax+1B8h]
+  .text:0000000180502D3B                 mov     rsi, rax
+  .text:0000000180502D3E                 mov     rcx, [rbx]
+  .text:0000000180502D41                 mov     rax, [rcx]
+  .text:0000000180502D44                 call    qword ptr [rax+560h]
+  .text:0000000180502D4A                 test    al, al
+  .text:0000000180502D4C                 jnz     short loc_180502D73
+  .text:0000000180502D4E                 mov     r8d, [rbx+30h]
+  .text:0000000180502D52                 test    r8d, r8d
+  .text:0000000180502D55                 js      short loc_180502D73
+  .text:0000000180502D57                 test    rsi, rsi
+  .text:0000000180502D5A                 jz      short loc_180502D73
+  .text:0000000180502D5C                 lea     rdx, [rsp+138h+var_E8]
+  .text:0000000180502D61                 mov     rcx, rsi
+  .text:0000000180502D64                 call    CBaseModelEntity_GetBoneTransform
+  .text:0000000180502D69                 movups  xmm7, xmmword ptr [rax]
+  .text:0000000180502D6C                 movups  xmm14, xmmword ptr [rax+10h]
+  .text:0000000180502D71                 jmp     short loc_180502D8A
+  .text:0000000180502D73                 mov     rcx, [rbx]
+  .text:0000000180502D76                 call    sub_1803C0610
+  .text:0000000180502D7B                 movups  xmm7, xmmword ptr [rax]
+  .text:0000000180502D7E                 movups  xmm14, xmmword ptr [rax+10h]
+  .text:0000000180502D83                 mov     dword ptr [rbx+30h], 0FFFFFFFFh
+  .text:0000000180502D8A                 movss   xmm11, cs:dword_1815E5670
+  .text:0000000180502D93                 movaps  xmm9, xmm14
+  .text:0000000180502D97                 mulps   xmm9, cs:xmmword_181CE6750
+  .text:0000000180502D9F                 xorps   xmm15, xmm15
+  .text:0000000180502DA3                 movaps  [rsp+138h+var_F8], xmm14
+  .text:0000000180502DA9                 movaps  [rsp+138h+var_108], xmm7
+  .text:0000000180502DAE                 movaps  xmm0, xmm9
+  .text:0000000180502DB2                 dpps    xmm0, xmm9, 0FFh
+  .text:0000000180502DB9                 sqrtps  xmm1, xmm0
+  .text:0000000180502DBC                 xorps   xmm0, xmm0
+  .text:0000000180502DBF                 cmpeqps xmm0, xmm1
+  .text:0000000180502DC3                 andps   xmm0, cs:xmmword_181CE66F0
+  .text:0000000180502DCA                 orps    xmm0, xmm1
+  .text:0000000180502DCD                 divps   xmm9, xmm0
+  .text:0000000180502DD1                 movaps  xmm0, xmm7
+  .text:0000000180502DD4                 shufps  xmm0, xmm7, 0FFh
+  .text:0000000180502DD8                 ucomiss xmm0, xmm11
+  .text:0000000180502DDC                 jp      loc_180502E77
+  .text:0000000180502DE2                 jnz     loc_180502E77
+  .text:0000000180502DE8                 movaps  xmm12, xmm9
+  .text:0000000180502DEC                 movaps  xmm13, xmm9
+  .text:0000000180502DF0                 shufps  xmm12, xmm9, 9
+  .text:0000000180502DF5                 movaps  xmm5, xmm7
+  .text:0000000180502DF8                 shufps  xmm5, xmm7, 55h ; 'U'
+  .text:0000000180502DFC                 movaps  xmm4, xmm7
+  .text:0000000180502DFF                 shufps  xmm4, xmm7, 0AAh
+  .text:0000000180502E03                 movaps  xmm1, xmm5
+  .text:0000000180502E06                 unpcklps xmm1, xmm7
+  .text:0000000180502E09                 movaps  xmm6, xmm4
+  .text:0000000180502E0C                 unpcklps xmm6, xmm7
+  .text:0000000180502E0F                 movaps  xmm3, xmm5
+  .text:0000000180502E12                 movlhps xmm6, xmm1
+  .text:0000000180502E15                 movaps  xmm2, xmm7
+  .text:0000000180502E18                 unpcklps xmm3, xmm4
+  .text:0000000180502E1B                 xorps   xmm1, xmm1
+  .text:0000000180502E1E                 mulps   xmm6, xmm12
+  .text:0000000180502E22                 xorps   xmm10, xmm10
+  .text:0000000180502E26                 unpcklps xmm2, xmm7
+  .text:0000000180502E29                 movlhps xmm3, xmm2
+  .text:0000000180502E2C                 movaps  xmm2, xmm4
+  .text:0000000180502E2F                 unpcklps xmm2, xmm1
+  .text:0000000180502E32                 movaps  xmm4, xmm7
+  .text:0000000180502E35                 shufps  xmm13, xmm9, 12h
+  .text:0000000180502E3A                 mulps   xmm3, xmm13
+  .text:0000000180502E3E                 unpcklps xmm4, xmm5
+  .text:0000000180502E41                 shufps  xmm9, xmm9, 0FFh
+  .text:0000000180502E46                 movlhps xmm4, xmm2
+  .text:0000000180502E49                 subps   xmm6, xmm3
+  .text:0000000180502E4C                 movaps  xmm3, xmm9
+  .text:0000000180502E50                 addps   xmm6, xmm6
+  .text:0000000180502E53                 movaps  xmm1, xmm6
+  .text:0000000180502E56                 mulps   xmm3, xmm6
+  .text:0000000180502E59                 shufps  xmm1, xmm6, 12h
+  .text:0000000180502E5D                 mulps   xmm1, xmm12
+  .text:0000000180502E61                 shufps  xmm6, xmm6, 9
+  .text:0000000180502E65                 addps   xmm4, xmm3
+  .text:0000000180502E68                 mulps   xmm6, xmm13
+  .text:0000000180502E6C                 subps   xmm1, xmm6
+  .text:0000000180502E6F                 addps   xmm1, xmm4
+  .text:0000000180502E72                 jmp     loc_180502F2B
+  .text:0000000180502E77                 xorps   xmm10, xmm10
+  .text:0000000180502E7B                 ucomiss xmm0, xmm10
+  .text:0000000180502E7F                 jp      short loc_180502E8E
+  .text:0000000180502E81                 jnz     short loc_180502E8E
+  .text:0000000180502E83                 movss   xmm11, cs:dword_1815E567C
+  .text:0000000180502E8C                 jmp     short loc_180502E93
+  .text:0000000180502E8E                 divss   xmm11, xmm0
+  .text:0000000180502E93                 movaps  xmm12, xmm9
+  .text:0000000180502E97                 movaps  xmm13, xmm9
+  .text:0000000180502E9B                 shufps  xmm12, xmm9, 9
+  .text:0000000180502EA0                 movaps  xmm0, xmm9
+  .text:0000000180502EA4                 shufps  xmm0, xmm9, 0FFh
+  .text:0000000180502EA9                 movaps  xmm5, xmm7
+  .text:0000000180502EAC                 shufps  xmm5, xmm7, 55h ; 'U'
+  .text:0000000180502EB0                 movaps  xmm4, xmm7
+  .text:0000000180502EB3                 shufps  xmm4, xmm7, 0AAh
+  .text:0000000180502EB7                 movaps  xmm1, xmm5
+  .text:0000000180502EBA                 unpcklps xmm1, xmm7
+  .text:0000000180502EBD                 movaps  xmm6, xmm4
+  .text:0000000180502EC0                 unpcklps xmm6, xmm7
+  .text:0000000180502EC3                 movaps  xmm3, xmm5
+  .text:0000000180502EC6                 movlhps xmm6, xmm1
+  .text:0000000180502EC9                 movaps  xmm2, xmm7
+  .text:0000000180502ECC                 unpcklps xmm3, xmm4
+  .text:0000000180502ECF                 xorps   xmm1, xmm1
+  .text:0000000180502ED2                 mulps   xmm6, xmm12
+  .text:0000000180502ED6                 unpcklps xmm2, xmm7
+  .text:0000000180502ED9                 movlhps xmm3, xmm2
+  .text:0000000180502EDC                 movaps  xmm2, xmm4
+  .text:0000000180502EDF                 unpcklps xmm2, xmm1
+  .text:0000000180502EE2                 movaps  xmm4, xmm7
+  .text:0000000180502EE5                 shufps  xmm13, xmm9, 12h
+  .text:0000000180502EEA                 movaps  xmm9, xmm0
+  .text:0000000180502EEE                 mulps   xmm3, xmm13
+  .text:0000000180502EF2                 unpcklps xmm4, xmm5
+  .text:0000000180502EF5                 movlhps xmm4, xmm2
+  .text:0000000180502EF8                 subps   xmm6, xmm3
+  .text:0000000180502EFB                 movaps  xmm3, xmm0
+  .text:0000000180502EFE                 movaps  xmm0, xmm11
+  .text:0000000180502F02                 shufps  xmm0, xmm0, 0
+  .text:0000000180502F06                 addps   xmm6, xmm6
+  .text:0000000180502F09                 movaps  xmm1, xmm6
+  .text:0000000180502F0C                 mulps   xmm3, xmm6
+  .text:0000000180502F0F                 shufps  xmm1, xmm6, 12h
+  .text:0000000180502F13                 mulps   xmm1, xmm12
+  .text:0000000180502F17                 shufps  xmm6, xmm6, 9
+  .text:0000000180502F1B                 addps   xmm4, xmm3
+  .text:0000000180502F1E                 mulps   xmm6, xmm13
+  .text:0000000180502F22                 subps   xmm1, xmm6
+  .text:0000000180502F25                 addps   xmm1, xmm4
+  .text:0000000180502F28                 mulps   xmm1, xmm0
+  .text:0000000180502F2B                 xorps   xmm0, xmm0
+  .text:0000000180502F2E                 movaps  xmm3, xmm1
+  .text:0000000180502F31                 subss   xmm0, xmm1
+  .text:0000000180502F35                 shufps  xmm3, xmm1, 0AAh
+  .text:0000000180502F39                 movaps  xmm2, xmm1
+  .text:0000000180502F3C                 movaps  xmm6, xmm11
+  .text:0000000180502F40                 shufps  xmm2, xmm1, 55h ; 'U'
+  .text:0000000180502F44                 xorps   xmm1, xmm1
+  .text:0000000180502F47                 subss   xmm1, xmm2
+  .text:0000000180502F4B                 shufps  xmm6, xmm6, 0
+  .text:0000000180502F4F                 xorps   xmm2, xmm2
+  .text:0000000180502F52                 subss   xmm2, xmm3
+  .text:0000000180502F56                 unpcklps xmm0, xmm1
+  .text:0000000180502F59                 movss   xmm1, dword ptr [r13+4]
+  .text:0000000180502F5F                 movsd   [rsp+138h+var_E8], xmm0
+  .text:0000000180502F65                 movss   xmm0, dword ptr [r13+0]
+  .text:0000000180502F6B                 movss   dword ptr [rsp+138h+var_118], xmm0
+  .text:0000000180502F71                 movaps  xmm8, xmm0
+  .text:0000000180502F75                 movss   dword ptr [rsp+138h+var_118+4], xmm1
+  .text:0000000180502F7B                 movlhps xmm8, xmm1
+  .text:0000000180502F7F                 movd    eax, xmm2
+  .text:0000000180502F83                 movss   xmm2, dword ptr [r13+8]
+  .text:0000000180502F89                 shufps  xmm8, xmm2, 88h
+  .text:0000000180502F8E                 movss   [rsp+138h+var_110], xmm2
+  .text:0000000180502F94                 movaps  xmm1, xmm8
+  .text:0000000180502F98                 movss   xmm2, dword ptr [rsp+138h+var_E8+4]
+  .text:0000000180502F9E                 movaps  xmm0, xmm8
+  .text:0000000180502FA2                 shufps  xmm0, xmm8, 9
+  .text:0000000180502FA7                 shufps  xmm1, xmm8, 12h
+  .text:0000000180502FAC                 mulps   xmm0, xmm13
+  .text:0000000180502FB0                 mulps   xmm1, xmm12
+  .text:0000000180502FB4                 movss   dword ptr [rsp+138h+var_118+4], xmm2
+  .text:0000000180502FBA                 movd    xmm3, eax
+  .text:0000000180502FBE                 movss   [rsp+138h+var_110], xmm3
+  .text:0000000180502FC4                 subps   xmm1, xmm0
+  .text:0000000180502FC7                 addps   xmm1, xmm1
+  .text:0000000180502FCA                 movaps  xmm7, xmm1
+  .text:0000000180502FCD                 movaps  xmm0, xmm1
+  .text:0000000180502FD0                 shufps  xmm7, xmm1, 12h
+  .text:0000000180502FD4                 mulps   xmm0, xmm9
+  .text:0000000180502FD8                 mulps   xmm7, xmm12
+  .text:0000000180502FDC                 shufps  xmm1, xmm1, 9
+  .text:0000000180502FE0                 addps   xmm8, xmm0
+  .text:0000000180502FE4                 mulps   xmm1, xmm13
+  .text:0000000180502FE8                 movaps  xmm0, xmm11
+  .text:0000000180502FEC                 subps   xmm7, xmm1
+  .text:0000000180502FEF                 movss   xmm1, dword ptr [rsp+138h+var_E8]
+  .text:0000000180502FF5                 movss   dword ptr [rsp+138h+var_118], xmm1
+  .text:0000000180502FFB                 movaps  xmm5, xmm1
+  .text:0000000180502FFE                 movlhps xmm5, xmm2
+  .text:0000000180503001                 shufps  xmm5, xmm3, 88h
+  .text:0000000180503005                 insertps xmm5, xmm0, 30h ; '0'
+  .text:000000018050300B                 addps   xmm7, xmm8
+  .text:000000018050300F                 mulps   xmm7, xmm6
+  .text:0000000180503012                 addps   xmm7, xmm5
+  .text:0000000180503015                 movss   dword ptr [rbx+8], xmm7
+  .text:000000018050301A                 movaps  xmm0, xmm7
+  .text:000000018050301D                 shufps  xmm0, xmm7, 39h ; '9'
+  .text:0000000180503021                 movss   dword ptr [rbx+0Ch], xmm0
+  .text:0000000180503026                 shufps  xmm7, xmm7, 4Eh ; 'N'
+  .text:000000018050302A                 movss   dword ptr [rbx+10h], xmm7
+  .text:000000018050302F                 xorps   xmm14, cs:xmmword_181CE6760
+  .text:0000000180503037                 movss   xmm6, dword ptr [r12]
+  .text:000000018050303D                 movaps  xmm0, xmm14
+  .text:0000000180503041                 movss   xmm4, dword ptr [r12+8]
+  .text:0000000180503048                 movss   xmm5, dword ptr [r12+4]
+  .text:000000018050304F                 movaps  xmm8, xmm4
+  .text:0000000180503053                 dpps    xmm0, xmm14, 0FFh
+  .text:000000018050305A                 sqrtps  xmm0, xmm0
+  .text:000000018050305D                 movaps  xmm2, xmm5
+  .text:0000000180503060                 unpcklps xmm2, xmm6
+  .text:0000000180503063                 divps   xmm14, xmm0
+  .text:0000000180503067                 cmpeqps xmm0, xmm15
+  .text:000000018050306C                 blendvps xmm14, cs:xmmword_181DA3900
+  .text:0000000180503076                 unpcklps xmm8, xmm6
+  .text:000000018050307A                 movaps  xmm9, xmm14
+  .text:000000018050307E                 movaps  xmm7, xmm14
+  .text:0000000180503082                 movlhps xmm8, xmm2
+  .text:0000000180503086                 shufps  xmm9, xmm14, 9
+  .text:000000018050308B                 movaps  xmm2, xmm6
+  .text:000000018050308E                 shufps  xmm7, xmm14, 12h
+  .text:0000000180503093                 mov     r14, [rsp+138h+arg_28]
+  .text:000000018050309B                 movaps  xmm3, xmm5
+  .text:000000018050309E                 unpcklps xmm3, xmm4
+  .text:00000001805030A1                 mulps   xmm8, xmm9
+  .text:00000001805030A5                 unpcklps xmm2, xmm6
+  .text:00000001805030A8                 movlhps xmm3, xmm2
+  .text:00000001805030AB                 mulps   xmm3, xmm7
+  .text:00000001805030AE                 shufps  xmm14, xmm14, 0FFh
+  .text:00000001805030B3                 subps   xmm8, xmm3
+  .text:00000001805030B7                 movaps  xmm3, xmm6
+  .text:00000001805030BA                 unpcklps xmm3, xmm5
+  .text:00000001805030BD                 movlhps xmm3, xmm4
+  .text:00000001805030C0                 addps   xmm8, xmm8
+  .text:00000001805030C4                 mulps   xmm14, xmm8
+  .text:00000001805030C8                 movaps  xmm0, xmm8
+  .text:00000001805030CC                 shufps  xmm0, xmm8, 12h
+  .text:00000001805030D1                 mulps   xmm0, xmm9
+  .text:00000001805030D5                 shufps  xmm8, xmm8, 9
+  .text:00000001805030DA                 addps   xmm3, xmm14
+  .text:00000001805030DE                 mulps   xmm8, xmm7
+  .text:00000001805030E2                 subps   xmm0, xmm8
+  .text:00000001805030E6                 addps   xmm0, xmm3
+  .text:00000001805030E9                 movaps  xmm1, xmm0
+  .text:00000001805030EC                 movaps  xmm2, xmm0
+  .text:00000001805030EF                 shufps  xmm2, xmm0, 0AAh
+  .text:00000001805030F3                 shufps  xmm1, xmm0, 55h ; 'U'
+  .text:00000001805030F7                 unpcklps xmm0, xmm1
+  .text:00000001805030FA                 movsd   qword ptr [rbx+14h], xmm0
+  .text:00000001805030FF                 movss   dword ptr [rbx+1Ch], xmm2
+  .text:0000000180503104                 test    r14, r14
+  .text:0000000180503107                 jz      short loc_18050311D
+  .text:0000000180503109                 mov     r8, r14
+  .text:000000018050310C                 lea     rdx, [rsp+138h+var_118]
+  .text:0000000180503111                 lea     rcx, [rsp+138h+var_108]
+  .text:0000000180503116                 call    sub_180529DC0
+  .text:000000018050311B                 jmp     short loc_18050313A
+  .text:000000018050311D                 mov     eax, cs:dword_18165FA18
+  .text:0000000180503123                 movsd   xmm0, cs:qword_18165FA10
+  .text:000000018050312B                 mov     [rsp+138h+var_110], eax
+  .text:000000018050312F                 lea     rax, [rsp+138h+var_118]
+  .text:0000000180503134                 movsd   [rsp+138h+var_118], xmm0
+  .text:000000018050313A                 movsd   xmm0, qword ptr [rax]
+  .text:000000018050313E                 lea     rcx, [rbx+14h]
+  .text:0000000180503142                 movsd   qword ptr [rbx+20h], xmm0
+  .text:0000000180503147                 mov     eax, [rax+8]
+  .text:000000018050314A                 mov     [rbx+28h], eax
+  .text:000000018050314D                 movsd   xmm6, cs:qword_1815E09F8
+  .text:0000000180503155                 mov     r15d, cs:dword_1815E0A00
+  .text:000000018050315C                 call    sub_18130C780
+  .text:0000000180503161                 ucomiss xmm0, xmm10
+  .text:0000000180503165                 jp      short loc_180503172
+  .text:0000000180503167                 jnz     short loc_180503172
+  .text:0000000180503169                 movsd   qword ptr [rbx+14h], xmm6
+  .text:000000018050316E                 mov     [rbx+1Ch], r15d
+  .text:0000000180503172                 test    r14, r14
+  .text:0000000180503175                 jz      short loc_18050319E
+  .text:0000000180503177                 movsd   xmm6, cs:qword_1815E09F8
+  .text:000000018050317F                 lea     rcx, [rbx+20h]
+  .text:0000000180503183                 mov     ebp, cs:dword_1815E0A00
+  .text:0000000180503189                 call    sub_18130C780
+  .text:000000018050318E                 ucomiss xmm0, xmm10
+  .text:0000000180503192                 jp      short loc_18050319E
+  .text:0000000180503194                 jnz     short loc_18050319E
+  .text:0000000180503196                 movsd   qword ptr [rbx+20h], xmm6
+  .text:000000018050319B                 mov     [rbx+28h], ebp
+  .text:000000018050319E                 mov     r9, rbx
+  .text:00000001805031A1                 mov     r8, r12
+  .text:00000001805031A4                 mov     rdx, r13
+  .text:00000001805031A7                 mov     rcx, rsi
+  .text:00000001805031AA                 call    sub_18050C940
+  .text:00000001805031AF                 movaps  xmm15, [rsp+138h+var_C8]
+  .text:00000001805031B5                 lea     r11, [rsp+138h+var_28]
+  .text:00000001805031BD                 mov     rbp, [r11+38h]
+  .text:00000001805031C1                 mov     rax, rbx
+  .text:00000001805031C4                 mov     rbx, [r11+30h]
+  .text:00000001805031C8                 mov     rsi, [r11+40h]
+  .text:00000001805031CC                 movaps  xmm6, xmmword ptr [r11-10h]
+  .text:00000001805031D1                 movaps  xmm7, xmmword ptr [r11-20h]
+  .text:00000001805031D6                 movaps  xmm8, xmmword ptr [r11-30h]
+  .text:00000001805031DB                 movaps  xmm9, xmmword ptr [r11-40h]
+  .text:00000001805031E0                 movaps  xmm10, xmmword ptr [r11-50h]
+  .text:00000001805031E5                 movaps  xmm11, xmmword ptr [r11-60h]
+  .text:00000001805031EA                 movaps  xmm12, xmmword ptr [r11-70h]
+  .text:00000001805031EF                 movaps  xmm13, xmmword ptr [r11-80h]
+  .text:00000001805031F4                 movaps  xmm14, xmmword ptr [r11-90h]
+  .text:00000001805031FC                 mov     rsp, r11
+  .text:00000001805031FF                 pop     r15
+  .text:0000000180503201                 pop     r14
+  .text:0000000180503203                 pop     r13
+  .text:0000000180503205                 pop     r12
+  .text:0000000180503207                 pop     rdi
+  .text:0000000180503208                 retn
+procedure: |-
+  __int64 *__fastcall DecalPlacementInfo_ctor(__int64 *a1, __int64 a2, _DWORD *a3, unsigned int *a4, int a5, __int64 a6)
+  {
+    __int64 v6; // rsi
+    __int64 v10; // rax
+    int v11; // r8d
+    __m128 *BoneTransform; // rax
+    __m128 v13; // xmm7
+    __m128 v14; // xmm14
+    __m128 *v15; // rax
+    __m128 v16; // xmm11
+    __m128 v17; // xmm9
+    __m128 v18; // xmm1
+    __m128 v19; // xmm9
+    float v20; // xmm0_4
+    __m128 v21; // xmm12
+    __m128 v22; // xmm5
+    __m128 v23; // xmm4
+    __m128 v24; // xmm13
+    __m128 v25; // xmm9
+    __m128 v26; // xmm6
+    __m128 v27; // xmm6
+    __m128 v28; // xmm1
+    __m128 v29; // xmm5
+    __m128 v30; // xmm4
+    __m128 v31; // xmm6
+    __m128 v32; // xmm6
+    __m128 v33; // xmm0
+    float v34; // xmm3_4
+    float v35; // xmm2_4
+    __m128 v36; // xmm1
+    __m128i v37; // xmm2
+    __m128 v38; // xmm1
+    __m128 v39; // xmm8
+    __m128 v40; // xmm3
+    __m128 v41; // xmm1
+    __m128 v42; // xmm1
+    __m128 v43; // xmm7
+    __m128 v44; // xmm14
+    __m128 v45; // xmm4
+    __m128 v46; // xmm0
+    __m128 v47; // xmm14
+    __m128 v48; // xmm9
+    __m128 v49; // xmm7
+    __m128 v50; // xmm8
+    __m128 v51; // xmm8
+    __m128 v52; // xmm0
+    __int64 *v53; // rax
+    __int64 v55; // [rsp+20h] [rbp-118h] BYREF
+    int v56; // [rsp+28h] [rbp-110h]
+    __m128 v57; // [rsp+30h] [rbp-108h] BYREF
+    __m128 v58; // [rsp+40h] [rbp-F8h]
+    unsigned __int64 v59[4]; // [rsp+50h] [rbp-E8h] BYREF
+
+    v6 = 0;
+    *a1 = 0;
+    a1[1] = 0;
+    *((_DWORD *)a1 + 4) = 0;
+    *(__int64 *)((char *)a1 + 20) = 0;
+    *((_DWORD *)a1 + 7) = 0;
+    a1[4] = 0;
+    *((_DWORD *)a1 + 10) = 0;
+    *((_DWORD *)a1 + 11) = -1;
+    a1[6] = -1;
+    *((_DWORD *)a1 + 14) = -1082130432;
+    *((_DWORD *)a1 + 15) = 0;
+    *((_BYTE *)a1 + 64) = 0;
+    *(__int64 *)((char *)a1 + 68) = 0;
+    *((_DWORD *)a1 + 19) = 0;
+    a1[10] = 0;
+    *((_DWORD *)a1 + 22) = 0;
+    if ( a2 )
+    {
+      *a1 = a2;
+      *((_DWORD *)a1 + 12) = a5;
+  LABEL_4:
+      v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a2 + 440LL))(a2);
+      goto LABEL_5;
+    }
+    v10 = sub_180C332F0();
+    *a1 = v10;
+    a2 = v10;
+    *((_DWORD *)a1 + 12) = a5;
+    if ( v10 )
+      goto LABEL_4;
+  LABEL_5:
+    if ( (*(unsigned __int8 (__fastcall **)(_QWORD, __int64))(*(_QWORD *)*a1 + 1376LL))(*a1, a2)
+      || (v11 = *((_DWORD *)a1 + 12), v11 < 0)
+      || !v6 )
+    {
+      v15 = (__m128 *)sub_1803C0610(*a1);
+      v13 = *v15;
+      v14 = v15[1];
+      *((_DWORD *)a1 + 12) = -1;
+    }
+    else
+    {
+      BoneTransform = (__m128 *)CBaseModelEntity_GetBoneTransform(v6, v59, v11);
+      v13 = *BoneTransform;
+      v14 = BoneTransform[1];
+    }
+    v16 = (__m128)0x3F800000u;
+    v17 = _mm_mul_ps(v14, (__m128)xmmword_181CE6750);
+    v58 = v14;
+    v57 = v13;
+    v18 = _mm_sqrt_ps(_mm_dp_ps(v17, v17, 255));
+    v19 = _mm_div_ps(v17, _mm_or_ps(_mm_and_ps(_mm_cmpeq_ps((__m128)0LL, v18), (__m128)xmmword_181CE66F0), v18));
+    v20 = _mm_shuffle_ps(v13, v13, 255).m128_f32[0];
+    if ( v20 == 1.0 )
+    {
+      v21 = _mm_shuffle_ps(v19, v19, 9);
+      v22 = _mm_shuffle_ps(v13, v13, 85);
+      v23 = _mm_shuffle_ps(v13, v13, 170);
+      v24 = _mm_shuffle_ps(v19, v19, 18);
+      v25 = _mm_shuffle_ps(v19, v19, 255);
+      v26 = _mm_sub_ps(
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v23, v13), _mm_unpacklo_ps(v22, v13)), v21),
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v22, v23), _mm_unpacklo_ps(v13, v13)), v24));
+      v27 = _mm_add_ps(v26, v26);
+      v28 = _mm_add_ps(
+              _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v27, v27, 18), v21), _mm_mul_ps(_mm_shuffle_ps(v27, v27, 9), v24)),
+              _mm_add_ps(
+                _mm_movelh_ps(_mm_unpacklo_ps(v13, v22), _mm_unpacklo_ps(v23, (__m128)0LL)),
+                _mm_mul_ps(v25, v27)));
+    }
+    else
+    {
+      if ( v20 == 0.0 )
+        v16 = (__m128)0x4B000000u;
+      else
+        v16.m128_f32[0] = 1.0 / v20;
+      v21 = _mm_shuffle_ps(v19, v19, 9);
+      v29 = _mm_shuffle_ps(v13, v13, 85);
+      v30 = _mm_shuffle_ps(v13, v13, 170);
+      v24 = _mm_shuffle_ps(v19, v19, 18);
+      v25 = _mm_shuffle_ps(v19, v19, 255);
+      v31 = _mm_sub_ps(
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v30, v13), _mm_unpacklo_ps(v29, v13)), v21),
+              _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v29, v30), _mm_unpacklo_ps(v13, v13)), v24));
+      v32 = _mm_add_ps(v31, v31);
+      v28 = _mm_mul_ps(
+              _mm_add_ps(
+                _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v32, v32, 18), v21), _mm_mul_ps(_mm_shuffle_ps(v32, v32, 9), v24)),
+                _mm_add_ps(
+                  _mm_movelh_ps(_mm_unpacklo_ps(v13, v29), _mm_unpacklo_ps(v30, (__m128)0LL)),
+                  _mm_mul_ps(v25, v32))),
+              _mm_shuffle_ps(v16, v16, 0));
+    }
+    v33 = 0;
+    v33.m128_f32[0] = 0.0 - v28.m128_f32[0];
+    v34 = _mm_shuffle_ps(v28, v28, 170).m128_f32[0];
+    v35 = _mm_shuffle_ps(v28, v28, 85).m128_f32[0];
+    v36 = 0;
+    v36.m128_f32[0] = 0.0 - v35;
+    v37 = 0;
+    *(float *)v37.m128i_i32 = 0.0 - v34;
+    v33.m128_u64[0] = _mm_unpacklo_ps(v33, v36).m128_u64[0];
+    v38 = (__m128)(unsigned int)a3[1];
+    v59[0] = v33.m128_u64[0];
+    LODWORD(v55) = *a3;
+    HIDWORD(v55) = v38.m128_i32[0];
+    v39 = _mm_shuffle_ps(_mm_movelh_ps((__m128)(unsigned int)v55, v38), (__m128)(unsigned int)a3[2], 136);
+    v40 = (__m128)_mm_cvtsi32_si128(_mm_cvtsi128_si32(v37));
+    v56 = v40.m128_i32[0];
+    v41 = _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v39, v39, 18), v21), _mm_mul_ps(_mm_shuffle_ps(v39, v39, 9), v24));
+    v42 = _mm_add_ps(v41, v41);
+    v55 = v33.m128_u64[0];
+    v43 = _mm_add_ps(
+            _mm_mul_ps(
+              _mm_add_ps(
+                _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v42, v42, 18), v21), _mm_mul_ps(_mm_shuffle_ps(v42, v42, 9), v24)),
+                _mm_add_ps(v39, _mm_mul_ps(v42, v25))),
+              _mm_shuffle_ps(v16, v16, 0)),
+            _mm_insert_ps(
+              _mm_shuffle_ps(_mm_movelh_ps((__m128)v33.m128_u32[0], (__m128)v33.m128_u32[1]), v40, 136),
+              v16,
+              48));
+    *((_DWORD *)a1 + 2) = v43.m128_i32[0];
+    *((float *)a1 + 3) = _mm_shuffle_ps(v43, v43, 57).m128_f32[0];
+    *((float *)a1 + 4) = _mm_shuffle_ps(v43, v43, 78).m128_f32[0];
+    v44 = _mm_xor_ps(v14, (__m128)xmmword_181CE6760);
+    v45 = (__m128)a4[2];
+    v46 = _mm_sqrt_ps(_mm_dp_ps(v44, v44, 255));
+    v47 = _mm_blendv_ps(_mm_div_ps(v44, v46), (__m128)xmmword_181DA3900, _mm_cmpeq_ps(v46, (__m128)0LL));
+    v48 = _mm_shuffle_ps(v47, v47, 9);
+    v49 = _mm_shuffle_ps(v47, v47, 18);
+    v50 = _mm_sub_ps(
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps(v45, (__m128)*a4), _mm_unpacklo_ps((__m128)a4[1], (__m128)*a4)), v48),
+            _mm_mul_ps(_mm_movelh_ps(_mm_unpacklo_ps((__m128)a4[1], v45), _mm_unpacklo_ps((__m128)*a4, (__m128)*a4)), v49));
+    v51 = _mm_add_ps(v50, v50);
+    v52 = _mm_add_ps(
+            _mm_sub_ps(_mm_mul_ps(_mm_shuffle_ps(v51, v51, 18), v48), _mm_mul_ps(_mm_shuffle_ps(v51, v51, 9), v49)),
+            _mm_add_ps(
+              _mm_movelh_ps(_mm_unpacklo_ps((__m128)*a4, (__m128)a4[1]), v45),
+              _mm_mul_ps(_mm_shuffle_ps(v47, v47, 255), v51)));
+    *(__int64 *)((char *)a1 + 20) = _mm_unpacklo_ps(v52, _mm_shuffle_ps(v52, v52, 85)).m128_u64[0];
+    *((_DWORD *)a1 + 7) = _mm_shuffle_ps(v52, v52, 170).m128_u32[0];
+    if ( a6 )
+    {
+      v53 = (__int64 *)sub_180529DC0(&v57, &v55, a6);
+    }
+    else
+    {
+      v56 = 2139095039;
+      v53 = &v55;
+      v55 = 0x7F7FFFFF7F7FFFFFLL;
+    }
+    a1[4] = *v53;
+    *((_DWORD *)a1 + 10) = *((_DWORD *)v53 + 2);
+    if ( sub_18130C780((char *)a1 + 20) == 0.0 )
+    {
+      *(__int64 *)((char *)a1 + 20) = 0;
+      *((_DWORD *)a1 + 7) = 0;
+    }
+    if ( a6 && sub_18130C780(a1 + 4) == 0.0 )
+    {
+      a1[4] = 0;
+      *((_DWORD *)a1 + 10) = 0;
+    }
+    sub_18050C940(v6, a3, a4, a1, v55, v56, v57.m128_u64[0], v57.m128_u64[1], v58.m128_u64[0], v58.m128_u64[1], v59[0]);
+    return a1;
+  }


### PR DESCRIPTION
## Summary
- Add an LLM-decompile chain from `CBasePlayerPawn_OnTakeDamage` through `DecalPlacementInfo_ctor` to `CBaseModelEntity_GetBoneTransform`.
- Publish the corresponding 14174 symbol snapshot and ModSharp server gamedata signatures.

## Validation
- targeted LLM preprocessor runs: passed on Windows and Linux for both new finder stages
- non-MCP unittest suite: 1057 tests passed
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with 12 runnable tests and zero compile, invalid-item, or layout-difference failures
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: `59aa97f903043907d2c0abb40902ff5c608bdb25`