### PR TITLE
feat(preprocessor): add find-CNetworkGameServerBase_GetClassBaseline

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -616,6 +616,11 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_GetMaxClients.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetClassBaseline
+        expected_output:
+          - CNetworkGameServerBase_GetClassBaseline.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_ServerPollNetworking
         expected_output:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
@@ -2338,6 +2343,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::GetMaxClients
+      - name: CNetworkGameServerBase_GetClassBaseline
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetClassBaseline
       - name: CNetworkGameServerBase_SetMaxClients
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:eac64159217272d0af7241147a25953e5f2586b0602aa53130d45d1b7f819cba
-file_count: 3273
+config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
+file_count: 3275
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10610,6 +10610,24 @@ files:
     vfunc_index: 40
     vfunc_offset: '0x140'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetClassBaseline.linux.yaml:
+    func_name: CNetworkGameServerBase_GetClassBaseline
+    func_rva: '0x4f2ec0'
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 41 56 49 89 D6 41 55 49 89 FD
+    func_size: '0x389'
+    func_va: '0x4f2ec0'
+    vfunc_index: 81
+    vfunc_offset: '0x288'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetClassBaseline.windows.yaml:
+    func_name: CNetworkGameServerBase_GetClassBaseline
+    func_rva: '0xad6c0'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 41 56 48 83 EC ?? 48 8B F1
+    func_size: '0x15f'
+    func_va: '0x1800ad6c0'
+    vfunc_index: 76
+    vfunc_offset: '0x260'
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_GetMaxClients.linux.yaml:
     func_name: CNetworkGameServerBase_GetMaxClients
     func_rva: '0x4f0f50'
@@ -42307,5 +42325,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T07:48:00Z'
+last_publish_time: '2026-08-05T09:10:50Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClassBaseline.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClassBaseline.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetClassBaseline skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetClassBaseline",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_GetClassBaseline",
+        "xref_strings": [
+            "GetClassBaseline: missing instance baseline for class '%s",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetClassBaseline", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_GetClassBaseline",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_GetClassBaseline` preprocessor script (Pattern B: virtual function via xref string `"GetClassBaseline: missing instance baseline for class '%s"`), resolved against `CNetworkGameServer_vtable`.
- Register the skill (with `CNetworkGameServer_vtable` input) and the `CNetworkGameServerBase_GetClassBaseline` vfunc symbol (alias `CNetworkGameServerBase::GetClassBaseline`) in `configs/14174.yaml`.
- Publish the 14174 gamesymbol snapshot: Windows vtable index 76 (offset `0x260`), Linux index 81 (offset `0x288`).

## Validation
- IDA preprocessor run (`ida_analyze_bin.py -debug`): passed, Failed 0; both platform YAMLs generated.
- Non-MCP unittest suite: 1053 tests, 0 failures (3 skipped).
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (13 layout, 11 vtable, 2 record compares; 0 differences)
- candidate publication: passed; published SHA-256 matches the validated candidate (`sha256:434a91bc...`)
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created