### PR TITLE
CNetworkGameServerBase_GetChallengeType

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -792,6 +792,12 @@ modules:
       - name: find-CNetworkGameServerBase_SendChallenge
         expected_output:
           - CNetworkGameServerBase_SendChallenge.{platform}.yaml
+      - name: find-CNetworkGameServerBase_GetChallengeType
+        expected_output:
+          - CNetworkGameServerBase_GetChallengeType.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_SendChallenge.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_ConnectClient
         expected_output:
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
@@ -2297,6 +2303,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::SendChallenge
+      - name: CNetworkGameServerBase_GetChallengeType
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::GetChallengeType
       - name: CNetworkGameServerBase_ConnectClient
         category: func
         alias:

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -789,6 +789,9 @@ modules:
           - CNetworkGameServerBase_SendPeerList.{platform}.yaml
         expected_input:
           - CSVCMsg_PeerList_t_vtable.{platform}.yaml
+      - name: find-CNetworkGameServerBase_SendChallenge
+        expected_output:
+          - CNetworkGameServerBase_SendChallenge.{platform}.yaml
       - name: find-CNetworkGameServerBase_ConnectClient
         expected_output:
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
@@ -2290,6 +2293,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::SendPeerList
+      - name: CNetworkGameServerBase_SendChallenge
+        category: func
+        alias:
+          - CNetworkGameServerBase::SendChallenge
       - name: CNetworkGameServerBase_ConnectClient
         category: func
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10853,26 +10847,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12505,7 +12505,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12514,7 +12514,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:f7f7678eea61cdbbe4b4e73ae28b52438fe52256cea4109825af991a2f3aebaa
+file_count: 3337
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10675,6 +10681,18 @@ files:
     vfunc_index: 40
     vfunc_offset: '0x140'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_GetChallengeType.linux.yaml:
+    func_name: CNetworkGameServerBase_GetChallengeType
+    vfunc_index: 86
+    vfunc_offset: '0x2b0'
+    vfunc_sig: FF 90 B0 02 00 00 BA ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_GetChallengeType.windows.yaml:
+    func_name: CNetworkGameServerBase_GetChallengeType
+    vfunc_index: 81
+    vfunc_offset: '0x288'
+    vfunc_sig: FF 90 88 02 00 00 BA ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_GetClassBaseline.linux.yaml:
     func_name: CNetworkGameServerBase_GetClassBaseline
     func_rva: '0x4f2ec0'
@@ -10835,32 +10853,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -10987,6 +10999,18 @@ files:
     vfunc_index: 45
     vfunc_offset: '0x168'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_SendChallenge.linux.yaml:
+    func_name: CNetworkGameServerBase_SendChallenge
+    func_rva: '0x4fa710'
+    func_sig: 55 B9 ?? ?? ?? ?? 48 89 E5 41 57 41 56 49 89 D6
+    func_size: '0x45a'
+    func_va: '0x4fa710'
+  engine/CNetworkGameServerBase_SendChallenge.windows.yaml:
+    func_name: CNetworkGameServerBase_SendChallenge
+    func_rva: '0xaa980'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 48 89 7C 24 ?? 55 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 4D 8B E8
+    func_size: '0x488'
+    func_va: '0x1800aa980'
   engine/CNetworkGameServerBase_SendPeerList.linux.yaml:
     func_name: CNetworkGameServerBase_SendPeerList
     func_rva: '0x4f4ff0'
@@ -12481,7 +12505,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12514,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -42784,5 +42808,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-07T07:32:31Z'
+last_publish_time: '2026-08-08T06:38:15Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetChallengeType.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_GetChallengeType.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_GetChallengeType skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_GetChallengeType",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_GetChallengeType",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_SendChallenge.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_SendChallenge.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_GetChallengeType", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "CNetworkGameServerBase_GetChallengeType",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_SendChallenge.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_SendChallenge.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_SendChallenge skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_SendChallenge",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CNetworkGameServerBase_SendChallenge",
+        "xref_strings": [
+            "Sending S2C_CHALLENGE [%u auth %d] to %s\n",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CNetworkGameServerBase_SendChallenge",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_SendChallenge.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_SendChallenge.linux.yaml
@@ -1,0 +1,453 @@
+func_name: CNetworkGameServerBase_SendChallenge
+func_va: '0x4fa710'
+disasm_code: |-
+  .text:00000000004FA710                 push    rbp
+  .text:00000000004FA711                 mov     ecx, 0FFFFFFFFh
+  .text:00000000004FA716                 mov     rbp, rsp
+  .text:00000000004FA719                 push    r15
+  .text:00000000004FA71B                 push    r14
+  .text:00000000004FA71D                 mov     r14, rdx
+  .text:00000000004FA720                 mov     edx, 200h
+  .text:00000000004FA725                 push    r13
+  .text:00000000004FA727                 mov     r13, rdi
+  .text:00000000004FA72A                 push    r12
+  .text:00000000004FA72C                 mov     r12, rsi
+  .text:00000000004FA72F                 push    rbx
+  .text:00000000004FA730                 lea     rbx, [rbp+var_2A0]
+  .text:00000000004FA737                 sub     rsp, 278h
+  .text:00000000004FA73E                 mov     rdi, rbx
+  .text:00000000004FA741                 lea     rsi, [rbp+var_230]
+  .text:00000000004FA748                 call    sub_5E1560
+  .text:00000000004FA74D                 mov     rax, [r13+0]
+  .text:00000000004FA751                 mov     rdi, r13
+  .text:00000000004FA754                 mov     rsi, r12
+  .text:00000000004FA757                 ; 0x2B0 = 688LL = CNetworkGameServerBase_GetChallengeType
+  .text:00000000004FA757                 call    qword ptr [rax+2B0h]; 0x2B0 = 688LL = CNetworkGameServerBase_GetChallengeType
+  .text:00000000004FA75D                 mov     edx, 20h ; ' '
+  .text:00000000004FA762                 mov     esi, 0FFFFFFFFh
+  .text:00000000004FA767                 mov     rdi, rbx
+  .text:00000000004FA76A                 mov     r13d, eax
+  .text:00000000004FA76D                 call    sub_5E15E0
+  .text:00000000004FA772                 mov     eax, [rbp+var_294]
+  .text:00000000004FA778                 mov     ecx, [rbp+var_290]
+  .text:00000000004FA77E                 mov     edx, eax
+  .text:00000000004FA780                 sub     edx, ecx
+  .text:00000000004FA782                 cmp     edx, 7
+  .text:00000000004FA785                 jle     loc_4FAA10
+  .text:00000000004FA78B                 mov     rdx, [rbp+var_2A0]
+  .text:00000000004FA792                 lea     eax, [rcx+8]
+  .text:00000000004FA795                 mov     r8d, ecx
+  .text:00000000004FA798                 mov     [rbp+var_290], eax
+  .text:00000000004FA79E                 mov     eax, ecx
+  .text:00000000004FA7A0                 and     r8d, 1Fh
+  .text:00000000004FA7A4                 sar     eax, 5
+  .text:00000000004FA7A7                 cdqe
+  .text:00000000004FA7A9                 lea     rsi, [rdx+rax*4]
+  .text:00000000004FA7AD                 mov     edx, 41h ; 'A'
+  .text:00000000004FA7B2                 mov     eax, 7Fh
+  .text:00000000004FA7B7                 rol     edx, cl
+  .text:00000000004FA7B9                 mov     ecx, 1Fh
+  .text:00000000004FA7BE                 mov     edi, [rsi]
+  .text:00000000004FA7C0                 sub     ecx, r8d
+  .text:00000000004FA7C3                 shr     eax, cl
+  .text:00000000004FA7C5                 mov     ecx, eax
+  .text:00000000004FA7C7                 and     eax, 1
+  .text:00000000004FA7CA                 lea     r9, [rsi+rax*4]
+  .text:00000000004FA7CE                 mov     eax, edx
+  .text:00000000004FA7D0                 xor     edx, edi
+  .text:00000000004FA7D2                 mov     r10d, [r9]
+  .text:00000000004FA7D5                 xor     eax, r10d
+  .text:00000000004FA7D8                 and     eax, ecx
+  .text:00000000004FA7DA                 mov     ecx, r8d
+  .text:00000000004FA7DD                 xor     eax, r10d
+  .text:00000000004FA7E0                 mov     [r9], eax
+  .text:00000000004FA7E3                 mov     eax, 0FFh
+  .text:00000000004FA7E8                 shl     eax, cl
+  .text:00000000004FA7EA                 and     eax, edx
+  .text:00000000004FA7EC                 xor     eax, edi
+  .text:00000000004FA7EE                 mov     [rsi], eax
+  .text:00000000004FA7F0                 xor     esi, esi
+  .text:00000000004FA7F2                 mov     edx, 20h ; ' '
+  .text:00000000004FA7F7                 mov     rdi, rbx
+  .text:00000000004FA7FA                 call    sub_5E15E0
+  .text:00000000004FA7FF                 mov     edx, 20h ; ' '
+  .text:00000000004FA804                 mov     esi, r13d
+  .text:00000000004FA807                 mov     rdi, rbx
+  .text:00000000004FA80A                 call    sub_5E15E0
+  .text:00000000004FA80F                 cmp     r13d, 3
+  .text:00000000004FA813                 jz      loc_4FA930
+  .text:00000000004FA819                 mov     edx, 10h
+  .text:00000000004FA81E                 mov     esi, 1
+  .text:00000000004FA823                 mov     rdi, rbx
+  .text:00000000004FA826                 call    sub_5E15E0
+  .text:00000000004FA82B                 xor     esi, esi
+  .text:00000000004FA82D                 mov     rdi, rbx
+  .text:00000000004FA830                 call    sub_5E1F80
+  .text:00000000004FA835                 mov     edx, [rbp+var_294]
+  .text:00000000004FA83B                 mov     eax, [rbp+var_290]
+  .text:00000000004FA841                 mov     ecx, edx
+  .text:00000000004FA843                 sub     ecx, eax
+  .text:00000000004FA845                 cmp     ecx, 7
+  .text:00000000004FA848                 jle     loc_4FA918
+  .text:00000000004FA84E                 lea     edx, [rax+8]
+  .text:00000000004FA851                 mov     edi, eax
+  .text:00000000004FA853                 sar     eax, 5
+  .text:00000000004FA856                 mov     [rbp+var_290], edx
+  .text:00000000004FA85C                 and     edi, 1Fh
+  .text:00000000004FA85F                 cdqe
+  .text:00000000004FA861                 mov     ecx, 1Fh
+  .text:00000000004FA866                 mov     rdx, [rbp+var_2A0]
+  .text:00000000004FA86D                 sub     ecx, edi
+  .text:00000000004FA86F                 lea     rsi, [rdx+rax*4]
+  .text:00000000004FA873                 mov     edx, 7Fh
+  .text:00000000004FA878                 mov     eax, 0FFh
+  .text:00000000004FA87D                 shr     edx, cl
+  .text:00000000004FA87F                 mov     ecx, edi
+  .text:00000000004FA881                 shl     eax, cl
+  .text:00000000004FA883                 mov     r8d, edx
+  .text:00000000004FA886                 not     edx
+  .text:00000000004FA888                 not     eax
+  .text:00000000004FA88A                 and     eax, [rsi]
+  .text:00000000004FA88C                 and     r8d, 1
+  .text:00000000004FA890                 and     [rsi+r8*4], edx
+  .text:00000000004FA894                 mov     [rsi], eax
+  .text:00000000004FA896                 mov     rsi, r14
+  .text:00000000004FA899                 mov     rdi, rbx
+  .text:00000000004FA89C                 call    sub_5E20D0
+  .text:00000000004FA8A1                 cmp     dword ptr [r12+1Ch], 4
+  .text:00000000004FA8A7                 mov     esi, 2
+  .text:00000000004FA8AC                 jnz     short loc_4FA8B3
+  .text:00000000004FA8AE                 mov     esi, 1
+  .text:00000000004FA8B3                 mov     edi, cs:dword_A30294
+  .text:00000000004FA8B9                 call    sub_2C9B50
+  .text:00000000004FA8BE                 test    al, al
+  .text:00000000004FA8C0                 jnz     loc_4FAA28
+  .text:00000000004FA8C6                 lea     rax, g_pNetworkSystem
+  .text:00000000004FA8CD                 mov     rdi, [rax]
+  .text:00000000004FA8D0                 mov     rax, [rdi]
+  .text:00000000004FA8D3                 call    qword ptr [rax+160h]
+  .text:00000000004FA8D9                 mov     esi, [r12+70h]
+  .text:00000000004FA8DE                 xor     r9d, r9d
+  .text:00000000004FA8E1                 mov     r8d, 5
+  .text:00000000004FA8E7                 mov     rdi, rax
+  .text:00000000004FA8EA                 mov     eax, [rbp+var_290]
+  .text:00000000004FA8F0                 mov     rdx, [rbp+var_2A0]
+  .text:00000000004FA8F7                 lea     ecx, [rax+7]
+  .text:00000000004FA8FA                 mov     rax, [rdi]
+  .text:00000000004FA8FD                 sar     ecx, 3
+  .text:00000000004FA900                 call    qword ptr [rax+58h]
+  .text:00000000004FA903                 add     rsp, 278h
+  .text:00000000004FA90A                 pop     rbx
+  .text:00000000004FA90B                 pop     r12
+  .text:00000000004FA90D                 pop     r13
+  .text:00000000004FA90F                 pop     r14
+  .text:00000000004FA911                 pop     r15
+  .text:00000000004FA913                 pop     rbp
+  .text:00000000004FA914                 retn
+  .text:00000000004FA918                 mov     [rbp+var_290], edx
+  .text:00000000004FA91E                 mov     [rbp+var_280], 1
+  .text:00000000004FA925                 jmp     loc_4FA896
+  .text:00000000004FA930                 call    sub_575B00
+  .text:00000000004FA935                 mov     rdi, rax
+  .text:00000000004FA938                 call    sub_5762A0
+  .text:00000000004FA93D                 mov     edx, 10h
+  .text:00000000004FA942                 xor     esi, esi
+  .text:00000000004FA944                 mov     rdi, rbx
+  .text:00000000004FA947                 mov     r15, [rax]
+  .text:00000000004FA94A                 call    sub_5E15E0
+  .text:00000000004FA94F                 mov     rdi, rbx
+  .text:00000000004FA952                 mov     rsi, r15
+  .text:00000000004FA955                 call    sub_5E1F80
+  .text:00000000004FA95A                 lea     r15, off_9D7F10
+  .text:00000000004FA961                 call    sub_575B00
+  .text:00000000004FA966                 mov     rdi, r15
+  .text:00000000004FA969                 call    sub_2CA3A0
+  .text:00000000004FA96E                 mov     rdx, rax
+  .text:00000000004FA971                 xor     eax, eax
+  .text:00000000004FA973                 cmp     qword ptr [rdx], 0
+  .text:00000000004FA977                 jz      short loc_4FA98D
+  .text:00000000004FA979                 mov     rdi, r15
+  .text:00000000004FA97C                 call    sub_2CA3A0
+  .text:00000000004FA981                 mov     rdi, [rax]
+  .text:00000000004FA984                 mov     rax, [rdi]
+  .text:00000000004FA987                 call    qword ptr [rax+48h]
+  .text:00000000004FA98A                 movzx   eax, al
+  .text:00000000004FA98D                 mov     edx, [rbp+var_294]
+  .text:00000000004FA993                 mov     ecx, [rbp+var_290]
+  .text:00000000004FA999                 mov     esi, edx
+  .text:00000000004FA99B                 sub     esi, ecx
+  .text:00000000004FA99D                 cmp     esi, 7
+  .text:00000000004FA9A0                 jle     loc_4FA918
+  .text:00000000004FA9A6                 mov     rsi, [rbp+var_2A0]
+  .text:00000000004FA9AD                 lea     edx, [rcx+8]
+  .text:00000000004FA9B0                 mov     r8d, ecx
+  .text:00000000004FA9B3                 rol     eax, cl
+  .text:00000000004FA9B5                 mov     [rbp+var_290], edx
+  .text:00000000004FA9BB                 mov     edx, ecx
+  .text:00000000004FA9BD                 and     r8d, 1Fh
+  .text:00000000004FA9C1                 mov     ecx, 1Fh
+  .text:00000000004FA9C6                 sar     edx, 5
+  .text:00000000004FA9C9                 sub     ecx, r8d
+  .text:00000000004FA9CC                 movsxd  rdx, edx
+  .text:00000000004FA9CF                 lea     rsi, [rsi+rdx*4]
+  .text:00000000004FA9D3                 mov     edx, 7Fh
+  .text:00000000004FA9D8                 shr     edx, cl
+  .text:00000000004FA9DA                 mov     edi, [rsi]
+  .text:00000000004FA9DC                 mov     ecx, edx
+  .text:00000000004FA9DE                 and     edx, 1
+  .text:00000000004FA9E1                 lea     r9, [rsi+rdx*4]
+  .text:00000000004FA9E5                 mov     edx, eax
+  .text:00000000004FA9E7                 mov     r10d, [r9]
+  .text:00000000004FA9EA                 xor     eax, edi
+  .text:00000000004FA9EC                 xor     edx, r10d
+  .text:00000000004FA9EF                 and     edx, ecx
+  .text:00000000004FA9F1                 mov     ecx, r8d
+  .text:00000000004FA9F4                 xor     edx, r10d
+  .text:00000000004FA9F7                 mov     [r9], edx
+  .text:00000000004FA9FA                 mov     edx, 0FFh
+  .text:00000000004FA9FF                 shl     edx, cl
+  .text:00000000004FAA01                 and     edx, eax
+  .text:00000000004FAA03                 xor     edx, edi
+  .text:00000000004FAA05                 mov     [rsi], edx
+  .text:00000000004FAA07                 jmp     loc_4FA896
+  .text:00000000004FAA10                 mov     [rbp+var_290], eax
+  .text:00000000004FAA16                 mov     [rbp+var_280], 1
+  .text:00000000004FAA1D                 jmp     loc_4FA7F0
+  .text:00000000004FAA28                 mov     eax, [r12+1Ch]
+  .text:00000000004FAA2D                 cmp     eax, 3
+  .text:00000000004FAA30                 ja      loc_4FAAE0
+  .text:00000000004FAA36                 cmp     eax, 1
+  .text:00000000004FAA39                 ja      short loc_4FAA80
+  .text:00000000004FAA3B                 test    eax, eax
+  .text:00000000004FAA3D                 jz      loc_4FAB08
+  .text:00000000004FAA43                 mov     ecx, [r12+18h]
+  .text:00000000004FAA48                 lea     rdx, unk_27CC16
+  .text:00000000004FAA4F                 mov     r14d, [r12+14h]
+  .text:00000000004FAA54                 test    ecx, ecx
+  .text:00000000004FAA56                 jz      loc_4FAB58
+  .text:00000000004FAA5C                 lea     rbx, [rbp+var_270]
+  .text:00000000004FAA63                 mov     ecx, r14d
+  .text:00000000004FAA66                 xor     eax, eax
+  .text:00000000004FAA68                 lea     rsi, aSD_5; "%s:%d"
+  .text:00000000004FAA6F                 mov     rdi, rbx
+  .text:00000000004FAA72                 call    sub_2CF290
+  .text:00000000004FAA77                 jmp     short loc_4FAAAC
+  .text:00000000004FAA80                 mov     eax, [r12+18h]
+  .text:00000000004FAA85                 lea     rdx, unk_27CC16
+  .text:00000000004FAA8C                 test    eax, eax
+  .text:00000000004FAA8E                 jz      loc_4FAB40
+  .text:00000000004FAA94                 lea     rbx, [rbp+var_270]
+  .text:00000000004FAA9B                 xor     eax, eax
+  .text:00000000004FAA9D                 lea     rsi, aS_23; "=%s"
+  .text:00000000004FAAA4                 mov     rdi, rbx
+  .text:00000000004FAAA7                 call    sub_2CF290
+  .text:00000000004FAAAC                 cmp     dword ptr [r12+1Ch], 4
+  .text:00000000004FAAB2                 mov     esi, 1
+  .text:00000000004FAAB7                 jz      short loc_4FAABE
+  .text:00000000004FAAB9                 mov     esi, 2
+  .text:00000000004FAABE                 mov     edi, cs:dword_A30294
+  .text:00000000004FAAC4                 mov     r9, rbx
+  .text:00000000004FAAC7                 mov     r8d, r13d
+  .text:00000000004FAACA                 xor     ecx, ecx
+  .text:00000000004FAACC                 lea     rdx, aSendingS2cChal; "Sending S2C_CHALLENGE [%u auth %d] to %"...
+  .text:00000000004FAAD3                 xor     eax, eax
+  .text:00000000004FAAD5                 call    sub_2C8BC0
+  .text:00000000004FAADA                 jmp     loc_4FA8C6
+  .text:00000000004FAAE0                 cmp     eax, 4
+  .text:00000000004FAAE3                 jnz     short loc_4FAB28
+  .text:00000000004FAAE5                 mov     edx, [r12+14h]
+  .text:00000000004FAAEA                 lea     rbx, [rbp+var_270]
+  .text:00000000004FAAF1                 xor     eax, eax
+  .text:00000000004FAAF3                 lea     rsi, aLoopbackD; "loopback:%d"
+  .text:00000000004FAAFA                 mov     rdi, rbx
+  .text:00000000004FAAFD                 call    sub_2CF290
+  .text:00000000004FAB02                 jmp     short loc_4FAAAC
+  .text:00000000004FAB08                 lea     rbx, [rbp+var_270]
+  .text:00000000004FAB0F                 xor     ecx, ecx
+  .text:00000000004FAB11                 mov     edx, 40h ; '@'
+  .text:00000000004FAB16                 mov     rsi, rbx
+  .text:00000000004FAB19                 mov     rdi, r12
+  .text:00000000004FAB1C                 call    sub_2C95A0
+  .text:00000000004FAB21                 jmp     short loc_4FAAAC
+  .text:00000000004FAB28                 mov     [rbp+var_270], 0
+  .text:00000000004FAB2F                 lea     rbx, [rbp+var_270]
+  .text:00000000004FAB36                 jmp     loc_4FAAB9
+  .text:00000000004FAB40                 lea     rdi, [r12+0Ch]
+  .text:00000000004FAB45                 call    sub_599F20
+  .text:00000000004FAB4A                 mov     rdx, rax
+  .text:00000000004FAB4D                 jmp     loc_4FAA94
+  .text:00000000004FAB58                 lea     rdi, [r12+0Ch]
+  .text:00000000004FAB5D                 call    sub_599F20
+  .text:00000000004FAB62                 mov     rdx, rax
+  .text:00000000004FAB65                 jmp     loc_4FAA5C
+procedure: |-
+  __int64 __fastcall CNetworkGameServerBase_SendChallenge(__int64 a1, _DWORD *a2, __int64 a3)
+  {
+    unsigned int v5; // r13d
+    int v6; // ecx
+    int *v7; // rsi
+    int v8; // edi
+    int v9; // eax
+    int v10; // edx
+    int v11; // edx
+    int v12; // eax
+    char v13; // di
+    int *v14; // rsi
+    unsigned int v15; // edx
+    int v16; // eax
+    __int64 v17; // rsi
+    int v18; // ecx
+    int v19; // r8d
+    int v20; // r9d
+    __int64 v21; // rax
+    void *v23; // rax
+    __int64 v24; // r15
+    _QWORD *v25; // rdx
+    int v26; // eax
+    _QWORD *v27; // rax
+    int v28; // ecx
+    int *v29; // rsi
+    int v30; // edi
+    int v31; // edx
+    int v32; // eax
+    unsigned int v33; // eax
+    void *v34; // rdx
+    int v35; // r14d
+    void *v36; // rdx
+    __int64 v37; // rsi
+    __int64 v38; // [rsp+0h] [rbp-2A0h] BYREF
+    int v39; // [rsp+Ch] [rbp-294h]
+    int v40; // [rsp+10h] [rbp-290h]
+    char v41; // [rsp+20h] [rbp-280h]
+    char v42[64]; // [rsp+30h] [rbp-270h] BYREF
+    char v43[560]; // [rsp+70h] [rbp-230h] BYREF
+
+    sub_5E1560(&v38, v43, 512, 0xFFFFFFFFLL);
+    v5 = (*(__int64 (__fastcall **)(__int64, _DWORD *))(*(_QWORD *)a1 + 688LL))(a1, a2);// 0x2B0 = 688LL = CNetworkGameServerBase_GetChallengeType
+    sub_5E15E0(&v38, 0xFFFFFFFFLL, 32);
+    v6 = v40;
+    if ( v39 - v40 <= 7 )
+    {
+      v40 = v39;
+      v41 = 1;
+    }
+    else
+    {
+      v40 += 8;
+      v7 = (int *)(v38 + 4LL * (v6 >> 5));
+      v8 = *v7;
+      v9 = __ROL4__(65, v6);
+      v10 = *v7 ^ v9;
+      v7[(0x7Fu >> (31 - (v6 & 0x1F))) & 1] ^= (0x7Fu >> (31 - (v6 & 0x1F)))
+                                             & (v7[(0x7Fu >> (31 - (v6 & 0x1F))) & 1]
+                                              ^ v9);
+      *v7 = v8 ^ v10 & (255 << (v6 & 0x1F));
+    }
+    sub_5E15E0(&v38, 0, 32);
+    sub_5E15E0(&v38, v5, 32);
+    if ( v5 != 3 )
+    {
+      sub_5E15E0(&v38, 1, 16);
+      sub_5E1F80(&v38, 0);
+      v11 = v39;
+      v12 = v40;
+      if ( v39 - v40 > 7 )
+      {
+        v40 += 8;
+        v13 = v12 & 0x1F;
+        v14 = (int *)(v38 + 4LL * (v12 >> 5));
+        v15 = ~(0x7Fu >> (31 - (v12 & 0x1F)));
+        v16 = *v14 & ~(255 << (v12 & 0x1F));
+        v14[(0x7Fu >> (31 - v13)) & 1] &= v15;
+        *v14 = v16;
+        goto LABEL_6;
+      }
+      goto LABEL_10;
+    }
+    v23 = sub_575B00();
+    v24 = *(_QWORD *)sub_5762A0(v23);
+    sub_5E15E0(&v38, 0, 16);
+    sub_5E1F80(&v38, v24);
+    sub_575B00();
+    v25 = (_QWORD *)sub_2CA3A0(&off_9D7F10);
+    v26 = 0;
+    if ( *v25 )
+    {
+      v27 = (_QWORD *)sub_2CA3A0(&off_9D7F10);
+      v26 = (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v27 + 72LL))(*v27);
+    }
+    v11 = v39;
+    v28 = v40;
+    if ( v39 - v40 <= 7 )
+    {
+  LABEL_10:
+      v40 = v11;
+      v41 = 1;
+      goto LABEL_6;
+    }
+    v40 += 8;
+    v29 = (int *)(v38 + 4LL * (v28 >> 5));
+    v30 = *v29;
+    v31 = __ROL4__(v26, v28);
+    v32 = *v29 ^ v31;
+    v29[(0x7Fu >> (31 - (v28 & 0x1F))) & 1] ^= (0x7Fu >> (31 - (v28 & 0x1F)))
+                                             & (v29[(0x7Fu >> (31 - (v28 & 0x1F))) & 1]
+                                              ^ v31);
+    *v29 = v30 ^ v32 & (255 << (v28 & 0x1F));
+  LABEL_6:
+    sub_5E20D0(&v38, a3);
+    v17 = 2;
+    if ( a2[7] == 4 )
+      v17 = 1;
+    if ( (unsigned __int8)sub_2C9B50((unsigned int)dword_A30294, v17) )
+    {
+      v33 = a2[7];
+      if ( v33 > 3 )
+      {
+        if ( v33 != 4 )
+        {
+          v42[0] = 0;
+          goto LABEL_26;
+        }
+        sub_2CF290((unsigned int)v42, (unsigned int)"loopback:%d", a2[5], v18, v19, v20);
+      }
+      else if ( v33 > 1 )
+      {
+        v36 = &unk_27CC16;
+        if ( !a2[6] )
+          LODWORD(v36) = sub_599F20(a2 + 3, v17, &unk_27CC16);
+        sub_2CF290((unsigned int)v42, (unsigned int)"=%s", (_DWORD)v36, v18, v19, v20);
+      }
+      else if ( v33 )
+      {
+        v34 = &unk_27CC16;
+        v35 = a2[5];
+        if ( !a2[6] )
+          LODWORD(v34) = sub_599F20(a2 + 3, v17, &unk_27CC16);
+        sub_2CF290((unsigned int)v42, (unsigned int)"%s:%d", (_DWORD)v34, v35, v19, v20);
+      }
+      else
+      {
+        sub_2C95A0(a2, v42, 64, 0);
+      }
+      v37 = 1;
+      if ( a2[7] == 4 )
+      {
+  LABEL_27:
+        sub_2C8BC0((unsigned int)dword_A30294, v37, "Sending S2C_CHALLENGE [%u auth %d] to %s\n", 0, v5, v42);
+        goto LABEL_9;
+      }
+  LABEL_26:
+      v37 = 2;
+      goto LABEL_27;
+    }
+  LABEL_9:
+    v21 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pNetworkSystem + 352LL))(g_pNetworkSystem);
+    return (*(__int64 (__fastcall **)(__int64, _QWORD, __int64, _QWORD, __int64, _QWORD))(*(_QWORD *)v21 + 88LL))(
+             v21,
+             (unsigned int)a2[28],
+             v38,
+             (unsigned int)((v40 + 7) >> 3),
+             5,
+             0);
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_SendChallenge.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_SendChallenge.windows.yaml
@@ -1,0 +1,484 @@
+func_name: CNetworkGameServerBase_SendChallenge
+func_va: '0x1800aa980'
+disasm_code: |-
+  .text:00000001800AA980                 mov     [rsp-8+arg_0], rbx
+  .text:00000001800AA985                 mov     [rsp-8+arg_8], rsi
+  .text:00000001800AA98A                 mov     [rsp-8+arg_10], rdi
+  .text:00000001800AA98F                 push    rbp
+  .text:00000001800AA990                 push    r12
+  .text:00000001800AA992                 push    r13
+  .text:00000001800AA994                 push    r14
+  .text:00000001800AA996                 push    r15
+  .text:00000001800AA998                 lea     rbp, [rsp-1A0h]
+  .text:00000001800AA9A0                 sub     rsp, 2A0h
+  .text:00000001800AA9A7                 mov     r13, r8
+  .text:00000001800AA9AA                 mov     rdi, rdx
+  .text:00000001800AA9AD                 mov     rbx, rcx
+  .text:00000001800AA9B0                 lea     rdx, [rbp+1C0h+var_228]
+  .text:00000001800AA9B4                 mov     r8d, 200h
+  .text:00000001800AA9BA                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AA9BF                 mov     r9d, 0FFFFFFFFh
+  .text:00000001800AA9C5                 call    sub_1803FC710
+  .text:00000001800AA9CA                 mov     rax, [rbx]
+  .text:00000001800AA9CD                 mov     rdx, rdi
+  .text:00000001800AA9D0                 mov     rcx, rbx
+  .text:00000001800AA9D3                 ; 0x288 = 648LL = CNetworkGameServerBase_GetChallengeType
+  .text:00000001800AA9D3                 call    qword ptr [rax+288h]; 0x288 = 648LL = CNetworkGameServerBase_GetChallengeType
+  .text:00000001800AA9D9                 mov     edx, 0FFFFFFFFh
+  .text:00000001800AA9DE                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AA9E3                 mov     r8d, 20h ; ' '
+  .text:00000001800AA9E9                 mov     r15d, eax
+  .text:00000001800AA9EC                 call    sub_1803FDED0
+  .text:00000001800AA9F1                 mov     edx, [rsp+2C0h+var_284]
+  .text:00000001800AA9F5                 mov     esi, 0FFh
+  .text:00000001800AA9FA                 mov     r8d, [rsp+2C0h+var_280]
+  .text:00000001800AA9FF                 mov     ecx, edx
+  .text:00000001800AAA01                 sub     ecx, r8d
+  .text:00000001800AAA04                 mov     r12d, 1Fh
+  .text:00000001800AAA0A                 mov     r14d, 7Fh
+  .text:00000001800AAA10                 cmp     ecx, 8
+  .text:00000001800AAA13                 jge     short loc_1800AAA20
+  .text:00000001800AAA15                 mov     [rsp+2C0h+var_280], edx
+  .text:00000001800AAA19                 mov     [rsp+2C0h+var_270], 1
+  .text:00000001800AAA1E                 jmp     short loc_1800AAA8B
+  .text:00000001800AAA20                 mov     eax, r8d
+  .text:00000001800AAA23                 mov     edx, r8d
+  .text:00000001800AAA26                 sar     eax, 5
+  .text:00000001800AAA29                 and     edx, r12d
+  .text:00000001800AAA2C                 movsxd  rcx, eax
+  .text:00000001800AAA2F                 add     r8d, 8
+  .text:00000001800AAA33                 mov     rax, [rsp+2C0h+var_290]
+  .text:00000001800AAA38                 mov     r11d, 41h ; 'A'
+  .text:00000001800AAA3E                 lea     rbx, [rax+rcx*4]
+  .text:00000001800AAA42                 mov     [rsp+2C0h+var_280], r8d
+  .text:00000001800AAA47                 mov     r9d, [rbx]
+  .text:00000001800AAA4A                 movzx   ecx, dl
+  .text:00000001800AAA4D                 rol     r11d, cl
+  .text:00000001800AAA50                 mov     r8d, esi
+  .text:00000001800AAA53                 mov     ecx, edx
+  .text:00000001800AAA55                 mov     r10d, r14d
+  .text:00000001800AAA58                 shl     r8d, cl
+  .text:00000001800AAA5B                 mov     ecx, r12d
+  .text:00000001800AAA5E                 sub     ecx, edx
+  .text:00000001800AAA60                 shr     r10d, cl
+  .text:00000001800AAA63                 mov     eax, r10d
+  .text:00000001800AAA66                 and     eax, 1
+  .text:00000001800AAA69                 mov     ecx, [rbx+rax*4]
+  .text:00000001800AAA6C                 lea     rdx, [rbx+rax*4]
+  .text:00000001800AAA70                 mov     eax, r9d
+  .text:00000001800AAA73                 xor     eax, r11d
+  .text:00000001800AAA76                 and     eax, r8d
+  .text:00000001800AAA79                 xor     r9d, eax
+  .text:00000001800AAA7C                 mov     eax, ecx
+  .text:00000001800AAA7E                 xor     eax, r11d
+  .text:00000001800AAA81                 and     eax, r10d
+  .text:00000001800AAA84                 xor     ecx, eax
+  .text:00000001800AAA86                 mov     [rdx], ecx
+  .text:00000001800AAA88                 mov     [rbx], r9d
+  .text:00000001800AAA8B                 xor     edx, edx
+  .text:00000001800AAA8D                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AAA92                 mov     r8d, 20h ; ' '
+  .text:00000001800AAA98                 call    sub_1803FDED0
+  .text:00000001800AAA9D                 mov     r8d, 20h ; ' '
+  .text:00000001800AAAA3                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AAAA8                 mov     edx, r15d
+  .text:00000001800AAAAB                 call    sub_1803FDED0
+  .text:00000001800AAAB0                 cmp     r15d, 3
+  .text:00000001800AAAB4                 jnz     loc_1800AABCC
+  .text:00000001800AAABA                 cmp     cs:dword_1806129B0, 1
+  .text:00000001800AAAC1                 jnz     short loc_1800AAAF3
+  .text:00000001800AAAC3                 mov     ecx, cs:TlsIndex
+  .text:00000001800AAAC9                 mov     rax, gs:58h
+  .text:00000001800AAAD2                 mov     edx, 68h ; 'h'
+  .text:00000001800AAAD7                 mov     rax, [rax+rcx*8]
+  .text:00000001800AAADB                 mov     eax, [rdx+rax]
+  .text:00000001800AAADE                 cmp     cs:dword_180912320, eax
+  .text:00000001800AAAE4                 jg      loc_1800AADC3
+  .text:00000001800AAAEA                 mov     rbx, cs:qword_180612A30
+  .text:00000001800AAAF1                 jmp     short loc_1800AAAFA
+  .text:00000001800AAAF3                 mov     rbx, cs:qword_1806129BD
+  .text:00000001800AAAFA                 xor     edx, edx
+  .text:00000001800AAAFC                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AAB01                 mov     r8d, 10h
+  .text:00000001800AAB07                 call    sub_1803FDED0
+  .text:00000001800AAB0C                 mov     rdx, rbx
+  .text:00000001800AAB0F                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AAB14                 call    sub_1803FDD90
+  .text:00000001800AAB19                 lea     rcx, off_18060E650
+  .text:00000001800AAB20                 call    cs:SteamInternal_ContextInit
+  .text:00000001800AAB26                 cmp     qword ptr [rax], 0
+  .text:00000001800AAB2A                 jz      short loc_1800AAB4D
+  .text:00000001800AAB2C                 lea     rcx, off_18060E650
+  .text:00000001800AAB33                 call    cs:SteamInternal_ContextInit
+  .text:00000001800AAB39                 mov     rcx, [rax]
+  .text:00000001800AAB3C                 mov     rax, [rcx]
+  .text:00000001800AAB3F                 call    qword ptr [rax+48h]
+  .text:00000001800AAB42                 test    al, al
+  .text:00000001800AAB44                 jz      short loc_1800AAB4D
+  .text:00000001800AAB46                 mov     ebx, 1
+  .text:00000001800AAB4B                 jmp     short loc_1800AAB4F
+  .text:00000001800AAB4D                 xor     ebx, ebx
+  .text:00000001800AAB4F                 mov     ecx, [rsp+2C0h+var_284]
+  .text:00000001800AAB53                 mov     eax, ecx
+  .text:00000001800AAB55                 mov     edx, [rsp+2C0h+var_280]
+  .text:00000001800AAB59                 sub     eax, edx
+  .text:00000001800AAB5B                 cmp     eax, 8
+  .text:00000001800AAB5E                 jge     short loc_1800AAB6E
+  .text:00000001800AAB60                 mov     [rsp+2C0h+var_280], ecx
+  .text:00000001800AAB64                 mov     [rsp+2C0h+var_270], 1
+  .text:00000001800AAB69                 jmp     loc_1800AAC4D
+  .text:00000001800AAB6E                 mov     eax, edx
+  .text:00000001800AAB70                 mov     r11d, edx
+  .text:00000001800AAB73                 sar     eax, 5
+  .text:00000001800AAB76                 add     edx, 8
+  .text:00000001800AAB79                 movsxd  rcx, eax
+  .text:00000001800AAB7C                 and     r11d, r12d
+  .text:00000001800AAB7F                 mov     rax, [rsp+2C0h+var_290]
+  .text:00000001800AAB84                 sub     r12d, r11d
+  .text:00000001800AAB87                 lea     r10, [rax+rcx*4]
+  .text:00000001800AAB8B                 mov     [rsp+2C0h+var_280], edx
+  .text:00000001800AAB8F                 mov     r9d, [r10]
+  .text:00000001800AAB92                 movzx   ecx, r11b
+  .text:00000001800AAB96                 rol     ebx, cl
+  .text:00000001800AAB98                 movzx   ecx, r12b
+  .text:00000001800AAB9C                 shr     r14d, cl
+  .text:00000001800AAB9F                 mov     ecx, r11d
+  .text:00000001800AABA2                 mov     eax, r14d
+  .text:00000001800AABA5                 shl     esi, cl
+  .text:00000001800AABA7                 and     eax, 1
+  .text:00000001800AABAA                 mov     edx, [r10+rax*4]
+  .text:00000001800AABAE                 lea     r8, [r10+rax*4]
+  .text:00000001800AABB2                 xor     edx, ebx
+  .text:00000001800AABB4                 mov     eax, r9d
+  .text:00000001800AABB7                 and     edx, r14d
+  .text:00000001800AABBA                 xor     eax, ebx
+  .text:00000001800AABBC                 xor     [r8], edx
+  .text:00000001800AABBF                 and     eax, esi
+  .text:00000001800AABC1                 xor     eax, r9d
+  .text:00000001800AABC4                 mov     [r10], eax
+  .text:00000001800AABC7                 jmp     loc_1800AAC4D
+  .text:00000001800AABCC                 mov     edx, 1
+  .text:00000001800AABD1                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AABD6                 mov     r8d, 10h
+  .text:00000001800AABDC                 call    sub_1803FDED0
+  .text:00000001800AABE1                 xor     edx, edx
+  .text:00000001800AABE3                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AABE8                 call    sub_1803FDD90
+  .text:00000001800AABED                 mov     edx, [rsp+2C0h+var_284]
+  .text:00000001800AABF1                 mov     eax, edx
+  .text:00000001800AABF3                 mov     ecx, [rsp+2C0h+var_280]
+  .text:00000001800AABF7                 sub     eax, ecx
+  .text:00000001800AABF9                 cmp     eax, 8
+  .text:00000001800AABFC                 jge     short loc_1800AAC09
+  .text:00000001800AABFE                 mov     [rsp+2C0h+var_280], edx
+  .text:00000001800AAC02                 mov     [rsp+2C0h+var_270], 1
+  .text:00000001800AAC07                 jmp     short loc_1800AAC4D
+  .text:00000001800AAC09                 mov     eax, ecx
+  .text:00000001800AAC0B                 mov     r9d, ecx
+  .text:00000001800AAC0E                 sar     eax, 5
+  .text:00000001800AAC11                 add     ecx, 8
+  .text:00000001800AAC14                 movsxd  rdx, eax
+  .text:00000001800AAC17                 and     r9d, r12d
+  .text:00000001800AAC1A                 mov     rax, [rsp+2C0h+var_290]
+  .text:00000001800AAC1F                 sub     r12d, r9d
+  .text:00000001800AAC22                 mov     [rsp+2C0h+var_280], ecx
+  .text:00000001800AAC26                 movzx   ecx, r12b
+  .text:00000001800AAC2A                 shr     r14d, cl
+  .text:00000001800AAC2D                 mov     ecx, r9d
+  .text:00000001800AAC30                 shl     esi, cl
+  .text:00000001800AAC32                 lea     r8, [rax+rdx*4]
+  .text:00000001800AAC36                 not     esi
+  .text:00000001800AAC38                 mov     edx, [r8]
+  .text:00000001800AAC3B                 mov     eax, r14d
+  .text:00000001800AAC3E                 and     eax, 1
+  .text:00000001800AAC41                 not     r14d
+  .text:00000001800AAC44                 and     [r8+rax*4], r14d
+  .text:00000001800AAC48                 and     esi, edx
+  .text:00000001800AAC4A                 mov     [r8], esi
+  .text:00000001800AAC4D                 mov     rdx, r13
+  .text:00000001800AAC50                 lea     rcx, [rsp+2C0h+var_290]
+  .text:00000001800AAC55                 call    sub_1803FDFB0
+  .text:00000001800AAC5A                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800AAC60                 xor     edx, edx
+  .text:00000001800AAC62                 cmp     dword ptr [rdi+1Ch], 4
+  .text:00000001800AAC66                 setnz   dl
+  .text:00000001800AAC69                 inc     edx
+  .text:00000001800AAC6B                 call    cs:LoggingSystem_IsChannelEnabled
+  .text:00000001800AAC71                 test    al, al
+  .text:00000001800AAC73                 jz      loc_1800AAD62
+  .text:00000001800AAC79                 mov     ecx, [rdi+1Ch]
+  .text:00000001800AAC7C                 test    ecx, ecx
+  .text:00000001800AAC7E                 jz      loc_1800AAD1B
+  .text:00000001800AAC84                 sub     ecx, 1
+  .text:00000001800AAC87                 jz      short loc_1800AACE7
+  .text:00000001800AAC89                 sub     ecx, 1
+  .text:00000001800AAC8C                 jz      short loc_1800AACB9
+  .text:00000001800AAC8E                 sub     ecx, 1
+  .text:00000001800AAC91                 jz      short loc_1800AACB9
+  .text:00000001800AAC93                 cmp     ecx, 1
+  .text:00000001800AAC96                 jz      short loc_1800AACA2
+  .text:00000001800AAC98                 mov     [rsp+2C0h+var_268], 0
+  .text:00000001800AAC9D                 jmp     loc_1800AAD32
+  .text:00000001800AACA2                 mov     r8d, [rdi+14h]
+  .text:00000001800AACA6                 lea     rdx, aLoopbackD; "loopback:%d"
+  .text:00000001800AACAD                 lea     rcx, [rsp+2C0h+var_268]
+  .text:00000001800AACB2                 call    sub_180058E30
+  .text:00000001800AACB7                 jmp     short loc_1800AAD32
+  .text:00000001800AACB9                 cmp     dword ptr [rdi+18h], 0
+  .text:00000001800AACBD                 lea     rcx, [rdi+0Ch]
+  .text:00000001800AACC1                 jz      short loc_1800AACCC
+  .text:00000001800AACC3                 lea     rax, unk_180528AFF
+  .text:00000001800AACCA                 jmp     short loc_1800AACD1
+  .text:00000001800AACCC                 call    sub_180110960
+  .text:00000001800AACD1                 mov     r8, rax
+  .text:00000001800AACD4                 lea     rdx, aS_3; "=%s"
+  .text:00000001800AACDB                 lea     rcx, [rsp+2C0h+var_268]
+  .text:00000001800AACE0                 call    sub_180058E30
+  .text:00000001800AACE5                 jmp     short loc_1800AAD32
+  .text:00000001800AACE7                 cmp     dword ptr [rdi+18h], 0
+  .text:00000001800AACEB                 lea     rcx, [rdi+0Ch]
+  .text:00000001800AACEF                 mov     ebx, [rdi+14h]
+  .text:00000001800AACF2                 jz      short loc_1800AACFD
+  .text:00000001800AACF4                 lea     rax, unk_180528AFF
+  .text:00000001800AACFB                 jmp     short loc_1800AAD02
+  .text:00000001800AACFD                 call    sub_180110960
+  .text:00000001800AAD02                 mov     r9d, ebx
+  .text:00000001800AAD05                 lea     rdx, aSD_0; "%s:%d"
+  .text:00000001800AAD0C                 mov     r8, rax
+  .text:00000001800AAD0F                 lea     rcx, [rsp+2C0h+var_268]
+  .text:00000001800AAD14                 call    sub_180058E30
+  .text:00000001800AAD19                 jmp     short loc_1800AAD32
+  .text:00000001800AAD1B                 xor     r9d, r9d
+  .text:00000001800AAD1E                 lea     rdx, [rsp+2C0h+var_268]
+  .text:00000001800AAD23                 mov     r8d, 40h ; '@'
+  .text:00000001800AAD29                 mov     rcx, rdi
+  .text:00000001800AAD2C                 call    cs:?ToString@netadr_t@@QEBAXPEADI_N@Z; netadr_t::ToString(char *,uint,bool)
+  .text:00000001800AAD32                 mov     ecx, cs:dword_1808CC6B8
+  .text:00000001800AAD38                 lea     rax, [rsp+2C0h+var_268]
+  .text:00000001800AAD3D                 xor     edx, edx
+  .text:00000001800AAD3F                 mov     [rsp+2C0h+var_298], rax
+  .text:00000001800AAD44                 cmp     dword ptr [rdi+1Ch], 4
+  .text:00000001800AAD48                 lea     r8, aSendingS2cChal; "Sending S2C_CHALLENGE [%u auth %d] to %"...
+  .text:00000001800AAD4F                 mov     [rsp+2C0h+var_2A0], r15d
+  .text:00000001800AAD54                 setnz   dl
+  .text:00000001800AAD57                 xor     r9d, r9d
+  .text:00000001800AAD5A                 inc     edx
+  .text:00000001800AAD5C                 call    cs:LoggingSystem_Log
+  .text:00000001800AAD62                 mov     rcx, cs:g_pNetworkSystem
+  .text:00000001800AAD69                 mov     rax, [rcx]
+  .text:00000001800AAD6C                 call    qword ptr [rax+160h]
+  .text:00000001800AAD72                 mov     r9d, [rsp+2C0h+var_280]
+  .text:00000001800AAD77                 mov     rcx, rax
+  .text:00000001800AAD7A                 mov     r8, [rsp+2C0h+var_290]
+  .text:00000001800AAD7F                 add     r9d, 7
+  .text:00000001800AAD83                 mov     edx, [rdi+70h]
+  .text:00000001800AAD86                 mov     r10, [rax]
+  .text:00000001800AAD89                 sar     r9d, 3
+  .text:00000001800AAD8D                 mov     [rsp+2C0h+var_298], 0
+  .text:00000001800AAD96                 mov     [rsp+2C0h+var_2A0], 5
+  .text:00000001800AAD9E                 call    qword ptr [r10+58h]
+  .text:00000001800AADA2                 lea     r11, [rsp+2C0h+var_20]
+  .text:00000001800AADAA                 mov     rbx, [r11+30h]
+  .text:00000001800AADAE                 mov     rsi, [r11+38h]
+  .text:00000001800AADB2                 mov     rdi, [r11+40h]
+  .text:00000001800AADB6                 mov     rsp, r11
+  .text:00000001800AADB9                 pop     r15
+  .text:00000001800AADBB                 pop     r14
+  .text:00000001800AADBD                 pop     r13
+  .text:00000001800AADBF                 pop     r12
+  .text:00000001800AADC1                 pop     rbp
+  .text:00000001800AADC2                 retn
+  .text:00000001800AADC3                 lea     rcx, dword_180912320
+  .text:00000001800AADCA                 call    sub_180427558
+  .text:00000001800AADCF                 cmp     cs:dword_180912320, 0FFFFFFFFh
+  .text:00000001800AADD6                 jnz     loc_1800AAAEA
+  .text:00000001800AADDC                 mov     byte ptr cs:qword_180612A30+7, 1
+  .text:00000001800AADE3                 lea     rcx, dword_180912320
+  .text:00000001800AADEA                 and     dword ptr cs:qword_180612A30+4, 0FF000000h
+  .text:00000001800AADF4                 mov     dword ptr cs:qword_180612A30, 0
+  .text:00000001800AADFE                 call    sub_1804274EC
+  .text:00000001800AAE03                 jmp     loc_1800AAAEA
+procedure: |-
+  __int64 __fastcall sub_1800AA980(__int64 a1, netadr_t *a2, __int64 a3)
+  {
+    unsigned int v6; // r15d
+    char v7; // r8
+    int *v8; // rbx
+    int v9; // r11d
+    __int64 v10; // rax
+    int v11; // r9d
+    __int64 v12; // r8
+    __int64 v13; // rbx
+    _QWORD *v14; // rax
+    BOOL v15; // ebx
+    char v16; // dl
+    int *v17; // r10
+    int v18; // r9d
+    int v19; // ebx
+    unsigned int v20; // r14d
+    int v21; // eax
+    int v22; // ecx
+    int *v23; // r8
+    int v24; // edx
+    int v25; // ecx
+    int v26; // ecx
+    int v27; // ecx
+    int v28; // ecx
+    const char *v29; // rax
+    int v30; // ebx
+    const char *v31; // rax
+    __int64 v32; // rax
+    __int64 v34; // [rsp+30h] [rbp-D0h] BYREF
+    int v35; // [rsp+3Ch] [rbp-C4h]
+    int v36; // [rsp+40h] [rbp-C0h]
+    char v37; // [rsp+50h] [rbp-B0h]
+    char v38[64]; // [rsp+58h] [rbp-A8h] BYREF
+    char v39[520]; // [rsp+98h] [rbp-68h] BYREF
+
+    sub_1803FC710(&v34, v39, 512, 0xFFFFFFFFLL);
+    v6 = (*(__int64 (__fastcall **)(__int64, netadr_t *))(*(_QWORD *)a1 + 648LL))(a1, a2);// 0x288 = 648LL = CNetworkGameServerBase_GetChallengeType
+    sub_1803FDED0(&v34, 0xFFFFFFFFLL, 32);
+    v7 = v36;
+    if ( v35 - v36 >= 8 )
+    {
+      v8 = (int *)(v34 + 4LL * (v36 >> 5));
+      v36 += 8;
+      v9 = __ROL4__(65, v7 & 0x1F);
+      v10 = (0x7Fu >> (31 - (v7 & 0x1F))) & 1;
+      v11 = (255 << (v7 & 0x1F)) & (v9 ^ *v8) ^ *v8;
+      v8[v10] ^= (0x7Fu >> (31 - (v7 & 0x1F))) & (v9 ^ v8[v10]);
+      *v8 = v11;
+    }
+    else
+    {
+      v36 = v35;
+      v37 = 1;
+    }
+    sub_1803FDED0(&v34, 0, 32);
+    sub_1803FDED0(&v34, v6, 32);
+    if ( v6 == 3 )
+    {
+      if ( dword_1806129B0 == 1 )
+      {
+        if ( dword_180912320 > *(_DWORD *)(*((_QWORD *)NtCurrentTeb()->ThreadLocalStoragePointer + (unsigned int)TlsIndex)
+                                         + 104LL) )
+        {
+          sub_180427558(&dword_180912320, 104, v12);
+          if ( dword_180912320 == -1 )
+          {
+            HIBYTE(qword_180612A30) = 1;
+            qword_180612A30 &= 0xFF00000000000000uLL;
+            sub_1804274EC(&dword_180912320);
+          }
+        }
+        v13 = qword_180612A30;
+      }
+      else
+      {
+        v13 = qword_1806129BD;
+      }
+      sub_1803FDED0(&v34, 0, 16);
+      sub_1803FDD90(&v34, v13);
+      v15 = false;
+      if ( *(_QWORD *)SteamInternal_ContextInit(&off_18060E650) )
+      {
+        v14 = (_QWORD *)SteamInternal_ContextInit(&off_18060E650);
+        if ( (*(unsigned __int8 (__fastcall **)(_QWORD))(*(_QWORD *)*v14 + 72LL))(*v14) )
+          v15 = true;
+      }
+      v16 = v36;
+      if ( v35 - v36 >= 8 )
+      {
+        v17 = (int *)(v34 + 4LL * (v36 >> 5));
+        v36 += 8;
+        v18 = *v17;
+        v19 = __ROL4__(v15, v16 & 0x1F);
+        v20 = 0x7Fu >> (31 - (v16 & 0x1F));
+        v21 = v19 ^ *v17;
+        v17[v20 & 1] ^= v20 & (v19 ^ v17[v20 & 1]);
+        *v17 = v18 ^ (255 << (v16 & 0x1F)) & v21;
+      }
+      else
+      {
+        v36 = v35;
+        v37 = 1;
+      }
+    }
+    else
+    {
+      sub_1803FDED0(&v34, 1, 16);
+      sub_1803FDD90(&v34, 0);
+      v22 = v36;
+      if ( v35 - v36 >= 8 )
+      {
+        v36 += 8;
+        v23 = (int *)(v34 + 4LL * (v22 >> 5));
+        v24 = *v23;
+        v23[(0x7Fu >> (31 - (v22 & 0x1F))) & 1] &= ~(0x7Fu >> (31 - (v22 & 0x1F)));
+        *v23 = v24 & ~(255 << (v22 & 0x1F));
+      }
+      else
+      {
+        v36 = v35;
+        v37 = 1;
+      }
+    }
+    sub_1803FDFB0(&v34, a3);
+    if ( (unsigned __int8)LoggingSystem_IsChannelEnabled(
+                            (unsigned int)dword_1808CC6B8,
+                            (unsigned int)(*((_DWORD *)a2 + 7) != 4) + 1) )
+    {
+      v25 = *((_DWORD *)a2 + 7);
+      if ( v25 )
+      {
+        v26 = v25 - 1;
+        if ( v26 )
+        {
+          v27 = v26 - 1;
+          if ( v27 && (v28 = v27 - 1) != 0 )
+          {
+            if ( v28 == 1 )
+              sub_180058E30(v38, "loopback:%d", *((_DWORD *)a2 + 5));
+            else
+              v38[0] = 0;
+          }
+          else
+          {
+            if ( *((_DWORD *)a2 + 6) )
+              v29 = (const char *)&unk_180528AFF;
+            else
+              v29 = (const char *)sub_180110960((char *)a2 + 12);
+            sub_180058E30(v38, "=%s", v29);
+          }
+        }
+        else
+        {
+          v30 = *((_DWORD *)a2 + 5);
+          if ( *((_DWORD *)a2 + 6) )
+            v31 = (const char *)&unk_180528AFF;
+          else
+            v31 = (const char *)sub_180110960((char *)a2 + 12);
+          sub_180058E30(v38, "%s:%d", v31, v30);
+        }
+      }
+      else
+      {
+        netadr_t::ToString(a2, v38, 0x40u, 0);
+      }
+      LoggingSystem_Log(
+        (unsigned int)dword_1808CC6B8,
+        (unsigned int)(*((_DWORD *)a2 + 7) != 4) + 1,
+        "Sending S2C_CHALLENGE [%u auth %d] to %s\n",
+        0,
+        v6,
+        v38);
+    }
+    v32 = (*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pNetworkSystem + 352LL))(g_pNetworkSystem);
+    return (*(__int64 (__fastcall **)(__int64, _QWORD, __int64, _QWORD, int, _QWORD))(*(_QWORD *)v32 + 88LL))(
+             v32,
+             *((unsigned int *)a2 + 28),
+             v34,
+             (unsigned int)((v36 + 7) >> 3),
+             5,
+             0);
+  }


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_SendChallenge` preprocessor script (Pattern A): locates the engine-module regular function `CNetworkGameServerBase_SendChallenge` by xref to the debug string `"Sending S2C_CHALLENGE [%u auth %d] to %s\n"`, emitting `func_name/func_sig/func_va/func_rva/func_size`.
- Add `find-CNetworkGameServerBase_GetChallengeType` preprocessor script (Pattern C): resolves the engine vfunc `CNetworkGameServerBase_GetChallengeType` of `CNetworkGameServer_vtable` via LLM_DECOMPILE of `CNetworkGameServerBase_SendChallenge`, emitting the mandatory `vfunc_sig` plus `func_name/vfunc_offset/vfunc_index/vtable_name`.
- Add annotated Windows/Linux reference decompiles for `CNetworkGameServerBase_SendChallenge` (the GetChallengeType vcall is annotated at `[rax+0x288]`/648LL on Windows and `[rax+0x2B0]`/688LL on Linux).
- Register both finders in `configs/14174.yaml` (skill + symbol entries; GetChallengeType categorized as `vfunc` with alias `CNetworkGameServerBase::GetChallengeType`).

## Validation
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (0 compile failures; layout/vtable/record-layout diffs all 0)
- candidate publication: passed; published `gamesymbols/14174.yaml` SHA-256 matches the validated candidate (`sha256:4fca4b5b09a3ee29152b70d84054f6d004a0d36e9fe20430e281eb4c7917eaaf`)
- existing committed branch: 2 initial commit(s) ahead of `origin/main`; supplemental publication commit: created (`chore(gamesymbols): publish 14174 snapshot`)
