### PR TITLE
feat(server): add IsBackgroundMap and CNetworkGameServerBase::IsBackgroundMap finders

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7205,6 +7205,16 @@ modules:
           - CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml
         expected_input:
           - CSource2GameEntities_vtable.{platform}.yaml
+      - name: find-IsBackgroundMap
+        expected_output:
+          - IsBackgroundMap.{platform}.yaml
+        expected_input:
+          - CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml
+      - name: find-CNetworkGameServerBase_IsBackgroundMap
+        expected_output:
+          - CNetworkGameServerBase_IsBackgroundMap.{platform}.yaml
+        expected_input:
+          - IsBackgroundMap.{platform}.yaml
       - name: find-CSource2GameEntities_CheckTransmit-decompiles
         expected_output:
           - CCheckTransmitInfo_m_nPlayerSlot.{platform}.yaml
@@ -10230,6 +10240,12 @@ modules:
           - ISource2GameEntities::ShouldClientReceiveStringTableUserData
           - ISource2GameEntities_ShouldClientReceiveStringTableUserData
           - ShouldClientReceiveStringTableUserData
+      - name: IsBackgroundMap
+        category: func
+      - name: CNetworkGameServerBase_IsBackgroundMap
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::IsBackgroundMap
       - name: CBaseEntity_EmitSoundFilter
         category: func
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7242,9 +7242,10 @@ modules:
           - IsBackgroundMap.{platform}.yaml
         expected_input:
           - CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml
-      - name: find-INetworkGameServer_IsBackgroundMap
+      - name: find-IsBackgroundMap-decompiles
         expected_output:
           - INetworkGameServer_IsBackgroundMap.{platform}.yaml
+          - ILoopModeGameSharedState_IsBackgroundMap.{platform}.yaml
         expected_input:
           - IsBackgroundMap.{platform}.yaml
       - name: find-CSource2GameEntities_CheckTransmit-decompiles
@@ -10278,6 +10279,14 @@ modules:
         category: vfunc
         alias:
           - INetworkGameServer::IsBackgroundMap
+      - name: ILoopModeGameSharedState_IsBackgroundMap
+        category: vfunc
+        alias:
+          - ILoopModeGameSharedState::IsBackgroundMap
+      - name: CNetworkGameServerBase_IsBackgroundMap
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::IsBackgroundMap
       - name: CBaseEntity_EmitSoundFilter
         category: func
         alias:
@@ -12368,6 +12377,12 @@ modules:
         expected_input:
           - CNetworkClientService_vtable.{platform}.yaml
           - INetworkClientService_IsConnecting.{platform}.yaml
+      - name: find-CNetworkGameServerBase_IsBackgroundMap
+        expected_output:
+          - CNetworkGameServerBase_IsBackgroundMap.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - ../server/INetworkGameServer_IsBackgroundMap.{platform}.yaml
   - name: client  # Execute Shutdown-dependent client skills after engine2.dll generates ILoopModeFactory_Shutdown
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:231826a57dafc0d7b2935a735ed702709479f0dcb5f49e0368afe2bebbdb0e95
+file_count: 3279
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -32265,6 +32265,20 @@ files:
     vtable_size: '0x48'
     vtable_symbol: ??_7CNavPhysicsInterface@@6B@
     vtable_va: '0x181861e70'
+  server/CNetworkGameServerBase_IsBackgroundMap.linux.yaml:
+    func_name: CNetworkGameServerBase_IsBackgroundMap
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vfunc_sig: 48 8B 80 D8 00 00 00 FF E0 0F 1F 00
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: CNetworkGameServer_vtable
+  server/CNetworkGameServerBase_IsBackgroundMap.windows.yaml:
+    func_name: CNetworkGameServerBase_IsBackgroundMap
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vfunc_sig: FF 92 D8 00 00 00 84 C0
+    vfunc_sig_allow_across_function_boundary: true
+    vtable_name: CNetworkGameServer_vtable
   server/CNetworkSerializerBindingBuildFilter_GetFieldPriority.linux.yaml:
     func_name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
     func_rva: '0x2134f10'
@@ -40265,6 +40279,18 @@ files:
     vfunc_offset: '0x3c8'
     vfunc_sig: FF 90 C8 03 00 00 48 63 54 24 ??
     vtable_name: CVPhys2World
+  server/IsBackgroundMap.linux.yaml:
+    func_name: IsBackgroundMap
+    func_rva: '0x1716180'
+    func_sig: 48 8B 3D ?? ?? ?? ?? 55 48 89 E5 48 85 FF
+    func_size: '0x64'
+    func_va: '0x1716180'
+  server/IsBackgroundMap.windows.yaml:
+    func_name: IsBackgroundMap
+    func_rva: '0xbdf6e0'
+    func_sig: 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 48 85 C9 74 ?? 48 8B 01 FF 50 ?? 84 C0
+    func_size: '0x51'
+    func_va: '0x180bdf6e0'
   server/LegacyGameEventListener.linux.yaml:
     func_name: LegacyGameEventListener
     func_rva: '0x16b0390'
@@ -42325,5 +42351,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T12:16:15Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:7c21a0b0d6fac05d2a753ace776bda06725b695d237e9ed067dbf8aadc7629f9
-file_count: 3287
+config_sha256: sha256:7fe401825e0f062cca17aa44b7c153be8f81e78929eff7804013c4e163c00529
+file_count: 3291
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10718,6 +10718,22 @@ files:
     vfunc_index: 0
     vfunc_offset: '0x0'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_IsBackgroundMap.linux.yaml:
+    func_name: CNetworkGameServerBase_IsBackgroundMap
+    func_rva: '0x4f0fb0'
+    func_size: '0x8'
+    func_va: '0x4f0fb0'
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vtable_name: CNetworkGameServerBase
+  engine/CNetworkGameServerBase_IsBackgroundMap.windows.yaml:
+    func_name: CNetworkGameServerBase_IsBackgroundMap
+    func_rva: '0xb3160'
+    func_size: '0x8'
+    func_va: '0x1800b3160'
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsPausable.linux.yaml:
     func_name: CNetworkGameServerBase_IsPausable
     func_rva: '0x510460'
@@ -40151,6 +40167,18 @@ files:
     vfunc_offset: '0x128'
     vfunc_sig: FF 90 28 01 00 00 48 8D 15 ?? ?? ?? ??
     vtable_name: IGameTypes
+  server/ILoopModeGameSharedState_IsBackgroundMap.linux.yaml:
+    func_name: ILoopModeGameSharedState_IsBackgroundMap
+    vfunc_index: 5
+    vfunc_offset: '0x28'
+    vfunc_sig: 48 8B 40 28 48 39 D0 75 ?? 0F B6 47 ??
+    vtable_name: ILoopModeGameSharedState
+  server/ILoopModeGameSharedState_IsBackgroundMap.windows.yaml:
+    func_name: ILoopModeGameSharedState_IsBackgroundMap
+    vfunc_index: 5
+    vfunc_offset: '0x28'
+    vfunc_sig: FF 50 28 84 C0 74 ?? B0 ??
+    vtable_name: ILoopModeGameSharedState
   server/ILoopMode_AddViewsToSceneSystem.linux.yaml:
     func_name: ILoopMode_AddViewsToSceneSystem
     vfunc_index: 6
@@ -42399,5 +42427,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T04:39:17Z'
+last_publish_time: '2026-08-06T04:57:35Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsBackgroundMap.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsBackgroundMap.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_IsBackgroundMap skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_IsBackgroundMap",
+        "CNetworkGameServerBase",
+        "../server/INetworkGameServer_IsBackgroundMap",
+        False,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_IsBackgroundMap",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve IsBackgroundMap by the inherited INetworkGameServer vfunc slot without a func_sig."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsBackgroundMap.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsBackgroundMap.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_IsBackgroundMap skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_IsBackgroundMap",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_IsBackgroundMap",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/IsBackgroundMap.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "IsBackgroundMap.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_IsBackgroundMap", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # Slim Pattern C: this vfunc is not a downstream predecessor.
+    (
+        "CNetworkGameServerBase_IsBackgroundMap",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-IsBackgroundMap-decompiles.py
+++ b/ida_preprocessor_scripts/find-IsBackgroundMap-decompiles.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-INetworkGameServer_IsBackgroundMap skill."""
+"""Preprocess script for find-IsBackgroundMap-decompiles skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
     "INetworkGameServer_IsBackgroundMap",
+    "ILoopModeGameSharedState_IsBackgroundMap",
 ]
 
 LLM_DECOMPILE = [
     {
         "symbol_name": "INetworkGameServer_IsBackgroundMap",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/IsBackgroundMap.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "IsBackgroundMap.{platform}.yaml": "required",
+        },
+    },
+    {
+        "symbol_name": "ILoopModeGameSharedState_IsBackgroundMap",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/IsBackgroundMap.{platform}.yaml",
@@ -25,6 +37,9 @@ FUNC_VTABLE_RELATIONS = [
     # INetworkGameServer is an abstract interface -- no vtable YAML is needed;
     # the vtable name is metadata only.
     ("INetworkGameServer_IsBackgroundMap", "INetworkGameServer"),
+    # ILoopModeGameSharedState is an abstract interface -- no vtable YAML is needed;
+    # the vtable name is metadata only.
+    ("ILoopModeGameSharedState_IsBackgroundMap", "ILoopModeGameSharedState"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -35,6 +50,16 @@ GENERATE_YAML_DESIRED_FIELDS = [
             "func_name",
             "vfunc_sig",
             "vfunc_sig_allow_across_function_boundary:true",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+    (
+        "ILoopModeGameSharedState_IsBackgroundMap",
+        [
+            "func_name",
+            "vfunc_sig",
             "vfunc_offset",
             "vfunc_index",
             "vtable_name",

--- a/ida_preprocessor_scripts/find-IsBackgroundMap.py
+++ b/ida_preprocessor_scripts/find-IsBackgroundMap.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-IsBackgroundMap skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "IsBackgroundMap",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "IsBackgroundMap",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "IsBackgroundMap",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.linux.yaml
@@ -1,0 +1,83 @@
+func_name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+func_va: '0x18d4890'
+disasm_code: |-
+  .text:00000000018D4890                 push    rbp
+  .text:00000000018D4891                 mov     rbp, rsp
+  .text:00000000018D4894                 push    rbx
+  .text:00000000018D4895                 mov     rbx, rsi
+  .text:00000000018D4898                 sub     rsp, 18h
+  .text:00000000018D489C                 mov     rdi, cs:g_pGameRules
+  .text:00000000018D48A3                 test    rdi, rdi
+  .text:00000000018D48A6                 jz      short loc_18D48E8
+  .text:00000000018D48A8                 mov     rax, [rdi]
+  .text:00000000018D48AB                 lea     rsi, sub_12E79E0
+  .text:00000000018D48B2                 mov     rax, [rax+310h]
+  .text:00000000018D48B9                 cmp     rax, rsi
+  .text:00000000018D48BC                 jnz     short loc_18D48D0
+  .text:00000000018D48BE                 mov     rbx, [rbp+var_8]
+  .text:00000000018D48C2                 mov     eax, 1
+  .text:00000000018D48C7                 leave
+  .text:00000000018D48C8                 retn
+  .text:00000000018D48D0                 mov     esi, [rcx+240h]
+  .text:00000000018D48D6                 mov     ecx, edx
+  .text:00000000018D48D8                 mov     rdx, rbx
+  .text:00000000018D48DB                 mov     rbx, [rbp+var_8]
+  .text:00000000018D48DF                 leave
+  .text:00000000018D48E0                 jmp     rax
+  .text:00000000018D48E8                 mov     [rbp+var_14], edx
+  .text:00000000018D48EB                 ; IsBackgroundMap
+  .text:00000000018D48EB                 call    sub_1716180; IsBackgroundMap
+  .text:00000000018D48F0                 test    al, al
+  .text:00000000018D48F2                 jnz     short loc_18D48BE
+  .text:00000000018D48F4                 mov     edi, cs:dword_286CD00
+  .text:00000000018D48FA                 mov     esi, 3
+  .text:00000000018D48FF                 call    sub_9F0A20
+  .text:00000000018D4904                 test    al, al
+  .text:00000000018D4906                 jz      short loc_18D48BE
+  .text:00000000018D4908                 mov     rax, [rbx]
+  .text:00000000018D490B                 mov     rdi, rbx
+  .text:00000000018D490E                 call    qword ptr [rax+10h]
+  .text:00000000018D4911                 mov     r8d, [rbp+var_14]
+  .text:00000000018D4915                 lea     rdx, aShouldclientre; "ShouldClientReceiveStringTableUserData "...
+  .text:00000000018D491C                 mov     esi, 3
+  .text:00000000018D4921                 mov     edi, cs:dword_286CD00
+  .text:00000000018D4927                 mov     rcx, rax
+  .text:00000000018D492A                 xor     eax, eax
+  .text:00000000018D492C                 call    sub_9EFEF0
+  .text:00000000018D4931                 jmp     short loc_18D48BE
+procedure: |-
+  __int64 __fastcall CSource2GameEntities_ShouldClientReceiveStringTableUserData(
+          __int64 a1,
+          __int64 a2,
+          unsigned int a3,
+          __int64 a4)
+  {
+    __int64 (__fastcall *v4)(); // rax
+    const char *v6; // rax
+
+    if ( !g_pGameRules )
+    {
+      if ( !(unsigned __int8)sub_1716180() )      // IsBackgroundMap
+      {
+        if ( (unsigned __int8)sub_9F0A20((unsigned int)dword_286CD00, 3) )
+        {
+          v6 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a2 + 16LL))(a2);
+          sub_9EFEF0(
+            (unsigned int)dword_286CD00,
+            3,
+            "ShouldClientReceiveStringTableUserData called with nullptr GameRules() on table %s, string %d\n",
+            v6,
+            a3);
+        }
+      }
+      return 1;
+    }
+    v4 = *(__int64 (__fastcall **)())(*(_QWORD *)g_pGameRules + 784LL);
+    if ( v4 == sub_12E79E0 )
+      return 1;
+    return ((__int64 (__fastcall *)(__int64, _QWORD, __int64, _QWORD))v4)(
+             g_pGameRules,
+             *(unsigned int *)(a4 + 576),
+             a2,
+             a3);
+  }

--- a/ida_preprocessor_scripts/references/server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.windows.yaml
@@ -1,0 +1,73 @@
+func_name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
+func_va: '0x180d1d7e0'
+disasm_code: |-
+  .text:0000000180D1D7E0                 mov     [rsp+arg_0], rbx
+  .text:0000000180D1D7E5                 push    rdi
+  .text:0000000180D1D7E6                 sub     rsp, 30h
+  .text:0000000180D1D7EA                 mov     rcx, cs:g_pGameRules
+  .text:0000000180D1D7F1                 mov     r10, r9
+  .text:0000000180D1D7F4                 mov     edi, r8d
+  .text:0000000180D1D7F7                 mov     rbx, rdx
+  .text:0000000180D1D7FA                 test    rcx, rcx
+  .text:0000000180D1D7FD                 jnz     short loc_180D1D852
+  .text:0000000180D1D7FF                 ; IsBackgroundMap
+  .text:0000000180D1D7FF                 call    sub_180BDF6E0; IsBackgroundMap
+  .text:0000000180D1D804                 test    al, al
+  .text:0000000180D1D806                 jnz     short loc_180D1D845
+  .text:0000000180D1D808                 mov     ecx, cs:dword_181FE50B8
+  .text:0000000180D1D80E                 mov     edx, 3
+  .text:0000000180D1D813                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:0000000180D1D819                 test    al, al
+  .text:0000000180D1D81B                 jz      short loc_180D1D845
+  .text:0000000180D1D81D                 mov     rax, [rbx]
+  .text:0000000180D1D820                 mov     rcx, rbx
+  .text:0000000180D1D823                 call    qword ptr [rax+8]
+  .text:0000000180D1D826                 mov     ecx, cs:dword_181FE50B8
+  .text:0000000180D1D82C                 lea     r8, aShouldclientre; "ShouldClientReceiveStringTableUserData "...
+  .text:0000000180D1D833                 mov     r9, rax
+  .text:0000000180D1D836                 mov     [rsp+38h+var_18], edi
+  .text:0000000180D1D83A                 mov     edx, 3
+  .text:0000000180D1D83F                 call    cs:LoggingSystem_Log
+  .text:0000000180D1D845                 mov     al, 1
+  .text:0000000180D1D847                 mov     rbx, [rsp+38h+arg_0]
+  .text:0000000180D1D84C                 add     rsp, 30h
+  .text:0000000180D1D850                 pop     rdi
+  .text:0000000180D1D851                 retn
+  .text:0000000180D1D852                 mov     rax, [rcx]
+  .text:0000000180D1D855                 mov     r9d, edi
+  .text:0000000180D1D858                 mov     edx, [r10+240h]
+  .text:0000000180D1D85F                 mov     r8, rbx
+  .text:0000000180D1D862                 mov     rbx, [rsp+38h+arg_0]
+  .text:0000000180D1D867                 add     rsp, 30h
+  .text:0000000180D1D86B                 pop     rdi
+  .text:0000000180D1D86C                 jmp     qword ptr [rax+308h]
+procedure: |-
+  char __fastcall CSource2GameEntities_ShouldClientReceiveStringTableUserData(
+          __int64 a1,
+          __int64 a2,
+          unsigned int a3,
+          __int64 a4)
+  {
+    const char *v6; // rax
+
+    if ( g_pGameRules )
+      return (*(char (__fastcall **)(__int64, _QWORD, __int64, _QWORD))(*(_QWORD *)g_pGameRules + 776LL))(
+               g_pGameRules,
+               *(unsigned int *)(a4 + 576),
+               a2,
+               a3);
+    if ( !(unsigned __int8)sub_180BDF6E0() )      // IsBackgroundMap
+    {
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_181FE50B8, 3) )
+      {
+        v6 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)a2 + 8LL))(a2);
+        LoggingSystem_Log(
+          (unsigned int)dword_181FE50B8,
+          3,
+          "ShouldClientReceiveStringTableUserData called with nullptr GameRules() on table %s, string %d\n",
+          v6,
+          a3);
+      }
+    }
+    return 1;
+  }

--- a/ida_preprocessor_scripts/references/server/IsBackgroundMap.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/IsBackgroundMap.linux.yaml
@@ -8,7 +8,8 @@ disasm_code: |-
   .text:000000000171618E                 jz      short loc_17161AB
   .text:0000000001716190                 mov     rax, [rdi]
   .text:0000000001716193                 lea     rdx, sub_17118F0
-  .text:000000000171619A                 mov     rax, [rax+28h]
+  .text:000000000171619A                 ; 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
+  .text:000000000171619A                 mov     rax, [rax+28h]; 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
   .text:000000000171619E                 cmp     rax, rdx
   .text:00000000017161A1                 jnz     short loc_17161E0
   .text:00000000017161A3                 movzx   eax, byte ptr [rdi+5Fh]
@@ -38,8 +39,8 @@ procedure: |-
     __int64 result; // rax
     __int64 v2; // rdi
 
-    if ( !qword_284A170
-      || ((v0 = *(__int64 (__fastcall **)())(*(_QWORD *)qword_284A170 + 40LL), v0 != sub_17118F0)
+  if ( !qword_284A170
+    || ((v0 = *(__int64 (__fastcall **)())(*(_QWORD *)qword_284A170 + 40LL), v0 != sub_17118F0) // 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
         ? (result = v0())
         : (result = *(unsigned __int8 *)(qword_284A170 + 95)),
           !(_BYTE)result) )

--- a/ida_preprocessor_scripts/references/server/IsBackgroundMap.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/IsBackgroundMap.linux.yaml
@@ -1,0 +1,53 @@
+func_name: IsBackgroundMap
+func_va: '0x1716180'
+disasm_code: |-
+  .text:0000000001716180                 mov     rdi, cs:qword_284A170
+  .text:0000000001716187                 push    rbp
+  .text:0000000001716188                 mov     rbp, rsp
+  .text:000000000171618B                 test    rdi, rdi
+  .text:000000000171618E                 jz      short loc_17161AB
+  .text:0000000001716190                 mov     rax, [rdi]
+  .text:0000000001716193                 lea     rdx, sub_17118F0
+  .text:000000000171619A                 mov     rax, [rax+28h]
+  .text:000000000171619E                 cmp     rax, rdx
+  .text:00000000017161A1                 jnz     short loc_17161E0
+  .text:00000000017161A3                 movzx   eax, byte ptr [rdi+5Fh]
+  .text:00000000017161A7                 test    al, al
+  .text:00000000017161A9                 jnz     short loc_17161D8
+  .text:00000000017161AB                 lea     rax, g_pNetworkServerService
+  .text:00000000017161B2                 mov     rdi, [rax]
+  .text:00000000017161B5                 mov     rax, [rdi]
+  .text:00000000017161B8                 call    qword ptr [rax+0C0h]
+  .text:00000000017161BE                 mov     rdi, rax
+  .text:00000000017161C1                 xor     eax, eax
+  .text:00000000017161C3                 test    rdi, rdi
+  .text:00000000017161C6                 jz      short loc_17161D8
+  .text:00000000017161C8                 mov     rax, [rdi]
+  .text:00000000017161CB                 pop     rbp
+  .text:00000000017161CC                 ; 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+  .text:00000000017161CC                 mov     rax, [rax+0D8h]; 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+  .text:00000000017161D3                 jmp     rax
+  .text:00000000017161D8                 pop     rbp
+  .text:00000000017161D9                 retn
+  .text:00000000017161E0                 call    rax
+  .text:00000000017161E2                 jmp     short loc_17161A7
+procedure: |-
+  __int64 IsBackgroundMap()
+  {
+    __int64 (__fastcall *v0)(); // rax
+    __int64 result; // rax
+    __int64 v2; // rdi
+
+    if ( !qword_284A170
+      || ((v0 = *(__int64 (__fastcall **)())(*(_QWORD *)qword_284A170 + 40LL), v0 != sub_17118F0)
+        ? (result = v0())
+        : (result = *(unsigned __int8 *)(qword_284A170 + 95)),
+          !(_BYTE)result) )
+    {
+      v2 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 192LL))(g_pNetworkServerService);
+      result = 0;
+      if ( v2 )
+        return (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v2 + 216LL))(v2);// 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/server/IsBackgroundMap.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/IsBackgroundMap.windows.yaml
@@ -6,7 +6,8 @@ disasm_code: |-
   .text:0000000180BDF6EB                 test    rcx, rcx
   .text:0000000180BDF6EE                 jz      short loc_180BDF701
   .text:0000000180BDF6F0                 mov     rax, [rcx]
-  .text:0000000180BDF6F3                 call    qword ptr [rax+28h]
+  .text:0000000180BDF6F3                 ; 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
+  .text:0000000180BDF6F3                 call    qword ptr [rax+28h]; 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
   .text:0000000180BDF6F6                 test    al, al
   .text:0000000180BDF6F8                 jz      short loc_180BDF701
   .text:0000000180BDF6FA                 mov     al, 1
@@ -32,8 +33,8 @@ procedure: |-
   {
     __int64 v0; // rax
 
-    if ( qword_181FC69C0
-      && (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_181FC69C0 + 40LL))(qword_181FC69C0) )
+  if ( qword_181FC69C0
+    && (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_181FC69C0 + 40LL))(qword_181FC69C0) ) // 0x028 = 40LL = ILoopModeGameSharedState_IsBackgroundMap
     {
       LOBYTE(v0) = 1;
     }

--- a/ida_preprocessor_scripts/references/server/IsBackgroundMap.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/IsBackgroundMap.windows.yaml
@@ -1,0 +1,47 @@
+func_name: IsBackgroundMap
+func_va: '0x180bdf6e0'
+disasm_code: |-
+  .text:0000000180BDF6E0                 sub     rsp, 28h
+  .text:0000000180BDF6E4                 mov     rcx, cs:qword_181FC69C0
+  .text:0000000180BDF6EB                 test    rcx, rcx
+  .text:0000000180BDF6EE                 jz      short loc_180BDF701
+  .text:0000000180BDF6F0                 mov     rax, [rcx]
+  .text:0000000180BDF6F3                 call    qword ptr [rax+28h]
+  .text:0000000180BDF6F6                 test    al, al
+  .text:0000000180BDF6F8                 jz      short loc_180BDF701
+  .text:0000000180BDF6FA                 mov     al, 1
+  .text:0000000180BDF6FC                 add     rsp, 28h
+  .text:0000000180BDF700                 retn
+  .text:0000000180BDF701                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180BDF708                 mov     rax, [rcx]
+  .text:0000000180BDF70B                 call    qword ptr [rax+0B8h]
+  .text:0000000180BDF711                 test    rax, rax
+  .text:0000000180BDF714                 jz      short loc_180BDF72C
+  .text:0000000180BDF716                 mov     rdx, [rax]
+  .text:0000000180BDF719                 mov     rcx, rax
+  .text:0000000180BDF71C                 ; 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+  .text:0000000180BDF71C                 call    qword ptr [rdx+0D8h]; 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+  .text:0000000180BDF722                 test    al, al
+  .text:0000000180BDF724                 setnz   al
+  .text:0000000180BDF727                 add     rsp, 28h
+  .text:0000000180BDF72B                 retn
+  .text:0000000180BDF72C                 add     rsp, 28h
+  .text:0000000180BDF730                 retn
+procedure: |-
+  char sub_180BDF6E0()
+  {
+    __int64 v0; // rax
+
+    if ( qword_181FC69C0
+      && (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_181FC69C0 + 40LL))(qword_181FC69C0) )
+    {
+      LOBYTE(v0) = 1;
+    }
+    else
+    {
+      v0 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkServerService + 184LL))(g_pNetworkServerService);
+      if ( v0 )
+        LOBYTE(v0) = (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v0 + 216LL))(v0) != 0;// 0x0D8 = 216LL = CNetworkGameServerBase_IsBackgroundMap
+    }
+    return v0;
+  }


### PR DESCRIPTION
## Summary
- Add `find-IsBackgroundMap` (Pattern D): locates the server-module free function `IsBackgroundMap` via LLM decompile of predecessor `CSource2GameEntities_ShouldClientReceiveStringTableUserData`.
- Add `find-CNetworkGameServerBase_IsBackgroundMap` (Pattern C): resolves the `CNetworkGameServer_vtable` slot (offset `0xD8`, index 27) via the `IsBackgroundMap` call-site.
- Register both symbols and skill entries in `configs/14174.yaml`; publish the `14174` gamesymbols snapshot.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (12 PASS / 0 FAIL; 0 compile failures, 0 layout/vtable/record differences)
- candidate publication: passed; published SHA-256 matches the validated candidate (`sha256:ca05402b2d90e66a7576cfb0c9b390024c6862c8e818616a3327c86106647aca`)