### PR TITLE
refactor(analyzer): remove legacy preprocess fallback

### DIFF
--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -1585,26 +1585,7 @@ def _run_preprocess_single_skill_via_mcp(
         "symbol_aliases": symbol_aliases,
     }
 
-    try:
-        return asyncio.run(preprocess_single_skill_via_mcp(**preprocess_kwargs))
-    except TypeError as exc:
-        if "unexpected keyword argument" not in str(exc):
-            raise
-
-        fallback_kwargs = dict(preprocess_kwargs)
-        fallback_kwargs.pop("llm_model", None)
-        fallback_kwargs.pop("llm_apikey", None)
-        fallback_kwargs.pop("llm_baseurl", None)
-        fallback_kwargs.pop("llm_temperature", None)
-        fallback_kwargs.pop("llm_effort", None)
-        fallback_kwargs.pop("llm_fake_as", None)
-        fallback_kwargs.pop("llm_max_retries", None)
-        fallback_kwargs.pop("symbol_aliases", None)
-        fallback_kwargs.pop("expected_inputs", None)
-        fallback_kwargs.pop("optional_inputs", None)
-        fallback_kwargs.pop("expected_binary", None)
-        fallback_kwargs.pop("explicit_database", None)
-        return asyncio.run(preprocess_single_skill_via_mcp(**fallback_kwargs))
+    return asyncio.run(preprocess_single_skill_via_mcp(**preprocess_kwargs))
 
 
 def _optional_config_description(value, owner):


### PR DESCRIPTION
## Summary
- remove the legacy unexpected-keyword compatibility retry around preprocess_single_skill_via_mcp
- always preserve MCP database/binary binding, input paths, and LLM configuration on the single preprocess invocation

## Validation
- uv run python -m unittest tests.test_ida_analyze_bin -v (164 tests passed)
- git diff --check (passed)
- uv run ruff check ida_analyze_bin.py (reports pre-existing F401 for the unused yaml import at line 55)