### PR TITLE
feat(engine): add CNetworkGameServerBase::GetServerNetworkAddress vfunc signature

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -1282,6 +1282,12 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - INetworkGameServer_GetTimescale.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetServerNetworkAddress
+        expected_output:
+          - CNetworkGameServerBase_GetServerNetworkAddress.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_Init.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-ISource2Server_PreWorldUpdate
         expected_output:
           - ISource2Server_PreWorldUpdate.{platform}.yaml
@@ -2893,6 +2899,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::GetTimescale
+      - name: CNetworkGameServerBase_GetServerNetworkAddress
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetServerNetworkAddress
       - name: ISource2Server_PreWorldUpdate
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:956e26f9882a5acc44005ea846086b0ffbd8c90230b8a3cc81e0b7569f031390
+file_count: 3277
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10660,6 +10660,18 @@ files:
     vfunc_index: 65
     vfunc_offset: '0x208'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetServerNetworkAddress.linux.yaml:
+    func_name: CNetworkGameServerBase_GetServerNetworkAddress
+    vfunc_index: 31
+    vfunc_offset: '0xf8'
+    vfunc_sig: 48 8B 80 F8 00 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 48 8D 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetServerNetworkAddress.windows.yaml:
+    func_name: CNetworkGameServerBase_GetServerNetworkAddress
+    vfunc_index: 31
+    vfunc_offset: '0xf8'
+    vfunc_sig: FF 90 F8 00 00 00 48 8B C8
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_GetTimescale.linux.yaml:
     func_name: CNetworkGameServerBase_GetTimescale
     func_rva: '0x4f0fc0'
@@ -42325,5 +42337,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T12:51:16Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetServerNetworkAddress.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetServerNetworkAddress.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetServerNetworkAddress skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetServerNetworkAddress",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_GetServerNetworkAddress",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_Init.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_Init.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetServerNetworkAddress", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: this vfunc is not a downstream predecessor.
+    (
+        "CNetworkGameServerBase_GetServerNetworkAddress",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_Init.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_Init.linux.yaml
@@ -1,0 +1,568 @@
+func_name: CNetworkGameServerBase_Init
+func_va: '0x4f6fd0'
+disasm_code: |-
+  .text:00000000004F6FB0                 lea     rdi, aBasicStringSCo; "basic_string::_S_construct null not val"...
+  .text:00000000004F6FB7                 call    sub_2C30C0
+  .text:00000000004F6FBC                 lea     rdi, aBasicStringSCr; "basic_string::_S_create"
+  .text:00000000004F6FC3                 call    sub_2C30D0
+  .text:00000000004F6FD0                 push    rbp
+  .text:00000000004F6FD1                 mov     rbp, rsp
+  .text:00000000004F6FD4                 push    r15
+  .text:00000000004F6FD6                 push    r14
+  .text:00000000004F6FD8                 push    r13
+  .text:00000000004F6FDA                 push    r12
+  .text:00000000004F6FDC                 mov     r12, rsi
+  .text:00000000004F6FDF                 mov     rsi, rdx
+  .text:00000000004F6FE2                 push    rbx
+  .text:00000000004F6FE3                 mov     rbx, rdi
+  .text:00000000004F6FE6                 add     rdi, 150h
+  .text:00000000004F6FED                 sub     rsp, 98h
+  .text:00000000004F6FF4                 mov     [rbp+var_B0], rdx
+  .text:00000000004F6FFB                 call    sub_2C8ED0
+  .text:00000000004F7000                 mov     r14, [r12+70h]
+  .text:00000000004F7005                 test    r14, r14
+  .text:00000000004F7008                 jz      loc_4F7398
+  .text:00000000004F700E                 mov     rdi, r14
+  .text:00000000004F7011                 call    sub_2C92E0
+  .text:00000000004F7016                 mov     [rbx+170h], rax
+  .text:00000000004F701D                 movzx   eax, byte ptr [r12+5Ah]
+  .text:00000000004F7023                 mov     [rbx+240h], al
+  .text:00000000004F7029                 call    sub_2C9990
+  .text:00000000004F702E                 xor     edx, edx
+  .text:00000000004F7030                 mov     esi, 27268C85h
+  .text:00000000004F7035                 mov     rdi, rax
+  .text:00000000004F7038                 mov     rax, [rax]
+  .text:00000000004F703B                 call    qword ptr [rax+30h]
+  .text:00000000004F703E                 mov     edx, eax
+  .text:00000000004F7040                 xor     eax, eax
+  .text:00000000004F7042                 test    edx, edx
+  .text:00000000004F7044                 jz      loc_4F7340
+  .text:00000000004F704A                 mov     cs:byte_A30290, al
+  .text:00000000004F7050                 call    sub_5889D0
+  .text:00000000004F7055                 lea     rdi, [rbx+0D8h]
+  .text:00000000004F705C                 mov     rsi, r12
+  .text:00000000004F705F                 call    sub_2F85A0
+  .text:00000000004F7064                 mov     rax, [rbx]
+  .text:00000000004F7067                 lea     rdx, sub_4F0FF0
+  .text:00000000004F706E                 ; 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+  .text:00000000004F706E                 mov     rax, [rax+0F8h]; 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+  .text:00000000004F7075                 cmp     rax, rdx
+  .text:00000000004F7078                 jnz     loc_4F7430
+  .text:00000000004F707E                 lea     rax, g_pNetworkSystem
+  .text:00000000004F7085                 mov     rdi, [rax]
+  .text:00000000004F7088                 mov     rax, [rdi]
+  .text:00000000004F708B                 call    qword ptr [rax+108h]
+  .text:00000000004F7091                 mov     rdx, [rax]
+  .text:00000000004F7094                 mov     [rbp+var_80], rdx
+  .text:00000000004F7098                 mov     eax, [rax+8]
+  .text:00000000004F709B                 mov     [rbp+var_90], rdx
+  .text:00000000004F70A2                 mov     [rbp+var_9C], rdx
+  .text:00000000004F70A9                 mov     dword ptr [rbp+var_78], eax
+  .text:00000000004F70AC                 mov     [rbp+var_88], eax
+  .text:00000000004F70B2                 mov     [rbp+var_94], eax
+  .text:00000000004F70B8                 lea     rdi, [rbp+var_9C]
+  .text:00000000004F70BF                 xor     esi, esi
+  .text:00000000004F70C1                 call    sub_2C80E0
+  .text:00000000004F70C6                 lea     r15, [rbx+110h]
+  .text:00000000004F70CD                 or      dword ptr [rbx+0E8h], 10h
+  .text:00000000004F70D4                 mov     r13, rax
+  .text:00000000004F70D7                 mov     rax, [rbx+0E0h]
+  .text:00000000004F70DE                 mov     rcx, rax
+  .text:00000000004F70E1                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:00000000004F70E5                 mov     [rbp+var_A8], rcx
+  .text:00000000004F70EC                 test    al, 1
+  .text:00000000004F70EE                 jnz     loc_4F7548
+  .text:00000000004F70F4                 test    r13, r13
+  .text:00000000004F70F7                 jz      loc_4F6FB0
+  .text:00000000004F70FD                 mov     rdi, r13
+  .text:00000000004F7100                 call    sub_2CA790
+  .text:00000000004F7105                 mov     r14, rax
+  .text:00000000004F7108                 test    rax, rax
+  .text:00000000004F710B                 jz      loc_4F7328
+  .text:00000000004F7111                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:00000000004F711B                 cmp     rax, r14
+  .text:00000000004F711E                 jb      loc_4F6FBC
+  .text:00000000004F7124                 lea     rax, [r14+39h]
+  .text:00000000004F7128                 cmp     rax, 1000h
+  .text:00000000004F712E                 jbe     loc_4F72F0
+  .text:00000000004F7134                 lea     r8, [r14+1000h]
+  .text:00000000004F713B                 and     eax, 0FFFh
+  .text:00000000004F7140                 sub     r8, rax
+  .text:00000000004F7143                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:00000000004F714D                 cmp     r8, rax
+  .text:00000000004F7150                 cmova   r8, rax
+  .text:00000000004F7154                 lea     rdi, [r8+19h]
+  .text:00000000004F7158                 mov     [rbp+var_B8], r8
+  .text:00000000004F715F                 call    sub_2BBC80
+  .text:00000000004F7164                 mov     r8, [rbp+var_B8]
+  .text:00000000004F716B                 mov     dword ptr [rax+10h], 0
+  .text:00000000004F7172                 lea     rdi, [rax+18h]
+  .text:00000000004F7176                 mov     rcx, rax
+  .text:00000000004F7179                 mov     [rax+8], r8
+  .text:00000000004F717D                 mov     rdx, r14
+  .text:00000000004F7180                 mov     rsi, r13
+  .text:00000000004F7183                 mov     [rbp+var_B8], rcx
+  .text:00000000004F718A                 call    sub_2CA970
+  .text:00000000004F718F                 mov     rcx, [rbp+var_B8]
+  .text:00000000004F7196                 mov     rdi, rax
+  .text:00000000004F7199                 mov     r13, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:00000000004F71A0                 cmp     rcx, r13
+  .text:00000000004F71A3                 jnz     loc_4F7590
+  .text:00000000004F71A9                 mov     rdx, [rbp+var_A8]
+  .text:00000000004F71B0                 mov     [rbp+var_90], rdi
+  .text:00000000004F71B7                 lea     rsi, [rbp+var_90]
+  .text:00000000004F71BE                 mov     rdi, r15
+  .text:00000000004F71C1                 call    sub_60022E
+  .text:00000000004F71C6                 mov     rdx, [rbp+var_90]
+  .text:00000000004F71CD                 lea     rdi, [rdx-18h]
+  .text:00000000004F71D1                 cmp     rdi, r13
+  .text:00000000004F71D4                 jnz     loc_4F7560
+  .text:00000000004F71DA                 call    sub_2C9990
+  .text:00000000004F71DF                 xor     edx, edx
+  .text:00000000004F71E1                 mov     esi, 0CEC3D011h
+  .text:00000000004F71E6                 mov     rdi, rax
+  .text:00000000004F71E9                 mov     rax, [rax]
+  .text:00000000004F71EC                 call    qword ptr [rax+18h]
+  .text:00000000004F71EF                 test    rax, rax
+  .text:00000000004F71F2                 jz      short loc_4F720F
+  .text:00000000004F71F4                 lea     rax, g_pFileSystem
+  .text:00000000004F71FB                 movss   xmm0, cs:dword_26A084
+  .text:00000000004F7203                 mov     rdi, [rax]
+  .text:00000000004F7206                 mov     rax, [rdi]
+  .text:00000000004F7209                 call    qword ptr [rax+338h]
+  .text:00000000004F720F                 mov     rax, [rbx]
+  .text:00000000004F7212                 mov     esi, 1
+  .text:00000000004F7217                 mov     rdi, rbx
+  .text:00000000004F721A                 call    qword ptr [rax+118h]
+  .text:00000000004F7220                 call    sub_2C9630
+  .text:00000000004F7225                 mov     rdx, qword ptr cs:unk_26A1E8
+  .text:00000000004F722C                 xor     esi, esi
+  .text:00000000004F722E                 mov     rdi, rbx
+  .text:00000000004F7231                 mov     dword ptr [rbx+9Ch], 40h ; '@'
+  .text:00000000004F723B                 mov     dword ptr [rbx+0A8h], 0
+  .text:00000000004F7245                 mov     [rbx+0B0h], rax
+  .text:00000000004F724C                 mov     [rbx+88h], rdx
+  .text:00000000004F7253                 mov     dword ptr [rbx+44h], 40h ; '@'
+  .text:00000000004F725A                 movzx   eax, byte ptr [r12+58h]
+  .text:00000000004F7260                 mov     [rbx+455h], al
+  .text:00000000004F7266                 mov     rax, [rbx]
+  .text:00000000004F7269                 call    qword ptr [rax+200h]
+  .text:00000000004F726F                 lea     rax, dword_9D7958
+  .text:00000000004F7276                 mov     eax, [rax]
+  .text:00000000004F7278                 cmp     [rbx+40h], eax
+  .text:00000000004F727B                 jz      loc_4F7358
+  .text:00000000004F7281                 call    sub_86C9F0
+  .text:00000000004F7286                 test    al, al
+  .text:00000000004F7288                 jz      short loc_4F72B6
+  .text:00000000004F728A                 lea     rax, g_pVApplication
+  .text:00000000004F7291                 mov     rdi, [rax]
+  .text:00000000004F7294                 mov     rax, [rdi]
+  .text:00000000004F7297                 call    qword ptr [rax+98h]
+  .text:00000000004F729D                 lea     rsi, aGmsAdvertise; "GMS/Advertise"
+  .text:00000000004F72A4                 xor     edx, edx
+  .text:00000000004F72A6                 mov     rdi, rax
+  .text:00000000004F72A9                 call    sub_2CA0E0
+  .text:00000000004F72AE                 test    eax, eax
+  .text:00000000004F72B0                 jg      loc_4F7450
+  .text:00000000004F72B6                 mov     rdi, rbx
+  .text:00000000004F72B9                 call    sub_4F6F50
+  .text:00000000004F72BE                 call    sub_86C9F0
+  .text:00000000004F72C3                 test    al, al
+  .text:00000000004F72C5                 jz      short loc_4F72D4
+  .text:00000000004F72C7                 cmp     cs:byte_A300E1, 0
+  .text:00000000004F72CE                 jz      loc_4F74A8
+  .text:00000000004F72D4                 add     rsp, 98h
+  .text:00000000004F72DB                 pop     rbx
+  .text:00000000004F72DC                 pop     r12
+  .text:00000000004F72DE                 pop     r13
+  .text:00000000004F72E0                 pop     r14
+  .text:00000000004F72E2                 pop     r15
+  .text:00000000004F72E4                 pop     rbp
+  .text:00000000004F72E5                 retn
+  .text:00000000004F72F0                 lea     rdi, [r14+19h]
+  .text:00000000004F72F4                 call    sub_2BBC80
+  .text:00000000004F72F9                 mov     [rax+8], r14
+  .text:00000000004F72FD                 lea     rdi, [rax+18h]
+  .text:00000000004F7301                 mov     rcx, rax
+  .text:00000000004F7304                 mov     dword ptr [rax+10h], 0
+  .text:00000000004F730B                 cmp     r14, 1
+  .text:00000000004F730F                 jnz     loc_4F717D
+  .text:00000000004F7315                 movzx   eax, byte ptr [r13+0]
+  .text:00000000004F731A                 mov     [rcx+18h], al
+  .text:00000000004F731D                 jmp     loc_4F7199
+  .text:00000000004F7328                 mov     r13, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:00000000004F732F                 lea     rdi, [r13+18h]
+  .text:00000000004F7333                 jmp     loc_4F71A9
+  .text:00000000004F7340                 call    sub_2C9420
+  .text:00000000004F7345                 movzx   eax, byte ptr [rax+0Dh]
+  .text:00000000004F7349                 shr     al, 7
+  .text:00000000004F734C                 jmp     loc_4F704A
+  .text:00000000004F7358                 lea     rax, g_pSource2Server
+  .text:00000000004F735F                 lea     rsi, [rbx+58h]
+  .text:00000000004F7363                 mov     rdi, [rax]
+  .text:00000000004F7366                 mov     rax, [rdi]
+  .text:00000000004F7369                 call    qword ptr [rax+60h]
+  .text:00000000004F736C                 call    sub_86C9F0
+  .text:00000000004F7371                 test    al, al
+  .text:00000000004F7373                 jz      loc_4F7528
+  .text:00000000004F7379                 call    sub_5D5580
+  .text:00000000004F737E                 xor     edx, edx
+  .text:00000000004F7380                 mov     esi, 9
+  .text:00000000004F7385                 mov     rdi, rax
+  .text:00000000004F7388                 call    sub_5D5A80
+  .text:00000000004F738D                 jmp     loc_4F7281
+  .text:00000000004F7398                 lea     r15, [rbp+var_80]
+  .text:00000000004F739C                 xor     ecx, ecx
+  .text:00000000004F739E                 xor     edx, edx
+  .text:00000000004F73A0                 xor     esi, esi
+  .text:00000000004F73A2                 mov     rdi, r15
+  .text:00000000004F73A5                 call    sub_2C9100
+  .text:00000000004F73AA                 mov     rax, [r12+40h]
+  .text:00000000004F73AF                 mov     rdi, r15
+  .text:00000000004F73B2                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:00000000004F73B6                 mov     rsi, [rax]
+  .text:00000000004F73B9                 mov     edx, [rsi-18h]
+  .text:00000000004F73BC                 call    sub_2C9410
+  .text:00000000004F73C1                 mov     edi, 1Ch
+  .text:00000000004F73C6                 call    sub_2C7B00
+  .text:00000000004F73CB                 lea     rsi, aBaseCmdkeyvalu; "Base_CmdKeyValues"
+  .text:00000000004F73D2                 xor     edx, edx
+  .text:00000000004F73D4                 mov     r14, rax
+  .text:00000000004F73D7                 mov     rdi, rax
+  .text:00000000004F73DA                 call    sub_2C8AE0
+  .text:00000000004F73DF                 mov     [r12+70h], r14
+  .text:00000000004F73E4                 mov     rdi, r14
+  .text:00000000004F73E7                 mov     rsi, r15
+  .text:00000000004F73EA                 call    sub_2C8010
+  .text:00000000004F73EF                 mov     eax, dword ptr [rbp+var_80+4]
+  .text:00000000004F73F2                 mov     dword ptr [rbp+var_80], 0
+  .text:00000000004F73F9                 mov     r14, [r12+70h]
+  .text:00000000004F73FE                 test    eax, 7FFFFFFFh
+  .text:00000000004F7403                 jz      loc_4F700E
+  .text:00000000004F7409                 test    eax, eax
+  .text:00000000004F740B                 js      loc_4F700E
+  .text:00000000004F7411                 mov     rax, cs:g_pMemAlloc_ptr
+  .text:00000000004F7418                 mov     rsi, [rbp+var_78]
+  .text:00000000004F741C                 mov     rdi, [rax]
+  .text:00000000004F741F                 mov     rax, [rdi]
+  .text:00000000004F7422                 call    qword ptr [rax+20h]
+  .text:00000000004F7425                 jmp     loc_4F700E
+  .text:00000000004F7430                 mov     rdi, rbx
+  .text:00000000004F7433                 call    rax
+  .text:00000000004F7435                 mov     [rbp+var_9C], rax
+  .text:00000000004F743C                 mov     [rbp+var_94], edx
+  .text:00000000004F7442                 jmp     loc_4F70B8
+  .text:00000000004F7450                 call    sub_2C9990
+  .text:00000000004F7455                 xor     edx, edx
+  .text:00000000004F7457                 mov     esi, 0D01961ADh
+  .text:00000000004F745C                 mov     rdi, rax
+  .text:00000000004F745F                 mov     rax, [rax]
+  .text:00000000004F7462                 call    qword ptr [rax+18h]
+  .text:00000000004F7465                 test    rax, rax
+  .text:00000000004F7468                 jnz     loc_4F72B6
+  .text:00000000004F746E                 lea     r12, off_9D7F10
+  .text:00000000004F7475                 mov     rdi, r12
+  .text:00000000004F7478                 call    sub_2CA3A0
+  .text:00000000004F747D                 cmp     qword ptr [rax], 0
+  .text:00000000004F7481                 jz      loc_4F72B6
+  .text:00000000004F7487                 mov     rdi, r12
+  .text:00000000004F748A                 call    sub_2CA3A0
+  .text:00000000004F748F                 mov     esi, 1
+  .text:00000000004F7494                 mov     rdi, [rax]
+  .text:00000000004F7497                 mov     rax, [rdi]
+  .text:00000000004F749A                 call    qword ptr [rax+0C0h]
+  .text:00000000004F74A0                 jmp     loc_4F72B6
+  .text:00000000004F74A8                 xor     edx, edx
+  .text:00000000004F74AA                 mov     edi, 2
+  .text:00000000004F74AF                 mov     cs:byte_A300E1, 1
+  .text:00000000004F74B6                 lea     rsi, sub_4F0D80
+  .text:00000000004F74BD                 call    sub_2C7AC0
+  .text:00000000004F74C2                 xor     edx, edx
+  .text:00000000004F74C4                 mov     edi, 0Fh
+  .text:00000000004F74C9                 lea     rsi, sub_4F0D90
+  .text:00000000004F74D0                 call    sub_2C7AC0
+  .text:00000000004F74D5                 call    sub_2C9990
+  .text:00000000004F74DA                 mov     esi, 9402B42h
+  .text:00000000004F74DF                 mov     rdi, rax
+  .text:00000000004F74E2                 mov     rax, [rax]
+  .text:00000000004F74E5                 call    qword ptr [rax+20h]
+  .text:00000000004F74E8                 test    al, al
+  .text:00000000004F74EA                 jz      loc_4F72D4
+  .text:00000000004F74F0                 lea     rsi, sub_4F0DA0
+  .text:00000000004F74F7                 mov     edi, 2
+  .text:00000000004F74FC                 call    sub_2CA560
+  .text:00000000004F7501                 add     rsp, 98h
+  .text:00000000004F7508                 mov     edi, 0Fh
+  .text:00000000004F750D                 pop     rbx
+  .text:00000000004F750E                 lea     rsi, sub_4F0DB0
+  .text:00000000004F7515                 pop     r12
+  .text:00000000004F7517                 pop     r13
+  .text:00000000004F7519                 pop     r14
+  .text:00000000004F751B                 pop     r15
+  .text:00000000004F751D                 pop     rbp
+  .text:00000000004F751E                 jmp     sub_2CA560
+  .text:00000000004F7528                 call    sub_5D5580
+  .text:00000000004F752D                 mov     rsi, [rbp+var_B0]
+  .text:00000000004F7534                 mov     rdi, rax
+  .text:00000000004F7537                 call    sub_5D5CC0
+  .text:00000000004F753C                 jmp     loc_4F7379
+  .text:00000000004F7548                 mov     rax, [rcx]
+  .text:00000000004F754B                 mov     [rbp+var_A8], rax
+  .text:00000000004F7552                 jmp     loc_4F70F4
+  .text:00000000004F7560                 cmp     cs:__pthread_key_create_ptr, 0
+  .text:00000000004F7568                 jz      short loc_4F75A0
+  .text:00000000004F756A                 mov     eax, 0FFFFFFFFh
+  .text:00000000004F756F                 lock xadd [rdx-8], eax
+  .text:00000000004F7574                 test    eax, eax
+  .text:00000000004F7576                 jg      loc_4F71DA
+  .text:00000000004F757C                 mov     rsi, [rdx-10h]
+  .text:00000000004F7580                 add     rsi, 19h
+  .text:00000000004F7584                 call    sub_2BBCB0
+  .text:00000000004F7589                 jmp     loc_4F71DA
+  .text:00000000004F7590                 mov     [rcx], r14
+  .text:00000000004F7593                 mov     byte ptr [rcx+r14+18h], 0
+  .text:00000000004F7599                 jmp     loc_4F71A9
+  .text:00000000004F75A0                 mov     eax, [rdx-8]
+  .text:00000000004F75A3                 lea     ecx, [rax-1]
+  .text:00000000004F75A6                 mov     [rdx-8], ecx
+  .text:00000000004F75A9                 jmp     short loc_4F7574
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_Init(__int64 a1, __int64 a2, __int64 *a3, double a4)
+  {
+    __int64 *v5; // rsi
+    __int64 v7; // r14
+    __int64 v8; // rax
+    int v9; // edx
+    char v10; // al
+    __int64 (__fastcall *v11)(); // rax
+    __int64 v12; // rax
+    __int64 v13; // rax
+    _BYTE *v14; // r13
+    unsigned __int64 v15; // r14
+    unsigned __int64 v16; // r8
+    __int64 v17; // rax
+    volatile signed __int32 *v18; // rdi
+    _BYTE *v19; // rcx
+    __int64 v20; // rax
+    void **v21; // rsi
+    volatile signed __int32 *v22; // rdx
+    volatile signed __int32 *v23; // rdi
+    __int64 v24; // rax
+    __int64 v25; // rax
+    __int64 v26; // rdi
+    __int64 result; // rax
+    __int64 v28; // rax
+    __int64 *v29; // rsi
+    _QWORD *v30; // rdi
+    __int64 v31; // rdx
+    __int64 v32; // rax
+    __int64 v33; // r14
+    int v34; // edx
+    __int64 v35; // rax
+    _QWORD *v36; // rax
+    __int64 v37; // rax
+    __int64 v38; // rax
+    int v39; // eax
+    unsigned __int64 v40; // [rsp+8h] [rbp-B8h]
+    _BYTE *v41; // [rsp+8h] [rbp-B8h]
+    unsigned __int64 v43; // [rsp+18h] [rbp-A8h]
+    __int64 v44; // [rsp+24h] [rbp-9Ch] BYREF
+    int v45; // [rsp+2Ch] [rbp-94h]
+    volatile signed __int32 *v46; // [rsp+30h] [rbp-90h] BYREF
+    int v47; // [rsp+38h] [rbp-88h]
+    __int64 v48; // [rsp+40h] [rbp-80h] BYREF
+    __int64 *v49; // [rsp+48h] [rbp-78h]
+
+    v5 = a3;
+    sub_2C8ED0(a1 + 336, a3);
+    v7 = *(_QWORD *)(a2 + 112);
+    if ( !v7 )
+    {
+      sub_2C9100(&v48, 0, 0, 0);
+      sub_2C9410(
+        &v48,
+        *(_QWORD *)(*(_QWORD *)(a2 + 64) & 0xFFFFFFFFFFFFFFFCLL),
+        *(unsigned int *)(*(_QWORD *)(*(_QWORD *)(a2 + 64) & 0xFFFFFFFFFFFFFFFCLL) - 24LL));
+      v33 = sub_2C7B00(28);
+      sub_2C8AE0(v33, "Base_CmdKeyValues", 0);
+      *(_QWORD *)(a2 + 112) = v33;
+      v5 = &v48;
+      sub_2C8010(v33, &v48);
+      LODWORD(v48) = 0;
+      v7 = *(_QWORD *)(a2 + 112);
+      if ( (v48 & 0x7FFFFFFF00000000LL) != 0 && v48 >= 0 )
+      {
+        v5 = v49;
+        (*(void (__fastcall **)(_QWORD *, __int64 *))(*g_pMemAlloc + 32LL))(g_pMemAlloc, v49);
+      }
+    }
+    *(_QWORD *)(a1 + 368) = sub_2C92E0(v7);
+    *(_BYTE *)(a1 + 576) = *(_BYTE *)(a2 + 90);
+    v8 = sub_2C9990(v7, v5);
+    v9 = (*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v8 + 48LL))(v8, 656837765, 0);
+    v10 = 0;
+    if ( !v9 )
+      v10 = *(_BYTE *)(sub_2C9420() + 13) >> 7;
+    byte_A30290 = v10;
+    sub_5889D0();
+    sub_2F85A0(a1 + 216, a2);
+    v11 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 248LL);// 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+    if ( v11 == sub_4F0FF0 )
+    {
+      v12 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkSystem + 264LL))(g_pNetworkSystem);
+      v48 = *(_QWORD *)v12;
+      LODWORD(v12) = *(_DWORD *)(v12 + 8);
+      v46 = (volatile signed __int32 *)v48;
+      v44 = v48;
+      LODWORD(v49) = v12;
+      v47 = v12;
+      v45 = v12;
+    }
+    else
+    {
+      v44 = ((__int64 (__fastcall *)(__int64))v11)(a1);
+      v45 = v34;
+    }
+    v13 = sub_2C80E0(&v44, 0);
+    *(_DWORD *)(a1 + 232) |= 0x10u;
+    v14 = (_BYTE *)v13;
+    v43 = *(_QWORD *)(a1 + 224) & 0xFFFFFFFFFFFFFFFCLL;
+    if ( (*(_QWORD *)(a1 + 224) & 1) != 0 )
+      v43 = *(_QWORD *)(*(_QWORD *)(a1 + 224) & 0xFFFFFFFFFFFFFFFCLL);
+    if ( !v13 )
+    {
+      sub_2C30C0("basic_string::_S_construct null not valid");
+      goto LABEL_48;
+    }
+    v15 = sub_2CA790(v13);
+    if ( !v15 )
+    {
+      v18 = (volatile signed __int32 *)&unk_CD1378;
+      goto LABEL_18;
+    }
+    if ( v15 > 0x3FFFFFFFFFFFFFF9LL )
+    {
+  LABEL_48:
+      sub_2C30D0("basic_string::_S_create");
+      JUMPOUT(0x4F6FC8);
+    }
+    if ( v15 + 57 > 0x1000 )
+    {
+      v16 = v15 + 4096 - (((_WORD)v15 + 57) & 0xFFF);
+      if ( v16 > 0x3FFFFFFFFFFFFFF9LL )
+        v16 = 0x3FFFFFFFFFFFFFF9LL;
+      v40 = v16;
+      v17 = sub_2BBC80(v16 + 25);
+      *(_DWORD *)(v17 + 16) = 0;
+      v18 = (volatile signed __int32 *)(v17 + 24);
+      v19 = (_BYTE *)v17;
+      *(_QWORD *)(v17 + 8) = v40;
+      goto LABEL_15;
+    }
+    v28 = sub_2BBC80(v15 + 25);
+    *(_QWORD *)(v28 + 8) = v15;
+    v18 = (volatile signed __int32 *)(v28 + 24);
+    v19 = (_BYTE *)v28;
+    *(_DWORD *)(v28 + 16) = 0;
+    if ( v15 != 1 )
+    {
+  LABEL_15:
+      v41 = v19;
+      v20 = sub_2CA970(v18, v14, v15, v19);
+      v19 = v41;
+      v18 = (volatile signed __int32 *)v20;
+      goto LABEL_16;
+    }
+    *(_BYTE *)(v28 + 24) = *v14;
+  LABEL_16:
+    if ( v19 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+    {
+      *(_QWORD *)v19 = v15;
+      v19[v15 + 24] = 0;
+    }
+  LABEL_18:
+    v46 = v18;
+    v21 = (void **)&v46;
+    sub_60022E(a1 + 272, &v46, v43);
+    v22 = v46;
+    v23 = v46 - 6;
+    if ( v46 - 6 != (volatile signed __int32 *)&std::string::_Rep::_S_empty_rep_storage )
+    {
+      if ( &_pthread_key_create )
+      {
+        v39 = _InterlockedExchangeAdd(v46 - 2, 0xFFFFFFFF);
+      }
+      else
+      {
+        v39 = *((_DWORD *)v46 - 2);
+        *((_DWORD *)v46 - 2) = v39 - 1;
+      }
+      if ( v39 <= 0 )
+      {
+        v21 = (void **)(*((_QWORD *)v22 - 2) + 25LL);
+        sub_2BBCB0(v23, v21);
+      }
+    }
+    v24 = sub_2C9990(v23, v21);
+    if ( (*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v24 + 24LL))(v24, 3468939281LL, 0) )
+    {
+      *(_QWORD *)&a4 = 1056964608;
+      (*(void (__fastcall **)(_QWORD *, float))(*g_pFileSystem + 824LL))(g_pFileSystem, 0.5);
+    }
+    (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 280LL))(a1, 1);
+    v25 = sub_2C9630();
+    *(_DWORD *)(a1 + 156) = 64;
+    *(_DWORD *)(a1 + 168) = 0;
+    *(_QWORD *)(a1 + 176) = v25;
+    *(_QWORD *)(a1 + 136) = unk_26A1E8;
+    *(_DWORD *)(a1 + 68) = 64;
+    *(_BYTE *)(a1 + 1109) = *(_BYTE *)(a2 + 88);
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 512LL))(a1, 0);
+    if ( *(_DWORD *)(a1 + 64) == dword_9D7958 )
+    {
+      v29 = (__int64 *)(a1 + 88);
+      v30 = g_pSource2Server;
+      a4 = (*(double (__fastcall **)(_QWORD *, __int64))(*g_pSource2Server + 96LL))(g_pSource2Server, a1 + 88);
+      if ( !(unsigned __int8)sub_86C9F0(a4) )
+      {
+        v38 = sub_5D5580(v30, v29, v31);
+        v29 = a3;
+        v30 = (_QWORD *)v38;
+        sub_5D5CC0(v38, a3);
+      }
+      v32 = sub_5D5580(v30, v29, v31);
+      sub_5D5A80(v32, 9, 0);
+    }
+    if ( (unsigned __int8)sub_86C9F0(a4) )
+    {
+      v26 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pVApplication + 152LL))(g_pVApplication);
+      if ( (int)sub_2CA0E0(v26, "GMS/Advertise", 0) > 0 )
+      {
+        v35 = sub_2C9990(v26, "GMS/Advertise");
+        if ( !(*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v35 + 24LL))(v35, 3491324333LL, 0) )
+        {
+          if ( *(_QWORD *)sub_2CA3A0(&off_9D7F10) )
+          {
+            v36 = (_QWORD *)sub_2CA3A0(&off_9D7F10);
+            (*(void (__fastcall **)(_QWORD, __int64))(*(_QWORD *)*v36 + 192LL))(*v36, 1);
+          }
+        }
+      }
+    }
+    sub_4F6F50(a1);
+    result = sub_86C9F0(a4);
+    if ( (_BYTE)result && !byte_A300E1 )
+    {
+      byte_A300E1 = 1;
+      sub_2C7AC0(2, sub_4F0D80, 0);
+      sub_2C7AC0(15, sub_4F0D90, 0);
+      v37 = sub_2C9990(15, sub_4F0D90);
+      result = (*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v37 + 32LL))(v37, 155200322);
+      if ( (_BYTE)result )
+      {
+        sub_2CA560(2, sub_4F0DA0);
+        return sub_2CA560(15, sub_4F0DB0);
+      }
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_Init.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_Init.windows.yaml
@@ -1,0 +1,452 @@
+func_name: CNetworkGameServerBase_Init
+func_va: '0x1800aca00'
+disasm_code: |-
+  .text:00000001800ACA00                 mov     [rsp+arg_0], rbx
+  .text:00000001800ACA05                 mov     [rsp+arg_8], rbp
+  .text:00000001800ACA0A                 mov     [rsp+arg_10], rsi
+  .text:00000001800ACA0F                 push    rdi
+  .text:00000001800ACA10                 push    r14
+  .text:00000001800ACA12                 push    r15
+  .text:00000001800ACA14                 sub     rsp, 80h
+  .text:00000001800ACA1B                 mov     rbp, rdx
+  .text:00000001800ACA1E                 mov     rdi, rcx
+  .text:00000001800ACA21                 add     rcx, 150h
+  .text:00000001800ACA28                 mov     rdx, r8
+  .text:00000001800ACA2B                 mov     r15, r8
+  .text:00000001800ACA2E                 call    cs:?Set@CUtlString@@QEAAXPEBD@Z; CUtlString::Set(char const *)
+  .text:00000001800ACA34                 mov     rsi, [rbp+70h]
+  .text:00000001800ACA38                 xor     ebx, ebx
+  .text:00000001800ACA3A                 test    rsi, rsi
+  .text:00000001800ACA3D                 jnz     loc_1800ACAE9
+  .text:00000001800ACA43                 xor     r9d, r9d
+  .text:00000001800ACA46                 lea     rcx, [rsp+98h+var_58]
+  .text:00000001800ACA4B                 xor     r8d, r8d
+  .text:00000001800ACA4E                 xor     edx, edx
+  .text:00000001800ACA50                 call    cs:??0CUtlBuffer@@QEAA@HHW4BufferFlags_t@0@@Z; CUtlBuffer::CUtlBuffer(int,int,CUtlBuffer::BufferFlags_t)
+  .text:00000001800ACA56                 mov     rdx, [rbp+40h]
+  .text:00000001800ACA5A                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800ACA5E                 cmp     qword ptr [rdx+18h], 0Fh
+  .text:00000001800ACA63                 mov     r8d, [rdx+10h]
+  .text:00000001800ACA67                 jbe     short loc_1800ACA6C
+  .text:00000001800ACA69                 mov     rdx, [rdx]
+  .text:00000001800ACA6C                 lea     rcx, [rsp+98h+var_58]
+  .text:00000001800ACA71                 call    cs:?Put@CUtlBuffer@@QEAAXPEBXH@Z; CUtlBuffer::Put(void const *,int)
+  .text:00000001800ACA77                 mov     ecx, 1Ch
+  .text:00000001800ACA7C                 call    cs:??2KeyValues@@SAPEAX_K@Z; KeyValues::operator new(unsigned __int64)
+  .text:00000001800ACA82                 test    rax, rax
+  .text:00000001800ACA85                 jz      short loc_1800ACA9C
+  .text:00000001800ACA87                 xor     r8d, r8d
+  .text:00000001800ACA8A                 lea     rdx, aBaseCmdkeyvalu; "Base_CmdKeyValues"
+  .text:00000001800ACA91                 mov     rcx, rax
+  .text:00000001800ACA94                 call    cs:??0KeyValues@@QEAA@PEBDW4KV_DISPOSABLE_STRING_TABLE_STATE@0@@Z; KeyValues::KeyValues(char const *,KeyValues::KV_DISPOSABLE_STRING_TABLE_STATE)
+  .text:00000001800ACA9A                 jmp     short loc_1800ACA9F
+  .text:00000001800ACA9C                 mov     rax, rbx
+  .text:00000001800ACA9F                 lea     rdx, [rsp+98h+var_58]
+  .text:00000001800ACAA4                 mov     [rbp+70h], rax
+  .text:00000001800ACAA8                 mov     rcx, rax
+  .text:00000001800ACAAB                 call    cs:?ReadAsBinary@KeyValues@@QEAA_NAEAVCUtlBuffer@@@Z; KeyValues::ReadAsBinary(CUtlBuffer &)
+  .text:00000001800ACAB1                 mov     eax, dword ptr [rsp+98h+var_58+4]
+  .text:00000001800ACAB5                 mov     rsi, [rbp+70h]
+  .text:00000001800ACAB9                 mov     dword ptr [rsp+98h+var_58], ebx
+  .text:00000001800ACABD                 test    eax, 7FFFFFFFh
+  .text:00000001800ACAC2                 jbe     short loc_1800ACAE5
+  .text:00000001800ACAC4                 shr     eax, 1Fh
+  .text:00000001800ACAC7                 test    al, al
+  .text:00000001800ACAC9                 jnz     short loc_1800ACAE0
+  .text:00000001800ACACB                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800ACAD2                 mov     rdx, qword ptr [rsp+98h+var_58+8]
+  .text:00000001800ACAD7                 mov     rcx, [rax]
+  .text:00000001800ACADA                 mov     rax, [rcx]
+  .text:00000001800ACADD                 call    qword ptr [rax+18h]
+  .text:00000001800ACAE0                 mov     qword ptr [rsp+98h+var_58+8], rbx
+  .text:00000001800ACAE5                 mov     dword ptr [rsp+98h+var_58+4], ebx
+  .text:00000001800ACAE9                 mov     rcx, rsi
+  .text:00000001800ACAEC                 call    cs:?MakeCopy@KeyValues@@QEBAPEAV1@XZ; KeyValues::MakeCopy(void)
+  .text:00000001800ACAF2                 mov     [rdi+170h], rax
+  .text:00000001800ACAF9                 movzx   eax, byte ptr [rbp+5Ah]
+  .text:00000001800ACAFD                 mov     [rdi+240h], al
+  .text:00000001800ACB03                 call    cs:CommandLine
+  .text:00000001800ACB09                 xor     r8d, r8d
+  .text:00000001800ACB0C                 mov     edx, 27268C85h
+  .text:00000001800ACB11                 mov     rcx, [rax]
+  .text:00000001800ACB14                 mov     r9, [rcx+30h]
+  .text:00000001800ACB18                 mov     rcx, rax
+  .text:00000001800ACB1B                 call    r9
+  .text:00000001800ACB1E                 test    eax, eax
+  .text:00000001800ACB20                 jnz     short loc_1800ACB31
+  .text:00000001800ACB22                 call    cs:GetCPUInformation
+  .text:00000001800ACB28                 cmp     [rax+0Dh], bl
+  .text:00000001800ACB2B                 jge     short loc_1800ACB31
+  .text:00000001800ACB2D                 mov     al, 1
+  .text:00000001800ACB2F                 jmp     short loc_1800ACB33
+  .text:00000001800ACB31                 xor     al, al
+  .text:00000001800ACB33                 mov     edx, 0FFFFFFFFh
+  .text:00000001800ACB38                 mov     cs:byte_18068B2CC, al
+  .text:00000001800ACB3E                 lea     rcx, unk_1808CCFD8
+  .text:00000001800ACB45                 call    sub_1803FEF60
+  .text:00000001800ACB4A                 test    rax, rax
+  .text:00000001800ACB4D                 jnz     short loc_1800ACB5A
+  .text:00000001800ACB4F                 mov     rax, cs:qword_1808CCFE0
+  .text:00000001800ACB56                 mov     rax, [rax+8]
+  .text:00000001800ACB5A                 mov     rcx, [rax]
+  .text:00000001800ACB5D                 test    rcx, rcx
+  .text:00000001800ACB60                 jz      short loc_1800ACB6A
+  .text:00000001800ACB62                 cmp     [rcx], bl
+  .text:00000001800ACB64                 jnz     loc_1800ACC14
+  .text:00000001800ACB6A                 call    sub_180415A00
+  .text:00000001800ACB6F                 test    al, al
+  .text:00000001800ACB71                 jnz     short loc_1800ACBD2
+  .text:00000001800ACB73                 lea     rcx, off_18060E308
+  .text:00000001800ACB7A                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACB80                 cmp     [rax], rbx
+  .text:00000001800ACB83                 jz      short loc_1800ACBD2
+  .text:00000001800ACB85                 lea     rcx, off_18060E308
+  .text:00000001800ACB8C                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACB92                 mov     rcx, [rax]
+  .text:00000001800ACB95                 mov     rax, [rcx]
+  .text:00000001800ACB98                 call    qword ptr [rax+8]
+  .text:00000001800ACB9B                 test    al, al
+  .text:00000001800ACB9D                 jz      short loc_1800ACBD2
+  .text:00000001800ACB9F                 lea     rcx, off_18060E2D8
+  .text:00000001800ACBA6                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACBAC                 cmp     [rax], rbx
+  .text:00000001800ACBAF                 jz      short loc_1800ACBD2
+  .text:00000001800ACBB1                 lea     rcx, off_18060E2D8
+  .text:00000001800ACBB8                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACBBE                 mov     rcx, [rax]
+  .text:00000001800ACBC1                 mov     rax, [rcx]
+  .text:00000001800ACBC4                 call    qword ptr [rax]
+  .text:00000001800ACBC6                 mov     rsi, rax
+  .text:00000001800ACBC9                 test    rax, rax
+  .text:00000001800ACBCC                 jz      short loc_1800ACBD2
+  .text:00000001800ACBCE                 cmp     [rax], bl
+  .text:00000001800ACBD0                 jnz     short loc_1800ACBE2
+  .text:00000001800ACBD2                 mov     rcx, cs:qword_180911898
+  .text:00000001800ACBD9                 mov     rax, [rcx]
+  .text:00000001800ACBDC                 call    qword ptr [rax+58h]
+  .text:00000001800ACBDF                 mov     rsi, rax
+  .text:00000001800ACBE2                 mov     edx, 0FFFFFFFFh
+  .text:00000001800ACBE7                 lea     rcx, unk_1808CCFD8
+  .text:00000001800ACBEE                 call    sub_1803FEF60
+  .text:00000001800ACBF3                 test    rax, rax
+  .text:00000001800ACBF6                 jz      short loc_1800ACC14
+  .text:00000001800ACBF8                 mov     r9, rax
+  .text:00000001800ACBFB                 mov     [rsp+98h+var_78], rsi
+  .text:00000001800ACC00                 mov     r8, rbx
+  .text:00000001800ACC03                 lea     rcx, unk_1808CCFD8
+  .text:00000001800ACC0A                 mov     edx, 0FFFFFFFFh
+  .text:00000001800ACC0F                 call    sub_1800541F0
+  .text:00000001800ACC14                 lea     rsi, [rdi+0D8h]
+  .text:00000001800ACC1B                 cmp     rbp, rsi
+  .text:00000001800ACC1E                 jz      short loc_1800ACC33
+  .text:00000001800ACC20                 mov     rcx, rsi
+  .text:00000001800ACC23                 call    sub_18017A130
+  .text:00000001800ACC28                 mov     rdx, rbp
+  .text:00000001800ACC2B                 mov     rcx, rsi
+  .text:00000001800ACC2E                 call    sub_18017AF20
+  .text:00000001800ACC33                 mov     rax, [rdi]
+  .text:00000001800ACC36                 lea     rdx, [rsp+98h+var_68]
+  .text:00000001800ACC3B                 mov     rcx, rdi
+  .text:00000001800ACC3E                 ; 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+  .text:00000001800ACC3E                 call    qword ptr [rax+0F8h]; 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+  .text:00000001800ACC44                 mov     rcx, rax
+  .text:00000001800ACC47                 xor     edx, edx
+  .text:00000001800ACC49                 call    cs:?ToString@netadr_t@@QEBAPEBD_N@Z; netadr_t::ToString(bool)
+  .text:00000001800ACC4F                 or      dword ptr [rdi+0E8h], 10h
+  .text:00000001800ACC56                 mov     rsi, [rdi+0E0h]
+  .text:00000001800ACC5D                 and     rsi, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800ACC61                 test    byte ptr [rdi+0E0h], 1
+  .text:00000001800ACC68                 jz      short loc_1800ACC6D
+  .text:00000001800ACC6A                 mov     rsi, [rsi]
+  .text:00000001800ACC6D                 xorps   xmm0, xmm0
+  .text:00000001800ACC70                 xorps   xmm1, xmm1
+  .text:00000001800ACC73                 movups  [rsp+98h+var_58], xmm0
+  .text:00000001800ACC78                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:00000001800ACC7F                 movdqu  [rsp+98h+var_48], xmm1
+  .text:00000001800ACC85                 inc     r8
+  .text:00000001800ACC88                 cmp     [rax+r8], bl
+  .text:00000001800ACC8C                 jnz     short loc_1800ACC85
+  .text:00000001800ACC8E                 mov     rdx, rax
+  .text:00000001800ACC91                 lea     rcx, [rsp+98h+var_58]
+  .text:00000001800ACC96                 call    sub_1800439B0
+  .text:00000001800ACC9B                 mov     r8, rsi
+  .text:00000001800ACC9E                 lea     rdx, [rsp+98h+var_58]
+  .text:00000001800ACCA3                 lea     rcx, [rdi+110h]
+  .text:00000001800ACCAA                 call    sub_18024FE80
+  .text:00000001800ACCAF                 mov     rax, qword ptr [rsp+98h+var_48+8]
+  .text:00000001800ACCB4                 cmp     rax, 0Fh
+  .text:00000001800ACCB8                 jbe     short loc_1800ACCF2
+  .text:00000001800ACCBA                 mov     rdx, qword ptr [rsp+98h+var_58]
+  .text:00000001800ACCBF                 inc     rax
+  .text:00000001800ACCC2                 mov     rcx, rdx
+  .text:00000001800ACCC5                 cmp     rax, 1000h
+  .text:00000001800ACCCB                 jb      short loc_1800ACCE2
+  .text:00000001800ACCCD                 mov     rdx, [rdx-8]
+  .text:00000001800ACCD1                 sub     rcx, rdx
+  .text:00000001800ACCD4                 lea     rax, [rcx-8]
+  .text:00000001800ACCD8                 cmp     rax, 1Fh
+  .text:00000001800ACCDC                 ja      loc_1800ACE86
+  .text:00000001800ACCE2                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800ACCE9                 mov     rcx, [rax]
+  .text:00000001800ACCEC                 mov     rax, [rcx]
+  .text:00000001800ACCEF                 call    qword ptr [rax+18h]
+  .text:00000001800ACCF2                 call    cs:CommandLine
+  .text:00000001800ACCF8                 xor     r8d, r8d
+  .text:00000001800ACCFB                 mov     edx, 0CEC3D011h
+  .text:00000001800ACD00                 mov     rcx, [rax]
+  .text:00000001800ACD03                 mov     r9, [rcx+18h]
+  .text:00000001800ACD07                 mov     rcx, rax
+  .text:00000001800ACD0A                 call    r9
+  .text:00000001800ACD0D                 test    rax, rax
+  .text:00000001800ACD10                 jz      short loc_1800ACD2A
+  .text:00000001800ACD12                 mov     rcx, cs:g_pFileSystem
+  .text:00000001800ACD19                 movss   xmm1, cs:dword_180584FF8
+  .text:00000001800ACD21                 mov     rax, [rcx]
+  .text:00000001800ACD24                 call    qword ptr [rax+340h]
+  .text:00000001800ACD2A                 mov     rax, [rdi]
+  .text:00000001800ACD2D                 mov     edx, 1
+  .text:00000001800ACD32                 mov     rcx, rdi
+  .text:00000001800ACD35                 call    qword ptr [rax+118h]
+  .text:00000001800ACD3B                 movss   xmm0, cs:dword_180584F90
+  .text:00000001800ACD43                 lea     r8, [rdi+58h]
+  .text:00000001800ACD47                 mov     [rsp+98h+var_70], ebx
+  .text:00000001800ACD4B                 lea     rdx, aCBuildworkerCs_20; "C:\\buildworker\\csgo_rel_win64\\build"...
+  .text:00000001800ACD52                 mov     r9d, 40h ; '@'
+  .text:00000001800ACD58                 movss   dword ptr [rsp+98h+var_78], xmm0
+  .text:00000001800ACD5E                 lea     rcx, [rsp+98h+var_58]
+  .text:00000001800ACD63                 call    sub_18005EBE0
+  .text:00000001800ACD68                 mov     eax, [rdi+9Ch]
+  .text:00000001800ACD6E                 xor     edx, edx
+  .text:00000001800ACD70                 mov     [rdi+44h], eax
+  .text:00000001800ACD73                 mov     rcx, rdi
+  .text:00000001800ACD76                 movzx   eax, byte ptr [rbp+58h]
+  .text:00000001800ACD7A                 mov     [rdi+455h], al
+  .text:00000001800ACD80                 mov     rax, [rdi]
+  .text:00000001800ACD83                 call    qword ptr [rax+1F0h]
+  .text:00000001800ACD89                 mov     eax, cs:dword_18060EFC0
+  .text:00000001800ACD8F                 cmp     [rdi+40h], eax
+  .text:00000001800ACD92                 jnz     short loc_1800ACDDA
+  .text:00000001800ACD94                 mov     rcx, cs:g_pSource2Server
+  .text:00000001800ACD9B                 lea     rdx, [rdi+58h]
+  .text:00000001800ACD9F                 mov     rax, [rcx]
+  .text:00000001800ACDA2                 call    qword ptr [rax+60h]
+  .text:00000001800ACDA5                 call    sub_180415A00
+  .text:00000001800ACDAA                 test    al, al
+  .text:00000001800ACDAC                 jnz     short loc_1800ACDC6
+  .text:00000001800ACDAE                 mov     rcx, cs:qword_180612C98
+  .text:00000001800ACDB5                 test    rcx, rcx
+  .text:00000001800ACDB8                 jz      short loc_1800ACDC6
+  .text:00000001800ACDBA                 mov     rax, [rcx]
+  .text:00000001800ACDBD                 mov     rdx, r15
+  .text:00000001800ACDC0                 call    qword ptr [rax+0A0h]
+  .text:00000001800ACDC6                 xor     r8d, r8d
+  .text:00000001800ACDC9                 lea     rcx, off_180612C70
+  .text:00000001800ACDD0                 mov     edx, 9
+  .text:00000001800ACDD5                 call    sub_18013BA50
+  .text:00000001800ACDDA                 call    sub_180415A00
+  .text:00000001800ACDDF                 test    al, al
+  .text:00000001800ACDE1                 jz      short loc_1800ACE57
+  .text:00000001800ACDE3                 mov     rcx, cs:g_pVApplication
+  .text:00000001800ACDEA                 mov     rax, [rcx]
+  .text:00000001800ACDED                 call    qword ptr [rax+90h]
+  .text:00000001800ACDF3                 xor     r8d, r8d
+  .text:00000001800ACDF6                 lea     rdx, aGmsAdvertise; "GMS/Advertise"
+  .text:00000001800ACDFD                 mov     rcx, rax
+  .text:00000001800ACE00                 call    cs:?GetInt@KeyValues@@QEBAHPEBDH@Z; KeyValues::GetInt(char const *,int)
+  .text:00000001800ACE06                 test    eax, eax
+  .text:00000001800ACE08                 jle     short loc_1800ACE57
+  .text:00000001800ACE0A                 call    cs:CommandLine
+  .text:00000001800ACE10                 xor     r8d, r8d
+  .text:00000001800ACE13                 mov     edx, 0D01961ADh
+  .text:00000001800ACE18                 mov     rcx, [rax]
+  .text:00000001800ACE1B                 mov     r9, [rcx+18h]
+  .text:00000001800ACE1F                 mov     rcx, rax
+  .text:00000001800ACE22                 call    r9
+  .text:00000001800ACE25                 test    rax, rax
+  .text:00000001800ACE28                 jnz     short loc_1800ACE57
+  .text:00000001800ACE2A                 lea     rcx, off_18060E650
+  .text:00000001800ACE31                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACE37                 cmp     [rax], rbx
+  .text:00000001800ACE3A                 jz      short loc_1800ACE57
+  .text:00000001800ACE3C                 lea     rcx, off_18060E650
+  .text:00000001800ACE43                 call    cs:SteamInternal_ContextInit
+  .text:00000001800ACE49                 mov     dl, 1
+  .text:00000001800ACE4B                 mov     rcx, [rax]
+  .text:00000001800ACE4E                 mov     rax, [rcx]
+  .text:00000001800ACE51                 call    qword ptr [rax+0C0h]
+  .text:00000001800ACE57                 mov     rcx, rdi
+  .text:00000001800ACE5A                 call    sub_1800ACE90
+  .text:00000001800ACE5F                 lea     rcx, [rsp+98h+var_58]
+  .text:00000001800ACE64                 call    sub_18005EC80
+  .text:00000001800ACE69                 lea     r11, [rsp+98h+var_18]
+  .text:00000001800ACE71                 mov     rbx, [r11+20h]
+  .text:00000001800ACE75                 mov     rbp, [r11+28h]
+  .text:00000001800ACE79                 mov     rsi, [r11+30h]
+  .text:00000001800ACE7D                 mov     rsp, r11
+  .text:00000001800ACE80                 pop     r15
+  .text:00000001800ACE82                 pop     r14
+  .text:00000001800ACE84                 pop     rdi
+  .text:00000001800ACE85                 retn
+  .text:00000001800ACE86                 call    _invalid_parameter_noinfo_noreturn
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_Init(__int64 a1, __int64 a2, const char *a3)
+  {
+    KeyValues *v6; // rsi
+    _DWORD *v7; // rdx
+    int v8; // r8d
+    void *v9; // rax
+    KeyValues *v10; // rax
+    __int64 v11; // rcx
+    __int64 v12; // rax
+    bool v13; // al
+    _BYTE **v14; // rax
+    __int64 v15; // rdx
+    _BYTE *v16; // rcx
+    _QWORD *v17; // rax
+    _QWORD *v18; // rax
+    _BYTE *v19; // rax
+    __int64 v20; // rsi
+    __int64 v21; // rax
+    netadr_t *v22; // rax
+    const char *v23; // rax
+    _QWORD *v24; // rsi
+    __int64 v25; // r8
+    __int64 v26; // rcx
+    __int64 v27; // rax
+    __int64 v28; // rdx
+    __int64 v29; // rcx
+    __int64 v30; // rdx
+    __int64 v31; // rcx
+    KeyValues *v32; // rax
+    __int64 v33; // rcx
+    __int64 v34; // rax
+    _QWORD *v35; // rax
+    __int64 v36; // rdx
+    _BYTE v38[16]; // [rsp+30h] [rbp-68h] BYREF
+    __int128 v39; // [rsp+40h] [rbp-58h] BYREF
+    __int128 v40; // [rsp+50h] [rbp-48h]
+
+    CUtlString::Set((CUtlString *)(a1 + 336), a3);
+    v6 = *(KeyValues **)(a2 + 112);
+    if ( !v6 )
+    {
+      CUtlBuffer::CUtlBuffer(&v39, 0, 0, 0);
+      v7 = (_DWORD *)(*(_QWORD *)(a2 + 64) & 0xFFFFFFFFFFFFFFFCuLL);
+      v8 = v7[4];
+      if ( *((_QWORD *)v7 + 3) > 0xFu )
+        v7 = *(_DWORD **)v7;
+      CUtlBuffer::Put((CUtlBuffer *)&v39, v7, v8);
+      v9 = KeyValues::operator new(0x1Cu);
+      if ( v9 )
+        v10 = (KeyValues *)KeyValues::KeyValues(v9, "Base_CmdKeyValues", 0);
+      else
+        v10 = nullptr;
+      *(_QWORD *)(a2 + 112) = v10;
+      KeyValues::ReadAsBinary(v10, (struct CUtlBuffer *)&v39);
+      v6 = *(KeyValues **)(a2 + 112);
+      LODWORD(v39) = 0;
+      if ( (DWORD1(v39) & 0x7FFFFFFF) != 0 )
+      {
+        if ( (SDWORD1(v39) & 0x80000000) == 0 )
+          (*(void (__fastcall **)(_QWORD, _QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc, *((_QWORD *)&v39 + 1));
+        *((_QWORD *)&v39 + 1) = 0;
+      }
+      DWORD1(v39) = 0;
+    }
+    *(_QWORD *)(a1 + 368) = KeyValues::MakeCopy(v6);
+    *(_BYTE *)(a1 + 576) = *(_BYTE *)(a2 + 90);
+    v12 = CommandLine(v11);
+    v13 = !(*(unsigned int (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v12 + 48LL))(v12, 656837765, 0)
+       && *(char *)(GetCPUInformation() + 13) < 0;
+    byte_18068B2CC = v13;
+    v14 = (_BYTE **)sub_1803FEF60(&unk_1808CCFD8, 0xFFFFFFFFLL);
+    if ( !v14 )
+      v14 = *(_BYTE ***)(qword_1808CCFE0 + 8);
+    v16 = *v14;
+    if ( !*v14 || !*v16 )
+    {
+      if ( (unsigned __int8)sub_180415A00(v16, v15)
+        || !*(_QWORD *)SteamInternal_ContextInit(&off_18060E308)
+        || (v17 = (_QWORD *)SteamInternal_ContextInit(&off_18060E308),
+            !(*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v17 + 8LL))(*v17))
+        || !*(_QWORD *)SteamInternal_ContextInit(&off_18060E2D8)
+        || (v18 = (_QWORD *)SteamInternal_ContextInit(&off_18060E2D8),
+            v19 = (_BYTE *)(**(__int64 (__fastcall ***)(_QWORD))*v18)(*v18),
+            (v20 = (__int64)v19) == 0)
+        || !*v19 )
+      {
+        v20 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_180911898 + 88LL))(qword_180911898);
+      }
+      v21 = sub_1803FEF60(&unk_1808CCFD8, 0xFFFFFFFFLL);
+      if ( v21 )
+        sub_1800541F0((unsigned int)&unk_1808CCFD8, -1, 0, v21, v20);
+    }
+    if ( a2 != a1 + 216 )
+    {
+      sub_18017A130(a1 + 216);
+      sub_18017AF20(a1 + 216, a2);
+    }
+    v22 = (netadr_t *)(*(__int64 (__fastcall **)(__int64, _BYTE *))(*(_QWORD *)a1 + 248LL))(a1, v38);// 0x0F8 = 248LL = CNetworkGameServerBase_GetServerNetworkAddress
+    v23 = netadr_t::ToString(v22, 0);
+    *(_DWORD *)(a1 + 232) |= 0x10u;
+    v24 = (_QWORD *)(*(_QWORD *)(a1 + 224) & 0xFFFFFFFFFFFFFFFCuLL);
+    if ( (*(_BYTE *)(a1 + 224) & 1) != 0 )
+      v24 = (_QWORD *)*v24;
+    v39 = 0;
+    v25 = -1;
+    v40 = 0;
+    do
+      ++v25;
+    while ( v23[v25] );
+    sub_1800439B0(&v39, v23);
+    sub_18024FE80(a1 + 272, &v39, v24);
+    if ( *((_QWORD *)&v40 + 1) > 0xFu )
+    {
+      if ( (unsigned __int64)(*((_QWORD *)&v40 + 1) + 1LL) >= 0x1000
+        && (unsigned __int64)(v39 - *(_QWORD *)(v39 - 8) - 8) > 0x1F )
+      {
+        invalid_parameter_noinfo_noreturn();
+      }
+      (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+    }
+    v27 = CommandLine(v26);
+    if ( (*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v27 + 24LL))(v27, 3468939281LL, 0) )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pFileSystem + 832LL))(g_pFileSystem);
+    (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)a1 + 280LL))(a1, 1);
+    sub_18005EBE0(
+      (unsigned int)&v39,
+      (unsigned int)"C:\\buildworker\\csgo_rel_win64\\build\\src\\engine2\\networkgameserverbase.cpp:3028",
+      a1 + 88,
+      64,
+      1015021568,
+      0);
+    *(_DWORD *)(a1 + 68) = *(_DWORD *)(a1 + 156);
+    *(_BYTE *)(a1 + 1109) = *(_BYTE *)(a2 + 88);
+    (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 496LL))(a1, 0);
+    if ( *(_DWORD *)(a1 + 64) == dword_18060EFC0 )
+    {
+      (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)g_pSource2Server + 96LL))(g_pSource2Server, a1 + 88);
+      if ( !(unsigned __int8)sub_180415A00(v31, v30) && qword_180612C98 )
+        (*(void (__fastcall **)(__int64, const char *))(*(_QWORD *)qword_180612C98 + 160LL))(qword_180612C98, a3);
+      sub_18013BA50(&off_180612C70, 9, 0);
+    }
+    if ( (unsigned __int8)sub_180415A00(v29, v28) )
+    {
+      v32 = (KeyValues *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pVApplication + 144LL))(g_pVApplication);
+      if ( (int)KeyValues::GetInt(v32, "GMS/Advertise", 0) > 0 )
+      {
+        v34 = CommandLine(v33);
+        if ( !(*(__int64 (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v34 + 24LL))(v34, 3491324333LL, 0) )
+        {
+          if ( *(_QWORD *)SteamInternal_ContextInit(&off_18060E650) )
+          {
+            v35 = (_QWORD *)SteamInternal_ContextInit(&off_18060E650);
+            LOBYTE(v36) = 1;
+            (*(void (__fastcall **)(_QWORD, __int64))(*(_QWORD *)*v35 + 192LL))(*v35, v36);
+          }
+        }
+      }
+    }
+    sub_1800ACE90(a1);
+    return sub_18005EC80(&v39);
+  }


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_GetServerNetworkAddress` preprocessor script (Pattern C, vfunc via LLM_DECOMPILE) locating `CNetworkGameServerBase::GetServerNetworkAddress` in the engine module via its predecessor `CNetworkGameServerBase_Init`.
- Resolve the vfunc as `CNetworkGameServer_vtable` slot: offset `0xf8`, index `31`, on both Windows and Linux (Linux devirtualized slot-compare against the concrete impl).
- Add `configs/14174.yaml` skill + symbol entries and both annotated `CNetworkGameServerBase_Init.{windows,linux}.yaml` references.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (Compile 0, Invalid 0, Layout diffs 0, VTable diffs 0, Record-layout diffs 0)
- candidate publication: passed; published SHA-256 `263384fc161a15b218c779566f8426c6194c3d0782294ef01eebcd19ad534b8e` matches the validated candidate