### PR TITLE
feat(engine): add finders for CNetworkGameServerBase GetMapName/GetHostName

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -626,7 +626,7 @@ modules:
           - CSteam3Server_SendUpdatedServerDetails.{platform}.yaml
         expected_input:
           - CNetworkGameServer_ActivateServer.{platform}.yaml
-      - name: find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName
+      - name: find-CSteam3Server_SendUpdatedServerDetails-decompiles
         expected_output:
           - CNetworkGameServerBase_GetMapName.{platform}.yaml
           - CNetworkGameServerBase_GetHostName.{platform}.yaml

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -616,6 +616,18 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_GetMaxClients.{platform}.yaml
+      - name: find-CSteam3Server_SendUpdatedServerDetails
+        expected_output:
+          - CSteam3Server_SendUpdatedServerDetails.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_ActivateServer.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName
+        expected_output:
+          - CNetworkGameServerBase_GetMapName.{platform}.yaml
+          - CNetworkGameServerBase_GetHostName.{platform}.yaml
+        expected_input:
+          - CSteam3Server_SendUpdatedServerDetails.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_ServerPollNetworking
         expected_output:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
@@ -2338,6 +2350,18 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::GetMaxClients
+      - name: CSteam3Server_SendUpdatedServerDetails
+        category: func
+        alias:
+          - CSteam3Server::SendUpdatedServerDetails
+      - name: CNetworkGameServerBase_GetMapName
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetMapName
+      - name: CNetworkGameServerBase_GetHostName
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetHostName
       - name: CNetworkGameServerBase_SetMaxClients
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:eac64159217272d0af7241147a25953e5f2586b0602aa53130d45d1b7f819cba
-file_count: 3273
+config_sha256: sha256:23922a7661312c266655c1676c738ec1bcee02b38a2c4955121330a83ff92d06
+file_count: 3279
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10610,6 +10610,30 @@ files:
     vfunc_index: 40
     vfunc_offset: '0x140'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetHostName.linux.yaml:
+    func_name: CNetworkGameServerBase_GetHostName
+    vfunc_index: 72
+    vfunc_offset: '0x240'
+    vfunc_sig: FF 90 40 02 00 00 4C 89 F7
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetHostName.windows.yaml:
+    func_name: CNetworkGameServerBase_GetHostName
+    vfunc_index: 67
+    vfunc_offset: '0x218'
+    vfunc_sig: FF 90 18 02 00 00 48 8B D0
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetMapName.linux.yaml:
+    func_name: CNetworkGameServerBase_GetMapName
+    vfunc_index: 25
+    vfunc_offset: '0xc8'
+    vfunc_sig: FF 90 C8 00 00 00 4C 89 E7 48 89 C6
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetMapName.windows.yaml:
+    func_name: CNetworkGameServerBase_GetMapName
+    vfunc_index: 25
+    vfunc_offset: '0xc8'
+    vfunc_sig: FF 90 C8 00 00 00 48 8B D0
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_GetMaxClients.linux.yaml:
     func_name: CNetworkGameServerBase_GetMaxClients
     func_rva: '0x4f0f50'
@@ -12830,6 +12854,18 @@ files:
     vtable_size: '0x158'
     vtable_symbol: CSplitScreenService_vtable
     vtable_va: '0x180578ca8'
+  engine/CSteam3Server_SendUpdatedServerDetails.linux.yaml:
+    func_name: CSteam3Server_SendUpdatedServerDetails
+    func_rva: '0x5763f0'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 4C 8D 25 ?? ?? ?? ?? 53 48 89 FB 4C 89 E7
+    func_size: '0x276'
+    func_va: '0x5763f0'
+  engine/CSteam3Server_SendUpdatedServerDetails.windows.yaml:
+    func_name: CSteam3Server_SendUpdatedServerDetails
+    func_rva: '0xf9fb0'
+    func_sig: 40 55 41 56 48 83 EC ?? 48 8B E9
+    func_size: '0x1fd'
+    func_va: '0x1800f9fb0'
   engine/ConnectInterfaces.linux.yaml:
     func_name: ConnectInterfaces
     func_rva: '0x5f8bc0'
@@ -42307,5 +42343,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T07:48:00Z'
+last_publish_time: '2026-08-05T10:48:49Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,7 +121,7 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:ea449a6222d978bcd36093b352310babd4f11c423012c407643bfb711135d582
+config_sha256: sha256:8bff2454492c085631c2eaf79e22ff2e050ac0f9b33ec4e321191bd384dd7727
 file_count: 3281
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -42361,5 +42361,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T02:39:03Z'
+last_publish_time: '2026-08-06T03:26:41Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetMapName",
+    "CNetworkGameServerBase_GetHostName",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_GetMapName",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CSteam3Server_SendUpdatedServerDetails.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSteam3Server_SendUpdatedServerDetails.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "CNetworkGameServerBase_GetHostName",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CSteam3Server_SendUpdatedServerDetails.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSteam3Server_SendUpdatedServerDetails.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetMapName", "CNetworkGameServer_vtable"),
+    ("CNetworkGameServerBase_GetHostName", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: these vfuncs are not downstream predecessors.
+    (
+        "CNetworkGameServerBase_GetMapName",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "CNetworkGameServerBase_GetHostName",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSteam3Server_SendUpdatedServerDetails-decompiles.py
+++ b/ida_preprocessor_scripts/find-CSteam3Server_SendUpdatedServerDetails-decompiles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName skill."""
+"""Preprocess script for find-CSteam3Server_SendUpdatedServerDetails-decompiles skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
@@ -41,7 +41,6 @@ FUNC_VTABLE_RELATIONS = [
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
-    # Slim Pattern C: these vfuncs are not downstream predecessors.
     (
         "CNetworkGameServerBase_GetMapName",
         [
@@ -76,7 +75,9 @@ async def preprocess_skill(
     llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Locate CNetworkGameServerBase map and host name vfuncs from Steam updates."""
+    _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,

--- a/ida_preprocessor_scripts/find-CSteam3Server_SendUpdatedServerDetails.py
+++ b/ida_preprocessor_scripts/find-CSteam3Server_SendUpdatedServerDetails.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSteam3Server_SendUpdatedServerDetails skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSteam3Server_SendUpdatedServerDetails",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CSteam3Server_SendUpdatedServerDetails",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServer_ActivateServer.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CNetworkGameServer_ActivateServer.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSteam3Server_SendUpdatedServerDetails",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ActivateServer.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ActivateServer.linux.yaml
@@ -1,0 +1,209 @@
+func_name: CNetworkGameServer_ActivateServer
+func_va: '0x5100c0'
+disasm_code: |-
+  .text:00000000005100C0                 push    rbp
+  .text:00000000005100C1                 xor     eax, eax
+  .text:00000000005100C3                 mov     rbp, rsp
+  .text:00000000005100C6                 push    r12
+  .text:00000000005100C8                 push    rbx
+  .text:00000000005100C9                 mov     rbx, rdi
+  .text:00000000005100CC                 lea     rdi, aCnetworkgamese_4; "CNetworkGameServer::ActivateServer"
+  .text:00000000005100D3                 call    sub_2CA1C0
+  .text:00000000005100D8                 call    sub_5D5580
+  .text:00000000005100DD                 mov     esi, 0Bh
+  .text:00000000005100E2                 xor     edx, edx
+  .text:00000000005100E4                 mov     rdi, rax
+  .text:00000000005100E7                 call    sub_5D5A80
+  .text:00000000005100EC                 mov     rax, cs:qword_A30308
+  .text:00000000005100F3                 mov     dword ptr [rbx+38h], 3
+  .text:00000000005100FA                 lea     rsi, aUnknown_0; "unknown"
+  .text:0000000000510101                 mov     byte ptr [rbx+2740h], 0
+  .text:0000000000510108                 test    rax, rax
+  .text:000000000051010B                 jz      short loc_510117
+  .text:000000000051010D                 test    byte ptr [rax+31h], 4
+  .text:0000000000510111                 jz      loc_510250
+  .text:0000000000510117                 lea     rdi, [rbx+160h]
+  .text:000000000051011E                 call    sub_2C8ED0
+  .text:0000000000510123                 mov     rax, [rbx]
+  .text:0000000000510126                 lea     rdx, sub_4F0BD0
+  .text:000000000051012D                 mov     rax, [rax+178h]
+  .text:0000000000510134                 cmp     rax, rdx
+  .text:0000000000510137                 jnz     loc_510300
+  .text:000000000051013D                 movzx   eax, byte ptr [rbx+455h]
+  .text:0000000000510144                 lea     r12, dword_A30294
+  .text:000000000051014B                 mov     esi, 2
+  .text:0000000000510150                 mov     edi, [r12]
+  .text:0000000000510154                 test    al, al
+  .text:0000000000510156                 jz      loc_510220
+  .text:000000000051015C                 call    sub_2C9B50
+  .text:0000000000510161                 test    al, al
+  .text:0000000000510163                 jnz     loc_5102D0
+  .text:0000000000510169                 mov     rdi, [rbx+158h]
+  .text:0000000000510170                 test    rdi, rdi
+  .text:0000000000510173                 jz      short loc_510182
+  .text:0000000000510175                 call    sub_2CA790
+  .text:000000000051017A                 test    eax, eax
+  .text:000000000051017C                 jg      loc_510280
+  .text:0000000000510182                 lea     rdi, aActivatesteamg; "ActivateSteamGameServer(start)"
+  .text:0000000000510189                 xor     eax, eax
+  .text:000000000051018B                 call    sub_2CA1C0
+  .text:0000000000510190                 mov     rdi, rbx
+  .text:0000000000510193                 call    sub_50BBF0
+  .text:0000000000510198                 lea     rdi, aActivatesteamg_0; "ActivateSteamGameServer(finished)"
+  .text:000000000051019F                 xor     eax, eax
+  .text:00000000005101A1                 call    sub_2CA1C0
+  .text:00000000005101A6                 mov     rdi, rbx
+  .text:00000000005101A9                 call    CNetworkGameServerBase_StartHLTVMaster
+  .text:00000000005101AE                 lea     rbx, g_pNetworkServerService
+  .text:00000000005101B5                 mov     rdi, [rbx]
+  .text:00000000005101B8                 mov     rax, [rdi]
+  .text:00000000005101BB                 call    qword ptr [rax+138h]
+  .text:00000000005101C1                 test    al, al
+  .text:00000000005101C3                 jz      short loc_5101D1
+  .text:00000000005101C5                 mov     rdi, [rbx]
+  .text:00000000005101C8                 mov     rax, [rdi]
+  .text:00000000005101CB                 call    qword ptr [rax+130h]
+  .text:00000000005101D1                 call    sub_575B00
+  .text:00000000005101D6                 xor     esi, esi
+  .text:00000000005101D8                 mov     rdi, rax
+  .text:00000000005101DB                 call    CSteam3Server_SendUpdatedServerDetails
+  .text:00000000005101E0                 lea     rbx, g_pSource2Server
+  .text:00000000005101E7                 mov     rdi, [rbx]
+  .text:00000000005101EA                 mov     rax, [rdi]
+  .text:00000000005101ED                 call    qword ptr [rax+0B8h]
+  .text:00000000005101F3                 test    rax, rax
+  .text:00000000005101F6                 jz      short loc_51020D
+  .text:00000000005101F8                 mov     rdi, [rbx]
+  .text:00000000005101FB                 mov     rax, [rdi]
+  .text:00000000005101FE                 call    qword ptr [rax+0B8h]
+  .text:0000000000510204                 mov     rdi, rax
+  .text:0000000000510207                 mov     rax, [rax]
+  .text:000000000051020A                 call    qword ptr [rax+10h]
+  .text:000000000051020D                 pop     rbx
+  .text:000000000051020E                 mov     eax, 1
+  .text:0000000000510213                 pop     r12
+  .text:0000000000510215                 pop     rbp
+  .text:0000000000510216                 retn
+  .text:0000000000510220                 call    sub_2C9B50
+  .text:0000000000510225                 test    al, al
+  .text:0000000000510227                 jz      loc_510169
+  .text:000000000051022D                 mov     edi, [r12]
+  .text:0000000000510231                 lea     rdx, aSvGameStarted; "SV:  Game started\n"
+  .text:0000000000510238                 mov     esi, 2
+  .text:000000000051023D                 xor     eax, eax
+  .text:000000000051023F                 call    sub_2C8BC0
+  .text:0000000000510244                 jmp     loc_510169
+  .text:0000000000510250                 lea     rdi, unk_A30300
+  .text:0000000000510257                 mov     esi, 0FFFFFFFFh
+  .text:000000000051025C                 call    sub_5E60F0
+  .text:0000000000510261                 test    rax, rax
+  .text:0000000000510264                 jz      loc_510310
+  .text:000000000051026A                 mov     rsi, [rax]
+  .text:000000000051026D                 lea     rax, unk_27CC16
+  .text:0000000000510274                 test    rsi, rsi
+  .text:0000000000510277                 cmovz   rsi, rax
+  .text:000000000051027B                 jmp     loc_510117
+  .text:0000000000510280                 mov     edi, [r12]
+  .text:0000000000510284                 mov     esi, 2
+  .text:0000000000510289                 call    sub_2C9B50
+  .text:000000000051028E                 test    al, al
+  .text:0000000000510290                 jz      loc_510182
+  .text:0000000000510296                 mov     edi, [r12]
+  .text:000000000051029A                 lea     rax, unk_27CC16
+  .text:00000000005102A1                 mov     esi, 2
+  .text:00000000005102A6                 mov     rcx, [rbx+158h]
+  .text:00000000005102AD                 lea     rdx, aSvAddonS; "SV:  addon='%s'\n"
+  .text:00000000005102B4                 test    rcx, rcx
+  .text:00000000005102B7                 cmovz   rcx, rax
+  .text:00000000005102BB                 xor     eax, eax
+  .text:00000000005102BD                 call    sub_2C8BC0
+  .text:00000000005102C2                 jmp     loc_510182
+  .text:00000000005102D0                 mov     rax, [rbx]
+  .text:00000000005102D3                 mov     rdi, rbx
+  .text:00000000005102D6                 call    qword ptr [rax+60h]
+  .text:00000000005102D9                 mov     edi, [r12]
+  .text:00000000005102DD                 lea     rdx, aSvIPlayerServe; "SV:  %i player server started\n"
+  .text:00000000005102E4                 mov     esi, 2
+  .text:00000000005102E9                 mov     ecx, eax
+  .text:00000000005102EB                 xor     eax, eax
+  .text:00000000005102ED                 call    sub_2C8BC0
+  .text:00000000005102F2                 jmp     loc_510169
+  .text:0000000000510300                 mov     rdi, rbx
+  .text:0000000000510303                 call    rax
+  .text:0000000000510305                 jmp     loc_510144
+  .text:0000000000510310                 mov     rax, cs:qword_A30308
+  .text:0000000000510317                 mov     rax, [rax+8]
+  .text:000000000051031B                 jmp     loc_51026A
+procedure: |-
+  __int64 __fastcall CNetworkGameServer_ActivateServer(_QWORD *a1, __int64 a2)
+  {
+    __int64 v3; // rdx
+    __int64 v4; // rax
+    __int64 v5; // rax
+    const char *v6; // rsi
+    __int64 (__fastcall *v7)(); // rax
+    char v8; // al
+    __int64 v9; // rdi
+    __int64 v10; // rax
+    __int64 v11; // rax
+    const char **v13; // rax
+    void *v14; // rcx
+    int v15; // eax
+
+    sub_2CA1C0("CNetworkGameServer::ActivateServer");
+    v4 = sub_5D5580("CNetworkGameServer::ActivateServer", a2, v3);
+    sub_5D5A80(v4, 11, 0);
+    v5 = qword_A30308;
+    *((_DWORD *)a1 + 14) = 3;
+    v6 = "unknown";
+    *((_BYTE *)a1 + 10048) = 0;
+    if ( v5 && (*(_BYTE *)(v5 + 49) & 4) == 0 )
+    {
+      v13 = (const char **)sub_5E60F0(&unk_A30300, 0xFFFFFFFFLL);
+      if ( !v13 )
+        v13 = *(const char ***)(qword_A30308 + 8);
+      v6 = *v13;
+      if ( !*v13 )
+        v6 = (const char *)&unk_27CC16;
+    }
+    sub_2C8ED0(a1 + 44, v6);
+    v7 = *(__int64 (__fastcall **)())(*a1 + 376LL);
+    if ( v7 == sub_4F0BD0 )
+      v8 = *((_BYTE *)a1 + 1109);
+    else
+      v8 = ((__int64 (__fastcall *)(_QWORD *))v7)(a1);
+    if ( v8 )
+    {
+      if ( (unsigned __int8)sub_2C9B50((unsigned int)dword_A30294, 2) )
+      {
+        v15 = (*(__int64 (__fastcall **)(_QWORD *))(*a1 + 96LL))(a1);
+        sub_2C8BC0((unsigned int)dword_A30294, 2, "SV:  %i player server started\n", v15);
+      }
+    }
+    else if ( (unsigned __int8)sub_2C9B50((unsigned int)dword_A30294, 2) )
+    {
+      sub_2C8BC0((unsigned int)dword_A30294, 2, "SV:  Game started\n");
+    }
+    v9 = a1[43];
+    if ( v9 && (int)sub_2CA790(v9) > 0 && (unsigned __int8)sub_2C9B50((unsigned int)dword_A30294, 2) )
+    {
+      v14 = (void *)a1[43];
+      if ( !v14 )
+        v14 = &unk_27CC16;
+      sub_2C8BC0((unsigned int)dword_A30294, 2, "SV:  addon='%s'\n", v14);
+    }
+    sub_2CA1C0("ActivateSteamGameServer(start)");
+    sub_50BBF0(a1);
+    sub_2CA1C0("ActivateSteamGameServer(finished)");
+    CNetworkGameServerBase_StartHLTVMaster((__int64)a1);
+    if ( (*(unsigned __int8 (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 312LL))(g_pNetworkServerService) )
+      (*(void (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 304LL))(g_pNetworkServerService);
+    v10 = sub_575B00();
+    CSteam3Server_SendUpdatedServerDetails(v10, 0);
+    if ( (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2Server + 184LL))(g_pSource2Server) )
+    {
+      v11 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2Server + 184LL))(g_pSource2Server);
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)v11 + 16LL))(v11);
+    }
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ActivateServer.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_ActivateServer.windows.yaml
@@ -1,0 +1,281 @@
+func_name: CNetworkGameServer_ActivateServer
+func_va: '0x18009e200'
+disasm_code: |-
+  .text:000000018009E200                 mov     [rsp+arg_8], rbx
+  .text:000000018009E205                 push    rdi
+  .text:000000018009E206                 sub     rsp, 30h
+  .text:000000018009E20A                 mov     rbx, rcx
+  .text:000000018009E20D                 lea     rcx, aCnetworkgamese; "CNetworkGameServer::ActivateServer"
+  .text:000000018009E214                 call    cs:COM_TimestampedLog
+  .text:000000018009E21A                 xor     r8d, r8d
+  .text:000000018009E21D                 lea     rcx, off_180612C70
+  .text:000000018009E224                 mov     edx, 0Bh
+  .text:000000018009E229                 call    sub_18013BA50
+  .text:000000018009E22E                 mov     dword ptr [rbx+38h], 3
+  .text:000000018009E235                 lea     rdi, unk_180528AFF
+  .text:000000018009E23C                 mov     byte ptr [rbx+2740h], 0
+  .text:000000018009E243                 mov     rax, cs:qword_18068E2C0
+  .text:000000018009E24A                 test    rax, rax
+  .text:000000018009E24D                 jz      short loc_18009E289
+  .text:000000018009E24F                 mov     eax, [rax+30h]
+  .text:000000018009E252                 bt      rax, 0Ah
+  .text:000000018009E257                 jb      short loc_18009E289
+  .text:000000018009E259                 mov     edx, 0FFFFFFFFh
+  .text:000000018009E25E                 lea     rcx, unk_18068E2B8
+  .text:000000018009E265                 call    sub_1803FEF60
+  .text:000000018009E26A                 test    rax, rax
+  .text:000000018009E26D                 jnz     short loc_18009E27A
+  .text:000000018009E26F                 mov     rax, cs:qword_18068E2C0
+  .text:000000018009E276                 mov     rax, [rax+8]
+  .text:000000018009E27A                 mov     rax, [rax]
+  .text:000000018009E27D                 mov     rdx, rdi
+  .text:000000018009E280                 test    rax, rax
+  .text:000000018009E283                 cmovnz  rdx, rax
+  .text:000000018009E287                 jmp     short loc_18009E290
+  .text:000000018009E289                 lea     rdx, aUnknown; "unknown"
+  .text:000000018009E290                 lea     rcx, [rbx+160h]
+  .text:000000018009E297                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:000000018009E29D                 mov     rax, [rbx]
+  .text:000000018009E2A0                 mov     rcx, rbx
+  .text:000000018009E2A3                 call    qword ptr [rax+178h]
+  .text:000000018009E2A9                 mov     ecx, cs:dword_1808CC6B8
+  .text:000000018009E2AF                 mov     edx, 2
+  .text:000000018009E2B4                 test    al, al
+  .text:000000018009E2B6                 jz      short loc_18009E2E8
+  .text:000000018009E2B8                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009E2BE                 test    al, al
+  .text:000000018009E2C0                 jz      short loc_18009E30A
+  .text:000000018009E2C2                 mov     rax, [rbx]
+  .text:000000018009E2C5                 mov     rcx, rbx
+  .text:000000018009E2C8                 call    qword ptr [rax+60h]
+  .text:000000018009E2CB                 mov     ecx, cs:dword_1808CC6B8
+  .text:000000018009E2D1                 lea     r8, aSvIPlayerServe; "SV:  %i player server started\n"
+  .text:000000018009E2D8                 mov     r9d, eax
+  .text:000000018009E2DB                 mov     edx, 2
+  .text:000000018009E2E0                 call    cs:LoggingSystem_Log
+  .text:000000018009E2E6                 jmp     short loc_18009E30A
+  .text:000000018009E2E8                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009E2EE                 test    al, al
+  .text:000000018009E2F0                 jz      short loc_18009E30A
+  .text:000000018009E2F2                 mov     ecx, cs:dword_1808CC6B8
+  .text:000000018009E2F8                 lea     r8, aSvGameStarted; "SV:  Game started\n"
+  .text:000000018009E2FF                 mov     edx, 2
+  .text:000000018009E304                 call    cs:LoggingSystem_Log
+  .text:000000018009E30A                 mov     rcx, [rbx+158h]
+  .text:000000018009E311                 test    rcx, rcx
+  .text:000000018009E314                 jz      short loc_18009E36B
+  .text:000000018009E316                 mov     rax, 0FFFFFFFFFFFFFFFFh
+  .text:000000018009E31D                 nop     dword ptr [rax]
+  .text:000000018009E320                 inc     rax
+  .text:000000018009E323                 cmp     byte ptr [rcx+rax], 0
+  .text:000000018009E327                 jnz     short loc_18009E320
+  .text:000000018009E329                 test    eax, eax
+  .text:000000018009E32B                 jle     short loc_18009E36B
+  .text:000000018009E32D                 mov     ecx, cs:dword_1808CC6B8
+  .text:000000018009E333                 mov     edx, 2
+  .text:000000018009E338                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:000000018009E33E                 test    al, al
+  .text:000000018009E340                 jz      short loc_18009E36B
+  .text:000000018009E342                 mov     rax, [rbx+158h]
+  .text:000000018009E349                 lea     r8, aSvAddonS; "SV:  addon='%s'\n"
+  .text:000000018009E350                 mov     ecx, cs:dword_1808CC6B8
+  .text:000000018009E356                 test    rax, rax
+  .text:000000018009E359                 mov     edx, 2
+  .text:000000018009E35E                 cmovnz  rdi, rax
+  .text:000000018009E362                 mov     r9, rdi
+  .text:000000018009E365                 call    cs:LoggingSystem_Log
+  .text:000000018009E36B                 lea     rcx, aActivatesteamg; "ActivateSteamGameServer(start)"
+  .text:000000018009E372                 call    cs:COM_TimestampedLog
+  .text:000000018009E378                 mov     rax, [rbx]
+  .text:000000018009E37B                 mov     rcx, rbx
+  .text:000000018009E37E                 call    qword ptr [rax+178h]
+  .text:000000018009E384                 test    al, al
+  .text:000000018009E386                 jz      loc_18009E445
+  .text:000000018009E38C                 mov     rax, [rbx]
+  .text:000000018009E38F                 mov     rcx, rbx
+  .text:000000018009E392                 call    qword ptr [rax+0D8h]
+  .text:000000018009E398                 test    al, al
+  .text:000000018009E39A                 jnz     loc_18009E445
+  .text:000000018009E3A0                 mov     rax, [rbx]
+  .text:000000018009E3A3                 mov     rcx, rbx
+  .text:000000018009E3A6                 call    qword ptr [rax+160h]
+  .text:000000018009E3AC                 cmp     byte ptr [rax+6Ch], 0
+  .text:000000018009E3B0                 jnz     loc_18009E445
+  .text:000000018009E3B6                 mov     rax, [rbx]
+  .text:000000018009E3B9                 mov     rcx, rbx
+  .text:000000018009E3BC                 call    qword ptr [rax+160h]
+  .text:000000018009E3C2                 cmp     byte ptr [rax+6Dh], 0
+  .text:000000018009E3C6                 jnz     short loc_18009E445
+  .text:000000018009E3C8                 cmp     byte ptr [rbx+2B9h], 0
+  .text:000000018009E3CF                 lea     rdi, [rbx+2BAh]
+  .text:000000018009E3D6                 jz      short loc_18009E3DD
+  .text:000000018009E3D8                 cmp     byte ptr [rdi], 0
+  .text:000000018009E3DB                 jz      short loc_18009E408
+  .text:000000018009E3DD                 mov     dl, 1
+  .text:000000018009E3DF                 lea     rcx, off_180612910
+  .text:000000018009E3E6                 call    sub_1800F8120
+  .text:000000018009E3EB                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009E3F2                 test    rcx, rcx
+  .text:000000018009E3F5                 jz      short loc_18009E400
+  .text:000000018009E3F7                 mov     rax, [rcx]
+  .text:000000018009E3FA                 call    qword ptr [rax+148h]
+  .text:000000018009E400                 cmp     byte ptr [rdi], 0
+  .text:000000018009E403                 jz      short loc_18009E408
+  .text:000000018009E405                 mov     byte ptr [rdi], 0
+  .text:000000018009E408                 mov     rcx, [rbx+198h]
+  .text:000000018009E40F                 test    rcx, rcx
+  .text:000000018009E412                 jz      short loc_18009E445
+  .text:000000018009E414                 movzx   eax, cs:word_180612A24
+  .text:000000018009E41B                 lea     r9, [rsp+38h+var_18]
+  .text:000000018009E420                 mov     [rsp+38h+arg_0], eax
+  .text:000000018009E424                 lea     r8, aQueryport; "QueryPort"
+  .text:000000018009E42B                 lea     rax, [rsp+38h+arg_0]
+  .text:000000018009E430                 mov     [rsp+38h+var_10], 4
+  .text:000000018009E438                 mov     [rsp+38h+var_18], rax
+  .text:000000018009E43D                 mov     dl, 1
+  .text:000000018009E43F                 mov     rax, [rcx]
+  .text:000000018009E442                 call    qword ptr [rax+38h]
+  .text:000000018009E445                 xor     edx, edx
+  .text:000000018009E447                 lea     rcx, off_180612910
+  .text:000000018009E44E                 call    CSteam3Server_SendUpdatedServerDetails
+  .text:000000018009E453                 mov     rcx, rbx
+  .text:000000018009E456                 call    sub_1800B12E0
+  .text:000000018009E45B                 lea     rcx, aActivatesteamg_0; "ActivateSteamGameServer(finished)"
+  .text:000000018009E462                 call    cs:COM_TimestampedLog
+  .text:000000018009E468                 mov     rcx, rbx
+  .text:000000018009E46B                 call    CNetworkGameServerBase_StartHLTVMaster
+  .text:000000018009E470                 mov     rcx, cs:g_pNetworkServerService
+  .text:000000018009E477                 mov     rax, [rcx]
+  .text:000000018009E47A                 call    qword ptr [rax+130h]
+  .text:000000018009E480                 test    al, al
+  .text:000000018009E482                 jz      short loc_18009E494
+  .text:000000018009E484                 mov     rcx, cs:g_pNetworkServerService
+  .text:000000018009E48B                 mov     rax, [rcx]
+  .text:000000018009E48E                 call    qword ptr [rax+128h]
+  .text:000000018009E494                 xor     edx, edx
+  .text:000000018009E496                 lea     rcx, off_180612910
+  .text:000000018009E49D                 call    CSteam3Server_SendUpdatedServerDetails
+  .text:000000018009E4A2                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009E4A9                 mov     rax, [rcx]
+  .text:000000018009E4AC                 call    qword ptr [rax+0B8h]
+  .text:000000018009E4B2                 test    rax, rax
+  .text:000000018009E4B5                 jz      short loc_18009E4D0
+  .text:000000018009E4B7                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009E4BE                 mov     rax, [rcx]
+  .text:000000018009E4C1                 call    qword ptr [rax+0B8h]
+  .text:000000018009E4C7                 mov     rcx, rax
+  .text:000000018009E4CA                 mov     rdx, [rax]
+  .text:000000018009E4CD                 call    qword ptr [rdx+10h]
+  .text:000000018009E4D0                 mov     rbx, [rsp+38h+arg_8]
+  .text:000000018009E4D5                 mov     al, 1
+  .text:000000018009E4D7                 add     rsp, 30h
+  .text:000000018009E4DB                 pop     rdi
+  .text:000000018009E4DC                 retn
+procedure: |-
+  char __fastcall CNetworkGameServer_ActivateServer(__int64 a1)
+  {
+    void *v2; // rdi
+    const char **v3; // rax
+    const char *v4; // rax
+    const char *v5; // rdx
+    int v6; // eax
+    __int64 v7; // rcx
+    __int64 v8; // rax
+    __int64 v9; // rdx
+    _BYTE *v10; // rdi
+    __int64 v11; // rcx
+    __int64 v12; // rax
+    int *v14; // [rsp+20h] [rbp-18h] BYREF
+    int v15; // [rsp+28h] [rbp-10h]
+    int v16; // [rsp+40h] [rbp+8h] BYREF
+
+    COM_TimestampedLog("CNetworkGameServer::ActivateServer");
+    sub_18013BA50(&off_180612C70, 11, 0);
+    *(_DWORD *)(a1 + 56) = 3;
+    v2 = &unk_180528AFF;
+    *(_BYTE *)(a1 + 10048) = 0;
+    if ( !qword_18068E2C0 || (*(_DWORD *)(qword_18068E2C0 + 48) & 0x400LL) != 0 )
+    {
+      v5 = "unknown";
+    }
+    else
+    {
+      v3 = (const char **)sub_1803FEF60(&unk_18068E2B8, 0xFFFFFFFFLL);
+      if ( !v3 )
+        v3 = *(const char ***)(qword_18068E2C0 + 8);
+      v4 = *v3;
+      v5 = (const char *)&unk_180528AFF;
+      if ( v4 )
+        v5 = v4;
+    }
+    CUtlString::Set((CUtlString *)(a1 + 352), v5);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+      {
+        v6 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 96LL))(a1);
+        LoggingSystem_Log((unsigned int)dword_1808CC6B8, 2, "SV:  %i player server started\n", v6);
+      }
+    }
+    else if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+    {
+      LoggingSystem_Log((unsigned int)dword_1808CC6B8, 2, "SV:  Game started\n");
+    }
+    v7 = *(_QWORD *)(a1 + 344);
+    if ( v7 )
+    {
+      v8 = -1;
+      do
+        ++v8;
+      while ( *(_BYTE *)(v7 + v8) );
+      if ( (int)v8 > 0 && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+      {
+        if ( *(_QWORD *)(a1 + 344) )
+          v2 = *(void **)(a1 + 344);
+        LoggingSystem_Log((unsigned int)dword_1808CC6B8, 2, "SV:  addon='%s'\n", v2);
+      }
+    }
+    COM_TimestampedLog("ActivateSteamGameServer(start)");
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1)
+      && !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 216LL))(a1)
+      && !*(_BYTE *)((*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 352LL))(a1) + 108)
+      && !*(_BYTE *)((*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a1 + 352LL))(a1) + 109) )
+    {
+      v10 = (_BYTE *)(a1 + 698);
+      if ( !*(_BYTE *)(a1 + 697) || *v10 )
+      {
+        LOBYTE(v9) = 1;
+        sub_1800F8120(&off_180612910, v9);
+        if ( g_pSource2Server )
+          (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 328LL))(g_pSource2Server);
+        if ( *v10 )
+          *v10 = 0;
+      }
+      v11 = *(_QWORD *)(a1 + 408);
+      if ( v11 )
+      {
+        v16 = (unsigned __int16)word_180612A24;
+        v15 = 4;
+        v14 = &v16;
+        LOBYTE(v9) = 1;
+        (*(void (__fastcall **)(__int64, __int64, const char *, int **))(*(_QWORD *)v11 + 56LL))(
+          v11,
+          v9,
+          "QueryPort",
+          &v14);
+      }
+    }
+    CSteam3Server_SendUpdatedServerDetails(&off_180612910, 0);
+    sub_1800B12E0(a1);
+    COM_TimestampedLog("ActivateSteamGameServer(finished)");
+    CNetworkGameServerBase_StartHLTVMaster(a1);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkServerService + 304LL))(g_pNetworkServerService) )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkServerService + 296LL))(g_pNetworkServerService);
+    CSteam3Server_SendUpdatedServerDetails(&off_180612910, 0);
+    if ( (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 184LL))(g_pSource2Server) )
+    {
+      v12 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 184LL))(g_pSource2Server);
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)v12 + 16LL))(v12);
+    }
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/engine/CSteam3Server_SendUpdatedServerDetails.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CSteam3Server_SendUpdatedServerDetails.linux.yaml
@@ -1,0 +1,289 @@
+func_name: CSteam3Server_SendUpdatedServerDetails
+func_va: '0x5763f0'
+disasm_code: |-
+  .text:00000000005763F0                 push    rbp
+  .text:00000000005763F1                 mov     rbp, rsp
+  .text:00000000005763F4                 push    r15
+  .text:00000000005763F6                 push    r14
+  .text:00000000005763F8                 push    r13
+  .text:00000000005763FA                 push    r12
+  .text:00000000005763FC                 lea     r12, off_9D7F10
+  .text:0000000000576403                 push    rbx
+  .text:0000000000576404                 mov     rbx, rdi
+  .text:0000000000576407                 mov     rdi, r12
+  .text:000000000057640A                 sub     rsp, 48h
+  .text:000000000057640E                 mov     [rbp+var_64], esi
+  .text:0000000000576411                 call    sub_2CA3A0
+  .text:0000000000576416                 cmp     qword ptr [rax], 0
+  .text:000000000057641A                 jz      loc_576584
+  .text:0000000000576420                 mov     edi, [rbx+0C8h]
+  .text:0000000000576426                 test    edi, edi
+  .text:0000000000576428                 jle     loc_576584
+  .text:000000000057642E                 lea     rax, off_9D7BB0
+  .text:0000000000576435                 mov     rdi, [rax]
+  .text:0000000000576438                 call    sub_3F7360
+  .text:000000000057643D                 mov     r13, rax
+  .text:0000000000576440                 test    rax, rax
+  .text:0000000000576443                 jz      loc_576584
+  .text:0000000000576449                 lea     rcx, [rbp+var_54]
+  .text:000000000057644D                 mov     rdi, rax
+  .text:0000000000576450                 lea     rdx, [rbp+var_58]
+  .text:0000000000576454                 lea     rsi, [rbp+var_5C]
+  .text:0000000000576458                 call    sub_4F8130
+  .text:000000000057645D                 mov     rdi, r12
+  .text:0000000000576460                 call    sub_2CA3A0
+  .text:0000000000576465                 mov     esi, [rbp+var_54]
+  .text:0000000000576468                 mov     rdi, [rax]
+  .text:000000000057646B                 mov     rax, [rdi]
+  .text:000000000057646E                 call    qword ptr [rax+68h]
+  .text:0000000000576471                 mov     rdi, r12
+  .text:0000000000576474                 call    sub_2CA3A0
+  .text:0000000000576479                 mov     esi, [rbp+var_58]
+  .text:000000000057647C                 mov     rdi, [rax]
+  .text:000000000057647F                 mov     rax, [rdi]
+  .text:0000000000576482                 call    qword ptr [rax+60h]
+  .text:0000000000576485                 mov     rdi, r12
+  .text:0000000000576488                 call    sub_2CA3A0
+  .text:000000000057648D                 lea     rdi, unk_A301F0
+  .text:0000000000576494                 mov     esi, 0FFFFFFFFh
+  .text:0000000000576499                 mov     r14, [rax]
+  .text:000000000057649C                 mov     rax, [r14]
+  .text:000000000057649F                 mov     r15, [rax+0B8h]
+  .text:00000000005764A6                 call    sub_5E60F0
+  .text:00000000005764AB                 test    rax, rax
+  .text:00000000005764AE                 jz      loc_576598
+  .text:00000000005764B4                 mov     edi, [rax]
+  .text:00000000005764B6                 lea     rsi, [rbp+var_50]
+  .text:00000000005764BA                 mov     [rbp+var_70], rsi
+  .text:00000000005764BE                 call    sub_2C8C70
+  .text:00000000005764C3                 mov     rsi, [rbp+var_70]
+  .text:00000000005764C7                 mov     rdi, r14
+  .text:00000000005764CA                 call    r15
+  .text:00000000005764CD                 mov     rdi, r12
+  .text:00000000005764D0                 call    sub_2CA3A0
+  .text:00000000005764D5                 mov     rdi, r13
+  .text:00000000005764D8                 mov     r14, [rax]
+  .text:00000000005764DB                 mov     rax, [r14]
+  .text:00000000005764DE                 mov     r15, [rax+70h]
+  .text:00000000005764E2                 mov     rax, [r13+0]
+  .text:00000000005764E6                 ; 0x240 = 576LL = CNetworkGameServerBase_GetHostName
+  .text:00000000005764E6                 call    qword ptr [rax+240h]; 0x240 = 576LL = CNetworkGameServerBase_GetHostName
+  .text:00000000005764EC                 mov     rdi, r14
+  .text:00000000005764EF                 mov     rsi, rax
+  .text:00000000005764F2                 call    r15
+  .text:00000000005764F5                 mov     rdi, r12
+  .text:00000000005764F8                 call    sub_2CA3A0
+  .text:00000000005764FD                 mov     rdi, r13
+  .text:0000000000576500                 mov     r12, [rax]
+  .text:0000000000576503                 mov     rax, [r12]
+  .text:0000000000576507                 mov     r14, [rax+78h]
+  .text:000000000057650B                 mov     rax, [r13+0]
+  .text:000000000057650F                 ; 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+  .text:000000000057650F                 call    qword ptr [rax+0C8h]; 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+  .text:0000000000576515                 mov     rdi, r12
+  .text:0000000000576518                 mov     rsi, rax
+  .text:000000000057651B                 call    r14
+  .text:000000000057651E                 lea     r12, g_pSource2Server
+  .text:0000000000576525                 cmp     qword ptr [r12], 0
+  .text:000000000057652A                 jz      short loc_576584
+  .text:000000000057652C                 cmp     dword ptr [rbx+0C8h], 1
+  .text:0000000000576533                 lea     rdx, [rbx+0D5h]
+  .text:000000000057653A                 jz      loc_5765E0
+  .text:0000000000576540                 movzx   eax, byte ptr [rdx+6]
+  .text:0000000000576544                 cmp     al, 0Fh
+  .text:0000000000576546                 jbe     short loc_576584
+  .text:0000000000576548                 cmp     al, 0AFh
+  .text:000000000057654A                 ja      short loc_576584
+  .text:000000000057654C                 movzx   ecx, byte ptr [rdx+7]
+  .text:0000000000576550                 sub     ecx, 1
+  .text:0000000000576553                 cmp     cl, 3
+  .text:0000000000576556                 ja      short loc_576584
+  .text:0000000000576558                 and     eax, 0FFFFFFF0h
+  .text:000000000057655B                 cmp     al, 10h
+  .text:000000000057655D                 jz      short loc_5765B0
+  .text:000000000057655F                 cmp     al, 70h ; 'p'
+  .text:0000000000576561                 jz      loc_576600
+  .text:0000000000576567                 cmp     al, 30h ; '0'
+  .text:0000000000576569                 jnz     short loc_576571
+  .text:000000000057656B                 mov     eax, [rdx]
+  .text:000000000057656D                 test    eax, eax
+  .text:000000000057656F                 jz      short loc_576584
+  .text:0000000000576571                 mov     rdi, [r12]
+  .text:0000000000576575                 xor     edx, edx
+  .text:0000000000576577                 movzx   esi, byte ptr [rbp+var_64]
+  .text:000000000057657B                 mov     rax, [rdi]
+  .text:000000000057657E                 call    qword ptr [rax+220h]
+  .text:0000000000576584                 add     rsp, 48h
+  .text:0000000000576588                 pop     rbx
+  .text:0000000000576589                 pop     r12
+  .text:000000000057658B                 pop     r13
+  .text:000000000057658D                 pop     r14
+  .text:000000000057658F                 pop     r15
+  .text:0000000000576591                 pop     rbp
+  .text:0000000000576592                 retn
+  .text:0000000000576598                 lea     rax, unk_A301F0
+  .text:000000000057659F                 mov     rax, [rax+8]
+  .text:00000000005765A3                 mov     rax, [rax+8]
+  .text:00000000005765A7                 jmp     loc_5764B4
+  .text:00000000005765B0                 mov     esi, [rdx]
+  .text:00000000005765B2                 test    esi, esi
+  .text:00000000005765B4                 jz      short loc_576584
+  .text:00000000005765B6                 movzx   ecx, byte ptr [rdx+5]
+  .text:00000000005765BA                 movzx   eax, byte ptr [rdx+4]
+  .text:00000000005765BE                 shl     rcx, 8
+  .text:00000000005765C2                 or      rcx, rax
+  .text:00000000005765C5                 movzx   eax, byte ptr [rdx+6]
+  .text:00000000005765C9                 and     eax, 0Fh
+  .text:00000000005765CC                 shl     rax, 10h
+  .text:00000000005765D0                 or      rax, rcx
+  .text:00000000005765D3                 cmp     eax, 1
+  .text:00000000005765D6                 jnz     short loc_576584
+  .text:00000000005765D8                 jmp     short loc_576571
+  .text:00000000005765E0                 movzx   eax, cs:byte_C70078
+  .text:00000000005765E7                 test    al, al
+  .text:00000000005765E9                 jz      short loc_576638
+  .text:00000000005765EB                 lea     rdx, qword_C70080
+  .text:00000000005765F2                 jmp     loc_576540
+  .text:0000000000576600                 mov     ecx, [rdx]
+  .text:0000000000576602                 test    ecx, ecx
+  .text:0000000000576604                 jz      loc_576584
+  .text:000000000057660A                 movzx   ecx, byte ptr [rdx+5]
+  .text:000000000057660E                 movzx   eax, byte ptr [rdx+4]
+  .text:0000000000576612                 shl     rcx, 8
+  .text:0000000000576616                 or      rcx, rax
+  .text:0000000000576619                 movzx   eax, byte ptr [rdx+6]
+  .text:000000000057661D                 and     eax, 0Fh
+  .text:0000000000576620                 shl     rax, 10h
+  .text:0000000000576624                 or      rax, rcx
+  .text:0000000000576627                 jz      loc_576571
+  .text:000000000057662D                 jmp     loc_576584
+  .text:0000000000576638                 lea     rbx, byte_C70078
+  .text:000000000057663F                 mov     rdi, rbx
+  .text:0000000000576642                 call    sub_2BE340
+  .text:0000000000576647                 test    eax, eax
+  .text:0000000000576649                 jz      short loc_5765EB
+  .text:000000000057664B                 mov     rax, 100000000000000h
+  .text:0000000000576655                 mov     rdi, rbx
+  .text:0000000000576658                 mov     cs:qword_C70080, rax
+  .text:000000000057665F                 call    sub_2BE360
+  .text:0000000000576664                 jmp     short loc_5765EB
+procedure: |-
+  __int64 __fastcall sub_5763F0(__int64 a1, unsigned __int8 a2)
+  {
+    __int64 result; // rax
+    __int64 v3; // r13
+    _QWORD *v4; // rax
+    _QWORD *v5; // rax
+    __int64 v6; // rax
+    __int64 v7; // r14
+    void (__fastcall *v8)(__int64, _BYTE *); // r15
+    unsigned int *v9; // rax
+    __int64 v10; // rax
+    __int64 v11; // r14
+    void (__fastcall *v12)(__int64, __int64); // r15
+    __int64 v13; // rax
+    __int64 v14; // rax
+    __int64 v15; // r12
+    __int64 (__fastcall *v16)(__int64, __int64); // r14
+    __int64 v17; // rax
+    __int64 *v18; // rdx
+    _BYTE v19[4]; // [rsp+14h] [rbp-5Ch] BYREF
+    unsigned int v20; // [rsp+18h] [rbp-58h] BYREF
+    unsigned int v21; // [rsp+1Ch] [rbp-54h] BYREF
+    _BYTE v22[80]; // [rsp+20h] [rbp-50h] BYREF
+
+    result = sub_2CA3A0(&off_9D7F10);
+    if ( *(_QWORD *)result )
+    {
+      if ( *(int *)(a1 + 200) > 0 )
+      {
+        result = sub_3F7360(off_9D7BB0);
+        v3 = result;
+        if ( result )
+        {
+          sub_4F8130(result, v19, &v20, &v21);
+          v4 = (_QWORD *)sub_2CA3A0(&off_9D7F10);
+          (*(void (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v4 + 104LL))(*v4, v21);
+          v5 = (_QWORD *)sub_2CA3A0(&off_9D7F10);
+          (*(void (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v5 + 96LL))(*v5, v20);
+          v6 = sub_2CA3A0(&off_9D7F10);
+          v7 = *(_QWORD *)v6;
+          v8 = *(void (__fastcall **)(__int64, _BYTE *))(**(_QWORD **)v6 + 184LL);
+          v9 = (unsigned int *)sub_5E60F0(&unk_A301F0, 0xFFFFFFFFLL);
+          if ( !v9 )
+            v9 = *(unsigned int **)(unk_A301F8 + 8LL);
+          sub_2C8C70(*v9);
+          v8(v7, v22);
+          v10 = sub_2CA3A0(&off_9D7F10);
+          v11 = *(_QWORD *)v10;
+          v12 = *(void (__fastcall **)(__int64, __int64))(**(_QWORD **)v10 + 112LL);
+          v13 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v3 + 576LL))(v3);// 0x240 = 576LL = CNetworkGameServerBase_GetHostName
+          v12(v11, v13);
+          v14 = sub_2CA3A0(&off_9D7F10);
+          v15 = *(_QWORD *)v14;
+          v16 = *(__int64 (__fastcall **)(__int64, __int64))(**(_QWORD **)v14 + 120LL);
+          v17 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v3 + 200LL))(v3);// 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+          result = v16(v15, v17);
+          if ( g_pSource2Server )
+          {
+            v18 = (__int64 *)(a1 + 213);
+            if ( *(_DWORD *)(a1 + 200) == 1 )
+            {
+              if ( !byte_C70078 && (unsigned int)sub_2BE340(&byte_C70078) )
+              {
+                qword_C70080 = 0x100000000000000LL;
+                sub_2BE360(&byte_C70078);
+              }
+              v18 = &qword_C70080;
+            }
+            result = *((unsigned __int8 *)v18 + 6);
+            if ( (unsigned __int8)result > 0xFu
+              && (unsigned __int8)result <= 0xAFu
+              && (unsigned __int8)(*((_BYTE *)v18 + 7) - 1) <= 3u )
+            {
+              result = (unsigned int)result & 0xFFFFFFF0;
+              switch ( (_BYTE)result )
+              {
+                case 0x10:
+                  if ( *(_DWORD *)v18 )
+                  {
+                    result = *((unsigned __int16 *)v18 + 2) | ((unsigned __int64)(*((_BYTE *)v18 + 6) & 0xF) << 16);
+                    if ( (_DWORD)result == 1 )
+                      return (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pSource2Server + 544LL))(
+                               g_pSource2Server,
+                               a2,
+                               0);
+                  }
+                  break;
+                case 0x70:
+                  if ( *(_DWORD *)v18 )
+                  {
+                    result = *((unsigned __int16 *)v18 + 2) | ((unsigned __int64)(*((_BYTE *)v18 + 6) & 0xF) << 16);
+                    if ( !result )
+                      return (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pSource2Server + 544LL))(
+                               g_pSource2Server,
+                               a2,
+                               0);
+                  }
+                  break;
+                case 0x30:
+                  result = *(unsigned int *)v18;
+                  if ( (_DWORD)result )
+                    return (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pSource2Server + 544LL))(
+                             g_pSource2Server,
+                             a2,
+                             0);
+                  break;
+                default:
+                  return (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD))(*g_pSource2Server + 544LL))(
+                           g_pSource2Server,
+                           a2,
+                           0);
+              }
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CSteam3Server_SendUpdatedServerDetails.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CSteam3Server_SendUpdatedServerDetails.windows.yaml
@@ -1,0 +1,223 @@
+func_name: CSteam3Server_SendUpdatedServerDetails
+func_va: '0x1800f9fb0'
+disasm_code: |-
+  .text:00000001800F9FB0                 push    rbp
+  .text:00000001800F9FB2                 push    r14
+  .text:00000001800F9FB4                 sub     rsp, 48h
+  .text:00000001800F9FB8                 mov     rbp, rcx
+  .text:00000001800F9FBB                 movzx   r14d, dl
+  .text:00000001800F9FBF                 lea     rcx, off_18060E650
+  .text:00000001800F9FC6                 call    cs:SteamInternal_ContextInit
+  .text:00000001800F9FCC                 cmp     qword ptr [rax], 0
+  .text:00000001800F9FD0                 jz      loc_1800FA182
+  .text:00000001800F9FD6                 cmp     dword ptr [rbp+0A0h], 1
+  .text:00000001800F9FDD                 jl      loc_1800FA182
+  .text:00000001800F9FE3                 mov     [rsp+58h+arg_8], rsi
+  .text:00000001800F9FE8                 mov     rsi, cs:qword_18090DA50
+  .text:00000001800F9FEF                 test    rsi, rsi
+  .text:00000001800F9FF2                 jz      loc_1800FA17D
+  .text:00000001800F9FF8                 mov     [rsp+58h+arg_0], rbx
+  .text:00000001800F9FFD                 lea     r9, [rsp+58h+arg_10]
+  .text:00000001800FA002                 lea     r8, [rsp+58h+arg_18]
+  .text:00000001800FA007                 mov     [rsp+58h+var_18], rdi
+  .text:00000001800FA00C                 lea     rdx, [rsp+58h+var_38]
+  .text:00000001800FA011                 mov     rcx, rsi
+  .text:00000001800FA014                 call    sub_1800B1BC0
+  .text:00000001800FA019                 lea     rcx, off_18060E650
+  .text:00000001800FA020                 call    cs:SteamInternal_ContextInit
+  .text:00000001800FA026                 mov     edx, [rsp+58h+arg_10]
+  .text:00000001800FA02A                 mov     rcx, [rax]
+  .text:00000001800FA02D                 mov     rax, [rcx]
+  .text:00000001800FA030                 call    qword ptr [rax+68h]
+  .text:00000001800FA033                 lea     rcx, off_18060E650
+  .text:00000001800FA03A                 call    cs:SteamInternal_ContextInit
+  .text:00000001800FA040                 mov     edx, [rsp+58h+arg_18]
+  .text:00000001800FA044                 mov     rcx, [rax]
+  .text:00000001800FA047                 mov     rax, [rcx]
+  .text:00000001800FA04A                 call    qword ptr [rax+60h]
+  .text:00000001800FA04D                 lea     rcx, off_18060E650
+  .text:00000001800FA054                 call    cs:SteamInternal_ContextInit
+  .text:00000001800FA05A                 mov     edx, 0FFFFFFFFh
+  .text:00000001800FA05F                 lea     rcx, unk_1808CC750
+  .text:00000001800FA066                 mov     rbx, [rax]
+  .text:00000001800FA069                 mov     rax, [rbx]
+  .text:00000001800FA06C                 mov     rdi, [rax+0B8h]
+  .text:00000001800FA073                 call    sub_1803FEF60
+  .text:00000001800FA078                 test    rax, rax
+  .text:00000001800FA07B                 jnz     short loc_1800FA088
+  .text:00000001800FA07D                 mov     rax, cs:qword_1808CC758
+  .text:00000001800FA084                 mov     rax, [rax+8]
+  .text:00000001800FA088                 mov     ecx, [rax]
+  .text:00000001800FA08A                 lea     rdx, [rsp+58h+var_34]
+  .text:00000001800FA08F                 call    cs:V_Int32ToString_Unsafe
+  .text:00000001800FA095                 lea     rdx, [rsp+58h+var_34]
+  .text:00000001800FA09A                 mov     rcx, rbx
+  .text:00000001800FA09D                 call    rdi
+  .text:00000001800FA09F                 lea     rcx, off_18060E650
+  .text:00000001800FA0A6                 call    cs:SteamInternal_ContextInit
+  .text:00000001800FA0AC                 mov     rcx, rsi
+  .text:00000001800FA0AF                 mov     rdi, [rax]
+  .text:00000001800FA0B2                 mov     rax, [rdi]
+  .text:00000001800FA0B5                 mov     rbx, [rax+70h]
+  .text:00000001800FA0B9                 mov     rax, [rsi]
+  .text:00000001800FA0BC                 ; 0x218 = 536LL = CNetworkGameServerBase_GetHostName
+  .text:00000001800FA0BC                 call    qword ptr [rax+218h]; 0x218 = 536LL = CNetworkGameServerBase_GetHostName
+  .text:00000001800FA0C2                 mov     rdx, rax
+  .text:00000001800FA0C5                 mov     rcx, rdi
+  .text:00000001800FA0C8                 call    rbx
+  .text:00000001800FA0CA                 lea     rcx, off_18060E650
+  .text:00000001800FA0D1                 call    cs:SteamInternal_ContextInit
+  .text:00000001800FA0D7                 mov     rcx, rsi
+  .text:00000001800FA0DA                 mov     rdi, [rax]
+  .text:00000001800FA0DD                 mov     rax, [rdi]
+  .text:00000001800FA0E0                 mov     rbx, [rax+78h]
+  .text:00000001800FA0E4                 mov     rax, [rsi]
+  .text:00000001800FA0E7                 ; 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+  .text:00000001800FA0E7                 call    qword ptr [rax+0C8h]; 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+  .text:00000001800FA0ED                 mov     rdx, rax
+  .text:00000001800FA0F0                 mov     rcx, rdi
+  .text:00000001800FA0F3                 call    rbx
+  .text:00000001800FA0F5                 cmp     cs:g_pSource2Server, 0
+  .text:00000001800FA0FD                 mov     rdi, [rsp+58h+var_18]
+  .text:00000001800FA102                 mov     rbx, [rsp+58h+arg_0]
+  .text:00000001800FA107                 jz      short loc_1800FA17D
+  .text:00000001800FA109                 mov     rcx, rbp
+  .text:00000001800FA10C                 call    sub_1800F8750
+  .text:00000001800FA111                 mov     r9, rax
+  .text:00000001800FA114                 mov     edx, [rax+4]
+  .text:00000001800FA117                 mov     r8d, edx
+  .text:00000001800FA11A                 and     r8d, 0F00000h
+  .text:00000001800FA121                 jbe     short loc_1800FA17D
+  .text:00000001800FA123                 cmp     r8d, 0B00000h
+  .text:00000001800FA12A                 jnb     short loc_1800FA17D
+  .text:00000001800FA12C                 mov     ecx, edx
+  .text:00000001800FA12E                 sar     ecx, 18h
+  .text:00000001800FA131                 dec     ecx
+  .text:00000001800FA133                 cmp     ecx, 3
+  .text:00000001800FA136                 ja      short loc_1800FA17D
+  .text:00000001800FA138                 cmp     r8d, 100000h
+  .text:00000001800FA13F                 jnz     short loc_1800FA18A
+  .text:00000001800FA141                 cmp     dword ptr [rax], 0
+  .text:00000001800FA144                 jz      short loc_1800FA17D
+  .text:00000001800FA146                 mov     eax, edx
+  .text:00000001800FA148                 and     eax, 0FFFFFh
+  .text:00000001800FA14D                 cmp     eax, 1
+  .text:00000001800FA150                 jnz     short loc_1800FA17D
+  .text:00000001800FA152                 and     edx, 0F00000h
+  .text:00000001800FA158                 cmp     edx, 300000h
+  .text:00000001800FA15E                 jnz     short loc_1800FA166
+  .text:00000001800FA160                 cmp     dword ptr [r9], 0
+  .text:00000001800FA164                 jz      short loc_1800FA17D
+  .text:00000001800FA166                 mov     rcx, cs:g_pSource2Server
+  .text:00000001800FA16D                 xor     r8d, r8d
+  .text:00000001800FA170                 movzx   edx, r14b
+  .text:00000001800FA174                 mov     rax, [rcx]
+  .text:00000001800FA177                 call    qword ptr [rax+220h]
+  .text:00000001800FA17D                 mov     rsi, [rsp+58h+arg_8]
+  .text:00000001800FA182                 add     rsp, 48h
+  .text:00000001800FA186                 pop     r14
+  .text:00000001800FA188                 pop     rbp
+  .text:00000001800FA189                 retn
+  .text:00000001800FA18A                 cmp     r8d, 700000h
+  .text:00000001800FA191                 jnz     short loc_1800FA152
+  .text:00000001800FA193                 cmp     dword ptr [rax], 0
+  .text:00000001800FA196                 jz      short loc_1800FA17D
+  .text:00000001800FA198                 test    edx, 0FFFFFh
+  .text:00000001800FA19E                 jz      short loc_1800FA166
+  .text:00000001800FA1A0                 mov     rsi, [rsp+58h+arg_8]
+  .text:00000001800FA1A5                 add     rsp, 48h
+  .text:00000001800FA1A9                 pop     r14
+  .text:00000001800FA1AB                 pop     rbp
+  .text:00000001800FA1AC                 retn
+procedure: |-
+  __int64 __fastcall sub_1800F9FB0(__int64 a1, unsigned __int8 a2)
+  {
+    __int64 result; // rax
+    __int64 v5; // rsi
+    _QWORD *v6; // rax
+    _QWORD *v7; // rax
+    __int64 v8; // rax
+    __int64 v9; // rbx
+    void (__fastcall *v10)(__int64, _BYTE *); // rdi
+    unsigned int *v11; // rax
+    __int64 v12; // rax
+    __int64 v13; // rdi
+    void (__fastcall *v14)(__int64, __int64); // rbx
+    __int64 v15; // rax
+    __int64 v16; // rax
+    __int64 v17; // rdi
+    __int64 (__fastcall *v18)(__int64, __int64); // rbx
+    __int64 v19; // rax
+    _DWORD *v20; // r9
+    int v21; // edx
+    unsigned int v22; // r8d
+    _BYTE v23[4]; // [rsp+20h] [rbp-38h] BYREF
+    _BYTE v24[28]; // [rsp+24h] [rbp-34h] BYREF
+    unsigned int v25; // [rsp+70h] [rbp+18h] BYREF
+    unsigned int v26; // [rsp+78h] [rbp+20h] BYREF
+
+    result = SteamInternal_ContextInit(&off_18060E650);
+    if ( !*(_QWORD *)result )
+      return result;
+    if ( *(int *)(a1 + 160) < 1 )
+      return result;
+    v5 = qword_18090DA50;
+    if ( !qword_18090DA50 )
+      return result;
+    sub_1800B1BC0(qword_18090DA50, v23, &v26, &v25);
+    v6 = (_QWORD *)SteamInternal_ContextInit(&off_18060E650);
+    (*(void (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v6 + 104LL))(*v6, v25);
+    v7 = (_QWORD *)SteamInternal_ContextInit(&off_18060E650);
+    (*(void (__fastcall **)(_QWORD, _QWORD))(*(_QWORD *)*v7 + 96LL))(*v7, v26);
+    v8 = SteamInternal_ContextInit(&off_18060E650);
+    v9 = *(_QWORD *)v8;
+    v10 = *(void (__fastcall **)(__int64, _BYTE *))(**(_QWORD **)v8 + 184LL);
+    v11 = (unsigned int *)sub_1803FEF60(&unk_1808CC750, 0xFFFFFFFFLL);
+    if ( !v11 )
+      v11 = *(unsigned int **)(qword_1808CC758 + 8);
+    V_Int32ToString_Unsafe(*v11, v24);
+    v10(v9, v24);
+    v12 = SteamInternal_ContextInit(&off_18060E650);
+    v13 = *(_QWORD *)v12;
+    v14 = *(void (__fastcall **)(__int64, __int64))(**(_QWORD **)v12 + 112LL);
+    v15 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 536LL))(v5);// 0x218 = 536LL = CNetworkGameServerBase_GetHostName
+    v14(v13, v15);
+    v16 = SteamInternal_ContextInit(&off_18060E650);
+    v17 = *(_QWORD *)v16;
+    v18 = *(__int64 (__fastcall **)(__int64, __int64))(**(_QWORD **)v16 + 120LL);
+    v19 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v5 + 200LL))(v5);// 0x0C8 = 200LL = CNetworkGameServerBase_GetMapName
+    result = v18(v17, v19);
+    if ( !g_pSource2Server )
+      return result;
+    result = sub_1800F8750(a1);
+    v20 = (_DWORD *)result;
+    v21 = *(_DWORD *)(result + 4);
+    v22 = v21 & 0xF00000;
+    if ( (v21 & 0xF00000) == 0 || v22 >= 0xB00000 || (unsigned int)((v21 >> 24) - 1) > 3 )
+      return result;
+    if ( v22 == 0x100000 )
+    {
+      if ( !*(_DWORD *)result )
+        return result;
+      result = v21 & 0xFFFFF;
+      if ( (_DWORD)result != 1 )
+        return result;
+    }
+    else if ( v22 == 7340032 )
+    {
+      if ( *(_DWORD *)result && (v21 & 0xFFFFF) == 0 )
+        return (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD, _DWORD *))(*(_QWORD *)g_pSource2Server + 544LL))(
+                 g_pSource2Server,
+                 a2,
+                 0,
+                 v20);
+      return result;
+    }
+    if ( (v21 & 0xF00000) != 0x300000 || *v20 )
+      return (*(__int64 (__fastcall **)(__int64, _QWORD, _QWORD, _DWORD *))(*(_QWORD *)g_pSource2Server + 544LL))(
+               g_pSource2Server,
+               a2,
+               0,
+               v20);
+    return result;
+  }


### PR DESCRIPTION
## Summary
- Add preprocessor script `find-CSteam3Server_SendUpdatedServerDetails` (Pattern D) locating the engine regular function via LLM_DECOMPILE of predecessor `CNetworkGameServer_ActivateServer`.
- Add preprocessor script `find-CNetworkGameServerBase_GetMapName-AND-CNetworkGameServerBase_GetHostName` (Pattern C) locating both `CNetworkGameServer_vtable` vfuncs via LLM_DECOMPILE of predecessor `CSteam3Server_SendUpdatedServerDetails`.
- Add engine reference YAMLs (windows/linux) for both predecessors and register new config skill + symbol entries.
- Publish validated `gamesymbols/14174.yaml` snapshot.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (0 compile failures, 0 invalid items, 0 layout/vtable/record differences)
- candidate publication: passed; published SHA-256 matches the validated candidate (`72da696938...`)