### PR TITLE
fix(preprocessor): report exceptions outside debug mode

### DIFF
--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -42784,5 +42784,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T11:10:48Z'
+last_publish_time: '2026-08-09T12:35:41Z'
 schema_version: 5

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -66,6 +66,7 @@ from ida_skill_preprocessor import (
     PREPROCESS_STATUS_NO_SCRIPT,
     PREPROCESS_STATUS_SUCCESS,
     preprocess_single_skill_via_mcp,
+    report_preprocess_exception,
 )
 from ida_mcp_session import (
     McpConnectionError,
@@ -3487,8 +3488,7 @@ def process_binary(
                         symbol_aliases=symbol_aliases,
                     )
                 except Exception as e:
-                    if debug:
-                        print(f"  Pre-processing error for {skill_name}: {e}")
+                    report_preprocess_exception(skill_name, "runner dispatch", e, debug=debug)
                     preprocess_status = PREPROCESS_STATUS_FAILED
 
             if preprocess_status is True or preprocess_status == PREPROCESS_STATUS_SUCCESS:

--- a/ida_preprocessor_scripts/find-CSource2Server_vtable2.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_vtable2.py
@@ -202,11 +202,8 @@ async def preprocess_skill(
     if not output_path or not isinstance(main_data, dict):
         return False
 
-    try:
-        main_vtable_va = _parse_int(main_data["vtable_va"])
-        selected = await _lookup_vtable2(session, platform, main_vtable_va, image_base, debug)
-    except Exception:
-        return False
+    main_vtable_va = _parse_int(main_data["vtable_va"])
+    selected = await _lookup_vtable2(session, platform, main_vtable_va, image_base, debug)
 
     if not isinstance(selected, dict):
         return False

--- a/ida_skill_preprocessor.py
+++ b/ida_skill_preprocessor.py
@@ -10,6 +10,8 @@ and delegates preprocessing to the script's exported method.
 import importlib.util
 import inspect
 import re
+import sys
+import traceback
 from pathlib import Path
 
 from ida_analyze_util import parse_mcp_result
@@ -35,6 +37,15 @@ PREPROCESS_STATUS_SUCCESS = PreprocessStatus("success", True)
 PREPROCESS_STATUS_FAILED = PreprocessStatus("failed", False)
 PREPROCESS_STATUS_ABSENT_OK = PreprocessStatus("absent_ok", True)
 PREPROCESS_STATUS_NO_SCRIPT = PreprocessStatus("no_script", False)
+
+
+def report_preprocess_exception(skill_name, phase, exc, debug=False):
+    exception_type = type(exc).__name__
+    exception_message = str(exc)
+    exception_details = f"{exception_type}: {exception_message}" if exception_message else exception_type
+    print(f"    Preprocess error [{phase}] for {skill_name}: {exception_details}")
+    if debug:
+        traceback.print_exception(type(exc), exc, exc.__traceback__, file=sys.stdout)
 
 
 def _normalize_preprocess_status(result):
@@ -71,8 +82,7 @@ def _get_preprocess_entry(skill_name, debug=False):
     try:
         spec.loader.exec_module(module)
     except Exception as e:
-        if debug:
-            print(f"    Preprocess: failed to import script {script_path}: {e}")
+        report_preprocess_exception(skill_name, "script import", e, debug=debug)
         _SCRIPT_ENTRY_CACHE[skill_name] = None
         return None
 
@@ -196,12 +206,10 @@ async def preprocess_single_skill_via_mcp(
                     result = await result
                 return _normalize_preprocess_status(result)
             except Exception as e:
-                if debug:
-                    print(f"    Preprocess: script execution failed for {skill_name}: {e}")
+                report_preprocess_exception(skill_name, "script execution", e, debug=debug)
                 return PREPROCESS_STATUS_FAILED
 
     except Exception as e:
-        if debug:
-            print(f"  Preprocess MCP connection error for {skill_name}: {e}")
+        report_preprocess_exception(skill_name, "MCP session", e, debug=debug)
 
     return PREPROCESS_STATUS_FAILED

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -2799,6 +2799,61 @@ class TestProcessBinary(unittest.TestCase):
         )
         mock_run_skill.assert_called_once()
 
+    def test_process_binary_reports_unexpected_preprocess_exception_before_fallback(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "libengine2.so")
+            fake_process = object()
+
+            with (
+                patch.object(ida_analyze_bin, "start_idalib_mcp", return_value=fake_process),
+                patch.object(
+                    ida_analyze_bin,
+                    "ensure_mcp_available",
+                    return_value=(fake_process, True),
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_validate_expected_input_artifacts_via_mcp",
+                    return_value=[],
+                ),
+                patch.object(
+                    ida_analyze_bin,
+                    "_run_preprocess_single_skill_via_mcp",
+                    side_effect=RuntimeError("runner exploded"),
+                ),
+                patch.object(ida_analyze_bin, "report_preprocess_exception") as mock_report_exception,
+                patch.object(ida_analyze_bin, "run_skill", return_value=True) as mock_run_skill,
+                patch.object(ida_analyze_bin, "quit_ida_gracefully", return_value=None),
+            ):
+                success, fail, skip = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "a_preprocess_raises",
+                            "expected_output": ["A.{platform}.yaml"],
+                            "expected_input": [],
+                        },
+                    ],
+                    old_binary_dir=None,
+                    platform="windows",
+                    agent="codex",
+                    max_retries=1,
+                    debug=False,
+                    host="127.0.0.1",
+                    port=39091,
+                    ida_args=None,
+                )
+
+        self.assertEqual((1, 0, 0), (success, fail, skip))
+        mock_report_exception.assert_called_once()
+        self.assertEqual("a_preprocess_raises", mock_report_exception.call_args.args[0])
+        self.assertEqual("runner dispatch", mock_report_exception.call_args.args[1])
+        self.assertIsInstance(mock_report_exception.call_args.args[2], RuntimeError)
+        self.assertFalse(mock_report_exception.call_args.kwargs["debug"])
+        mock_run_skill.assert_called_once()
+
     def test_process_binary_skips_vcall_targets_after_preprocess_fallback_failure(self) -> None:
         with TemporaryDirectory() as temp_dir:
             binary_dir = Path(temp_dir) / "bin" / "14141" / "engine"

--- a/tests/test_ida_preprocessor_contracts_misc.py
+++ b/tests/test_ida_preprocessor_contracts_misc.py
@@ -498,6 +498,31 @@ class TestCanonicalVtablePreprocessors(unittest.IsolatedAsyncioTestCase):
                     written_payload["vtable_symbol"],
                 )
 
+    async def test_source2_server_vtable2_propagates_lookup_errors(self) -> None:
+        module = _load_module(
+            Path("ida_preprocessor_scripts/find-CSource2Server_vtable2.py"),
+            "diagnostic_CSource2Server_vtable2",
+        )
+        with (
+            patch.object(module, "_read_yaml", return_value={"vtable_va": "0x1"}),
+            patch.object(
+                module,
+                "_lookup_vtable2",
+                AsyncMock(side_effect=RuntimeError("lookup exploded")),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "lookup exploded"):
+                await module.preprocess_skill(
+                    session="session",
+                    skill_name="skill",
+                    expected_outputs=["tmp/CSource2Server_vtable2.windows.yaml"],
+                    old_yaml_map={},
+                    new_binary_dir="bin_dir",
+                    platform="windows",
+                    image_base=0x180000000,
+                    debug=False,
+                )
+
 
 class TestFindOnServerVoiceDataIsPlayingDemoCallee(unittest.IsolatedAsyncioTestCase):
     async def test_generates_patch_yaml_from_unique_vfunc_signature_match(self) -> None:

--- a/tests/test_ida_skill_preprocessor.py
+++ b/tests/test_ida_skill_preprocessor.py
@@ -1,5 +1,7 @@
 import types
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import ida_skill_preprocessor
@@ -20,7 +22,7 @@ class TestPreprocessSingleSkillViaMcp(unittest.IsolatedAsyncioTestCase):
         self.open_session_patcher = patch.object(
             ida_skill_preprocessor,
             "open_ida_mcp_session",
-            return_value=_async_context(_FakeClientSession("read-stream", "write-stream")),
+            side_effect=lambda *args, **kwargs: _async_context(_FakeClientSession("read-stream", "write-stream")),
         )
         self.open_session_patcher.start()
         self.addCleanup(self.open_session_patcher.stop)
@@ -406,6 +408,50 @@ class TestPreprocessSingleSkillViaMcp(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("success", result)
         self.assertEqual(0x180000000, received["args"]["image_base"])
         self.assertTrue(received["args"]["debug"])
+
+    async def test_reports_script_exceptions_without_requiring_debug(self) -> None:
+        async def fake_preprocess_skill(**kwargs):
+            raise RuntimeError("exploded")
+
+        for debug in (False, True):
+            with self.subTest(debug=debug):
+                output = StringIO()
+                with (
+                    patch.object(
+                        ida_skill_preprocessor,
+                        "_get_preprocess_entry",
+                        return_value=fake_preprocess_skill,
+                    ),
+                    patch.object(
+                        ida_skill_preprocessor,
+                        "open_ida_mcp_session",
+                        return_value=_async_context(_FakeClientSession("read-stream", "write-stream")),
+                    ),
+                    patch.object(
+                        ida_skill_preprocessor,
+                        "parse_mcp_result",
+                        return_value={"result": "0x180000000"},
+                    ),
+                    redirect_stdout(output),
+                ):
+                    result = await ida_skill_preprocessor.preprocess_single_skill_via_mcp(
+                        host="127.0.0.1",
+                        port=13337,
+                        skill_name="find-CNetworkMessages_FindNetworkGroup",
+                        expected_outputs=["out.yaml"],
+                        old_yaml_map={},
+                        new_binary_dir="bin_dir",
+                        platform="windows",
+                        debug=debug,
+                    )
+
+                diagnostic = output.getvalue()
+                self.assertEqual("failed", result)
+                self.assertIn(
+                    "Preprocess error [script execution] for find-CNetworkMessages_FindNetworkGroup: RuntimeError: exploded",
+                    diagnostic,
+                )
+                self.assertEqual(debug, "Traceback (most recent call last):" in diagnostic)
 
     async def test_normalizes_script_statuses(self) -> None:
         cases = [


### PR DESCRIPTION
## Summary
- report preprocessor exception type and message in non-debug mode
- include tracebacks only when debug output is enabled
- propagate the CSource2Server vtable lookup exception to the unified diagnostic path
- add regression coverage for dispatcher, runner fallback, and script propagation
- publish the validated 14174 symbol candidate

## Validation
- `uv run python format_repo_files.py --check`
- `uv run python -m unittest tests.test_ida_analyze_bin tests.test_ida_skill_preprocessor tests.test_ida_preprocessor_contracts_misc` (188 tests)
- `uv run run_cpp_tests.py -gamever 14174 -configyaml configs/14174.yaml -snapshot <validated-candidate> -debug` (13 runnable tests, 0 failures/differences)