### PR TITLE
fix(validation): validate primary Source2 server vtable

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -12990,3 +12990,27 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - client  # bin/{gamever}/client/CGameEventManager_*.{platform}.yaml
+  - name: ISource2Server_MSVC
+    symbol: ISource2Server
+    cpp: cpp_tests/isource2server.cpp
+    headers:
+      - hl2sdk_cs2/public/eiface.h  # Used by the fix-cppheaders SKILL
+    target: x86_64-pc-windows-msvc
+    include_directories:
+      - cpp_tests/stubs
+      - hl2sdk_cs2/game/shared
+      - hl2sdk_cs2/public
+      - hl2sdk_cs2/public/tier0
+      - hl2sdk_cs2/public/tier1
+      - hl2sdk_cs2/public/mathlib
+    defines:
+      - COMPILER_MSVC=1
+      - COMPILER_MSVC64=1
+      - _MSVC_STL_USE_ABORT_AS_DOOM_FUNCTION
+    additional_compiler_options:
+      - fms-extensions
+      - fms-compatibility
+      - Xclang
+      - fdump-vtable-layouts
+    reference_modules:
+      - engine  # bin/{gamever}/engine/ISource2Server_*.{platform}.yaml

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -2020,9 +2020,9 @@ modules:
         expected_input:
           - CLoopTypeSimple_vtable.{platform}.yaml
           - CLoopTypeBase_FrameUpdate.{platform}.yaml
-      - name: find-ISource2Server_OutOfGameFrameBoundary
+      - name: find-ISource2Server_UpdateWhenNotInGame
         expected_output:
-          - ISource2Server_OutOfGameFrameBoundary.{platform}.yaml
+          - ISource2Server_UpdateWhenNotInGame.{platform}.yaml
         expected_input:
           - CLoopTypeSimple_FrameUpdate.{platform}.yaml
       - name: find-SetInfo_CommandHandler
@@ -3050,10 +3050,10 @@ modules:
         alias:
           - ISource2Server::PreWorldUpdate
         shared: true
-      - name: ISource2Server_OutOfGameFrameBoundary
+      - name: ISource2Server_UpdateWhenNotInGame
         category: vfunc
         alias:
-          - ISource2Server::OutOfGameFrameBoundary
+          - ISource2Server::UpdateWhenNotInGame
       - name: INetworkMessages_SetIsForServer
         category: vfunc
         alias:
@@ -5975,17 +5975,17 @@ modules:
           - CSource2Server_OnStreamEntitiesFromFileCompleted.{platform}.yaml
         expected_input:
           - CSource2Server_vtable2.{platform}.yaml
-      - name: find-CSource2Server_OutOfGameFrameBoundary
+      - name: find-CSource2Server_UpdateWhenNotInGame
         expected_output:
-          - CSource2Server_OutOfGameFrameBoundary.{platform}.yaml
+          - CSource2Server_UpdateWhenNotInGame.{platform}.yaml
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
-          - ../engine/ISource2Server_OutOfGameFrameBoundary.{platform}.yaml
+          - ../engine/ISource2Server_UpdateWhenNotInGame.{platform}.yaml
       - name: find-IGameSystem_OnOutOfGameFrameBoundary
         expected_output:
           - IGameSystem_OnOutOfGameFrameBoundary.{platform}.yaml
         expected_input:
-          - CSource2Server_OutOfGameFrameBoundary.{platform}.yaml
+          - CSource2Server_UpdateWhenNotInGame.{platform}.yaml
           - IGameSystem_vtable.{platform}.yaml
       - name: find-CSource2GameEntities_vtable
         expected_output:
@@ -8960,10 +8960,10 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::PreWorldUpdate
-      - name: CSource2Server_OutOfGameFrameBoundary
+      - name: CSource2Server_UpdateWhenNotInGame
         category: vfunc
         alias:
-          - CSource2Server::OutOfGameFrameBoundary
+          - CSource2Server::UpdateWhenNotInGame
       - name: CSource2GameEntities_vtable
         category: vtable
       - name: CSource2GameClients_vtable

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -12992,6 +12992,10 @@ cpp_tests:
       - client  # bin/{gamever}/client/CGameEventManager_*.{platform}.yaml
   - name: ISource2Server_MSVC
     symbol: ISource2Server
+    alias_symbols:
+      - CSource2Server
+    exclude_reference_vtables:
+      - CSource2Server_vtable2
     cpp: cpp_tests/isource2server.cpp
     headers:
       - hl2sdk_cs2/public/eiface.h  # Used by the fix-cppheaders SKILL
@@ -13014,3 +13018,4 @@ cpp_tests:
       - fdump-vtable-layouts
     reference_modules:
       - engine  # bin/{gamever}/engine/ISource2Server_*.{platform}.yaml
+      - server  # bin/{gamever}/server/CSource2Server_*.{platform}.yaml

--- a/cpp_tests/inetworkgameserver.cpp
+++ b/cpp_tests/inetworkgameserver.cpp
@@ -27,10 +27,8 @@ private:
 class bf_read;
 enum NetChannelBufType_t : int8 {};
 
-// Forward declarations for types added to inetworkserializer.h in hl2sdk_cs2 update
+// Forward declaration used by inetworkserializer.h.
 class CPlayerBitVec;
-typedef void *(*SchemaClassManipulatorFn_t)(int, void *);
-typedef void *(*SchemaCollectionManipulatorFn_t)(int, void *, int, int);
 
 #include <bitvec.h>
 #include <playerslot.h>

--- a/cpp_tests/inetworkmessages.cpp
+++ b/cpp_tests/inetworkmessages.cpp
@@ -9,10 +9,8 @@
 #define INETCHANNEL_H
 enum NetChannelBufType_t : int8 {};
 
-// Forward declarations for types added to inetworkserializer.h in hl2sdk_cs2 update
+// Forward declaration used by inetworkserializer.h.
 class CPlayerBitVec;
-typedef void *(*SchemaClassManipulatorFn_t)(int, void *);
-typedef void *(*SchemaCollectionManipulatorFn_t)(int, void *, int, int);
 
 #include <networksystem/inetworkmessages.h>
 

--- a/cpp_tests/isource2server.cpp
+++ b/cpp_tests/isource2server.cpp
@@ -1,0 +1,25 @@
+#include <tier0/platform.h>
+#undef RESTRICT
+#define RESTRICT
+
+// Avoid pulling edict.h's heavier transitive include chain; eiface.h only needs
+// these as pointer/reference types for the ISource2Server layout tests.
+#define EDICT_H
+#define ISERVERENTITY_H
+class CGlobalVars;
+class CCheckTransmitInfo;
+class CSharedEdictChangeInfo;
+class IServerEntity;
+struct edict_t;
+
+#include <entity2/entityidentity.h>
+#include <eiface.h>
+
+ISource2Server *sourceserver();
+
+int main()
+{
+	sourceserver()->PreWorldUpdate(false);
+
+	return 0;
+}

--- a/cpp_tests/isource2server.cpp
+++ b/cpp_tests/isource2server.cpp
@@ -11,6 +11,10 @@ class CCheckTransmitInfo;
 class CSharedEdictChangeInfo;
 class IServerEntity;
 struct edict_t;
+struct ChangeAccessorFieldPathIndex_t
+{
+	int32 m_Value;
+};
 
 #include <entity2/entityidentity.h>
 #include <eiface.h>

--- a/cpp_tests/ivengineserver2.cpp
+++ b/cpp_tests/ivengineserver2.cpp
@@ -11,6 +11,10 @@ class CCheckTransmitInfo;
 class CSharedEdictChangeInfo;
 class IServerEntity;
 struct edict_t;
+struct ChangeAccessorFieldPathIndex_t
+{
+	int32 m_Value;
+};
 
 #include <entity2/entityidentity.h>
 #include <eiface.h>

--- a/cpp_tests_util.py
+++ b/cpp_tests_util.py
@@ -515,6 +515,42 @@ def _normalize_vtable_owner(value: Any) -> str:
     return owner
 
 
+def _reference_artifact_name(filename: str, platform: str) -> str:
+    suffix = f".{platform}.yaml"
+    if filename.endswith(suffix):
+        return filename[: -len(suffix)]
+    return Path(filename).stem
+
+
+def _reference_vtable_name(
+    *,
+    payload: Dict[str, Any],
+    filename: str,
+    platform: str,
+) -> str:
+    vtable_name = str(payload.get("vtable_name") or "").strip()
+    if vtable_name:
+        return vtable_name
+
+    if any(key in payload for key in ("vtable_size", "vtable_numvfunc", "vtable_entries")):
+        return _reference_artifact_name(filename, platform)
+
+    return ""
+
+
+def _is_excluded_reference_vtable(
+    *,
+    payload: Dict[str, Any],
+    filename: str,
+    platform: str,
+    exclude_reference_vtables: Sequence[str],
+) -> bool:
+    excluded = {str(name).strip() for name in exclude_reference_vtables if str(name).strip()}
+    if not excluded:
+        return False
+    return _reference_vtable_name(payload=payload, filename=filename, platform=platform) in excluded
+
+
 def _ordered_reference_modules(
     symbol_store: SymbolStore,
     requested_modules: Sequence[str],
@@ -544,6 +580,7 @@ def audit_reference_vfunc_ownership(
     compiler_section: Optional[Dict[str, Any]],
     alias_class_names: Sequence[str] = (),
     reference_vtable_owners: Sequence[str] = (),
+    exclude_reference_vtables: Sequence[str] = (),
 ) -> Dict[str, Any]:
     """Audit every relevant vfunc YAML across all symbol-store modules."""
     owners = list(dict.fromkeys([class_name, *[name for name in alias_class_names if name]]))
@@ -553,6 +590,7 @@ def audit_reference_vfunc_ownership(
     modules = _ordered_reference_modules(symbol_store, reference_modules)
     methods_by_index = compiler_section.get("methods_by_index", {}) if compiler_section else {}
     files_checked: List[str] = []
+    files_excluded: List[str] = []
     differences: List[Dict[str, Any]] = []
 
     for module in modules:
@@ -570,6 +608,15 @@ def audit_reference_vfunc_ownership(
             file_owner = _match_reference_owner(file_stem, owners)
             func_owner = _match_reference_owner(func_name, owners)
             if file_owner is None and func_owner is None:
+                continue
+
+            if _is_excluded_reference_vtable(
+                payload=payload,
+                filename=entry.filename,
+                platform=platform,
+                exclude_reference_vtables=exclude_reference_vtables,
+            ):
+                files_excluded.append(entry.path)
                 continue
 
             files_checked.append(entry.path)
@@ -642,6 +689,7 @@ def audit_reference_vfunc_ownership(
     return {
         "modules_checked": modules,
         "files_checked": files_checked,
+        "files_excluded": files_excluded,
         "differences": differences,
     }
 
@@ -671,6 +719,7 @@ def load_merged_reference_vtable_data(
     platform: str,
     reference_modules: Sequence[str],
     alias_class_names: Sequence[str] = (),
+    exclude_reference_vtables: Sequence[str] = (),
 ) -> Optional[Dict[str, Any]]:
     """Load and merge reference YAML info for a class from all modules."""
     class_names_to_try = [class_name] + [n for n in alias_class_names if n]
@@ -678,6 +727,7 @@ def load_merged_reference_vtable_data(
         "mode": "merged",
         "modules": [],
         "files": [],
+        "excluded_files": [],
         "vtable_size": None,
         "vtable_size_raw": None,
         "vtable_size_source": None,
@@ -701,6 +751,15 @@ def load_merged_reference_vtable_data(
                 payload = entry.payload
                 path = entry.path
                 file_stem = Path(entry.filename).stem
+
+                if _is_excluded_reference_vtable(
+                    payload=payload,
+                    filename=entry.filename,
+                    platform=platform,
+                    exclude_reference_vtables=exclude_reference_vtables,
+                ):
+                    merged["excluded_files"].append(path)
+                    continue
 
                 parsed_size = _parse_int_maybe(payload.get("vtable_size"))
                 parsed_numvfunc = _parse_int_maybe(payload.get("vtable_numvfunc"))
@@ -837,6 +896,7 @@ def load_reference_vtable_data(
     platform: str,
     reference_modules: Sequence[str],
     alias_class_names: Sequence[str] = (),
+    exclude_reference_vtables: Sequence[str] = (),
 ) -> Optional[Dict[str, Any]]:
     """
     Load reference YAML info for a class from modules in priority order.
@@ -859,11 +919,22 @@ def load_reference_vtable_data(
             vtable_numvfunc: Optional[int] = None
             reference_functions: Dict[int, Dict[str, str]] = {}
             matched_files: List[str] = []
+            excluded_files: List[str] = []
 
             for entry in entries:
                 payload = entry.payload
                 path = entry.path
                 file_stem = Path(entry.filename).stem
+
+                if _is_excluded_reference_vtable(
+                    payload=payload,
+                    filename=entry.filename,
+                    platform=platform,
+                    exclude_reference_vtables=exclude_reference_vtables,
+                ):
+                    excluded_files.append(path)
+                    continue
+
                 matched_files.append(path)
 
                 if "vtable_size" in payload:
@@ -895,6 +966,7 @@ def load_reference_vtable_data(
                 result = {
                     "module": module,
                     "files": matched_files,
+                    "excluded_files": excluded_files,
                     "vtable_size": vtable_size,
                     "vtable_size_raw": vtable_size_raw,
                     "vtable_numvfunc": vtable_numvfunc,
@@ -1108,6 +1180,7 @@ def compare_compiler_vtable_with_yaml(
     pointer_size: int,
     alias_class_names: Sequence[str] = (),
     reference_vtable_owners: Sequence[str] = (),
+    exclude_reference_vtables: Sequence[str] = (),
     merge_reference_modules: bool = True,
 ) -> Dict[str, Any]:
     """
@@ -1124,6 +1197,7 @@ def compare_compiler_vtable_with_yaml(
             platform=platform,
             reference_modules=reference_modules,
             alias_class_names=alias_class_names,
+            exclude_reference_vtables=exclude_reference_vtables,
         )
     else:
         reference = load_reference_vtable_data(
@@ -1132,12 +1206,14 @@ def compare_compiler_vtable_with_yaml(
             platform=platform,
             reference_modules=reference_modules,
             alias_class_names=alias_class_names,
+            exclude_reference_vtables=exclude_reference_vtables,
         )
 
     alias_used = reference.get("alias_class_name") if reference else None
     reference_mode = "merged" if merge_reference_modules else "single"
     reference_modules_merged = list(reference.get("modules", [])) if merge_reference_modules and reference else []
     reference_files_merged = list(reference.get("files", [])) if merge_reference_modules and reference else []
+    reference_files_excluded = list(reference.get("excluded_files", [])) if reference else []
     reference_conflicts = list(reference.get("conflicts", [])) if merge_reference_modules and reference else []
     ownership_audit = audit_reference_vfunc_ownership(
         symbol_store=symbol_store,
@@ -1147,6 +1223,7 @@ def compare_compiler_vtable_with_yaml(
         compiler_section=compiler_section,
         alias_class_names=alias_class_names,
         reference_vtable_owners=reference_vtable_owners,
+        exclude_reference_vtables=exclude_reference_vtables,
     )
 
     report: Dict[str, Any] = {
@@ -1159,9 +1236,11 @@ def compare_compiler_vtable_with_yaml(
         "reference_mode": reference_mode,
         "reference_modules_merged": reference_modules_merged,
         "reference_files_merged": reference_files_merged,
+        "reference_files_excluded": reference_files_excluded,
         "reference_conflicts": reference_conflicts,
         "ownership_modules_checked": ownership_audit["modules_checked"],
         "ownership_files_checked": ownership_audit["files_checked"],
+        "ownership_files_excluded": ownership_audit["files_excluded"],
         "differences": [],
         "notes": [],
     }
@@ -1292,6 +1371,7 @@ def format_vtable_compare_report(report: Dict[str, Any], *, include_differences:
         else:
             lines.append("Reference modules:")
         lines.append(f"Reference files merged: {len(report.get('reference_files_merged', []))}")
+        lines.append(f"Reference files excluded: {len(report.get('reference_files_excluded', []))}")
         lines.append(f"Reference functions: {report.get('reference_functions_count', 0)}")
         lines.append(f"Reference conflicts found: {len(report.get('reference_conflicts', []))}")
     elif report.get("reference_found"):

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,7 +121,7 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:2d83e5fe522753570dca5f0b88a0f4249b4d06caee800e45b599ed5f87c66d4a
+config_sha256: sha256:31b39750c33a7c0e2f196f65f4498038e9422d79deec989308987ae96a4cd84d
 file_count: 3327
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -13569,18 +13569,6 @@ files:
     vfunc_offset: '0x98'
     vfunc_sig: FF 90 98 00 00 00 48 8D 0D ?? ?? ?? ??
     vtable_name: ISource2GameClients
-  engine/ISource2Server_OutOfGameFrameBoundary.linux.yaml:
-    func_name: ISource2Server_OutOfGameFrameBoundary
-    vfunc_index: 45
-    vfunc_offset: '0x168'
-    vfunc_sig: FF 90 68 01 00 00 48 8D 05 ?? ?? ?? ?? 48 8B 38
-    vtable_name: ISource2Server
-  engine/ISource2Server_OutOfGameFrameBoundary.windows.yaml:
-    func_name: ISource2Server_OutOfGameFrameBoundary
-    vfunc_index: 45
-    vfunc_offset: '0x168'
-    vfunc_sig: FF 90 68 01 00 00 48 8B 0D ?? ?? ?? ??
-    vtable_name: ISource2Server
   engine/ISource2Server_PreWorldUpdate.linux.yaml:
     func_name: ISource2Server_PreWorldUpdate
     vfunc_index: 15
@@ -13590,6 +13578,18 @@ files:
     func_name: ISource2Server_PreWorldUpdate
     vfunc_index: 15
     vfunc_offset: '0x78'
+    vtable_name: ISource2Server
+  engine/ISource2Server_UpdateWhenNotInGame.linux.yaml:
+    func_name: ISource2Server_UpdateWhenNotInGame
+    vfunc_index: 45
+    vfunc_offset: '0x168'
+    vfunc_sig: FF 90 68 01 00 00 48 8D 05 ?? ?? ?? ?? 48 8B 38
+    vtable_name: ISource2Server
+  engine/ISource2Server_UpdateWhenNotInGame.windows.yaml:
+    func_name: ISource2Server_UpdateWhenNotInGame
+    vfunc_index: 45
+    vfunc_offset: '0x168'
+    vfunc_sig: FF 90 68 01 00 00 48 8B 0D ?? ?? ?? ??
     vtable_name: ISource2Server
   engine/InitSteam.linux.yaml:
     func_name: InitSteam
@@ -37820,24 +37820,6 @@ files:
     vfunc_index: 0
     vfunc_offset: '0x0'
     vtable_name: CSource2Server_vtable2
-  server/CSource2Server_OutOfGameFrameBoundary.linux.yaml:
-    func_name: CSource2Server_OutOfGameFrameBoundary
-    func_rva: '0x18d1830'
-    func_sig: 55 48 89 E5 41 54 53 48 83 EC ?? 8B 3D ?? ?? ?? ?? F3 0F 11 45 ??
-    func_size: '0xbb'
-    func_va: '0x18d1830'
-    vfunc_index: 45
-    vfunc_offset: '0x168'
-    vtable_name: CSource2Server
-  server/CSource2Server_OutOfGameFrameBoundary.windows.yaml:
-    func_name: CSource2Server_OutOfGameFrameBoundary
-    func_rva: '0xd1b4f0'
-    func_sig: 48 83 EC ?? 8B 0D ?? ?? ?? ?? F3 0F 11 4C 24 ??
-    func_size: '0xd6'
-    func_va: '0x180d1b4f0'
-    vfunc_index: 45
-    vfunc_offset: '0x168'
-    vtable_name: CSource2Server
   server/CSource2Server_PreShutdown.linux.yaml:
     func_name: CSource2Server_PreShutdown
     func_rva: '0x18d3da0'
@@ -37925,6 +37907,24 @@ files:
     func_va: '0x180d1a410'
     vfunc_index: 4
     vfunc_offset: '0x20'
+    vtable_name: CSource2Server
+  server/CSource2Server_UpdateWhenNotInGame.linux.yaml:
+    func_name: CSource2Server_UpdateWhenNotInGame
+    func_rva: '0x18d1830'
+    func_sig: 55 48 89 E5 41 54 53 48 83 EC ?? 8B 3D ?? ?? ?? ?? F3 0F 11 45 ??
+    func_size: '0xbb'
+    func_va: '0x18d1830'
+    vfunc_index: 45
+    vfunc_offset: '0x168'
+    vtable_name: CSource2Server
+  server/CSource2Server_UpdateWhenNotInGame.windows.yaml:
+    func_name: CSource2Server_UpdateWhenNotInGame
+    func_rva: '0xd1b4f0'
+    func_sig: 48 83 EC ?? 8B 0D ?? ?? ?? ?? F3 0F 11 4C 24 ??
+    func_size: '0xd6'
+    func_va: '0x180d1b4f0'
+    vfunc_index: 45
+    vfunc_offset: '0x168'
     vtable_name: CSource2Server
   server/CSource2Server_WriteSignonMessages.linux.yaml:
     func_name: CSource2Server_WriteSignonMessages
@@ -42721,5 +42721,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-06T16:10:23Z'
+last_publish_time: '2026-08-07T03:13:26Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -42721,5 +42721,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-07T03:13:26Z'
+last_publish_time: '2026-08-07T04:35:09Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CSource2Server_UpdateWhenNotInGame.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_UpdateWhenNotInGame.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-CSource2Server_OutOfGameFrameBoundary skill."""
+"""Preprocess script for find-CSource2Server_UpdateWhenNotInGame skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 INHERIT_VFUNCS = [
     # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
     (
-        "CSource2Server_OutOfGameFrameBoundary",
+        "CSource2Server_UpdateWhenNotInGame",
         "CSource2Server",
-        "../engine/ISource2Server_OutOfGameFrameBoundary",
+        "../engine/ISource2Server_UpdateWhenNotInGame",
         True,
     ),
 ]
@@ -16,7 +16,7 @@ INHERIT_VFUNCS = [
 GENERATE_YAML_DESIRED_FIELDS = [
     # (symbol_name, generate_yaml_fields)
     (
-        "CSource2Server_OutOfGameFrameBoundary",
+        "CSource2Server_UpdateWhenNotInGame",
         [
             "func_name",
             "func_va",

--- a/ida_preprocessor_scripts/find-IGameSystem_OnOutOfGameFrameBoundary.py
+++ b/ida_preprocessor_scripts/find-IGameSystem_OnOutOfGameFrameBoundary.py
@@ -5,7 +5,7 @@ from ida_preprocessor_scripts._igamesystem_dispatch_common import (
     preprocess_igamesystem_dispatch_skill,
 )
 
-SOURCE_YAML_STEM = "CSource2Server_OutOfGameFrameBoundary"
+SOURCE_YAML_STEM = "CSource2Server_UpdateWhenNotInGame"
 TARGET_SPECS = [
     {"target_name": "IGameSystem_OnOutOfGameFrameBoundary", "rename_to": "GameSystem_OnOutOfGameFrameBoundary"},
 ]

--- a/ida_preprocessor_scripts/find-ISource2Server_UpdateWhenNotInGame.py
+++ b/ida_preprocessor_scripts/find-ISource2Server_UpdateWhenNotInGame.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
-"""Preprocess script for find-ISource2Server_OutOfGameFrameBoundary skill."""
+"""Preprocess script for find-ISource2Server_UpdateWhenNotInGame skill."""
 
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "ISource2Server_OutOfGameFrameBoundary",
+    "ISource2Server_UpdateWhenNotInGame",
 ]
 
 LLM_DECOMPILE = [
     {
-        "symbol_name": "ISource2Server_OutOfGameFrameBoundary",
+        "symbol_name": "ISource2Server_UpdateWhenNotInGame",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/engine/CLoopTypeSimple_FrameUpdate.{platform}.yaml",
@@ -22,12 +22,12 @@ LLM_DECOMPILE = [
 ]
 
 FUNC_VTABLE_RELATIONS = [
-    ("ISource2Server_OutOfGameFrameBoundary", "ISource2Server"),
+    ("ISource2Server_UpdateWhenNotInGame", "ISource2Server"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
     (
-        "ISource2Server_OutOfGameFrameBoundary",
+        "ISource2Server_UpdateWhenNotInGame",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeSimple_FrameUpdate.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeSimple_FrameUpdate.linux.yaml
@@ -411,7 +411,7 @@ disasm_code: |-
   .text:0000000000555671                 jz      short loc_555684
   .text:0000000000555673                 mov     rax, [rdi]
   .text:0000000000555676                 movss   xmm0, dword ptr [rbp+var_1A0]
-  .text:000000000055567E                 call    qword ptr [rax+168h]; 0x168 = 360LL = ISource2Server_OutOfGameFrameBoundary
+  .text:000000000055567E                 call    qword ptr [rax+168h]; 0x168 = 360LL = ISource2Server_UpdateWhenNotInGame
   .text:0000000000555684                 mov     rdi, cs:qword_9740D8
   .text:000000000055568B                 test    rdi, rdi
   .text:000000000055568E                 jz      short loc_5556A1
@@ -2411,7 +2411,7 @@ procedure: |-
       v209 = v195;
     }
     if ( g_pSource2Server )
-      (*(void (__fastcall **)(__int64, float))(*(_QWORD *)g_pSource2Server + 360LL))(g_pSource2Server, *(float *)&v196);// 0x168 = 360LL = ISource2Server_OutOfGameFrameBoundary
+      (*(void (__fastcall **)(__int64, float))(*(_QWORD *)g_pSource2Server + 360LL))(g_pSource2Server, *(float *)&v196);// 0x168 = 360LL = ISource2Server_UpdateWhenNotInGame
     if ( qword_9740D8 )
       (*(void (__fastcall **)(__int64, float))(*(_QWORD *)qword_9740D8 + 976LL))(qword_9740D8, *(float *)&v196);
     if ( qword_97BB10 )

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeSimple_FrameUpdate.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeSimple_FrameUpdate.windows.yaml
@@ -174,8 +174,8 @@ disasm_code: |-
   .text:000000018023E42D                 jz      short loc_18023E43B
   .text:000000018023E42F                 mov     rax, [rcx]
   .text:000000018023E432                 movaps  xmm1, xmm7
-  .text:000000018023E435                 ; 0x168 = 360LL = ISource2Server_OutOfGameFrameBoundary
-  .text:000000018023E435                 call    qword ptr [rax+168h]; 0x168 = 360LL = ISource2Server_OutOfGameFrameBoundary
+  .text:000000018023E435                 ; 0x168 = 360LL = ISource2Server_UpdateWhenNotInGame
+  .text:000000018023E435                 call    qword ptr [rax+168h]; 0x168 = 360LL = ISource2Server_UpdateWhenNotInGame
   .text:000000018023E43B                 mov     rcx, cs:g_pSource2Client
   .text:000000018023E442                 test    rcx, rcx
   .text:000000018023E445                 jz      short loc_18023E453
@@ -488,7 +488,7 @@ procedure: |-
     v29 = sub_180229780((__int64)v53, a2, v11, v26, 0);
     DispatchEvent(a1, v13, v29, v52);
     if ( g_pSource2Server )
-      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 360LL))(g_pSource2Server);// 0x168 = 360LL = ISource2Server_OutOfGameFrameBoundary
+      (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 360LL))(g_pSource2Server);// 0x168 = 360LL = ISource2Server_UpdateWhenNotInGame
     if ( g_pSource2Client )
       (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Client + 976LL))(g_pSource2Client);
     if ( g_pSource2Host )

--- a/run_cpp_tests.py
+++ b/run_cpp_tests.py
@@ -517,8 +517,8 @@ def main():
         print(f"- skip: {skipped.get('name', 'unnamed_test')} (target={skipped.get('target', '')})")
 
     if not runnable_tests:
-        print("No runnable tests for current clang++ environment.")
-        return 0
+        print("Error: No runnable tests for current clang++ environment.")
+        return 1
 
     print("=== running cpp_tests ===")
     compile_failed_count = 0

--- a/run_cpp_tests.py
+++ b/run_cpp_tests.py
@@ -370,6 +370,7 @@ def compile_and_compare(
             if should_parse_vtable:
                 alias_symbols = _to_list(test_item.get("alias_symbols"))
                 reference_vtable_owners = _to_list(test_item.get("reference_vtable_owners"))
+                exclude_reference_vtables = _to_list(test_item.get("exclude_reference_vtables"))
                 try:
                     merge_reference_modules = _to_bool(test_item.get("merge_reference_modules"), default=True)
                 except ValueError as exc:
@@ -392,6 +393,7 @@ def compile_and_compare(
                             pointer_size=pointer_size_from_target_triple(target),
                             alias_class_names=alias_symbols,
                             reference_vtable_owners=reference_vtable_owners,
+                            exclude_reference_vtables=exclude_reference_vtables,
                         )
                     )
                 else:
@@ -407,6 +409,7 @@ def compile_and_compare(
                                 pointer_size=pointer_size_from_target_triple(target),
                                 alias_class_names=alias_symbols,
                                 reference_vtable_owners=reference_vtable_owners,
+                                exclude_reference_vtables=exclude_reference_vtables,
                             )
                         )
             if should_parse_record:

--- a/tests/test_run_cpp_tests.py
+++ b/tests/test_run_cpp_tests.py
@@ -318,6 +318,119 @@ class TestCompareVtableWithYaml(unittest.TestCase):
 
         self.assertEqual([], report["differences"])
 
+    def test_excludes_configured_reference_vtable_from_merge_and_ownership_audit(self) -> None:
+        compiler_output = "VFTable indices for 'ITest' (1 entry).\n   0 | void ITest::First() [pure]\n"
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "14167"
+            engine_dir = root / "engine"
+            engine_dir.mkdir(parents=True)
+            (engine_dir / "ITest_First.windows.yaml").write_text(
+                "func_name: ITest_First\nvtable_name: ITest\nvfunc_index: 0\n",
+                encoding="utf-8",
+            )
+
+            server_dir = root / "server"
+            server_dir.mkdir(parents=True)
+            (server_dir / "CConcrete_First.windows.yaml").write_text(
+                "func_name: CConcrete_First\nvtable_name: CConcrete\nvfunc_index: 0\n",
+                encoding="utf-8",
+            )
+            (server_dir / "CConcrete_Secondary.windows.yaml").write_text(
+                "func_name: CConcrete_Secondary\nvtable_name: CConcrete_vtable2\nvfunc_index: 0\n",
+                encoding="utf-8",
+            )
+            (server_dir / "CConcrete_vtable.windows.yaml").write_text(
+                "vtable_size: '0x8'\nvtable_numvfunc: 1\n",
+                encoding="utf-8",
+            )
+            (server_dir / "CConcrete_vtable2.windows.yaml").write_text(
+                "vtable_size: '0x10'\nvtable_numvfunc: 2\n",
+                encoding="utf-8",
+            )
+
+            symbol_store = DirectorySymbolStore(temp_dir, "14167")
+            unfiltered_report = cpp_tests_util.compare_compiler_vtable_with_yaml(
+                class_name="ITest",
+                compiler_output=compiler_output,
+                symbol_store=symbol_store,
+                platform="windows",
+                reference_modules=["engine", "server"],
+                alias_class_names=["CConcrete"],
+                pointer_size=8,
+            )
+            filtered_report = cpp_tests_util.compare_compiler_vtable_with_yaml(
+                class_name="ITest",
+                compiler_output=compiler_output,
+                symbol_store=symbol_store,
+                platform="windows",
+                reference_modules=["engine", "server"],
+                alias_class_names=["CConcrete"],
+                exclude_reference_vtables=["CConcrete_vtable2"],
+                pointer_size=8,
+            )
+
+        self.assertIn(
+            "reference_conflict_vfunc_name",
+            [item["type"] for item in unfiltered_report["differences"]],
+        )
+        self.assertIn(
+            "reference_conflict_vtable_size",
+            [item["type"] for item in unfiltered_report["differences"]],
+        )
+        self.assertEqual([], filtered_report["differences"])
+        self.assertCountEqual(
+            [
+                "server/CConcrete_Secondary.windows.yaml",
+                "server/CConcrete_vtable2.windows.yaml",
+            ],
+            filtered_report["reference_files_excluded"],
+        )
+        self.assertEqual(
+            ["server/CConcrete_Secondary.windows.yaml"],
+            filtered_report["ownership_files_excluded"],
+        )
+
+
+class TestCompileAndCompareConfig(unittest.TestCase):
+    @patch.object(run_cpp_tests, "compare_compiler_vtable_with_yaml")
+    @patch.object(run_cpp_tests.subprocess, "run")
+    def test_passes_excluded_reference_vtables_to_vtable_compare(
+        self,
+        mock_run,
+        mock_compare,
+    ) -> None:
+        mock_run.return_value = argparse.Namespace(returncode=0, stdout="", stderr="")
+        mock_compare.return_value = {
+            "class_name": "ITest",
+            "platform": "windows",
+            "differences": [],
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            (root / "test.cpp").write_text("int main() { return 0; }\n", encoding="utf-8")
+            result = run_cpp_tests.compile_and_compare(
+                test_item={
+                    "name": "ITest_MSVC",
+                    "symbol": "ITest",
+                    "alias_symbols": ["CConcrete"],
+                    "exclude_reference_vtables": ["CConcrete_vtable2"],
+                    "cpp": "test.cpp",
+                    "target": "x86_64-pc-windows-msvc",
+                    "additional_compiler_options": ["fdump-vtable-layouts"],
+                    "reference_modules": ["engine", "server"],
+                },
+                args=argparse.Namespace(clang="clang++", std="c++20"),
+                config_dir=root,
+                symbol_store=object(),
+            )
+
+        self.assertEqual("ok", result["status"])
+        self.assertEqual(
+            ["CConcrete_vtable2"],
+            mock_compare.call_args.kwargs["exclude_reference_vtables"],
+        )
+
 
 class TestParseRecordLayouts(unittest.TestCase):
     def test_parses_struct_member_offsets_from_record_layout(self) -> None:

--- a/tests/test_run_cpp_tests.py
+++ b/tests/test_run_cpp_tests.py
@@ -395,6 +395,47 @@ class TestMainExitStatus(unittest.TestCase):
     @patch.object(run_cpp_tests, "get_default_target_triple")
     @patch.object(run_cpp_tests, "parse_config")
     @patch.object(run_cpp_tests, "parse_args")
+    def test_returns_failure_when_no_targets_are_runnable(
+        self,
+        mock_parse_args,
+        mock_parse_config,
+        mock_get_default_target_triple,
+        mock_probe_target_support,
+        mock_run_one_test,
+        mock_open_snapshot_store,
+    ) -> None:
+        mock_parse_args.return_value = argparse.Namespace(
+            configyaml="configs/14174.yaml",
+            snapshot="candidate.yaml",
+            gamever="14174",
+            clang="clang++",
+            std="c++20",
+            debug=False,
+        )
+        mock_parse_config.return_value = [
+            {
+                "name": "UnsupportedLayout",
+                "symbol": "IUnsupportedLayout",
+                "cpp": "test.cpp",
+                "target": "x86_64-pc-windows-msvc",
+            }
+        ]
+        mock_get_default_target_triple.return_value = "x86_64-unknown-linux-gnu"
+        mock_probe_target_support.return_value = {"supported": False, "output": "unsupported target"}
+        mock_open_snapshot_store.return_value.candidate_sha256 = "sha256:test"
+        mock_open_snapshot_store.return_value.game_version = "14174"
+        mock_open_snapshot_store.return_value.file_count = 1
+        mock_open_snapshot_store.return_value.config_sha256 = "sha256:config"
+
+        self.assertEqual(1, run_cpp_tests.main())
+        mock_run_one_test.assert_not_called()
+
+    @patch.object(run_cpp_tests, "open_snapshot_store")
+    @patch.object(run_cpp_tests, "run_one_test")
+    @patch.object(run_cpp_tests, "probe_target_support")
+    @patch.object(run_cpp_tests, "get_default_target_triple")
+    @patch.object(run_cpp_tests, "parse_config")
+    @patch.object(run_cpp_tests, "parse_args")
     def test_returns_failure_when_record_or_vtable_compare_has_differences(
         self,
         mock_parse_args,


### PR DESCRIPTION
## Summary

- Correct `ISource2Server` / `CSource2Server` vfunc metadata and keep skipped C++ targets as validation failures.
- Validate the primary Source2 server vtable against both `ISource2Server_*` and `CSource2Server_*` symbols.
- Add config-driven `exclude_reference_vtables`; version 14174 excludes `CSource2Server_vtable2` so secondary-vtable symbols do not interfere with the primary-vtable audit.
- Sync `hl2sdk_cs2` branch `cs2_vibe` from `cs2` and align the 99-slot `ISource2Server` declaration, retaining known method names and naming unknown slots `unk_XXX`.

## Validation

- `uv run python -m unittest tests.test_run_cpp_tests`: 17 tests passed.
- Immutable post-change validation for 14174: 13/13 runnable, 0 skipped, 0 compile failures, 0 invalid items, and 0 layout differences.
- Validated candidate SHA-256: `10c48b0e6104dfb2788db1159539f780b9ccaaffd9971a324b55e4bc396a9700`.
- The latest validated candidate was not published as part of this update.