### PR TITLE
feat(preprocessor): add server frame time finders

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -5965,6 +5965,9 @@ modules:
       - name: find-CSource2Server_vtable
         expected_output:
           - CSource2Server_vtable.{platform}.yaml
+      - name: find-CUserMessageServerFrameTime_t_vtable
+        expected_output:
+          - CUserMessageServerFrameTime_t_vtable.{platform}.yaml
       - name: find-CSource2Server_vtable2
         expected_output:
           - CSource2Server_vtable2.{platform}.yaml
@@ -6733,6 +6736,17 @@ modules:
           - CSource2Server_ApplyGameSettings.{platform}.yaml
         expected_input:
           - CSource2Server_vtable.{platform}.yaml
+      - name: find-CSource2Server_GetEntityReport
+        expected_output:
+          - CSource2Server_GetEntityReport.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+      - name: find-CSource2Server_BroadcastServerFrameTime
+        expected_output:
+          - CSource2Server_BroadcastServerFrameTime.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+          - CUserMessageServerFrameTime_t_vtable.{platform}.yaml
       - name: find-CSource2Server_WriteSignonMessages
         expected_output:
           - CSource2Server_WriteSignonMessages.{platform}.yaml
@@ -8950,6 +8964,8 @@ modules:
     symbols:
       - name: CSource2Server_vtable
         category: vtable
+      - name: CUserMessageServerFrameTime_t_vtable
+        category: vtable
       - name: CSource2Server_vtable2
         category: vtable
       - name: CSource2Server_OnStreamEntitiesFromFileCompleted
@@ -9934,6 +9950,14 @@ modules:
         category: vfunc
         alias:
           - CSource2Server::ApplyGameSettings
+      - name: CSource2Server_GetEntityReport
+        category: vfunc
+        alias:
+          - CSource2Server::GetEntityReport
+      - name: CSource2Server_BroadcastServerFrameTime
+        category: vfunc
+        alias:
+          - CSource2Server::BroadcastServerFrameTime
       - name: CSource2Server_WriteSignonMessages
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:31b39750c33a7c0e2f196f65f4498038e9422d79deec989308987ae96a4cd84d
-file_count: 3327
+config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
+file_count: 3333
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -37640,6 +37640,24 @@ files:
     vfunc_index: 18
     vfunc_offset: '0x90'
     vtable_name: CSource2Server
+  server/CSource2Server_BroadcastServerFrameTime.linux.yaml:
+    func_name: CSource2Server_BroadcastServerFrameTime
+    func_rva: '0x18d4cf0'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 4C 8D 65 ?? 53 48 8D 9D ?? ?? ?? ??
+    func_size: '0x12a'
+    func_va: '0x18d4cf0'
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vtable_name: CSource2Server_vtable
+  server/CSource2Server_BroadcastServerFrameTime.windows.yaml:
+    func_name: CSource2Server_BroadcastServerFrameTime
+    func_rva: '0xd1c150'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 81 EC ?? ?? ?? ?? 0F 29 B4 24 ?? ?? ?? ?? 48 8D 4C 24 ??
+    func_size: '0x14b'
+    func_va: '0x180d1c150'
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vtable_name: CSource2Server_vtable
   server/CSource2Server_Connect.linux.yaml:
     func_name: CSource2Server_Connect
     func_rva: '0x18d6f00'
@@ -37730,6 +37748,24 @@ files:
     vfunc_index: 42
     vfunc_offset: '0x150'
     vtable_name: CSource2Server
+  server/CSource2Server_GetEntityReport.linux.yaml:
+    func_name: CSource2Server_GetEntityReport
+    func_rva: '0x18e6fc0'
+    func_sig: 55 48 8D 35 ?? ?? ?? ?? 48 89 E5 41 57 41 56 41 55 4C 8D 2D ?? ?? ?? ??
+    func_size: '0x55d'
+    func_va: '0x18e6fc0'
+    vfunc_index: 82
+    vfunc_offset: '0x290'
+    vtable_name: CSource2Server_vtable
+  server/CSource2Server_GetEntityReport.windows.yaml:
+    func_name: CSource2Server_GetEntityReport
+    func_rva: '0xd1c300'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 54 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 49 8B 40 ??
+    func_size: '0x441'
+    func_va: '0x180d1c300'
+    vfunc_index: 82
+    vfunc_offset: '0x290'
+    vtable_name: CSource2Server_vtable
   server/CSource2Server_GetLevelsFromSaveFile.linux.yaml:
     func_name: CSource2Server_GetLevelsFromSaveFile
     func_rva: '0x18d19e0'
@@ -39334,6 +39370,33 @@ files:
     vtable_size: '0x8a8'
     vtable_symbol: ??_7CTriggerPush@@6B@
     vtable_va: '0x18184cc28'
+  server/CUserMessageServerFrameTime_t_vtable.linux.yaml:
+    vtable_class: CUserMessageServerFrameTime_t
+    vtable_entries:
+      0: '0x18d1df0'
+      1: '0x18d1e30'
+      2: '0x17769d0'
+      3: '0x17769e0'
+      4: '0x17769f0'
+      5: '0x1778490'
+    vtable_numvfunc: 6
+    vtable_rva: '0x24ccb10'
+    vtable_size: '0x30'
+    vtable_symbol: _ZTV29CUserMessageServerFrameTime_t + 0x10
+    vtable_va: '0x24ccb10'
+  server/CUserMessageServerFrameTime_t_vtable.windows.yaml:
+    vtable_class: CUserMessageServerFrameTime_t
+    vtable_entries:
+      0: '0x180d20f60'
+      1: '0x180c158b0'
+      2: '0x180c158a0'
+      3: '0x180c158c0'
+      4: '0x180c15910'
+    vtable_numvfunc: 5
+    vtable_rva: '0x17e3548'
+    vtable_size: '0x28'
+    vtable_symbol: ??_7CUserMessageServerFrameTime_t@@6B@
+    vtable_va: '0x1817e3548'
   server/CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount.windows.yaml:
     func_name: CUtlVectorEmbeddedNetworkVar_CSPerRoundStats_t_NetworkVar_m_perRoundStats_SetCount
     func_rva: '0x1c64f0'
@@ -42721,5 +42784,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-07T04:35:09Z'
+last_publish_time: '2026-08-07T07:32:31Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CSource2Server_BroadcastServerFrameTime.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_BroadcastServerFrameTime.py
@@ -68,10 +68,7 @@ async def preprocess_skill(
     vtable_va = _read_vtable_va(vtable_yaml_path)
     if not vtable_va:
         if debug:
-            print(
-                "    Preprocess: CUserMessageServerFrameTime_t_vtable vtable_va not found, "
-                "cannot resolve xref_gvs"
-            )
+            print("    Preprocess: CUserMessageServerFrameTime_t_vtable vtable_va not found, cannot resolve xref_gvs")
         return False
 
     func_xrefs = [

--- a/ida_preprocessor_scripts/find-CSource2Server_BroadcastServerFrameTime.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_BroadcastServerFrameTime.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_BroadcastServerFrameTime skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_BroadcastServerFrameTime",
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CSource2Server_BroadcastServerFrameTime", "CSource2Server_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Server_BroadcastServerFrameTime",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CSource2Server::BroadcastServerFrameTime via the message vtable xref."""
+    vtable_yaml_path = os.path.join(
+        new_binary_dir,
+        f"CUserMessageServerFrameTime_t_vtable.{platform}.yaml",
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CUserMessageServerFrameTime_t_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    func_xrefs = [
+        {
+            "func_name": "CSource2Server_BroadcastServerFrameTime",
+            "xref_strings": [],
+            "xref_gvs": [vtable_va],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": [],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": [],
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GetEntityReport.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetEntityReport.py
@@ -70,4 +70,3 @@ async def preprocess_skill(
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )
-

--- a/ida_preprocessor_scripts/find-CSource2Server_GetEntityReport.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetEntityReport.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GetEntityReport skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GetEntityReport",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2Server_GetEntityReport",
+        "xref_strings": [
+            "FULLMATCH:[-1] -> empty",
+            "FULLMATCH:%d (s/n %d)",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CSource2Server_GetEntityReport", "CSource2Server_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Server_GetEntityReport",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Locate CSource2Server::GetEntityReport from its exact debug strings."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )
+

--- a/ida_preprocessor_scripts/find-CUserMessageServerFrameTime_t_vtable.py
+++ b/ida_preprocessor_scripts/find-CUserMessageServerFrameTime_t_vtable.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CUserMessageServerFrameTime_t_vtable skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_CLASS_NAMES = ["CUserMessageServerFrameTime_t"]
+
+MANGLED_CLASS_NAMES = {
+    "CUserMessageServerFrameTime_t": [
+        "??_7CUserMessageServerFrameTime_t@@6B@",
+        "_ZTV29CUserMessageServerFrameTime_t",
+    ],
+}
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CUserMessageServerFrameTime_t",
+        [
+            "vtable_class",
+            "vtable_symbol",
+            "vtable_va",
+            "vtable_rva",
+            "vtable_size",
+            "vtable_numvfunc",
+            "vtable_entries",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Generate the CUserMessageServerFrameTime_t vtable YAML via mangled aliases."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        vtable_class_names=TARGET_CLASS_NAMES,
+        mangled_class_names=MANGLED_CLASS_NAMES,
+        platform=platform,
+        image_base=image_base,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )
+

--- a/ida_preprocessor_scripts/find-CUserMessageServerFrameTime_t_vtable.py
+++ b/ida_preprocessor_scripts/find-CUserMessageServerFrameTime_t_vtable.py
@@ -50,4 +50,3 @@ async def preprocess_skill(
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )
-


### PR DESCRIPTION
## Summary
- Add preprocessors for CSource2Server::GetEntityReport and CSource2Server::BroadcastServerFrameTime.
- Add mangled-symbol discovery for CUserMessageServerFrameTime_t and align the ISource2Server vtable declarations.

## Validation
- `uv run ida_analyze_bin.py -debug`: Successful 4, Failed 0, Skipped 2158.
- non-MCP unittest suite: 1060 tests passed, 3 skipped.
- candidate preparation: passed for `14174`.
- C++ post-change validation: passed with runnable tests and zero compile/layout differences.
- candidate publication: passed; published SHA-256 matches the validated candidate (`055c6649856af345dc37ac397981413698a9315321e20c99678a0ed5f7067e38`).