### PR TITLE
feat(preprocessor): add server client finders

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -682,6 +682,17 @@ modules:
       - name: find-CServerSideClient_vtable
         expected_output:
           - CServerSideClient_vtable.{platform}.yaml
+      - name: find-CServerSideClient_ctor
+        expected_output:
+          - CServerSideClient_ctor.{platform}.yaml
+        expected_input:
+          - CServerSideClient_vtable.{platform}.yaml
+      - name: find-CNetworkGameServer_CreateNewClient
+        expected_output:
+          - CNetworkGameServer_CreateNewClient.{platform}.yaml
+        expected_input:
+          - CServerSideClient_ctor.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CSVCMsg_PeerList_t_vtable
         expected_output:
           - CSVCMsg_PeerList_t_vtable.{platform}.yaml
@@ -2187,6 +2198,14 @@ modules:
         category: vtable
       - name: CSVCMsg_PeerList_t_vtable
         category: vtable
+      - name: CServerSideClient_ctor
+        category: func
+        alias:
+          - CServerSideClient::CServerSideClient
+      - name: CNetworkGameServer_CreateNewClient
+        category: vfunc
+        alias:
+          - CNetworkGameServer::CreateNewClient
       - name: CServerSideClient_IsHearingClient
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:5bef93aeb7b78a21a08aed48f1f3a9efa1e7fd44ff4f0ef1750d337447fa6eff
-file_count: 3323
+config_sha256: sha256:2d83e5fe522753570dca5f0b88a0f4249b4d06caee800e45b599ed5f87c66d4a
+file_count: 3327
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -11478,6 +11478,24 @@ files:
     offset_sig_disp: 0
     size: 4
     struct_name: CNetworkGameServer
+  engine/CNetworkGameServer_CreateNewClient.linux.yaml:
+    func_name: CNetworkGameServer_CreateNewClient
+    func_rva: '0x50f980'
+    func_sig: 55 48 89 E5 41 55 41 89 F5 41 54 49 89 FC BF ?? ?? ?? ?? 53 48 83 EC ?? E8 ?? ?? ?? ?? 44 89 EA 4C 89 E6 48 89 C7 48 89 C3 E8 ?? ?? ?? ?? 48 C7 45 ?? ?? ?? ?? ??
+    func_size: '0x78'
+    func_va: '0x50f980'
+    vfunc_index: 84
+    vfunc_offset: '0x2a0'
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServer_CreateNewClient.windows.yaml:
+    func_name: CNetworkGameServer_CreateNewClient
+    func_rva: '0x9d6f0'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 48 8B 05 ?? ?? ?? ?? 48 8B F9 8B DA
+    func_size: '0xa4'
+    func_va: '0x18009d6f0'
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServer_DirectUpdate.linux.yaml:
     func_name: CNetworkGameServer_DirectUpdate
     func_rva: '0x513370'
@@ -12721,6 +12739,18 @@ files:
     vfunc_offset: '0x98'
     vfunc_sig: FF 90 98 00 00 00 83 4F ?? ?? 49 8B CF
     vtable_name: CServerSideClient
+  engine/CServerSideClient_ctor.linux.yaml:
+    func_name: CServerSideClient_ctor
+    func_rva: '0x533b70'
+    func_sig: 55 48 89 E5 41 55 41 54 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? B9 ?? ?? ?? ??
+    func_size: '0x21d'
+    func_va: '0x533b70'
+  engine/CServerSideClient_ctor.windows.yaml:
+    func_name: CServerSideClient_ctor
+    func_rva: '0xbab40'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B F9 E8 ?? ?? ?? ?? 33 F6
+    func_size: '0x1bd'
+    func_va: '0x1800bab40'
   engine/CServerSideClient_vtable.linux.yaml:
     vtable_class: CServerSideClient
     vtable_entries:
@@ -42691,5 +42721,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T15:37:18Z'
+last_publish_time: '2026-08-06T16:10:23Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_CreateNewClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_CreateNewClient.py
@@ -67,4 +67,3 @@ async def preprocess_skill(
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )
-

--- a/ida_preprocessor_scripts/find-CNetworkGameServer_CreateNewClient.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServer_CreateNewClient.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServer_CreateNewClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServer_CreateNewClient",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServer_CreateNewClient",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CServerSideClient_ctor"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CNetworkGameServer_CreateNewClient", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkGameServer_CreateNewClient",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the vfunc caller of CServerSideClient_ctor."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )
+

--- a/ida_preprocessor_scripts/find-CServerSideClient_ctor.py
+++ b/ida_preprocessor_scripts/find-CServerSideClient_ctor.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CServerSideClient_ctor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CServerSideClient_ctor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CServerSideClient_ctor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate the regular constructor from its vtable reference and constructor signature."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir,
+        f"CServerSideClient_vtable.{platform}.yaml",
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CServerSideClient_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "CServerSideClient_ctor",
+            "xref_strings": [],
+            "xref_gvs": [str(vtable_va)],
+            "xref_signatures": ["BA 80 00 00 00"],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )
+

--- a/ida_preprocessor_scripts/find-CServerSideClient_ctor.py
+++ b/ida_preprocessor_scripts/find-CServerSideClient_ctor.py
@@ -61,10 +61,7 @@ async def preprocess_skill(
     vtable_va = _read_vtable_va(vtable_yaml_path)
     if not vtable_va:
         if debug:
-            print(
-                "    Preprocess: CServerSideClient_vtable vtable_va not found, "
-                "cannot resolve xref_gvs"
-            )
+            print("    Preprocess: CServerSideClient_vtable vtable_va not found, cannot resolve xref_gvs")
         return False
 
     func_xrefs = [
@@ -93,4 +90,3 @@ async def preprocess_skill(
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )
-


### PR DESCRIPTION
## Summary
- Add the regular CServerSideClient constructor finder using its vtable reference and the BA 80 00 00 00 xref signature.
- Add the CNetworkGameServer::CreateNewClient vfunc finder using the constructor caller and CNetworkGameServer_vtable metadata.
- Register both finders and their dependency chain in configs/14174.yaml.

## Validation
- ida_analyze_bin.py -debug: Successful 4, Failed 0, Skipped 2152
- non-MCP unittest suite: 1057 tests, 3 skipped, 0 failures
- candidate preparation: passed for 14174
- C++ post-change validation: passed with 12/12 runnable tests and zero compile/layout failures
- candidate publication: passed; published SHA-256 matches validated candidate sha256:a6cae39d27177ebbcb000a9acba23c008cad74480e70f065c3a8c192f6ed34c5
- existing committed branch: 1 initial commit ahead of origin/main; supplemental publication commit: created (3320bdec)