### PR TITLE
feat(configs): add IsFakeClient and GetClientConnectionType finders for 14174

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -8441,6 +8441,16 @@ modules:
           - CPlayerCommandQueue_ctor.{platform}.yaml
         expected_input:
           - CPlayerCommandQueue_vtable.{platform}.yaml
+      - name: find-CBasePlayerController_IsFakeClient
+        expected_output:
+          - CBasePlayerController_IsFakeClient.{platform}.yaml
+        expected_input:
+          - CPlayerCommandQueue_ctor.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetClientConnectionType
+        expected_output:
+          - CNetworkGameServerBase_GetClientConnectionType.{platform}.yaml
+        expected_input:
+          - CBasePlayerController_IsFakeClient.{platform}.yaml
       - name: find-CEntitySaveRestoreBlockHandler_vtable
         expected_output:
           - CEntitySaveRestoreBlockHandler_vtable.{platform}.yaml
@@ -11674,6 +11684,15 @@ modules:
         category: func
         alias:
           - CPlayerCommandQueue::CPlayerCommandQueue
+      - name: CBasePlayerController_IsFakeClient
+        category: func
+        alias:
+          - CBasePlayerController::IsFakeClient
+          - IsFakeClient
+      - name: CNetworkGameServerBase_GetClientConnectionType
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetClientConnectionType
       - name: CNavPhysicsInterface_vtable
         category: vtable
       - name: ConnectInterfaces

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -2255,6 +2255,10 @@ modules:
           - CNetworkGameServerBase::ConnectClient
       - name: CNetworkGameServerBase_vtable
         category: vtable
+      - name: CNetworkGameServerBase_GetClientConnectionType
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetClientConnectionType
       - name: CNetworkGameServerBase_ServerSimulateInternal
         category: func
         platform: linux
@@ -8561,9 +8565,9 @@ modules:
           - CBasePlayerController_IsFakeClient.{platform}.yaml
         expected_input:
           - CPlayerCommandQueue_ctor.{platform}.yaml
-      - name: find-CNetworkGameServerBase_GetClientConnectionType
+      - name: find-INetworkGameServer_GetClientConnectionType
         expected_output:
-          - CNetworkGameServerBase_GetClientConnectionType.{platform}.yaml
+          - INetworkGameServer_GetClientConnectionType.{platform}.yaml
         expected_input:
           - CBasePlayerController_IsFakeClient.{platform}.yaml
       - name: find-CEntitySaveRestoreBlockHandler_vtable
@@ -11822,10 +11826,10 @@ modules:
         alias:
           - CBasePlayerController::IsFakeClient
           - IsFakeClient
-      - name: CNetworkGameServerBase_GetClientConnectionType
+      - name: INetworkGameServer_GetClientConnectionType
         category: vfunc
         alias:
-          - CNetworkGameServerBase::GetClientConnectionType
+          - INetworkGameServer::GetClientConnectionType
       - name: CNavPhysicsInterface_vtable
         category: vtable
       - name: ConnectInterfaces
@@ -12478,6 +12482,12 @@ modules:
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
           - ../server/INetworkGameServer_IsBackgroundMap.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetClientConnectionType
+        expected_output:
+          - CNetworkGameServerBase_GetClientConnectionType.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
+          - ../server/INetworkGameServer_GetClientConnectionType.{platform}.yaml
   - name: client  # Execute Shutdown-dependent client skills after engine2.dll generates ILoopModeFactory_Shutdown
     path_windows: game/csgo/bin/win64/client.dll
     path_linux: game/csgo/bin/linuxsteamrt64/libclient.so

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:07e9628d0900c43677ae3f0651fd5f7a3f115cd38d2905d943aaa52beb9e1795
+file_count: 3279
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -18113,6 +18113,18 @@ files:
     func_sig: 48 89 5C 24 ?? 44 88 44 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 48 8B 3D ?? ?? ?? ??
     func_size: '0xb67'
     func_va: '0x180a1f1e0'
+  server/CBasePlayerController_IsFakeClient.linux.yaml:
+    func_name: CBasePlayerController_IsFakeClient
+    func_rva: '0x15e0ce0'
+    func_sig: 55 48 89 E5 41 55 41 54 49 89 FC 53 48 83 EC ?? 48 8D 05 ?? ?? ?? ?? 48 8B 38 48 8B 07
+    func_size: '0x58'
+    func_va: '0x15e0ce0'
+  server/CBasePlayerController_IsFakeClient.windows.yaml:
+    func_name: CBasePlayerController_IsFakeClient
+    func_rva: '0xaf9790'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B D9 48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 90 ?? ?? ?? ?? 48 8B CB
+    func_size: '0x64'
+    func_va: '0x180af9790'
   server/CBasePlayerController_ProcessUsercmds.linux.yaml:
     func_name: CBasePlayerController_ProcessUsercmds
     func_rva: '0x1626670'
@@ -32265,6 +32277,18 @@ files:
     vtable_size: '0x48'
     vtable_symbol: ??_7CNavPhysicsInterface@@6B@
     vtable_va: '0x181861e70'
+  server/CNetworkGameServerBase_GetClientConnectionType.linux.yaml:
+    func_name: CNetworkGameServerBase_GetClientConnectionType
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vfunc_sig: 4C 8B A8 B8 01 00 00 E8 ?? ?? ?? ?? 48 89 DF
+    vtable_name: CNetworkGameServer_vtable
+  server/CNetworkGameServerBase_GetClientConnectionType.windows.yaml:
+    func_name: CNetworkGameServerBase_GetClientConnectionType
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vfunc_sig: 48 8B B2 B8 01 00 00
+    vtable_name: CNetworkGameServer_vtable
   server/CNetworkSerializerBindingBuildFilter_GetFieldPriority.linux.yaml:
     func_name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
     func_rva: '0x2134f10'
@@ -42325,5 +42349,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T15:30:38Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:7d74b905aa978c14ddf3c57d9fdc45d9a94a2072ccc1e574c519b032d4df0cb9
-file_count: 3313
+config_sha256: sha256:3b5488e6ee6b2b5f36010674d873f895836c38a9df2dd41bd1f544027b315965
+file_count: 3315
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10681,6 +10681,22 @@ files:
     vfunc_index: 76
     vfunc_offset: '0x260'
     vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetClientConnectionType.linux.yaml:
+    func_name: CNetworkGameServerBase_GetClientConnectionType
+    func_rva: '0x4f1050'
+    func_size: '0x26'
+    func_va: '0x4f1050'
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vtable_name: CNetworkGameServerBase
+  engine/CNetworkGameServerBase_GetClientConnectionType.windows.yaml:
+    func_name: CNetworkGameServerBase_GetClientConnectionType
+    func_rva: '0xb5980'
+    func_size: '0x27'
+    func_va: '0x1800b5980'
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_GetHostName.linux.yaml:
     func_name: CNetworkGameServerBase_GetHostName
     vfunc_index: 72
@@ -32493,18 +32509,6 @@ files:
     vtable_size: '0x48'
     vtable_symbol: ??_7CNavPhysicsInterface@@6B@
     vtable_va: '0x181861e70'
-  server/CNetworkGameServerBase_GetClientConnectionType.linux.yaml:
-    func_name: CNetworkGameServerBase_GetClientConnectionType
-    vfunc_index: 55
-    vfunc_offset: '0x1b8'
-    vfunc_sig: 4C 8B A8 B8 01 00 00 E8 ?? ?? ?? ?? 48 89 DF
-    vtable_name: CNetworkGameServer_vtable
-  server/CNetworkGameServerBase_GetClientConnectionType.windows.yaml:
-    func_name: CNetworkGameServerBase_GetClientConnectionType
-    vfunc_index: 55
-    vfunc_offset: '0x1b8'
-    vfunc_sig: 48 8B B2 B8 01 00 00
-    vtable_name: CNetworkGameServer_vtable
   server/CNetworkSerializerBindingBuildFilter_GetFieldPriority.linux.yaml:
     func_name: CNetworkSerializerBindingBuildFilter_GetFieldPriority
     func_rva: '0x2134f10'
@@ -40405,6 +40409,18 @@ files:
     vfunc_index: 3
     vfunc_offset: '0x18'
     vtable_name: ILoopMode
+  server/INetworkGameServer_GetClientConnectionType.linux.yaml:
+    func_name: INetworkGameServer_GetClientConnectionType
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vfunc_sig: 4C 8B A8 B8 01 00 00 E8 ?? ?? ?? ?? 48 89 DF
+    vtable_name: INetworkGameServer
+  server/INetworkGameServer_GetClientConnectionType.windows.yaml:
+    func_name: INetworkGameServer_GetClientConnectionType
+    vfunc_index: 55
+    vfunc_offset: '0x1b8'
+    vfunc_sig: 48 8B B2 B8 01 00 00
+    vtable_name: INetworkGameServer
   server/INetworkGameServer_IsBackgroundMap.linux.yaml:
     func_name: INetworkGameServer_IsBackgroundMap
     vfunc_index: 27
@@ -42615,5 +42631,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T12:12:13Z'
+last_publish_time: '2026-08-06T12:39:14Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CBasePlayerController_IsFakeClient.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_IsFakeClient.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_IsFakeClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_IsFakeClient",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CBasePlayerController_IsFakeClient",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CPlayerCommandQueue_ctor.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_call"],
+        "dependency_policy": {
+            "CPlayerCommandQueue_ctor.{platform}.yaml": "required",
+        },
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_IsFakeClient",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClientConnectionType.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClientConnectionType.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetClientConnectionType skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetClientConnectionType",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_GetClientConnectionType",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CBasePlayerController_IsFakeClient.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CBasePlayerController_IsFakeClient.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetClientConnectionType", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_GetClientConnectionType",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClientConnectionType.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetClientConnectionType.py
@@ -3,27 +3,15 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_GetClientConnectionType",
-]
 
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CNetworkGameServerBase_GetClientConnectionType",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/server/CBasePlayerController_IsFakeClient.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CBasePlayerController_IsFakeClient.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class)
-    ("CNetworkGameServerBase_GetClientConnectionType", "CNetworkGameServer_vtable"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkGameServerBase_GetClientConnectionType",
+        "CNetworkGameServerBase",
+        "../server/INetworkGameServer_GetClientConnectionType",
+        False,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -32,10 +20,12 @@ GENERATE_YAML_DESIRED_FIELDS = [
         "CNetworkGameServerBase_GetClientConnectionType",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -49,10 +39,11 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    """Resolve the inherited interface slot without generating a func_sig."""
+    _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -60,10 +51,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-INetworkGameServer_GetClientConnectionType.py
+++ b/ida_preprocessor_scripts/find-INetworkGameServer_GetClientConnectionType.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-INetworkGameServer_GetClientConnectionType skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "INetworkGameServer_GetClientConnectionType",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "INetworkGameServer_GetClientConnectionType",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/server/CBasePlayerController_IsFakeClient.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CBasePlayerController_IsFakeClient.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("INetworkGameServer_GetClientConnectionType", "INetworkGameServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "INetworkGameServer_GetClientConnectionType",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Resolve the abstract INetworkGameServer vfunc slot from its caller."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.linux.yaml
@@ -1,0 +1,46 @@
+func_name: CBasePlayerController_IsFakeClient
+func_va: '0x15e0ce0'
+disasm_code: |-
+  .text:00000000015E0CE0                 push    rbp
+  .text:00000000015E0CE1                 mov     rbp, rsp
+  .text:00000000015E0CE4                 push    r13
+  .text:00000000015E0CE6                 push    r12
+  .text:00000000015E0CE8                 mov     r12, rdi
+  .text:00000000015E0CEB                 push    rbx
+  .text:00000000015E0CEC                 sub     rsp, 8
+  .text:00000000015E0CF0                 lea     rax, g_pNetworkServerService
+  .text:00000000015E0CF7                 mov     rdi, [rax]
+  .text:00000000015E0CFA                 mov     rax, [rdi]
+  .text:00000000015E0CFD                 call    qword ptr [rax+0C0h]
+  .text:00000000015E0D03                 mov     rdi, r12
+  .text:00000000015E0D06                 mov     rbx, rax
+  .text:00000000015E0D09                 mov     rax, [rax]
+  .text:00000000015E0D0C                 ; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:00000000015E0D0C                 mov     r13, [rax+1B8h]; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:00000000015E0D13                 call    sub_2109F30
+  .text:00000000015E0D18                 mov     rdi, rbx
+  .text:00000000015E0D1B                 mov     esi, eax
+  .text:00000000015E0D1D                 xor     eax, eax
+  .text:00000000015E0D1F                 cmp     esi, 0FFFFFFFFh
+  .text:00000000015E0D22                 setnz   al
+  .text:00000000015E0D25                 sub     esi, eax
+  .text:00000000015E0D27                 call    r13
+  .text:00000000015E0D2A                 add     rsp, 8
+  .text:00000000015E0D2E                 pop     rbx
+  .text:00000000015E0D2F                 and     eax, 1
+  .text:00000000015E0D32                 pop     r12
+  .text:00000000015E0D34                 pop     r13
+  .text:00000000015E0D36                 pop     rbp
+  .text:00000000015E0D37                 retn
+procedure: |-
+  __int64 __fastcall CBasePlayerController_IsFakeClient(__int64 a1)
+  {
+    __int64 v1; // rbx
+    __int64 (__fastcall *v2)(__int64, _QWORD); // r13
+    int v3; // eax
+
+    v1 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 192LL))(g_pNetworkServerService);
+    v2 = *(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)v1 + 440LL);// 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+    v3 = sub_2109F30(a1);
+    return v2(v1, v3 - (unsigned int)(v3 != -1)) & 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.linux.yaml
@@ -15,8 +15,8 @@ disasm_code: |-
   .text:00000000015E0D03                 mov     rdi, r12
   .text:00000000015E0D06                 mov     rbx, rax
   .text:00000000015E0D09                 mov     rax, [rax]
-  .text:00000000015E0D0C                 ; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
-  .text:00000000015E0D0C                 mov     r13, [rax+1B8h]; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:00000000015E0D0C                 ; 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
+  .text:00000000015E0D0C                 mov     r13, [rax+1B8h]; 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
   .text:00000000015E0D13                 call    sub_2109F30
   .text:00000000015E0D18                 mov     rdi, rbx
   .text:00000000015E0D1B                 mov     esi, eax
@@ -40,7 +40,7 @@ procedure: |-
     int v3; // eax
 
     v1 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkServerService + 192LL))(g_pNetworkServerService);
-    v2 = *(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)v1 + 440LL);// 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+    v2 = *(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)v1 + 440LL);// 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
     v3 = sub_2109F30(a1);
     return v2(v1, v3 - (unsigned int)(v3 != -1)) & 1;
   }

--- a/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.windows.yaml
@@ -12,8 +12,8 @@ disasm_code: |-
   .text:0000000180AF97B2                 mov     rcx, rbx
   .text:0000000180AF97B5                 mov     rdi, rax
   .text:0000000180AF97B8                 mov     rdx, [rax]
-  .text:0000000180AF97BB                 ; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
-  .text:0000000180AF97BB                 mov     rsi, [rdx+1B8h]; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:0000000180AF97BB                 ; 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
+  .text:0000000180AF97BB                 mov     rsi, [rdx+1B8h]; 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
   .text:0000000180AF97C2                 lea     rdx, [rsp+28h+arg_8]
   .text:0000000180AF97C7                 call    sub_1812436E0
   .text:0000000180AF97CC                 mov     ecx, [rsp+28h+arg_8]
@@ -38,7 +38,7 @@ procedure: |-
     int v6; // [rsp+38h] [rbp+10h] BYREF
 
     v2 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkServerService + 184LL))(g_pNetworkServerService);
-    v3 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v2 + 440LL);// 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+    v3 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v2 + 440LL);// 0x1B8 = 440LL = INetworkGameServer_GetClientConnectionType
     sub_1812436E0(a1, &v6);
     v4 = (unsigned int)(v6 - 1);
     if ( v6 == -1 )

--- a/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CBasePlayerController_IsFakeClient.windows.yaml
@@ -1,0 +1,47 @@
+func_name: CBasePlayerController_IsFakeClient
+func_va: '0x180af9790'
+disasm_code: |-
+  .text:0000000180AF9790                 mov     [rsp+arg_0], rbx
+  .text:0000000180AF9795                 mov     [rsp+arg_10], rsi
+  .text:0000000180AF979A                 push    rdi
+  .text:0000000180AF979B                 sub     rsp, 20h
+  .text:0000000180AF979F                 mov     rbx, rcx
+  .text:0000000180AF97A2                 mov     rcx, cs:g_pNetworkServerService
+  .text:0000000180AF97A9                 mov     rax, [rcx]
+  .text:0000000180AF97AC                 call    qword ptr [rax+0B8h]
+  .text:0000000180AF97B2                 mov     rcx, rbx
+  .text:0000000180AF97B5                 mov     rdi, rax
+  .text:0000000180AF97B8                 mov     rdx, [rax]
+  .text:0000000180AF97BB                 ; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:0000000180AF97BB                 mov     rsi, [rdx+1B8h]; 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+  .text:0000000180AF97C2                 lea     rdx, [rsp+28h+arg_8]
+  .text:0000000180AF97C7                 call    sub_1812436E0
+  .text:0000000180AF97CC                 mov     ecx, [rsp+28h+arg_8]
+  .text:0000000180AF97D0                 lea     edx, [rcx-1]
+  .text:0000000180AF97D3                 cmp     ecx, 0FFFFFFFFh
+  .text:0000000180AF97D6                 jnz     short loc_180AF97DD
+  .text:0000000180AF97D8                 mov     edx, 0FFFFFFFFh
+  .text:0000000180AF97DD                 mov     rcx, rdi
+  .text:0000000180AF97E0                 call    rsi
+  .text:0000000180AF97E2                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180AF97E7                 and     al, 1
+  .text:0000000180AF97E9                 mov     rsi, [rsp+28h+arg_10]
+  .text:0000000180AF97EE                 add     rsp, 20h
+  .text:0000000180AF97F2                 pop     rdi
+  .text:0000000180AF97F3                 retn
+procedure: |-
+  char __fastcall sub_180AF9790(__int64 a1)
+  {
+    __int64 v2; // rdi
+    __int64 (__fastcall *v3)(__int64, __int64); // rsi
+    __int64 v4; // rdx
+    int v6; // [rsp+38h] [rbp+10h] BYREF
+
+    v2 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkServerService + 184LL))(g_pNetworkServerService);
+    v3 = *(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v2 + 440LL);// 0x1B8 = 440LL = CNetworkGameServerBase_GetClientConnectionType
+    sub_1812436E0(a1, &v6);
+    v4 = (unsigned int)(v6 - 1);
+    if ( v6 == -1 )
+      v4 = 0xFFFFFFFFLL;
+    return v3(v2, v4) & 1;
+  }

--- a/ida_preprocessor_scripts/references/server/CPlayerCommandQueue_ctor.linux.yaml
+++ b/ida_preprocessor_scripts/references/server/CPlayerCommandQueue_ctor.linux.yaml
@@ -1,0 +1,122 @@
+func_name: CPlayerCommandQueue_ctor
+func_va: '0x199e1c0'
+disasm_code: |-
+  .text:000000000199E1C0                 push    rbp
+  .text:000000000199E1C1                 mov     rbp, rsp
+  .text:000000000199E1C4                 push    r12
+  .text:000000000199E1C6                 mov     r12, rdi
+  .text:000000000199E1C9                 mov     edi, 268h
+  .text:000000000199E1CE                 push    rbx
+  .text:000000000199E1CF                 call    sub_9E5E60
+  .text:000000000199E1D4                 mov     ecx, 28h ; '('
+  .text:000000000199E1D9                 pxor    xmm0, xmm0
+  .text:000000000199E1DD                 xor     edx, edx
+  .text:000000000199E1DF                 mov     rbx, rax
+  .text:000000000199E1E2                 xor     esi, esi
+  .text:000000000199E1E4                 lea     rax, CPlayerCommandQueue_vtable
+  .text:000000000199E1EB                 mov     [rbx+8], r12
+  .text:000000000199E1EF                 mov     [rbx], rax
+  .text:000000000199E1F2                 lea     rdi, [rbx+10h]
+  .text:000000000199E1F6                 xor     eax, eax
+  .text:000000000199E1F8                 rep stosq
+  .text:000000000199E1FB                 mov     rax, cs:qword_8CE280
+  .text:000000000199E202                 movups  xmmword ptr [rbx+158h], xmm0
+  .text:000000000199E209                 lea     rdi, [rbx+1D8h]
+  .text:000000000199E210                 movdqa  xmm0, cs:xmmword_8CC510
+  .text:000000000199E218                 mov     byte ptr [rbx+16Ch], 0
+  .text:000000000199E21F                 mov     qword ptr [rbx+150h], 0
+  .text:000000000199E22A                 movups  xmmword ptr [rbx+1A8h], xmm0
+  .text:000000000199E231                 mov     [rbx+190h], rax
+  .text:000000000199E238                 lea     rax, _ZTV12CUserCmdBase; `vtable for'CUserCmdBase
+  .text:000000000199E23F                 mov     dword ptr [rbx+168h], 0
+  .text:000000000199E249                 mov     dword ptr [rbx+170h], 7FFFFFFFh
+  .text:000000000199E253                 mov     byte ptr [rbx+174h], 0
+  .text:000000000199E25A                 mov     dword ptr [rbx+178h], 0
+  .text:000000000199E264                 add     rax, 10h
+  .text:000000000199E268                 mov     [rbx+1C8h], rax
+  .text:000000000199E26F                 mov     qword ptr [rbx+180h], 0
+  .text:000000000199E27A                 mov     qword ptr [rbx+188h], 0
+  .text:000000000199E285                 mov     qword ptr [rbx+198h], 0
+  .text:000000000199E290                 mov     qword ptr [rbx+1A0h], 0
+  .text:000000000199E29B                 mov     qword ptr [rbx+1B8h], 0
+  .text:000000000199E2A6                 mov     dword ptr [rbx+1C0h], 0
+  .text:000000000199E2B0                 mov     dword ptr [rbx+1D0h], 0
+  .text:000000000199E2BA                 call    sub_13EAC20
+  .text:000000000199E2BF                 lea     rax, off_2387988
+  .text:000000000199E2C6                 mov     [rbx+1C8h], rax
+  .text:000000000199E2CD                 add     rax, 58h ; 'X'
+  .text:000000000199E2D1                 mov     [rbx+1D8h], rax
+  .text:000000000199E2D8                 lea     rdi, [rbx+220h]
+  .text:000000000199E2DF                 call    sub_1057430
+  .text:000000000199E2E4                 lea     rax, off_2387A80
+  .text:000000000199E2EB                 pxor    xmm0, xmm0
+  .text:000000000199E2EF                 mov     qword ptr [rbx+258h], 0
+  .text:000000000199E2FA                 mov     [rbx+1C8h], rax
+  .text:000000000199E301                 add     rax, 58h ; 'X'
+  .text:000000000199E305                 mov     [rbx+1D8h], rax
+  .text:000000000199E30C                 mov     eax, 0FFFFFFFFh
+  .text:000000000199E311                 mov     [rbx+240h], rax
+  .text:000000000199E318                 mov     eax, 1
+  .text:000000000199E31D                 movups  xmmword ptr [rbx+248h], xmm0
+  .text:000000000199E324                 mov     qword ptr [rbx+260h], 0
+  .text:000000000199E32F                 test    byte ptr [r12+669h], 1
+  .text:000000000199E338                 jz      short loc_199E350
+  .text:000000000199E33A                 mov     [rbx+174h], al
+  .text:000000000199E340                 mov     rax, rbx
+  .text:000000000199E343                 pop     rbx
+  .text:000000000199E344                 pop     r12
+  .text:000000000199E346                 pop     rbp
+  .text:000000000199E347                 retn
+  .text:000000000199E350                 mov     rdi, r12
+  .text:000000000199E353                 ; CBasePlayerController_IsFakeClient
+  .text:000000000199E353                 call    sub_15E0CE0; CBasePlayerController_IsFakeClient
+  .text:000000000199E358                 mov     [rbx+174h], al
+  .text:000000000199E35E                 mov     rax, rbx
+  .text:000000000199E361                 pop     rbx
+  .text:000000000199E362                 pop     r12
+  .text:000000000199E364                 pop     rbp
+  .text:000000000199E365                 retn
+procedure: |-
+  __int64 __fastcall CPlayerCommandQueue_ctor(__int64 a1)
+  {
+    __int64 v1; // rbx
+    __m128i si128; // xmm0
+
+    v1 = sub_9E5E60(616);
+    *(_QWORD *)(v1 + 8) = a1;
+    *(_QWORD *)v1 = CPlayerCommandQueue_vtable;
+    memset((void *)(v1 + 16), 0, 0x140u);
+    *(_OWORD *)(v1 + 344) = 0;
+    si128 = _mm_load_si128((const __m128i *)&xmmword_8CC510);
+    *(_BYTE *)(v1 + 364) = 0;
+    *(_QWORD *)(v1 + 336) = 0;
+    *(__m128i *)(v1 + 424) = si128;
+    *(_QWORD *)(v1 + 400) = 0xFFFFFFFFFFFFLL;
+    *(_DWORD *)(v1 + 360) = 0;
+    *(_DWORD *)(v1 + 368) = 0x7FFFFFFF;
+    *(_BYTE *)(v1 + 372) = 0;
+    *(_DWORD *)(v1 + 376) = 0;
+    *(_QWORD *)(v1 + 456) = &unk_24AE288;
+    *(_QWORD *)(v1 + 384) = 0;
+    *(_QWORD *)(v1 + 392) = 0;
+    *(_QWORD *)(v1 + 408) = 0;
+    *(_QWORD *)(v1 + 416) = 0;
+    *(_QWORD *)(v1 + 440) = 0;
+    *(_DWORD *)(v1 + 448) = 0;
+    *(_DWORD *)(v1 + 464) = 0;
+    sub_13EAC20(v1 + 472, 0, 0);
+    *(_QWORD *)(v1 + 456) = off_2387988;
+    *(_QWORD *)(v1 + 472) = off_23879E0;
+    sub_1057430(v1 + 544);
+    *(_QWORD *)(v1 + 600) = 0;
+    *(_QWORD *)(v1 + 456) = off_2387A80;
+    *(_QWORD *)(v1 + 472) = off_2387AD8;
+    *(_QWORD *)(v1 + 576) = 0xFFFFFFFFLL;
+    *(_OWORD *)(v1 + 584) = 0;
+    *(_QWORD *)(v1 + 608) = 0;
+    if ( (*(_BYTE *)(a1 + 1641) & 1) != 0 )
+      *(_BYTE *)(v1 + 372) = 1;
+    else
+      *(_BYTE *)(v1 + 372) = sub_15E0CE0(a1);// CBasePlayerController_IsFakeClient
+    return v1;
+  }

--- a/ida_preprocessor_scripts/references/server/CPlayerCommandQueue_ctor.windows.yaml
+++ b/ida_preprocessor_scripts/references/server/CPlayerCommandQueue_ctor.windows.yaml
@@ -1,0 +1,164 @@
+func_name: CPlayerCommandQueue_ctor
+func_va: '0x180dacef0'
+disasm_code: |-
+  .text:0000000180DACEF0                 mov     [rsp+arg_8], rbp
+  .text:0000000180DACEF5                 mov     [rsp+arg_10], rsi
+  .text:0000000180DACEFA                 push    rdi
+  .text:0000000180DACEFB                 sub     rsp, 20h
+  .text:0000000180DACEFF                 mov     rbp, rcx
+  .text:0000000180DACF02                 mov     ecx, 270h
+  .text:0000000180DACF07                 call    sub_180EACC70
+  .text:0000000180DACF0C                 mov     rsi, rax
+  .text:0000000180DACF0F                 test    rax, rax
+  .text:0000000180DACF12                 jz      loc_180DAD0BF
+  .text:0000000180DACF18                 lea     rax, CPlayerCommandQueue_vtable
+  .text:0000000180DACF1F                 mov     [rsp+28h+arg_0], rbx
+  .text:0000000180DACF24                 mov     [rsi], rax
+  .text:0000000180DACF27                 lea     rbx, [rsi+10h]
+  .text:0000000180DACF2B                 mov     [rsi+8], rbp
+  .text:0000000180DACF2F                 mov     edi, 14h
+  .text:0000000180DACF34                 mov     rcx, rbx
+  .text:0000000180DACF37                 call    unknown_libname_287; Microsoft VisualC v7/14 64bit runtime
+  .text:0000000180DACF3C                 add     rbx, 10h
+  .text:0000000180DACF40                 sub     rdi, 1
+  .text:0000000180DACF44                 jnz     short loc_180DACF34
+  .text:0000000180DACF46                 mov     [rsi+150h], rdi
+  .text:0000000180DACF4D                 lea     rax, ??_7CUserCmdBase@@6B@; const CUserCmdBase::`vftable'
+  .text:0000000180DACF54                 mov     [rsi+158h], rdi
+  .text:0000000180DACF5B                 lea     rcx, [rsi+1D8h]
+  .text:0000000180DACF62                 mov     [rsi+160h], rdi
+  .text:0000000180DACF69                 xor     r8d, r8d
+  .text:0000000180DACF6C                 mov     [rsi+168h], edi
+  .text:0000000180DACF72                 xor     edx, edx
+  .text:0000000180DACF74                 mov     [rsi+16Ch], dil
+  .text:0000000180DACF7B                 mov     dword ptr [rsi+170h], 7FFFFFFFh
+  .text:0000000180DACF85                 mov     [rsi+174h], dil
+  .text:0000000180DACF8C                 mov     [rsi+178h], edi
+  .text:0000000180DACF92                 mov     [rsi+180h], edi
+  .text:0000000180DACF98                 mov     [rsi+188h], rdi
+  .text:0000000180DACF9F                 mov     dword ptr [rsi+190h], 0FFFFFFFFh
+  .text:0000000180DACFA9                 mov     qword ptr [rsi+194h], 0FFFFh
+  .text:0000000180DACFB4                 mov     [rsi+19Ch], edi
+  .text:0000000180DACFBA                 mov     [rsi+1A0h], rdi
+  .text:0000000180DACFC1                 mov     qword ptr [rsi+1A8h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000180DACFCC                 mov     dword ptr [rsi+1B0h], 0FFFFFFFFh
+  .text:0000000180DACFD6                 mov     [rsi+1B4h], edi
+  .text:0000000180DACFDC                 mov     [rsi+1B8h], rdi
+  .text:0000000180DACFE3                 mov     [rsi+1C0h], edi
+  .text:0000000180DACFE9                 mov     [rsi+1C8h], rax
+  .text:0000000180DACFF0                 mov     [rsi+1D0h], edi
+  .text:0000000180DACFF6                 call    sub_180943680
+  .text:0000000180DACFFB                 lea     rax, ??_7?$CUserCmdBaseHost@VCSGOUserCmdPB@@@@6B@; const CUserCmdBaseHost<CSGOUserCmdPB>::`vftable'
+  .text:0000000180DAD002                 mov     [rsi+1C8h], rax
+  .text:0000000180DAD009                 lea     rcx, [rsi+220h]
+  .text:0000000180DAD010                 lea     rax, ??_7?$CUserCmdBaseHost@VCSGOUserCmdPB@@@@6B@_0; const CUserCmdBaseHost<CSGOUserCmdPB>::`vftable'
+  .text:0000000180DAD017                 mov     [rsi+1D8h], rax
+  .text:0000000180DAD01E                 call    sub_180658CA0
+  .text:0000000180DAD023                 mov     rbx, [rsp+28h+arg_0]
+  .text:0000000180DAD028                 lea     rax, ??_7CUserCmd@@6B@; const CUserCmd::`vftable'
+  .text:0000000180DAD02F                 mov     [rsi+1C8h], rax
+  .text:0000000180DAD036                 lea     rax, ??_7CUserCmd@@6B@_0; const CUserCmd::`vftable'
+  .text:0000000180DAD03D                 mov     [rsi+1D8h], rax
+  .text:0000000180DAD044                 xor     eax, eax
+  .text:0000000180DAD046                 mov     dword ptr [rsi+240h], 0FFFFFFFFh
+  .text:0000000180DAD050                 mov     [rsi+248h], edi
+  .text:0000000180DAD056                 mov     [rsi+250h], rdi
+  .text:0000000180DAD05D                 mov     [rsi+258h], rdi
+  .text:0000000180DAD064                 mov     [rsi+260h], rax
+  .text:0000000180DAD06B                 mov     [rsi+268h], rdi
+  .text:0000000180DAD072                 mov     eax, [rbp+388h]
+  .text:0000000180DAD078                 shr     eax, 8
+  .text:0000000180DAD07B                 test    al, 1
+  .text:0000000180DAD07D                 jnz     short loc_180DAD0A4
+  .text:0000000180DAD07F                 mov     rcx, rbp
+  .text:0000000180DAD082                 ; CBasePlayerController_IsFakeClient
+  .text:0000000180DAD082                 call    sub_180AF9790; CBasePlayerController_IsFakeClient
+  .text:0000000180DAD087                 test    al, al
+  .text:0000000180DAD089                 jnz     short loc_180DAD0A4
+  .text:0000000180DAD08B                 mov     [rsi+174h], al
+  .text:0000000180DAD091                 mov     rax, rsi
+  .text:0000000180DAD094                 mov     rbp, [rsp+28h+arg_8]
+  .text:0000000180DAD099                 mov     rsi, [rsp+28h+arg_10]
+  .text:0000000180DAD09E                 add     rsp, 20h
+  .text:0000000180DAD0A2                 pop     rdi
+  .text:0000000180DAD0A3                 retn
+  .text:0000000180DAD0A4                 mov     al, 1
+  .text:0000000180DAD0A6                 mov     [rsi+174h], al
+  .text:0000000180DAD0AC                 mov     rax, rsi
+  .text:0000000180DAD0AF                 mov     rbp, [rsp+28h+arg_8]
+  .text:0000000180DAD0B4                 mov     rsi, [rsp+28h+arg_10]
+  .text:0000000180DAD0B9                 add     rsp, 20h
+  .text:0000000180DAD0BD                 pop     rdi
+  .text:0000000180DAD0BE                 retn
+  .text:0000000180DAD0BF                 mov     rbp, [rsp+28h+arg_8]
+  .text:0000000180DAD0C4                 xor     edi, edi
+  .text:0000000180DAD0C6                 mov     rsi, [rsp+28h+arg_10]
+  .text:0000000180DAD0CB                 mov     eax, edi
+  .text:0000000180DAD0CD                 add     rsp, 20h
+  .text:0000000180DAD0D1                 pop     rdi
+  .text:0000000180DAD0D2                 retn
+procedure: |-
+  __int64 __fastcall CPlayerCommandQueue_ctor(__int64 a1)
+  {
+    __int64 v2; // rsi
+    __int64 v3; // rbx
+    __int64 v4; // rdi
+
+    v2 = sub_180EACC70(624);
+    if ( !v2 )
+      return 0;
+    *(_QWORD *)v2 = &CPlayerCommandQueue_vtable;
+    v3 = v2 + 16;
+    *(_QWORD *)(v2 + 8) = a1;
+    v4 = 20;
+    do
+    {
+      unknown_libname_287(v3);
+      v3 += 16;
+      --v4;
+    }
+    while ( v4 );
+    *(_QWORD *)(v2 + 336) = 0;
+    *(_QWORD *)(v2 + 344) = 0;
+    *(_QWORD *)(v2 + 352) = 0;
+    *(_DWORD *)(v2 + 360) = 0;
+    *(_BYTE *)(v2 + 364) = 0;
+    *(_DWORD *)(v2 + 368) = 0x7FFFFFFF;
+    *(_BYTE *)(v2 + 372) = 0;
+    *(_DWORD *)(v2 + 376) = 0;
+    *(_DWORD *)(v2 + 384) = 0;
+    *(_QWORD *)(v2 + 392) = 0;
+    *(_DWORD *)(v2 + 400) = -1;
+    *(_QWORD *)(v2 + 404) = 0xFFFF;
+    *(_DWORD *)(v2 + 412) = 0;
+    *(_QWORD *)(v2 + 416) = 0;
+    *(_QWORD *)(v2 + 424) = -1;
+    *(_DWORD *)(v2 + 432) = -1;
+    *(_DWORD *)(v2 + 436) = 0;
+    *(_QWORD *)(v2 + 440) = 0;
+    *(_DWORD *)(v2 + 448) = 0;
+    *(_QWORD *)(v2 + 456) = &CUserCmdBase::`vftable';
+    *(_DWORD *)(v2 + 464) = 0;
+    sub_180943680(v2 + 472, 0, 0);
+    *(_QWORD *)(v2 + 456) = &CUserCmdBaseHost<CSGOUserCmdPB>::`vftable';
+    *(_QWORD *)(v2 + 472) = &CUserCmdBaseHost<CSGOUserCmdPB>::`vftable';
+    sub_180658CA0(v2 + 544);
+    *(_QWORD *)(v2 + 456) = &CUserCmd::`vftable';
+    *(_QWORD *)(v2 + 472) = &CUserCmd::`vftable';
+    *(_DWORD *)(v2 + 576) = -1;
+    *(_DWORD *)(v2 + 584) = 0;
+    *(_QWORD *)(v2 + 592) = 0;
+    *(_QWORD *)(v2 + 600) = 0;
+    *(_QWORD *)(v2 + 608) = 0;
+    *(_QWORD *)(v2 + 616) = 0;
+    if ( (*(_DWORD *)(a1 + 904) & 0x100) != 0 || (unsigned __int8)sub_180AF9790(a1) )// CBasePlayerController_IsFakeClient
+    {
+      *(_BYTE *)(v2 + 372) = 1;
+      return v2;
+    }
+    else
+    {
+      *(_BYTE *)(v2 + 372) = 0;
+      return v2;
+    }
+  }


### PR DESCRIPTION
## Summary
- Add a Pattern D finder for `CBasePlayerController_IsFakeClient` (server module), located by decompiling its predecessor `CPlayerCommandQueue_ctor` and resolving the direct call.
- Add a slim Pattern C finder for `CNetworkGameServerBase_GetClientConnectionType` (vfunc on `CNetworkGameServer_vtable`), resolved from the devirtualized call site inside `CBasePlayerController_IsFakeClient` (vfunc_offset 0x1B8 = index 55).
- Wire both symbols and skills into `configs/14174.yaml` and add the supporting reference YAMLs (windows + linux).

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (compile 0, invalid 0, layout diffs 0, vtable diffs 0, record diffs 0)
- candidate publication: passed; published SHA-256 matches the validated candidate (`a79fd25e48961fe20211713218fc10e23e3bcabab9700ede1af42c04108e153e`)