### PR TITLE
fix(pages): allow legacy schema v2 snapshots in archives

### DIFF
--- a/pages/verifyGameSymbolAssets.mjs
+++ b/pages/verifyGameSymbolAssets.mjs
@@ -10,6 +10,12 @@ const MD5_PATTERN = /^[0-9a-f]{32}$/
 const CRC32_PATTERN = /^[0-9a-f]{8}$/
 const CRC64_PATTERN = /^[0-9a-f]{16}$/
 const SNAPSHOT_FILE_PATTERN = /^(\d{4,10}[a-z]?)\.([0-9a-f]{64})\.json$/
+const LEGACY_DATASET_SCHEMA_VERSION = 2
+const CURRENT_DATASET_SCHEMA_VERSION = 3
+const SUPPORTED_DATASET_SCHEMA_VERSIONS = new Set([
+  LEGACY_DATASET_SCHEMA_VERSION,
+  CURRENT_DATASET_SCHEMA_VERSION,
+])
 
 function sha256(bytes) {
   return createHash('sha256').update(bytes).digest('hex')
@@ -69,10 +75,17 @@ function validateBinaryMetadata(value, source) {
   if (!Number.isInteger(value.size) || value.size < 0) throw new Error(`${source}.size must be a non-negative integer`)
 }
 
-function validateGameSymbolDataset(value, source, gameVersion) {
-  if (!isObject(value) || value.schemaVersion !== 3 || !isObject(value.source) || value.source.gameVersion !== gameVersion) {
+function validateGameSymbolDataset(value, source, gameVersion, requiredSchemaVersion) {
+  if (
+    !isObject(value)
+    || !SUPPORTED_DATASET_SCHEMA_VERSIONS.has(value.schemaVersion)
+    || !isObject(value.source)
+    || value.source.gameVersion !== gameVersion
+    || (requiredSchemaVersion !== undefined && value.schemaVersion !== requiredSchemaVersion)
+  ) {
     throw new Error(`${source}: snapshot body game version or schema is invalid`)
   }
+  if (value.schemaVersion === LEGACY_DATASET_SCHEMA_VERSION) return
   if (!isObject(value.binaries)) throw new Error(`${source}: binaries must be an object`)
   for (const [module, platforms] of Object.entries(value.binaries)) {
     if (!isObject(platforms)) throw new Error(`${source}: binaries.${module} must be an object`)
@@ -107,13 +120,13 @@ export function validateGameSymbolVerificationManifest(value, source = 'game-sym
   return value
 }
 
-function verifySnapshotBytes(fileName, bytes, source, expectedEntry) {
+function verifySnapshotBytes(fileName, bytes, source, expectedEntry, requiredSchemaVersion) {
   const match = SNAPSHOT_FILE_PATTERN.exec(fileName)
   if (!match) throw new Error(`${source}: snapshot filename must be <gameVersion>.<sha256>.json`)
   const actualSha256 = sha256(bytes)
   if (actualSha256 !== match[2]) throw new Error(`${source}: filename SHA-256 does not match content bytes`)
   const value = parseJson(bytes, source)
-  validateGameSymbolDataset(value, source, match[1])
+  validateGameSymbolDataset(value, source, match[1], requiredSchemaVersion)
   if (expectedEntry) {
     if (fileName !== expectedEntry.url) throw new Error(`${source}: index URL does not match filename`)
     if (bytes.byteLength !== expectedEntry.size) {
@@ -155,7 +168,7 @@ export async function verifyGameSymbolAssetDirectory(directory) {
   for (const entry of index.versions) {
     const filePath = join(root, entry.url)
     const bytes = await readFile(filePath)
-    verifySnapshotBytes(entry.url, bytes, filePath, entry)
+    verifySnapshotBytes(entry.url, bytes, filePath, entry, CURRENT_DATASET_SCHEMA_VERSION)
     if (!snapshots.has(entry.url)) throw new Error(`${filePath}: indexed snapshot is missing from the asset inventory`)
   }
   return {

--- a/pages/verifyGameSymbolAssets.test.mjs
+++ b/pages/verifyGameSymbolAssets.test.mjs
@@ -56,6 +56,35 @@ async function writeCurrentAssets(directory, gameVersion, marker) {
   return { bytes, digest, url }
 }
 
+async function writeLegacySnapshot(directory, gameVersion, marker) {
+  await mkdir(directory, { recursive: true })
+  const dataset = {
+    schemaVersion: 2,
+    source: { gameVersion },
+    records: [{ marker }],
+  }
+  const bytes = Buffer.from(JSON.stringify(dataset), 'utf8')
+  const digest = createHash('sha256').update(bytes).digest('hex')
+  const url = `${gameVersion}.${digest}.json`
+  await writeFile(join(directory, url), bytes)
+  return { bytes, digest, url }
+}
+
+async function writeIndex(directory, gameVersion, asset) {
+  await writeFile(join(directory, 'index.json'), JSON.stringify({
+    schemaVersion: 4,
+    versions: [{
+      gameVersion,
+      url: asset.url,
+      sha256: asset.digest,
+      size: asset.bytes.byteLength,
+      snapshotSchemaVersion: 4,
+      fileCount: 1,
+      lastPublishTime: '2026-07-28T00:00:00Z',
+    }],
+  }))
+}
+
 afterEach(async () => {
   vi.unstubAllGlobals()
   await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
@@ -91,6 +120,30 @@ describe('immutable game-symbol asset verification', () => {
     expect(await readFile(join(current, second.url))).toEqual(second.bytes)
   })
 
+  it('preserves legacy schema v2 snapshots as immutable archive history', async () => {
+    const root = await temporaryRoot()
+    const current = join(root, 'current')
+    const archive = join(root, 'archive')
+    const legacy = await writeLegacySnapshot(archive, '14172', 'legacy')
+    const latest = await writeCurrentAssets(current, '14172', 'latest')
+
+    const result = await mergeImmutableArchive(current, archive)
+
+    expect(result.added).toBe(1)
+    expect(result.archived).toBe(2)
+    expect(await readFile(join(archive, latest.url))).toEqual(latest.bytes)
+    expect(await readFile(join(current, legacy.url))).toEqual(legacy.bytes)
+  })
+
+  it('rejects legacy schema v2 snapshots when the current index points to them', async () => {
+    const root = await temporaryRoot()
+    const current = join(root, 'current')
+    const legacy = await writeLegacySnapshot(current, '14172', 'legacy')
+    await writeIndex(current, '14172', legacy)
+
+    await expect(verifyGameSymbolAssetDirectory(current)).rejects.toThrow(/snapshot body game version or schema/)
+  })
+
   it('rejects any modification of an archived content-addressed snapshot', async () => {
     const root = await temporaryRoot()
     const current = join(root, 'current')
@@ -107,6 +160,7 @@ describe('immutable game-symbol asset verification', () => {
     const current = join(root, 'current')
     const archive = join(root, 'archive')
     const manifestPath = join(root, 'verification.json')
+    const legacy = await writeLegacySnapshot(archive, '14172', 'legacy')
     const first = await writeCurrentAssets(current, '14172', 'first')
     const staleIndex = await readFile(join(current, 'index.json'))
     await mergeImmutableArchive(current, archive)
@@ -131,8 +185,9 @@ describe('immutable game-symbol asset verification', () => {
       attempts: 2,
       delayMs: 0,
       batchSize: 2,
-    })).resolves.toEqual(expect.objectContaining({ verified: 2 }))
+    })).resolves.toEqual(expect.objectContaining({ verified: 3 }))
     expect(indexRequests).toBe(2)
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes(legacy.url))).toBe(true)
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes(first.url))).toBe(true)
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes(second.url))).toBe(true)
   })


### PR DESCRIPTION
## Summary
- Accept schema v2 and v3 for immutable archived/CDN snapshots.
- Keep current index-referenced snapshots strict at schema v3 with binary metadata.
- Add regression coverage for legacy archive compatibility and current-index rejection.

## Tests
- npm test -- verifyGameSymbolAssets.test.mjs