### PR TITLE
feat(preprocessor): add find-CNetworkGameServerBase_IsChangelevelPending

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -626,6 +626,12 @@ modules:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_IsChangelevelPending
+        expected_output:
+          - CNetworkGameServerBase_IsChangelevelPending.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
       - name: find-CNetworkGameServerBase_SetMaxClients
         expected_output:
           - CNetworkGameServerBase_SetMaxClients.{platform}.yaml
@@ -2213,6 +2219,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerPollNetworking
+      - name: CNetworkGameServerBase_IsChangelevelPending
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::IsChangelevelPending
       - name: CNetworkGameServerBase_BroadcastMessage
         category: vfunc
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -637,12 +637,18 @@ modules:
           - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
+      - name: find-INetworkGameServer_IsChangelevelPending
+        expected_output:
+          - INetworkGameServer_IsChangelevelPending.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_vtable.{platform}.yaml
+          - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
       - name: find-CNetworkGameServerBase_IsChangelevelPending
         expected_output:
           - CNetworkGameServerBase_IsChangelevelPending.{platform}.yaml
         expected_input:
-          - CNetworkGameServer_vtable.{platform}.yaml
-          - CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - INetworkGameServer_IsChangelevelPending.{platform}.yaml
       - name: find-CNetworkGameServerBase_SetMaxClients
         expected_output:
           - CNetworkGameServerBase_SetMaxClients.{platform}.yaml
@@ -2262,6 +2268,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::ServerPollNetworking
+      - name: INetworkGameServer_IsChangelevelPending
+        category: vfunc
+        alias:
+          - INetworkGameServer::IsChangelevelPending
       - name: CNetworkGameServerBase_IsChangelevelPending
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:2bb48180a8153caf20fff1867864342776cac210bc4fa64531cabb296ad95717
-file_count: 3307
+config_sha256: sha256:4f04000eacffe073b28268c6287f8589f1f5ddd1002aa12a7701e0fbccea1907
+file_count: 3309
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10789,16 +10789,20 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsPausable.linux.yaml:
     func_name: CNetworkGameServerBase_IsPausable
     func_rva: '0x510460'
@@ -13279,6 +13283,18 @@ files:
     vfunc_index: 22
     vfunc_offset: '0xb0'
     vfunc_sig: FF 90 B0 00 00 00 EB ??
+    vtable_name: INetworkGameServer
+  engine/INetworkGameServer_IsChangelevelPending.linux.yaml:
+    func_name: INetworkGameServer_IsChangelevelPending
+    vfunc_index: 41
+    vfunc_offset: '0x148'
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: INetworkGameServer
+  engine/INetworkGameServer_IsChangelevelPending.windows.yaml:
+    func_name: INetworkGameServer_IsChangelevelPending
+    vfunc_index: 41
+    vfunc_offset: '0x148'
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
     vtable_name: INetworkGameServer
   engine/INetworkGameServer_PreWorldUpdate.linux.yaml:
     func_name: INetworkGameServer_PreWorldUpdate
@@ -42575,5 +42591,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T09:52:05Z'
+last_publish_time: '2026-08-06T11:41:49Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:534200bee55012d7b33a500844168e553ab18d82445b2e20396719e18d24c07c
+file_count: 3277
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10694,6 +10694,18 @@ files:
     vfunc_index: 0
     vfunc_offset: '0x0'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
+    func_name: CNetworkGameServerBase_IsChangelevelPending
+    vfunc_index: 41
+    vfunc_offset: '0x148'
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
+    func_name: CNetworkGameServerBase_IsChangelevelPending
+    vfunc_index: 41
+    vfunc_offset: '0x148'
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsPausable.linux.yaml:
     func_name: CNetworkGameServerBase_IsPausable
     func_rva: '0x510460'
@@ -42325,5 +42337,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T14:44:14Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsChangelevelPending.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsChangelevelPending.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_IsChangelevelPending skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_IsChangelevelPending",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_IsChangelevelPending",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_IsChangelevelPending", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_IsChangelevelPending",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsChangelevelPending.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_IsChangelevelPending.py
@@ -3,27 +3,15 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_IsChangelevelPending",
-]
 
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CNetworkGameServerBase_IsChangelevelPending",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/engine/CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
-    ("CNetworkGameServerBase_IsChangelevelPending", "CNetworkGameServer_vtable"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_IsChangelevelPending",
+        "CNetworkGameServerBase",
+        "INetworkGameServer_IsChangelevelPending",
+        False,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -32,10 +20,12 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CNetworkGameServerBase_IsChangelevelPending",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -49,10 +39,11 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
+    """Resolve the override from the inherited interface vfunc slot without a func_sig."""
+    _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -60,10 +51,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-INetworkGameServer_IsChangelevelPending.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_IsChangelevelPending.py
@@ -23,7 +23,7 @@ LLM_DECOMPILE = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("INetworkGameServer_IsChangelevelPending", "CNetworkGameServer_vtable"),
+    ("INetworkGameServer_IsChangelevelPending", "INetworkGameServer"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [

--- a/ida_preprocessor_scripts/find-INetworkGameServer_IsChangelevelPending.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_IsChangelevelPending.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkGameServer_IsChangelevelPending skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkGameServer_IsChangelevelPending",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "INetworkGameServer_IsChangelevelPending",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_ServerPollNetworking.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkGameServer_IsChangelevelPending", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "INetworkGameServer_IsChangelevelPending",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.linux.yaml
@@ -14,8 +14,8 @@ disasm_code: |-
   .text:00000000004F3636                 jbe     loc_4F36F6
   .text:00000000004F363C                 mov     rax, [rbx]
   .text:00000000004F363F                 lea     rdx, sub_4F0FD0
-  .text:00000000004F3646                 ; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
-  .text:00000000004F3646                 mov     rax, [rax+148h]; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000000004F3646                 ; 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
+  .text:00000000004F3646                 mov     rax, [rax+148h]; 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
   .text:00000000004F364D                 cmp     rax, rdx
   .text:00000000004F3650                 jnz     loc_4F37E8
   .text:00000000004F3656                 movzx   eax, byte ptr [rbx+2B8h]
@@ -199,7 +199,7 @@ procedure: |-
     if ( *(_DWORD *)(a1 + 56) <= 1u )
       return;
   LABEL_4:
-    v2 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 328LL);// 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+    v2 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 328LL);// 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
     if ( v2 == sub_4F0FD0 )
       v3 = *(_BYTE *)(a1 + 696);
     else

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.linux.yaml
@@ -1,0 +1,212 @@
+func_name: CNetworkGameServerBase_ServerPollNetworking
+func_va: '0x4f3610'
+disasm_code: |-
+  .text:00000000004F3610                 push    rbp
+  .text:00000000004F3611                 mov     rbp, rsp
+  .text:00000000004F3614                 push    rbx
+  .text:00000000004F3615                 mov     rbx, rdi
+  .text:00000000004F3618                 sub     rsp, 8
+  .text:00000000004F361C                 cmp     cs:byte_A30292, 0
+  .text:00000000004F3623                 jnz     loc_4F3700
+  .text:00000000004F3629                 cmp     cs:byte_A30291, 0
+  .text:00000000004F3630                 jnz     short loc_4F3690
+  .text:00000000004F3632                 cmp     dword ptr [rbx+38h], 1
+  .text:00000000004F3636                 jbe     loc_4F36F6
+  .text:00000000004F363C                 mov     rax, [rbx]
+  .text:00000000004F363F                 lea     rdx, sub_4F0FD0
+  .text:00000000004F3646                 ; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000000004F3646                 mov     rax, [rax+148h]; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000000004F364D                 cmp     rax, rdx
+  .text:00000000004F3650                 jnz     loc_4F37E8
+  .text:00000000004F3656                 movzx   eax, byte ptr [rbx+2B8h]
+  .text:00000000004F365D                 test    al, al
+  .text:00000000004F365F                 jnz     loc_4F36F6
+  .text:00000000004F3665                 lea     rax, g_pNetworkSystem
+  .text:00000000004F366C                 lea     rdx, [rbx+8]
+  .text:00000000004F3670                 mov     esi, [rbx+40h]
+  .text:00000000004F3673                 mov     rbx, [rbp+var_8]
+  .text:00000000004F3677                 mov     rdi, [rax]
+  .text:00000000004F367A                 mov     rax, [rdi]
+  .text:00000000004F367D                 mov     rax, [rax+0A0h]
+  .text:00000000004F3684                 leave
+  .text:00000000004F3685                 jmp     rax
+  .text:00000000004F3690                 lea     rax, g_pNetworkServerService
+  .text:00000000004F3697                 mov     cs:byte_A30291, 0
+  .text:00000000004F369E                 cmp     qword ptr [rax], 0
+  .text:00000000004F36A2                 jz      short loc_4F36C5
+  .text:00000000004F36A4                 lea     rax, off_9D7BB0
+  .text:00000000004F36AB                 mov     rdi, [rax]
+  .text:00000000004F36AE                 call    sub_3F7360
+  .text:00000000004F36B3                 test    rax, rax
+  .text:00000000004F36B6                 jz      short loc_4F36C5
+  .text:00000000004F36B8                 cmp     byte ptr [rax+2BBh], 0
+  .text:00000000004F36BF                 jz      loc_4F37D0
+  .text:00000000004F36C5                 lea     rdi, aSigtermReceive; "SIGTERM received while server hibernati"...
+  .text:00000000004F36CC                 xor     eax, eax
+  .text:00000000004F36CE                 call    sub_2C8A30
+  .text:00000000004F36D3                 lea     rax, g_pHostStateMgr
+  .text:00000000004F36DA                 mov     rdi, [rax]
+  .text:00000000004F36DD                 test    rdi, rdi
+  .text:00000000004F36E0                 jz      loc_4F37F8
+  .text:00000000004F36E6                 mov     rax, [rdi]
+  .text:00000000004F36E9                 call    qword ptr [rax+58h]
+  .text:00000000004F36EC                 cmp     dword ptr [rbx+38h], 1
+  .text:00000000004F36F0                 ja      loc_4F363C
+  .text:00000000004F36F6                 mov     rbx, [rbp+var_8]
+  .text:00000000004F36FA                 leave
+  .text:00000000004F36FB                 retn
+  .text:00000000004F3700                 lea     rdi, aSigintReceived; "SIGINT received\n"
+  .text:00000000004F3707                 xor     eax, eax
+  .text:00000000004F3709                 mov     cs:byte_A30292, 0
+  .text:00000000004F3710                 call    sub_2C8A30
+  .text:00000000004F3715                 lea     rax, g_pNetworkServerService
+  .text:00000000004F371C                 mov     cs:byte_A300E0, 1
+  .text:00000000004F3723                 lea     rdi, aShutdownReques; "Shutdown request received when no netwo"...
+  .text:00000000004F372A                 cmp     qword ptr [rax], 0
+  .text:00000000004F372E                 jz      short loc_4F37A7
+  .text:00000000004F3730                 lea     rax, off_9D7BB0
+  .text:00000000004F3737                 mov     rdi, [rax]
+  .text:00000000004F373A                 call    sub_3F7360
+  .text:00000000004F373F                 lea     rdi, aShutdownReques_0; "Shutdown request received and server do"...
+  .text:00000000004F3746                 test    rax, rax
+  .text:00000000004F3749                 jz      short loc_4F37A9
+  .text:00000000004F374B                 cmp     byte ptr [rax+2BBh], 0
+  .text:00000000004F3752                 jz      short loc_4F377F
+  .text:00000000004F3754                 mov     rdx, [rax]
+  .text:00000000004F3757                 lea     rcx, sub_4F0C80
+  .text:00000000004F375E                 mov     rdx, [rdx+170h]
+  .text:00000000004F3765                 cmp     rdx, rcx
+  .text:00000000004F3768                 jnz     loc_4F3830
+  .text:00000000004F376E                 mov     rax, [rax+398h]
+  .text:00000000004F3775                 cmp     qword ptr [rax], 0
+  .text:00000000004F3779                 jz      loc_4F3840
+  .text:00000000004F377F                 lea     rdi, unk_A30210
+  .text:00000000004F3786                 mov     esi, 0FFFFFFFFh
+  .text:00000000004F378B                 call    sub_5E60F0
+  .text:00000000004F3790                 test    rax, rax
+  .text:00000000004F3793                 jz      loc_4F3818
+  .text:00000000004F3799                 movzx   eax, byte ptr [rax]
+  .text:00000000004F379C                 test    al, al
+  .text:00000000004F379E                 jz      short loc_4F3800
+  .text:00000000004F37A0                 lea     rdi, aShutdownReques_1; "Shutdown request received for a server "...
+  .text:00000000004F37A7                 xor     eax, eax
+  .text:00000000004F37A9                 call    sub_2C8A30
+  .text:00000000004F37AE                 lea     rax, g_pHostStateMgr
+  .text:00000000004F37B5                 mov     rdi, [rax]
+  .text:00000000004F37B8                 test    rdi, rdi
+  .text:00000000004F37BB                 jz      short loc_4F37F8
+  .text:00000000004F37BD                 mov     rax, [rdi]
+  .text:00000000004F37C0                 call    qword ptr [rax+58h]
+  .text:00000000004F37C3                 jmp     loc_4F3629
+  .text:00000000004F37D0                 lea     rdi, aSigtermReceive_0; "SIGTERM received while server was **not"...
+  .text:00000000004F37D7                 xor     eax, eax
+  .text:00000000004F37D9                 call    sub_2C8A30
+  .text:00000000004F37DE                 jmp     loc_4F36D3
+  .text:00000000004F37E8                 mov     rdi, rbx
+  .text:00000000004F37EB                 call    rax
+  .text:00000000004F37ED                 jmp     loc_4F365D
+  .text:00000000004F37F8                 xor     edi, edi
+  .text:00000000004F37FA                 call    sub_2CA480
+  .text:00000000004F37FF                 nop
+  .text:00000000004F3800                 lea     rdi, aShutdownReques_2; "Shutdown request received. Server will "...
+  .text:00000000004F3807                 xor     eax, eax
+  .text:00000000004F3809                 call    sub_2C8A30
+  .text:00000000004F380E                 jmp     loc_4F3629
+  .text:00000000004F3818                 mov     rax, cs:qword_A30218
+  .text:00000000004F381F                 mov     rax, [rax+8]
+  .text:00000000004F3823                 jmp     loc_4F3799
+  .text:00000000004F3830                 mov     rdi, rax
+  .text:00000000004F3833                 call    rdx
+  .text:00000000004F3835                 test    al, al
+  .text:00000000004F3837                 jnz     loc_4F377F
+  .text:00000000004F383D                 nop     dword ptr [rax]
+  .text:00000000004F3840                 lea     rdi, aShutdownReques_3; "Shutdown request received while server "...
+  .text:00000000004F3847                 xor     eax, eax
+  .text:00000000004F3849                 jmp     loc_4F37A9
+procedure: |-
+  void __fastcall CNetworkGameServerBase_ServerPollNetworking(__int64 a1)
+  {
+    __int64 (__fastcall *v2)(); // rax
+    char v3; // al
+    __int64 v4; // rax
+    const char *v5; // rdi
+    __int64 v6; // rax
+    __int64 (__fastcall *v7)(); // rdx
+    _BYTE *v8; // rax
+
+    if ( !byte_A30292 )
+      goto LABEL_2;
+    byte_A30292 = 0;
+    sub_2C8A30("SIGINT received\n");
+    byte_A300E0 = 1;
+    v5 = "Shutdown request received when no network service exists.\n";
+    if ( !g_pNetworkServerService )
+      goto LABEL_24;
+    v6 = sub_3F7360(off_9D7BB0);
+    v5 = "Shutdown request received and server doesn't exist. Shutting down right now\n";
+    if ( !v6 )
+      goto LABEL_24;
+    if ( *(_BYTE *)(v6 + 699) )
+    {
+      v7 = *(__int64 (__fastcall **)())(*(_QWORD *)v6 + 368LL);
+      if ( v7 == sub_4F0C80 )
+      {
+        if ( **(_QWORD **)(v6 + 920) )
+          goto LABEL_20;
+      }
+      else if ( ((unsigned __int8 (__fastcall *)(__int64))v7)(v6) )
+      {
+        goto LABEL_20;
+      }
+      sub_2C8A30("Shutdown request received while server is hibernating. Shutting down right now\n");
+      goto LABEL_25;
+    }
+  LABEL_20:
+    v8 = (_BYTE *)sub_5E60F0(&unk_A30210, 0xFFFFFFFFLL);
+    if ( !v8 )
+      v8 = *(_BYTE **)(qword_A30218 + 8);
+    if ( !*v8 )
+      goto LABEL_30;
+    v5 = "Shutdown request received for a server that will never hibernate. Shutting down right now\n";
+  LABEL_24:
+    sub_2C8A30(v5);
+  LABEL_25:
+    if ( !g_pHostStateMgr )
+      goto LABEL_29;
+    (*(void (__fastcall **)(_QWORD *))(*g_pHostStateMgr + 88LL))(g_pHostStateMgr);
+    while ( 1 )
+    {
+  LABEL_2:
+      if ( !byte_A30291 )
+      {
+        if ( *(_DWORD *)(a1 + 56) <= 1u )
+          return;
+        goto LABEL_4;
+      }
+      byte_A30291 = 0;
+      if ( g_pNetworkServerService && (v4 = sub_3F7360(off_9D7BB0)) != 0 && !*(_BYTE *)(v4 + 699) )
+        sub_2C8A30("SIGTERM received while server was **not** hibernating!  Shutting down even though a game may be in progress!\n");
+      else
+        sub_2C8A30("SIGTERM received while server hibernating.\n");
+      if ( g_pHostStateMgr )
+        break;
+  LABEL_29:
+      sub_2CA480(0);
+  LABEL_30:
+      sub_2C8A30("Shutdown request received. Server will shutdown when empty.\n");
+    }
+    (*(void (__fastcall **)(_QWORD *))(*g_pHostStateMgr + 88LL))(g_pHostStateMgr);
+    if ( *(_DWORD *)(a1 + 56) <= 1u )
+      return;
+  LABEL_4:
+    v2 = *(__int64 (__fastcall **)())(*(_QWORD *)a1 + 328LL);// 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+    if ( v2 == sub_4F0FD0 )
+      v3 = *(_BYTE *)(a1 + 696);
+    else
+      v3 = ((__int64 (__fastcall *)(__int64))v2)(a1);
+    if ( !v3 )
+      (*(void (__fastcall **)(_QWORD *, _QWORD, __int64))(*g_pNetworkSystem + 160LL))(
+        g_pNetworkSystem,
+        *(unsigned int *)(a1 + 64),
+        a1 + 8);
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.windows.yaml
@@ -1,0 +1,93 @@
+func_name: CNetworkGameServerBase_ServerPollNetworking
+func_va: '0x1800b49c0'
+disasm_code: |-
+  .text:00000001800B49C0                 push    rbx
+  .text:00000001800B49C2                 sub     rsp, 20h
+  .text:00000001800B49C6                 cmp     cs:byte_18068B2CD, 0
+  .text:00000001800B49CD                 mov     rbx, rcx
+  .text:00000001800B49D0                 jz      short loc_1800B49EB
+  .text:00000001800B49D2                 lea     rcx, aSigintReceived; "SIGINT received\n"
+  .text:00000001800B49D9                 mov     cs:byte_18068B2CD, 0
+  .text:00000001800B49E0                 call    cs:Warning
+  .text:00000001800B49E6                 call    sub_1800B00D0
+  .text:00000001800B49EB                 cmp     cs:byte_18068B2CE, 0
+  .text:00000001800B49F2                 jz      short loc_1800B4A40
+  .text:00000001800B49F4                 cmp     cs:g_pNetworkServerService, 0
+  .text:00000001800B49FC                 mov     cs:byte_18068B2CE, 0
+  .text:00000001800B4A03                 jz      short loc_1800B4A21
+  .text:00000001800B4A05                 mov     rax, cs:qword_18090DA50
+  .text:00000001800B4A0C                 test    rax, rax
+  .text:00000001800B4A0F                 jz      short loc_1800B4A21
+  .text:00000001800B4A11                 cmp     byte ptr [rax+2BBh], 0
+  .text:00000001800B4A18                 lea     rcx, aSigtermReceive; "SIGTERM received while server was **not"...
+  .text:00000001800B4A1F                 jz      short loc_1800B4A28
+  .text:00000001800B4A21                 lea     rcx, aSigtermReceive_0; "SIGTERM received while server hibernati"...
+  .text:00000001800B4A28                 call    cs:Warning
+  .text:00000001800B4A2E                 mov     rcx, cs:g_pHostStateMgr
+  .text:00000001800B4A35                 test    rcx, rcx
+  .text:00000001800B4A38                 jz      short loc_1800B4A82
+  .text:00000001800B4A3A                 mov     rax, [rcx]
+  .text:00000001800B4A3D                 call    qword ptr [rax+58h]
+  .text:00000001800B4A40                 cmp     dword ptr [rbx+38h], 1
+  .text:00000001800B4A44                 jbe     short loc_1800B4A7C
+  .text:00000001800B4A46                 mov     rax, [rbx]
+  .text:00000001800B4A49                 mov     rcx, rbx
+  .text:00000001800B4A4C                 ; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000001800B4A4C                 call    qword ptr [rax+148h]; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000001800B4A52                 test    al, al
+  .text:00000001800B4A54                 jnz     short loc_1800B4A7C
+  .text:00000001800B4A56                 mov     rcx, cs:g_pNetworkSystem
+  .text:00000001800B4A5D                 lea     r8, [rbx+8]
+  .text:00000001800B4A61                 xor     edx, edx
+  .text:00000001800B4A63                 test    rbx, rbx
+  .text:00000001800B4A66                 mov     rax, [rcx]
+  .text:00000001800B4A69                 cmovz   r8, rdx
+  .text:00000001800B4A6D                 mov     edx, [rbx+40h]
+  .text:00000001800B4A70                 add     rsp, 20h
+  .text:00000001800B4A74                 pop     rbx
+  .text:00000001800B4A75                 jmp     qword ptr [rax+0A0h]
+  .text:00000001800B4A7C                 add     rsp, 20h
+  .text:00000001800B4A80                 pop     rbx
+  .text:00000001800B4A81                 retn
+  .text:00000001800B4A82                 call    sub_180436170
+procedure: |-
+  void __fastcall CNetworkGameServerBase_ServerPollNetworking(_DWORD *a1)
+  {
+    const char *v2; // rcx
+    _DWORD *v3; // r8
+
+    if ( byte_18068B2CD )
+    {
+      byte_18068B2CD = 0;
+      Warning("SIGINT received\n");
+      sub_1800B00D0();
+    }
+    if ( byte_18068B2CE )
+    {
+      byte_18068B2CE = 0;
+      if ( !g_pNetworkServerService
+        || !qword_18090DA50
+        || (v2 = "SIGTERM received while server was **not** hibernating!  Shutting down even though a game may be in progress!\n",
+            *(_BYTE *)(qword_18090DA50 + 699)) )
+      {
+        v2 = "SIGTERM received while server hibernating.\n";
+      }
+      Warning(v2);
+      if ( !g_pHostStateMgr )
+      {
+        sub_180436170();
+        JUMPOUT(0x1800B4A87LL);
+      }
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pHostStateMgr + 88LL))(g_pHostStateMgr);
+    }
+    if ( a1[14] > 1u && !(*(unsigned __int8 (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 328LL))(a1) )// 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+    {
+      v3 = a1 + 2;
+      if ( !a1 )
+        v3 = nullptr;
+      (*(void (__fastcall **)(__int64, _QWORD, _DWORD *))(*(_QWORD *)g_pNetworkSystem + 160LL))(
+        g_pNetworkSystem,
+        (unsigned int)a1[16],
+        v3);
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ServerPollNetworking.windows.yaml
@@ -32,8 +32,8 @@ disasm_code: |-
   .text:00000001800B4A44                 jbe     short loc_1800B4A7C
   .text:00000001800B4A46                 mov     rax, [rbx]
   .text:00000001800B4A49                 mov     rcx, rbx
-  .text:00000001800B4A4C                 ; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
-  .text:00000001800B4A4C                 call    qword ptr [rax+148h]; 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+  .text:00000001800B4A4C                 ; 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
+  .text:00000001800B4A4C                 call    qword ptr [rax+148h]; 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
   .text:00000001800B4A52                 test    al, al
   .text:00000001800B4A54                 jnz     short loc_1800B4A7C
   .text:00000001800B4A56                 mov     rcx, cs:g_pNetworkSystem
@@ -80,7 +80,7 @@ procedure: |-
       }
       (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pHostStateMgr + 88LL))(g_pHostStateMgr);
     }
-    if ( a1[14] > 1u && !(*(unsigned __int8 (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 328LL))(a1) )// 0x148 = 328LL = CNetworkGameServerBase_IsChangelevelPending
+    if ( a1[14] > 1u && !(*(unsigned __int8 (__fastcall **)(_DWORD *))(*(_QWORD *)a1 + 328LL))(a1) )// 0x148 = 328LL = INetworkGameServer_IsChangelevelPending
     {
       v3 = a1 + 2;
       if ( !a1 )


### PR DESCRIPTION
## Summary
- Add a Pattern C engine preprocessor that resolves `CNetworkGameServerBase::IsChangelevelPending` as vfunc index 41 (offset 0x148) of `CNetworkGameServer_vtable`, anchored via the devirtualized vcall in `CNetworkGameServerBase::ServerPollNetworking`.
- Add the annotated `CNetworkGameServerBase_ServerPollNetworking` engine reference YAMLs (windows auto-annotated, linux hand-annotated) that the LLM_DECOMPILE step consumes.
- Register the skill and symbol entries in `configs/14174.yaml` and publish the validated `gamesymbols/14174.yaml` snapshot.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with 12/12 runnable tests and zero failure counters (compile, invalid-item, layout, vtable, and record-layout differences all 0)
- candidate publication: passed; published SHA-256 `c5c7da3d261b96f6943d6656d428a646acdcfe29588b2430e8f93b5e197127eb` matches the validated candidate