### PR TITLE
feat(engine): add CNetworkGameServerBase::CreateNewClient signature

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -779,6 +779,14 @@ modules:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
+      - name: find-CNetworkGameServer_GetFreeClientCreatePath
+        expected_output:
+          - CNetworkGameServer_GetFreeClientCreatePath.{platform}.yaml
+      - name: find-CNetworkGameServerBase_CreateNewClient
+        expected_output:
+          - CNetworkGameServerBase_CreateNewClient.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_GetFreeClientCreatePath.{platform}.yaml
       - name: find-CNetworkGameServerBase_CreateFakeClient
         expected_output:
           - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
@@ -2250,6 +2258,15 @@ modules:
         alias:
           - CNetworkGameServer::GetFreeClient
           - GetFreeClient
+      - name: CNetworkGameServer_GetFreeClientCreatePath
+        category: func
+        alias:
+          - CNetworkGameServer::GetFreeClientCreatePath
+      - name: CNetworkGameServerBase_CreateNewClient
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::CreateNewClient
+          - CreateNewClient
       - name: CNetworkGameServerBase_CreateFakeClient
         category: func
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:248849daca67fe4580ab9f1b360746fc30656f09b9ee916bb7da0bcc037c26d4
-file_count: 3275
+config_sha256: sha256:4d95e302a120f872eef813bc4fd043cf6b94209da1f45f4b526e8978a72ebdd9
+file_count: 3279
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10574,6 +10574,18 @@ files:
     func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 54 41 55 41 57 48 8B EC 48 83 EC ?? 48 8B FA
     func_size: '0x24d'
     func_va: '0x1800ae8f0'
+  engine/CNetworkGameServerBase_CreateNewClient.linux.yaml:
+    func_name: CNetworkGameServerBase_CreateNewClient
+    vfunc_index: 84
+    vfunc_offset: '0x2a0'
+    vfunc_sig: FF 90 A0 02 00 00 49 89 C5 48 8B 45 ?? F3 0F 6F 08 41 0F 11 8D ?? ?? ?? ?? F3 0F 6F 40 ?? 41 0F 11 8D ?? ?? ?? ?? 41 0F 11 85 ?? ?? ?? ?? 41 0F 11 85 ?? ?? ?? ?? 49 63 9E ?? ?? ?? ?? 41 3B 9E ?? ?? ?? ??
+    vtable_name: CNetworkGameServer
+  engine/CNetworkGameServerBase_CreateNewClient.windows.yaml:
+    func_name: CNetworkGameServerBase_CreateNewClient
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vfunc_sig: FF 90 78 02 00 00 41 0F 10 06 48 8B F8
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillKV3ServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillKV3ServerInfo
     func_rva: '0x4fce40'
@@ -11379,6 +11391,18 @@ files:
   engine/CNetworkGameServer_GetFreeClient.windows.yaml:
     func_name: CNetworkGameServer_GetFreeClient
     func_rva: '0xae560'
+    func_size: '0x38c'
+    func_va: '0x1800ae560'
+  engine/CNetworkGameServer_GetFreeClientCreatePath.linux.yaml:
+    func_name: CNetworkGameServer_GetFreeClientCreatePath
+    func_rva: '0x503940'
+    func_sig: 55 48 89 E5 41 57 41 56 49 89 FE 41 55 41 54 53 48 83 EC ?? 8B 87 ?? ?? ?? ??
+    func_size: '0x456'
+    func_va: '0x503940'
+  engine/CNetworkGameServer_GetFreeClientCreatePath.windows.yaml:
+    func_name: CNetworkGameServer_GetFreeClientCreatePath
+    func_rva: '0xae560'
+    func_sig: 48 89 54 24 ?? 53 56 57 41 56 48 83 EC ??
     func_size: '0x38c'
     func_va: '0x1800ae560'
   engine/CNetworkGameServer_GetPlayerNetworkIDString.linux.yaml:
@@ -42325,5 +42349,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-05T09:10:50Z'
+last_publish_time: '2026-08-05T19:16:35Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_CreateNewClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_CreateNewClient.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_CreateNewClient skill.
+
+CNetworkGameServerBase::CreateNewClient is a virtual function with no
+identifying debug string of its own. It is located as the virtual call made on
+`this` inside CNetworkGameServer::GetFreeClient's create path
+(CNetworkGameServer_GetFreeClientCreatePath): the call whose result is
+initialized with the client-slot netadr fields (offsets +204/+220/+236/+252).
+Windows resolves to CNetworkGameServer vtable offset 0x278 (index 79); Linux to
+offset 0x2A0 (index 84).
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_CreateNewClient",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_CreateNewClient",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServer_GetFreeClientCreatePath.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServer_GetFreeClientCreatePath.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_CreateNewClient", "CNetworkGameServer"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_CreateNewClient",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate the CreateNewClient virtual call inside the GetFreeClient create path."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_GetFreeClientCreatePath.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_GetFreeClientCreatePath.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_GetFreeClientCreatePath skill.
+
+This is the "create a new client" branch of CNetworkGameServer::GetFreeClient.
+On Windows the whole find-or-create logic lives in a single function
+(the same body as CNetworkGameServer_GetFreeClient), while on Linux the
+compiler split the create path into its own function. Both bodies uniquely
+reference the debug string "Kicked to free up slot" and call
+CNetworkGameServerBase::CreateNewClient on `this`, so this function serves as
+the predecessor for locating that virtual call.
+"""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_GetFreeClientCreatePath",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_GetFreeClientCreatePath",
+        "xref_strings": ["Kicked to free up slot"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServer_GetFreeClientCreatePath",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the GetFreeClient create path via its unique debug string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_GetFreeClientCreatePath.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_GetFreeClientCreatePath.linux.yaml
@@ -1,0 +1,410 @@
+func_name: CNetworkGameServer_GetFreeClientCreatePath
+func_va: '0x503940'
+disasm_code: |-
+  .text:0000000000503940                 push    rbp
+  .text:0000000000503941                 mov     rbp, rsp
+  .text:0000000000503944                 push    r15
+  .text:0000000000503946                 push    r14
+  .text:0000000000503948                 mov     r14, rdi
+  .text:000000000050394B                 push    r13
+  .text:000000000050394D                 push    r12
+  .text:000000000050394F                 push    rbx
+  .text:0000000000503950                 sub     rsp, 28h
+  .text:0000000000503954                 mov     eax, [rdi+248h]
+  .text:000000000050395A                 mov     [rbp+var_48], rsi
+  .text:000000000050395E                 mov     [rbp+var_4C], edx
+  .text:0000000000503961                 mov     [rbp+var_3C], eax
+  .text:0000000000503964                 lea     rax, qword_9E2328
+  .text:000000000050396B                 mov     rdi, [rax]
+  .text:000000000050396E                 mov     rax, [rdi]
+  .text:0000000000503971                 call    qword ptr [rax+0D0h]
+  .text:0000000000503977                 test    al, al
+  .text:0000000000503979                 jz      short loc_50398B
+  .text:000000000050397B                 mov     eax, [rbp+var_3C]
+  .text:000000000050397E                 cmp     eax, [r14+29Ch]
+  .text:0000000000503985                 jl      loc_503C60
+  .text:000000000050398B                 mov     r8d, [rbp+var_3C]
+  .text:000000000050398F                 test    r8d, r8d
+  .text:0000000000503992                 jle     loc_503AB8
+  .text:0000000000503998                 movsxd  r12, [rbp+var_3C]
+  .text:000000000050399C                 xor     r15d, r15d
+  .text:000000000050399F                 xor     r13d, r13d
+  .text:00000000005039A2                 mov     [rbp+var_40], 0FFFFFFFFh
+  .text:00000000005039A9                 lea     rbx, sub_4F0CC0
+  .text:00000000005039B0                 lea     rax, ds:0[r12*8]
+  .text:00000000005039B8                 mov     [rbp+var_38], rax
+  .text:00000000005039BC                 nop     dword ptr [rax+00h]
+  .text:00000000005039C0                 mov     rax, [r14+250h]
+  .text:00000000005039C7                 mov     r12, [rax+r15]
+  .text:00000000005039CB                 mov     rax, [r12]
+  .text:00000000005039CF                 mov     rax, [rax+98h]
+  .text:00000000005039D6                 cmp     rax, rbx
+  .text:00000000005039D9                 jnz     loc_503A98
+  .text:00000000005039DF                 movzx   eax, byte ptr [r12+0A0h]
+  .text:00000000005039E8                 test    al, al
+  .text:00000000005039EA                 jnz     short loc_503A40
+  .text:00000000005039EC                 mov     rdi, r12
+  .text:00000000005039EF                 call    sub_523F90
+  .text:00000000005039F4                 test    al, al
+  .text:00000000005039F6                 jnz     short loc_503A40
+  .text:00000000005039F8                 mov     eax, [r12+0E8h]
+  .text:0000000000503A00                 cmp     eax, 3
+  .text:0000000000503A03                 ja      loc_503AA8
+  .text:0000000000503A09                 test    eax, eax
+  .text:0000000000503A0B                 jnz     loc_503BF0
+  .text:0000000000503A11                 lea     rdi, [r12+0CCh]
+  .text:0000000000503A19                 call    sub_2C9540
+  .text:0000000000503A1E                 test    eax, eax
+  .text:0000000000503A20                 jnz     short loc_503A40
+  .text:0000000000503A22                 mov     eax, [r12+10Ch]
+  .text:0000000000503A2A                 mov     ecx, [rbp+var_40]
+  .text:0000000000503A2D                 cmp     eax, ecx
+  .text:0000000000503A2F                 jnb     short loc_503A40
+  .text:0000000000503A31                 mov     [rbp+var_40], eax
+  .text:0000000000503A34                 mov     r13, r12
+  .text:0000000000503A37                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000503A40                 add     r15, 8
+  .text:0000000000503A44                 cmp     [rbp+var_38], r15
+  .text:0000000000503A48                 jnz     loc_5039C0
+  .text:0000000000503A4E                 test    r13, r13
+  .text:0000000000503A51                 jz      short loc_503AB8
+  .text:0000000000503A53                 mov     rax, [rbp+var_48]
+  .text:0000000000503A57                 movdqu  xmm1, xmmword ptr [rax]
+  .text:0000000000503A5B                 movups  xmmword ptr [r13+0CCh], xmm1
+  .text:0000000000503A63                 movdqu  xmm0, xmmword ptr [rax+10h]
+  .text:0000000000503A68                 movups  xmmword ptr [r13+0ECh], xmm1
+  .text:0000000000503A70                 movups  xmmword ptr [r13+0DCh], xmm0
+  .text:0000000000503A78                 movups  xmmword ptr [r13+0FCh], xmm0
+  .text:0000000000503A80                 add     rsp, 28h
+  .text:0000000000503A84                 mov     rax, r13
+  .text:0000000000503A87                 pop     rbx
+  .text:0000000000503A88                 pop     r12
+  .text:0000000000503A8A                 pop     r13
+  .text:0000000000503A8C                 pop     r14
+  .text:0000000000503A8E                 pop     r15
+  .text:0000000000503A90                 pop     rbp
+  .text:0000000000503A91                 retn
+  .text:0000000000503A98                 mov     rdi, r12
+  .text:0000000000503A9B                 call    rax
+  .text:0000000000503A9D                 jmp     loc_5039E8
+  .text:0000000000503AA8                 cmp     eax, 4
+  .text:0000000000503AAB                 jz      short loc_503A40
+  .text:0000000000503AAD                 jmp     loc_503A22
+  .text:0000000000503AB8                 lea     rax, qword_9E2328
+  .text:0000000000503ABF                 mov     rdi, [rax]
+  .text:0000000000503AC2                 mov     rax, [rdi]
+  .text:0000000000503AC5                 call    qword ptr [rax+80h]
+  .text:0000000000503ACB                 test    al, al
+  .text:0000000000503ACD                 jnz     short loc_503AD9
+  .text:0000000000503ACF                 cmp     byte ptr [rbp+var_4C], 0
+  .text:0000000000503AD3                 jz      loc_503B70
+  .text:0000000000503AD9                 mov     eax, [rbp+var_3C]
+  .text:0000000000503ADC                 cmp     eax, [r14+29Ch]
+  .text:0000000000503AE3                 jl      loc_503B80
+  .text:0000000000503AE9                 mov     eax, [rbp+var_3C]
+  .text:0000000000503AEC                 test    eax, eax
+  .text:0000000000503AEE                 jle     loc_503CD1
+  .text:0000000000503AF4                 movsxd  rdx, [rbp+var_3C]
+  .text:0000000000503AF8                 lea     rbx, sub_4F0CC0
+  .text:0000000000503AFF                 xor     r15d, r15d
+  .text:0000000000503B02                 lea     r12, ds:0[rdx*8]
+  .text:0000000000503B0A                 jmp     short loc_503B4D
+  .text:0000000000503B10                 movzx   eax, byte ptr [r13+0A0h]
+  .text:0000000000503B18                 test    al, al
+  .text:0000000000503B1A                 jz      short loc_503B44
+  .text:0000000000503B1C                 mov     rax, [r13+0]
+  .text:0000000000503B20                 lea     rcx, sub_4F0CF0
+  .text:0000000000503B27                 mov     rax, [rax+0C0h]
+  .text:0000000000503B2E                 cmp     rax, rcx
+  .text:0000000000503B31                 jnz     loc_503CE0
+  .text:0000000000503B37                 movzx   eax, byte ptr [r13+68h]
+  .text:0000000000503B3C                 test    al, al
+  .text:0000000000503B3E                 jz      loc_503D34
+  .text:0000000000503B44                 add     r15, 8
+  .text:0000000000503B48                 cmp     r12, r15
+  .text:0000000000503B4B                 jz      short loc_503B70
+  .text:0000000000503B4D                 mov     rax, [r14+250h]
+  .text:0000000000503B54                 mov     r13, [rax+r15]
+  .text:0000000000503B58                 mov     rax, [r13+0]
+  .text:0000000000503B5C                 mov     rax, [rax+98h]
+  .text:0000000000503B63                 cmp     rax, rbx
+  .text:0000000000503B66                 jz      short loc_503B10
+  .text:0000000000503B68                 mov     rdi, r13
+  .text:0000000000503B6B                 call    rax
+  .text:0000000000503B6D                 jmp     short loc_503B18
+  .text:0000000000503B70                 mov     eax, [rbp+var_3C]
+  .text:0000000000503B73                 cmp     eax, [r14+29Ch]
+  .text:0000000000503B7A                 jge     loc_503CD1
+  .text:0000000000503B80                 mov     rax, [r14]
+  .text:0000000000503B83                 mov     rdi, r14
+  .text:0000000000503B86                 mov     esi, [rbp+var_3C]
+  .text:0000000000503B89                 call    qword ptr [rax+2A0h]
+  .text:0000000000503B8F                 mov     r13, rax
+  .text:0000000000503B92                 mov     rax, [rbp+var_48]
+  .text:0000000000503B96                 movdqu  xmm1, xmmword ptr [rax]
+  .text:0000000000503B9A                 movups  xmmword ptr [r13+0CCh], xmm1
+  .text:0000000000503BA2                 movdqu  xmm0, xmmword ptr [rax+10h]
+  .text:0000000000503BA7                 movups  xmmword ptr [r13+0ECh], xmm1
+  .text:0000000000503BAF                 movups  xmmword ptr [r13+0DCh], xmm0
+  .text:0000000000503BB7                 movups  xmmword ptr [r13+0FCh], xmm0
+  .text:0000000000503BBF                 movsxd  rbx, dword ptr [r14+248h]
+  .text:0000000000503BC6                 cmp     ebx, [r14+258h]
+  .text:0000000000503BCD                 jz      loc_503CB4
+  .text:0000000000503BD3                 mov     eax, ebx
+  .text:0000000000503BD5                 add     eax, 1
+  .text:0000000000503BD8                 mov     [r14+248h], eax
+  .text:0000000000503BDF                 mov     rax, [r14+250h]
+  .text:0000000000503BE6                 mov     [rax+rbx*8], r13
+  .text:0000000000503BEA                 jmp     loc_503A80
+  .text:0000000000503BF0                 mov     edi, [r12+0E4h]
+  .text:0000000000503BF8                 test    edi, edi
+  .text:0000000000503BFA                 jnz     loc_503A22
+  .text:0000000000503C00                 movzx   eax, byte ptr [r12+0DEh]
+  .text:0000000000503C09                 cmp     al, 0Fh
+  .text:0000000000503C0B                 jbe     loc_503A22
+  .text:0000000000503C11                 cmp     al, 0AFh
+  .text:0000000000503C13                 ja      loc_503A22
+  .text:0000000000503C19                 movzx   edx, byte ptr [r12+0DFh]
+  .text:0000000000503C22                 lea     esi, [rdx-1]
+  .text:0000000000503C25                 cmp     sil, 3
+  .text:0000000000503C29                 ja      loc_503A22
+  .text:0000000000503C2F                 and     eax, 0FFFFFFF0h
+  .text:0000000000503C32                 cmp     al, 10h
+  .text:0000000000503C34                 jz      loc_503CEA
+  .text:0000000000503C3A                 cmp     al, 70h ; 'p'
+  .text:0000000000503C3C                 jz      loc_503D4F
+  .text:0000000000503C42                 cmp     al, 30h ; '0'
+  .text:0000000000503C44                 jnz     loc_503A40
+  .text:0000000000503C4A                 mov     edx, [r12+0D8h]
+  .text:0000000000503C52                 test    edx, edx
+  .text:0000000000503C54                 jnz     loc_503A40
+  .text:0000000000503C5A                 jmp     loc_503A22
+  .text:0000000000503C60                 mov     esi, eax
+  .text:0000000000503C62                 mov     rax, [r14]
+  .text:0000000000503C65                 mov     rdi, r14
+  .text:0000000000503C68                 call    qword ptr [rax+2A0h]
+  .text:0000000000503C6E                 mov     r13, rax
+  .text:0000000000503C71                 mov     rax, [rbp+var_48]
+  .text:0000000000503C75                 movdqu  xmm1, xmmword ptr [rax]
+  .text:0000000000503C79                 movups  xmmword ptr [r13+0CCh], xmm1
+  .text:0000000000503C81                 movdqu  xmm0, xmmword ptr [rax+10h]
+  .text:0000000000503C86                 movups  xmmword ptr [r13+0ECh], xmm1
+  .text:0000000000503C8E                 movups  xmmword ptr [r13+0DCh], xmm0
+  .text:0000000000503C96                 movups  xmmword ptr [r13+0FCh], xmm0
+  .text:0000000000503C9E                 movsxd  rbx, dword ptr [r14+248h]
+  .text:0000000000503CA5                 mov     eax, ebx
+  .text:0000000000503CA7                 cmp     ebx, [r14+258h]
+  .text:0000000000503CAE                 jnz     loc_503BD5
+  .text:0000000000503CB4                 mov     esi, 1
+  .text:0000000000503CB9                 lea     rdi, [r14+250h]
+  .text:0000000000503CC0                 call    sub_5024E0
+  .text:0000000000503CC5                 mov     eax, [r14+248h]
+  .text:0000000000503CCC                 jmp     loc_503BD5
+  .text:0000000000503CD1                 xor     r13d, r13d
+  .text:0000000000503CD4                 jmp     loc_503A80
+  .text:0000000000503CE0                 mov     rdi, r13
+  .text:0000000000503CE3                 call    rax
+  .text:0000000000503CE5                 jmp     loc_503B3C
+  .text:0000000000503CEA                 mov     esi, [r12+0D8h]
+  .text:0000000000503CF2                 test    esi, esi
+  .text:0000000000503CF4                 jz      loc_503A22
+  .text:0000000000503CFA                 movzx   esi, byte ptr [r12+0DDh]
+  .text:0000000000503D03                 movzx   eax, byte ptr [r12+0DCh]
+  .text:0000000000503D0C                 shl     rsi, 8
+  .text:0000000000503D10                 or      rsi, rax
+  .text:0000000000503D13                 movzx   eax, byte ptr [r12+0DEh]
+  .text:0000000000503D1C                 and     eax, 0Fh
+  .text:0000000000503D1F                 shl     rax, 10h
+  .text:0000000000503D23                 or      rax, rsi
+  .text:0000000000503D26                 cmp     eax, 1
+  .text:0000000000503D29                 jnz     loc_503A22
+  .text:0000000000503D2F                 jmp     loc_503A40
+  .text:0000000000503D34                 mov     rax, [r13+0]
+  .text:0000000000503D38                 lea     rdx, aKickedToFreeUp; "Kicked to free up slot"
+  .text:0000000000503D3F                 mov     esi, 27h ; '''
+  .text:0000000000503D44                 mov     rdi, r13
+  .text:0000000000503D47                 call    qword ptr [rax+40h]
+  .text:0000000000503D4A                 jmp     loc_503A53
+  .text:0000000000503D4F                 mov     ecx, [r12+0D8h]
+  .text:0000000000503D57                 test    ecx, ecx
+  .text:0000000000503D59                 jz      loc_503A22
+  .text:0000000000503D5F                 movzx   esi, byte ptr [r12+0DDh]
+  .text:0000000000503D68                 movzx   eax, byte ptr [r12+0DCh]
+  .text:0000000000503D71                 shl     rsi, 8
+  .text:0000000000503D75                 or      rsi, rax
+  .text:0000000000503D78                 movzx   eax, byte ptr [r12+0DEh]
+  .text:0000000000503D81                 and     eax, 0Fh
+  .text:0000000000503D84                 shl     rax, 10h
+  .text:0000000000503D88                 or      rax, rsi
+  .text:0000000000503D8B                 jz      loc_503A40
+  .text:0000000000503D91                 jmp     loc_503A22
+procedure: |-
+  __int64 __fastcall sub_503940(__int64 a1, const __m128i *a2, char a3)
+  {
+    __int64 v3; // r15
+    __int64 v4; // r13
+    __int64 v5; // r12
+    __int64 (__fastcall *v6)(); // rax
+    char v7; // al
+    unsigned int v8; // eax
+    __m128i v9; // xmm1
+    __m128i v10; // xmm0
+    __int64 v12; // r15
+    __int64 (__fastcall *v14)(); // rax
+    __int64 (__fastcall *v16)(); // rax
+    __int64 v17; // rdx
+    __m128i v18; // xmm1
+    __m128i v19; // xmm0
+    __int64 v20; // rbx
+    int v21; // eax
+    unsigned __int8 v22; // al
+    char v23; // al
+    __m128i v24; // xmm1
+    __m128i v25; // xmm0
+    unsigned int v27; // [rsp+10h] [rbp-40h]
+    int v28; // [rsp+14h] [rbp-3Ch]
+
+    v28 = *(_DWORD *)(a1 + 584);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_9E2328 + 208LL))(qword_9E2328)
+      && v28 < *(_DWORD *)(a1 + 668) )
+    {
+      v4 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 672LL))(a1, (unsigned int)v28);
+      v24 = _mm_loadu_si128(a2);
+      *(__m128i *)(v4 + 204) = v24;
+      v25 = _mm_loadu_si128(a2 + 1);
+      *(__m128i *)(v4 + 236) = v24;
+      *(__m128i *)(v4 + 220) = v25;
+      *(__m128i *)(v4 + 252) = v25;
+      v20 = *(int *)(a1 + 584);
+      v21 = v20;
+      if ( (_DWORD)v20 != *(_DWORD *)(a1 + 600) )
+        goto LABEL_37;
+      goto LABEL_48;
+    }
+    if ( v28 <= 0 )
+      goto LABEL_21;
+    v3 = 0;
+    v4 = 0;
+    v27 = -1;
+    do
+    {
+      v5 = *(_QWORD *)(*(_QWORD *)(a1 + 592) + v3);
+      v6 = *(__int64 (__fastcall **)())(*(_QWORD *)v5 + 152LL);
+      if ( v6 == sub_4F0CC0 )
+        v7 = *(_BYTE *)(v5 + 160);
+      else
+        v7 = ((__int64 (__fastcall *)(_QWORD))v6)(*(_QWORD *)(*(_QWORD *)(a1 + 592) + v3));
+      if ( !v7 && !(unsigned __int8)sub_523F90(v5) )
+      {
+        v8 = *(_DWORD *)(v5 + 232);
+        if ( v8 > 3 )
+        {
+          if ( v8 == 4 )
+            goto LABEL_14;
+        }
+        else if ( v8 )
+        {
+          if ( !*(_DWORD *)(v5 + 228) )
+          {
+            v22 = *(_BYTE *)(v5 + 222);
+            if ( v22 > 0xFu && v22 <= 0xAFu && (unsigned __int8)(*(_BYTE *)(v5 + 223) - 1) <= 3u )
+            {
+              v23 = v22 & 0xF0;
+              if ( v23 == 16 )
+              {
+                if ( *(_DWORD *)(v5 + 216)
+                  && (*(unsigned __int16 *)(v5 + 220) | ((*(_BYTE *)(v5 + 222) & 0xF) << 16)) == 1 )
+                {
+                  goto LABEL_14;
+                }
+              }
+              else if ( v23 == 112 )
+              {
+                if ( *(_DWORD *)(v5 + 216)
+                  && !(*(unsigned __int16 *)(v5 + 220) | ((unsigned __int64)(*(_BYTE *)(v5 + 222) & 0xF) << 16)) )
+                {
+                  goto LABEL_14;
+                }
+              }
+              else if ( v23 != 48 || *(_DWORD *)(v5 + 216) )
+              {
+                goto LABEL_14;
+              }
+            }
+          }
+        }
+        else if ( (unsigned int)sub_2C9540(v5 + 204) )
+        {
+          goto LABEL_14;
+        }
+        if ( *(_DWORD *)(v5 + 268) < v27 )
+        {
+          v27 = *(_DWORD *)(v5 + 268);
+          v4 = v5;
+        }
+      }
+  LABEL_14:
+      v3 += 8;
+    }
+    while ( 8LL * v28 != v3 );
+    if ( v4 )
+      goto LABEL_16;
+  LABEL_21:
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_9E2328 + 128LL))(qword_9E2328) && !a3 )
+    {
+  LABEL_34:
+      if ( v28 >= *(_DWORD *)(a1 + 668) )
+        return 0;
+  LABEL_35:
+      v4 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 672LL))(a1, (unsigned int)v28);
+      v18 = _mm_loadu_si128(a2);
+      *(__m128i *)(v4 + 204) = v18;
+      v19 = _mm_loadu_si128(a2 + 1);
+      *(__m128i *)(v4 + 236) = v18;
+      *(__m128i *)(v4 + 220) = v19;
+      *(__m128i *)(v4 + 252) = v19;
+      v20 = *(int *)(a1 + 584);
+      if ( (_DWORD)v20 != *(_DWORD *)(a1 + 600) )
+      {
+        v21 = *(_DWORD *)(a1 + 584);
+  LABEL_37:
+        *(_DWORD *)(a1 + 584) = v21 + 1;
+        *(_QWORD *)(*(_QWORD *)(a1 + 592) + 8 * v20) = v4;
+        return v4;
+      }
+  LABEL_48:
+      sub_5024E0(a1 + 592, 1, v17);
+      v21 = *(_DWORD *)(a1 + 584);
+      goto LABEL_37;
+    }
+    if ( v28 < *(_DWORD *)(a1 + 668) )
+      goto LABEL_35;
+    if ( v28 <= 0 )
+      return 0;
+    v12 = 0;
+    while ( 1 )
+    {
+      v4 = *(_QWORD *)(*(_QWORD *)(a1 + 592) + v12);
+      v16 = *(__int64 (__fastcall **)())(*(_QWORD *)v4 + 152LL);
+      if ( v16 == sub_4F0CC0
+         ? *(_BYTE *)(v4 + 160)
+         : ((__int64 (__fastcall *)(_QWORD))v16)(*(_QWORD *)(*(_QWORD *)(a1 + 592) + v12)) )
+      {
+        v14 = *(__int64 (__fastcall **)())(*(_QWORD *)v4 + 192LL);
+        if ( !(v14 == sub_4F0CF0 ? *(_BYTE *)(v4 + 104) : ((__int64 (__fastcall *)(__int64))v14)(v4)) )
+          break;
+      }
+      v12 += 8;
+      if ( 8LL * v28 == v12 )
+        goto LABEL_34;
+    }
+    (*(void (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v4 + 64LL))(v4, 39, "Kicked to free up slot");
+  LABEL_16:
+    v9 = _mm_loadu_si128(a2);
+    *(__m128i *)(v4 + 204) = v9;
+    v10 = _mm_loadu_si128(a2 + 1);
+    *(__m128i *)(v4 + 236) = v9;
+    *(__m128i *)(v4 + 220) = v10;
+    *(__m128i *)(v4 + 252) = v10;
+    return v4;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_GetFreeClientCreatePath.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_GetFreeClientCreatePath.windows.yaml
@@ -1,0 +1,423 @@
+func_name: CNetworkGameServer_GetFreeClientCreatePath
+func_va: '0x1800ae560'
+disasm_code: |-
+  .text:00000001800AE560                 mov     [rsp+arg_8], rdx
+  .text:00000001800AE565                 push    rbx
+  .text:00000001800AE566                 push    rsi
+  .text:00000001800AE567                 push    rdi
+  .text:00000001800AE568                 push    r14
+  .text:00000001800AE56A                 sub     rsp, 28h
+  .text:00000001800AE56E                 mov     rdi, [rsp+48h+arg_28]
+  .text:00000001800AE573                 mov     rbx, r9
+  .text:00000001800AE576                 mov     r14, rdx
+  .text:00000001800AE579                 mov     rsi, rcx
+  .text:00000001800AE57C                 mov     byte ptr [rdi], 0
+  .text:00000001800AE57F                 call    sub_1800AD980
+  .text:00000001800AE584                 test    rax, rax
+  .text:00000001800AE587                 jz      short loc_1800AE596
+  .text:00000001800AE589                 mov     byte ptr [rdi], 1
+  .text:00000001800AE58C                 add     rsp, 28h
+  .text:00000001800AE590                 pop     r14
+  .text:00000001800AE592                 pop     rdi
+  .text:00000001800AE593                 pop     rsi
+  .text:00000001800AE594                 pop     rbx
+  .text:00000001800AE595                 retn
+  .text:00000001800AE596                 mov     r9, rbx
+  .text:00000001800AE599                 mov     rdx, r14
+  .text:00000001800AE59C                 mov     rcx, rsi
+  .text:00000001800AE59F                 call    sub_1800ADE10
+  .text:00000001800AE5A4                 test    rax, rax
+  .text:00000001800AE5A7                 jnz     short loc_1800AE589
+  .text:00000001800AE5A9                 mov     rcx, cs:qword_180911898
+  .text:00000001800AE5B0                 lea     rbx, [rsi+248h]
+  .text:00000001800AE5B7                 mov     [rsp+48h+arg_10], r12
+  .text:00000001800AE5BC                 movsxd  r12, dword ptr [rbx]
+  .text:00000001800AE5BF                 mov     rax, [rcx]
+  .text:00000001800AE5C2                 call    qword ptr [rax+0D0h]
+  .text:00000001800AE5C8                 test    al, al
+  .text:00000001800AE5CA                 jz      short loc_1800AE63F
+  .text:00000001800AE5CC                 cmp     r12d, [rsi+29Ch]
+  .text:00000001800AE5D3                 jge     short loc_1800AE63F
+  .text:00000001800AE5D5                 mov     rax, [rsi]
+  .text:00000001800AE5D8                 mov     edx, r12d
+  .text:00000001800AE5DB                 mov     rcx, rsi
+  .text:00000001800AE5DE                 ; 0x278 = 632LL = CNetworkGameServerBase_CreateNewClient
+  .text:00000001800AE5DE                 call    qword ptr [rax+278h]; 0x278 = 632LL = CNetworkGameServerBase_CreateNewClient
+  .text:00000001800AE5E4                 movups  xmm0, xmmword ptr [r14]
+  .text:00000001800AE5E8                 mov     rdi, rax
+  .text:00000001800AE5EB                 movups  xmmword ptr [rax+0CCh], xmm0
+  .text:00000001800AE5F2                 movups  xmm1, xmmword ptr [r14+10h]
+  .text:00000001800AE5F7                 movups  xmmword ptr [rax+0DCh], xmm1
+  .text:00000001800AE5FE                 movups  xmm0, xmmword ptr [rax+0CCh]
+  .text:00000001800AE605                 movups  xmmword ptr [rax+0ECh], xmm0
+  .text:00000001800AE60C                 movups  xmmword ptr [rax+0FCh], xmm1
+  .text:00000001800AE613                 movsxd  rsi, dword ptr [rbx]
+  .text:00000001800AE616                 cmp     esi, [rbx+10h]
+  .text:00000001800AE619                 jnz     short loc_1800AE623
+  .text:00000001800AE61B                 mov     rcx, rbx
+  .text:00000001800AE61E                 call    sub_1800B6BC0
+  .text:00000001800AE623                 inc     dword ptr [rbx]
+  .text:00000001800AE625                 mov     rax, [rbx+8]
+  .text:00000001800AE629                 mov     r12, [rsp+48h+arg_10]
+  .text:00000001800AE62E                 mov     [rax+rsi*8], rdi
+  .text:00000001800AE632                 mov     rax, rdi
+  .text:00000001800AE635                 add     rsp, 28h
+  .text:00000001800AE639                 pop     r14
+  .text:00000001800AE63B                 pop     rdi
+  .text:00000001800AE63C                 pop     rsi
+  .text:00000001800AE63D                 pop     rbx
+  .text:00000001800AE63E                 retn
+  .text:00000001800AE63F                 mov     [rsp+48h+arg_0], rbp
+  .text:00000001800AE644                 xor     edi, edi
+  .text:00000001800AE646                 mov     [rsp+48h+arg_18], r13
+  .text:00000001800AE64B                 mov     ebp, edi
+  .text:00000001800AE64D                 mov     [rsp+48h+var_28], r15
+  .text:00000001800AE652                 mov     r13d, 0FFFFFFFFh
+  .text:00000001800AE658                 test    r12d, r12d
+  .text:00000001800AE65B                 jle     loc_1800AE7B5
+  .text:00000001800AE661                 mov     r14d, edi
+  .text:00000001800AE664                 nop     dword ptr [rax+00h]
+  .text:00000001800AE668                 nop     dword ptr [rax+rax+00000000h]
+  .text:00000001800AE670                 mov     rax, [rsi+250h]
+  .text:00000001800AE677                 mov     rbx, [rax+r14*8]
+  .text:00000001800AE67B                 mov     rcx, rbx
+  .text:00000001800AE67E                 mov     rax, [rbx]
+  .text:00000001800AE681                 call    qword ptr [rax+88h]
+  .text:00000001800AE687                 test    al, al
+  .text:00000001800AE689                 jnz     loc_1800AE768
+  .text:00000001800AE68F                 cmp     dword ptr [rbx+64h], 2
+  .text:00000001800AE693                 jge     loc_1800AE768
+  .text:00000001800AE699                 lea     rdx, [rbx+0CCh]
+  .text:00000001800AE6A0                 mov     ecx, [rdx+1Ch]
+  .text:00000001800AE6A3                 test    ecx, ecx
+  .text:00000001800AE6A5                 jz      loc_1800AE745
+  .text:00000001800AE6AB                 sub     ecx, 1
+  .text:00000001800AE6AE                 jz      short loc_1800AE6C2
+  .text:00000001800AE6B0                 sub     ecx, 1
+  .text:00000001800AE6B3                 jz      short loc_1800AE6C2
+  .text:00000001800AE6B5                 sub     ecx, 1
+  .text:00000001800AE6B8                 jz      short loc_1800AE6C2
+  .text:00000001800AE6BA                 cmp     ecx, 1
+  .text:00000001800AE6BD                 jmp     loc_1800AE755
+  .text:00000001800AE6C2                 cmp     [rdx+18h], edi
+  .text:00000001800AE6C5                 jz      short loc_1800AE6CE
+  .text:00000001800AE6C7                 mov     al, 1
+  .text:00000001800AE6C9                 jmp     loc_1800AE753
+  .text:00000001800AE6CE                 mov     ecx, [rdx+10h]
+  .text:00000001800AE6D1                 mov     r8d, ecx
+  .text:00000001800AE6D4                 and     r8d, 0F00000h
+  .text:00000001800AE6DB                 jbe     short loc_1800AE70C
+  .text:00000001800AE6DD                 cmp     r8d, 0B00000h
+  .text:00000001800AE6E4                 jnb     short loc_1800AE70C
+  .text:00000001800AE6E6                 mov     eax, ecx
+  .text:00000001800AE6E8                 sar     eax, 18h
+  .text:00000001800AE6EB                 dec     eax
+  .text:00000001800AE6ED                 cmp     eax, 3
+  .text:00000001800AE6F0                 ja      short loc_1800AE70C
+  .text:00000001800AE6F2                 cmp     r8d, 100000h
+  .text:00000001800AE6F9                 jnz     short loc_1800AE710
+  .text:00000001800AE6FB                 cmp     [rdx+0Ch], edi
+  .text:00000001800AE6FE                 jz      short loc_1800AE70C
+  .text:00000001800AE700                 mov     eax, ecx
+  .text:00000001800AE702                 and     eax, 0FFFFFh
+  .text:00000001800AE707                 cmp     eax, 1
+  .text:00000001800AE70A                 jz      short loc_1800AE710
+  .text:00000001800AE70C                 mov     al, 1
+  .text:00000001800AE70E                 jmp     short loc_1800AE753
+  .text:00000001800AE710                 cmp     r8d, 700000h
+  .text:00000001800AE717                 jnz     short loc_1800AE72A
+  .text:00000001800AE719                 cmp     [rdx+0Ch], edi
+  .text:00000001800AE71C                 jz      short loc_1800AE70C
+  .text:00000001800AE71E                 test    ecx, 0FFFFFh
+  .text:00000001800AE724                 jz      short loc_1800AE741
+  .text:00000001800AE726                 mov     al, 1
+  .text:00000001800AE728                 jmp     short loc_1800AE753
+  .text:00000001800AE72A                 and     ecx, 0F00000h
+  .text:00000001800AE730                 cmp     ecx, 300000h
+  .text:00000001800AE736                 jnz     short loc_1800AE741
+  .text:00000001800AE738                 cmp     [rdx+0Ch], edi
+  .text:00000001800AE73B                 jnz     short loc_1800AE741
+  .text:00000001800AE73D                 mov     al, 1
+  .text:00000001800AE73F                 jmp     short loc_1800AE753
+  .text:00000001800AE741                 xor     al, al
+  .text:00000001800AE743                 jmp     short loc_1800AE753
+  .text:00000001800AE745                 mov     rcx, rdx
+  .text:00000001800AE748                 call    cs:?GetType@netadr_t@@QEBA?AW4netadrtype_t@@XZ; netadr_t::GetType(void)
+  .text:00000001800AE74E                 test    eax, eax
+  .text:00000001800AE750                 setz    al
+  .text:00000001800AE753                 test    al, al
+  .text:00000001800AE755                 jz      short loc_1800AE768
+  .text:00000001800AE757                 mov     eax, [rbx+10Ch]
+  .text:00000001800AE75D                 cmp     eax, r13d
+  .text:00000001800AE760                 jnb     short loc_1800AE768
+  .text:00000001800AE762                 mov     rbp, rbx
+  .text:00000001800AE765                 mov     r13d, eax
+  .text:00000001800AE768                 inc     r14
+  .text:00000001800AE76B                 cmp     r14, r12
+  .text:00000001800AE76E                 jl      loc_1800AE670
+  .text:00000001800AE774                 test    rbp, rbp
+  .text:00000001800AE777                 jz      short loc_1800AE7B0
+  .text:00000001800AE779                 mov     rax, [rsp+48h+arg_8]
+  .text:00000001800AE77E                 movups  xmm0, xmmword ptr [rax]
+  .text:00000001800AE781                 movups  xmmword ptr [rbp+0CCh], xmm0
+  .text:00000001800AE788                 movups  xmm1, xmmword ptr [rax+10h]
+  .text:00000001800AE78C                 mov     rax, rbp
+  .text:00000001800AE78F                 movups  xmmword ptr [rbp+0DCh], xmm1
+  .text:00000001800AE796                 movups  xmm0, xmmword ptr [rbp+0CCh]
+  .text:00000001800AE79D                 movups  xmmword ptr [rbp+0ECh], xmm0
+  .text:00000001800AE7A4                 movups  xmmword ptr [rbp+0FCh], xmm1
+  .text:00000001800AE7AB                 jmp     loc_1800AE8CE
+  .text:00000001800AE7B0                 mov     r14, [rsp+48h+arg_8]
+  .text:00000001800AE7B5                 mov     rcx, cs:qword_180911898
+  .text:00000001800AE7BC                 mov     rax, [rcx]
+  .text:00000001800AE7BF                 call    qword ptr [rax+80h]
+  .text:00000001800AE7C5                 test    al, al
+  .text:00000001800AE7C7                 jnz     short loc_1800AE7D0
+  .text:00000001800AE7C9                 cmp     [rsp+48h+arg_20], dil
+  .text:00000001800AE7CE                 jz      short loc_1800AE815
+  .text:00000001800AE7D0                 cmp     r12d, [rsi+29Ch]
+  .text:00000001800AE7D7                 jl      loc_1800AE86C
+  .text:00000001800AE7DD                 test    r12d, r12d
+  .text:00000001800AE7E0                 jle     short loc_1800AE815
+  .text:00000001800AE7E2                 mov     rax, [rsi+250h]
+  .text:00000001800AE7E9                 mov     rbx, [rax+rdi*8]
+  .text:00000001800AE7ED                 mov     rcx, rbx
+  .text:00000001800AE7F0                 mov     rax, [rbx]
+  .text:00000001800AE7F3                 call    qword ptr [rax+88h]
+  .text:00000001800AE7F9                 test    al, al
+  .text:00000001800AE7FB                 jz      short loc_1800AE80D
+  .text:00000001800AE7FD                 mov     rax, [rbx]
+  .text:00000001800AE800                 mov     rcx, rbx
+  .text:00000001800AE803                 call    qword ptr [rax+0B0h]
+  .text:00000001800AE809                 test    al, al
+  .text:00000001800AE80B                 jz      short loc_1800AE825
+  .text:00000001800AE80D                 inc     rdi
+  .text:00000001800AE810                 cmp     rdi, r12
+  .text:00000001800AE813                 jl      short loc_1800AE7E2
+  .text:00000001800AE815                 cmp     r12d, [rsi+29Ch]
+  .text:00000001800AE81C                 jl      short loc_1800AE86C
+  .text:00000001800AE81E                 xor     eax, eax
+  .text:00000001800AE820                 jmp     loc_1800AE8CE
+  .text:00000001800AE825                 mov     r9, [rbx]
+  .text:00000001800AE828                 lea     r8, aKickedToFreeUp; "Kicked to free up slot"
+  .text:00000001800AE82F                 mov     edx, 27h ; '''
+  .text:00000001800AE834                 mov     rcx, rbx
+  .text:00000001800AE837                 call    qword ptr [r9+38h]
+  .text:00000001800AE83B                 movups  xmm0, xmmword ptr [r14]
+  .text:00000001800AE83F                 mov     rax, rbx
+  .text:00000001800AE842                 movups  xmmword ptr [rbx+0CCh], xmm0
+  .text:00000001800AE849                 movups  xmm1, xmmword ptr [r14+10h]
+  .text:00000001800AE84E                 movups  xmmword ptr [rbx+0DCh], xmm1
+  .text:00000001800AE855                 movups  xmm0, xmmword ptr [rbx+0CCh]
+  .text:00000001800AE85C                 movups  xmmword ptr [rbx+0ECh], xmm0
+  .text:00000001800AE863                 movups  xmmword ptr [rbx+0FCh], xmm1
+  .text:00000001800AE86A                 jmp     short loc_1800AE8CE
+  .text:00000001800AE86C                 mov     rax, [rsi]
+  .text:00000001800AE86F                 mov     edx, r12d
+  .text:00000001800AE872                 mov     rcx, rsi
+  .text:00000001800AE875                 call    qword ptr [rax+278h]
+  .text:00000001800AE87B                 movups  xmm0, xmmword ptr [r14]
+  .text:00000001800AE87F                 lea     rbx, [rsi+248h]
+  .text:00000001800AE886                 mov     rdi, rax
+  .text:00000001800AE889                 movups  xmmword ptr [rax+0CCh], xmm0
+  .text:00000001800AE890                 movups  xmm1, xmmword ptr [r14+10h]
+  .text:00000001800AE895                 movups  xmmword ptr [rax+0DCh], xmm1
+  .text:00000001800AE89C                 movups  xmm0, xmmword ptr [rax+0CCh]
+  .text:00000001800AE8A3                 movups  xmmword ptr [rax+0ECh], xmm0
+  .text:00000001800AE8AA                 movups  xmmword ptr [rax+0FCh], xmm1
+  .text:00000001800AE8B1                 movsxd  rsi, dword ptr [rbx]
+  .text:00000001800AE8B4                 cmp     esi, [rbx+10h]
+  .text:00000001800AE8B7                 jnz     short loc_1800AE8C1
+  .text:00000001800AE8B9                 mov     rcx, rbx
+  .text:00000001800AE8BC                 call    sub_1800B6BC0
+  .text:00000001800AE8C1                 inc     dword ptr [rbx]
+  .text:00000001800AE8C3                 mov     rax, [rbx+8]
+  .text:00000001800AE8C7                 mov     [rax+rsi*8], rdi
+  .text:00000001800AE8CB                 mov     rax, rdi
+  .text:00000001800AE8CE                 mov     r13, [rsp+48h+arg_18]
+  .text:00000001800AE8D3                 mov     rbp, [rsp+48h+arg_0]
+  .text:00000001800AE8D8                 mov     r15, [rsp+48h+var_28]
+  .text:00000001800AE8DD                 mov     r12, [rsp+48h+arg_10]
+  .text:00000001800AE8E2                 add     rsp, 28h
+  .text:00000001800AE8E6                 pop     r14
+  .text:00000001800AE8E8                 pop     rdi
+  .text:00000001800AE8E9                 pop     rsi
+  .text:00000001800AE8EA                 pop     rbx
+  .text:00000001800AE8EB                 retn
+procedure: |-
+  int *__fastcall CNetworkGameServer_GetFreeClient(__int64 a1, _OWORD *a2, __int64 a3, __int64 a4, char a5, _BYTE *a6)
+  {
+    _OWORD *v7; // r14
+    int *result; // rax
+    __int64 v10; // r8
+    int *v11; // rbx
+    __int64 v12; // r12
+    __int64 v13; // rdi
+    __int128 v14; // xmm1
+    __int64 v15; // rsi
+    __int64 v16; // rdi
+    int *v17; // rbp
+    unsigned int v18; // r13d
+    __int64 i; // r14
+    int *v20; // rbx
+    int v21; // ecx
+    int v22; // ecx
+    int v23; // ecx
+    int v24; // ecx
+    bool v25; // zf
+    bool v26; // al
+    int v27; // ecx
+    unsigned int v28; // r8d
+    __int128 v29; // xmm1
+    __int64 v30; // rbx
+    __int128 v31; // xmm1
+    __int64 v32; // rbx
+    __int64 v33; // rdi
+    __int128 v34; // xmm1
+    __int64 v35; // rsi
+
+    v7 = a2;
+    *a6 = 0;
+    result = (int *)sub_1800AD980();
+    if ( result || (result = (int *)sub_1800ADE10(a1, v7, v10, a4)) != nullptr )
+    {
+      *a6 = 1;
+      return result;
+    }
+    v11 = (int *)(a1 + 584);
+    v12 = *(int *)(a1 + 584);
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_180911898 + 208LL))(qword_180911898)
+      && (int)v12 < *(_DWORD *)(a1 + 668) )
+    {
+      v13 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 632LL))(a1, (unsigned int)v12);// 0x278 = 632LL = CNetworkGameServerBase_CreateNewClient
+      *(_OWORD *)(v13 + 204) = *v7;
+      v14 = v7[1];
+      *(_OWORD *)(v13 + 220) = v14;
+      *(_OWORD *)(v13 + 236) = *(_OWORD *)(v13 + 204);
+      *(_OWORD *)(v13 + 252) = v14;
+      v15 = *v11;
+      if ( (_DWORD)v15 == v11[4] )
+        sub_1800B6BC0(v11);
+      ++*v11;
+      *(_QWORD *)(*((_QWORD *)v11 + 1) + 8 * v15) = v13;
+      return (int *)v13;
+    }
+    v16 = 0;
+    v17 = nullptr;
+    v18 = -1;
+    if ( (int)v12 <= 0 )
+      goto LABEL_44;
+    for ( i = 0; i < v12; ++i )
+    {
+      v20 = *(int **)(*(_QWORD *)(a1 + 592) + 8 * i);
+      if ( (*(unsigned __int8 (__fastcall **)(int *))(*(_QWORD *)v20 + 136LL))(v20) || v20[25] >= 2 )
+        continue;
+      v21 = v20[58];
+      if ( !v21 )
+      {
+        v26 = (unsigned int)netadr_t::GetType(v20 + 51) == 0;
+        goto LABEL_36;
+      }
+      v22 = v21 - 1;
+      if ( !v22 || (v23 = v22 - 1) == 0 || (v24 = v23 - 1) == 0 )
+      {
+        if ( v20[57] )
+        {
+          v26 = 1;
+  LABEL_36:
+          v25 = !v26;
+          goto LABEL_37;
+        }
+        v27 = v20[55];
+        v28 = v27 & 0xF00000;
+        if ( (v27 & 0xF00000) == 0
+          || v28 >= 0xB00000
+          || (unsigned int)((v27 >> 24) - 1) > 3
+          || v28 == 0x100000 && (!v20[54] || (v27 & 0xFFFFF) != 1) )
+        {
+  LABEL_26:
+          v26 = 1;
+          goto LABEL_36;
+        }
+        if ( v28 == 7340032 )
+        {
+          if ( !v20[54] )
+            goto LABEL_26;
+          if ( (v27 & 0xFFFFF) != 0 )
+          {
+            v26 = 1;
+            goto LABEL_36;
+          }
+        }
+        else if ( (v27 & 0xF00000) == 0x300000 && !v20[54] )
+        {
+          v26 = 1;
+          goto LABEL_36;
+        }
+        v26 = 0;
+        goto LABEL_36;
+      }
+      v25 = v24 == 1;
+  LABEL_37:
+      if ( !v25 && v20[67] < v18 )
+      {
+        v17 = v20;
+        v18 = v20[67];
+      }
+    }
+    if ( v17 )
+    {
+      *(_OWORD *)(v17 + 51) = *a2;
+      v29 = a2[1];
+      *(_OWORD *)(v17 + 55) = v29;
+      *(_OWORD *)(v17 + 59) = *(_OWORD *)(v17 + 51);
+      *(_OWORD *)(v17 + 63) = v29;
+      return v17;
+    }
+    v7 = a2;
+  LABEL_44:
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)qword_180911898 + 128LL))(qword_180911898) && !a5 )
+      goto LABEL_51;
+    if ( (int)v12 < *(_DWORD *)(a1 + 668) )
+    {
+  LABEL_54:
+      v32 = a1 + 584;
+      v33 = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)a1 + 632LL))(a1, (unsigned int)v12);
+      *(_OWORD *)(v33 + 204) = *v7;
+      v34 = v7[1];
+      *(_OWORD *)(v33 + 220) = v34;
+      *(_OWORD *)(v33 + 236) = *(_OWORD *)(v33 + 204);
+      *(_OWORD *)(v33 + 252) = v34;
+      v35 = *(int *)(a1 + 584);
+      if ( (_DWORD)v35 == *(_DWORD *)(v32 + 16) )
+        sub_1800B6BC0(v32);
+      ++*(_DWORD *)v32;
+      *(_QWORD *)(*(_QWORD *)(v32 + 8) + 8 * v35) = v33;
+      return (int *)v33;
+    }
+    if ( (int)v12 <= 0 )
+    {
+  LABEL_51:
+      if ( (int)v12 >= *(_DWORD *)(a1 + 668) )
+        return nullptr;
+      goto LABEL_54;
+    }
+    while ( 1 )
+    {
+      v30 = *(_QWORD *)(*(_QWORD *)(a1 + 592) + 8 * v16);
+      if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v30 + 136LL))(v30) )
+      {
+        if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v30 + 176LL))(v30) )
+          break;
+      }
+      if ( ++v16 >= v12 )
+        goto LABEL_51;
+    }
+    (*(void (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v30 + 56LL))(v30, 39, "Kicked to free up slot");
+    *(_OWORD *)(v30 + 204) = *v7;
+    v31 = v7[1];
+    *(_OWORD *)(v30 + 220) = v31;
+    *(_OWORD *)(v30 + 236) = *(_OWORD *)(v30 + 204);
+    *(_OWORD *)(v30 + 252) = v31;
+    return (int *)v30;
+  }


### PR DESCRIPTION
## Summary
- Add `CNetworkGameServerBase::CreateNewClient` (engine, vfunc) signature: `CNetworkGameServer` vtable offset 0x278 / index 79 on Windows, offset 0x2A0 / index 84 on Linux, anchored by the `vfunc_sig` call-site.
- Add supporting predecessor `CNetworkGameServer_GetFreeClientCreatePath` (engine, func), a string-anchored ("Kicked to free up slot") finder that resolves the find-or-create path on both platforms (Windows 0x1800ae560, Linux 0x503940) and hosts the virtual call to CreateNewClient.
- Add committed reference YAMLs for the predecessor on both platforms and register both symbols in `configs/14174.yaml`.

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (compile 0, layout diffs 0, vtable diffs 0, record layout diffs 0)
- candidate publication: passed; published SHA-256 `ed7383a00a412729c6fd19fce393e7a3c91975c193bba968aacbc3c116d8e608` matches the validated candidate