### PR TITLE
feat(preprocessor): add network game server and server info finders

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -2053,6 +2053,17 @@ modules:
       - name: find-CServerSideClientBase_vtable
         expected_output:
           - CServerSideClientBase_vtable.{platform}.yaml
+      - name: find-CServerSideClientBase_SendServerInfo
+        expected_output:
+          - CServerSideClientBase_SendServerInfo.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_vtable.{platform}.yaml
+      - name: find-CServerSideClientBase_SendServerInfo-decompiles
+        expected_output:
+          - CNetworkGameServerBase_FillServerInfo.{platform}.yaml
+        expected_input:
+          - CServerSideClientBase_SendServerInfo.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-CDelayedCall2_CServerSideClientBase_UpdateAcknowledgedFramecountCall_vtable
         expected_output:
           - CDelayedCall2_CServerSideClientBase_UpdateAcknowledgedFramecountCall_vtable.{platform}.yaml
@@ -3445,6 +3456,14 @@ modules:
           - CHLTVBroadcast::RecordSnapshot
       - name: CServerSideClientBase_vtable
         category: vtable
+      - name: CServerSideClientBase_SendServerInfo
+        category: vfunc
+        alias:
+          - CServerSideClientBase::SendServerInfo
+      - name: CNetworkGameServerBase_FillServerInfo
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::FillServerInfo
       - name: CDelayedCall2_CServerSideClientBase_UpdateAcknowledgedFramecountCall_vtable
         category: vtable
       - name: CServerSideClientBase_ProcessTick

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -662,6 +662,12 @@ modules:
       - name: find-CNetworkGameServerBase_CheckTimeouts
         expected_output:
           - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
+      - name: find-CNetworkGameServerBase_CheckTimeouts-decompiles
+        expected_output:
+          - CNetworkGameServerBase_IsHLTV.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_OnKickById
         expected_output:
           - CNetworkGameServerBase_OnKickById.{platform}.yaml
@@ -2438,6 +2444,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::CheckTimeouts
+      - name: CNetworkGameServerBase_IsHLTV
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::IsHLTV
       - name: CNetworkGameServerBase_OnKickById
         category: func
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -850,28 +850,28 @@ modules:
           - CNetworkGameServerBase_IsSaveRestoreAllowed.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_vtable.{platform}.yaml
-      - name: find-CNetworkGameServerBase_IsPausable_OfflineCheck
+      - name: find-CNetworkGameServer_IsPausable_OfflineCheck
         optional_output:
-          - CNetworkGameServerBase_IsPausable_OfflineCheck.{platform}.yaml
+          - CNetworkGameServer_IsPausable_OfflineCheck.{platform}.yaml
         skip_if_exists:
-          - CNetworkGameServerBase_IsPausable.{platform}.yaml
-      - name: find-CNetworkGameServerBase_IsPausable-noinline
+          - CNetworkGameServer_IsPausable.{platform}.yaml
+      - name: find-CNetworkGameServer_IsPausable-noinline
         optional_output:
-          - CNetworkGameServerBase_IsPausable.{platform}.yaml
+          - CNetworkGameServer_IsPausable.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
         prerequisite:
-          - find-CNetworkGameServerBase_IsPausable_OfflineCheck
-      - name: find-CNetworkGameServerBase_IsPausable-inlined
+          - find-CNetworkGameServer_IsPausable_OfflineCheck
+      - name: find-CNetworkGameServer_IsPausable-inlined
         expected_output:
-          - CNetworkGameServerBase_IsPausable.{platform}.yaml
+          - CNetworkGameServer_IsPausable.{platform}.yaml
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
         skip_if_exists:
-          - CNetworkGameServerBase_IsPausable.{platform}.yaml
+          - CNetworkGameServer_IsPausable.{platform}.yaml
         prerequisite:
-          - find-CNetworkGameServerBase_IsPausable-noinline
+          - find-CNetworkGameServer_IsPausable-noinline
       - name: find-CNetworkGameServerBase_Init
         expected_output:
           - CNetworkGameServerBase_Init.{platform}.yaml
@@ -2369,10 +2369,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::IsSaveRestoreAllowed
-      - name: CNetworkGameServerBase_IsPausable
+      - name: CNetworkGameServer_IsPausable
         category: vfunc
         alias:
-          - CNetworkGameServerBase::IsPausable
+          - CNetworkGameServer::IsPausable
       - name: CNetworkGameServerBase_Init
         category: vfunc
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -668,6 +668,11 @@ modules:
         expected_input:
           - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetPassword
+        expected_output:
+          - CNetworkGameServerBase_GetPassword.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_OnKickById
         expected_output:
           - CNetworkGameServerBase_OnKickById.{platform}.yaml
@@ -2448,6 +2453,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::IsHLTV
+      - name: CNetworkGameServerBase_GetPassword
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetPassword
       - name: CNetworkGameServerBase_OnKickById
         category: func
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -3489,10 +3489,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::GetPlayerNetworkIDString
-      - name: CNetworkGameServerBase_RemoveClientFromGame
+      - name: CNetworkGameServer_RemoveClientFromGame
         category: vfunc
         alias:
-          - CNetworkGameServerBase::RemoveClientFromGame
+          - CNetworkGameServer::RemoveClientFromGame
       - name: CEngineServer_GetPlayerNetworkIDString
         category: vfunc
         alias:
@@ -12447,9 +12447,9 @@ modules:
       # Discovered as the CNetworkGameServer_vtable entry that BOTH calls
       # CServerSideClientBase_GetNetworkIDString and references g_pSource2GameClients (the
       # xref_funcs + xref_gvs + vtable intersection uniquely selects it, no excludes needed).
-      - name: find-CNetworkGameServerBase_RemoveClientFromGame
+      - name: find-CNetworkGameServer_RemoveClientFromGame
         expected_output:
-          - CNetworkGameServerBase_RemoveClientFromGame.{platform}.yaml
+          - CNetworkGameServer_RemoveClientFromGame.{platform}.yaml
         expected_input:
           - CServerSideClientBase_GetNetworkIDString.{platform}.yaml
           - CNetworkGameServer_vtable.{platform}.yaml

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:3b5488e6ee6b2b5f36010674d873f895836c38a9df2dd41bd1f544027b315965
-file_count: 3315
+config_sha256: sha256:5bef93aeb7b78a21a08aed48f1f3a9efa1e7fd44ff4f0ef1750d337447fa6eff
+file_count: 3323
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10645,6 +10645,18 @@ files:
     vfunc_index: 69
     vfunc_offset: '0x228'
     vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
+    func_name: CNetworkGameServerBase_FillServerInfo
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vfunc_sig: FF 90 78 02 00 00 49 8B 3F
+    vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
+    func_name: CNetworkGameServerBase_FillServerInfo
+    vfunc_index: 74
+    vfunc_offset: '0x250'
+    vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10737,6 +10749,24 @@ files:
     vfunc_index: 12
     vfunc_offset: '0x60'
     vtable_name: CNetworkGameServerBase
+  engine/CNetworkGameServerBase_GetPassword.linux.yaml:
+    func_name: CNetworkGameServerBase_GetPassword
+    func_rva: '0x4f2cf0'
+    func_sig: 55 48 8D 3D ?? ?? ?? ?? BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? E8 ?? ?? ?? ?? 48 85 C0 74 ?? 48 8B 18
+    func_size: '0x6d'
+    func_va: '0x4f2cf0'
+    vfunc_index: 77
+    vfunc_offset: '0x268'
+    vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetPassword.windows.yaml:
+    func_name: CNetworkGameServerBase_GetPassword
+    func_rva: '0xa3910'
+    func_sig: 40 53 48 83 EC ?? BA ?? ?? ?? ?? 48 8D 0D ?? ?? ?? ??
+    func_size: '0x66'
+    func_va: '0x1800a3910'
+    vfunc_index: 72
+    vfunc_offset: '0x240'
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_GetPlayerNetworkIDString.linux.yaml:
     func_name: CNetworkGameServerBase_GetPlayerNetworkIDString
     func_rva: '0x518810'
@@ -10819,30 +10849,18 @@ files:
     vfunc_index: 41
     vfunc_offset: '0x148'
     vtable_name: CNetworkGameServerBase
-  engine/CNetworkGameServer_IsPausable.linux.yaml:
-    func_name: CNetworkGameServer_IsPausable
-    func_rva: '0x510460'
-    func_sig: 55 48 89 E5 41 55 41 89 F5 41 54 49 89 FC 53 48 83 EC ??
-    func_size: '0x1fc'
-    func_va: '0x510460'
-    vfunc_index: 76
-    vfunc_offset: '0x260'
-    vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServer_IsPausable.windows.yaml:
-    func_name: CNetworkGameServer_IsPausable
-    func_rva: '0x9bf80'
-    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 8B FA 48 8B D9 E8 ?? ?? ?? ??
-    func_size: '0x28c'
-    func_va: '0x18009bf80'
-    vfunc_index: 71
-    vfunc_offset: '0x238'
-    vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServer_IsPausable_OfflineCheck.linux.yaml:
-    func_name: CNetworkGameServer_IsPausable_OfflineCheck
-    func_rva: '0x4f4ec0'
-    func_sig: 55 48 89 E5 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 84 C0 75 ?? 80 BB ?? 04 00 00 ??
-    func_size: '0xa7'
-    func_va: '0x4f4ec0'
+  engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
+    func_name: CNetworkGameServerBase_IsHLTV
+    vfunc_index: 75
+    vfunc_offset: '0x258'
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
+  engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
+    func_name: CNetworkGameServerBase_IsHLTV
+    vfunc_index: 70
+    vfunc_offset: '0x230'
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -10951,24 +10969,6 @@ files:
     vfunc_index: 3
     vfunc_offset: '0x18'
     vtable_name: CNetworkGameServerBase_vtable
-  engine/CNetworkGameServer_RemoveClientFromGame.linux.yaml:
-    func_name: CNetworkGameServer_RemoveClientFromGame
-    func_rva: '0x50ffa0'
-    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 F3 48 83 EC ?? 8B 46 ??
-    func_size: '0x11a'
-    func_va: '0x50ffa0'
-    vfunc_index: 78
-    vfunc_offset: '0x270'
-    vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServer_RemoveClientFromGame.windows.yaml:
-    func_name: CNetworkGameServer_RemoveClientFromGame
-    func_rva: '0x9d5c0'
-    func_sig: 40 53 41 57 48 83 EC ?? 45 33 FF
-    func_size: '0x121'
-    func_va: '0x18009d5c0'
-    vfunc_index: 73
-    vfunc_offset: '0x248'
-    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_ReserveServerForQueuedGame.linux.yaml:
     func_name: CNetworkGameServerBase_ReserveServerForQueuedGame
     func_rva: '0x50bd60'
@@ -11547,6 +11547,30 @@ files:
     func_rva: '0x50dea0'
     func_size: '0x25'
     func_va: '0x50dea0'
+  engine/CNetworkGameServer_IsPausable.linux.yaml:
+    func_name: CNetworkGameServer_IsPausable
+    func_rva: '0x510460'
+    func_sig: 55 48 89 E5 41 55 41 89 F5 41 54 49 89 FC 53 48 83 EC ??
+    func_size: '0x1fc'
+    func_va: '0x510460'
+    vfunc_index: 76
+    vfunc_offset: '0x260'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServer_IsPausable.windows.yaml:
+    func_name: CNetworkGameServer_IsPausable
+    func_rva: '0x9bf80'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 8B FA 48 8B D9 E8 ?? ?? ?? ??
+    func_size: '0x28c'
+    func_va: '0x18009bf80'
+    vfunc_index: 71
+    vfunc_offset: '0x238'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServer_IsPausable_OfflineCheck.linux.yaml:
+    func_name: CNetworkGameServer_IsPausable_OfflineCheck
+    func_rva: '0x4f4ec0'
+    func_sig: 55 48 89 E5 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 84 C0 75 ?? 80 BB ?? 04 00 00 ??
+    func_size: '0xa7'
+    func_va: '0x4f4ec0'
   engine/CNetworkGameServer_PreWorldUpdate.linux.yaml:
     func_name: CNetworkGameServer_PreWorldUpdate
     func_rva: '0x50fd40'
@@ -11582,6 +11606,24 @@ files:
     func_va: '0x18009e4f0'
     vfunc_index: 30
     vfunc_offset: '0xf0'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServer_RemoveClientFromGame.linux.yaml:
+    func_name: CNetworkGameServer_RemoveClientFromGame
+    func_rva: '0x50ffa0'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 F3 48 83 EC ?? 8B 46 ??
+    func_size: '0x11a'
+    func_va: '0x50ffa0'
+    vfunc_index: 78
+    vfunc_offset: '0x270'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServer_RemoveClientFromGame.windows.yaml:
+    func_name: CNetworkGameServer_RemoveClientFromGame
+    func_rva: '0x9d5c0'
+    func_sig: 40 53 41 57 48 83 EC ?? 45 33 FF
+    func_size: '0x121'
+    func_va: '0x18009d5c0'
+    vfunc_index: 73
+    vfunc_offset: '0x248'
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServer_ServerPostSimulate.linux.yaml:
     func_name: CNetworkGameServer_ServerPostSimulate
@@ -12413,6 +12455,24 @@ files:
     vfunc_index: 23
     vfunc_offset: '0xb8'
     vtable_name: CServerSideClientBase
+  engine/CServerSideClientBase_SendServerInfo.linux.yaml:
+    func_name: CServerSideClientBase_SendServerInfo
+    func_rva: '0x527620'
+    func_sig: 48 83 7F ?? ?? 0F 84 ?? ?? ?? ?? 55 48 89 E5 41 57 41 56 49 89 F6
+    func_size: '0xfc2'
+    func_va: '0x527620'
+    vfunc_index: 52
+    vfunc_offset: '0x1a0'
+    vtable_name: CServerSideClientBase_vtable
+  engine/CServerSideClientBase_SendServerInfo.windows.yaml:
+    func_name: CServerSideClientBase_SendServerInfo
+    func_rva: '0xc5720'
+    func_sig: 48 8B C4 48 89 50 ?? 48 89 48 ?? 55 53 57 41 57
+    func_size: '0xc94'
+    func_va: '0x1800c5720'
+    vfunc_index: 48
+    vfunc_offset: '0x180'
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -42631,5 +42691,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T12:39:14Z'
+last_publish_time: '2026-08-06T15:37:18Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -10819,8 +10819,8 @@ files:
     vfunc_index: 41
     vfunc_offset: '0x148'
     vtable_name: CNetworkGameServerBase
-  engine/CNetworkGameServerBase_IsPausable.linux.yaml:
-    func_name: CNetworkGameServerBase_IsPausable
+  engine/CNetworkGameServer_IsPausable.linux.yaml:
+    func_name: CNetworkGameServer_IsPausable
     func_rva: '0x510460'
     func_sig: 55 48 89 E5 41 55 41 89 F5 41 54 49 89 FC 53 48 83 EC ??
     func_size: '0x1fc'
@@ -10828,8 +10828,8 @@ files:
     vfunc_index: 76
     vfunc_offset: '0x260'
     vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServerBase_IsPausable.windows.yaml:
-    func_name: CNetworkGameServerBase_IsPausable
+  engine/CNetworkGameServer_IsPausable.windows.yaml:
+    func_name: CNetworkGameServer_IsPausable
     func_rva: '0x9bf80'
     func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 8B FA 48 8B D9 E8 ?? ?? ?? ??
     func_size: '0x28c'
@@ -10837,8 +10837,8 @@ files:
     vfunc_index: 71
     vfunc_offset: '0x238'
     vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServerBase_IsPausable_OfflineCheck.linux.yaml:
-    func_name: CNetworkGameServerBase_IsPausable_OfflineCheck
+  engine/CNetworkGameServer_IsPausable_OfflineCheck.linux.yaml:
+    func_name: CNetworkGameServer_IsPausable_OfflineCheck
     func_rva: '0x4f4ec0'
     func_sig: 55 48 89 E5 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 84 C0 75 ?? 80 BB ?? 04 00 00 ??
     func_size: '0xa7'

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -10951,8 +10951,8 @@ files:
     vfunc_index: 3
     vfunc_offset: '0x18'
     vtable_name: CNetworkGameServerBase_vtable
-  engine/CNetworkGameServerBase_RemoveClientFromGame.linux.yaml:
-    func_name: CNetworkGameServerBase_RemoveClientFromGame
+  engine/CNetworkGameServer_RemoveClientFromGame.linux.yaml:
+    func_name: CNetworkGameServer_RemoveClientFromGame
     func_rva: '0x50ffa0'
     func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 F3 48 83 EC ?? 8B 46 ??
     func_size: '0x11a'
@@ -10960,8 +10960,8 @@ files:
     vfunc_index: 78
     vfunc_offset: '0x270'
     vtable_name: CNetworkGameServer_vtable
-  engine/CNetworkGameServerBase_RemoveClientFromGame.windows.yaml:
-    func_name: CNetworkGameServerBase_RemoveClientFromGame
+  engine/CNetworkGameServer_RemoveClientFromGame.windows.yaml:
+    func_name: CNetworkGameServer_RemoveClientFromGame
     func_rva: '0x9d5c0'
     func_sig: 40 53 41 57 48 83 EC ?? 45 33 FF
     func_size: '0x121'

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckTimeouts-decompiles.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckTimeouts-decompiles.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_CheckTimeouts-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_IsHLTV",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_IsHLTV",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_CheckTimeouts.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_CheckTimeouts.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_IsHLTV", "CNetworkGameServerBase"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameServerBase_IsHLTV",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CNetworkGameServerBase_IsHLTV from CheckTimeouts via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetPassword.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetPassword.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetPassword skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetPassword",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_GetPassword",
+        "xref_strings": [
+            "FULLMATCH:none",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable artifact stem)
+    ("CNetworkGameServerBase_GetPassword", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameServerBase_GetPassword",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CNetworkGameServerBase_GetPassword from the exact ``none`` string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable-inlined.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable-inlined.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_IsPausable-inlined skill.
+"""Preprocess script for find-CNetworkGameServer_IsPausable-inlined skill.
 
-Deinline-fix chain, link 3/3.  Resolves ``CNetworkGameServerBase_IsPausable`` (a vfunc of
+Deinline-fix chain, link 3/3.  Resolves ``CNetworkGameServer_IsPausable`` (a vfunc of
 ``CNetworkGameServer_vtable``) directly from the ``"offline"`` + ``"System/network"`` VProf
 string references.  This applies when the offline/network-session check helper is inlined into
 the vfunc so the strings live inside the vfunc body (e.g. Windows 14174).  Because the inlined
 ``offline`` / ``System/network`` intersection also matches a standalone sibling function, the
 ``CNetworkGameServer_vtable`` relation is load-bearing here: only the vfunc is a vtable member,
 so the string-cap-vtable intersection collapses to it.  It is the fallback for the
-``find-CNetworkGameServerBase_IsPausable-noinline`` path (which handles the de-inlined case) and
-is skipped whenever ``CNetworkGameServerBase_IsPausable.{platform}.yaml`` already exists.
+``find-CNetworkGameServer_IsPausable-noinline`` path (which handles the de-inlined case) and
+is skipped whenever ``CNetworkGameServer_IsPausable.{platform}.yaml`` already exists.
 """
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_IsPausable",
+    "CNetworkGameServer_IsPausable",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServerBase_IsPausable",
+        "func_name": "CNetworkGameServer_IsPausable",
         "xref_strings": [
             "FULLMATCH:offline",
             "FULLMATCH:System/network",
@@ -37,13 +37,13 @@ FUNC_XREFS = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CNetworkGameServerBase_IsPausable", "CNetworkGameServer_vtable"),
+    ("CNetworkGameServer_IsPausable", "CNetworkGameServer_vtable"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServerBase_IsPausable",
+        "CNetworkGameServer_IsPausable",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable-noinline.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable-noinline.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_IsPausable-noinline skill.
+"""Preprocess script for find-CNetworkGameServer_IsPausable-noinline skill.
 
-Deinline-fix chain, link 2/3.  Resolves ``CNetworkGameServerBase_IsPausable`` (a vfunc of
+Deinline-fix chain, link 2/3.  Resolves ``CNetworkGameServer_IsPausable`` (a vfunc of
 ``CNetworkGameServer_vtable``) as the caller of the standalone
-``CNetworkGameServerBase_IsPausable_OfflineCheck`` helper.  This path only applies when the
+``CNetworkGameServer_IsPausable_OfflineCheck`` helper.  This path only applies when the
 helper is NOT inlined into the vfunc (e.g. Linux 14174, where the ``offline`` /
 ``System/network`` strings live in the de-inlined ``sub_4F4EC0`` helper and IsPausable merely
 calls it).  When the helper is inlined the helper YAML resolves to the vfunc's own address and
@@ -15,23 +15,23 @@ so it survives the vtable intersection alongside IsPausable (e.g. Linux 14174 yi
 address is read from ``CNetworkGameServerBase_ConnectClient.{platform}.yaml``) to leave IsPausable
 as the sole candidate.  Its output is optional, so when the caller cannot be resolved (e.g. the
 helper YAML is absent because the inlined anchor was ambiguous) the
-``find-CNetworkGameServerBase_IsPausable-inlined`` fallback runs instead.
+``find-CNetworkGameServer_IsPausable-inlined`` fallback runs instead.
 """
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_IsPausable",
+    "CNetworkGameServer_IsPausable",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServerBase_IsPausable",
+        "func_name": "CNetworkGameServer_IsPausable",
         "xref_strings": [],
         "xref_gvs": [],
         "xref_signatures": [],
         "xref_funcs": [
-            "CNetworkGameServerBase_IsPausable_OfflineCheck",
+            "CNetworkGameServer_IsPausable_OfflineCheck",
         ],
         "exclude_funcs": [
             "CNetworkGameServerBase_ConnectClient",
@@ -44,13 +44,13 @@ FUNC_XREFS = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CNetworkGameServerBase_IsPausable", "CNetworkGameServer_vtable"),
+    ("CNetworkGameServer_IsPausable", "CNetworkGameServer_vtable"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServerBase_IsPausable",
+        "CNetworkGameServer_IsPausable",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable_OfflineCheck.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_IsPausable_OfflineCheck.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_IsPausable_OfflineCheck skill.
+"""Preprocess script for find-CNetworkGameServer_IsPausable_OfflineCheck skill.
 
 Deinline-fix chain, link 1/3.  Resolves the standalone offline/network-session check helper
 that ``CNetworkGameServerBase::IsPausable`` calls, anchored on the ``"offline"`` +
@@ -10,25 +10,25 @@ alongside the lowercase ``"system/network"`` literal instead).
 This is the first link of the inline/noinline fallback chain.  On builds where the helper is
 de-inlined (e.g. Linux 14174, standalone ``sub_4F4EC0``) the strings live inside the helper
 body, so this skill resolves it directly.  On builds where the helper is inlined into the
-``CNetworkGameServerBase_IsPausable`` vfunc (e.g. Windows 14174) the ``offline`` +
+``CNetworkGameServer_IsPausable`` vfunc (e.g. Windows 14174) the ``offline`` +
 ``System/network`` intersection yields >1 function (the vfunc plus a standalone sibling), so
-this skill soft-skips and control falls through to ``find-CNetworkGameServerBase_IsPausable-inlined``
+this skill soft-skips and control falls through to ``find-CNetworkGameServer_IsPausable-inlined``
 whose string-cap-vtable intersection is the load-bearing path.  The helper symbol is
 deliberately NOT registered in the active version config -- the YAML is used only as an
-intermediate for the ``find-CNetworkGameServerBase_IsPausable-noinline`` xref_funcs lookup.  The
+intermediate for the ``find-CNetworkGameServer_IsPausable-noinline`` xref_funcs lookup.  The
 skill's output is optional and is skipped whenever
-``CNetworkGameServerBase_IsPausable.{platform}.yaml`` already exists.
+``CNetworkGameServer_IsPausable.{platform}.yaml`` already exists.
 """
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_IsPausable_OfflineCheck",
+    "CNetworkGameServer_IsPausable_OfflineCheck",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServerBase_IsPausable_OfflineCheck",
+        "func_name": "CNetworkGameServer_IsPausable_OfflineCheck",
         "xref_strings": [
             "FULLMATCH:offline",
             "FULLMATCH:System/network",
@@ -46,7 +46,7 @@ FUNC_XREFS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServerBase_IsPausable_OfflineCheck",
+        "CNetworkGameServer_IsPausable_OfflineCheck",
         [
             "func_name",
             "func_sig",

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_RemoveClientFromGame.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_RemoveClientFromGame.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CNetworkGameServerBase_RemoveClientFromGame skill."""
+"""Preprocess script for find-CNetworkGameServer_RemoveClientFromGame skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkGameServerBase_RemoveClientFromGame",
+    "CNetworkGameServer_RemoveClientFromGame",
 ]
 
 FUNC_XREFS = [
     {
-        "func_name": "CNetworkGameServerBase_RemoveClientFromGame",
+        "func_name": "CNetworkGameServer_RemoveClientFromGame",
         "xref_strings": [],
         # gv_va auto-loaded from g_pSource2GameClients.{platform}.yaml. Among the
         # CNetworkGameServer_vtable entries that call CServerSideClientBase_GetNetworkIDString
@@ -32,13 +32,13 @@ FUNC_XREFS = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CNetworkGameServerBase_RemoveClientFromGame", "CNetworkGameServer_vtable"),
+    ("CNetworkGameServer_RemoveClientFromGame", "CNetworkGameServer_vtable"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CNetworkGameServerBase_RemoveClientFromGame",
+        "CNetworkGameServer_RemoveClientFromGame",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-CServerSideClientBase_SendServerInfo-decompiles.py
+++ b/ida_preprocessor_scripts/find-CServerSideClientBase_SendServerInfo-decompiles.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClientBase_SendServerInfo-decompiles skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_FillServerInfo",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_FillServerInfo",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CServerSideClientBase_SendServerInfo.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CServerSideClientBase_SendServerInfo.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable artifact stem)
+    ("CNetworkGameServerBase_FillServerInfo", "CNetworkGameServerBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameServerBase_FillServerInfo",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate FillServerInfo from CServerSideClientBase_SendServerInfo via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CServerSideClientBase_SendServerInfo.py
+++ b/ida_preprocessor_scripts/find-CServerSideClientBase_SendServerInfo.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClientBase_SendServerInfo skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClientBase_SendServerInfo",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CServerSideClientBase_SendServerInfo",
+        "xref_strings": [
+            "FULLMATCH:SV_SendServerinfo->msg",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable artifact stem)
+    ("CServerSideClientBase_SendServerInfo", "CServerSideClientBase_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CServerSideClientBase_SendServerInfo",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CServerSideClientBase_SendServerInfo from the exact debug string."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.linux.yaml
@@ -1,0 +1,399 @@
+func_name: CNetworkGameServerBase_CheckTimeouts
+func_va: '0x4f9c00'
+disasm_code: |-
+  .text:00000000004F9C00                 movsxd  rax, dword ptr [rdi+248h]
+  .text:00000000004F9C07                 mov     edx, eax
+  .text:00000000004F9C09                 sub     edx, 1
+  .text:00000000004F9C0C                 js      locret_4F9FF0
+  .text:00000000004F9C12                 push    rbp
+  .text:00000000004F9C13                 mov     rbp, rsp
+  .text:00000000004F9C16                 push    r15
+  .text:00000000004F9C18                 push    r14
+  .text:00000000004F9C1A                 push    r13
+  .text:00000000004F9C1C                 lea     r13, sub_4F0CC0
+  .text:00000000004F9C23                 push    r12
+  .text:00000000004F9C25                 mov     r12, rdi
+  .text:00000000004F9C28                 push    rbx
+  .text:00000000004F9C29                 movsxd  rbx, edx
+  .text:00000000004F9C2C                 mov     edx, edx
+  .text:00000000004F9C2E                 sub     rax, rdx
+  .text:00000000004F9C31                 sub     rsp, 138h
+  .text:00000000004F9C38                 shl     rbx, 3
+  .text:00000000004F9C3C                 lea     rax, ds:0FFFFFFFFFFFFFFF0h[rax*8]
+  .text:00000000004F9C44                 mov     [rbp-148h], rax
+  .text:00000000004F9C4B                 nop     dword ptr [rax+rax+00h]
+  .text:00000000004F9C50                 mov     rax, [r12+250h]
+  .text:00000000004F9C58                 mov     r14, [rax+rbx]
+  .text:00000000004F9C5C                 mov     rax, [r14]
+  .text:00000000004F9C5F                 mov     rax, [rax+98h]
+  .text:00000000004F9C66                 cmp     rax, r13
+  .text:00000000004F9C69                 jnz     loc_4F9D68
+  .text:00000000004F9C6F                 movzx   eax, byte ptr [r14+0A0h]
+  .text:00000000004F9C77                 test    al, al
+  .text:00000000004F9C79                 jnz     loc_4F9D40
+  .text:00000000004F9C7F                 mov     rdi, r14
+  .text:00000000004F9C82                 call    sub_523F90
+  .text:00000000004F9C87                 test    al, al
+  .text:00000000004F9C89                 jz      loc_4F9D40
+  .text:00000000004F9C8F                 mov     rdi, r14
+  .text:00000000004F9C92                 call    sub_5256C0
+  .text:00000000004F9C97                 test    al, al
+  .text:00000000004F9C99                 jnz     loc_4F9F00
+  .text:00000000004F9C9F                 mov     r15, [r14+58h]
+  .text:00000000004F9CA3                 test    r15, r15
+  .text:00000000004F9CA6                 jz      loc_4F9D40
+  .text:00000000004F9CAC                 mov     rax, [r15]
+  .text:00000000004F9CAF                 mov     rdi, r15
+  .text:00000000004F9CB2                 call    qword ptr [rax+1C8h]
+  .text:00000000004F9CB8                 test    al, al
+  .text:00000000004F9CBA                 jnz     loc_4F9DE0
+  .text:00000000004F9CC0                 mov     rax, [r12]
+  .text:00000000004F9CC4                 mov     rdi, r12
+  .text:00000000004F9CC7                 call    qword ptr [rax+258h] ; 258h = CNetworkGameServerBase_IsHLTV
+  .text:00000000004F9CCD                 test    al, al
+  .text:00000000004F9CCF                 jnz     short loc_4F9D20
+  .text:00000000004F9CD1                 lea     rax, g_pSource2Server
+  .text:00000000004F9CD8                 mov     rax, [rax]
+  .text:00000000004F9CDB                 test    rax, rax
+  .text:00000000004F9CDE                 jz      short loc_4F9D20
+  .text:00000000004F9CE0                 mov     rdx, [rax]
+  .text:00000000004F9CE3                 mov     rdi, r15
+  .text:00000000004F9CE6                 mov     [rbp-158h], rax
+  .text:00000000004F9CED                 mov     rcx, [r15]
+  .text:00000000004F9CF0                 mov     rdx, [rdx+0C8h]
+  .text:00000000004F9CF7                 mov     [rbp-150h], rdx
+  .text:00000000004F9CFE                 call    qword ptr [rcx+0A0h]
+  .text:00000000004F9D04                 mov     esi, [r14+48h]
+  .text:00000000004F9D08                 mov     rdi, [rbp-158h]
+  .text:00000000004F9D0F                 mov     rdx, [rbp-150h]
+  .text:00000000004F9D16                 call    rdx
+  .text:00000000004F9D18                 test    al, al
+  .text:00000000004F9D1A                 jnz     loc_4F9F38
+  .text:00000000004F9D20                 mov     rax, [r15]
+  .text:00000000004F9D23                 mov     rdi, r15
+  .text:00000000004F9D26                 call    qword ptr [rax+188h]
+  .text:00000000004F9D2C                 test    al, al
+  .text:00000000004F9D2E                 jz      short loc_4F9D78
+  .text:00000000004F9D30                 mov     rax, [r14]
+  .text:00000000004F9D33                 xor     edx, edx
+  .text:00000000004F9D35                 mov     esi, 1Ah
+  .text:00000000004F9D3A                 mov     rdi, r14
+  .text:00000000004F9D3D                 call    qword ptr [rax+40h]
+  .text:00000000004F9D40                 sub     rbx, 8
+  .text:00000000004F9D44                 cmp     [rbp-148h], rbx
+  .text:00000000004F9D4B                 jnz     loc_4F9C50
+  .text:00000000004F9D51                 add     rsp, 138h
+  .text:00000000004F9D58                 pop     rbx
+  .text:00000000004F9D59                 pop     r12
+  .text:00000000004F9D5B                 pop     r13
+  .text:00000000004F9D5D                 pop     r14
+  .text:00000000004F9D5F                 pop     r15
+  .text:00000000004F9D61                 pop     rbp
+  .text:00000000004F9D62                 retn
+  .text:00000000004F9D68                 mov     rdi, r14
+  .text:00000000004F9D6B                 call    rax
+  .text:00000000004F9D6D                 jmp     loc_4F9C77
+  .text:00000000004F9D78                 mov     dword ptr [rbp-140h], 0
+  .text:00000000004F9D82                 mov     rax, [r15]
+  .text:00000000004F9D85                 lea     rsi, [rbp-140h]
+  .text:00000000004F9D8C                 mov     rdi, r15
+  .text:00000000004F9D8F                 call    qword ptr [rax+1E8h]
+  .text:00000000004F9D95                 test    al, al
+  .text:00000000004F9D97                 jz      short loc_4F9D40
+  .text:00000000004F9D99                 mov     esi, [rbp-140h]
+  .text:00000000004F9D9F                 test    esi, esi
+  .text:00000000004F9DA1                 jnz     short loc_4F9DB2
+  .text:00000000004F9DA3                 mov     dword ptr [rbp-140h], 1Eh
+  .text:00000000004F9DAD                 mov     esi, 1Eh
+  .text:00000000004F9DB2                 mov     rax, [r14]
+  .text:00000000004F9DB5                 lea     rdx, aRemoteDisconne; "remote disconnected"
+  .text:00000000004F9DBC                 mov     rdi, r14
+  .text:00000000004F9DBF                 sub     rbx, 8
+  .text:00000000004F9DC3                 call    qword ptr [rax+40h]
+  .text:00000000004F9DC6                 cmp     [rbp-148h], rbx
+  .text:00000000004F9DCD                 jnz     loc_4F9C50
+  .text:00000000004F9DD3                 jmp     loc_4F9D51
+  .text:00000000004F9DE0                 ; _QWORD
+  .text:00000000004F9DE0                 mov     edi, cs:dword_A30294; _QWORD
+  .text:00000000004F9DE6                 ; _QWORD
+  .text:00000000004F9DE6                 mov     esi, 2; _QWORD
+  .text:00000000004F9DEB                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000004F9DF0                 test    al, al
+  .text:00000000004F9DF2                 jz      short loc_4F9E62
+  .text:00000000004F9DF4                 mov     rax, [r15]
+  .text:00000000004F9DF7                 mov     rdi, r15
+  .text:00000000004F9DFA                 call    qword ptr [rax+0A0h]
+  .text:00000000004F9E00                 mov     rdi, r14
+  .text:00000000004F9E03                 cvtss2sd xmm0, xmm0
+  .text:00000000004F9E07                 movsd   qword ptr [rbp-158h], xmm0
+  .text:00000000004F9E0F                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000000004F9E14                 mov     rdi, r14
+  .text:00000000004F9E17                 mov     r8, [rax]
+  .text:00000000004F9E1A                 lea     rax, src
+  .text:00000000004F9E21                 test    r8, r8
+  .text:00000000004F9E24                 cmovz   r8, rax
+  .text:00000000004F9E28                 mov     [rbp-150h], r8
+  .text:00000000004F9E2F                 call    sub_524D50
+  .text:00000000004F9E34                 ; _QWORD
+  .text:00000000004F9E34                 mov     edi, cs:dword_A30294; _QWORD
+  .text:00000000004F9E3A                 lea     rdx, aChecktimeoutsD; "CheckTimeouts: Disconnecting client: %s"...
+  .text:00000000004F9E41                 ; _QWORD
+  .text:00000000004F9E41                 mov     esi, 2; _QWORD
+  .text:00000000004F9E46                 mov     r8, [rbp-150h]
+  .text:00000000004F9E4D                 mov     rcx, rax
+  .text:00000000004F9E50                 mov     eax, 1
+  .text:00000000004F9E55                 movsd   xmm0, qword ptr [rbp-158h]
+  .text:00000000004F9E5D                 call    _LoggingSystem_Log
+  .text:00000000004F9E62                 mov     rax, [r14]
+  .text:00000000004F9E65                 mov     rdi, r15
+  .text:00000000004F9E68                 mov     rcx, [rax+40h]
+  .text:00000000004F9E6C                 mov     rax, [r15]
+  .text:00000000004F9E6F                 lea     r15, [rbp-140h]
+  .text:00000000004F9E76                 mov     [rbp-150h], rcx
+  .text:00000000004F9E7D                 call    qword ptr [rax+0A0h]
+  .text:00000000004F9E83                 lea     rsi, aNetchanTimeout; "netchan timeout: %.2fs since recv"
+  .text:00000000004F9E8A                 cvtss2sd xmm0, xmm0
+  .text:00000000004F9E8E                 mov     rdi, r15
+  .text:00000000004F9E91                 mov     eax, 1
+  .text:00000000004F9E96                 call    sub_2CF1D0
+  .text:00000000004F9E9B                 test    byte ptr [rbp-139h], 40h
+  .text:00000000004F9EA2                 lea     rdx, [rbp-138h]
+  .text:00000000004F9EA9                 mov     rcx, [rbp-150h]
+  .text:00000000004F9EB0                 jnz     short loc_4F9ECC
+  .text:00000000004F9EB2                 lea     rdx, src
+  .text:00000000004F9EB9                 test    dword ptr [rbp-13Ch], 3FFFFFFFh
+  .text:00000000004F9EC3                 jz      short loc_4F9ECC
+  .text:00000000004F9EC5                 mov     rdx, [rbp-138h]
+  .text:00000000004F9ECC                 mov     esi, 1Dh
+  .text:00000000004F9ED1                 mov     rdi, r14
+  .text:00000000004F9ED4                 sub     rbx, 8
+  .text:00000000004F9ED8                 call    rcx
+  .text:00000000004F9EDA                 ; int
+  .text:00000000004F9EDA                 xor     esi, esi; int
+  .text:00000000004F9EDC                 ; this
+  .text:00000000004F9EDC                 mov     rdi, r15; this
+  .text:00000000004F9EDF                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:00000000004F9EE4                 cmp     [rbp-148h], rbx
+  .text:00000000004F9EEB                 jnz     loc_4F9C50
+  .text:00000000004F9EF1                 jmp     loc_4F9D51
+  .text:00000000004F9F00                 lea     rsi, aOninvalidsteam; "OnInvalidSteamLogonErrorForClient"
+  .text:00000000004F9F07                 mov     rdi, r14
+  .text:00000000004F9F0A                 sub     rbx, 8
+  .text:00000000004F9F0E                 call    sub_525620
+  .text:00000000004F9F13                 mov     esi, 9
+  .text:00000000004F9F18                 mov     rdi, r14
+  .text:00000000004F9F1B                 call    sub_5269B0
+  .text:00000000004F9F20                 cmp     [rbp-148h], rbx
+  .text:00000000004F9F27                 jnz     loc_4F9C50
+  .text:00000000004F9F2D                 jmp     loc_4F9D51
+  .text:00000000004F9F38                 ; _QWORD
+  .text:00000000004F9F38                 mov     edi, cs:dword_A30294; _QWORD
+  .text:00000000004F9F3E                 ; _QWORD
+  .text:00000000004F9F3E                 mov     esi, 2; _QWORD
+  .text:00000000004F9F43                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000004F9F48                 test    al, al
+  .text:00000000004F9F4A                 jz      short loc_4F9FBA
+  .text:00000000004F9F4C                 mov     rax, [r15]
+  .text:00000000004F9F4F                 mov     rdi, r15
+  .text:00000000004F9F52                 call    qword ptr [rax+0A0h]
+  .text:00000000004F9F58                 mov     rdi, r14
+  .text:00000000004F9F5B                 cvtss2sd xmm0, xmm0
+  .text:00000000004F9F5F                 movsd   qword ptr [rbp-158h], xmm0
+  .text:00000000004F9F67                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000000004F9F6C                 mov     rdi, r14
+  .text:00000000004F9F6F                 mov     r8, [rax]
+  .text:00000000004F9F72                 lea     rax, src
+  .text:00000000004F9F79                 test    r8, r8
+  .text:00000000004F9F7C                 cmovz   r8, rax
+  .text:00000000004F9F80                 mov     [rbp-150h], r8
+  .text:00000000004F9F87                 call    sub_524D50
+  .text:00000000004F9F8C                 ; _QWORD
+  .text:00000000004F9F8C                 mov     edi, cs:dword_A30294; _QWORD
+  .text:00000000004F9F92                 lea     rdx, aChecktimeoutsD_0; "CheckTimeouts: Disconnecting client: %s"...
+  .text:00000000004F9F99                 ; _QWORD
+  .text:00000000004F9F99                 mov     esi, 2; _QWORD
+  .text:00000000004F9F9E                 mov     r8, [rbp-150h]
+  .text:00000000004F9FA5                 mov     rcx, rax
+  .text:00000000004F9FA8                 mov     eax, 1
+  .text:00000000004F9FAD                 movsd   xmm0, qword ptr [rbp-158h]
+  .text:00000000004F9FB5                 call    _LoggingSystem_Log
+  .text:00000000004F9FBA                 mov     rax, [r14]
+  .text:00000000004F9FBD                 mov     rdi, r15
+  .text:00000000004F9FC0                 mov     rcx, [rax+40h]
+  .text:00000000004F9FC4                 mov     rax, [r15]
+  .text:00000000004F9FC7                 lea     r15, [rbp-140h]
+  .text:00000000004F9FCE                 mov     [rbp-150h], rcx
+  .text:00000000004F9FD5                 call    qword ptr [rax+0A0h]
+  .text:00000000004F9FDB                 lea     rsi, aServerDecidedT; "server-decided timeout: %.2fs since rec"...
+  .text:00000000004F9FE2                 cvtss2sd xmm0, xmm0
+  .text:00000000004F9FE6                 jmp     loc_4F9E8E
+  .text:00000000004F9FF0                 retn
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_CheckTimeouts(__int64 a1, __int64 a2)
+  {
+    __int64 result; // rax
+    __int64 v3; // rdx
+    __int64 v4; // rbx
+    unsigned int *v5; // r14
+    __int64 (__fastcall *v6)(); // rax
+    __int64 v7; // r15
+    const bool *v8; // r8
+    __int64 v9; // rax
+    const char *v10; // rsi
+    int v11; // edx
+    int v12; // ecx
+    int v13; // r8d
+    int v14; // r9d
+    double v15; // xmm0_8
+    const bool *v16; // rdx
+    const bool *v17; // r8
+    __int64 v18; // rax
+    _QWORD *v19; // [rsp-160h] [rbp-160h]
+    double v20; // [rsp-160h] [rbp-160h]
+    double v21; // [rsp-160h] [rbp-160h]
+    unsigned __int8 (__fastcall *v22)(_QWORD *, _QWORD); // [rsp-158h] [rbp-158h]
+    const bool *v23; // [rsp-158h] [rbp-158h]
+    void (__fastcall *v24)(unsigned int *, __int64, const bool *); // [rsp-158h] [rbp-158h]
+    const bool *v25; // [rsp-158h] [rbp-158h]
+    __int64 v26; // [rsp-150h] [rbp-150h]
+    unsigned int v27; // [rsp-148h] [rbp-148h] BYREF
+    int v28; // [rsp-144h] [rbp-144h]
+    const bool *v29; // [rsp-140h] [rbp-140h] BYREF
+
+    result = *(int *)(a1 + 584);
+    LODWORD(v3) = *(_DWORD *)(a1 + 584) - 1;
+    if ( (int)v3 >= 0 )
+    {
+      v3 = (unsigned int)v3;
+      v4 = 8LL * (int)v3;
+      v26 = 8 * (result - (unsigned int)v3) - 16;
+      while ( 1 )
+      {
+        while ( 1 )
+        {
+          while ( 1 )
+          {
+            v5 = *(unsigned int **)(*(_QWORD *)(a1 + 592) + v4);
+            v6 = *(__int64 (__fastcall **)())(*(_QWORD *)v5 + 152LL);
+            if ( v6 == sub_4F0CC0 )
+              result = *((unsigned __int8 *)v5 + 160);
+            else
+              result = ((__int64 (__fastcall *)(_QWORD))v6)(*(_QWORD *)(*(_QWORD *)(a1 + 592) + v4));
+            if ( (_BYTE)result )
+              goto LABEL_15;
+            result = sub_523F90(v5, a2, v3);
+            if ( !(_BYTE)result )
+              goto LABEL_15;
+            result = sub_5256C0(v5);
+            if ( !(_BYTE)result )
+              break;
+            v4 -= 8;
+            sub_525620(v5, "OnInvalidSteamLogonErrorForClient");
+            a2 = 9;
+            result = sub_5269B0(v5, 9);
+            if ( v26 == v4 )
+              return result;
+          }
+          v7 = *((_QWORD *)v5 + 11);
+          if ( v7 )
+            break;
+  LABEL_15:
+          v4 -= 8;
+          if ( v26 == v4 )
+            return result;
+        }
+        if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)v7 + 456LL))(*((_QWORD *)v5 + 11)) )
+          break;
+        if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 600LL))(a1) // 600LL = 0x258 = CNetworkGameServerBase_IsHLTV
+          && g_pSource2Server
+          && (v19 = g_pSource2Server,
+              v22 = *(unsigned __int8 (__fastcall **)(_QWORD *, _QWORD))(*g_pSource2Server + 200LL),
+              (*(void (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7),
+              v22(v19, v5[18])) )
+        {
+          if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_A30294, 2) )
+          {
+            v21 = (*(float (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7);
+            v17 = *(const bool **)CServerSideClientBase_GetNetworkIDString((__int64)v5, 2);
+            if ( !v17 )
+              v17 = &src;
+            v25 = v17;
+            v18 = sub_524D50(v5);
+            LoggingSystem_Log(
+              (unsigned int)dword_A30294,
+              2,
+              "CheckTimeouts: Disconnecting client: %s %s, after a server-decided timeout of %0.2fs with no acks received\n",
+              v18,
+              v25,
+              v21);
+          }
+          v24 = *(void (__fastcall **)(unsigned int *, __int64, const bool *))(*(_QWORD *)v5 + 64LL);
+          v10 = "server-decided timeout: %.2fs since recv";
+          v15 = (*(float (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7);
+  LABEL_28:
+          sub_2CF1D0((unsigned int)&v27, (_DWORD)v10, v11, v12, v13, v14, v15);
+          v16 = (const bool *)&v29;
+          if ( (v28 & 0x40000000) == 0 )
+          {
+            v16 = &src;
+            if ( (v28 & 0x3FFFFFFF) != 0 )
+              v16 = v29;
+          }
+          v4 -= 8;
+          v24(v5, 29, v16);
+          a2 = 0;
+          result = CBufferString::Purge((CBufferString *)&v27, 0);
+          if ( v26 == v4 )
+            return result;
+        }
+        else
+        {
+          if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v7 + 392LL))(v7) )
+          {
+            a2 = 26;
+            result = (*(__int64 (__fastcall **)(unsigned int *, __int64, _QWORD))(*(_QWORD *)v5 + 64LL))(v5, 26, 0);
+            goto LABEL_15;
+          }
+          v27 = 0;
+          a2 = (__int64)&v27;
+          result = (*(__int64 (__fastcall **)(__int64, unsigned int *))(*(_QWORD *)v7 + 488LL))(v7, &v27);
+          if ( !(_BYTE)result )
+            goto LABEL_15;
+          a2 = v27;
+          if ( !v27 )
+          {
+            v27 = 30;
+            a2 = 30;
+          }
+          v4 -= 8;
+          result = (*(__int64 (__fastcall **)(unsigned int *, __int64, const char *))(*(_QWORD *)v5 + 64LL))(
+                     v5,
+                     a2,
+                     "remote disconnected");
+          if ( v26 == v4 )
+            return result;
+        }
+      }
+      if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_A30294, 2) )
+      {
+        v20 = (*(float (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7);
+        v8 = *(const bool **)CServerSideClientBase_GetNetworkIDString((__int64)v5, 2);
+        if ( !v8 )
+          v8 = &src;
+        v23 = v8;
+        v9 = sub_524D50(v5);
+        LoggingSystem_Log(
+          (unsigned int)dword_A30294,
+          2,
+          "CheckTimeouts: Disconnecting client: %s %s, after a netchan-decided timeout of %0.2fs with no acks received\n",
+          v9,
+          v23,
+          v20);
+      }
+      v24 = *(void (__fastcall **)(unsigned int *, __int64, const bool *))(*(_QWORD *)v5 + 64LL);
+      v10 = "netchan timeout: %.2fs since recv";
+      v15 = (*(float (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7);
+      goto LABEL_28;
+    }
+    return result;
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.windows.yaml
@@ -1,0 +1,413 @@
+func_name: CNetworkGameServerBase_CheckTimeouts
+func_va: '0x1800abe60'
+disasm_code: |-
+  .text:00000001800ABE60                 mov     r11, rsp
+  .text:00000001800ABE63                 push    rbp
+  .text:00000001800ABE64                 push    r14
+  .text:00000001800ABE66                 sub     rsp, 178h
+  .text:00000001800ABE6D                 mov     eax, [rcx+248h]
+  .text:00000001800ABE73                 mov     r14, rcx
+  .text:00000001800ABE76                 sub     eax, 1
+  .text:00000001800ABE79                 movsxd  rbp, eax
+  .text:00000001800ABE7C                 js      loc_1800AC24F
+  .text:00000001800ABE82                 mov     [r11-18h], rdi
+  .text:00000001800ABE86                 mov     [r11-20h], r12
+  .text:00000001800ABE8A                 lea     r12, aOninvalidsteam; "OnInvalidSteamLogonErrorForClient"
+  .text:00000001800ABE91                 mov     [r11-28h], r15
+  .text:00000001800ABE95                 xor     r15d, r15d
+  .text:00000001800ABE98                 movaps  xmmword ptr [r11-48h], xmm7
+  .text:00000001800ABE9D                 xorps   xmm7, xmm7
+  .text:00000001800ABEA0                 mov     [r11+10h], rbx
+  .text:00000001800ABEA4                 mov     [r11+18h], rsi
+  .text:00000001800ABEA8                 movaps  xmmword ptr [r11-38h], xmm6
+  .text:00000001800ABEAD                 nop     dword ptr [rax]
+  .text:00000001800ABEB0                 mov     rax, [r14+250h]
+  .text:00000001800ABEB7                 mov     rdi, [rax+rbp*8]
+  .text:00000001800ABEBB                 mov     rcx, rdi
+  .text:00000001800ABEBE                 mov     rax, [rdi]
+  .text:00000001800ABEC1                 call    qword ptr [rax+88h]
+  .text:00000001800ABEC7                 test    al, al
+  .text:00000001800ABEC9                 jnz     loc_1800AC20D
+  .text:00000001800ABECF                 cmp     dword ptr [rdi+64h], 2
+  .text:00000001800ABED3                 jl      loc_1800AC20D
+  .text:00000001800ABED9                 comiss  xmm7, dword ptr [rdi+0A04h]
+  .text:00000001800ABEE0                 ja      loc_1800ABFC2
+  .text:00000001800ABEE6                 call    cs:Plat_FloatTime
+  .text:00000001800ABEEC                 movss   xmm1, dword ptr [rdi+0A04h]
+  .text:00000001800ABEF4                 cvtps2pd xmm1, xmm1
+  .text:00000001800ABEF7                 subsd   xmm0, xmm1
+  .text:00000001800ABEFB                 cvttsd2si eax, xmm0
+  .text:00000001800ABEFF                 cmp     eax, 1Eh
+  .text:00000001800ABF02                 jl      loc_1800ABFC2
+  .text:00000001800ABF08                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800ABF0E                 mov     edx, 2
+  .text:00000001800ABF13                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800ABF19                 test    al, al
+  .text:00000001800ABF1B                 jz      short loc_1800ABF4E
+  .text:00000001800ABF1D                 mov     rcx, rdi
+  .text:00000001800ABF20                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000001800ABF25                 lea     r9, unk_180528AFF
+  .text:00000001800ABF2C                 mov     edx, 2
+  .text:00000001800ABF31                 lea     r8, aSvDisconnectin; "SV: Disconnecting due to unresolved k_E"...
+  .text:00000001800ABF38                 mov     rcx, [rax]
+  .text:00000001800ABF3B                 test    rcx, rcx
+  .text:00000001800ABF3E                 cmovnz  r9, rcx
+  .text:00000001800ABF42                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800ABF48                 call    cs:LoggingSystem_Log
+  .text:00000001800ABF4E                 movss   xmm0, dword ptr [rdi+0A04h]
+  .text:00000001800ABF56                 comiss  xmm0, xmm7
+  .text:00000001800ABF59                 jbe     short loc_1800ABFB0
+  .text:00000001800ABF5B                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800ABF61                 mov     edx, 2
+  .text:00000001800ABF66                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800ABF6C                 test    al, al
+  .text:00000001800ABF6E                 jz      short loc_1800ABFA6
+  .text:00000001800ABF70                 mov     rcx, rdi
+  .text:00000001800ABF73                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000001800ABF78                 lea     r9, unk_180528AFF
+  .text:00000001800ABF7F                 mov     [rsp+188h+var_168], r12
+  .text:00000001800ABF84                 lea     r8, aSvCancelingKEa; "SV: Canceling k_EAuthSessionResponseAut"...
+  .text:00000001800ABF8B                 mov     edx, 2
+  .text:00000001800ABF90                 mov     rcx, [rax]
+  .text:00000001800ABF93                 test    rcx, rcx
+  .text:00000001800ABF96                 cmovnz  r9, rcx
+  .text:00000001800ABF9A                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800ABFA0                 call    cs:LoggingSystem_Log
+  .text:00000001800ABFA6                 mov     dword ptr [rdi+0A04h], 0BF800000h
+  .text:00000001800ABFB0                 mov     edx, 9
+  .text:00000001800ABFB5                 mov     rcx, rdi
+  .text:00000001800ABFB8                 call    sub_1800CB060
+  .text:00000001800ABFBD                 jmp     loc_1800AC20D
+  .text:00000001800ABFC2                 mov     rsi, [rdi+58h]
+  .text:00000001800ABFC6                 test    rsi, rsi
+  .text:00000001800ABFC9                 jz      loc_1800AC20D
+  .text:00000001800ABFCF                 mov     rax, [rsi]
+  .text:00000001800ABFD2                 mov     rcx, rsi
+  .text:00000001800ABFD5                 call    qword ptr [rax+1C0h]
+  .text:00000001800ABFDB                 test    al, al
+  .text:00000001800ABFDD                 jz      loc_1800AC078
+  .text:00000001800ABFE3                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800ABFE9                 mov     edx, 2
+  .text:00000001800ABFEE                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800ABFF4                 test    al, al
+  .text:00000001800ABFF6                 jz      short loc_1800AC059
+  .text:00000001800ABFF8                 mov     rax, [rsi]
+  .text:00000001800ABFFB                 mov     rcx, rsi
+  .text:00000001800ABFFE                 call    qword ptr [rax+0A0h]
+  .text:00000001800AC004                 xorps   xmm6, xmm6
+  .text:00000001800AC007                 mov     rcx, rdi
+  .text:00000001800AC00A                 cvtss2sd xmm6, xmm0
+  .text:00000001800AC00E                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000001800AC013                 lea     rdx, unk_180528AFF
+  .text:00000001800AC01A                 lea     r9, unk_180528AFF
+  .text:00000001800AC021                 lea     r8, aChecktimeoutsD; "CheckTimeouts: Disconnecting client: %s"...
+  .text:00000001800AC028                 movsd   [rsp+188h+var_160], xmm6
+  .text:00000001800AC02E                 mov     rcx, [rax]
+  .text:00000001800AC031                 mov     rax, [rdi+40h]
+  .text:00000001800AC035                 test    rcx, rcx
+  .text:00000001800AC038                 cmovnz  rdx, rcx
+  .text:00000001800AC03C                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800AC042                 test    rax, rax
+  .text:00000001800AC045                 mov     [rsp+188h+var_168], rdx
+  .text:00000001800AC04A                 mov     edx, 2
+  .text:00000001800AC04F                 cmovnz  r9, rax
+  .text:00000001800AC053                 call    cs:LoggingSystem_Log
+  .text:00000001800AC059                 mov     rax, [rdi]
+  .text:00000001800AC05C                 mov     rcx, rsi
+  .text:00000001800AC05F                 mov     rbx, [rax+38h]
+  .text:00000001800AC063                 mov     rax, [rsi]
+  .text:00000001800AC066                 call    qword ptr [rax+0A0h]
+  .text:00000001800AC06C                 lea     rdx, aNetchanTimeout; "netchan timeout: %.2fs since recv"
+  .text:00000001800AC073                 jmp     loc_1800AC159
+  .text:00000001800AC078                 mov     rax, [r14]
+  .text:00000001800AC07B                 mov     rcx, r14
+  .text:00000001800AC07E                 call    qword ptr [rax+230h] ; 230h = CNetworkGameServerBase_IsHLTV
+  .text:00000001800AC084                 test    al, al
+  .text:00000001800AC086                 jnz     loc_1800AC1AC
+  .text:00000001800AC08C                 mov     rax, cs:g_pSource2Server
+  .text:00000001800AC093                 test    rax, rax
+  .text:00000001800AC096                 jz      loc_1800AC1AC
+  .text:00000001800AC09C                 mov     rax, [rax]
+  .text:00000001800AC09F                 mov     rcx, rsi
+  .text:00000001800AC0A2                 mov     rbx, [rax+0C8h]
+  .text:00000001800AC0A9                 mov     rax, [rsi]
+  .text:00000001800AC0AC                 call    qword ptr [rax+0A0h]
+  .text:00000001800AC0B2                 mov     edx, [rdi+48h]
+  .text:00000001800AC0B5                 movaps  xmm2, xmm0
+  .text:00000001800AC0B8                 mov     rcx, cs:g_pSource2Server
+  .text:00000001800AC0BF                 call    rbx
+  .text:00000001800AC0C1                 test    al, al
+  .text:00000001800AC0C3                 jz      loc_1800AC1AC
+  .text:00000001800AC0C9                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800AC0CF                 mov     edx, 2
+  .text:00000001800AC0D4                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800AC0DA                 test    al, al
+  .text:00000001800AC0DC                 jz      short loc_1800AC13F
+  .text:00000001800AC0DE                 mov     rax, [rsi]
+  .text:00000001800AC0E1                 mov     rcx, rsi
+  .text:00000001800AC0E4                 call    qword ptr [rax+0A0h]
+  .text:00000001800AC0EA                 xorps   xmm6, xmm6
+  .text:00000001800AC0ED                 mov     rcx, rdi
+  .text:00000001800AC0F0                 cvtss2sd xmm6, xmm0
+  .text:00000001800AC0F4                 call    CServerSideClientBase_GetNetworkIDString
+  .text:00000001800AC0F9                 lea     rdx, unk_180528AFF
+  .text:00000001800AC100                 lea     r9, unk_180528AFF
+  .text:00000001800AC107                 lea     r8, aChecktimeoutsD_0; "CheckTimeouts: Disconnecting client: %s"...
+  .text:00000001800AC10E                 movsd   [rsp+188h+var_160], xmm6
+  .text:00000001800AC114                 mov     rcx, [rax]
+  .text:00000001800AC117                 mov     rax, [rdi+40h]
+  .text:00000001800AC11B                 test    rcx, rcx
+  .text:00000001800AC11E                 cmovnz  rdx, rcx
+  .text:00000001800AC122                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800AC128                 test    rax, rax
+  .text:00000001800AC12B                 mov     [rsp+188h+var_168], rdx
+  .text:00000001800AC130                 mov     edx, 2
+  .text:00000001800AC135                 cmovnz  r9, rax
+  .text:00000001800AC139                 call    cs:LoggingSystem_Log
+  .text:00000001800AC13F                 mov     rax, [rdi]
+  .text:00000001800AC142                 mov     rcx, rsi
+  .text:00000001800AC145                 mov     rbx, [rax+38h]
+  .text:00000001800AC149                 mov     rax, [rsi]
+  .text:00000001800AC14C                 call    qword ptr [rax+0A0h]
+  .text:00000001800AC152                 lea     rdx, aServerDecidedT; "server-decided timeout: %.2fs since rec"...
+  .text:00000001800AC159                 xorps   xmm2, xmm2
+  .text:00000001800AC15C                 lea     rcx, [rsp+188h+var_158]
+  .text:00000001800AC161                 cvtss2sd xmm2, xmm0
+  .text:00000001800AC165                 movq    r8, xmm2
+  .text:00000001800AC16A                 call    sub_1800241C0
+  .text:00000001800AC16F                 mov     ecx, [rax+4]
+  .text:00000001800AC172                 bt      ecx, 1Eh
+  .text:00000001800AC176                 jnb     short loc_1800AC17E
+  .text:00000001800AC178                 lea     r8, [rax+8]
+  .text:00000001800AC17C                 jmp     short loc_1800AC193
+  .text:00000001800AC17E                 test    ecx, 3FFFFFFFh
+  .text:00000001800AC184                 jbe     short loc_1800AC18C
+  .text:00000001800AC186                 mov     r8, [rax+8]
+  .text:00000001800AC18A                 jmp     short loc_1800AC193
+  .text:00000001800AC18C                 lea     r8, unk_180528AFF
+  .text:00000001800AC193                 mov     edx, 1Dh
+  .text:00000001800AC198                 mov     rcx, rdi
+  .text:00000001800AC19B                 call    rbx
+  .text:00000001800AC19D                 xor     edx, edx
+  .text:00000001800AC19F                 lea     rcx, [rsp+188h+var_158]
+  .text:00000001800AC1A4                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001800AC1AA                 jmp     short loc_1800AC20D
+  .text:00000001800AC1AC                 mov     rax, [rsi]
+  .text:00000001800AC1AF                 mov     rcx, rsi
+  .text:00000001800AC1B2                 call    qword ptr [rax+180h]
+  .text:00000001800AC1B8                 test    al, al
+  .text:00000001800AC1BA                 jz      short loc_1800AC1C6
+  .text:00000001800AC1BC                 xor     r8d, r8d
+  .text:00000001800AC1BF                 mov     edx, 1Ah
+  .text:00000001800AC1C4                 jmp     short loc_1800AC204
+  .text:00000001800AC1C6                 mov     rax, [rsi]
+  .text:00000001800AC1C9                 lea     rdx, [rsp+188h+arg_0]
+  .text:00000001800AC1D1                 mov     rcx, rsi
+  .text:00000001800AC1D4                 mov     [rsp+188h+arg_0], r15d
+  .text:00000001800AC1DC                 call    qword ptr [rax+1E0h]
+  .text:00000001800AC1E2                 test    al, al
+  .text:00000001800AC1E4                 jz      short loc_1800AC20D
+  .text:00000001800AC1E6                 mov     edx, [rsp+188h+arg_0]
+  .text:00000001800AC1ED                 test    edx, edx
+  .text:00000001800AC1EF                 jnz     short loc_1800AC1FD
+  .text:00000001800AC1F1                 mov     edx, 1Eh
+  .text:00000001800AC1F6                 mov     [rsp+188h+arg_0], edx
+  .text:00000001800AC1FD                 lea     r8, aRemoteDisconne; "remote disconnected"
+  .text:00000001800AC204                 mov     rax, [rdi]
+  .text:00000001800AC207                 mov     rcx, rdi
+  .text:00000001800AC20A                 call    qword ptr [rax+38h]
+  .text:00000001800AC20D                 sub     rbp, 1
+  .text:00000001800AC211                 jns     loc_1800ABEB0
+  .text:00000001800AC217                 movaps  xmm7, [rsp+188h+var_48]
+  .text:00000001800AC21F                 movaps  xmm6, [rsp+188h+var_38]
+  .text:00000001800AC227                 mov     r15, [rsp+188h+var_28]
+  .text:00000001800AC22F                 mov     r12, [rsp+188h+var_20]
+  .text:00000001800AC237                 mov     rdi, [rsp+188h+var_18]
+  .text:00000001800AC23F                 mov     rsi, [rsp+188h+arg_10]
+  .text:00000001800AC247                 mov     rbx, [rsp+188h+arg_8]
+  .text:00000001800AC24F                 add     rsp, 178h
+  .text:00000001800AC256                 pop     r14
+  .text:00000001800AC258                 pop     rbp
+  .text:00000001800AC259                 retn
+procedure: |-
+  void __fastcall CNetworkGameServerBase_CheckTimeouts(__int64 a1)
+  {
+    double v1; // xmm0_8
+    int v3; // eax
+    __int64 i; // rbp
+    __int64 v5; // rdi
+    __int64 v6; // rdx
+    __int64 v7; // rcx
+    void **NetworkIDString; // rax
+    void *v9; // r9
+    void **v10; // rax
+    void *v11; // r9
+    __int64 *v12; // rsi
+    double v13; // xmm6_8
+    void **v14; // rax
+    void *v15; // rdx
+    void *v16; // r9
+    void (__fastcall *v17)(__int64, __int64, void *); // rbx
+    const char *v18; // rdx
+    unsigned __int8 (__fastcall *v19)(__int64, _QWORD); // rbx
+    double v20; // xmm6_8
+    void **v21; // rax
+    void *v22; // rdx
+    void *v23; // r9
+    __int64 v24; // rax
+    int v25; // ecx
+    void *v26; // r8
+    const char *v27; // r8
+    __int64 v28; // rdx
+    __int64 v29; // rax
+    _BYTE v30[272]; // [rsp+30h] [rbp-158h] BYREF
+    unsigned int v31; // [rsp+190h] [rbp+8h] BYREF
+
+    v3 = *(_DWORD *)(a1 + 584) - 1;
+    for ( i = v3; i >= 0; --i )
+    {
+      v5 = *(_QWORD *)(*(_QWORD *)(a1 + 592) + 8 * i);
+      if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)v5 + 136LL))(v5) && *(int *)(v5 + 100) >= 2 )
+      {
+        if ( *(float *)(v5 + 2564) >= 0.0 )
+        {
+          v1 = Plat_FloatTime(v7, v6) - *(float *)(v5 + 2564);
+          if ( (int)v1 >= 30 )
+          {
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+            {
+              NetworkIDString = (void **)CServerSideClientBase_GetNetworkIDString(v5);
+              v9 = &unk_180528AFF;
+              if ( *NetworkIDString )
+                v9 = *NetworkIDString;
+              LoggingSystem_Log(
+                (unsigned int)dword_1808CC6B8,
+                2,
+                "SV: Disconnecting due to unresolved k_EAuthSessionResponseAuthTicketCanceled for %s.\n",
+                v9);
+            }
+            LODWORD(v1) = *(_DWORD *)(v5 + 2564);
+            if ( *(float *)&v1 > 0.0 )
+            {
+              if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+              {
+                v10 = (void **)CServerSideClientBase_GetNetworkIDString(v5);
+                v11 = &unk_180528AFF;
+                if ( *v10 )
+                  v11 = *v10;
+                v1 = LoggingSystem_Log(
+                       (unsigned int)dword_1808CC6B8,
+                       2,
+                       "SV: Canceling k_EAuthSessionResponseAuthTicketCanceled for %s because %s.\n",
+                       v11,
+                       "OnInvalidSteamLogonErrorForClient");
+              }
+              *(_DWORD *)(v5 + 2564) = -1082130432;
+            }
+            sub_1800CB060(v5, 9);
+            continue;
+          }
+        }
+        v12 = *(__int64 **)(v5 + 88);
+        if ( v12 )
+        {
+          if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*v12 + 448))(*(_QWORD *)(v5 + 88)) )
+          {
+            if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+            {
+              v13 = (*(float (__fastcall **)(__int64 *))(*v12 + 160))(v12);
+              v14 = (void **)CServerSideClientBase_GetNetworkIDString(v5);
+              v15 = &unk_180528AFF;
+              v16 = &unk_180528AFF;
+              if ( *v14 )
+                v15 = *v14;
+              if ( *(_QWORD *)(v5 + 64) )
+                v16 = *(void **)(v5 + 64);
+              v1 = LoggingSystem_Log(
+                     (unsigned int)dword_1808CC6B8,
+                     2,
+                     "CheckTimeouts: Disconnecting client: %s %s, after a netchan-decided timeout of %0.2fs with no acks received\n",
+                     v16,
+                     v15,
+                     v13);
+            }
+            v17 = *(void (__fastcall **)(__int64, __int64, void *))(*(_QWORD *)v5 + 56LL);
+            (*(void (__fastcall **)(__int64 *))(*v12 + 160))(v12);
+            v18 = "netchan timeout: %.2fs since recv";
+  LABEL_36:
+            v24 = sub_1800241C0(v30, v18, *(float *)&v1);
+            v25 = *(_DWORD *)(v24 + 4);
+            if ( (v25 & 0x40000000) != 0 )
+            {
+              v26 = (void *)(v24 + 8);
+            }
+            else if ( (v25 & 0x3FFFFFFF) != 0 )
+            {
+              v26 = *(void **)(v24 + 8);
+            }
+            else
+            {
+              v26 = &unk_180528AFF;
+            }
+            v17(v5, 29, v26);
+            CBufferString::Purge((CBufferString *)v30, 0);
+            continue;
+          }
+          if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 560LL))(a1) )// 560LL = 0x230 = CNetworkGameServerBase_IsHLTV
+          {
+            if ( g_pSource2Server )
+            {
+              v19 = *(unsigned __int8 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Server + 200LL);
+              v1 = (*(double (__fastcall **)(__int64 *))(*v12 + 160))(v12);
+              if ( v19(g_pSource2Server, *(unsigned int *)(v5 + 72)) )
+              {
+                if ( (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC6B8, 2) )
+                {
+                  v20 = (*(float (__fastcall **)(__int64 *))(*v12 + 160))(v12);
+                  v21 = (void **)CServerSideClientBase_GetNetworkIDString(v5);
+                  v22 = &unk_180528AFF;
+                  v23 = &unk_180528AFF;
+                  if ( *v21 )
+                    v22 = *v21;
+                  if ( *(_QWORD *)(v5 + 64) )
+                    v23 = *(void **)(v5 + 64);
+                  v1 = LoggingSystem_Log(
+                         (unsigned int)dword_1808CC6B8,
+                         2,
+                         "CheckTimeouts: Disconnecting client: %s %s, after a server-decided timeout of %0.2fs with no acks received\n",
+                         v23,
+                         v22,
+                         v20);
+                }
+                v17 = *(void (__fastcall **)(__int64, __int64, void *))(*(_QWORD *)v5 + 56LL);
+                (*(void (__fastcall **)(__int64 *))(*v12 + 160))(v12);
+                v18 = "server-decided timeout: %.2fs since recv";
+                goto LABEL_36;
+              }
+            }
+          }
+          if ( (*(unsigned __int8 (__fastcall **)(__int64 *))(*v12 + 384))(v12) )
+          {
+            v27 = nullptr;
+            v28 = 26;
+  LABEL_48:
+            (*(void (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v5 + 56LL))(v5, v28, v27);
+            continue;
+          }
+          v29 = *v12;
+          v31 = 0;
+          if ( (*(unsigned __int8 (__fastcall **)(__int64 *, unsigned int *))(v29 + 480))(v12, &v31) )
+          {
+            v28 = v31;
+            if ( !v31 )
+            {
+              v28 = 30;
+              v31 = 30;
+            }
+            v27 = "remote disconnected";
+            goto LABEL_48;
+          }
+        }
+      }
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CServerSideClientBase_SendServerInfo.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClientBase_SendServerInfo.linux.yaml
@@ -1,0 +1,1523 @@
+func_name: CServerSideClientBase_SendServerInfo
+func_va: '0x527620'
+disasm_code: |-
+  .text:0000000000527564                 lea     rax, aNtries10000000; "nTries < 10000000"
+  .text:000000000052756B                 movdqa  xmm6, xmmword ptr [rbp-0A20h]
+  .text:0000000000527573                 mov     dword ptr [rbp-9D8h], 237h
+  .text:000000000052757D                 mov     [rbp-9E0h], rax
+  .text:0000000000527584                 movzx   eax, byte ptr [rbp-9D4h]
+  .text:000000000052758B                 ; _QWORD
+  .text:000000000052758B                 lea     rdi, [rbp-9F0h]; _QWORD
+  .text:0000000000527592                 lea     rsi, aCtsqueueCorrup; "CTSQueue corruption"
+  .text:0000000000527599                 movaps  xmmword ptr [rbp-9F0h], xmm6
+  .text:00000000005275A0                 and     eax, 0FFFFFF80h
+  .text:00000000005275A3                 or      eax, 16h
+  .text:00000000005275A6                 mov     [rbp-9D4h], al
+  .text:00000000005275AC                 xor     eax, eax
+  .text:00000000005275AE                 call    __Z28Assert_ConditionFailed_FatalRK34_AssertCompileTimeConstantStruct_tPKcz; Assert_ConditionFailed_Fatal(_AssertCompileTimeConstantStruct_t const&,char const*,...)
+  .text:00000000005275B3                 lea     rdi, aBasicStringSCo; "basic_string::_S_construct null not val"...
+  .text:00000000005275BA                 call    __ZSt19__throw_logic_errorPKc; std::__throw_logic_error(char const*)
+  .text:00000000005275BF                 lea     rax, aNtries10000000; "nTries < 10000000"
+  .text:00000000005275C6                 movdqa  xmm5, xmmword ptr [rbp-0A20h]
+  .text:00000000005275CE                 mov     dword ptr [rbp-9D8h], 237h
+  .text:00000000005275D8                 mov     [rbp-9E0h], rax
+  .text:00000000005275DF                 movzx   eax, byte ptr [rbp-9D4h]
+  .text:00000000005275E6                 ; _QWORD
+  .text:00000000005275E6                 lea     rdi, [rbp-9F0h]; _QWORD
+  .text:00000000005275ED                 lea     rsi, aCtsqueueCorrup; "CTSQueue corruption"
+  .text:00000000005275F4                 movaps  xmmword ptr [rbp-9F0h], xmm5
+  .text:00000000005275FB                 and     eax, 0FFFFFF80h
+  .text:00000000005275FE                 or      eax, 16h
+  .text:0000000000527601                 mov     [rbp-9D4h], al
+  .text:0000000000527607                 xor     eax, eax
+  .text:0000000000527609                 call    __Z28Assert_ConditionFailed_FatalRK34_AssertCompileTimeConstantStruct_tPKcz; Assert_ConditionFailed_Fatal(_AssertCompileTimeConstantStruct_t const&,char const*,...)
+  .text:000000000052760E                 lea     rdi, aBasicStringSCr; "basic_string::_S_create"
+  .text:0000000000527615                 call    __ZSt20__throw_length_errorPKc; std::__throw_length_error(char const*)
+  .text:0000000000527620                 cmp     qword ptr [rdi+58h], 0
+  .text:0000000000527625                 jz      locret_5283F0
+  .text:000000000052762B                 push    rbp
+  .text:000000000052762C                 mov     rbp, rsp
+  .text:000000000052762F                 push    r15
+  .text:0000000000527631                 push    r14
+  .text:0000000000527633                 mov     r14, rsi
+  .text:0000000000527636                 push    r13
+  .text:0000000000527638                 push    r12
+  .text:000000000052763A                 mov     r12, rdi
+  .text:000000000052763D                 push    rbx
+  .text:000000000052763E                 sub     rsp, 0A38h
+  .text:0000000000527645                 lea     rax, g_pNetworkSystem
+  .text:000000000052764C                 mov     rdi, [rax]
+  .text:000000000052764F                 mov     rax, [rdi]
+  .text:0000000000527652                 mov     [rbp-0A40h], rdi
+  .text:0000000000527659                 call    qword ptr [rax+138h]
+  .text:000000000052765F                 mov     ecx, 138800h
+  .text:0000000000527664                 mov     r8d, 0FFFFFFFFh
+  .text:000000000052766A                 lea     rdi, [rbp-9D0h]
+  .text:0000000000527671                 mov     rdx, rax
+  .text:0000000000527674                 mov     [rbp-0A48h], rax
+  .text:000000000052767B                 lea     rsi, aSvSendserverin; "SV_SendServerinfo->msg"
+  .text:0000000000527682                 mov     [rbp-0A00h], rdi
+  .text:0000000000527689                 call    sub_5E1530
+  .text:000000000052768E                 mov     eax, [r14+4]
+  .text:0000000000527692                 xor     edx, edx
+  .text:0000000000527694                 xor     esi, esi
+  .text:0000000000527696                 mov     qword ptr [rbp-838h], 0
+  .text:00000000005276A1                 mov     qword ptr [rbp-8B8h], 0
+  .text:00000000005276AC                 mov     dword ptr [rbp-8B0h], 0
+  .text:00000000005276B6                 mov     [r12+158h], eax
+  .text:00000000005276BE                 mov     rax, 0C000080000000000h
+  .text:00000000005276C8                 mov     [rbp-840h], rax
+  .text:00000000005276CF                 lea     rax, unk_99C8E0
+  .text:00000000005276D6                 mov     [rbp-8C0h], rax
+  .text:00000000005276DD                 mov     rax, qword ptr cs:xmmword_2683D0+8
+  .text:00000000005276E4                 mov     byte ptr [rbp-8ACh], 0FFh
+  .text:00000000005276EB                 mov     dword ptr [rbp-8A0h], 0BF800000h
+  .text:00000000005276F5                 mov     qword ptr [rbp-898h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000527700                 mov     [rbp-8A8h], rax
+  .text:0000000000527707                 lea     rax, [rbp-890h]
+  .text:000000000052770E                 mov     rdi, rax
+  .text:0000000000527711                 mov     [rbp-0A08h], rax
+  .text:0000000000527718                 call    sub_3086C0
+  .text:000000000052771D                 lea     rax, off_9AFA80
+  .text:0000000000527724                 mov     r13d, [r14+14h]
+  .text:0000000000527728                 mov     [rbp-8C0h], rax
+  .text:000000000052772F                 add     rax, 40h ; '@'
+  .text:0000000000527733                 mov     [rbp-890h], rax
+  .text:000000000052773A                 call    sub_3BB6B0
+  .text:000000000052773F                 mov     r15, rax
+  .text:0000000000527742                 call    sub_459AE0
+  .text:0000000000527747                 mov     rdi, [r12+50h]
+  .text:000000000052774C                 mov     r9d, [r14+10h]
+  .text:0000000000527750                 mov     [rbp-0A10h], eax
+  .text:0000000000527756                 mov     r8d, [r14+8]
+  .text:000000000052775A                 mov     ebx, [r14+0Ch]
+  .text:000000000052775E                 mov     rax, [rdi]
+  .text:0000000000527761                 mov     [rbp-0A38h], r9d
+  .text:0000000000527768                 mov     [rbp-0A30h], r8d
+  .text:000000000052776F                 call    qword ptr [rax+0C8h]
+  .text:0000000000527775                 mov     [rbp-0A28h], rax
+  .text:000000000052777C                 lea     rax, qword_9E2328
+  .text:0000000000527783                 mov     rdi, [rax]
+  .text:0000000000527786                 mov     rax, [rdi]
+  .text:0000000000527789                 call    qword ptr [rax+58h]
+  .text:000000000052778C                 lea     rdi, [rbp-840h]
+  .text:0000000000527793                 mov     [rbp-0A20h], rdi
+  .text:000000000052779A                 mov     rdx, rax
+  .text:000000000052779D                 push    r13
+  .text:000000000052779F                 lea     rsi, aGameSMapSPlaye; "\nGame: \"%s\"\nMap: \"%s\"\nPlayers: %"...
+  .text:00000000005277A6                 push    r15
+  .text:00000000005277A8                 mov     eax, [rbp-0A10h]
+  .text:00000000005277AE                 push    rax
+  .text:00000000005277AF                 xor     eax, eax
+  .text:00000000005277B1                 push    rbx
+  .text:00000000005277B2                 mov     r9d, [rbp-0A38h]
+  .text:00000000005277B9                 mov     r8d, [rbp-0A30h]
+  .text:00000000005277C0                 mov     rcx, [rbp-0A28h]
+  .text:00000000005277C7                 call    sub_353F30
+  .text:00000000005277CC                 add     rsp, 20h
+  .text:00000000005277D0                 test    byte ptr [rbp-839h], 40h
+  .text:00000000005277D7                 jnz     loc_5280C0
+  .text:00000000005277DD                 test    dword ptr [rbp-83Ch], 3FFFFFFFh
+  .text:00000000005277E7                 jnz     loc_527880
+  .text:00000000005277ED                 lea     rbx, src
+  .text:00000000005277F4                 mov     rax, [rbp-888h]
+  .text:00000000005277FB                 or      dword ptr [rbp-880h], 1
+  .text:0000000000527802                 mov     rcx, rax
+  .text:0000000000527805                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000000527809                 mov     [rbp-0A10h], rcx
+  .text:0000000000527810                 test    al, 1
+  .text:0000000000527812                 jnz     loc_528540
+  .text:0000000000527818                 ; s
+  .text:0000000000527818                 mov     rdi, rbx; s
+  .text:000000000052781B                 call    _strlen
+  .text:0000000000527820                 mov     r13, rax
+  .text:0000000000527823                 test    rax, rax
+  .text:0000000000527826                 jz      loc_528218
+  .text:000000000052782C                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:0000000000527836                 cmp     rax, r13
+  .text:0000000000527839                 jb      loc_52760E
+  .text:000000000052783F                 lea     rax, [r13+39h]
+  .text:0000000000527843                 cmp     rax, 1000h
+  .text:0000000000527849                 ja      short loc_5278C0
+  .text:000000000052784B                 ; _QWORD
+  .text:000000000052784B                 lea     rdi, [r13+19h]; _QWORD
+  .text:000000000052784F                 call    __Znwm; operator new(ulong)
+  .text:0000000000527854                 mov     [rax+8], r13
+  .text:0000000000527858                 lea     rcx, [rax+18h]
+  .text:000000000052785C                 mov     r15, rax
+  .text:000000000052785F                 mov     dword ptr [rax+10h], 0
+  .text:0000000000527866                 cmp     r13, 1
+  .text:000000000052786A                 jnz     loc_527909
+  .text:0000000000527870                 movzx   eax, byte ptr [rbx]
+  .text:0000000000527873                 mov     [r15+18h], al
+  .text:0000000000527877                 jmp     loc_52791A
+  .text:0000000000527880                 mov     rax, [rbp-888h]
+  .text:0000000000527887                 mov     rbx, [rbp-838h]
+  .text:000000000052788E                 or      dword ptr [rbp-880h], 1
+  .text:0000000000527895                 mov     rcx, rax
+  .text:0000000000527898                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:000000000052789C                 mov     [rbp-0A10h], rcx
+  .text:00000000005278A3                 test    al, 1
+  .text:00000000005278A5                 jnz     loc_5285B0
+  .text:00000000005278AB                 test    rbx, rbx
+  .text:00000000005278AE                 jz      loc_5275B3
+  .text:00000000005278B4                 jmp     loc_527818
+  .text:00000000005278C0                 lea     rdx, [r13+1000h]
+  .text:00000000005278C7                 and     eax, 0FFFh
+  .text:00000000005278CC                 sub     rdx, rax
+  .text:00000000005278CF                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:00000000005278D9                 cmp     rdx, rax
+  .text:00000000005278DC                 cmova   rdx, rax
+  .text:00000000005278E0                 ; _QWORD
+  .text:00000000005278E0                 lea     rdi, [rdx+19h]; _QWORD
+  .text:00000000005278E4                 mov     [rbp-0A28h], rdx
+  .text:00000000005278EB                 call    __Znwm; operator new(ulong)
+  .text:00000000005278F0                 mov     rdx, [rbp-0A28h]
+  .text:00000000005278F7                 mov     dword ptr [rax+10h], 0
+  .text:00000000005278FE                 lea     rcx, [rax+18h]
+  .text:0000000000527902                 mov     r15, rax
+  .text:0000000000527905                 mov     [rax+8], rdx
+  .text:0000000000527909                 ; dest
+  .text:0000000000527909                 mov     rdi, rcx; dest
+  .text:000000000052790C                 ; n
+  .text:000000000052790C                 mov     rdx, r13; n
+  .text:000000000052790F                 ; src
+  .text:000000000052790F                 mov     rsi, rbx; src
+  .text:0000000000527912                 call    _memcpy
+  .text:0000000000527917                 mov     rcx, rax
+  .text:000000000052791A                 mov     rbx, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:0000000000527921                 cmp     r15, rbx
+  .text:0000000000527924                 jnz     loc_528550
+  .text:000000000052792A                 mov     rdx, [rbp-0A10h]
+  .text:0000000000527931                 lea     r13, [rbp-940h]
+  .text:0000000000527938                 mov     [rbp-940h], rcx
+  .text:000000000052793F                 lea     rdi, [rbp-878h]
+  .text:0000000000527946                 mov     rsi, r13
+  .text:0000000000527949                 call    sub_60022E
+  .text:000000000052794E                 mov     rax, [rbp-940h]
+  .text:0000000000527955                 ; _QWORD
+  .text:0000000000527955                 lea     rdi, [rax-18h]; _QWORD
+  .text:0000000000527959                 cmp     rdi, rbx
+  .text:000000000052795C                 jnz     loc_5284C8
+  .text:0000000000527962                 lea     r15, g_pNetworkMessages
+  .text:0000000000527969                 lea     rax, [rbp-8C0h]
+  .text:0000000000527970                 mov     rdx, rax
+  .text:0000000000527973                 mov     [rbp-0A38h], rax
+  .text:000000000052797A                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527981                 mov     rdi, [r15]
+  .text:0000000000527984                 mov     rax, [rdi]
+  .text:0000000000527987                 call    qword ptr [rax+18h]
+  .text:000000000052798A                 test    al, al
+  .text:000000000052798C                 jz      loc_5281D8
+  .text:0000000000527992                 mov     rdi, [rbp-0A08h]
+  .text:0000000000527999                 lea     rax, off_9A2898
+  .text:00000000005279A0                 mov     [rbp-8C0h], rax
+  .text:00000000005279A7                 add     rax, 40h ; '@'
+  .text:00000000005279AB                 mov     [rbp-890h], rax
+  .text:00000000005279B2                 call    sub_31D650
+  .text:00000000005279B7                 ; this
+  .text:00000000005279B7                 mov     rdi, [rbp-0A20h]; this
+  .text:00000000005279BE                 ; int
+  .text:00000000005279BE                 xor     esi, esi; int
+  .text:00000000005279C0                 call    __ZN13CBufferString5PurgeEi; CBufferString::Purge(int)
+  .text:00000000005279C5                 xor     edx, edx
+  .text:00000000005279C7                 xor     esi, esi
+  .text:00000000005279C9                 mov     byte ptr [rbp-92Ch], 0FFh
+  .text:00000000005279D0                 mov     eax, [r12+158h]
+  .text:00000000005279D8                 mov     qword ptr [rbp-938h], 0
+  .text:00000000005279E3                 mov     dword ptr [rbp-930h], 0
+  .text:00000000005279ED                 mov     dword ptr [rbp-920h], 0BF800000h
+  .text:00000000005279F7                 mov     qword ptr [rbp-918h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000527A02                 mov     [rbp-0A10h], eax
+  .text:0000000000527A08                 lea     rax, unk_99C8E0
+  .text:0000000000527A0F                 mov     [rbp-940h], rax
+  .text:0000000000527A16                 mov     rax, qword ptr cs:xmmword_2683D0+8
+  .text:0000000000527A1D                 mov     [rbp-928h], rax
+  .text:0000000000527A24                 lea     rax, [rbp-910h]
+  .text:0000000000527A2B                 mov     rdi, rax
+  .text:0000000000527A2E                 mov     [rbp-0A30h], rax
+  .text:0000000000527A35                 call    sub_2ED610
+  .text:0000000000527A3A                 lea     rax, off_9AD570
+  .text:0000000000527A41                 mov     rdi, [r15]
+  .text:0000000000527A44                 mov     rdx, r13
+  .text:0000000000527A47                 mov     [rbp-940h], rax
+  .text:0000000000527A4E                 add     rax, 40h ; '@'
+  .text:0000000000527A52                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527A59                 or      dword ptr [rbp-900h], 2
+  .text:0000000000527A60                 mov     [rbp-910h], rax
+  .text:0000000000527A67                 mov     eax, [rbp-0A10h]
+  .text:0000000000527A6D                 mov     [rbp-8F0h], eax
+  .text:0000000000527A73                 mov     rax, [rdi]
+  .text:0000000000527A76                 call    qword ptr [rax+18h]
+  .text:0000000000527A79                 test    al, al
+  .text:0000000000527A7B                 jz      loc_528198
+  .text:0000000000527A81                 mov     rdi, [r12+50h]
+  .text:0000000000527A86                 lea     rdx, sub_4F0BD0
+  .text:0000000000527A8D                 mov     rax, [rdi]
+  .text:0000000000527A90                 mov     rax, [rax+178h]
+  .text:0000000000527A97                 cmp     rax, rdx
+  .text:0000000000527A9A                 jnz     loc_528408
+  .text:0000000000527AA0                 movzx   eax, byte ptr [rdi+455h]
+  .text:0000000000527AA7                 mov     r13d, 1
+  .text:0000000000527AAD                 test    al, al
+  .text:0000000000527AAF                 jz      short loc_527ABA
+  .text:0000000000527AB1                 movzx   r13d, byte ptr [r12+9F9h]
+  .text:0000000000527ABA                 lea     rax, unk_99C8E0
+  .text:0000000000527AC1                 xor     esi, esi
+  .text:0000000000527AC3                 xor     edx, edx
+  .text:0000000000527AC5                 mov     qword ptr [rbp-998h], 0
+  .text:0000000000527AD0                 mov     [rbp-9A0h], rax
+  .text:0000000000527AD7                 mov     rax, qword ptr cs:xmmword_2683D0+8
+  .text:0000000000527ADE                 mov     dword ptr [rbp-990h], 0
+  .text:0000000000527AE8                 mov     byte ptr [rbp-98Ch], 0FFh
+  .text:0000000000527AEF                 mov     dword ptr [rbp-980h], 0BF800000h
+  .text:0000000000527AF9                 mov     [rbp-988h], rax
+  .text:0000000000527B00                 lea     rax, [rbp-970h]
+  .text:0000000000527B07                 mov     rdi, rax
+  .text:0000000000527B0A                 mov     [rbp-0A28h], rax
+  .text:0000000000527B11                 mov     qword ptr [rbp-978h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000527B1C                 call    sub_308AC0
+  .text:0000000000527B21                 mov     rdi, [r12+50h]
+  .text:0000000000527B26                 lea     rax, off_9B1D48
+  .text:0000000000527B2D                 mov     [rbp-9A0h], rax
+  .text:0000000000527B34                 add     rax, 40h ; '@'
+  .text:0000000000527B38                 mov     [rbp-970h], rax
+  .text:0000000000527B3F                 mov     rax, [rdi]
+  .text:0000000000527B42                 call    qword ptr [rax+0C8h]
+  .text:0000000000527B48                 or      dword ptr [rbp-960h], 1
+  .text:0000000000527B4F                 mov     rsi, rax
+  .text:0000000000527B52                 mov     rax, [rbp-968h]
+  .text:0000000000527B59                 mov     rcx, rax
+  .text:0000000000527B5C                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:0000000000527B60                 mov     [rbp-0A10h], rcx
+  .text:0000000000527B67                 test    al, 1
+  .text:0000000000527B69                 jnz     loc_528500
+  .text:0000000000527B6F                 test    rsi, rsi
+  .text:0000000000527B72                 jz      loc_5275B3
+  .text:0000000000527B78                 ; s
+  .text:0000000000527B78                 mov     rdi, rsi; s
+  .text:0000000000527B7B                 mov     [rbp-0A50h], rsi
+  .text:0000000000527B82                 call    _strlen
+  .text:0000000000527B87                 mov     rdx, rax
+  .text:0000000000527B8A                 test    rax, rax
+  .text:0000000000527B8D                 jz      loc_5283F8
+  .text:0000000000527B93                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:0000000000527B9D                 cmp     rax, rdx
+  .text:0000000000527BA0                 jb      loc_52760E
+  .text:0000000000527BA6                 lea     rax, [rdx+39h]
+  .text:0000000000527BAA                 mov     rsi, [rbp-0A50h]
+  .text:0000000000527BB1                 cmp     rax, 1000h
+  .text:0000000000527BB7                 ja      short loc_527C08
+  .text:0000000000527BB9                 ; _QWORD
+  .text:0000000000527BB9                 lea     rdi, [rdx+19h]; _QWORD
+  .text:0000000000527BBD                 mov     [rbp-0A58h], rsi
+  .text:0000000000527BC4                 mov     [rbp-0A50h], rdx
+  .text:0000000000527BCB                 call    __Znwm; operator new(ulong)
+  .text:0000000000527BD0                 mov     rdx, [rbp-0A50h]
+  .text:0000000000527BD7                 mov     rsi, [rbp-0A58h]
+  .text:0000000000527BDE                 mov     rcx, rax
+  .text:0000000000527BE1                 mov     dword ptr [rax+10h], 0
+  .text:0000000000527BE8                 lea     rdi, [rax+18h]
+  .text:0000000000527BEC                 cmp     rdx, 1
+  .text:0000000000527BF0                 mov     [rax+8], rdx
+  .text:0000000000527BF4                 jnz     short loc_527C6D
+  .text:0000000000527BF6                 movzx   eax, byte ptr [rsi]
+  .text:0000000000527BF9                 mov     [rcx+18h], al
+  .text:0000000000527BFC                 jmp     loc_527C91
+  .text:0000000000527C08                 lea     r8, [rdx+1000h]
+  .text:0000000000527C0F                 and     eax, 0FFFh
+  .text:0000000000527C14                 mov     [rbp-0A60h], rsi
+  .text:0000000000527C1B                 sub     r8, rax
+  .text:0000000000527C1E                 mov     [rbp-0A58h], rdx
+  .text:0000000000527C25                 mov     rax, 3FFFFFFFFFFFFFF9h
+  .text:0000000000527C2F                 cmp     r8, rax
+  .text:0000000000527C32                 cmova   r8, rax
+  .text:0000000000527C36                 ; _QWORD
+  .text:0000000000527C36                 lea     rdi, [r8+19h]; _QWORD
+  .text:0000000000527C3A                 mov     [rbp-0A50h], r8
+  .text:0000000000527C41                 call    __Znwm; operator new(ulong)
+  .text:0000000000527C46                 mov     r8, [rbp-0A50h]
+  .text:0000000000527C4D                 ; n
+  .text:0000000000527C4D                 mov     rdx, [rbp-0A58h]; n
+  .text:0000000000527C54                 ; dest
+  .text:0000000000527C54                 lea     rdi, [rax+18h]; dest
+  .text:0000000000527C58                 mov     rcx, rax
+  .text:0000000000527C5B                 mov     dword ptr [rax+10h], 0
+  .text:0000000000527C62                 ; src
+  .text:0000000000527C62                 mov     rsi, [rbp-0A60h]; src
+  .text:0000000000527C69                 mov     [rax+8], r8
+  .text:0000000000527C6D                 mov     [rbp-0A58h], rcx
+  .text:0000000000527C74                 mov     [rbp-0A50h], rdx
+  .text:0000000000527C7B                 call    _memcpy
+  .text:0000000000527C80                 mov     rcx, [rbp-0A58h]
+  .text:0000000000527C87                 mov     rdx, [rbp-0A50h]
+  .text:0000000000527C8E                 mov     rdi, rax
+  .text:0000000000527C91                 cmp     rcx, rbx
+  .text:0000000000527C94                 jnz     loc_528588
+  .text:0000000000527C9A                 mov     rdx, [rbp-0A10h]
+  .text:0000000000527CA1                 mov     [rbp-840h], rdi
+  .text:0000000000527CA8                 lea     rdi, [rbp-958h]
+  .text:0000000000527CAF                 mov     rsi, [rbp-0A20h]
+  .text:0000000000527CB6                 call    sub_60022E
+  .text:0000000000527CBB                 mov     rax, [rbp-840h]
+  .text:0000000000527CC2                 ; _QWORD
+  .text:0000000000527CC2                 lea     rdi, [rax-18h]; _QWORD
+  .text:0000000000527CC6                 cmp     rdi, rbx
+  .text:0000000000527CC9                 jnz     loc_528510
+  .text:0000000000527CCF                 mov     rdi, [r15]
+  .text:0000000000527CD2                 test    r13b, r13b
+  .text:0000000000527CD5                 jz      loc_528070
+  .text:0000000000527CDB                 or      dword ptr [rbp-960h], 2
+  .text:0000000000527CE2                 mov     byte ptr [rbp-950h], 1
+  .text:0000000000527CE9                 lea     rdx, [rbp-9A0h]
+  .text:0000000000527CF0                 mov     rax, [rdi]
+  .text:0000000000527CF3                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527CFA                 call    qword ptr [rax+18h]
+  .text:0000000000527CFD                 test    al, al
+  .text:0000000000527CFF                 jz      loc_528458
+  .text:0000000000527D05                 lea     rax, unk_99C8E0
+  .text:0000000000527D0C                 xor     edx, edx
+  .text:0000000000527D0E                 xor     esi, esi
+  .text:0000000000527D10                 mov     qword ptr [rbp-838h], 0
+  .text:0000000000527D1B                 mov     [rbp-840h], rax
+  .text:0000000000527D22                 mov     rax, qword ptr cs:xmmword_2683D0+8
+  .text:0000000000527D29                 mov     dword ptr [rbp-830h], 0
+  .text:0000000000527D33                 mov     byte ptr [rbp-82Ch], 0FFh
+  .text:0000000000527D3A                 mov     dword ptr [rbp-820h], 0BF800000h
+  .text:0000000000527D44                 mov     [rbp-828h], rax
+  .text:0000000000527D4B                 lea     rax, [rbp-810h]
+  .text:0000000000527D52                 mov     rdi, rax
+  .text:0000000000527D55                 mov     [rbp-0A10h], rax
+  .text:0000000000527D5C                 mov     qword ptr [rbp-818h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000527D67                 call    sub_3085C0
+  .text:0000000000527D6C                 mov     rbx, [rbp-7C8h]
+  .text:0000000000527D73                 lea     rax, off_9B1C68
+  .text:0000000000527D7A                 or      dword ptr [rbp-800h], 40h
+  .text:0000000000527D81                 mov     [rbp-840h], rax
+  .text:0000000000527D88                 add     rax, 40h ; '@'
+  .text:0000000000527D8C                 mov     [rbp-810h], rax
+  .text:0000000000527D93                 test    rbx, rbx
+  .text:0000000000527D96                 jz      loc_5282F0
+  .text:0000000000527D9C                 mov     rdi, [r12+50h]
+  .text:0000000000527DA1                 lea     rdx, sub_4F0BC0
+  .text:0000000000527DA8                 mov     rax, [rdi]
+  .text:0000000000527DAB                 mov     rax, [rax+160h]
+  .text:0000000000527DB2                 cmp     rax, rdx
+  .text:0000000000527DB5                 jnz     loc_528410
+  .text:0000000000527DBB                 lea     rsi, [rdi+0D8h]
+  .text:0000000000527DC2                 mov     rdi, rbx
+  .text:0000000000527DC5                 call    sub_2F85A0
+  .text:0000000000527DCA                 mov     eax, [r12+48h]
+  .text:0000000000527DCF                 mov     rdi, [r12+50h]
+  .text:0000000000527DD4                 or      dword ptr [rbp-800h], 8000h
+  .text:0000000000527DDE                 mov     rbx, [rbp-0A20h]
+  .text:0000000000527DE5                 mov     [rbp-7A4h], eax
+  .text:0000000000527DEB                 mov     rax, [rdi]
+  .text:0000000000527DEE                 mov     rsi, rbx
+  .text:0000000000527DF1                 call    qword ptr [rax+278h]  ; 278h = CNetworkGameServerBase_FillServerInfo
+  .text:0000000000527DF7                 mov     rdi, [r15]
+  .text:0000000000527DFA                 mov     rdx, rbx
+  .text:0000000000527DFD                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527E04                 mov     rax, [rdi]
+  .text:0000000000527E07                 call    qword ptr [rax+18h]
+  .text:0000000000527E0A                 test    al, al
+  .text:0000000000527E0C                 jz      loc_5282B8
+  .text:0000000000527E12                 test    r13b, r13b
+  .text:0000000000527E15                 jnz     short loc_527E33
+  .text:0000000000527E17                 mov     rdi, [r15]
+  .text:0000000000527E1A                 lea     rdx, [r14+30h]
+  .text:0000000000527E1E                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527E25                 mov     rax, [rdi]
+  .text:0000000000527E28                 call    qword ptr [rax+18h]
+  .text:0000000000527E2B                 test    al, al
+  .text:0000000000527E2D                 jz      loc_528490
+  .text:0000000000527E33                 mov     rax, [r12+50h]
+  .text:0000000000527E38                 xor     edx, edx
+  .text:0000000000527E3A                 xor     esi, esi
+  .text:0000000000527E3C                 mov     rdi, [rbp-0A08h]
+  .text:0000000000527E43                 mov     ebx, [rax+2A0h]
+  .text:0000000000527E49                 lea     rax, unk_99C8E0
+  .text:0000000000527E50                 mov     qword ptr [rbp-8B8h], 0
+  .text:0000000000527E5B                 mov     [rbp-8C0h], rax
+  .text:0000000000527E62                 mov     rax, qword ptr cs:xmmword_2683D0+8
+  .text:0000000000527E69                 mov     dword ptr [rbp-8B0h], 0
+  .text:0000000000527E73                 mov     byte ptr [rbp-8ACh], 0FFh
+  .text:0000000000527E7A                 mov     dword ptr [rbp-8A0h], 0BF800000h
+  .text:0000000000527E84                 mov     [rbp-8A8h], rax
+  .text:0000000000527E8B                 mov     qword ptr [rbp-898h], 0FFFFFFFFFFFFFFFFh
+  .text:0000000000527E96                 call    sub_2ED6B0
+  .text:0000000000527E9B                 mov     rdi, [r15]
+  .text:0000000000527E9E                 lea     rax, off_9AC2B0
+  .text:0000000000527EA5                 mov     dword ptr [rbp-850h], 3
+  .text:0000000000527EAF                 mov     [rbp-8C0h], rax
+  .text:0000000000527EB6                 add     rax, 40h ; '@'
+  .text:0000000000527EBA                 mov     rdx, [rbp-0A38h]
+  .text:0000000000527EC1                 or      dword ptr [rbp-880h], 1Ch
+  .text:0000000000527EC8                 mov     [rbp-84Ch], ebx
+  .text:0000000000527ECE                 mov     [rbp-890h], rax
+  .text:0000000000527ED5                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527EDC                 mov     dword ptr [rbp-848h], 0
+  .text:0000000000527EE6                 mov     rax, [rdi]
+  .text:0000000000527EE9                 call    qword ptr [rax+18h]
+  .text:0000000000527EEC                 test    al, al
+  .text:0000000000527EEE                 jz      loc_528280
+  .text:0000000000527EF4                 cmp     byte ptr [r14], 0
+  .text:0000000000527EF8                 jnz     short loc_527F07
+  .text:0000000000527EFA                 mov     rax, [r12]
+  .text:0000000000527EFE                 mov     rdi, r12
+  .text:0000000000527F01                 call    qword ptr [rax+260h]
+  .text:0000000000527F07                 mov     rdi, [r12+58h]
+  .text:0000000000527F0C                 lea     rax, aPush; "Push"
+  .text:0000000000527F13                 movq    xmm0, cs:off_9B2360; "../public/tier0/tslist.h"
+  .text:0000000000527F1B                 lea     rdx, aSignon; "Signon"
+  .text:0000000000527F22                 mov     esi, [r12+158h]
+  .text:0000000000527F2A                 pinsrq  xmm0, rax, 1
+  .text:0000000000527F31                 movaps  xmmword ptr [rbp-0A20h], xmm0
+  .text:0000000000527F38                 mov     rax, [rdi]
+  .text:0000000000527F3B                 call    qword ptr [rax+2A0h]
+  .text:0000000000527F41                 mov     rdi, [r12+58h]
+  .text:0000000000527F46                 mov     edx, 1
+  .text:0000000000527F4B                 mov     rsi, [rbp-0A00h]
+  .text:0000000000527F52                 mov     rax, [rdi]
+  .text:0000000000527F55                 call    qword ptr [rax+148h]
+  .text:0000000000527F5B                 movzx   edx, byte ptr [r14]
+  .text:0000000000527F5F                 test    al, al
+  .text:0000000000527F61                 jz      loc_528230
+  .text:0000000000527F67                 mov     rax, [r12]
+  .text:0000000000527F6B                 lea     rsi, [r14+18h]
+  .text:0000000000527F6F                 mov     rdi, r12
+  .text:0000000000527F72                 call    qword ptr [rax+198h]
+  .text:0000000000527F78                 cmp     byte ptr [r14], 0
+  .text:0000000000527F7C                 mov     ebx, [rbp-7B0h]
+  .text:0000000000527F82                 jnz     loc_5280D0
+  .text:0000000000527F88                 movzx   eax, byte ptr [r12+61h]
+  .text:0000000000527F8E                 cmp     al, 1
+  .text:0000000000527F90                 jz      loc_5280D0
+  .text:0000000000527F96                 cmp     al, 2
+  .text:0000000000527F98                 jz      loc_5283E0
+  .text:0000000000527F9E                 lea     rsi, [rbp-9F0h]
+  .text:0000000000527FA5                 mov     rdi, r12
+  .text:0000000000527FA8                 mov     [rbp-9F0h], ebx
+  .text:0000000000527FAE                 call    sub_5243E0
+  .text:0000000000527FB3                 mov     rdi, [rbp-0A08h]
+  .text:0000000000527FBA                 lea     rax, off_9A1878
+  .text:0000000000527FC1                 mov     [rbp-8C0h], rax
+  .text:0000000000527FC8                 add     rax, 40h ; '@'
+  .text:0000000000527FCC                 mov     [rbp-890h], rax
+  .text:0000000000527FD3                 call    sub_2F5870
+  .text:0000000000527FD8                 mov     rdi, [rbp-0A10h]
+  .text:0000000000527FDF                 lea     rax, off_9A1E90
+  .text:0000000000527FE6                 mov     [rbp-840h], rax
+  .text:0000000000527FED                 add     rax, 40h ; '@'
+  .text:0000000000527FF1                 mov     [rbp-810h], rax
+  .text:0000000000527FF8                 call    sub_31D320
+  .text:0000000000527FFD                 mov     rdi, [rbp-0A28h]
+  .text:0000000000528004                 lea     rax, off_9A24F0
+  .text:000000000052800B                 mov     [rbp-9A0h], rax
+  .text:0000000000528012                 add     rax, 40h ; '@'
+  .text:0000000000528016                 mov     [rbp-970h], rax
+  .text:000000000052801D                 call    sub_31E810
+  .text:0000000000528022                 mov     rdi, [rbp-0A30h]
+  .text:0000000000528029                 lea     rax, off_9A1740
+  .text:0000000000528030                 mov     [rbp-940h], rax
+  .text:0000000000528037                 add     rax, 40h ; '@'
+  .text:000000000052803B                 mov     [rbp-910h], rax
+  .text:0000000000528042                 call    sub_2F5750
+  .text:0000000000528047                 mov     rdi, [rbp-0A40h]
+  .text:000000000052804E                 mov     rsi, [rbp-0A48h]
+  .text:0000000000528055                 mov     rax, [rdi]
+  .text:0000000000528058                 call    qword ptr [rax+140h]
+  .text:000000000052805E                 lea     rsp, [rbp-28h]
+  .text:0000000000528062                 pop     rbx
+  .text:0000000000528063                 pop     r12
+  .text:0000000000528065                 pop     r13
+  .text:0000000000528067                 pop     r14
+  .text:0000000000528069                 pop     r15
+  .text:000000000052806B                 pop     rbp
+  .text:000000000052806C                 retn
+  .text:0000000000528070                 mov     rax, [rdi]
+  .text:0000000000528073                 lea     rdx, [rbp-9A0h]
+  .text:000000000052807A                 mov     rsi, [rbp-0A00h]
+  .text:0000000000528081                 call    qword ptr [rax+18h]
+  .text:0000000000528084                 test    al, al
+  .text:0000000000528086                 jz      loc_528420
+  .text:000000000052808C                 cmp     byte ptr [r14], 0
+  .text:0000000000528090                 mov     rax, [r12+50h]
+  .text:0000000000528095                 jnz     loc_528320
+  .text:000000000052809B                 mov     rdi, [rax+178h]
+  .text:00000000005280A2                 mov     edx, [r14+4]
+  .text:00000000005280A6                 mov     rcx, r12
+  .text:00000000005280A9                 mov     rsi, [rbp-0A00h]
+  .text:00000000005280B0                 call    sub_590E60
+  .text:00000000005280B5                 jmp     loc_527D05
+  .text:00000000005280C0                 lea     rbx, [rbp-838h]
+  .text:00000000005280C7                 jmp     loc_5277F4
+  .text:00000000005280D0                 lea     r14, [r12+0AF0h]
+  .text:00000000005280D8                 ; _QWORD
+  .text:00000000005280D8                 mov     edi, 10h; _QWORD
+  .text:00000000005280DD                 call    __Znwm; operator new(ulong)
+  .text:00000000005280E2                 lea     rcx, off_9B2208
+  .text:00000000005280E9                 movq    xmm1, r14
+  .text:00000000005280EE                 mov     [rax], rcx
+  .text:00000000005280F1                 ; this
+  .text:00000000005280F1                 lea     rdi, [r12+0B20h]; this
+  .text:00000000005280F9                 pinsrq  xmm1, rax, 1
+  .text:0000000000528100                 mov     [rax+8], ebx
+  .text:0000000000528103                 movaps  xmmword ptr [rbp-0A00h], xmm1
+  .text:000000000052810A                 call    __ZN11CTSListBase11InternalPopEv; CTSListBase::InternalPop(void)
+  .text:000000000052810F                 mov     r9, rax
+  .text:0000000000528112                 test    rax, rax
+  .text:0000000000528115                 jz      loc_528598
+  .text:000000000052811B                 movdqa  xmm3, xmmword ptr [rbp-0A00h]
+  .text:0000000000528123                 movaps  xmmword ptr [r9], xmm3
+  .text:0000000000528127                 mov     r8d, 989680h
+  .text:000000000052812D                 jmp     short loc_528150
+  .text:0000000000528130                 mov     r10, rax
+  .text:0000000000528133                 mov     rax, rsi
+  .text:0000000000528136                 ; _QWORD
+  .text:0000000000528136                 mov     rdx, rdi; _QWORD
+  .text:0000000000528139                 mov     rbx, r10
+  .text:000000000052813C                 lock cmpxchg16b xmmword ptr [r12+0B00h]
+  .text:0000000000528146                 sub     r8d, 1
+  .text:000000000052814A                 jz      loc_5275BF
+  .text:0000000000528150                 mov     rsi, [r12+0B00h]
+  .text:0000000000528158                 mov     rdi, [r12+0B08h]
+  .text:0000000000528160                 mov     rax, r14
+  .text:0000000000528163                 lock cmpxchg [rsi], r9
+  .text:0000000000528168                 lea     rcx, [rdi+1]
+  .text:000000000052816C                 cmp     r14, rax
+  .text:000000000052816F                 jnz     short loc_528130
+  .text:0000000000528171                 mov     rax, rsi
+  .text:0000000000528174                 mov     rdx, rdi
+  .text:0000000000528177                 mov     rbx, r9
+  .text:000000000052817A                 lock cmpxchg16b xmmword ptr [r12+0B00h]
+  .text:0000000000528184                 lock add dword ptr [r12+0B10h], 1
+  .text:000000000052818E                 jmp     loc_527FB3
+  .text:0000000000528198                 lea     r13, dword_C70214
+  .text:000000000052819F                 ; _QWORD
+  .text:000000000052819F                 mov     esi, 3; _QWORD
+  .text:00000000005281A4                 ; _QWORD
+  .text:00000000005281A4                 mov     edi, [r13+0]; _QWORD
+  .text:00000000005281A8                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000005281AD                 test    al, al
+  .text:00000000005281AF                 jz      loc_527A81
+  .text:00000000005281B5                 ; _QWORD
+  .text:00000000005281B5                 mov     edi, [r13+0]; _QWORD
+  .text:00000000005281B9                 lea     rdx, aBuildserverinf; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000000005281C0                 ; _QWORD
+  .text:00000000005281C0                 mov     esi, 3; _QWORD
+  .text:00000000005281C5                 xor     eax, eax
+  .text:00000000005281C7                 call    _LoggingSystem_Log
+  .text:00000000005281CC                 jmp     loc_527A81
+  .text:00000000005281D8                 lea     rax, dword_C70214
+  .text:00000000005281DF                 ; _QWORD
+  .text:00000000005281DF                 mov     esi, 3; _QWORD
+  .text:00000000005281E4                 ; _QWORD
+  .text:00000000005281E4                 mov     edi, [rax]; _QWORD
+  .text:00000000005281E6                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000005281EB                 test    al, al
+  .text:00000000005281ED                 jz      loc_527992
+  .text:00000000005281F3                 lea     rax, dword_C70214
+  .text:00000000005281FA                 lea     rdx, aBuildserverinf_0; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:0000000000528201                 ; _QWORD
+  .text:0000000000528201                 mov     esi, 3; _QWORD
+  .text:0000000000528206                 ; _QWORD
+  .text:0000000000528206                 mov     edi, [rax]; _QWORD
+  .text:0000000000528208                 xor     eax, eax
+  .text:000000000052820A                 call    _LoggingSystem_Log
+  .text:000000000052820F                 jmp     loc_527992
+  .text:0000000000528218                 mov     rbx, cs:_ZNSs4_Rep20_S_empty_rep_storageE_ptr
+  .text:000000000052821F                 lea     rcx, [rbx+18h]
+  .text:0000000000528223                 jmp     loc_52792A
+  .text:0000000000528230                 test    dl, dl
+  .text:0000000000528232                 jnz     loc_528338
+  .text:0000000000528238                 movzx   eax, byte ptr [r12+61h]
+  .text:000000000052823E                 cmp     al, 1
+  .text:0000000000528240                 jz      loc_528338
+  .text:0000000000528246                 cmp     al, 2
+  .text:0000000000528248                 jnz     short loc_528252
+  .text:000000000052824A                 mov     rdi, r12
+  .text:000000000052824D                 call    sub_520F10
+  .text:0000000000528252                 mov     rax, [r12]
+  .text:0000000000528256                 lea     rdx, sub_525E80
+  .text:000000000052825D                 mov     rax, [rax+40h]
+  .text:0000000000528261                 cmp     rax, rdx
+  .text:0000000000528264                 jnz     loc_5285D1
+  .text:000000000052826A                 mov     esi, 12h
+  .text:000000000052826F                 mov     rdi, r12
+  .text:0000000000528272                 call    sub_5260F0
+  .text:0000000000528277                 jmp     loc_527FB3
+  .text:0000000000528280                 lea     rbx, dword_C70214
+  .text:0000000000528287                 ; _QWORD
+  .text:0000000000528287                 mov     esi, 3; _QWORD
+  .text:000000000052828C                 ; _QWORD
+  .text:000000000052828C                 mov     edi, [rbx]; _QWORD
+  .text:000000000052828E                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000000528293                 test    al, al
+  .text:0000000000528295                 jz      loc_527EF4
+  .text:000000000052829B                 ; _QWORD
+  .text:000000000052829B                 mov     edi, [rbx]; _QWORD
+  .text:000000000052829D                 lea     rdx, aBuildserverinf_1; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000000005282A4                 ; _QWORD
+  .text:00000000005282A4                 mov     esi, 3; _QWORD
+  .text:00000000005282A9                 xor     eax, eax
+  .text:00000000005282AB                 call    _LoggingSystem_Log
+  .text:00000000005282B0                 jmp     loc_527EF4
+  .text:00000000005282B8                 lea     rbx, dword_C70214
+  .text:00000000005282BF                 ; _QWORD
+  .text:00000000005282BF                 mov     esi, 3; _QWORD
+  .text:00000000005282C4                 ; _QWORD
+  .text:00000000005282C4                 mov     edi, [rbx]; _QWORD
+  .text:00000000005282C6                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000005282CB                 test    al, al
+  .text:00000000005282CD                 jz      loc_527E12
+  .text:00000000005282D3                 ; _QWORD
+  .text:00000000005282D3                 mov     edi, [rbx]; _QWORD
+  .text:00000000005282D5                 lea     rdx, aBuildserverinf_2; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000000005282DC                 ; _QWORD
+  .text:00000000005282DC                 mov     esi, 3; _QWORD
+  .text:00000000005282E1                 xor     eax, eax
+  .text:00000000005282E3                 call    _LoggingSystem_Log
+  .text:00000000005282E8                 jmp     loc_527E12
+  .text:00000000005282F0                 mov     rax, [rbp-808h]
+  .text:00000000005282F7                 mov     rdi, rax
+  .text:00000000005282FA                 and     rdi, 0FFFFFFFFFFFFFFFCh
+  .text:00000000005282FE                 test    al, 1
+  .text:0000000000528300                 jnz     loc_52857B
+  .text:0000000000528306                 call    sub_2EE7F0
+  .text:000000000052830B                 mov     rbx, rax
+  .text:000000000052830E                 mov     [rbp-7C8h], rax
+  .text:0000000000528315                 jmp     loc_527D9C
+  .text:0000000000528320                 mov     rdi, [rax+180h]
+  .text:0000000000528327                 test    rdi, rdi
+  .text:000000000052832A                 jnz     loc_5280A2
+  .text:0000000000528330                 jmp     loc_52809B
+  .text:0000000000528338                 lea     rbx, off_9B2230
+  .text:000000000052833F                 ; _QWORD
+  .text:000000000052833F                 mov     edi, 10h; _QWORD
+  .text:0000000000528344                 call    __Znwm; operator new(ulong)
+  .text:0000000000528349                 lea     r14, [r12+0AF0h]
+  .text:0000000000528351                 mov     [rax], rbx
+  .text:0000000000528354                 ; this
+  .text:0000000000528354                 lea     rdi, [r12+0B20h]; this
+  .text:000000000052835C                 movq    xmm2, r14
+  .text:0000000000528361                 pinsrq  xmm2, rax, 1
+  .text:0000000000528368                 movaps  xmmword ptr [rbp-0A00h], xmm2
+  .text:000000000052836F                 call    __ZN11CTSListBase11InternalPopEv; CTSListBase::InternalPop(void)
+  .text:0000000000528374                 mov     r9, rax
+  .text:0000000000528377                 test    rax, rax
+  .text:000000000052837A                 jz      loc_5285BF
+  .text:0000000000528380                 movdqa  xmm4, xmmword ptr [rbp-0A00h]
+  .text:0000000000528388                 movaps  xmmword ptr [r9], xmm4
+  .text:000000000052838C                 mov     r8d, 989680h
+  .text:0000000000528392                 jmp     short loc_5283B8
+  .text:0000000000528398                 mov     r10, rax
+  .text:000000000052839B                 mov     rax, rsi
+  .text:000000000052839E                 ; _QWORD
+  .text:000000000052839E                 mov     rdx, rdi; _QWORD
+  .text:00000000005283A1                 mov     rbx, r10
+  .text:00000000005283A4                 lock cmpxchg16b xmmword ptr [r12+0B00h]
+  .text:00000000005283AE                 sub     r8d, 1
+  .text:00000000005283B2                 jz      loc_527564
+  .text:00000000005283B8                 mov     rsi, [r12+0B00h]
+  .text:00000000005283C0                 mov     rdi, [r12+0B08h]
+  .text:00000000005283C8                 mov     rax, r14
+  .text:00000000005283CB                 lock cmpxchg [rsi], r9
+  .text:00000000005283D0                 lea     rcx, [rdi+1]
+  .text:00000000005283D4                 cmp     r14, rax
+  .text:00000000005283D7                 jnz     short loc_528398
+  .text:00000000005283D9                 jmp     loc_528171
+  .text:00000000005283E0                 mov     rdi, r12
+  .text:00000000005283E3                 call    sub_520F10
+  .text:00000000005283E8                 jmp     loc_527F9E
+  .text:00000000005283F0                 retn
+  .text:00000000005283F8                 lea     rdi, [rbx+18h]
+  .text:00000000005283FC                 jmp     loc_527C9A
+  .text:0000000000528408                 call    rax
+  .text:000000000052840A                 jmp     loc_527AA7
+  .text:0000000000528410                 call    rax
+  .text:0000000000528412                 mov     rsi, rax
+  .text:0000000000528415                 jmp     loc_527DC2
+  .text:0000000000528420                 lea     rbx, dword_C70214
+  .text:0000000000528427                 ; _QWORD
+  .text:0000000000528427                 mov     esi, 3; _QWORD
+  .text:000000000052842C                 ; _QWORD
+  .text:000000000052842C                 mov     edi, [rbx]; _QWORD
+  .text:000000000052842E                 call    _LoggingSystem_IsChannelEnabled
+  .text:0000000000528433                 test    al, al
+  .text:0000000000528435                 jz      loc_52808C
+  .text:000000000052843B                 ; _QWORD
+  .text:000000000052843B                 mov     edi, [rbx]; _QWORD
+  .text:000000000052843D                 lea     rdx, aBuildserverinf_3; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:0000000000528444                 ; _QWORD
+  .text:0000000000528444                 mov     esi, 3; _QWORD
+  .text:0000000000528449                 xor     eax, eax
+  .text:000000000052844B                 call    _LoggingSystem_Log
+  .text:0000000000528450                 jmp     loc_52808C
+  .text:0000000000528458                 lea     rbx, dword_C70214
+  .text:000000000052845F                 ; _QWORD
+  .text:000000000052845F                 mov     esi, 3; _QWORD
+  .text:0000000000528464                 ; _QWORD
+  .text:0000000000528464                 mov     edi, [rbx]; _QWORD
+  .text:0000000000528466                 call    _LoggingSystem_IsChannelEnabled
+  .text:000000000052846B                 test    al, al
+  .text:000000000052846D                 jz      loc_527D05
+  .text:0000000000528473                 ; _QWORD
+  .text:0000000000528473                 mov     edi, [rbx]; _QWORD
+  .text:0000000000528475                 lea     rdx, aBuildserverinf_3; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:000000000052847C                 ; _QWORD
+  .text:000000000052847C                 mov     esi, 3; _QWORD
+  .text:0000000000528481                 xor     eax, eax
+  .text:0000000000528483                 call    _LoggingSystem_Log
+  .text:0000000000528488                 jmp     loc_527D05
+  .text:0000000000528490                 lea     rbx, dword_C70214
+  .text:0000000000528497                 ; _QWORD
+  .text:0000000000528497                 mov     esi, 3; _QWORD
+  .text:000000000052849C                 ; _QWORD
+  .text:000000000052849C                 mov     edi, [rbx]; _QWORD
+  .text:000000000052849E                 call    _LoggingSystem_IsChannelEnabled
+  .text:00000000005284A3                 test    al, al
+  .text:00000000005284A5                 jz      loc_527E33
+  .text:00000000005284AB                 ; _QWORD
+  .text:00000000005284AB                 mov     edi, [rbx]; _QWORD
+  .text:00000000005284AD                 lea     rdx, aBuildserverinf_4; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000000005284B4                 ; _QWORD
+  .text:00000000005284B4                 mov     esi, 3; _QWORD
+  .text:00000000005284B9                 xor     eax, eax
+  .text:00000000005284BB                 call    _LoggingSystem_Log
+  .text:00000000005284C0                 jmp     loc_527E33
+  .text:00000000005284C8                 cmp     cs:__pthread_key_create_ptr, 0
+  .text:00000000005284D0                 jz      loc_528560
+  .text:00000000005284D6                 mov     edx, 0FFFFFFFFh
+  .text:00000000005284DB                 lock xadd [rax-8], edx
+  .text:00000000005284E0                 test    edx, edx
+  .text:00000000005284E2                 jg      loc_527962
+  .text:00000000005284E8                 mov     rsi, [rax-10h]
+  .text:00000000005284EC                 ; _QWORD
+  .text:00000000005284EC                 add     rsi, 19h; _QWORD
+  .text:00000000005284F0                 call    __ZdlPvm; operator delete(void *,ulong)
+  .text:00000000005284F5                 jmp     loc_527962
+  .text:0000000000528500                 mov     rax, [rcx]
+  .text:0000000000528503                 mov     [rbp-0A10h], rax
+  .text:000000000052850A                 jmp     loc_527B6F
+  .text:0000000000528510                 cmp     cs:__pthread_key_create_ptr, 0
+  .text:0000000000528518                 jz      short loc_528570
+  .text:000000000052851A                 mov     edx, 0FFFFFFFFh
+  .text:000000000052851F                 lock xadd [rax-8], edx
+  .text:0000000000528524                 test    edx, edx
+  .text:0000000000528526                 jg      loc_527CCF
+  .text:000000000052852C                 mov     rsi, [rax-10h]
+  .text:0000000000528530                 ; _QWORD
+  .text:0000000000528530                 add     rsi, 19h; _QWORD
+  .text:0000000000528534                 call    __ZdlPvm; operator delete(void *,ulong)
+  .text:0000000000528539                 jmp     loc_527CCF
+  .text:0000000000528540                 mov     rax, [rcx]
+  .text:0000000000528543                 mov     [rbp-0A10h], rax
+  .text:000000000052854A                 jmp     loc_527818
+  .text:0000000000528550                 mov     [r15], r13
+  .text:0000000000528553                 mov     byte ptr [r15+r13+18h], 0
+  .text:0000000000528559                 jmp     loc_52792A
+  .text:0000000000528560                 mov     edx, [rax-8]
+  .text:0000000000528563                 lea     ecx, [rdx-1]
+  .text:0000000000528566                 mov     [rax-8], ecx
+  .text:0000000000528569                 jmp     loc_5284E0
+  .text:0000000000528570                 mov     edx, [rax-8]
+  .text:0000000000528573                 lea     ecx, [rdx-1]
+  .text:0000000000528576                 mov     [rax-8], ecx
+  .text:0000000000528579                 jmp     short loc_528524
+  .text:000000000052857B                 mov     rdi, [rdi]
+  .text:000000000052857E                 jmp     loc_528306
+  .text:0000000000528588                 mov     [rcx], rdx
+  .text:000000000052858B                 mov     byte ptr [rcx+rdx+18h], 0
+  .text:0000000000528590                 jmp     loc_527C9A
+  .text:0000000000528598                 ; _QWORD
+  .text:0000000000528598                 mov     edi, 10h; _QWORD
+  .text:000000000052859D                 call    __Znwm; operator new(ulong)
+  .text:00000000005285A2                 mov     r9, rax
+  .text:00000000005285A5                 jmp     loc_52811B
+  .text:00000000005285B0                 mov     rax, [rcx]
+  .text:00000000005285B3                 mov     [rbp-0A10h], rax
+  .text:00000000005285BA                 jmp     loc_5278AB
+  .text:00000000005285BF                 ; _QWORD
+  .text:00000000005285BF                 mov     edi, 10h; _QWORD
+  .text:00000000005285C4                 call    __Znwm; operator new(ulong)
+  .text:00000000005285C9                 mov     r9, rax
+  .text:00000000005285CC                 jmp     loc_528380
+  .text:00000000005285D1                 xor     edx, edx
+  .text:00000000005285D3                 mov     esi, 12h
+  .text:00000000005285D8                 mov     rdi, r12
+  .text:00000000005285DB                 call    rax
+  .text:00000000005285DD                 jmp     loc_527FB3
+procedure: |-
+  void __fastcall CServerSideClientBase_SendServerInfo(__int64 a1, unsigned __int8 *a2)
+  {
+    __m128i v2; // xmm6
+    __m128i v3; // xmm5
+    int v6; // eax
+    __int64 v7; // r13
+    __int64 v8; // r15
+    int v9; // eax
+    __int64 v10; // rdi
+    int v11; // r9d
+    __int64 v12; // rbx
+    int v13; // eax
+    const char *v14; // rbx
+    size_t v15; // r13
+    __int64 v16; // rax
+    void *v17; // rcx
+    _BYTE *v18; // r15
+    unsigned __int64 v19; // rdx
+    __int64 v20; // rax
+    __int64 v21; // rax
+    __int64 v22; // rdi
+    int v23; // eax
+    _BYTE *v24; // rdi
+    __int64 (*v25)(void); // rax
+    char v26; // al
+    char v27; // r13
+    __int64 v28; // rdi
+    const char *v29; // rax
+    size_t v30; // rdx
+    __int64 v31; // rax
+    size_t v32; // rdx
+    const char *v33; // rsi
+    _BYTE *v34; // rcx
+    __int64 (__fastcall **v35)(); // rdi
+    unsigned __int64 v36; // r8
+    __int64 v37; // rax
+    __int64 (__fastcall **v38)(); // rax
+    __int64 (__fastcall **v39)(); // rax
+    __int64 (__fastcall **v40)(); // rdi
+    __int64 v41; // rbx
+    __int64 v42; // rdi
+    __int64 (*v43)(void); // rax
+    __int64 v44; // rsi
+    int v45; // eax
+    __int64 v46; // rdi
+    int v47; // ebx
+    __int64 v48; // rdi
+    __int64 v49; // rsi
+    char v50; // al
+    __int64 v51; // rdx
+    __int32 v52; // ebx
+    char v53; // al
+    __int64 v54; // rax
+    __int64 v55; // rdi
+    signed __int64 v56; // r14
+    signed __int64 v57; // rax
+    __m128i *v58; // r9
+    int v59; // r8d
+    __int64 v60; // rdx
+    __int128 v61; // rt0
+    volatile signed __int64 *v62; // rsi
+    __int64 v63; // rdi
+    signed __int64 v64; // rax
+    signed __int64 v65; // rcx
+    __int128 v66; // rt0
+    char v67; // al
+    void (__fastcall *v68)(__int64, __int64, _QWORD); // rax
+    _QWORD *v69; // rdi
+    _QWORD *v70; // rax
+    signed __int64 v71; // r14
+    int v72; // r8d
+    __int64 v73; // rdx
+    __int128 v74; // rt0
+    signed __int64 v75; // rax
+    int v76; // edx
+    int v77; // edx
+    const char *v78; // [rsp-A68h] [rbp-A68h]
+    const char *v79; // [rsp-A60h] [rbp-A60h]
+    size_t v80; // [rsp-A60h] [rbp-A60h]
+    _BYTE *v81; // [rsp-A60h] [rbp-A60h]
+    const char *v82; // [rsp-A58h] [rbp-A58h]
+    size_t v83; // [rsp-A58h] [rbp-A58h]
+    unsigned __int64 v84; // [rsp-A58h] [rbp-A58h]
+    size_t v85; // [rsp-A58h] [rbp-A58h]
+    __int64 v86; // [rsp-A50h] [rbp-A50h]
+    _QWORD *v87; // [rsp-A48h] [rbp-A48h]
+    int v88; // [rsp-A40h] [rbp-A40h]
+    int v89; // [rsp-A38h] [rbp-A38h]
+    int v90; // [rsp-A30h] [rbp-A30h]
+    unsigned __int64 v91; // [rsp-A30h] [rbp-A30h]
+    __m128i inserted; // [rsp-A28h] [rbp-A28h] BYREF
+    __int64 (__fastcall ***v93)(); // [rsp-A18h] [rbp-A18h]
+    __int64 (__fastcall ***v94)(); // [rsp-A10h] [rbp-A10h]
+    __m128i v95; // [rsp-A08h] [rbp-A08h] BYREF
+    __m128i v96; // [rsp-9F8h] [rbp-9F8h] BYREF
+    const char *v97; // [rsp-9E8h] [rbp-9E8h]
+    int v98; // [rsp-9E0h] [rbp-9E0h]
+    char v99; // [rsp-9DCh] [rbp-9DCh]
+    _BYTE v100[48]; // [rsp-9D8h] [rbp-9D8h] BYREF
+    _QWORD v101[2]; // [rsp-9A8h] [rbp-9A8h] BYREF
+    int v102; // [rsp-998h] [rbp-998h]
+    char v103; // [rsp-994h] [rbp-994h]
+    __int64 v104; // [rsp-990h] [rbp-990h]
+    int v105; // [rsp-988h] [rbp-988h]
+    __int64 v106; // [rsp-980h] [rbp-980h]
+    __int64 (__fastcall **v107)(); // [rsp-978h] [rbp-978h] BYREF
+    __int64 v108; // [rsp-970h] [rbp-970h]
+    int v109; // [rsp-968h] [rbp-968h]
+    _BYTE v110[24]; // [rsp-960h] [rbp-960h] BYREF
+    _QWORD v111[2]; // [rsp-948h] [rbp-948h] BYREF
+    int v112; // [rsp-938h] [rbp-938h]
+    char v113; // [rsp-934h] [rbp-934h]
+    __int64 v114; // [rsp-930h] [rbp-930h]
+    int v115; // [rsp-928h] [rbp-928h]
+    __int64 v116; // [rsp-920h] [rbp-920h]
+    _QWORD v117[2]; // [rsp-918h] [rbp-918h] BYREF
+    int v118; // [rsp-908h] [rbp-908h]
+    int v119; // [rsp-8F8h] [rbp-8F8h]
+    __int64 (__fastcall **v120)(); // [rsp-8C8h] [rbp-8C8h] BYREF
+    __int64 v121; // [rsp-8C0h] [rbp-8C0h]
+    int v122; // [rsp-8B8h] [rbp-8B8h]
+    char v123; // [rsp-8B4h] [rbp-8B4h]
+    __int64 v124; // [rsp-8B0h] [rbp-8B0h]
+    int v125; // [rsp-8A8h] [rbp-8A8h]
+    __int64 v126; // [rsp-8A0h] [rbp-8A0h]
+    __int64 (__fastcall **v127)(); // [rsp-898h] [rbp-898h] BYREF
+    __int64 v128; // [rsp-890h] [rbp-890h]
+    int v129; // [rsp-888h] [rbp-888h]
+    _DWORD v130[14]; // [rsp-880h] [rbp-880h] BYREF
+    __int64 (__fastcall **v131)(); // [rsp-848h] [rbp-848h] BYREF
+    const char *v132; // [rsp-840h] [rbp-840h] BYREF
+    int v133; // [rsp-838h] [rbp-838h]
+    char v134; // [rsp-834h] [rbp-834h]
+    __int64 v135; // [rsp-830h] [rbp-830h]
+    int v136; // [rsp-828h] [rbp-828h]
+    __int64 v137; // [rsp-820h] [rbp-820h]
+    __int64 (__fastcall **v138)(); // [rsp-818h] [rbp-818h] BYREF
+    __int64 v139; // [rsp-810h] [rbp-810h]
+    int v140; // [rsp-808h] [rbp-808h]
+    __int64 v141; // [rsp-7D0h] [rbp-7D0h]
+    __int32 v142; // [rsp-7B8h] [rbp-7B8h]
+    int v143; // [rsp-7ACh] [rbp-7ACh]
+
+    if ( *(_QWORD *)(a1 + 88) )
+    {
+      v87 = g_pNetworkSystem;
+      v86 = (*(__int64 (**)(void))(*g_pNetworkSystem + 312LL))();
+      v95.m128i_i64[0] = (__int64)v100;
+      sub_5E1530(v100, "SV_SendServerinfo->msg", v86, 1280000, 0xFFFFFFFFLL);
+      v6 = *((_DWORD *)a2 + 1);
+      v132 = nullptr;
+      v121 = 0;
+      v122 = 0;
+      *(_DWORD *)(a1 + 344) = v6;
+      v131 = (__int64 (__fastcall **)())0xC000080000000000LL;
+      v120 = (__int64 (__fastcall **)())&unk_99C8E0;
+      v123 = -1;
+      v125 = -1082130432;
+      v126 = -1;
+      v124 = -1;
+      v94 = &v127;
+      sub_3086C0(&v127, 0, 0);
+      v7 = *((unsigned int *)a2 + 5);
+      v120 = &off_9AFA80;
+      v127 = off_9AFAC0;
+      v8 = sub_3BB6B0();
+      v9 = sub_459AE0();
+      v10 = *(_QWORD *)(a1 + 80);
+      v11 = *((_DWORD *)a2 + 4);
+      LODWORD(v93) = v9;
+      v12 = *((unsigned int *)a2 + 3);
+      v88 = v11;
+      v89 = *((_DWORD *)a2 + 2);
+      v90 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v10 + 200LL))(v10);
+      v13 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_9E2328 + 88LL))(qword_9E2328);
+      inserted.m128i_i64[0] = (__int64)&v131;
+      sub_353F30(
+        (unsigned int)&v131,
+        (unsigned int)"\n"
+                      "Game: \"%s\"\n"
+                      "Map: \"%s\"\n"
+                      "Players: %i (%i bots) / %i humans\n"
+                      "Build: %u (revision %s)\n"
+                      "Server Number: %i\n"
+                      "\n",
+        v13,
+        v90,
+        v89,
+        v88,
+        v12,
+        (unsigned int)v93,
+        v8,
+        v7);
+      if ( (HIBYTE(v131) & 0x40) != 0 )
+      {
+        v14 = (const char *)&v132;
+      }
+      else
+      {
+        if ( (HIDWORD(v131) & 0x3FFFFFFF) != 0 )
+        {
+          v14 = v132;
+          v129 |= 1u;
+          v93 = (__int64 (__fastcall ***)())(v128 & 0xFFFFFFFFFFFFFFFCLL);
+          if ( (v128 & 1) != 0 )
+            v93 = *(__int64 (__fastcall ****)())(v128 & 0xFFFFFFFFFFFFFFFCLL);
+          if ( !v132 )
+            goto LABEL_121;
+  LABEL_7:
+          v15 = strlen(v14);
+          if ( !v15 )
+          {
+            v17 = &unk_CD1378;
+            goto LABEL_22;
+          }
+          if ( v15 > 0x3FFFFFFFFFFFFFF9LL )
+            goto LABEL_123;
+          if ( v15 + 57 > 0x1000 )
+          {
+            v19 = v15 + 4096 - (((_WORD)v15 + 57) & 0xFFF);
+            if ( v19 > 0x3FFFFFFFFFFFFFF9LL )
+              v19 = 0x3FFFFFFFFFFFFFF9LL;
+            v91 = v19;
+            v20 = operator new(v19 + 25);
+            *(_DWORD *)(v20 + 16) = 0;
+            v17 = (void *)(v20 + 24);
+            v18 = (_BYTE *)v20;
+            *(_QWORD *)(v20 + 8) = v91;
+          }
+          else
+          {
+            v16 = operator new(v15 + 25);
+            *(_QWORD *)(v16 + 8) = v15;
+            v17 = (void *)(v16 + 24);
+            v18 = (_BYTE *)v16;
+            *(_DWORD *)(v16 + 16) = 0;
+            if ( v15 == 1 )
+            {
+              *(_BYTE *)(v16 + 24) = *v14;
+              goto LABEL_20;
+            }
+          }
+          v17 = memcpy(v17, v14, v15);
+  LABEL_20:
+          if ( v18 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+          {
+            *(_QWORD *)v18 = v15;
+            v18[v15 + 24] = 0;
+          }
+  LABEL_22:
+          v111[0] = v17;
+          sub_60022E(v130, v111, v93);
+          v21 = v111[0];
+          v22 = v111[0] - 24LL;
+          if ( (_UNKNOWN *)(v111[0] - 24LL) != &std::string::_Rep::_S_empty_rep_storage )
+          {
+            if ( &_pthread_key_create )
+            {
+              v76 = _InterlockedExchangeAdd((volatile signed __int32 *)(v111[0] - 8LL), 0xFFFFFFFF);
+            }
+            else
+            {
+              v76 = *(_DWORD *)(v111[0] - 8LL);
+              *(_DWORD *)(v111[0] - 8LL) = v76 - 1;
+            }
+            if ( v76 <= 0 )
+              operator delete(v22, *(_QWORD *)(v21 - 16) + 25LL);
+          }
+          if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, __int64 (__fastcall ***)()))(*g_pNetworkMessages
+                                                                                                 + 24LL))(
+                  g_pNetworkMessages,
+                  v95.m128i_i64[0],
+                  &v120)
+            && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+          {
+            LoggingSystem_Log(
+              (unsigned int)dword_C70214,
+              3,
+              "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_Print_t\n");
+          }
+          v120 = &off_9A2898;
+          v127 = off_9A28D8;
+          sub_31D650(v94);
+          CBufferString::Purge((CBufferString *)inserted.m128i_i64[0], 0);
+          v113 = -1;
+          v23 = *(_DWORD *)(a1 + 344);
+          v111[1] = 0;
+          v112 = 0;
+          v115 = -1082130432;
+          v116 = -1;
+          LODWORD(v93) = v23;
+          v111[0] = &unk_99C8E0;
+          v114 = -1;
+          sub_2ED610(v117, 0, 0);
+          v111[0] = &off_9AD570;
+          v118 |= 2u;
+          v117[0] = off_9AD5B0;
+          v119 = (int)v93;
+          if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, _QWORD *))(*g_pNetworkMessages + 24LL))(
+                  g_pNetworkMessages,
+                  v95.m128i_i64[0],
+                  v111)
+            && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+          {
+            LoggingSystem_Log(
+              (unsigned int)dword_C70214,
+              3,
+              "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_Tick_t\n");
+          }
+          v24 = *(_BYTE **)(a1 + 80);
+          v25 = *(__int64 (**)(void))(*(_QWORD *)v24 + 376LL);
+          if ( v25 == sub_4F0BD0 )
+            v26 = v24[1109];
+          else
+            v26 = v25();
+          v27 = 1;
+          if ( v26 )
+            v27 = *(_BYTE *)(a1 + 2553);
+          v101[1] = 0;
+          v101[0] = &unk_99C8E0;
+          v102 = 0;
+          v103 = -1;
+          v105 = -1082130432;
+          v104 = -1;
+          v106 = -1;
+          sub_308AC0(&v107, 0, 0);
+          v28 = *(_QWORD *)(a1 + 80);
+          v101[0] = &off_9B1D48;
+          v107 = off_9B1D88;
+          v29 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v28 + 200LL))(v28);
+          v109 |= 1u;
+          v93 = (__int64 (__fastcall ***)())(v108 & 0xFFFFFFFFFFFFFFFCLL);
+          if ( (v108 & 1) != 0 )
+            v93 = *(__int64 (__fastcall ****)())(v108 & 0xFFFFFFFFFFFFFFFCLL);
+          if ( v29 )
+          {
+            v82 = v29;
+            v30 = strlen(v29);
+            if ( !v30 )
+            {
+              v35 = (__int64 (__fastcall **)())&unk_CD1378;
+  LABEL_43:
+              v131 = v35;
+              sub_60022E(v110, inserted.m128i_i64[0], v93);
+              v39 = v131;
+              v40 = v131 - 3;
+              if ( v131 - 3 != (__int64 (__fastcall **)())&std::string::_Rep::_S_empty_rep_storage )
+              {
+                if ( &_pthread_key_create )
+                {
+                  v77 = _InterlockedExchangeAdd((volatile signed __int32 *)v131 - 2, 0xFFFFFFFF);
+                }
+                else
+                {
+                  v77 = *((_DWORD *)v131 - 2);
+                  *((_DWORD *)v131 - 2) = v77 - 1;
+                }
+                if ( v77 <= 0 )
+                  operator delete(v40, (char *)*(v39 - 2) + 25);
+              }
+              if ( v27 )
+              {
+                v109 |= 2u;
+                v110[8] = 1;
+                if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, _QWORD *))(*g_pNetworkMessages + 24LL))(
+                        g_pNetworkMessages,
+                        v95.m128i_i64[0],
+                        v101)
+                  && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+                {
+                  LoggingSystem_Log(
+                    (unsigned int)dword_C70214,
+                    3,
+                    "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_ClearAllStringTables_t\n");
+                }
+              }
+              else
+              {
+                if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, _QWORD *))(*g_pNetworkMessages + 24LL))(
+                        g_pNetworkMessages,
+                        v95.m128i_i64[0],
+                        v101)
+                  && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+                {
+                  LoggingSystem_Log(
+                    (unsigned int)dword_C70214,
+                    3,
+                    "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_ClearAllStringTables_t\n");
+                }
+                v54 = *(_QWORD *)(a1 + 80);
+                if ( !*a2 || (v55 = *(_QWORD *)(v54 + 384)) == 0 )
+                  v55 = *(_QWORD *)(v54 + 376);
+                sub_590E60(v55, v95.m128i_i64[0], *((unsigned int *)a2 + 1), a1);
+              }
+              v132 = nullptr;
+              v131 = (__int64 (__fastcall **)())&unk_99C8E0;
+              v133 = 0;
+              v134 = -1;
+              v136 = -1082130432;
+              v135 = -1;
+              v93 = &v138;
+              v137 = -1;
+              sub_3085C0(&v138, 0, 0);
+              v41 = v141;
+              v140 |= 0x40u;
+              v131 = &off_9B1C68;
+              v138 = off_9B1CA8;
+              if ( !v141 )
+              {
+                v69 = (_QWORD *)(v139 & 0xFFFFFFFFFFFFFFFCLL);
+                if ( (v139 & 1) != 0 )
+                  v69 = (_QWORD *)*v69;
+                v41 = sub_2EE7F0(v69);
+                v141 = v41;
+              }
+              v42 = *(_QWORD *)(a1 + 80);
+              v43 = *(__int64 (**)(void))(*(_QWORD *)v42 + 352LL);
+              if ( v43 == sub_4F0BC0 )
+                v44 = v42 + 216;
+              else
+                v44 = v43();
+              sub_2F85A0(v41, v44);
+              v45 = *(_DWORD *)(a1 + 72);
+              v46 = *(_QWORD *)(a1 + 80);
+              v140 |= 0x8000u;
+              v143 = v45;
+              (*(void (__fastcall **)(__int64, __int64))(*(_QWORD *)v46 + 632LL))(v46, inserted.m128i_i64[0]);  // 632LL = 0x278 = CNetworkGameServerBase_FillServerInfo
+              if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, __int64))(*g_pNetworkMessages + 24LL))(
+                      g_pNetworkMessages,
+                      v95.m128i_i64[0],
+                      inserted.m128i_i64[0])
+                && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+              {
+                LoggingSystem_Log(
+                  (unsigned int)dword_C70214,
+                  3,
+                  "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_ServerInfo_t\n");
+              }
+              if ( !v27
+                && !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, unsigned __int8 *))(*g_pNetworkMessages + 24LL))(
+                      g_pNetworkMessages,
+                      v95.m128i_i64[0],
+                      a2 + 48)
+                && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+              {
+                LoggingSystem_Log(
+                  (unsigned int)dword_C70214,
+                  3,
+                  "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_SetConVar_t\n");
+              }
+              v47 = *(_DWORD *)(*(_QWORD *)(a1 + 80) + 672LL);
+              v121 = 0;
+              v120 = (__int64 (__fastcall **)())&unk_99C8E0;
+              v122 = 0;
+              v123 = -1;
+              v125 = -1082130432;
+              v124 = -1;
+              v126 = -1;
+              sub_2ED6B0(v94, 0, 0);
+              v130[10] = 3;
+              v120 = &off_9AC2B0;
+              v129 |= 0x1Cu;
+              v130[11] = v47;
+              v127 = off_9AC2F0;
+              v130[12] = 0;
+              if ( !(*(unsigned __int8 (__fastcall **)(_QWORD *, __int64, __int64 (__fastcall ***)()))(*g_pNetworkMessages + 24LL))(
+                      g_pNetworkMessages,
+                      v95.m128i_i64[0],
+                      &v120)
+                && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_C70214, 3) )
+              {
+                LoggingSystem_Log(
+                  (unsigned int)dword_C70214,
+                  3,
+                  "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_SignonState_t\n");
+              }
+              if ( !*a2 )
+                (*(void (__fastcall **)(__int64))(*(_QWORD *)a1 + 608LL))(a1);
+              v48 = *(_QWORD *)(a1 + 88);
+              v49 = *(unsigned int *)(a1 + 344);
+              inserted = _mm_insert_epi64(_mm_loadl_epi64((const __m128i *)off_9B2360), (signed __int64)"Push", 1);
+              (*(void (__fastcall **)(__int64, __int64, const char *))(*(_QWORD *)v48 + 672LL))(v48, v49, "Signon");
+              v50 = (*(__int64 (__fastcall **)(_QWORD, __int64, __int64))(**(_QWORD **)(a1 + 88) + 328LL))(
+                      *(_QWORD *)(a1 + 88),
+                      v95.m128i_i64[0],
+                      1);
+              v51 = *a2;
+              if ( !v50 )
+              {
+                if ( (_BYTE)v51 || (v67 = *(_BYTE *)(a1 + 97), v67 == 1) )
+                {
+                  v70 = (_QWORD *)operator new(16);
+                  v71 = a1 + 2800;
+                  *v70 = off_9B2230;
+                  v95 = _mm_insert_epi64((__m128i)(unsigned __int64)(a1 + 2800), (signed __int64)v70, 1);
+                  v58 = (__m128i *)CTSListBase::InternalPop((CTSListBase *)(a1 + 2848));
+                  if ( !v58 )
+                    v58 = (__m128i *)operator new(16);
+                  *v58 = _mm_load_si128(&v95);
+                  v72 = 10000000;
+                  while ( 1 )
+                  {
+                    v62 = *(volatile signed __int64 **)(a1 + 2816);
+                    v63 = *(_QWORD *)(a1 + 2824);
+                    v75 = _InterlockedCompareExchange64(v62, (signed __int64)v58, v71);
+                    v65 = v63 + 1;
+                    if ( v71 == v75 )
+                      break;
+                    *(_QWORD *)&v74 = v62;
+                    *((_QWORD *)&v74 + 1) = v63;
+                    _InterlockedCompareExchange128(
+                      (volatile signed __int64 *)(a1 + 2816),
+                      v65,
+                      v75,
+                      (signed __int64 *)&v74);
+                    v73 = *((_QWORD *)&v74 + 1);
+                    if ( !--v72 )
+                    {
+                      v2 = _mm_load_si128(&inserted);
+                      v98 = 567;
+                      v97 = "nTries < 10000000";
+                      v96 = v2;
+                      v99 = v99 & 0x80 | 0x16;
+                      Assert_ConditionFailed_Fatal(&v96, "CTSQueue corruption", v73);
+                      goto LABEL_121;
+                    }
+                  }
+  LABEL_72:
+                  *(_QWORD *)&v66 = v62;
+                  *((_QWORD *)&v66 + 1) = v63;
+                  _InterlockedCompareExchange128(
+                    (volatile signed __int64 *)(a1 + 2816),
+                    v65,
+                    (signed __int64)v58,
+                    (signed __int64 *)&v66);
+                  _InterlockedAdd((volatile signed __int32 *)(a1 + 2832), 1u);
+                }
+                else
+                {
+                  if ( v67 == 2 )
+                    sub_520F10(a1);
+                  v68 = *(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)a1 + 64LL);
+                  if ( (char *)v68 == (char *)sub_525E80 )
+                    sub_5260F0(a1, 18);
+                  else
+                    v68(a1, 18, 0);
+                }
+                goto LABEL_61;
+              }
+              (*(void (__fastcall **)(__int64, unsigned __int8 *, __int64))(*(_QWORD *)a1 + 408LL))(a1, a2 + 24, v51);
+              v52 = v142;
+              if ( !*a2 )
+              {
+                v53 = *(_BYTE *)(a1 + 97);
+                if ( v53 != 1 )
+                {
+                  if ( v53 == 2 )
+                    sub_520F10(a1);
+                  v96.m128i_i32[0] = v52;
+                  sub_5243E0(a1, &v96);
+  LABEL_61:
+                  v120 = &off_9A1878;
+                  v127 = off_9A18B8;
+                  sub_2F5870(v94);
+                  v131 = &off_9A1E90;
+                  v138 = off_9A1ED0;
+                  sub_31D320(v93);
+                  v101[0] = &off_9A24F0;
+                  v107 = off_9A2530;
+                  sub_31E810(&v107);
+                  v111[0] = &off_9A1740;
+                  v117[0] = off_9A1780;
+                  sub_2F5750(v117);
+                  (*(void (__fastcall **)(_QWORD *, __int64))(*v87 + 320LL))(v87, v86);
+                  return;
+                }
+              }
+              v56 = a1 + 2800;
+              v57 = operator new(16);
+              *(_QWORD *)v57 = off_9B2208;
+              *(_DWORD *)(v57 + 8) = v52;
+              v95 = _mm_insert_epi64((__m128i)(unsigned __int64)(a1 + 2800), v57, 1);
+              v58 = (__m128i *)CTSListBase::InternalPop((CTSListBase *)(a1 + 2848));
+              if ( !v58 )
+                v58 = (__m128i *)operator new(16);
+              *v58 = _mm_load_si128(&v95);
+              v59 = 10000000;
+              do
+              {
+                v62 = *(volatile signed __int64 **)(a1 + 2816);
+                v63 = *(_QWORD *)(a1 + 2824);
+                v64 = _InterlockedCompareExchange64(v62, (signed __int64)v58, v56);
+                v65 = v63 + 1;
+                if ( v56 == v64 )
+                  goto LABEL_72;
+                *(_QWORD *)&v61 = v62;
+                *((_QWORD *)&v61 + 1) = v63;
+                _InterlockedCompareExchange128((volatile signed __int64 *)(a1 + 2816), v65, v64, (signed __int64 *)&v61);
+                v60 = *((_QWORD *)&v61 + 1);
+                --v59;
+              }
+              while ( v59 );
+              v3 = _mm_load_si128(&inserted);
+              v98 = 567;
+              v97 = "nTries < 10000000";
+              v96 = v3;
+              v99 = v99 & 0x80 | 0x16;
+              Assert_ConditionFailed_Fatal(&v96, "CTSQueue corruption", v60);
+  LABEL_123:
+              std::__throw_length_error("basic_string::_S_create");
+            }
+            if ( v30 > 0x3FFFFFFFFFFFFFF9LL )
+              goto LABEL_123;
+            if ( v30 + 57 > 0x1000 )
+            {
+              v78 = v82;
+              v36 = v30 + 4096 - (((_WORD)v30 + 57) & 0xFFF);
+              v80 = v30;
+              if ( v36 > 0x3FFFFFFFFFFFFFF9LL )
+                v36 = 0x3FFFFFFFFFFFFFF9LL;
+              v84 = v36;
+              v37 = operator new(v36 + 25);
+              v32 = v80;
+              v35 = (__int64 (__fastcall **)())(v37 + 24);
+              v34 = (_BYTE *)v37;
+              *(_DWORD *)(v37 + 16) = 0;
+              v33 = v78;
+              *(_QWORD *)(v37 + 8) = v84;
+            }
+            else
+            {
+              v79 = v82;
+              v83 = v30;
+              v31 = operator new(v30 + 25);
+              v32 = v83;
+              v33 = v79;
+              v34 = (_BYTE *)v31;
+              *(_DWORD *)(v31 + 16) = 0;
+              v35 = (__int64 (__fastcall **)())(v31 + 24);
+              *(_QWORD *)(v31 + 8) = v83;
+              if ( v83 == 1 )
+              {
+                *(_BYTE *)(v31 + 24) = *v79;
+                goto LABEL_41;
+              }
+            }
+            v81 = v34;
+            v85 = v32;
+            v38 = (__int64 (__fastcall **)())memcpy(v35, v33, v32);
+            v34 = v81;
+            v32 = v85;
+            v35 = v38;
+  LABEL_41:
+            if ( v34 != (_BYTE *)&std::string::_Rep::_S_empty_rep_storage )
+            {
+              *(_QWORD *)v34 = v32;
+              v34[v32 + 24] = 0;
+            }
+            goto LABEL_43;
+          }
+  LABEL_121:
+          std::__throw_logic_error("basic_string::_S_construct null not valid");
+        }
+        v14 = (const char *)&src;
+      }
+      v129 |= 1u;
+      v93 = (__int64 (__fastcall ***)())(v128 & 0xFFFFFFFFFFFFFFFCLL);
+      if ( (v128 & 1) != 0 )
+        v93 = *(__int64 (__fastcall ****)())(v128 & 0xFFFFFFFFFFFFFFFCLL);
+      goto LABEL_7;
+    }
+  }

--- a/ida_preprocessor_scripts/references/engine/CServerSideClientBase_SendServerInfo.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CServerSideClientBase_SendServerInfo.windows.yaml
@@ -1,0 +1,1341 @@
+func_name: CServerSideClientBase_SendServerInfo
+func_va: '0x1800c5720'
+disasm_code: |-
+  .text:00000001800C5720                 mov     rax, rsp
+  .text:00000001800C5723                 mov     [rax+10h], rdx
+  .text:00000001800C5727                 mov     [rax+8], rcx
+  .text:00000001800C572B                 push    rbp
+  .text:00000001800C572C                 push    rbx
+  .text:00000001800C572D                 push    rdi
+  .text:00000001800C572E                 push    r15
+  .text:00000001800C5730                 lea     rbp, [rax-0A58h]
+  .text:00000001800C5737                 sub     rsp, 0B38h
+  .text:00000001800C573E                 xor     edi, edi
+  .text:00000001800C5740                 mov     r15, rdx
+  .text:00000001800C5743                 mov     rbx, rcx
+  .text:00000001800C5746                 cmp     [rcx+58h], rdi
+  .text:00000001800C574A                 jz      loc_1800C639B
+  .text:00000001800C5750                 mov     rcx, cs:g_pNetworkSystem
+  .text:00000001800C5757                 mov     [rax-28h], rsi
+  .text:00000001800C575B                 mov     [rax-30h], r12
+  .text:00000001800C575F                 mov     [rax-38h], r13
+  .text:00000001800C5763                 mov     [rax-40h], r14
+  .text:00000001800C5767                 movaps  xmmword ptr [rax-58h], xmm6
+  .text:00000001800C576B                 mov     rax, [rcx]
+  .text:00000001800C576E                 mov     [rbp+0A50h+arg_10], rcx
+  .text:00000001800C5775                 call    qword ptr [rax+138h]
+  .text:00000001800C577B                 mov     r9d, 138800h
+  .text:00000001800C5781                 mov     [rsp+0B50h+var_B30], 0FFFFFFFFh
+  .text:00000001800C5789                 mov     r8, rax
+  .text:00000001800C578C                 mov     [rbp+0A50h+arg_18], rax
+  .text:00000001800C5793                 lea     rdx, aSvSendserverin; "SV_SendServerinfo->msg"
+  .text:00000001800C579A                 lea     rcx, [rbp+0A50h+var_890]
+  .text:00000001800C57A1                 call    sub_1803FC750
+  .text:00000001800C57A6                 mov     ecx, [r15+4]
+  .text:00000001800C57AA                 lea     r12, unk_180528AFF
+  .text:00000001800C57B1                 xor     eax, eax
+  .text:00000001800C57B3                 mov     [rbx+158h], ecx
+  .text:00000001800C57B9                 mov     r13d, [r15+14h]
+  .text:00000001800C57BD                 xorps   xmm6, xmm6
+  .text:00000001800C57C0                 mov     [rbp+0A50h+var_A40], rax
+  .text:00000001800C57C4                 lea     rax, qword_18062DB90
+  .text:00000001800C57CB                 mov     [rbp+0A50h+var_A38], rax
+  .text:00000001800C57CF                 lea     rax, ??_7CSVCMsg_Print_t@@6B@; const CSVCMsg_Print_t::`vftable'
+  .text:00000001800C57D6                 mov     [rbp+0A50h+var_A80], rax
+  .text:00000001800C57DA                 lea     rax, ??_7CSVCMsg_Print_t@@6B@_0; const CSVCMsg_Print_t::`vftable'
+  .text:00000001800C57E1                 mov     [rbp+0A50h+var_A50], rax
+  .text:00000001800C57E5                 mov     rax, cs:qword_180918DB0
+  .text:00000001800C57EC                 test    rax, rax
+  .text:00000001800C57EF                 movsd   [rbp+0A50h+var_A78], xmm6
+  .text:00000001800C57F4                 mov     [rbp+0A50h+var_860], edi
+  .text:00000001800C57FA                 cmovnz  r12, rax
+  .text:00000001800C57FE                 mov     [rbp+0A50h+var_858], rdi
+  .text:00000001800C5805                 mov     [rbp+0A50h+var_85C], 0C0000800h
+  .text:00000001800C580F                 mov     [rbp+0A50h+var_A70], edi
+  .text:00000001800C5812                 mov     [rbp+0A50h+var_A6C], 0FFh
+  .text:00000001800C5816                 mov     [rbp+0A50h+var_A68], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C581E                 mov     [rbp+0A50h+var_A60], 0BF800000h
+  .text:00000001800C5825                 mov     [rbp+0A50h+var_A58], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C582D                 mov     [rbp+0A50h+var_A48], rdi
+  .text:00000001800C5831                 mov     dword ptr [rbp+0A50h+var_A40+4], edi
+  .text:00000001800C5834                 call    sub_18018BF20
+  .text:00000001800C5839                 mov     rcx, [rbx+50h]
+  .text:00000001800C583D                 mov     edi, eax
+  .text:00000001800C583F                 mov     esi, [r15+0Ch]
+  .text:00000001800C5843                 mov     r14d, [r15+10h]
+  .text:00000001800C5847                 mov     r15d, [r15+8]
+  .text:00000001800C584B                 mov     rdx, [rcx]
+  .text:00000001800C584E                 call    qword ptr [rdx+0C8h]
+  .text:00000001800C5854                 mov     rcx, cs:qword_180911898
+  .text:00000001800C585B                 mov     rbx, rax
+  .text:00000001800C585E                 mov     rdx, [rcx]
+  .text:00000001800C5861                 call    qword ptr [rdx+58h]
+  .text:00000001800C5864                 mov     dword ptr [rsp+0B50h+var_B08], r13d
+  .text:00000001800C5869                 lea     rdx, aGameSMapSPlaye; "\nGame: \"%s\"\nMap: \"%s\"\nPlayers: %"...
+  .text:00000001800C5870                 mov     qword ptr [rsp+0B50h+var_B10], r12
+  .text:00000001800C5875                 lea     rcx, [rbp+0A50h+var_860]
+  .text:00000001800C587C                 mov     dword ptr [rsp+0B50h+var_B18], edi
+  .text:00000001800C5880                 mov     r9, rbx
+  .text:00000001800C5883                 mov     [rsp+0B50h+var_B20], esi
+  .text:00000001800C5887                 mov     r8, rax
+  .text:00000001800C588A                 mov     [rsp+0B50h+var_B28], r14d
+  .text:00000001800C588F                 mov     [rsp+0B50h+var_B30], r15d
+  .text:00000001800C5894                 call    sub_1800CB320
+  .text:00000001800C5899                 mov     eax, [rbp+0A50h+var_85C]
+  .text:00000001800C589F                 bt      eax, 1Eh
+  .text:00000001800C58A3                 jnb     short loc_1800C58AE
+  .text:00000001800C58A5                 lea     rcx, [rbp+0A50h+var_858]
+  .text:00000001800C58AC                 jmp     short loc_1800C58C2
+  .text:00000001800C58AE                 test    eax, 3FFFFFFFh
+  .text:00000001800C58B3                 lea     rcx, unk_180528AFF
+  .text:00000001800C58BA                 cmova   rcx, [rbp+0A50h+var_858]
+  .text:00000001800C58C2                 or      dword ptr [rbp+0A50h+var_A40], 1
+  .text:00000001800C58C6                 test    byte ptr [rbp+0A50h+var_A48], 1
+  .text:00000001800C58CA                 jz      short loc_1800C58D9
+  .text:00000001800C58CC                 mov     rax, [rbp+0A50h+var_A48]
+  .text:00000001800C58D0                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C58D4                 mov     rbx, [rax]
+  .text:00000001800C58D7                 jmp     short loc_1800C58E1
+  .text:00000001800C58D9                 mov     rbx, [rbp+0A50h+var_A48]
+  .text:00000001800C58DD                 and     rbx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C58E1                 xorps   xmm0, xmm0
+  .text:00000001800C58E4                 xorps   xmm1, xmm1
+  .text:00000001800C58E7                 movups  [rsp+0B50h+var_B08+8], xmm0
+  .text:00000001800C58EC                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C58F3                 movdqu  [rsp+0B50h+var_AF8+8], xmm1
+  .text:00000001800C58F9                 nop     dword ptr [rax+00000000h]
+  .text:00000001800C5900                 inc     r8
+  .text:00000001800C5903                 cmp     byte ptr [rcx+r8], 0
+  .text:00000001800C5908                 jnz     short loc_1800C5900
+  .text:00000001800C590A                 mov     rdx, rcx
+  .text:00000001800C590D                 lea     rcx, [rsp+0B50h+var_B08+8]
+  .text:00000001800C5912                 call    sub_1800439B0
+  .text:00000001800C5917                 mov     r8, rbx
+  .text:00000001800C591A                 lea     rdx, [rsp+0B50h+var_B08+8]
+  .text:00000001800C591F                 lea     rcx, [rbp+0A50h+var_A38]
+  .text:00000001800C5923                 call    sub_18024FE80
+  .text:00000001800C5928                 mov     rax, [rsp+0B50h+var_AE8]
+  .text:00000001800C592D                 cmp     rax, 0Fh
+  .text:00000001800C5931                 jbe     short loc_1800C596B
+  .text:00000001800C5933                 mov     rdx, qword ptr [rsp+0B50h+var_B08+8]
+  .text:00000001800C5938                 inc     rax
+  .text:00000001800C593B                 mov     rcx, rdx
+  .text:00000001800C593E                 cmp     rax, 1000h
+  .text:00000001800C5944                 jb      short loc_1800C595B
+  .text:00000001800C5946                 mov     rdx, [rdx-8]
+  .text:00000001800C594A                 sub     rcx, rdx
+  .text:00000001800C594D                 lea     rax, [rcx-8]
+  .text:00000001800C5951                 cmp     rax, 1Fh
+  .text:00000001800C5955                 ja      loc_1800C63AE
+  .text:00000001800C595B                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C5962                 mov     rcx, [rax]
+  .text:00000001800C5965                 mov     rax, [rcx]
+  .text:00000001800C5968                 call    qword ptr [rax+18h]
+  .text:00000001800C596B                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5972                 lea     r8, [rbp+0A50h+var_A80]
+  .text:00000001800C5976                 movdqa  xmm0, cs:xmmword_1805852A0
+  .text:00000001800C597E                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5985                 movdqu  [rsp+0B50h+var_AF8+8], xmm0
+  .text:00000001800C598B                 mov     byte ptr [rsp+0B50h+var_B08+8], 0
+  .text:00000001800C5990                 mov     rax, [rcx]
+  .text:00000001800C5993                 call    qword ptr [rax+18h]
+  .text:00000001800C5996                 test    al, al
+  .text:00000001800C5998                 jnz     short loc_1800C59C7
+  .text:00000001800C599A                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C59A0                 mov     edx, 3
+  .text:00000001800C59A5                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C59AB                 test    al, al
+  .text:00000001800C59AD                 jz      short loc_1800C59C7
+  .text:00000001800C59AF                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C59B5                 lea     r8, aBuildserverinf; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C59BC                 mov     edx, 3
+  .text:00000001800C59C1                 call    cs:LoggingSystem_Log
+  .text:00000001800C59C7                 lea     rax, ??_7?$CNetMessagePB@$0DA@VCSVCMsg_Print@@$0A@$00$0A@@@6B@; const CNetMessagePB<48,CSVCMsg_Print,0,1,0>::`vftable'
+  .text:00000001800C59CE                 mov     [rbp+0A50h+var_A80], rax
+  .text:00000001800C59D2                 lea     rax, ??_7CSVCMsg_Print@@6B@; const CSVCMsg_Print::`vftable'
+  .text:00000001800C59D9                 mov     [rbp+0A50h+var_A50], rax
+  .text:00000001800C59DD                 movzx   eax, byte ptr [rbp+0A50h+var_A48]
+  .text:00000001800C59E1                 test    al, 1
+  .text:00000001800C59E3                 jz      short loc_1800C59FA
+  .text:00000001800C59E5                 lea     rcx, [rbp+0A50h+var_A48]
+  .text:00000001800C59E9                 call    sub_180145290
+  .text:00000001800C59EE                 mov     rcx, [rbp+0A50h+var_A48]
+  .text:00000001800C59F2                 mov     rdx, rax
+  .text:00000001800C59F5                 mov     rax, rcx
+  .text:00000001800C59F8                 jmp     short loc_1800C5A05
+  .text:00000001800C59FA                 mov     rcx, [rbp+0A50h+var_A48]
+  .text:00000001800C59FE                 mov     rdx, rcx
+  .text:00000001800C5A01                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C5A05                 test    rdx, rdx
+  .text:00000001800C5A08                 jnz     short loc_1800C5A1A
+  .text:00000001800C5A0A                 lea     rcx, [rbp+0A50h+var_A38]
+  .text:00000001800C5A0E                 call    sub_18024FC20
+  .text:00000001800C5A13                 mov     rcx, [rbp+0A50h+var_A48]
+  .text:00000001800C5A17                 movzx   eax, cl
+  .text:00000001800C5A1A                 shr     al, 1
+  .text:00000001800C5A1C                 test    al, 1
+  .text:00000001800C5A1E                 jz      short loc_1800C5A44
+  .text:00000001800C5A20                 lea     rbx, [rcx-2]
+  .text:00000001800C5A24                 test    rbx, rbx
+  .text:00000001800C5A27                 jz      short loc_1800C5A44
+  .text:00000001800C5A29                 mov     rcx, rbx
+  .text:00000001800C5A2C                 call    sub_1802BF3F0
+  .text:00000001800C5A31                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C5A38                 mov     rdx, rbx
+  .text:00000001800C5A3B                 mov     rcx, [rax]
+  .text:00000001800C5A3E                 mov     rax, [rcx]
+  .text:00000001800C5A41                 call    qword ptr [rax+18h]
+  .text:00000001800C5A44                 lea     r13, ??_7CNetMessage@@6B@; const CNetMessage::`vftable'
+  .text:00000001800C5A4B                 xor     edx, edx
+  .text:00000001800C5A4D                 lea     rcx, [rbp+0A50h+var_860]
+  .text:00000001800C5A54                 mov     [rbp+0A50h+var_A80], r13
+  .text:00000001800C5A58                 call    cs:?Purge@CBufferString@@QEAAXH@Z; CBufferString::Purge(int)
+  .text:00000001800C5A5E                 mov     rdi, [rbp+0A50h+arg_0]
+  .text:00000001800C5A65                 lea     rcx, ??_7CNETMsg_Tick_t@@6B@; const CNETMsg_Tick_t::`vftable'
+  .text:00000001800C5A6C                 xor     r12d, r12d
+  .text:00000001800C5A6F                 mov     [rbp+0A50h+var_9B0], rcx
+  .text:00000001800C5A76                 xor     eax, eax
+  .text:00000001800C5A78                 movsd   [rbp+0A50h+var_9A8], xmm6
+  .text:00000001800C5A80                 or      eax, 2
+  .text:00000001800C5A83                 mov     [rbp+0A50h+var_9A0], r12d
+  .text:00000001800C5A8A                 mov     [rbp+0A50h+var_970], eax
+  .text:00000001800C5A90                 lea     rcx, ??_7CNETMsg_Tick_t@@6B@_0; const CNETMsg_Tick_t::`vftable'
+  .text:00000001800C5A97                 mov     eax, [rdi+158h]
+  .text:00000001800C5A9D                 lea     rbx, qword_18062DB90
+  .text:00000001800C5AA4                 mov     [rbp+0A50h+var_980], rcx
+  .text:00000001800C5AAB                 lea     r8, [rbp+0A50h+var_9B0]
+  .text:00000001800C5AB2                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5AB9                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5AC0                 mov     [rbp+0A50h+var_99C], 0FFh
+  .text:00000001800C5AC7                 mov     [rbp+0A50h+var_998], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5AD2                 mov     [rbp+0A50h+var_990], 0BF800000h
+  .text:00000001800C5ADC                 mov     [rbp+0A50h+var_988], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5AE7                 mov     [rbp+0A50h+var_978], r12
+  .text:00000001800C5AEE                 mov     [rbp+0A50h+var_96C], r12d
+  .text:00000001800C5AF5                 mov     [rbp+0A50h+var_95C], r12
+  .text:00000001800C5AFC                 mov     [rbp+0A50h+var_954], r12
+  .text:00000001800C5B03                 mov     [rbp+0A50h+var_94C], r12
+  .text:00000001800C5B0A                 mov     [rbp+0A50h+var_944], r12
+  .text:00000001800C5B11                 mov     [rbp+0A50h+var_968], rbx
+  .text:00000001800C5B18                 mov     [rbp+0A50h+var_960], eax
+  .text:00000001800C5B1E                 mov     rax, [rcx]
+  .text:00000001800C5B21                 call    qword ptr [rax+18h]
+  .text:00000001800C5B24                 test    al, al
+  .text:00000001800C5B26                 jnz     short loc_1800C5B55
+  .text:00000001800C5B28                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5B2E                 mov     edx, 3
+  .text:00000001800C5B33                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C5B39                 test    al, al
+  .text:00000001800C5B3B                 jz      short loc_1800C5B55
+  .text:00000001800C5B3D                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5B43                 lea     r8, aBuildserverinf_0; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C5B4A                 mov     edx, 3
+  .text:00000001800C5B4F                 call    cs:LoggingSystem_Log
+  .text:00000001800C5B55                 mov     rcx, [rdi+50h]
+  .text:00000001800C5B59                 mov     rax, [rcx]
+  .text:00000001800C5B5C                 call    qword ptr [rax+178h]
+  .text:00000001800C5B62                 test    al, al
+  .text:00000001800C5B64                 jz      short loc_1800C5B74
+  .text:00000001800C5B66                 cmp     [rdi+9F9h], r12b
+  .text:00000001800C5B6D                 jnz     short loc_1800C5B74
+  .text:00000001800C5B6F                 xor     r14b, r14b
+  .text:00000001800C5B72                 jmp     short loc_1800C5B77
+  .text:00000001800C5B74                 mov     r14b, 1
+  .text:00000001800C5B77                 mov     rcx, [rdi+50h]
+  .text:00000001800C5B7B                 xor     eax, eax
+  .text:00000001800C5B7D                 mov     [rbp+0A50h+var_AA0], rax
+  .text:00000001800C5B81                 mov     [rbp+0A50h+var_A90], al
+  .text:00000001800C5B84                 lea     rax, ??_7CSVCMsg_ClearAllStringTables_t@@6B@; const CSVCMsg_ClearAllStringTables_t::`vftable'
+  .text:00000001800C5B8B                 mov     [rsp+0B50h+var_AE0], rax
+  .text:00000001800C5B90                 lea     rax, ??_7CSVCMsg_ClearAllStringTables_t@@6B@_0; const CSVCMsg_ClearAllStringTables_t::`vftable'
+  .text:00000001800C5B97                 mov     [rbp+0A50h+var_AB0], rax
+  .text:00000001800C5B9B                 movsd   qword ptr [rsp+78h], xmm6
+  .text:00000001800C5BA1                 mov     [rbp+0A50h+var_AD0], r12d
+  .text:00000001800C5BA5                 mov     [rbp+0A50h+var_ACC], 0FFh
+  .text:00000001800C5BA9                 mov     [rbp+0A50h+var_AC8], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5BB1                 mov     [rbp+0A50h+var_AC0], 0BF800000h
+  .text:00000001800C5BB8                 mov     [rbp+0A50h+var_AB8], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5BC0                 mov     [rbp+0A50h+var_AA8], r12
+  .text:00000001800C5BC4                 mov     dword ptr [rbp+0A50h+var_AA0+4], r12d
+  .text:00000001800C5BC8                 mov     [rbp+0A50h+var_A98], rbx
+  .text:00000001800C5BCC                 mov     rax, [rcx]
+  .text:00000001800C5BCF                 call    qword ptr [rax+0C8h]
+  .text:00000001800C5BD5                 or      dword ptr [rbp+0A50h+var_AA0], 1
+  .text:00000001800C5BD9                 test    byte ptr [rbp+0A50h+var_AA8], 1
+  .text:00000001800C5BDD                 jz      short loc_1800C5BEC
+  .text:00000001800C5BDF                 mov     rcx, [rbp+0A50h+var_AA8]
+  .text:00000001800C5BE3                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C5BE7                 mov     rbx, [rcx]
+  .text:00000001800C5BEA                 jmp     short loc_1800C5BF4
+  .text:00000001800C5BEC                 mov     rbx, [rbp+0A50h+var_AA8]
+  .text:00000001800C5BF0                 and     rbx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C5BF4                 xorps   xmm0, xmm0
+  .text:00000001800C5BF7                 xorps   xmm1, xmm1
+  .text:00000001800C5BFA                 movups  [rsp+0B50h+var_B08+8], xmm0
+  .text:00000001800C5BFF                 mov     r8, 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5C06                 movdqu  [rsp+0B50h+var_AF8+8], xmm1
+  .text:00000001800C5C0C                 nop     dword ptr [rax+00h]
+  .text:00000001800C5C10                 inc     r8
+  .text:00000001800C5C13                 cmp     [rax+r8], r12b
+  .text:00000001800C5C17                 jnz     short loc_1800C5C10
+  .text:00000001800C5C19                 mov     rdx, rax
+  .text:00000001800C5C1C                 lea     rcx, [rsp+0B50h+var_B08+8]
+  .text:00000001800C5C21                 call    sub_1800439B0
+  .text:00000001800C5C26                 mov     r8, rbx
+  .text:00000001800C5C29                 lea     rdx, [rsp+0B50h+var_B08+8]
+  .text:00000001800C5C2E                 lea     rcx, [rbp+0A50h+var_A98]
+  .text:00000001800C5C32                 call    sub_18024FE80
+  .text:00000001800C5C37                 mov     rax, [rsp+0B50h+var_AE8]
+  .text:00000001800C5C3C                 cmp     rax, 0Fh
+  .text:00000001800C5C40                 jbe     short loc_1800C5C7A
+  .text:00000001800C5C42                 mov     rdx, qword ptr [rsp+0B50h+var_B08+8]
+  .text:00000001800C5C47                 inc     rax
+  .text:00000001800C5C4A                 mov     rcx, rdx
+  .text:00000001800C5C4D                 cmp     rax, 1000h
+  .text:00000001800C5C53                 jb      short loc_1800C5C6A
+  .text:00000001800C5C55                 mov     rdx, [rdx-8]
+  .text:00000001800C5C59                 sub     rcx, rdx
+  .text:00000001800C5C5C                 lea     rax, [rcx-8]
+  .text:00000001800C5C60                 cmp     rax, 1Fh
+  .text:00000001800C5C64                 ja      loc_1800C63A8
+  .text:00000001800C5C6A                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C5C71                 mov     rcx, [rax]
+  .text:00000001800C5C74                 mov     rax, [rcx]
+  .text:00000001800C5C77                 call    qword ptr [rax+18h]
+  .text:00000001800C5C7A                 movdqa  xmm0, cs:xmmword_1805852A0
+  .text:00000001800C5C82                 mov     byte ptr [rsp+0B50h+var_B08+8], r12b
+  .text:00000001800C5C87                 movdqu  [rsp+0B50h+var_AF8+8], xmm0
+  .text:00000001800C5C8D                 test    r14b, r14b
+  .text:00000001800C5C90                 jz      short loc_1800C5C9A
+  .text:00000001800C5C92                 or      dword ptr [rbp+0A50h+var_AA0], 2
+  .text:00000001800C5C96                 mov     [rbp+0A50h+var_A90], 1
+  .text:00000001800C5C9A                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5CA1                 lea     r8, [rsp+0B50h+var_AE0]
+  .text:00000001800C5CA6                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5CAD                 mov     rax, [rcx]
+  .text:00000001800C5CB0                 call    qword ptr [rax+18h]
+  .text:00000001800C5CB3                 test    al, al
+  .text:00000001800C5CB5                 jnz     short loc_1800C5CE4
+  .text:00000001800C5CB7                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5CBD                 mov     edx, 3
+  .text:00000001800C5CC2                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C5CC8                 test    al, al
+  .text:00000001800C5CCA                 jz      short loc_1800C5CE4
+  .text:00000001800C5CCC                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5CD2                 lea     r8, aBuildserverinf_1; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C5CD9                 mov     edx, 3
+  .text:00000001800C5CDE                 call    cs:LoggingSystem_Log
+  .text:00000001800C5CE4                 mov     rsi, [rbp+0A50h+arg_8]
+  .text:00000001800C5CEB                 test    r14b, r14b
+  .text:00000001800C5CEE                 jnz     short loc_1800C5D23
+  .text:00000001800C5CF0                 cmp     [rsi], r12b
+  .text:00000001800C5CF3                 jz      short loc_1800C5D05
+  .text:00000001800C5CF5                 mov     rax, [rdi+50h]
+  .text:00000001800C5CF9                 mov     rcx, [rax+180h]
+  .text:00000001800C5D00                 test    rcx, rcx
+  .text:00000001800C5D03                 jnz     short loc_1800C5D10
+  .text:00000001800C5D05                 mov     rax, [rdi+50h]
+  .text:00000001800C5D09                 mov     rcx, [rax+178h]
+  .text:00000001800C5D10                 mov     r8d, [rsi+4]
+  .text:00000001800C5D14                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5D1B                 mov     r9, rdi
+  .text:00000001800C5D1E                 call    sub_18010BFD0
+  .text:00000001800C5D23                 xor     edx, edx
+  .text:00000001800C5D25                 movsd   [rbp+0A50h+var_928], xmm6
+  .text:00000001800C5D2D                 lea     rcx, [rbp+0A50h+var_900]
+  .text:00000001800C5D34                 mov     [rbp+0A50h+var_930], r13
+  .text:00000001800C5D3B                 mov     [rbp+0A50h+var_920], r12d
+  .text:00000001800C5D42                 mov     [rbp+0A50h+var_91C], 0FFh
+  .text:00000001800C5D49                 mov     [rbp+0A50h+var_918], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5D54                 mov     [rbp+0A50h+var_910], 0BF800000h
+  .text:00000001800C5D5E                 mov     [rbp+0A50h+var_908], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5D69                 call    sub_180158670
+  .text:00000001800C5D6E                 or      [rbp+0A50h+var_8F0], 40h
+  .text:00000001800C5D75                 lea     rax, ??_7CSVCMsg_ServerInfo_t@@6B@; const CSVCMsg_ServerInfo_t::`vftable'
+  .text:00000001800C5D7C                 mov     rbx, [rbp+0A50h+var_8B8]
+  .text:00000001800C5D83                 lea     rcx, ??_7CSVCMsg_ServerInfo_t@@6B@_0; const CSVCMsg_ServerInfo_t::`vftable'
+  .text:00000001800C5D8A                 mov     [rbp+0A50h+var_900], rax
+  .text:00000001800C5D91                 mov     [rbp+0A50h+var_930], rcx
+  .text:00000001800C5D98                 test    rbx, rbx
+  .text:00000001800C5D9B                 jnz     short loc_1800C5DD0
+  .text:00000001800C5D9D                 test    byte ptr [rbp+0A50h+var_8F8], 1
+  .text:00000001800C5DA4                 jz      short loc_1800C5DB6
+  .text:00000001800C5DA6                 mov     rax, [rbp+0A50h+var_8F8]
+  .text:00000001800C5DAD                 and     rax, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C5DB1                 mov     rcx, [rax]
+  .text:00000001800C5DB4                 jmp     short loc_1800C5DC1
+  .text:00000001800C5DB6                 mov     rcx, [rbp+0A50h+var_8F8]
+  .text:00000001800C5DBD                 and     rcx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C5DC1                 call    sub_18017CF60
+  .text:00000001800C5DC6                 mov     rbx, rax
+  .text:00000001800C5DC9                 mov     [rbp+0A50h+var_8B8], rax
+  .text:00000001800C5DD0                 mov     rcx, [rdi+50h]
+  .text:00000001800C5DD4                 mov     rax, [rcx]
+  .text:00000001800C5DD7                 call    qword ptr [rax+160h]
+  .text:00000001800C5DDD                 mov     r15, rax
+  .text:00000001800C5DE0                 cmp     rax, rbx
+  .text:00000001800C5DE3                 jz      short loc_1800C5DF8
+  .text:00000001800C5DE5                 mov     rcx, rbx
+  .text:00000001800C5DE8                 call    sub_18017A130
+  .text:00000001800C5DED                 mov     rdx, r15
+  .text:00000001800C5DF0                 mov     rcx, rbx
+  .text:00000001800C5DF3                 call    sub_18017AF20
+  .text:00000001800C5DF8                 mov     eax, [rdi+48h]
+  .text:00000001800C5DFB                 lea     rdx, [rbp+0A50h+var_930]
+  .text:00000001800C5E02                 mov     rcx, [rdi+50h]
+  .text:00000001800C5E06                 or      [rbp+0A50h+var_8F0], 8000h
+  .text:00000001800C5E10                 mov     [rbp+0A50h+var_894], eax
+  .text:00000001800C5E16                 mov     rax, [rcx]
+  .text:00000001800C5E19                 call    qword ptr [rax+250h]  ; 250h = CNetworkGameServerBase_FillServerInfo
+  .text:00000001800C5E1F                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5E26                 lea     r8, [rbp+0A50h+var_930]
+  .text:00000001800C5E2D                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5E34                 mov     rax, [rcx]
+  .text:00000001800C5E37                 call    qword ptr [rax+18h]
+  .text:00000001800C5E3A                 test    al, al
+  .text:00000001800C5E3C                 jnz     short loc_1800C5E6B
+  .text:00000001800C5E3E                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5E44                 mov     edx, 3
+  .text:00000001800C5E49                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C5E4F                 test    al, al
+  .text:00000001800C5E51                 jz      short loc_1800C5E6B
+  .text:00000001800C5E53                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5E59                 lea     r8, aBuildserverinf_2; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C5E60                 mov     edx, 3
+  .text:00000001800C5E65                 call    cs:LoggingSystem_Log
+  .text:00000001800C5E6B                 test    r14b, r14b
+  .text:00000001800C5E6E                 jnz     short loc_1800C5EB9
+  .text:00000001800C5E70                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5E77                 lea     r8, [rsi+30h]
+  .text:00000001800C5E7B                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5E82                 mov     rax, [rcx]
+  .text:00000001800C5E85                 call    qword ptr [rax+18h]
+  .text:00000001800C5E88                 test    al, al
+  .text:00000001800C5E8A                 jnz     short loc_1800C5EB9
+  .text:00000001800C5E8C                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5E92                 mov     edx, 3
+  .text:00000001800C5E97                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C5E9D                 test    al, al
+  .text:00000001800C5E9F                 jz      short loc_1800C5EB9
+  .text:00000001800C5EA1                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5EA7                 lea     r8, aBuildserverinf_3; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C5EAE                 mov     edx, 3
+  .text:00000001800C5EB3                 call    cs:LoggingSystem_Log
+  .text:00000001800C5EB9                 mov     rax, [rdi+50h]
+  .text:00000001800C5EBD                 lea     r14, ??_7CNETMsg_SignonState@@6B@; const CNETMsg_SignonState::`vftable'
+  .text:00000001800C5EC4                 xor     edx, edx
+  .text:00000001800C5EC6                 lea     rcx, [rbp+0A50h+var_9E8]
+  .text:00000001800C5ECA                 mov     ebx, [rax+2A0h]
+  .text:00000001800C5ED0                 xor     eax, eax
+  .text:00000001800C5ED2                 mov     [rbp+0A50h+var_9F0], rax
+  .text:00000001800C5ED6                 mov     dword ptr [rbp+0A50h+var_9F0+4], r12d
+  .text:00000001800C5EDA                 movsd   [rbp+0A50h+var_A28], xmm6
+  .text:00000001800C5EDF                 mov     [rbp+0A50h+var_A30], r13
+  .text:00000001800C5EE3                 mov     [rbp+0A50h+var_A20], r12d
+  .text:00000001800C5EE7                 mov     [rbp+0A50h+var_A1C], 0FFh
+  .text:00000001800C5EEB                 mov     [rbp+0A50h+var_A18], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5EF3                 mov     [rbp+0A50h+var_A10], 0BF800000h
+  .text:00000001800C5EFA                 mov     [rbp+0A50h+var_A08], 0FFFFFFFFFFFFFFFFh
+  .text:00000001800C5F02                 mov     [rbp+0A50h+var_9F8], r12
+  .text:00000001800C5F06                 mov     [rbp+0A50h+var_A00], r14
+  .text:00000001800C5F0A                 call    sub_1802507C0
+  .text:00000001800C5F0F                 mov     rcx, cs:g_pNetworkMessages
+  .text:00000001800C5F16                 lea     rax, qword_18062DB90
+  .text:00000001800C5F1D                 or      dword ptr [rbp+0A50h+var_9F0], 1Ch
+  .text:00000001800C5F21                 lea     r8, [rbp+0A50h+var_A30]
+  .text:00000001800C5F25                 mov     [rbp+0A50h+var_9D0], rax
+  .text:00000001800C5F2C                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5F33                 mov     [rbp+0A50h+var_9C8], rax
+  .text:00000001800C5F3A                 lea     rax, ??_7CNETMsg_SignonState_t@@6B@; const CNETMsg_SignonState_t::`vftable'
+  .text:00000001800C5F41                 mov     [rbp+0A50h+var_A30], rax
+  .text:00000001800C5F45                 lea     rax, ??_7CNETMsg_SignonState_t@@6B@_0; const CNETMsg_SignonState_t::`vftable'
+  .text:00000001800C5F4C                 mov     [rbp+0A50h+var_A00], rax
+  .text:00000001800C5F50                 mov     [rbp+0A50h+var_9C0], 3
+  .text:00000001800C5F5A                 mov     [rbp+0A50h+var_9BC], ebx
+  .text:00000001800C5F60                 mov     [rbp+0A50h+var_9B8], r12d
+  .text:00000001800C5F67                 mov     rax, [rcx]
+  .text:00000001800C5F6A                 call    qword ptr [rax+18h]
+  .text:00000001800C5F6D                 test    al, al
+  .text:00000001800C5F6F                 jnz     short loc_1800C5F9E
+  .text:00000001800C5F71                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5F77                 mov     edx, 3
+  .text:00000001800C5F7C                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800C5F82                 test    al, al
+  .text:00000001800C5F84                 jz      short loc_1800C5F9E
+  .text:00000001800C5F86                 mov     ecx, cs:dword_1808CC854
+  .text:00000001800C5F8C                 lea     r8, aBuildserverinf_4; "BuildServerInfoMessageAsync_t: Failed t"...
+  .text:00000001800C5F93                 mov     edx, 3
+  .text:00000001800C5F98                 call    cs:LoggingSystem_Log
+  .text:00000001800C5F9E                 cmp     [rsi], r12b
+  .text:00000001800C5FA1                 jnz     short loc_1800C5FAF
+  .text:00000001800C5FA3                 mov     rax, [rdi]
+  .text:00000001800C5FA6                 mov     rcx, rdi
+  .text:00000001800C5FA9                 call    qword ptr [rax+250h]
+  .text:00000001800C5FAF                 mov     rcx, [rdi+58h]
+  .text:00000001800C5FB3                 lea     r8, aSignon; "Signon"
+  .text:00000001800C5FBA                 mov     edx, [rdi+158h]
+  .text:00000001800C5FC0                 mov     rax, [rcx]
+  .text:00000001800C5FC3                 call    qword ptr [rax+298h]
+  .text:00000001800C5FC9                 mov     rcx, [rdi+58h]
+  .text:00000001800C5FCD                 lea     rdx, [rbp+0A50h+var_890]
+  .text:00000001800C5FD4                 mov     r8b, 1
+  .text:00000001800C5FD7                 mov     rax, [rcx]
+  .text:00000001800C5FDA                 call    qword ptr [rax+140h]
+  .text:00000001800C5FE0                 test    al, al
+  .text:00000001800C5FE2                 jz      short loc_1800C6054
+  .text:00000001800C5FE4                 mov     rax, [rdi]
+  .text:00000001800C5FE7                 lea     rdx, [rsi+18h]
+  .text:00000001800C5FEB                 movzx   r8d, byte ptr [rsi]
+  .text:00000001800C5FEF                 mov     rcx, rdi
+  .text:00000001800C5FF2                 call    qword ptr [rax+190h]
+  .text:00000001800C5FF8                 mov     ebx, [rbp+0A50h+var_8A0]
+  .text:00000001800C5FFE                 mov     dword ptr [rbp+0A50h+arg_0], ebx
+  .text:00000001800C6004                 cmp     [rsi], r12b
+  .text:00000001800C6007                 jnz     short loc_1800C602B
+  .text:00000001800C6009                 cmp     byte ptr [rdi+61h], 1
+  .text:00000001800C600D                 jz      short loc_1800C602B
+  .text:00000001800C600F                 mov     rcx, rdi
+  .text:00000001800C6012                 call    sub_1800C4350
+  .text:00000001800C6017                 lea     rdx, [rbp+0A50h+arg_0]
+  .text:00000001800C601E                 mov     rcx, rdi
+  .text:00000001800C6021                 call    sub_1800C63C0
+  .text:00000001800C6026                 jmp     loc_1800C60BD
+  .text:00000001800C602B                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C6032                 mov     edx, 10h
+  .text:00000001800C6037                 mov     rcx, [rax]
+  .text:00000001800C603A                 mov     rax, [rcx]
+  .text:00000001800C603D                 call    qword ptr [rax+8]
+  .text:00000001800C6040                 test    rax, rax
+  .text:00000001800C6043                 jz      short loc_1800C60A0
+  .text:00000001800C6045                 lea     rcx, ??_7?$CDelayedCall2@VCServerSideClientBase@@V1@USignonStateNewCall_t@1@Uempty_t@@@@6B@; const CDelayedCall2<CServerSideClientBase,CServerSideClientBase,CServerSideClientBase::SignonStateNewCall_t,empty_t>::`vftable'
+  .text:00000001800C604C                 mov     [rax+8], ebx
+  .text:00000001800C604F                 mov     [rax], rcx
+  .text:00000001800C6052                 jmp     short loc_1800C60A3
+  .text:00000001800C6054                 cmp     [rsi], r12b
+  .text:00000001800C6057                 jnz     short loc_1800C607A
+  .text:00000001800C6059                 cmp     byte ptr [rdi+61h], 1
+  .text:00000001800C605D                 jz      short loc_1800C607A
+  .text:00000001800C605F                 mov     rcx, rdi
+  .text:00000001800C6062                 call    sub_1800C4350
+  .text:00000001800C6067                 mov     rax, [rdi]
+  .text:00000001800C606A                 xor     r8d, r8d
+  .text:00000001800C606D                 mov     edx, 12h
+  .text:00000001800C6072                 mov     rcx, rdi
+  .text:00000001800C6075                 call    qword ptr [rax+38h]
+  .text:00000001800C6078                 jmp     short loc_1800C60BD
+  .text:00000001800C607A                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C6081                 mov     edx, 10h
+  .text:00000001800C6086                 mov     rcx, [rax]
+  .text:00000001800C6089                 mov     rax, [rcx]
+  .text:00000001800C608C                 call    qword ptr [rax+8]
+  .text:00000001800C608F                 test    rax, rax
+  .text:00000001800C6092                 jz      short loc_1800C60A0
+  .text:00000001800C6094                 lea     rcx, ??_7?$CDelayedCall2@VCServerSideClientBase@@V1@USignonStateNewFailedCall_t@1@Uempty_t@@@@6B@; const CDelayedCall2<CServerSideClientBase,CServerSideClientBase,CServerSideClientBase::SignonStateNewFailedCall_t,empty_t>::`vftable'
+  .text:00000001800C609B                 mov     [rax], rcx
+  .text:00000001800C609E                 jmp     short loc_1800C60A3
+  .text:00000001800C60A0                 mov     rax, r12
+  .text:00000001800C60A3                 lea     rdx, [rbp+0A50h+arg_0]
+  .text:00000001800C60AA                 mov     [rbp+0A50h+arg_0], rax
+  .text:00000001800C60B1                 lea     rcx, [rdi+0AF0h]
+  .text:00000001800C60B8                 call    sub_1800C0E60
+  .text:00000001800C60BD                 lea     rax, ??_7?$CNetMessagePB@$06VCNETMsg_SignonState@@$09$00$0A@@@6B@; const CNetMessagePB<7,CNETMsg_SignonState,10,1,0>::`vftable'
+  .text:00000001800C60C4                 mov     [rbp+0A50h+var_A00], r14
+  .text:00000001800C60C8                 mov     [rbp+0A50h+var_A30], rax
+  .text:00000001800C60CC                 movzx   eax, byte ptr [rbp+0A50h+var_9F8]
+  .text:00000001800C60D0                 test    al, 1
+  .text:00000001800C60D2                 jz      short loc_1800C60E9
+  .text:00000001800C60D4                 lea     rcx, [rbp+0A50h+var_9F8]
+  .text:00000001800C60D8                 call    sub_180145290
+  .text:00000001800C60DD                 mov     rcx, [rbp+0A50h+var_9F8]
+  .text:00000001800C60E1                 mov     rdx, rax
+  .text:00000001800C60E4                 mov     rax, rcx
+  .text:00000001800C60E7                 jmp     short loc_1800C60F4
+  .text:00000001800C60E9                 mov     rcx, [rbp+0A50h+var_9F8]
+  .text:00000001800C60ED                 mov     rdx, rcx
+  .text:00000001800C60F0                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C60F4                 test    rdx, rdx
+  .text:00000001800C60F7                 jnz     short loc_1800C6121
+  .text:00000001800C60F9                 lea     rcx, [rbp+0A50h+var_9E8]
+  .text:00000001800C60FD                 call    sub_180250870
+  .text:00000001800C6102                 lea     rcx, [rbp+0A50h+var_9D0]
+  .text:00000001800C6109                 call    sub_18024FC20
+  .text:00000001800C610E                 lea     rcx, [rbp+0A50h+var_9C8]
+  .text:00000001800C6115                 call    sub_18024FC20
+  .text:00000001800C611A                 mov     rcx, [rbp+0A50h+var_9F8]
+  .text:00000001800C611E                 movzx   eax, cl
+  .text:00000001800C6121                 shr     al, 1
+  .text:00000001800C6123                 test    al, 1
+  .text:00000001800C6125                 jz      short loc_1800C614B
+  .text:00000001800C6127                 lea     rbx, [rcx-2]
+  .text:00000001800C612B                 test    rbx, rbx
+  .text:00000001800C612E                 jz      short loc_1800C614B
+  .text:00000001800C6130                 mov     rcx, rbx
+  .text:00000001800C6133                 call    sub_1802BF3F0
+  .text:00000001800C6138                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C613F                 mov     rdx, rbx
+  .text:00000001800C6142                 mov     rcx, [rax]
+  .text:00000001800C6145                 mov     rax, [rcx]
+  .text:00000001800C6148                 call    qword ptr [rax+18h]
+  .text:00000001800C614B                 lea     rax, ??_7?$CNetMessagePB@$0CI@VCSVCMsg_ServerInfo@@$09$00$0A@@@6B@; const CNetMessagePB<40,CSVCMsg_ServerInfo,10,1,0>::`vftable'
+  .text:00000001800C6152                 mov     [rbp+0A50h+var_A30], r13
+  .text:00000001800C6156                 mov     [rbp+0A50h+var_930], rax
+  .text:00000001800C615D                 lea     rax, ??_7CSVCMsg_ServerInfo@@6B@; const CSVCMsg_ServerInfo::`vftable'
+  .text:00000001800C6164                 mov     [rbp+0A50h+var_900], rax
+  .text:00000001800C616B                 movzx   eax, byte ptr [rbp+0A50h+var_8F8]
+  .text:00000001800C6172                 test    al, 1
+  .text:00000001800C6174                 jz      short loc_1800C6191
+  .text:00000001800C6176                 lea     rcx, [rbp+0A50h+var_8F8]
+  .text:00000001800C617D                 call    sub_180145290
+  .text:00000001800C6182                 mov     rcx, [rbp+0A50h+var_8F8]
+  .text:00000001800C6189                 mov     rdx, rax
+  .text:00000001800C618C                 mov     rax, rcx
+  .text:00000001800C618F                 jmp     short loc_1800C619F
+  .text:00000001800C6191                 mov     rcx, [rbp+0A50h+var_8F8]
+  .text:00000001800C6198                 mov     rdx, rcx
+  .text:00000001800C619B                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C619F                 test    rdx, rdx
+  .text:00000001800C61A2                 jnz     short loc_1800C620C
+  .text:00000001800C61A4                 lea     rcx, [rbp+0A50h+var_8E8]
+  .text:00000001800C61AB                 call    sub_18024FC20
+  .text:00000001800C61B0                 lea     rcx, [rbp+0A50h+var_8E0]
+  .text:00000001800C61B7                 call    sub_18024FC20
+  .text:00000001800C61BC                 lea     rcx, [rbp+0A50h+var_8D8]
+  .text:00000001800C61C3                 call    sub_18024FC20
+  .text:00000001800C61C8                 lea     rcx, [rbp+0A50h+var_8D0]
+  .text:00000001800C61CF                 call    sub_18024FC20
+  .text:00000001800C61D4                 lea     rcx, [rbp+0A50h+var_8C8]
+  .text:00000001800C61DB                 call    sub_18024FC20
+  .text:00000001800C61E0                 lea     rcx, [rbp+0A50h+var_8C0]
+  .text:00000001800C61E7                 call    sub_18024FC20
+  .text:00000001800C61EC                 mov     rcx, [rbp+0A50h+var_8B8]
+  .text:00000001800C61F3                 test    rcx, rcx
+  .text:00000001800C61F6                 jz      short loc_1800C6202
+  .text:00000001800C61F8                 mov     rax, [rcx]
+  .text:00000001800C61FB                 mov     edx, 1
+  .text:00000001800C6200                 call    qword ptr [rax]
+  .text:00000001800C6202                 mov     rcx, [rbp+0A50h+var_8F8]
+  .text:00000001800C6209                 movzx   eax, cl
+  .text:00000001800C620C                 shr     al, 1
+  .text:00000001800C620E                 test    al, 1
+  .text:00000001800C6210                 jz      short loc_1800C6236
+  .text:00000001800C6212                 lea     rbx, [rcx-2]
+  .text:00000001800C6216                 test    rbx, rbx
+  .text:00000001800C6219                 jz      short loc_1800C6236
+  .text:00000001800C621B                 mov     rcx, rbx
+  .text:00000001800C621E                 call    sub_1802BF3F0
+  .text:00000001800C6223                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C622A                 mov     rdx, rbx
+  .text:00000001800C622D                 mov     rcx, [rax]
+  .text:00000001800C6230                 mov     rax, [rcx]
+  .text:00000001800C6233                 call    qword ptr [rax+18h]
+  .text:00000001800C6236                 lea     rax, ??_7?$CNetMessagePB@$0DD@VCSVCMsg_ClearAllStringTables@@$09$00$0A@@@6B@; const CNetMessagePB<51,CSVCMsg_ClearAllStringTables,10,1,0>::`vftable'
+  .text:00000001800C623D                 mov     [rbp+0A50h+var_930], r13
+  .text:00000001800C6244                 mov     [rsp+0B50h+var_AE0], rax
+  .text:00000001800C6249                 lea     rax, ??_7CSVCMsg_ClearAllStringTables@@6B@; const CSVCMsg_ClearAllStringTables::`vftable'
+  .text:00000001800C6250                 mov     [rbp+0A50h+var_AB0], rax
+  .text:00000001800C6254                 movzx   eax, byte ptr [rbp+0A50h+var_AA8]
+  .text:00000001800C6258                 test    al, 1
+  .text:00000001800C625A                 jz      short loc_1800C6271
+  .text:00000001800C625C                 lea     rcx, [rbp+0A50h+var_AA8]
+  .text:00000001800C6260                 call    sub_180145290
+  .text:00000001800C6265                 mov     rcx, [rbp+0A50h+var_AA8]
+  .text:00000001800C6269                 mov     rdx, rax
+  .text:00000001800C626C                 mov     rax, rcx
+  .text:00000001800C626F                 jmp     short loc_1800C627C
+  .text:00000001800C6271                 mov     rcx, [rbp+0A50h+var_AA8]
+  .text:00000001800C6275                 mov     rdx, rcx
+  .text:00000001800C6278                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C627C                 test    rdx, rdx
+  .text:00000001800C627F                 jnz     short loc_1800C6291
+  .text:00000001800C6281                 lea     rcx, [rbp+0A50h+var_A98]
+  .text:00000001800C6285                 call    sub_18024FC20
+  .text:00000001800C628A                 mov     rcx, [rbp+0A50h+var_AA8]
+  .text:00000001800C628E                 movzx   eax, cl
+  .text:00000001800C6291                 shr     al, 1
+  .text:00000001800C6293                 test    al, 1
+  .text:00000001800C6295                 jz      short loc_1800C62BB
+  .text:00000001800C6297                 lea     rbx, [rcx-2]
+  .text:00000001800C629B                 test    rbx, rbx
+  .text:00000001800C629E                 jz      short loc_1800C62BB
+  .text:00000001800C62A0                 mov     rcx, rbx
+  .text:00000001800C62A3                 call    sub_1802BF3F0
+  .text:00000001800C62A8                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C62AF                 mov     rdx, rbx
+  .text:00000001800C62B2                 mov     rcx, [rax]
+  .text:00000001800C62B5                 mov     rax, [rcx]
+  .text:00000001800C62B8                 call    qword ptr [rax+18h]
+  .text:00000001800C62BB                 lea     rax, ??_7?$CNetMessagePB@$03VCNETMsg_Tick@@$0BA@$0A@$0A@@@6B@; const CNetMessagePB<4,CNETMsg_Tick,16,0,0>::`vftable'
+  .text:00000001800C62C2                 mov     [rsp+0B50h+var_AE0], r13
+  .text:00000001800C62C7                 mov     [rbp+0A50h+var_9B0], rax
+  .text:00000001800C62CE                 lea     rax, ??_7CNETMsg_Tick@@6B@; const CNETMsg_Tick::`vftable'
+  .text:00000001800C62D5                 mov     [rbp+0A50h+var_980], rax
+  .text:00000001800C62DC                 movzx   eax, byte ptr [rbp+0A50h+var_978]
+  .text:00000001800C62E3                 test    al, 1
+  .text:00000001800C62E5                 jz      short loc_1800C6302
+  .text:00000001800C62E7                 lea     rcx, [rbp+0A50h+var_978]
+  .text:00000001800C62EE                 call    sub_180145290
+  .text:00000001800C62F3                 mov     rcx, [rbp+0A50h+var_978]
+  .text:00000001800C62FA                 mov     rdx, rax
+  .text:00000001800C62FD                 mov     rax, rcx
+  .text:00000001800C6300                 jmp     short loc_1800C6310
+  .text:00000001800C6302                 mov     rcx, [rbp+0A50h+var_978]
+  .text:00000001800C6309                 mov     rdx, rcx
+  .text:00000001800C630C                 and     rdx, 0FFFFFFFFFFFFFFFCh
+  .text:00000001800C6310                 test    rdx, rdx
+  .text:00000001800C6313                 jnz     short loc_1800C632B
+  .text:00000001800C6315                 lea     rcx, [rbp+0A50h+var_968]
+  .text:00000001800C631C                 call    sub_18024FC20
+  .text:00000001800C6321                 mov     rcx, [rbp+0A50h+var_978]
+  .text:00000001800C6328                 movzx   eax, cl
+  .text:00000001800C632B                 shr     al, 1
+  .text:00000001800C632D                 test    al, 1
+  .text:00000001800C632F                 jz      short loc_1800C6355
+  .text:00000001800C6331                 lea     rbx, [rcx-2]
+  .text:00000001800C6335                 test    rbx, rbx
+  .text:00000001800C6338                 jz      short loc_1800C6355
+  .text:00000001800C633A                 mov     rcx, rbx
+  .text:00000001800C633D                 call    sub_1802BF3F0
+  .text:00000001800C6342                 mov     rax, cs:g_pMemAlloc
+  .text:00000001800C6349                 mov     rdx, rbx
+  .text:00000001800C634C                 mov     rcx, [rax]
+  .text:00000001800C634F                 mov     rax, [rcx]
+  .text:00000001800C6352                 call    qword ptr [rax+18h]
+  .text:00000001800C6355                 mov     rcx, [rbp+0A50h+arg_10]
+  .text:00000001800C635C                 mov     rdx, [rbp+0A50h+arg_18]
+  .text:00000001800C6363                 mov     [rbp+0A50h+var_9B0], r13
+  .text:00000001800C636A                 mov     rax, [rcx]
+  .text:00000001800C636D                 call    qword ptr [rax+140h]
+  .text:00000001800C6373                 mov     r14, [rsp+0B50h+var_38]
+  .text:00000001800C637B                 mov     r13, [rsp+0B50h+var_30]
+  .text:00000001800C6383                 mov     r12, [rsp+0B50h+var_28]
+  .text:00000001800C638B                 mov     rsi, [rsp+0B30h]
+  .text:00000001800C6393                 movaps  xmm6, [rsp+0B50h+var_58+8]
+  .text:00000001800C639B                 add     rsp, 0B38h
+  .text:00000001800C63A2                 pop     r15
+  .text:00000001800C63A4                 pop     rdi
+  .text:00000001800C63A5                 pop     rbx
+  .text:00000001800C63A6                 pop     rbp
+  .text:00000001800C63A7                 retn
+  .text:00000001800C63A8                 call    _invalid_parameter_noinfo_noreturn
+  .text:00000001800C63AE                 call    _invalid_parameter_noinfo_noreturn
+procedure: |-
+  _UNKNOWN **__fastcall sub_1800C5720(__int64 a1, _DWORD *a2)
+  {
+    _UNKNOWN **result; // rax
+    __int64 v5; // rax
+    const char *v6; // r12
+    int v7; // r13d
+    int v8; // edi
+    int v9; // esi
+    int v10; // r14d
+    int v11; // r15d
+    const char *v12; // rbx
+    const char *v13; // rax
+    const __m128i *v14; // rcx
+    unsigned __int64 v15; // r8
+    char v16; // al
+    __int64 v17; // rax
+    __int64 v18; // rcx
+    unsigned __int64 v19; // rdx
+    __int64 v20; // rbx
+    __int64 v21; // rdi
+    int v22; // eax
+    bool v23; // r14
+    __int64 v24; // rcx
+    const __m128i *v25; // rax
+    unsigned __int64 v26; // rbx
+    unsigned __int64 v27; // r8
+    _BYTE *v28; // rsi
+    __int64 v29; // rcx
+    __int64 v30; // rbx
+    unsigned __int64 v31; // rcx
+    __int64 v32; // r15
+    int v33; // eax
+    __int64 v34; // rcx
+    int v35; // ebx
+    __int64 v36; // r8
+    int v37; // ebx
+    __int64 v38; // rax
+    char v39; // al
+    __int64 v40; // rax
+    __int64 v41; // rcx
+    unsigned __int64 v42; // rdx
+    __int64 v43; // rbx
+    char v44; // al
+    __int64 v45; // rax
+    __int64 v46; // rcx
+    unsigned __int64 v47; // rdx
+    __int64 v48; // rbx
+    char v49; // al
+    __int64 v50; // rax
+    __int64 v51; // rcx
+    unsigned __int64 v52; // rdx
+    __int64 v53; // rbx
+    char v54; // al
+    __int64 v55; // rax
+    __int64 v56; // rcx
+    unsigned __int64 v57; // rdx
+    __int64 v58; // rbx
+    __m128i v59; // [rsp+58h] [rbp-B0h] BYREF
+    __m128i si128; // [rsp+68h] [rbp-A0h]
+    _QWORD v61[2]; // [rsp+78h] [rbp-90h] BYREF
+    int v62; // [rsp+88h] [rbp-80h]
+    char v63; // [rsp+8Ch] [rbp-7Ch]
+    __int64 v64; // [rsp+90h] [rbp-78h]
+    int v65; // [rsp+98h] [rbp-70h]
+    __int64 v66; // [rsp+A0h] [rbp-68h]
+    void **v67; // [rsp+A8h] [rbp-60h]
+    __int64 v68; // [rsp+B0h] [rbp-58h] BYREF
+    __int64 v69; // [rsp+B8h] [rbp-50h]
+    __int64 *v70; // [rsp+C0h] [rbp-48h] BYREF
+    char v71; // [rsp+C8h] [rbp-40h]
+    _QWORD v72[2]; // [rsp+D8h] [rbp-30h] BYREF
+    int v73; // [rsp+E8h] [rbp-20h]
+    char v74; // [rsp+ECh] [rbp-1Ch]
+    __int64 v75; // [rsp+F0h] [rbp-18h]
+    int v76; // [rsp+F8h] [rbp-10h]
+    __int64 v77; // [rsp+100h] [rbp-8h]
+    void **v78; // [rsp+108h] [rbp+0h]
+    __int64 v79; // [rsp+110h] [rbp+8h] BYREF
+    __int64 v80; // [rsp+118h] [rbp+10h]
+    __int64 *v81; // [rsp+120h] [rbp+18h] BYREF
+    _QWORD v82[2]; // [rsp+128h] [rbp+20h] BYREF
+    int v83; // [rsp+138h] [rbp+30h]
+    char v84; // [rsp+13Ch] [rbp+34h]
+    __int64 v85; // [rsp+140h] [rbp+38h]
+    int v86; // [rsp+148h] [rbp+40h]
+    __int64 v87; // [rsp+150h] [rbp+48h]
+    void **v88; // [rsp+158h] [rbp+50h]
+    __int64 v89; // [rsp+160h] [rbp+58h] BYREF
+    __int64 v90; // [rsp+168h] [rbp+60h]
+    _BYTE v91[24]; // [rsp+170h] [rbp+68h] BYREF
+    __int64 *v92; // [rsp+188h] [rbp+80h] BYREF
+    __int64 *v93; // [rsp+190h] [rbp+88h] BYREF
+    int v94; // [rsp+198h] [rbp+90h]
+    int v95; // [rsp+19Ch] [rbp+94h]
+    int v96; // [rsp+1A0h] [rbp+98h]
+    _QWORD v97[2]; // [rsp+1A8h] [rbp+A0h] BYREF
+    int v98; // [rsp+1B8h] [rbp+B0h]
+    char v99; // [rsp+1BCh] [rbp+B4h]
+    __int64 v100; // [rsp+1C0h] [rbp+B8h]
+    int v101; // [rsp+1C8h] [rbp+C0h]
+    __int64 v102; // [rsp+1D0h] [rbp+C8h]
+    void **v103; // [rsp+1D8h] [rbp+D0h]
+    __int64 v104; // [rsp+1E0h] [rbp+D8h] BYREF
+    int v105; // [rsp+1E8h] [rbp+E0h]
+    int v106; // [rsp+1ECh] [rbp+E4h]
+    __int64 *v107; // [rsp+1F0h] [rbp+E8h] BYREF
+    int v108; // [rsp+1F8h] [rbp+F0h]
+    __int64 v109; // [rsp+1FCh] [rbp+F4h]
+    __int64 v110; // [rsp+204h] [rbp+FCh]
+    __int64 v111; // [rsp+20Ch] [rbp+104h]
+    __int64 v112; // [rsp+214h] [rbp+10Ch]
+    _QWORD v113[2]; // [rsp+228h] [rbp+120h] BYREF
+    int v114; // [rsp+238h] [rbp+130h]
+    char v115; // [rsp+23Ch] [rbp+134h]
+    __int64 v116; // [rsp+240h] [rbp+138h]
+    int v117; // [rsp+248h] [rbp+140h]
+    __int64 v118; // [rsp+250h] [rbp+148h]
+    void **v119; // [rsp+258h] [rbp+150h] BYREF
+    __int64 v120; // [rsp+260h] [rbp+158h] BYREF
+    int v121; // [rsp+268h] [rbp+160h]
+    char v122[8]; // [rsp+270h] [rbp+168h] BYREF
+    char v123[8]; // [rsp+278h] [rbp+170h] BYREF
+    char v124[8]; // [rsp+280h] [rbp+178h] BYREF
+    char v125[8]; // [rsp+288h] [rbp+180h] BYREF
+    char v126[8]; // [rsp+290h] [rbp+188h] BYREF
+    char v127[8]; // [rsp+298h] [rbp+190h] BYREF
+    void (__fastcall ***v128)(_QWORD, __int64); // [rsp+2A0h] [rbp+198h]
+    int v129; // [rsp+2B8h] [rbp+1B0h]
+    int v130; // [rsp+2C4h] [rbp+1BCh]
+    _BYTE v131[48]; // [rsp+2C8h] [rbp+1C0h] BYREF
+    int v132; // [rsp+2F8h] [rbp+1F0h] BYREF
+    int v133; // [rsp+2FCh] [rbp+1F4h]
+    const __m128i *v134; // [rsp+300h] [rbp+1F8h] BYREF
+    _UNKNOWN *retaddr; // [rsp+B60h] [rbp+A58h] BYREF
+    __int64 v136; // [rsp+B68h] [rbp+A60h] BYREF
+    _DWORD *v137; // [rsp+B70h] [rbp+A68h]
+    __int64 v138; // [rsp+B78h] [rbp+A70h]
+    __int64 v139; // [rsp+B80h] [rbp+A78h]
+
+    result = &retaddr;
+    v137 = a2;
+    v136 = a1;
+    if ( !*(_QWORD *)(a1 + 88) )
+      return result;
+    v5 = *(_QWORD *)g_pNetworkSystem;
+    v138 = g_pNetworkSystem;
+    v139 = (*(__int64 (**)(void))(v5 + 312))();
+    sub_1803FC750((unsigned int)v131, (unsigned int)"SV_SendServerinfo->msg", v139, 1280000, -1);
+    v6 = (const char *)&unk_180528AFF;
+    *(_DWORD *)(a1 + 344) = a2[1];
+    v7 = a2[5];
+    v80 = 0;
+    v81 = &qword_18062DB90;
+    v72[0] = &CSVCMsg_Print_t::`vftable';
+    v78 = &CSVCMsg_Print_t::`vftable';
+    v72[1] = 0;
+    v132 = 0;
+    if ( qword_180918DB0 )
+      v6 = (const char *)qword_180918DB0;
+    v134 = nullptr;
+    v133 = -1073739776;
+    v73 = 0;
+    v74 = -1;
+    v75 = -1;
+    v76 = -1082130432;
+    v77 = -1;
+    v79 = 0;
+    HIDWORD(v80) = 0;
+    v8 = sub_18018BF20();
+    v9 = a2[3];
+    v10 = a2[4];
+    v11 = a2[2];
+    v12 = (const char *)(*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)(a1 + 80) + 200LL))(*(_QWORD *)(a1 + 80));
+    v13 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)qword_180911898 + 88LL))(qword_180911898);
+    sub_1800CB320(
+      &v132,
+      "\nGame: \"%s\"\nMap: \"%s\"\nPlayers: %i (%i bots) / %i humans\nBuild: %u (revision %s)\nServer Number: %i\n\n",
+      v13,
+      v12,
+      v11,
+      v10,
+      v9,
+      v8,
+      v6,
+      v7);
+    if ( (v133 & 0x40000000) != 0 )
+    {
+      v14 = (const __m128i *)&v134;
+    }
+    else
+    {
+      v14 = (const __m128i *)&unk_180528AFF;
+      if ( (v133 & 0x3FFFFFFF) != 0 )
+        v14 = v134;
+    }
+    LODWORD(v80) = v80 | 1;
+    v59 = 0;
+    v15 = -1;
+    si128 = 0;
+    do
+      ++v15;
+    while ( v14->m128i_i8[v15] );
+    sub_1800439B0(&v59, v14, v15);
+    sub_18024FE80((__int64 *)&v81, &v59, 0);
+    if ( si128.m128i_i64[1] > 0xFuLL )
+    {
+      if ( (unsigned __int64)(si128.m128i_i64[1] + 1) >= 0x1000
+        && (unsigned __int64)(v59.m128i_i64[0] - *(_QWORD *)(v59.m128i_i64[0] - 8) - 8) > 0x1F )
+      {
+        invalid_parameter_noinfo_noreturn();
+      }
+      (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+    }
+    si128 = _mm_load_si128((const __m128i *)&xmmword_1805852A0);
+    v59.m128i_i8[0] = 0;
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v72)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_Print_t\n");
+    }
+    v72[0] = &CNetMessagePB<48,CSVCMsg_Print,0,1,0>::`vftable';
+    v78 = &CSVCMsg_Print::`vftable';
+    v16 = v79;
+    if ( (v79 & 1) != 0 )
+    {
+      v17 = sub_180145290(&v79);
+      v18 = v79;
+      v19 = v17;
+      v16 = v79;
+    }
+    else
+    {
+      v18 = v79;
+      v19 = v79 & 0xFFFFFFFFFFFFFFFCuLL;
+    }
+    if ( !v19 )
+    {
+      sub_18024FC20(&v81);
+      v18 = v79;
+      v16 = v79;
+    }
+    if ( (v16 & 2) != 0 )
+    {
+      v20 = v18 - 2;
+      if ( v18 != 2 )
+      {
+        sub_1802BF3F0(v18 - 2);
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v20);
+      }
+    }
+    v72[0] = &CNetMessage::`vftable';
+    CBufferString::Purge((CBufferString *)&v132, 0);
+    v21 = v136;
+    v97[0] = &CNETMsg_Tick_t::`vftable';
+    v97[1] = 0;
+    v98 = 0;
+    v105 = 2;
+    v22 = *(_DWORD *)(v136 + 344);
+    v103 = &CNETMsg_Tick_t::`vftable';
+    v99 = -1;
+    v100 = -1;
+    v101 = -1082130432;
+    v102 = -1;
+    v104 = 0;
+    v106 = 0;
+    v109 = 0;
+    v110 = 0;
+    v111 = 0;
+    v112 = 0;
+    v107 = &qword_18062DB90;
+    v108 = v22;
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v97)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_Tick_t\n");
+    }
+    v23 = !(*(unsigned __int8 (__fastcall **)(_QWORD))(**(_QWORD **)(v21 + 80) + 376LL))(*(_QWORD *)(v21 + 80))
+       || *(_BYTE *)(v21 + 2553);
+    v24 = *(_QWORD *)(v21 + 80);
+    v69 = 0;
+    v71 = 0;
+    v61[0] = &CSVCMsg_ClearAllStringTables_t::`vftable';
+    v67 = &CSVCMsg_ClearAllStringTables_t::`vftable';
+    v61[1] = 0;
+    v62 = 0;
+    v63 = -1;
+    v64 = -1;
+    v65 = -1082130432;
+    v66 = -1;
+    v68 = 0;
+    v70 = &qword_18062DB90;
+    v25 = (const __m128i *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v24 + 200LL))(v24);
+    LODWORD(v69) = v69 | 1;
+    if ( (v68 & 1) != 0 )
+      v26 = *(_QWORD *)(v68 & 0xFFFFFFFFFFFFFFFCuLL);
+    else
+      v26 = v68 & 0xFFFFFFFFFFFFFFFCuLL;
+    v59 = 0;
+    v27 = -1;
+    si128 = 0;
+    do
+      ++v27;
+    while ( v25->m128i_i8[v27] );
+    sub_1800439B0(&v59, v25, v27);
+    sub_18024FE80((__int64 *)&v70, &v59, v26);
+    if ( si128.m128i_i64[1] > 0xFuLL )
+    {
+      if ( (unsigned __int64)(si128.m128i_i64[1] + 1) >= 0x1000
+        && (unsigned __int64)(v59.m128i_i64[0] - *(_QWORD *)(v59.m128i_i64[0] - 8) - 8) > 0x1F )
+      {
+        invalid_parameter_noinfo_noreturn();
+      }
+      (*(void (__fastcall **)(_QWORD))(*g_pMemAlloc + 24LL))(g_pMemAlloc);
+    }
+    v59.m128i_i8[0] = 0;
+    si128 = _mm_load_si128((const __m128i *)&xmmword_1805852A0);
+    if ( v23 )
+    {
+      LODWORD(v69) = v69 | 2;
+      v71 = 1;
+    }
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v61)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_ClearAllStringTables_t\n");
+    }
+    v28 = v137;
+    if ( !v23 )
+    {
+      if ( !*(_BYTE *)v137 || (v29 = *(_QWORD *)(*(_QWORD *)(v21 + 80) + 384LL)) == 0 )
+        v29 = *(_QWORD *)(*(_QWORD *)(v21 + 80) + 376LL);
+      sub_18010BFD0(v29, v131, (unsigned int)v137[1], v21);
+    }
+    v113[1] = 0;
+    v113[0] = &CNetMessage::`vftable';
+    v114 = 0;
+    v115 = -1;
+    v116 = -1;
+    v117 = -1082130432;
+    v118 = -1;
+    sub_180158670(&v119, 0);
+    v121 |= 0x40u;
+    v30 = (__int64)v128;
+    v119 = &CSVCMsg_ServerInfo_t::`vftable';
+    v113[0] = &CSVCMsg_ServerInfo_t::`vftable';
+    if ( !v128 )
+    {
+      if ( (v120 & 1) != 0 )
+        v31 = *(_QWORD *)(v120 & 0xFFFFFFFFFFFFFFFCuLL);
+      else
+        v31 = v120 & 0xFFFFFFFFFFFFFFFCuLL;
+      v30 = sub_18017CF60(v31);
+      v128 = (void (__fastcall ***)(_QWORD, __int64))v30;
+    }
+    v32 = (*(__int64 (__fastcall **)(_QWORD))(**(_QWORD **)(v21 + 80) + 352LL))(*(_QWORD *)(v21 + 80));
+    if ( v32 != v30 )
+    {
+      sub_18017A130(v30);
+      sub_18017AF20(v30, v32);
+    }
+    v33 = *(_DWORD *)(v21 + 72);
+    v34 = *(_QWORD *)(v21 + 80);
+    v121 |= 0x8000u;
+    v130 = v33;
+    (*(void (__fastcall **)(__int64, _QWORD *))(*(_QWORD *)v34 + 592LL))(v34, v113)  // 592LL = 0x250 = CNetworkGameServerBase_FillServerInfo
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v113)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CSVCMsg_ServerInfo_t\n");
+    }
+    if ( !v23
+      && !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _BYTE *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v28 + 48)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_SetConVar_t\n");
+    }
+    v35 = *(_DWORD *)(*(_QWORD *)(v21 + 80) + 672LL);
+    v90 = 0;
+    v82[1] = 0;
+    v82[0] = &CNetMessage::`vftable';
+    v83 = 0;
+    v84 = -1;
+    v85 = -1;
+    v86 = -1082130432;
+    v87 = -1;
+    v89 = 0;
+    v88 = &CNETMsg_SignonState::`vftable';
+    sub_1802507C0(v91, 0);
+    LODWORD(v90) = v90 | 0x1C;
+    v92 = &qword_18062DB90;
+    v93 = &qword_18062DB90;
+    v82[0] = &CNETMsg_SignonState_t::`vftable';
+    v88 = &CNETMsg_SignonState_t::`vftable';
+    v94 = 3;
+    v95 = v35;
+    v96 = 0;
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, _BYTE *, _QWORD *))(*(_QWORD *)g_pNetworkMessages + 24LL))(
+            g_pNetworkMessages,
+            v131,
+            v82)
+      && (unsigned __int8)LoggingSystem_IsChannelEnabled((unsigned int)dword_1808CC854, 3) )
+    {
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC854,
+        3,
+        "BuildServerInfoMessageAsync_t: Failed to serialize CNETMsg_SignonState_t\n");
+    }
+    if ( !*v28 )
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)v21 + 592LL))(v21);
+    (*(void (__fastcall **)(_QWORD, _QWORD, const char *))(**(_QWORD **)(v21 + 88) + 664LL))(
+      *(_QWORD *)(v21 + 88),
+      *(unsigned int *)(v21 + 344),
+      "Signon");
+    LOBYTE(v36) = 1;
+    if ( !(*(unsigned __int8 (__fastcall **)(_QWORD, _BYTE *, __int64))(**(_QWORD **)(v21 + 88) + 320LL))(
+            *(_QWORD *)(v21 + 88),
+            v131,
+            v36) )
+    {
+      if ( !*v28 && *(_BYTE *)(v21 + 97) != 1 )
+      {
+        sub_1800C4350(v21);
+        (*(void (__fastcall **)(__int64, __int64, _QWORD))(*(_QWORD *)v21 + 56LL))(v21, 18, 0);
+        goto LABEL_83;
+      }
+      v38 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 16);
+      if ( v38 )
+      {
+        *(_QWORD *)v38 = &CDelayedCall2<CServerSideClientBase,CServerSideClientBase,CServerSideClientBase::SignonStateNewFailedCall_t,empty_t>::`vftable';
+        goto LABEL_82;
+      }
+  LABEL_81:
+      v38 = 0;
+      goto LABEL_82;
+    }
+    (*(void (__fastcall **)(__int64, _BYTE *, _QWORD))(*(_QWORD *)v21 + 400LL))(v21, v28 + 24, (unsigned __int8)*v28);
+    v37 = v129;
+    LODWORD(v136) = v129;
+    if ( *v28 || *(_BYTE *)(v21 + 97) == 1 )
+    {
+      v38 = (*(__int64 (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 8LL))(g_pMemAlloc, 16);
+      if ( v38 )
+      {
+        *(_DWORD *)(v38 + 8) = v37;
+        *(_QWORD *)v38 = &CDelayedCall2<CServerSideClientBase,CServerSideClientBase,CServerSideClientBase::SignonStateNewCall_t,empty_t>::`vftable';
+  LABEL_82:
+        v136 = v38;
+        sub_1800C0E60(v21 + 2800, &v136);
+        goto LABEL_83;
+      }
+      goto LABEL_81;
+    }
+    sub_1800C4350(v21);
+    sub_1800C63C0(v21, &v136);
+  LABEL_83:
+    v88 = &CNETMsg_SignonState::`vftable';
+    v82[0] = &CNetMessagePB<7,CNETMsg_SignonState,10,1,0>::`vftable';
+    v39 = v89;
+    if ( (v89 & 1) != 0 )
+    {
+      v40 = sub_180145290(&v89);
+      v41 = v89;
+      v42 = v40;
+      v39 = v89;
+    }
+    else
+    {
+      v41 = v89;
+      v42 = v89 & 0xFFFFFFFFFFFFFFFCuLL;
+    }
+    if ( !v42 )
+    {
+      sub_180250870(v91);
+      sub_18024FC20(&v92);
+      sub_18024FC20(&v93);
+      v41 = v89;
+      v39 = v89;
+    }
+    if ( (v39 & 2) != 0 )
+    {
+      v43 = v41 - 2;
+      if ( v41 != 2 )
+      {
+        sub_1802BF3F0(v41 - 2);
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v43);
+      }
+    }
+    v82[0] = &CNetMessage::`vftable';
+    v113[0] = &CNetMessagePB<40,CSVCMsg_ServerInfo,10,1,0>::`vftable';
+    v119 = &CSVCMsg_ServerInfo::`vftable';
+    v44 = v120;
+    if ( (v120 & 1) != 0 )
+    {
+      v45 = sub_180145290(&v120);
+      v46 = v120;
+      v47 = v45;
+      v44 = v120;
+    }
+    else
+    {
+      v46 = v120;
+      v47 = v120 & 0xFFFFFFFFFFFFFFFCuLL;
+    }
+    if ( !v47 )
+    {
+      sub_18024FC20(v122);
+      sub_18024FC20(v123);
+      sub_18024FC20(v124);
+      sub_18024FC20(v125);
+      sub_18024FC20(v126);
+      sub_18024FC20(v127);
+      if ( v128 )
+        (**v128)(v128, 1);
+      v46 = v120;
+      v44 = v120;
+    }
+    if ( (v44 & 2) != 0 )
+    {
+      v48 = v46 - 2;
+      if ( v46 != 2 )
+      {
+        sub_1802BF3F0(v46 - 2);
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v48);
+      }
+    }
+    v113[0] = &CNetMessage::`vftable';
+    v61[0] = &CNetMessagePB<51,CSVCMsg_ClearAllStringTables,10,1,0>::`vftable';
+    v67 = &CSVCMsg_ClearAllStringTables::`vftable';
+    v49 = v68;
+    if ( (v68 & 1) != 0 )
+    {
+      v50 = sub_180145290(&v68);
+      v51 = v68;
+      v52 = v50;
+      v49 = v68;
+    }
+    else
+    {
+      v51 = v68;
+      v52 = v68 & 0xFFFFFFFFFFFFFFFCuLL;
+    }
+    if ( !v52 )
+    {
+      sub_18024FC20(&v70);
+      v51 = v68;
+      v49 = v68;
+    }
+    if ( (v49 & 2) != 0 )
+    {
+      v53 = v51 - 2;
+      if ( v51 != 2 )
+      {
+        sub_1802BF3F0(v51 - 2);
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v53);
+      }
+    }
+    v61[0] = &CNetMessage::`vftable';
+    v97[0] = &CNetMessagePB<4,CNETMsg_Tick,16,0,0>::`vftable';
+    v103 = &CNETMsg_Tick::`vftable';
+    v54 = v104;
+    if ( (v104 & 1) != 0 )
+    {
+      v55 = sub_180145290(&v104);
+      v56 = v104;
+      v57 = v55;
+      v54 = v104;
+    }
+    else
+    {
+      v56 = v104;
+      v57 = v104 & 0xFFFFFFFFFFFFFFFCuLL;
+    }
+    if ( !v57 )
+    {
+      sub_18024FC20(&v107);
+      v56 = v104;
+      v54 = v104;
+    }
+    if ( (v54 & 2) != 0 )
+    {
+      v58 = v56 - 2;
+      if ( v56 != 2 )
+      {
+        sub_1802BF3F0(v56 - 2);
+        (*(void (__fastcall **)(_QWORD, __int64))(*g_pMemAlloc + 24LL))(g_pMemAlloc, v58);
+      }
+    }
+    v97[0] = &CNetMessage::`vftable';
+    return (_UNKNOWN **)(*(__int64 (__fastcall **)(__int64, __int64))(*(_QWORD *)v138 + 320LL))(v138, v139);
+  }


### PR DESCRIPTION
## Summary
- Add preprocessors for CNetworkGameServerBase timeout/password and server-info vfunc discovery.
- Add annotated engine reference YAMLs and update the 14174 config/symbol snapshot, including the related symbol renames.

## Validation
- implementation-specific tests: `uv run ida_analyze_bin.py -debug -oldgamever none` — 2 successful, 0 failed; non-MCP unittest suite — 1057 passed, 3 skipped
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with 12 runnable tests and zero compile failures, invalid items, or layout differences
- candidate publication: passed; published SHA-256 matches the validated candidate (`d65686cdd71859edf31ede38ae3fc27c1ddf661edadf7cd82de72eab294b02a4`)

- existing committed branch: `5` initial commit(s) ahead of `origin/main`; supplemental publication commit: `511ff40d`