### PR TITLE
feat(signatures): add CNetworkGameServerBase_MakeSpawnGroupActive finder for 14174

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7863,6 +7863,11 @@ modules:
           - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
         expected_input:
           - CSpawnGroupMgrGameSystem_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_MakeSpawnGroupActive
+        expected_output:
+          - CNetworkGameServerBase_MakeSpawnGroupActive.{platform}.yaml
+        expected_input:
+          - CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml
       - name: find-CSpawnGroupMgrGameSystem_UnloadSpawnGroup
         expected_output:
           - CSpawnGroupMgrGameSystem_UnloadSpawnGroup.{platform}.yaml
@@ -11127,6 +11132,10 @@ modules:
         category: vfunc
         alias:
           - CSpawnGroupMgrGameSystem::SetActiveSpawnGroup
+      - name: CNetworkGameServerBase_MakeSpawnGroupActive
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::MakeSpawnGroupActive
       - name: CSpawnGroupMgrGameSystem_UnloadSpawnGroup
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:42845432be729bc5b008929a3134849d735139b785cc13d9085811e4264d5d25
+file_count: 3277
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -32265,6 +32265,18 @@ files:
     vtable_size: '0x48'
     vtable_symbol: ??_7CNavPhysicsInterface@@6B@
     vtable_va: '0x181861e70'
+  server/CNetworkGameServerBase_MakeSpawnGroupActive.linux.yaml:
+    func_name: CNetworkGameServerBase_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: FF 90 00 02 00 00 89 5D ??
+    vtable_name: CNetworkGameServer_vtable
+  server/CNetworkGameServerBase_MakeSpawnGroupActive.windows.yaml:
+    func_name: CNetworkGameServerBase_MakeSpawnGroupActive
+    vfunc_index: 64
+    vfunc_offset: '0x200'
+    vfunc_sig: 4C 8B 82 00 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   server/CNetworkSerializerBindingBuildFilter_GetFieldPriority.linux.yaml:
     func_name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
     func_rva: '0x2134f10'
@@ -42325,5 +42337,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T13:23:07Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_MakeSpawnGroupActive.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_MakeSpawnGroupActive.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_MakeSpawnGroupActive skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_MakeSpawnGroupActive",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_MakeSpawnGroupActive",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_MakeSpawnGroupActive", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # Slim Pattern C: this vfunc is not a downstream predecessor.
+    (
+        "CNetworkGameServerBase_MakeSpawnGroupActive",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.linux.yaml
@@ -35,7 +35,8 @@ disasm_code: |-
   .text:0000000000F285C1                 mov     esi, ebx
   .text:0000000000F285C3                 mov     rdi, [rax]
   .text:0000000000F285C6                 mov     rax, [rdi]
-  .text:0000000000F285C9                 call    qword ptr [rax+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive
+  .text:0000000000F285C9                 ; 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
+  .text:0000000000F285C9                 call    qword ptr [rax+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive ; 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
   .text:0000000000F285CF                 mov     dword ptr [rbp+var_40], ebx
   .text:0000000000F285D2                 lea     rbx, [rbp+var_38]
   .text:0000000000F285D6                 ; char *
@@ -193,7 +194,7 @@ procedure: |-
       if ( (_DWORD)a2 != (_DWORD)result )
       {
         sub_2115E50(g_pEntitySystem, (unsigned int)a2);
-        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, (unsigned int)a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, (unsigned int)a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive // 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
         LODWORD(v12) = a2;
         v13 = 0;
         v14 = v7;

--- a/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CSpawnGroupMgrGameSystem_SetActiveSpawnGroup.windows.yaml
@@ -61,7 +61,8 @@ disasm_code: |-
   .text:000000018058B111                 call    sub_18122C680
   .text:000000018058B116                 mov     rcx, cs:g_engine
   .text:000000018058B11D                 mov     rdx, [rcx]
-  .text:000000018058B120                 mov     r8, [rdx+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive
+  .text:000000018058B120                 ; 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
+  .text:000000018058B120                 mov     r8, [rdx+200h] ; 200h = IVEngineServer2_MakeSpawnGroupActive ; 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
   .text:000000018058B127                 mov     edx, ebx
   .text:000000018058B129                 call    r8
   .text:000000018058B12C                 mov     rdx, rsi
@@ -154,7 +155,7 @@ procedure: |-
       if ( v7 != a2 )
       {
         sub_18122C680(g_pEntitySystem, a2);
-        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive
+        (*(void (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_engine + 512LL))(g_engine, a2);// 512LL = 0x200 = IVEngineServer2_MakeSpawnGroupActive // 0x200 = 512LL = CNetworkGameServerBase_MakeSpawnGroupActive
         v14 = 0;
         v13 = a2;
         v15 = v7;


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_MakeSpawnGroupActive.py` (slim Pattern C) locating the concrete `CNetworkGameServer_vtable` slot at offset `0x200` (index 64) via LLM decompile of the server-module predecessor `CSpawnGroupMgrGameSystem::SetActiveSpawnGroup`.
- Annotate the shared `CSpawnGroupMgrGameSystem_SetActiveSpawnGroup` reference (windows + linux) for the new consumer alongside the existing `IVEngineServer2_MakeSpawnGroupActive` annotation at the same `g_engine` vcall.
- Register the finder skill and `CNetworkGameServerBase_MakeSpawnGroupActive` vfunc symbol in `configs/14174.yaml`.

Result (both platforms): offset `0x200`, index 64, with `vfunc_sig` (windows `4C 8B 82 00 02 00 00`; linux `FF 90 00 02 00 00 89 5D ??`).

## Validation
- IDA analysis: `find-CNetworkGameServerBase_MakeSpawnGroupActive` server windows,linux — 2 successful, 0 failed
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (0 compile failures, 0 invalid items, 0 layout/vtable/record differences)
- candidate publication: passed; published SHA-256 matches the validated candidate