### PR TITLE
feat(engine): add finder for CNetworkGameServerBase GetTime

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -1255,6 +1255,12 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_ServerAdvanceTick.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetTime
+        expected_output:
+          - CNetworkGameServerBase_GetTime.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_ServerAdvanceTick.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-INetworkGameServer_ServerProcessNetworking
         expected_output:
           - INetworkGameServer_ServerProcessNetworking.{platform}.yaml
@@ -2868,6 +2874,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerAdvanceTick
+      - name: CNetworkGameServerBase_GetTime
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetTime
       - name: INetworkGameServer_ServerProcessNetworking
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:eac64159217272d0af7241147a25953e5f2586b0602aa53130d45d1b7f819cba
-file_count: 3273
+config_sha256: sha256:cb03c6ea1a5e2b5f38fc1a0c3d53a2888ffed492e53de987b6834d819f1fb79a
+file_count: 3275
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10642,6 +10642,18 @@ files:
     vfunc_index: 65
     vfunc_offset: '0x208'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetTime.linux.yaml:
+    func_name: CNetworkGameServerBase_GetTime
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vfunc_sig: 48 8B 80 E0 00 00 00 48 39 D0
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetTime.windows.yaml:
+    func_name: CNetworkGameServerBase_GetTime
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vfunc_sig: FF 90 E0 00 00 00 F3 0F 10 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_GetTimescale.linux.yaml:
     func_name: CNetworkGameServerBase_GetTimescale
     func_rva: '0x4f0fc0'
@@ -42307,5 +42319,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T07:48:00Z'
+last_publish_time: '2026-08-05T11:14:24Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetTime.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetTime.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetTime skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetTime",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_GetTime",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_ServerAdvanceTick.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_ServerAdvanceTick.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetTime", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: this vfunc is not a downstream predecessor.
+    (
+        "CNetworkGameServerBase_GetTime",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerAdvanceTick.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerAdvanceTick.linux.yaml
@@ -1,0 +1,187 @@
+func_name: CNetworkGameServerBase_ServerAdvanceTick
+func_va: '0x4f21e0'
+disasm_code: |-
+  .text:00000000004F21E0                 push    rbp
+  .text:00000000004F21E1                 mov     rbp, rsp
+  .text:00000000004F21E4                 push    r12
+  .text:00000000004F21E6                 mov     r12, rsi
+  .text:00000000004F21E9                 push    rbx
+  .text:00000000004F21EA                 mov     rbx, rdi
+  .text:00000000004F21ED                 sub     rsp, 10h
+  .text:00000000004F21F1                 cmp     byte ptr [rdi+2BBh], 0
+  .text:00000000004F21F8                 jnz     short loc_4F2204
+  .text:00000000004F21FA                 cmp     byte ptr [rsi+28h], 0
+  .text:00000000004F21FE                 jnz     loc_4F22F8
+  .text:00000000004F2204                 lea     rax, g_pSoundOpSystem
+  .text:00000000004F220B                 mov     rax, [rax]
+  .text:00000000004F220E                 test    rax, rax
+  .text:00000000004F2211                 jz      short loc_4F2221
+  .text:00000000004F2213                 lea     rdi, [rax+8]
+  .text:00000000004F2217                 mov     rax, [rax+8]
+  .text:00000000004F221B                 call    qword ptr [rax+130h]
+  .text:00000000004F2221                 mov     eax, [rbx+38h]
+  .text:00000000004F2224                 cmp     eax, 1
+  .text:00000000004F2227                 jbe     loc_4F22E8
+  .text:00000000004F222D                 cmp     eax, 4
+  .text:00000000004F2230                 jz      short loc_4F2236
+  .text:00000000004F2232                 add     dword ptr [rbx+44h], 1
+  .text:00000000004F2236                 mov     rax, [rbx]
+  .text:00000000004F2239                 lea     rdx, sub_4F0D50
+  .text:00000000004F2240                 ; 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+  .text:00000000004F2240                 mov     rax, [rax+0E0h]; 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+  .text:00000000004F2247                 cmp     rax, rdx
+  .text:00000000004F224A                 jnz     loc_4F23F0
+  .text:00000000004F2250                 pxor    xmm0, xmm0
+  .text:00000000004F2254                 cvtsi2ss xmm0, dword ptr [rbx+44h]
+  .text:00000000004F2259                 movss   xmm1, cs:dword_26A1EC
+  .text:00000000004F2261                 mulss   xmm0, xmm1
+  .text:00000000004F2265                 movss   [rbp+var_18], xmm1
+  .text:00000000004F226A                 movss   [rbp+var_14], xmm0
+  .text:00000000004F226F                 call    sub_2C9630
+  .text:00000000004F2274                 movss   xmm0, [rbp+var_14]
+  .text:00000000004F2279                 mov     dword ptr [rbx+0A8h], 0
+  .text:00000000004F2283                 movss   xmm1, [rbp+var_18]
+  .text:00000000004F2288                 mov     [rbx+0B0h], rax
+  .text:00000000004F228F                 movss   dword ptr [rbx+88h], xmm0
+  .text:00000000004F2297                 mulss   xmm0, cs:dword_26A0D8
+  .text:00000000004F229F                 addss   xmm0, cs:dword_26A084
+  .text:00000000004F22A7                 movss   dword ptr [rbx+8Ch], xmm1
+  .text:00000000004F22AF                 mov     esi, [rbx+44h]
+  .text:00000000004F22B2                 cvttss2si edx, xmm0
+  .text:00000000004F22B6                 mov     [rbx+9Ch], edx
+  .text:00000000004F22BC                 mov     eax, [r12+30h]
+  .text:00000000004F22C1                 xor     edx, edx
+  .text:00000000004F22C3                 mov     [rbx+6Ch], eax
+  .text:00000000004F22C6                 mov     eax, [r12+34h]
+  .text:00000000004F22CB                 mov     [rbx+70h], eax
+  .text:00000000004F22CE                 lea     rax, off_9D8298
+  .text:00000000004F22D5                 mov     rdi, [rax]
+  .text:00000000004F22D8                 add     rsp, 10h
+  .text:00000000004F22DC                 pop     rbx
+  .text:00000000004F22DD                 pop     r12
+  .text:00000000004F22DF                 pop     rbp
+  .text:00000000004F22E0                 jmp     sub_58F490
+  .text:00000000004F22E8                 add     rsp, 10h
+  .text:00000000004F22EC                 pop     rbx
+  .text:00000000004F22ED                 pop     r12
+  .text:00000000004F22EF                 pop     rbp
+  .text:00000000004F22F0                 retn
+  .text:00000000004F22F8                 xor     edi, edi
+  .text:00000000004F22FA                 call    GetFrameTimeAmnesty
+  .text:00000000004F22FF                 test    rax, rax
+  .text:00000000004F2302                 jnz     loc_4F2204
+  .text:00000000004F2308                 movd    xmm1, dword ptr [rbx+458h]
+  .text:00000000004F2310                 movd    eax, xmm1
+  .text:00000000004F2314                 test    eax, eax
+  .text:00000000004F2316                 jz      short loc_4F236D
+  .text:00000000004F2318                 movsxd  rax, dword ptr [r12+34h]
+  .text:00000000004F231D                 pxor    xmm2, xmm2
+  .text:00000000004F2321                 movdqu  xmm3, xmmword ptr [rbx+4B8h]
+  .text:00000000004F2329                 movq    xmm0, rax
+  .text:00000000004F232E                 mov     eax, 1
+  .text:00000000004F2333                 pinsrq  xmm0, rax, 1
+  .text:00000000004F233A                 paddq   xmm0, xmm3
+  .text:00000000004F233E                 movups  xmmword ptr [rbx+4B8h], xmm0
+  .text:00000000004F2345                 movd    xmm0, dword ptr [r12+34h]
+  .text:00000000004F234C                 pmaxsd  xmm0, xmm2
+  .text:00000000004F2351                 pcmpeqd xmm2, xmm2
+  .text:00000000004F2355                 paddd   xmm1, xmm2
+  .text:00000000004F2359                 pminsd  xmm0, xmm1
+  .text:00000000004F235E                 movd    eax, xmm0
+  .text:00000000004F2362                 cdqe
+  .text:00000000004F2364                 add     qword ptr [rbx+rax*8+460h], 1
+  .text:00000000004F236D                 mov     eax, [rbx+4C8h]
+  .text:00000000004F2373                 test    eax, eax
+  .text:00000000004F2375                 jz      loc_4F2204
+  .text:00000000004F237B                 call    sub_37A990
+  .text:00000000004F2380                 pxor    xmm1, xmm1
+  .text:00000000004F2384                 pcmpeqd xmm2, xmm2
+  .text:00000000004F2388                 movss   xmm0, cs:dword_269ED4
+  .text:00000000004F2390                 mulss   xmm0, dword ptr [rax+4]
+  .text:00000000004F2395                 add     qword ptr [rbx+6C0h], 1
+  .text:00000000004F239D                 cvtss2sd xmm1, xmm0
+  .text:00000000004F23A1                 addsd   xmm1, qword ptr [rbx+6B8h]
+  .text:00000000004F23A9                 movsd   qword ptr [rbx+6B8h], xmm1
+  .text:00000000004F23B1                 movaps  xmm1, xmm0
+  .text:00000000004F23B4                 movd    xmm0, dword ptr [rbx+4C8h]
+  .text:00000000004F23BC                 roundss xmm1, xmm1, 0Ah
+  .text:00000000004F23C2                 cvttss2si eax, xmm1
+  .text:00000000004F23C6                 paddd   xmm0, xmm2
+  .text:00000000004F23CA                 pxor    xmm2, xmm2
+  .text:00000000004F23CE                 movd    xmm1, eax
+  .text:00000000004F23D2                 pmaxsd  xmm1, xmm2
+  .text:00000000004F23D7                 pminsd  xmm0, xmm1
+  .text:00000000004F23DC                 movd    eax, xmm0
+  .text:00000000004F23E0                 cdqe
+  .text:00000000004F23E2                 add     qword ptr [rbx+rax*8+4D0h], 1
+  .text:00000000004F23EB                 jmp     loc_4F2204
+  .text:00000000004F23F0                 mov     rdi, rbx
+  .text:00000000004F23F3                 call    rax
+  .text:00000000004F23F5                 movss   xmm1, cs:dword_26A1EC
+  .text:00000000004F23FD                 jmp     loc_4F2265
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_ServerAdvanceTick(__int64 a1, __int64 a2, __m128i a3)
+  {
+    __int64 result; // rax
+    __int64 (__fastcall *v5)(); // rax
+    __int64 v6; // rax
+    __int64 v7; // rsi
+    __m128i v8; // xmm1
+    int v9; // eax
+    __m128 v10; // xmm0
+    int v11; // eax
+
+    if ( !*(_BYTE *)(a1 + 699) && *(_BYTE *)(a2 + 40) && !GetFrameTimeAmnesty(0) )
+    {
+      v8 = _mm_cvtsi32_si128(*(_DWORD *)(a1 + 1112));
+      if ( _mm_cvtsi128_si32(v8) )
+      {
+        *(__m128i *)(a1 + 1208) = _mm_add_epi64(
+                                    _mm_insert_epi64((__m128i)(unsigned __int64)*(int *)(a2 + 52), 1, 1),
+                                    _mm_loadu_si128((const __m128i *)(a1 + 1208)));
+        a3 = _mm_min_epi32(
+               _mm_max_epi32(_mm_cvtsi32_si128(*(_DWORD *)(a2 + 52)), (__m128i)0LL),
+               _mm_add_epi32(v8, (__m128i)-1LL));
+        v9 = _mm_cvtsi128_si32(a3);
+        ++*(_QWORD *)(a1 + 8LL * v9 + 1120);
+      }
+      if ( *(_DWORD *)(a1 + 1224) )
+      {
+        v10 = (__m128)0x447A0000u;
+        v10.m128_f32[0] = 1000.0 * *(float *)(sub_37A990(0) + 4);
+        ++*(_QWORD *)(a1 + 1728);
+        *(double *)(a1 + 1720) = v10.m128_f32[0] + *(double *)(a1 + 1720);
+        a3 = _mm_min_epi32(
+               _mm_add_epi32(_mm_cvtsi32_si128(*(_DWORD *)(a1 + 1224)), (__m128i)-1LL),
+               _mm_max_epi32(_mm_cvtsi32_si128((int)_mm_round_ss(v10, v10, 10).m128_f32[0]), (__m128i)0LL));
+        v11 = _mm_cvtsi128_si32(a3);
+        ++*(_QWORD *)(a1 + 8LL * v11 + 1232);
+      }
+    }
+    if ( g_pSoundOpSystem )
+      (*(void (__fastcall **)(_QWORD *, double))(g_pSoundOpSystem[1] + 304LL))(
+        g_pSoundOpSystem + 1,
+        *(double *)a3.m128i_i64);
+    result = *(unsigned int *)(a1 + 56);
+    if ( (unsigned int)result > 1 )
+    {
+      if ( (_DWORD)result != 4 )
+        ++*(_DWORD *)(a1 + 68);
+      v5 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 224LL);// 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+      if ( v5 == sub_4F0D50 )
+        *(float *)a3.m128i_i32 = (float)*(int *)(a1 + 68) * 0.015625;
+      else
+        ((void (__fastcall *)(__int64, double))v5)(a1, *(double *)a3.m128i_i64);
+      v6 = sub_2C9630();
+      *(_DWORD *)(a1 + 168) = 0;
+      *(_QWORD *)(a1 + 176) = v6;
+      *(_DWORD *)(a1 + 136) = a3.m128i_i32[0];
+      *(_DWORD *)(a1 + 140) = 1015021568;
+      v7 = *(unsigned int *)(a1 + 68);
+      *(_DWORD *)(a1 + 156) = (int)(float)((float)(*(float *)a3.m128i_i32 * 64.0) + 0.5);
+      *(_DWORD *)(a1 + 108) = *(_DWORD *)(a2 + 48);
+      *(_DWORD *)(a1 + 112) = *(_DWORD *)(a2 + 52);
+      return sub_58F490(off_9D8298, v7, 0);
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerAdvanceTick.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerAdvanceTick.windows.yaml
@@ -1,0 +1,279 @@
+func_name: CNetworkGameServerBase_ServerAdvanceTick
+func_va: '0x1800b4740'
+disasm_code: |-
+  .text:00000001800B4740                 mov     [rsp+arg_8], rbx
+  .text:00000001800B4745                 mov     [rsp+arg_10], rbp
+  .text:00000001800B474A                 mov     [rsp+arg_18], rsi
+  .text:00000001800B474F                 push    rdi
+  .text:00000001800B4750                 sub     rsp, 60h
+  .text:00000001800B4754                 xor     edi, edi
+  .text:00000001800B4756                 mov     rbp, rdx
+  .text:00000001800B4759                 mov     rsi, rcx
+  .text:00000001800B475C                 cmp     [rcx+2BBh], dil
+  .text:00000001800B4763                 jnz     loc_1800B48E0
+  .text:00000001800B4769                 cmp     [rdx+28h], dil
+  .text:00000001800B476D                 jz      loc_1800B48E0
+  .text:00000001800B4773                 call    cs:__imp_GetCurrentThreadId
+  .text:00000001800B4779                 cmp     cs:dword_18060F4A8, eax
+  .text:00000001800B477F                 mov     edx, eax
+  .text:00000001800B4781                 jnz     short loc_1800B478F
+  .text:00000001800B4783                 movzx   ecx, cs:word_18060F4A4
+  .text:00000001800B478A                 inc     cx
+  .text:00000001800B478D                 jmp     short loc_1800B47CA
+  .text:00000001800B478F                 mov     eax, cs:dword_18060F4A0
+  .text:00000001800B4795                 nop
+  .text:00000001800B4796                 test    eax, eax
+  .text:00000001800B4798                 jnz     short loc_1800B47B6
+  .text:00000001800B479A                 mov     ecx, 3
+  .text:00000001800B479F                 lock cmpxchg cs:dword_18060F4A0, ecx
+  .text:00000001800B47A7                 jnz     short loc_1800B47B6
+  .text:00000001800B47A9                 mov     ecx, 1
+  .text:00000001800B47AE                 mov     cs:dword_18060F4A8, edx
+  .text:00000001800B47B4                 jmp     short loc_1800B47CA
+  .text:00000001800B47B6                 lea     rcx, dword_18060F4A0
+  .text:00000001800B47BD                 call    cs:?AcquireLock@CAtomicMutex@@AEAAXI@Z; CAtomicMutex::AcquireLock(uint)
+  .text:00000001800B47C3                 movzx   ecx, cs:word_18060F4A4
+  .text:00000001800B47CA                 cmp     cs:dword_18090E1E8, edi
+  .text:00000001800B47D0                 jle     short loc_1800B4824
+  .text:00000001800B47D2                 mov     rax, cs:qword_180918D30
+  .text:00000001800B47D9                 lea     rbx, unk_180528AFF
+  .text:00000001800B47E0                 test    rax, rax
+  .text:00000001800B47E3                 cmovnz  rbx, rax
+  .text:00000001800B47E7                 sub     cx, 1
+  .text:00000001800B47EB                 mov     cs:word_18060F4A4, cx
+  .text:00000001800B47F2                 jnz     short loc_1800B4819
+  .text:00000001800B47F4                 mov     cs:dword_18060F4A8, edi
+  .text:00000001800B47FA                 mov     eax, 0FFFFFFFDh
+  .text:00000001800B47FF                 lock xadd cs:dword_18060F4A0, eax
+  .text:00000001800B4807                 add     eax, 0FFFFFFFDh
+  .text:00000001800B480A                 jz      short loc_1800B4819
+  .text:00000001800B480C                 lea     rcx, dword_18060F4A0
+  .text:00000001800B4813                 call    cs:?ThreadAtomicNotifyOne@@YAXPEBI@Z; ThreadAtomicNotifyOne(uint const *)
+  .text:00000001800B4819                 test    rbx, rbx
+  .text:00000001800B481C                 jnz     loc_1800B48E0
+  .text:00000001800B4822                 jmp     short loc_1800B4856
+  .text:00000001800B4824                 sub     cx, 1
+  .text:00000001800B4828                 mov     cs:word_18060F4A4, cx
+  .text:00000001800B482F                 jnz     short loc_1800B4856
+  .text:00000001800B4831                 mov     cs:dword_18060F4A8, edi
+  .text:00000001800B4837                 mov     eax, 0FFFFFFFDh
+  .text:00000001800B483C                 lock xadd cs:dword_18060F4A0, eax
+  .text:00000001800B4844                 add     eax, 0FFFFFFFDh
+  .text:00000001800B4847                 jz      short loc_1800B4856
+  .text:00000001800B4849                 lea     rcx, dword_18060F4A0
+  .text:00000001800B4850                 call    cs:?ThreadAtomicNotifyOne@@YAXPEBI@Z; ThreadAtomicNotifyOne(uint const *)
+  .text:00000001800B4856                 mov     ecx, [rsi+458h]
+  .text:00000001800B485C                 test    ecx, ecx
+  .text:00000001800B485E                 jz      short loc_1800B488C
+  .text:00000001800B4860                 movsxd  rax, dword ptr [rbp+38h]
+  .text:00000001800B4864                 add     [rsi+4B8h], rax
+  .text:00000001800B486B                 inc     qword ptr [rsi+4C0h]
+  .text:00000001800B4872                 mov     eax, [rbp+38h]
+  .text:00000001800B4875                 dec     ecx
+  .text:00000001800B4877                 test    eax, eax
+  .text:00000001800B4879                 cmovle  eax, edi
+  .text:00000001800B487C                 cmp     eax, ecx
+  .text:00000001800B487E                 cmovl   ecx, eax
+  .text:00000001800B4881                 movsxd  rax, ecx
+  .text:00000001800B4884                 inc     qword ptr [rsi+rax*8+460h]
+  .text:00000001800B488C                 mov     ebx, [rsi+4C8h]
+  .text:00000001800B4892                 test    ebx, ebx
+  .text:00000001800B4894                 jz      short loc_1800B48E0
+  .text:00000001800B4896                 movss   xmm0, cs:dword_18091195C
+  .text:00000001800B489E                 mulss   xmm0, cs:dword_18058517C
+  .text:00000001800B48A6                 inc     qword ptr [rsi+6C0h]
+  .text:00000001800B48AD                 dec     ebx
+  .text:00000001800B48AF                 cvtps2pd xmm1, xmm0
+  .text:00000001800B48B2                 addsd   xmm1, qword ptr [rsi+6B8h]
+  .text:00000001800B48BA                 movsd   qword ptr [rsi+6B8h], xmm1
+  .text:00000001800B48C2                 call    sub_1804410CC
+  .text:00000001800B48C7                 cvttss2si eax, xmm0
+  .text:00000001800B48CB                 test    eax, eax
+  .text:00000001800B48CD                 cmovle  eax, edi
+  .text:00000001800B48D0                 cmp     eax, ebx
+  .text:00000001800B48D2                 cmovl   ebx, eax
+  .text:00000001800B48D5                 movsxd  rax, ebx
+  .text:00000001800B48D8                 inc     qword ptr [rsi+rax*8+4D0h]
+  .text:00000001800B48E0                 mov     rcx, cs:g_pSoundOpSystem
+  .text:00000001800B48E7                 test    rcx, rcx
+  .text:00000001800B48EA                 jz      short loc_1800B48FA
+  .text:00000001800B48EC                 mov     rax, [rcx+8]
+  .text:00000001800B48F0                 add     rcx, 8
+  .text:00000001800B48F4                 call    qword ptr [rax+130h]
+  .text:00000001800B48FA                 mov     eax, [rsi+38h]
+  .text:00000001800B48FD                 cmp     eax, 1
+  .text:00000001800B4900                 jbe     loc_1800B499E
+  .text:00000001800B4906                 cmp     eax, 4
+  .text:00000001800B4909                 jz      short loc_1800B490E
+  .text:00000001800B490B                 inc     dword ptr [rsi+44h]
+  .text:00000001800B490E                 mov     rax, [rsi]
+  .text:00000001800B4911                 mov     rcx, rsi
+  .text:00000001800B4914                 ; 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+  .text:00000001800B4914                 call    qword ptr [rax+0E0h]; 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+  .text:00000001800B491A                 movss   xmm1, cs:dword_180584F90
+  .text:00000001800B4922                 lea     r8, [rsi+58h]
+  .text:00000001800B4926                 movaps  xmm3, xmm0
+  .text:00000001800B4929                 mov     [rsp+68h+var_40], edi
+  .text:00000001800B492D                 lea     rdx, aCBuildworkerCs_22; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001800B4934                 movss   [rsp+68h+var_48], xmm1
+  .text:00000001800B493A                 lea     rcx, [rsp+68h+var_38]
+  .text:00000001800B493F                 call    sub_18005EB40
+  .text:00000001800B4944                 mov     eax, [rbp+34h]
+  .text:00000001800B4947                 mov     [rsi+6Ch], eax
+  .text:00000001800B494A                 mov     eax, [rbp+38h]
+  .text:00000001800B494D                 mov     [rsi+70h], eax
+  .text:00000001800B4950                 cmp     cs:dword_1806126D8, edi
+  .text:00000001800B4956                 mov     esi, [rsi+44h]
+  .text:00000001800B4959                 mov     cs:dword_1806126D0, esi
+  .text:00000001800B495F                 jle     short loc_1800B4994
+  .text:00000001800B4961                 mov     rbx, rdi
+  .text:00000001800B4964                 nop     dword ptr [rax+00h]
+  .text:00000001800B4968                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001800B4970                 mov     rax, cs:qword_1806126E0
+  .text:00000001800B4977                 xor     r8d, r8d
+  .text:00000001800B497A                 mov     edx, esi
+  .text:00000001800B497C                 mov     rcx, [rbx+rax]
+  .text:00000001800B4980                 mov     rax, [rcx]
+  .text:00000001800B4983                 call    qword ptr [rax+20h]
+  .text:00000001800B4986                 inc     edi
+  .text:00000001800B4988                 lea     rbx, [rbx+8]
+  .text:00000001800B498C                 cmp     edi, cs:dword_1806126D8
+  .text:00000001800B4992                 jl      short loc_1800B4970
+  .text:00000001800B4994                 lea     rcx, [rsp+68h+var_38]
+  .text:00000001800B4999                 call    sub_18005EC80
+  .text:00000001800B499E                 lea     r11, [rsp+68h+var_8]
+  .text:00000001800B49A3                 mov     rbx, [r11+18h]
+  .text:00000001800B49A7                 mov     rbp, [r11+20h]
+  .text:00000001800B49AB                 mov     rsi, [r11+28h]
+  .text:00000001800B49AF                 mov     rsp, r11
+  .text:00000001800B49B2                 pop     rdi
+  .text:00000001800B49B3                 retn
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_ServerAdvanceTick(__int64 a1, __int64 a2)
+  {
+    int v2; // edi
+    DWORD CurrentThreadId; // eax
+    __int64 v6; // rdx
+    __int16 v7; // cx
+    void *v8; // rbx
+    __int64 v9; // rcx
+    int v10; // eax
+    int v11; // ebx
+    float v12; // xmm0_4
+    int v13; // ebx
+    int v14; // eax
+    __int64 result; // rax
+    int v16; // r9d
+    unsigned int v17; // esi
+    __int64 v18; // rbx
+    _BYTE v19[48]; // [rsp+30h] [rbp-38h] BYREF
+
+    v2 = 0;
+    if ( *(_BYTE *)(a1 + 699) || !*(_BYTE *)(a2 + 40) )
+      goto LABEL_32;
+    CurrentThreadId = GetCurrentThreadId();
+    v6 = CurrentThreadId;
+    if ( dword_18060F4A8 == CurrentThreadId )
+    {
+      v7 = word_18060F4A4 + 1;
+    }
+    else if ( dword_18060F4A0 || _InterlockedCompareExchange(&dword_18060F4A0, 3, 0) )
+    {
+      CAtomicMutex::AcquireLock((CAtomicMutex *)&dword_18060F4A0, CurrentThreadId);
+      v7 = word_18060F4A4;
+    }
+    else
+    {
+      v7 = 1;
+      dword_18060F4A8 = CurrentThreadId;
+    }
+    if ( dword_18090E1E8 <= 0 )
+    {
+      word_18060F4A4 = v7 - 1;
+      if ( v7 == 1 )
+      {
+        dword_18060F4A8 = 0;
+        if ( _InterlockedExchangeAdd(&dword_18060F4A0, 0xFFFFFFFD) != 3 )
+          ThreadAtomicNotifyOne((const unsigned int *)&dword_18060F4A0);
+      }
+      goto LABEL_20;
+    }
+    v8 = &unk_180528AFF;
+    if ( qword_180918D30 )
+      v8 = (void *)qword_180918D30;
+    word_18060F4A4 = v7 - 1;
+    if ( v7 == 1 )
+    {
+      dword_18060F4A8 = 0;
+      if ( _InterlockedExchangeAdd(&dword_18060F4A0, 0xFFFFFFFD) != 3 )
+        ThreadAtomicNotifyOne((const unsigned int *)&dword_18060F4A0);
+    }
+    if ( !v8 )
+    {
+  LABEL_20:
+      v9 = *(unsigned int *)(a1 + 1112);
+      if ( (_DWORD)v9 )
+      {
+        *(_QWORD *)(a1 + 1208) += *(int *)(a2 + 56);
+        ++*(_QWORD *)(a1 + 1216);
+        v10 = *(_DWORD *)(a2 + 56);
+        v9 = (unsigned int)(v9 - 1);
+        if ( v10 <= 0 )
+          v10 = 0;
+        if ( v10 < (int)v9 )
+          v9 = (unsigned int)v10;
+        ++*(_QWORD *)(a1 + 8LL * (int)v9 + 1120);
+      }
+      v11 = *(_DWORD *)(a1 + 1224);
+      if ( v11 )
+      {
+        v12 = *(float *)&dword_18091195C * 1000.0;
+        ++*(_QWORD *)(a1 + 1728);
+        v13 = v11 - 1;
+        *(double *)(a1 + 1720) = v12 + *(double *)(a1 + 1720);
+        v14 = (int)sub_1804410CC(v9, v6);
+        if ( v14 <= 0 )
+          v14 = 0;
+        if ( v14 < v13 )
+          v13 = v14;
+        ++*(_QWORD *)(a1 + 8LL * v13 + 1232);
+      }
+    }
+  LABEL_32:
+    if ( g_pSoundOpSystem )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)(g_pSoundOpSystem + 8) + 304LL))(g_pSoundOpSystem + 8);
+    result = *(unsigned int *)(a1 + 56);
+    if ( (unsigned int)result > 1 )
+    {
+      if ( (_DWORD)result != 4 )
+        ++*(_DWORD *)(a1 + 68);
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)a1 + 224LL))(a1);// 0x0E0 = 224LL = CNetworkGameServerBase_GetTime
+      sub_18005EB40(
+        (unsigned int)v19,
+        (unsigned int)"C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\networkgameserverbase.cpp:5698",
+        a1 + 88,
+        v16,
+        1015021568,
+        0);
+      *(_DWORD *)(a1 + 108) = *(_DWORD *)(a2 + 52);
+      *(_DWORD *)(a1 + 112) = *(_DWORD *)(a2 + 56);
+      v17 = *(_DWORD *)(a1 + 68);
+      dword_1806126D0 = v17;
+      if ( dword_1806126D8 > 0 )
+      {
+        v18 = 0;
+        do
+        {
+          (*(void (__fastcall **)(_QWORD, _QWORD, _QWORD))(**(_QWORD **)(v18 + qword_1806126E0) + 32LL))(
+            *(_QWORD *)(v18 + qword_1806126E0),
+            v17,
+            0);
+          ++v2;
+          v18 += 8;
+        }
+        while ( v2 < dword_1806126D8 );
+      }
+      return sub_18005EC80(v19);
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_GetTime` preprocessor script (Pattern C — vfunc via LLM_DECOMPILE) resolving `CNetworkGameServerBase::GetTime` as a `CNetworkGameServer_vtable` slot from the `CNetworkGameServerBase_ServerAdvanceTick` predecessor.
- Add annotated reference YAMLs for `CNetworkGameServerBase_ServerAdvanceTick` (windows + linux) marking the GetTime vcall at vtable offset `0xE0` (index 28) on both platforms.
- Register the skill and `CNetworkGameServerBase_GetTime` vfunc symbol in `configs/14174.yaml`.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with 12/12 runnable tests, 0 compile failures, 0 record-layout differences
- candidate publication: passed; published `gamesymbols/14174.yaml` SHA-256 matches the validated candidate