### PR TITLE
fix(analyzer): classify absent optional Agent output as skipped

### DIFF
--- a/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
+++ b/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
@@ -41,7 +41,7 @@
         },
         "CBaseEntity::DispatchTraceAttack": {
             "library": "server",
-            "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 FD 31 FF",
+            "linux": "55 66 0F EF C0 48 89 E5 41 57 41 56 41 55 49 89 FD 31 FF",
             "windows": "40 55 53 56 57 41 54 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4D 8B E0",
             "refs": {
                 "strings": [
@@ -226,7 +226,7 @@
             "library": "server",
             "linux": {
                 "factory": "+3 r",
-                "signature": "48 8B 3D ? ? ? ? E8 ? ? ? ? 48 C7 45 ? ? ? ? ? 48 89 DF E8 ? ? ? ? 48 83 C4 ? B8 ? ? ? ? 5B 41 5C 41 5D 41 5E 41 5F 5D C3 E8"
+                "signature": "48 8D 35 ? ? ? ? 89 C2 48 63 46"
             },
             "windows": {
                 "factory": "+3 r",
@@ -414,7 +414,7 @@
         "CEntityInstance::GetEntityIndex": {
             "library": "server",
             "linux": "48 8B 57 ? B8 ? ? ? ? 48 85 D2 0F 84 ? ? ? ? 48 8D 05 ? ? ? ? B9 ? ? ? ? 49 B8 ? ? ? ? ? ? ? ? 48 8B 38 48 81 C7 ? ? ? ? 66 0F 1F 44 00 ? 48 8B B7 ? ? ? ? 48 85 F6 74 ? 48 39 F2 72 ? 48 8D 86 ? ? ? ? 48 39 C2 73 ? 48 89 D0 48 29 F0 48 C1 F8 ? 49 0F AF C0 8D 84 01 ? ? ? ? 85 C0 79 ? 48 8B 37 48 85 F6 74 ? 48 39 F2 72 ? 48 8D 86 ? ? ? ? 48 39 C2 73 ? 48 89 D0 48 29 F0 48 C1 F8 ? 49 0F AF C0 01 C8 79 ? 81 C1 ? ? ? ? 48 83 C7 ? 81 F9 ? ? ? ? 75 ? B8 ? ? ? ? C3 48 8B 37 48 85 F6 75 ? EB ? CC CC CC CC CC 55 48 89 E5 53",
-            "windows": "40 53 48 83 EC 20 4C 8B 41 10 48 8B DA"
+            "windows": "4C 8B 0D ? ? ? ? 48 8B 49 10 49 83 C1 10 48 85 C9 0F 84 ? ? ? ? 45 33 D2 49 BB 25 49 92 24 49 92 24 49"
         },
         "CEntityInstance::GetOrCreatePrivateScriptScope": {
             "library": "server",
@@ -514,7 +514,7 @@
         },
         "CGameEntitySystem::FindEntityByIndex": {
             "library": "server",
-            "linux": "81 FE FE 7F 00 00 77 ? 89 F0",
+            "linux": "31 C0 81 FE FE 7F 00 00 77 ?",
             "windows": "4C 8D 49 10 81 FA ? ? ? ?"
         },
         "CGameEntitySystem::FindInSphere": {
@@ -851,7 +851,7 @@
         "SoundOpGameSystem::DoStartSoundEvent": {
             "library": "server",
             "linux": "55 48 89 E5 41 57 41 56 41 55 49 89 F5 44 89 C6",
-            "windows": "48 8B C4 48 89 48 ? 53 57",
+            "windows": "48 8B C4 48 89 48 ? 53 57 41 55",
             "refs": {
                 "strings": [
                     "%s:  %f tick(%d) curtime(%f) DoStartSoundEvent(%s)\n"
@@ -882,17 +882,6 @@
             "library": "server",
             "linux": "85 D2 74 ? 55 48 89 E5 41 57 41 56 4C 8D B7",
             "windows": "45 85 C0 0F 84 ? ? ? ? 53 41 55"
-        },
-        "StateChanged": {
-            "library": "server",
-            "linux": "80 BF ? ? ? ? ? 0F 85 ? ? ? ? 55 48 89 E5 41 57 49 89 D7",
-            "windows": "40 55 56 57 41 55 48 8D AC 24 68 FF FF FF",
-            "refs": {
-                "strings": [
-                    " ignored FL_FULL_EDICT_CHANGED",
-                    "CNetworkTransmitComponent::StateChanged( overflowed offsets )"
-                ]
-            }
         },
         "StudioModel::GetAttachment": {
             "library": "server",

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -42784,5 +42784,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-07T07:32:31Z'
+last_publish_time: '2026-08-09T11:10:48Z'
 schema_version: 5

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -3637,15 +3637,28 @@ def process_binary(
                 agent_model=agent_model,
                 progress_callback=progress_callback,
             ):
-                success_count += 1
-                print("    Success")
-                _report_skill_status(
-                    reporting,
-                    job_id,
-                    skill_name,
-                    TaskStatus.SUCCEEDED,
-                    ProcessPhase.FINISHED,
-                )
+                optional_output_generated = any(os.path.exists(path) for path in optional_outputs)
+                if not required_outputs and optional_outputs and not optional_output_generated:
+                    skip_count += 1
+                    print("    Skipped: optional outputs not generated")
+                    _report_skill_status(
+                        reporting,
+                        job_id,
+                        skill_name,
+                        TaskStatus.SKIPPED,
+                        ProcessPhase.FINISHED,
+                        reason=ProcessReason.OPTIONAL_OUTPUT_ABSENT,
+                    )
+                else:
+                    success_count += 1
+                    print("    Success")
+                    _report_skill_status(
+                        reporting,
+                        job_id,
+                        skill_name,
+                        TaskStatus.SUCCEEDED,
+                        ProcessPhase.FINISHED,
+                    )
             else:
                 fail_count += 1
                 print("    Failed")

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -2399,6 +2399,102 @@ class TestProcessBinary(unittest.TestCase):
         mock_preprocess.assert_not_called()
         mock_run_skill.assert_called_once()
 
+    def test_process_binary_skip_pp_skips_optional_only_skill_when_agent_writes_no_output(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+            skill_name = "find-optional-agent-skill"
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(ida_analyze_bin, "ensure_mcp_available", return_value=(fake_process, True)),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp") as mock_preprocess,
+                patch.object(ida_analyze_bin, "run_skill", return_value=True) as mock_run_skill,
+                patch.object(ida_analyze_bin, "_report_skill_status") as mock_report_skill_status,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                counts = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": skill_name,
+                            "optional_output": ["OptionalAgentSkill.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    agent="codex",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="",
+                    platform="windows",
+                    max_retries=1,
+                    skip_pp=True,
+                )
+
+        self.assertEqual((0, 0, 1), counts)
+        mock_preprocess.assert_not_called()
+        self.assertEqual([], mock_run_skill.call_args.kwargs["expected_yaml_paths"])
+        mock_report_skill_status.assert_any_call(
+            None,
+            None,
+            skill_name,
+            TaskStatus.SKIPPED,
+            ProcessPhase.FINISHED,
+            reason=ProcessReason.OPTIONAL_OUTPUT_ABSENT,
+        )
+
+    def test_process_binary_skip_pp_succeeds_optional_only_skill_when_agent_writes_output(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            optional_output = binary_dir / "OptionalAgentSkill.windows.yaml"
+            fake_process = object()
+
+            def write_optional_output(*_args, **_kwargs):
+                optional_output.write_text("func_name: OptionalAgentSkill\n", encoding="utf-8")
+                return True
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(ida_analyze_bin, "ensure_mcp_available", return_value=(fake_process, True)),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp") as mock_preprocess,
+                patch.object(ida_analyze_bin, "run_skill", side_effect=write_optional_output),
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                counts = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "find-optional-agent-skill",
+                            "optional_output": ["OptionalAgentSkill.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    agent="codex",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="",
+                    platform="windows",
+                    max_retries=1,
+                    skip_pp=True,
+                )
+
+        self.assertEqual((1, 0, 0), counts)
+        mock_preprocess.assert_not_called()
+
     def test_process_binary_skips_when_all_skip_if_exists_artifacts_exist_before_ida_start(
         self,
     ) -> None:


### PR DESCRIPTION
## 问题

使用 -skip_pp 强制运行 optional-only Agent Skill 时，run_skill 只校验 required_outputs。因为该类 skill 的 required_outputs 为空，Agent 只要退出码为 0，即使没有生成任何 optional output，也会被 process_binary 计为 succeeded。

这会造成无工件的假成功，并且与预处理路径已有的 optional_output_absent / skipped 语义不一致。

## 修复

- Agent 正常退出后检查 optional output 是否实际生成。
- optional-only skill 没有生成任何工件时，增加 skip_count，并上报 SKIPPED / OPTIONAL_OUTPUT_ABSENT。
- 至少生成一个 optional output 时才计为 SUCCEEDED。
- required output 的严格验证，以及 required + optional skill 只强制 required output 的既有语义保持不变。
- 新增回归测试，覆盖 Agent 零工件和成功生成 optional 工件两条路径。

## 候选工件

按照仓库 post-change lifecycle，构建、验证并发布了同一份 14174 immutable candidate：

- Candidate SHA-256: d4e39d46eec88b01b99a476aad3746d1d541062fd7ab4d3b9344251236c11c6b
- Published snapshot SHA-256 与 candidate 完全一致
- 同步更新由该 candidate 生成的 14174 gamedata

## 验证

- uv run python -m unittest tests.test_agent_runner tests.test_ida_analyze_bin tests.test_process_reporter
  - 208 tests passed
- uv run python format_repo_files.py --check
  - passed
- uv run run_cpp_tests.py -gamever 14174 -configyaml configs/14174.yaml -snapshot <immutable-candidate> -debug
  - 13/13 configured tests runnable
  - compile failures: 0
  - invalid test items: 0
  - layout differences: 0