### PR TITLE
feat(cs2fow): add gamedata generator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ Canonical tracked outputs are `gamesymbols/<GAMEVER>.yaml` and `gamedata/<GAMEVE
 
 ## Supported gamedata
 
-Versioned gamedata is generated for CounterStrikeSharp, CS2Fixes, swiftlys2, plugify, cs2kz-metamod, modsharp, and CS2Surf/Timer. See [supported gamedata paths and exceptions](docs/en/snapshot-and-gamedata.md#supported-gamedata).
+Versioned gamedata is generated for CounterStrikeSharp, CS2Fixes, CS2FOW, swiftlys2, plugify, cs2kz-metamod, modsharp, and CS2Surf/Timer. See [supported gamedata paths and exceptions](docs/en/snapshot-and-gamedata.md#supported-gamedata).

--- a/README_CN.md
+++ b/README_CN.md
@@ -42,4 +42,4 @@ canonical tracked output 是 `gamesymbols/<GAMEVER>.yaml` 与 `gamedata/<GAMEVER
 
 ## 支持的 gamedata
 
-本项目为 CounterStrikeSharp、CS2Fixes、swiftlys2、plugify、cs2kz-metamod、modsharp 和 CS2Surf/Timer 生成按版本保存的 gamedata。具体路径与例外见[支持的 gamedata](docs/zh-CN/snapshot-and-gamedata.md)。
+本项目为 CounterStrikeSharp、CS2Fixes、CS2FOW、swiftlys2、plugify、cs2kz-metamod、modsharp 和 CS2Surf/Timer 生成按版本保存的 gamedata。具体路径与例外见[支持的 gamedata](docs/zh-CN/snapshot-and-gamedata.md)。

--- a/docs/en/snapshot-and-gamedata.md
+++ b/docs/en/snapshot-and-gamedata.md
@@ -87,6 +87,15 @@ gamedata/<GAMEVER>/CS2Fixes/gamedata/cs2fixes.jsonc
 
 `CCSPlayerPawn_GetMaxSpeed` is skipped because it is not present in `server.dll`.
 
+### [CS2FOW](https://gitlab.com/karola3vax-group/cs2fow)
+
+```text
+gamedata/<GAMEVER>/CS2FOW/gamedata/cs2fow.games.txt
+```
+
+CS2FOW output is generated for game version `14174` and later. Server binary size and CRC32 values come from the
+same immutable symbol snapshot as the generated offsets and RVAs.
+
 ### [swiftlys2](https://github.com/swiftly-solution/swiftlys2)
 
 ```text

--- a/docs/zh-CN/snapshot-and-gamedata.md
+++ b/docs/zh-CN/snapshot-and-gamedata.md
@@ -87,6 +87,15 @@ gamedata/<GAMEVER>/CS2Fixes/gamedata/cs2fixes.jsonc
 
 跳过 `CCSPlayerPawn_GetMaxSpeed`，因为它并不存在于 `server.dll` 中。
 
+### [CS2FOW](https://gitlab.com/karola3vax-group/cs2fow)
+
+```text
+gamedata/<GAMEVER>/CS2FOW/gamedata/cs2fow.games.txt
+```
+
+CS2FOW 从游戏版本 `14174` 开始生成。server binary size 和 CRC32 与 offsets、RVA 均来自同一个 immutable
+symbol snapshot。
+
 ### [swiftlys2](https://github.com/swiftly-solution/swiftlys2)
 
 ```text

--- a/gamedata-generators/CS2FOW/gamedata.py
+++ b/gamedata-generators/CS2FOW/gamedata.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Update CS2FOW runtime compatibility data from one symbol snapshot."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MODULE_NAME = "CS2FOW"
+MODULE_ENABLED = True
+GENERATOR_API_VERSION = 2
+
+GAMEDATA_PATH = "gamedata/cs2fow.games.txt"
+OUTPUT_PATHS = (GAMEDATA_PATH,)
+DOWNLOAD_SOURCES = [
+    (
+        "https://gitlab.com/karola3vax-group/cs2fow/-/raw/main/gamedata/cs2fow.games.txt?ref_type=heads",
+        GAMEDATA_PATH,
+    ),
+]
+
+SUPPORTED_PLATFORMS = {"windows", "linux"}
+ASSIGNMENT_RE = re.compile(
+    r"^(?P<prefix>[ \t]*(?P<key>[a-z0-9_]+)[ \t]*=[ \t]*)"
+    r"(?P<value>[+-]?\d+)(?P<suffix>[ \t]*(?://.*)?)$"
+)
+
+BINARY_FIELDS = {
+    "server_binary_size": "size",
+    "server_binary_crc32": "crc32",
+}
+
+SYMBOL_FIELDS = {
+    "recipient_slot_offset": ("server", "CCheckTransmitInfo_m_nPlayerSlot", "struct_member_offset"),
+    "checktransmit_full_update_offset": (
+        "server",
+        "CCheckTransmitInfo_m_bFullUpdate",
+        "struct_member_offset",
+    ),
+    "game_entity_system_offset": ("engine", "CGameResourceService_m_pEntitySystem", "struct_member_offset"),
+    "game_event_manager_vtable_rva": ("server", "CGameEventManager_vtable", "vtable_rva"),
+    "lookup_bone_rva": ("server", "CBaseModelEntity_FindBone", "func_rva"),
+    "get_bone_transform_rva": ("server", "CBaseModelEntity_GetBoneTransform", "func_rva"),
+    "create_entity_by_name_rva": ("server", "UTIL_CreateEntityByName", "func_rva"),
+    "dispatch_spawn_rva": ("server", "CBaseEntity_DispatchSpawn", "func_rva"),
+    "remove_entity_rva": ("server", "UTIL_Remove", "func_rva"),
+    "teleport_vtable_index": ("server", "CBaseEntity_Teleport", "vfunc_index"),
+    "smoke_volume_offset": ("server", "CSmokeGrenadeProjectile_m_SmokeVolume", "struct_member_offset"),
+    "smoke_storage_offset": ("server", "SmokeVolume_m_pStorage", "struct_member_offset"),
+    "smoke_frame_offset": ("server", "SmokeVolume_m_nFrame", "struct_member_offset"),
+    "smoke_center_offset": ("server", "SmokeVolume_m_vecCenterOrigin", "struct_member_offset"),
+    "smoke_start_time_offset": ("server", "SmokeVolume_m_flStartTime", "struct_member_offset"),
+}
+
+
+def _decimal(value, *, label):
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be an integer")
+    try:
+        parsed = int(value.strip(), 0) if isinstance(value, str) else int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not an integer: {value!r}") from exc
+    if parsed < 0:
+        raise ValueError(f"{label} must not be negative: {parsed}")
+    return str(parsed)
+
+
+def _crc32_decimal(value, *, label):
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a CRC32 value")
+    try:
+        parsed = int(value.strip(), 16) if isinstance(value, str) else int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{label} is not a CRC32 value: {value!r}") from exc
+    if not 0 <= parsed <= 0xFFFFFFFF:
+        raise ValueError(f"{label} is outside the CRC32 range: {parsed}")
+    return str(parsed)
+
+
+def _binary_value(context, platform, metadata_name):
+    if context is None:
+        raise ValueError("CS2FOW requires generator context")
+    server = context.binaries.get("server")
+    metadata = server.get(platform) if server else None
+    if not metadata or metadata_name not in metadata:
+        raise ValueError(f"snapshot binary metadata is missing: server.{platform}.{metadata_name}")
+    value = metadata[metadata_name]
+    label = f"server.{platform}.{metadata_name}"
+    if metadata_name == "crc32":
+        return _crc32_decimal(value, label=label)
+    return _decimal(value, label=label)
+
+
+def _symbol_value(yaml_data, platform, module_name, symbol_name, value_name):
+    symbol = yaml_data.get(symbol_name)
+    if not symbol or symbol.get("library") != module_name:
+        raise ValueError(f"snapshot symbol is missing or belongs to the wrong module: {module_name}/{symbol_name}")
+    platform_data = symbol.get(platform)
+    if not platform_data or value_name not in platform_data:
+        raise ValueError(f"snapshot value is missing: {module_name}/{symbol_name}.{platform}.{value_name}")
+    return _decimal(
+        platform_data[value_name],
+        label=f"{module_name}/{symbol_name}.{platform}.{value_name}",
+    )
+
+
+def _replacement_values(yaml_data, platforms, context):
+    requested_platforms = tuple(dict.fromkeys(platforms))
+    unsupported = sorted(set(requested_platforms) - SUPPORTED_PLATFORMS)
+    if unsupported:
+        raise ValueError("CS2FOW does not support platforms: " + ", ".join(unsupported))
+    if not requested_platforms:
+        raise ValueError("CS2FOW requires at least one platform")
+
+    replacements = {}
+    metadata = {}
+    for platform in requested_platforms:
+        for key_prefix, metadata_name in BINARY_FIELDS.items():
+            key = f"{key_prefix}_{platform}"
+            replacements[key] = _binary_value(context, platform, metadata_name)
+            metadata[key] = ("binary_metadata", platform)
+        for key_prefix, (module_name, symbol_name, value_name) in SYMBOL_FIELDS.items():
+            key = f"{key_prefix}_{platform}"
+            replacements[key] = _symbol_value(
+                yaml_data,
+                platform,
+                module_name,
+                symbol_name,
+                value_name,
+            )
+            metadata[key] = (value_name, platform)
+    return replacements, metadata
+
+
+def _line_ending(line):
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith(("\r", "\n")):
+        return line[:-1], line[-1]
+    return line, ""
+
+
+def _replace_assignments(content, replacements):
+    seen = set()
+    updated_lines = []
+    for line in content.splitlines(keepends=True):
+        body, ending = _line_ending(line)
+        match = ASSIGNMENT_RE.fullmatch(body)
+        key = match.group("key") if match else None
+        if key not in replacements:
+            updated_lines.append(line)
+            continue
+        if key in seen:
+            raise ValueError(f"CS2FOW gamedata contains duplicate assignment: {key}")
+        seen.add(key)
+        updated_lines.append(f"{match.group('prefix')}{replacements[key]}{match.group('suffix')}{ending}")
+
+    missing = sorted(set(replacements) - seen)
+    if missing:
+        raise ValueError("CS2FOW gamedata is missing assignments: " + ", ".join(missing))
+    return "".join(updated_lines)
+
+
+def update(
+    yaml_data,
+    func_lib_map,
+    platforms,
+    output_dir,
+    alias_to_name_map,
+    debug=False,
+    *,
+    context,
+):
+    """Update the downloaded flat key=value compatibility file."""
+    del func_lib_map, alias_to_name_map
+    gamedata_path = Path(output_dir) / GAMEDATA_PATH
+    raw = gamedata_path.read_bytes()
+    has_bom = raw.startswith(b"\xef\xbb\xbf")
+    content = raw.decode("utf-8-sig" if has_bom else "utf-8")
+    replacements, metadata = _replacement_values(yaml_data, platforms, context)
+    updated_content = _replace_assignments(content, replacements)
+    encoded = updated_content.encode("utf-8")
+    gamedata_path.write_bytes((b"\xef\xbb\xbf" if has_bom else b"") + encoded)
+
+    updated_symbols = []
+    if debug:
+        updated_symbols = [
+            {"name": key, "type": metadata[key][0], "platform": metadata[key][1]} for key in replacements
+        ]
+    return len(replacements), 0, updated_symbols, []

--- a/gamedata/14174/CS2FOW/gamedata/cs2fow.games.txt
+++ b/gamedata/14174/CS2FOW/gamedata/cs2fow.games.txt
@@ -1,0 +1,49 @@
+// CS2FOW private runtime compatibility data.
+// Verified against the public CS2 app build 24537688 (1.41.7.4).
+// Unknown binaries fail open. Keep exactly one fingerprint per platform.
+
+// Exact server binaries (file size and CRC32).
+server_binary_size_windows=32818840
+server_binary_crc32_windows=1451045147
+server_binary_size_linux=40344184
+server_binary_crc32_linux=1097984287
+
+// CCheckTransmitInfo private layout.
+recipient_slot_offset_windows=576
+recipient_slot_offset_linux=576
+checktransmit_full_update_offset_windows=580
+checktransmit_full_update_offset_linux=580
+
+// GameResourceServiceServerV001 private layout in engine2.
+game_entity_system_offset_windows=88
+game_entity_system_offset_linux=80
+
+// Module-relative server function and vtable addresses.
+game_event_manager_vtable_rva_windows=24771832
+game_event_manager_vtable_rva_linux=38413048
+lookup_bone_rva_windows=11525088
+lookup_bone_rva_linux=22924928
+get_bone_transform_rva_windows=11465024
+get_bone_transform_rva_linux=22925488
+create_entity_by_name_rva_windows=12053024
+create_entity_by_name_rva_linux=23781248
+dispatch_spawn_rva_windows=12772832
+dispatch_spawn_rva_linux=24684864
+remove_entity_rva_windows=12312448
+remove_entity_rva_linux=23782048
+
+// CBaseEntity virtual function indexes used by temporary LOS debug beams.
+teleport_vtable_index_windows=163
+teleport_vtable_index_linux=162
+
+// CSmokeGrenadeProjectile::SmokeVolume private voxel layout.
+smoke_volume_offset_windows=2776
+smoke_volume_offset_linux=3504
+smoke_storage_offset_windows=112
+smoke_storage_offset_linux=112
+smoke_frame_offset_windows=236
+smoke_frame_offset_linux=236
+smoke_center_offset_windows=212
+smoke_center_offset_linux=212
+smoke_start_time_offset_windows=12
+smoke_start_time_offset_linux=12

--- a/gamedata_contract.py
+++ b/gamedata_contract.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import importlib.util
+import inspect
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from types import ModuleType
+from types import MappingProxyType, ModuleType
+from typing import Any
 
 from release_workflow_lib.hashing import (
     canonical_json_bytes,
@@ -18,16 +21,36 @@ MODULE_DIRECTORY_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 GAMEVER_RE = re.compile(r"\d+[a-z]?\Z")
 ALLOWED_OUTPUT_SUFFIXES = {".json", ".jsonc", ".txt"}
 RESERVED_MODULE_DIRECTORIES = {"completed", "cleanup-trash", "locks", "pr-index"}
+SUPPORTED_GENERATOR_API_VERSIONS = {1, 2}
 
 
 class GamedataContractError(ValueError):
     pass
 
 
+def _freeze_context_value(value):
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_context_value(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_context_value(item) for item in value)
+    return value
+
+
+@dataclass(frozen=True)
+class GeneratorContext:
+    game_version: str
+    binaries: Mapping[str, Any]
+
+    def __post_init__(self):
+        object.__setattr__(self, "game_version", str(self.game_version))
+        object.__setattr__(self, "binaries", _freeze_context_value(self.binaries))
+
+
 @dataclass(frozen=True)
 class GeneratorModule:
     directory: str
     name: str
+    api_version: int
     source_dir: Path
     module: ModuleType
     output_paths: tuple[str, ...]
@@ -39,6 +62,7 @@ class GeneratorModule:
         return {
             "directory": self.directory,
             "name": self.name,
+            "api_version": self.api_version,
             "output_paths": list(self.output_paths),
             "download_sources": [list(item) for item in self.download_sources],
             "static_sources": [list(item) for item in self.static_sources],
@@ -87,6 +111,26 @@ def _module_contract(directory: str, source_dir: Path, module: ModuleType) -> Ge
     name = getattr(module, "MODULE_NAME", None)
     if not isinstance(name, str) or not name.strip():
         raise GamedataContractError(f"generator {directory} has no valid MODULE_NAME")
+    api_version = getattr(module, "GENERATOR_API_VERSION", 1)
+    if (
+        isinstance(api_version, bool)
+        or not isinstance(api_version, int)
+        or api_version not in SUPPORTED_GENERATOR_API_VERSIONS
+    ):
+        raise GamedataContractError(f"generator {directory} has unsupported GENERATOR_API_VERSION: {api_version!r}")
+    update = getattr(module, "update", None)
+    if not callable(update):
+        raise GamedataContractError(f"generator {directory} has no callable update")
+    if api_version == 2:
+        try:
+            context_parameter = inspect.signature(update).parameters.get("context")
+        except (TypeError, ValueError) as exc:
+            raise GamedataContractError(f"generator {directory} has an unreadable update signature: {exc}") from exc
+        if context_parameter is None or context_parameter.kind not in {
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        }:
+            raise GamedataContractError(f"generator {directory} API v2 update must accept a context keyword argument")
     declared = getattr(module, "OUTPUT_PATHS", None)
     if not isinstance(declared, (tuple, list)) or not declared:
         raise GamedataContractError(f"generator {directory} must declare non-empty OUTPUT_PATHS")
@@ -146,6 +190,7 @@ def _module_contract(directory: str, source_dir: Path, module: ModuleType) -> Ge
     return GeneratorModule(
         directory=directory,
         name=name.strip(),
+        api_version=api_version,
         source_dir=source_dir,
         module=module,
         output_paths=output_paths,

--- a/gamesymbol_store.py
+++ b/gamesymbol_store.py
@@ -82,6 +82,9 @@ class SymbolStore(Protocol):
     @property
     def file_count(self) -> int: ...
 
+    @property
+    def binaries(self) -> Mapping[str, Any]: ...
+
     def contains(self, module: str, filename: str) -> bool: ...
 
     def get(self, module: str, filename: str) -> Mapping[str, Any] | None: ...
@@ -142,6 +145,7 @@ class _MemorySymbolStore:
         config_sha256: str,
         source_sha256: str,
         files: Mapping[str, Mapping],
+        binaries: Mapping[str, Any] | None = None,
     ):
         self._game_version = str(game_version)
         self._schema_version = schema_version
@@ -149,6 +153,7 @@ class _MemorySymbolStore:
         self._config_sha256 = config_sha256
         self._candidate_sha256 = source_sha256
         self._files = {path: copy.deepcopy(payload) for path, payload in files.items()}
+        self._binaries = copy.deepcopy(binaries or {})
         self._modules: dict[str, list[str]] = {}
         for path in sorted(self._files):
             module, _filename = _split_store_path(path)
@@ -177,6 +182,10 @@ class _MemorySymbolStore:
     @property
     def file_count(self) -> int:
         return len(self._files)
+
+    @property
+    def binaries(self) -> Mapping[str, Any]:
+        return copy.deepcopy(self._binaries)
 
     def contains(self, module: str, filename: str) -> bool:
         return self._key(module, filename) in self._files
@@ -243,6 +252,7 @@ class SnapshotSymbolStore(_MemorySymbolStore):
             config_sha256=document["config_sha256"],
             source_sha256=digest,
             files=document["files"],
+            binaries=document.get("binaries", {}),
         )
 
 

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -42265,5 +42265,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T04:46:20Z'
+last_publish_time: '2026-08-05T06:00:20Z'
 schema_version: 5

--- a/tests/run_test_suite.py
+++ b/tests/run_test_suite.py
@@ -62,6 +62,7 @@ UNIT_MODULES = frozenset(
         "test_binary_hashing",
         "test_bump_download",
         "test_copy_depot_bin",
+        "test_cs2fow_gamedata",
         "test_define_inputfunc_preprocessor",
         "test_download_depot",
         "test_format_repo_files",

--- a/tests/test_cs2fow_gamedata.py
+++ b/tests/test_cs2fow_gamedata.py
@@ -1,0 +1,221 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from gamedata_contract import GeneratorContext, discover_generator_modules
+
+
+SYMBOL_FIXTURES = {
+    "CCheckTransmitInfo_m_nPlayerSlot": ("server", "struct_member_offset", 10, 11),
+    "CCheckTransmitInfo_m_bFullUpdate": ("server", "struct_member_offset", 12, 13),
+    "CGameResourceService_m_pEntitySystem": ("engine", "struct_member_offset", 14, 15),
+    "CGameEventManager_vtable": ("server", "vtable_rva", "0x10", "0x11"),
+    "CBaseModelEntity_FindBone": ("server", "func_rva", "0x20", "0x21"),
+    "CBaseModelEntity_GetBoneTransform": ("server", "func_rva", "0x30", "0x31"),
+    "UTIL_CreateEntityByName": ("server", "func_rva", "0x40", "0x41"),
+    "CBaseEntity_DispatchSpawn": ("server", "func_rva", "0x50", "0x51"),
+    "UTIL_Remove": ("server", "func_rva", "0x60", "0x61"),
+    "CBaseEntity_Teleport": ("server", "vfunc_index", 70, 71),
+    "CSmokeGrenadeProjectile_m_SmokeVolume": ("server", "struct_member_offset", 72, 73),
+    "SmokeVolume_m_pStorage": ("server", "struct_member_offset", 74, 75),
+    "SmokeVolume_m_nFrame": ("server", "struct_member_offset", 76, 77),
+    "SmokeVolume_m_vecCenterOrigin": ("server", "struct_member_offset", 78, 79),
+    "SmokeVolume_m_flStartTime": ("server", "struct_member_offset", 80, 81),
+}
+
+EXPECTED_VALUES = {
+    "server_binary_size_windows": "1001",
+    "server_binary_crc32_windows": "4294967295",
+    "recipient_slot_offset_windows": "10",
+    "checktransmit_full_update_offset_windows": "12",
+    "game_entity_system_offset_windows": "14",
+    "game_event_manager_vtable_rva_windows": "16",
+    "lookup_bone_rva_windows": "32",
+    "get_bone_transform_rva_windows": "48",
+    "create_entity_by_name_rva_windows": "64",
+    "dispatch_spawn_rva_windows": "80",
+    "remove_entity_rva_windows": "96",
+    "teleport_vtable_index_windows": "70",
+    "smoke_volume_offset_windows": "72",
+    "smoke_storage_offset_windows": "74",
+    "smoke_frame_offset_windows": "76",
+    "smoke_center_offset_windows": "78",
+    "smoke_start_time_offset_windows": "80",
+    "server_binary_size_linux": "2001",
+    "server_binary_crc32_linux": "10",
+    "recipient_slot_offset_linux": "11",
+    "checktransmit_full_update_offset_linux": "13",
+    "game_entity_system_offset_linux": "15",
+    "game_event_manager_vtable_rva_linux": "17",
+    "lookup_bone_rva_linux": "33",
+    "get_bone_transform_rva_linux": "49",
+    "create_entity_by_name_rva_linux": "65",
+    "dispatch_spawn_rva_linux": "81",
+    "remove_entity_rva_linux": "97",
+    "teleport_vtable_index_linux": "71",
+    "smoke_volume_offset_linux": "73",
+    "smoke_storage_offset_linux": "75",
+    "smoke_frame_offset_linux": "77",
+    "smoke_center_offset_linux": "79",
+    "smoke_start_time_offset_linux": "81",
+}
+
+
+class TestCS2FOWGamedata(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        cls.contract = next(
+            contract
+            for contract in discover_generator_modules(repo_root / "gamedata-generators")
+            if contract.directory == "CS2FOW"
+        )
+        cls.module = cls.contract.module
+
+    @staticmethod
+    def _yaml_data():
+        data = {}
+        for symbol_name, (module_name, value_name, windows, linux) in SYMBOL_FIXTURES.items():
+            data[symbol_name] = {
+                "library": module_name,
+                "category": "fixture",
+                "aliases": [],
+                "windows": {value_name: windows},
+                "linux": {value_name: linux},
+            }
+        return data
+
+    @staticmethod
+    def _context():
+        return GeneratorContext(
+            game_version="14174",
+            binaries={
+                "server": {
+                    "windows": {"size": 1001, "crc32": "ffffffff"},
+                    "linux": {"size": 2001, "crc32": "0000000a"},
+                }
+            },
+        )
+
+    def _write_fixture(self, root, *, omitted=None, duplicate=None):
+        path = Path(root) / self.module.GAMEDATA_PATH
+        path.parent.mkdir(parents=True)
+        lines = ["// fixture\r\n"]
+        for key in EXPECTED_VALUES:
+            if key != omitted:
+                lines.append(f"{key}=999  // {key}\r\n")
+                if key == duplicate:
+                    lines.append(f"{key}=998\r\n")
+        path.write_bytes(b"\xef\xbb\xbf" + "".join(lines).encode("utf-8"))
+        return path
+
+    @staticmethod
+    def _assignments(content):
+        return {
+            line.split("=", 1)[0]: line.split("=", 1)[1].split("//", 1)[0].strip()
+            for line in content.splitlines()
+            if "=" in line
+        }
+
+    def test_contract_declares_v2_remote_source_and_output(self) -> None:
+        self.assertEqual(2, self.contract.api_version)
+        self.assertEqual(("gamedata/cs2fow.games.txt",), self.contract.output_paths)
+        self.assertEqual(
+            (
+                (
+                    "https://gitlab.com/karola3vax-group/cs2fow/-/raw/main/gamedata/cs2fow.games.txt?ref_type=heads",
+                    "gamedata/cs2fow.games.txt",
+                ),
+            ),
+            self.contract.download_sources,
+        )
+
+    def test_updates_all_assignments_and_preserves_formatting(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = self._write_fixture(temp_dir)
+            updated, skipped, updated_symbols, skipped_symbols = self.module.update(
+                self._yaml_data(),
+                {},
+                ["windows", "linux"],
+                temp_dir,
+                {},
+                True,
+                context=self._context(),
+            )
+            raw = path.read_bytes()
+
+        self.assertTrue(raw.startswith(b"\xef\xbb\xbf"))
+        content = raw.decode("utf-8-sig")
+        self.assertIn("\r\n", content)
+        self.assertIn("recipient_slot_offset_windows=10  // recipient_slot_offset_windows", content)
+        self.assertEqual(EXPECTED_VALUES, self._assignments(content))
+        self.assertEqual(34, updated)
+        self.assertEqual(0, skipped)
+        self.assertEqual(34, len(updated_symbols))
+        self.assertEqual([], skipped_symbols)
+
+    def test_platform_subset_leaves_other_platform_unchanged(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            path = self._write_fixture(temp_dir)
+            updated, skipped, _updated_symbols, _skipped_symbols = self.module.update(
+                self._yaml_data(),
+                {},
+                ["windows"],
+                temp_dir,
+                {},
+                context=self._context(),
+            )
+            assignments = self._assignments(path.read_text(encoding="utf-8-sig"))
+
+        self.assertEqual(17, updated)
+        self.assertEqual(0, skipped)
+        self.assertEqual("1001", assignments["server_binary_size_windows"])
+        self.assertEqual("999", assignments["server_binary_size_linux"])
+
+    def test_rejects_missing_and_duplicate_assignments(self) -> None:
+        for kwargs, message in (
+            ({"omitted": "remove_entity_rva_linux"}, "missing assignments"),
+            ({"duplicate": "remove_entity_rva_linux"}, "duplicate assignment"),
+        ):
+            with self.subTest(message=message), TemporaryDirectory() as temp_dir:
+                self._write_fixture(temp_dir, **kwargs)
+                with self.assertRaisesRegex(ValueError, message):
+                    self.module.update(
+                        self._yaml_data(),
+                        {},
+                        ["windows", "linux"],
+                        temp_dir,
+                        {},
+                        context=self._context(),
+                    )
+
+    def test_rejects_missing_snapshot_values(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            self._write_fixture(temp_dir)
+            yaml_data = self._yaml_data()
+            del yaml_data["UTIL_Remove"]["linux"]["func_rva"]
+            with self.assertRaisesRegex(ValueError, "snapshot value is missing"):
+                self.module.update(
+                    yaml_data,
+                    {},
+                    ["windows", "linux"],
+                    temp_dir,
+                    {},
+                    context=self._context(),
+                )
+
+        with TemporaryDirectory() as temp_dir:
+            self._write_fixture(temp_dir)
+            with self.assertRaisesRegex(ValueError, "snapshot binary metadata is missing"):
+                self.module.update(
+                    self._yaml_data(),
+                    {},
+                    ["windows", "linux"],
+                    temp_dir,
+                    {},
+                    context=GeneratorContext(game_version="14174", binaries={}),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gamedata_candidate.py
+++ b/tests/test_gamedata_candidate.py
@@ -374,11 +374,39 @@ class TestGamedataCandidate(unittest.TestCase):
             generator = modules / "fixture"
             generator.mkdir(parents=True)
             (generator / "gamedata.py").write_text(
-                'MODULE_NAME="Fixture"\nOUTPUT_PATHS=("config.yaml",)\nDOWNLOAD_SOURCES=()\n',
+                'MODULE_NAME="Fixture"\nOUTPUT_PATHS=("config.yaml",)\nDOWNLOAD_SOURCES=()\nupdate=lambda *_args: None\n',
                 encoding="utf-8",
             )
 
             with self.assertRaisesRegex(GamedataContractError, "forbidden extension"):
+                discover_generator_modules(modules)
+
+    def test_contract_validates_generator_api_v2_context_signature(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            modules = Path(tmp) / "gamedata-generators"
+            generator = modules / "fixture"
+            generator.mkdir(parents=True)
+            (generator / "gamedata.py").write_text(
+                'MODULE_NAME="Fixture"\n'
+                "GENERATOR_API_VERSION=2\n"
+                'OUTPUT_PATHS=("payload.txt",)\n'
+                "DOWNLOAD_SOURCES=()\n"
+                "def update(*_args):\n    return 0, 0, [], []\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(GamedataContractError, "must accept a context keyword argument"):
+                discover_generator_modules(modules)
+
+            (generator / "gamedata.py").write_text(
+                'MODULE_NAME="Fixture"\n'
+                "GENERATOR_API_VERSION=3\n"
+                'OUTPUT_PATHS=("payload.txt",)\n'
+                "DOWNLOAD_SOURCES=()\n"
+                "def update(*_args, context):\n    return 0, 0, [], []\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(GamedataContractError, "unsupported GENERATOR_API_VERSION"):
                 discover_generator_modules(modules)
 
 

--- a/tests/test_gamesymbol_store.py
+++ b/tests/test_gamesymbol_store.py
@@ -70,6 +70,10 @@ class TestSnapshotSymbolStore(unittest.TestCase):
             self.assertTrue(store.candidate_sha256.startswith("sha256:"))
             self.assertEqual(SCHEMA_VERSION, store.schema_version)
             self.assertEqual(2, store.config_digest_version)
+            binaries = store.binaries
+            self.assertGreater(binaries["server"]["windows"]["size"], 0)
+            binaries["server"]["windows"]["size"] = 0
+            self.assertGreater(store.binaries["server"]["windows"]["size"], 0)
 
     def test_missing_and_unsafe_queries_are_typed(self) -> None:
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_update_gamedata.py
+++ b/tests/test_update_gamedata.py
@@ -15,6 +15,15 @@ from gamesymbol_store import DirectorySymbolStore
 
 class RecordingStore:
     candidate_sha256 = "fixture-sha256"
+    game_version = "14141"
+    binaries = {
+        "server": {
+            "windows": {
+                "size": 123,
+                "crc32": "000000ff",
+            }
+        }
+    }
 
     def __init__(self, payloads=None):
         self.payloads = payloads or {}
@@ -455,6 +464,48 @@ class TestGenerateGamedataDiagnostics(unittest.TestCase):
         self.assertIn("Unique warning diagnostics: 2", rendered)
         self.assertIn("Warning observations: 3", rendered)
         self.assertIn("Duplicate observations suppressed: 1", rendered)
+
+    def test_generator_api_v2_receives_immutable_snapshot_context(self) -> None:
+        received = {}
+
+        def update(*_args, context):
+            received["context"] = context
+            return 0, 0, [], []
+
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            config_path = root / "config.yaml"
+            config_path.write_text("modules: []\n", encoding="utf-8")
+            source_dir = root / "generator"
+            source_dir.mkdir()
+            contract = SimpleNamespace(
+                name="Fixture",
+                directory="fixture",
+                api_version=2,
+                source_dir=source_dir,
+                static_sources=(),
+                download_sources=(),
+                module=SimpleNamespace(update=update),
+            )
+            with (
+                patch.object(update_gamedata, "open_snapshot_store", return_value=RecordingStore()),
+                patch.object(update_gamedata, "discover_generator_modules", return_value=[contract]),
+                patch.object(update_gamedata, "generator_contract_sha256", return_value="contract-sha256"),
+            ):
+                update_gamedata.generate_gamedata(
+                    gamever="14141",
+                    snapshot_path=root / "snapshot.yaml",
+                    config_path=config_path,
+                    modules_dir=root,
+                    output_root=root / "output",
+                    platforms=["windows"],
+                )
+
+        context = received["context"]
+        self.assertEqual("14141", context.game_version)
+        self.assertEqual(123, context.binaries["server"]["windows"]["size"])
+        with self.assertRaises(TypeError):
+            context.binaries["server"]["windows"]["size"] = 0
 
 
 if __name__ == "__main__":

--- a/update_gamedata.py
+++ b/update_gamedata.py
@@ -30,6 +30,7 @@ import shutil
 from analysis_config import AnalysisConfigError, resolve_analysis_config
 from gamedata_config_validation import finding_delta, print_config_findings, validate_gamedata_config
 from gamedata_contract import (
+    GeneratorContext,
     GamedataContractError,
     canonicalize_output_text,
     discover_generator_modules,
@@ -223,6 +224,10 @@ def generate_gamedata(
     )
     print("Symbol source: snapshot")
     print(f"Candidate SHA-256: {symbol_store.candidate_sha256}")
+    generator_context = GeneratorContext(
+        game_version=symbol_store.game_version,
+        binaries=symbol_store.binaries,
+    )
     print(f"Generator directory: {modules_dir}")
     print(f"Versioned output directory: {output_root}")
     print(f"Platforms: {', '.join(platforms)}")
@@ -271,9 +276,14 @@ def generate_gamedata(
             )
         module_output_root = os.path.join(output_root, contract.directory)
         try:
-            updated, skipped, updated_symbols, skipped_symbols = contract.module.update(
-                yaml_data, func_lib_map, platforms, module_output_root, alias_map, debug
-            )
+            update_args = (yaml_data, func_lib_map, platforms, module_output_root, alias_map, debug)
+            if getattr(contract, "api_version", 1) == 2:
+                updated, skipped, updated_symbols, skipped_symbols = contract.module.update(
+                    *update_args,
+                    context=generator_context,
+                )
+            else:
+                updated, skipped, updated_symbols, skipped_symbols = contract.module.update(*update_args)
         except Exception as exc:
             if strict:
                 raise GamedataContractError(f"generator {contract.directory} failed: {exc}") from exc


### PR DESCRIPTION
## Summary
- Add a CS2FOW gamedata generator that downloads the upstream flat compatibility file and updates all 34 platform values from one immutable symbol snapshot.
- Add backward-compatible generator API v2 binary metadata context, tests, documentation, and the generated 14174 CS2FOW payload.

## Validation
- implementation-specific tests: uv run python -m unittest discover -s tests -b — 1078 tests passed, 3 skipped
- formatting: uv run python format_repo_files.py --check passed
- candidate preparation: passed for 14174
- C++ post-change validation: 12 runnable tests; zero compile failures, invalid items, or layout differences
- candidate publication: passed; published SHA-256 matches sha256:95e191a11f6f1dbf7353c36bb812c308b6815db3b6d6bdb15d537d83fe0f54c6