### PR TITLE
CNetworkGameServerBase_CheckPassword

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -824,6 +824,12 @@ modules:
           - CNetworkGameServer_GetFreeClient.{platform}.yaml
         expected_input:
           - CNetworkGameServerBase_ConnectClient.{platform}.yaml
+      - name: find-CNetworkGameServerBase_CheckPassword
+        expected_output:
+          - CNetworkGameServerBase_CheckPassword.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_ConnectClient.{platform}.yaml
+          - CNetworkGameServer_vtable.{platform}.yaml
       - name: find-CNetworkGameServerBase_CreateFakeClient
         expected_output:
           - CNetworkGameServerBase_CreateFakeClient.{platform}.yaml
@@ -2294,6 +2300,10 @@ modules:
         category: func
         alias:
           - CNetworkGameServerBase::ConnectClient
+      - name: CNetworkGameServerBase_CheckPassword
+        category: vfunc
+        alias:
+          - CNetworkGameServerBase::CheckPassword
       - name: CNetworkGameServerBase_vtable
         category: vtable
       - name: CNetworkGameServerBase_GetClientConnectionType

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10595,9 +10595,9 @@ files:
     vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_CheckPassword.linux.yaml:
     func_name: CNetworkGameServerBase_CheckPassword
-    vfunc_index: 87
-    vfunc_offset: '0x2b8'
-    vfunc_sig: FF 90 B8 02 00 00 88 85 ?? FC FF FF
+    vfunc_index: 85
+    vfunc_offset: '0x2a8'
+    vfunc_sig: FF 90 A8 02 00 00 84 C0
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_CheckPassword.windows.yaml:
     func_name: CNetworkGameServerBase_CheckPassword
@@ -10659,22 +10659,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10853,26 +10847,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12493,7 +12493,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12502,7 +12502,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:70f1e218c5a2f3099b1a1a81b89e648503b4d14a6d3ae2861450ef4b4359dd44
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10593,6 +10593,18 @@ files:
     vfunc_index: 49
     vfunc_offset: '0x188'
     vtable_name: CNetworkGameServerBase_vtable
+  engine/CNetworkGameServerBase_CheckPassword.linux.yaml:
+    func_name: CNetworkGameServerBase_CheckPassword
+    vfunc_index: 87
+    vfunc_offset: '0x2b8'
+    vfunc_sig: FF 90 B8 02 00 00 88 85 ?? FC FF FF
+    vtable_name: CNetworkGameServer_vtable
+  engine/CNetworkGameServerBase_CheckPassword.windows.yaml:
+    func_name: CNetworkGameServerBase_CheckPassword
+    vfunc_index: 82
+    vfunc_offset: '0x290'
+    vfunc_sig: FF 90 90 02 00 00 84 C0
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_CheckTimeouts.linux.yaml:
     func_name: CNetworkGameServerBase_CheckTimeouts
     func_rva: '0x4f9c00'
@@ -10647,16 +10659,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10853,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12493,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12502,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -42784,5 +42796,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T11:02:27Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckPassword.py
+++ b/ida_preprocessor_scripts/find-CNetworkGameServerBase_CheckPassword.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkGameServerBase_CheckPassword skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+
+TARGET_FUNCTION_NAMES = [
+    "CNetworkGameServerBase_CheckPassword",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CNetworkGameServerBase_CheckPassword",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_ConnectClient.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_ConnectClient.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CNetworkGameServerBase_CheckPassword", "CNetworkGameServer_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # vfunc_sig is MANDATORY for Pattern C (LLM_DECOMPILE vfunc).
+    (
+        "CNetworkGameServerBase_CheckPassword",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate CNetworkGameServerBase_CheckPassword from ConnectClient via LLM decompile."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ConnectClient.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ConnectClient.linux.yaml
@@ -257,7 +257,7 @@ disasm_code: |-
   .text:000000000068D5D2                 mov     rsi, rbx
   .text:000000000068D5D5                 mov     rcx, [rbp+var_3C0]
   .text:000000000068D5DC                 mov     rax, [rdi]
-  .text:000000000068D5DF                 call    qword ptr [rax+2A8h]
+  .text:000000000068D5DF                 call    qword ptr [rax+2A8h] ; 2A8h = CNetworkGameServerBase_CheckPassword
   .text:000000000068D5E5                 test    al, al
   .text:000000000068D5E7                 jz      loc_68DF50
   .text:000000000068D5ED                 mov     rax, [rbp+var_3B8]
@@ -2050,7 +2050,7 @@ procedure: |-
       }
     }
     v30 = a3;
-    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64, __int64, const char *))(*(_QWORD *)a1 + 680LL))(
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64, __int64, const char *))(*(_QWORD *)a1 + 680LL))( // 680LL = 0x2A8 = CNetworkGameServerBase_CheckPassword
             a1,
             a3,
             a6,

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ConnectClient.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_ConnectClient.windows.yaml
@@ -221,7 +221,7 @@ disasm_code: |-
   .text:00000001800B188C                 mov     r8, rdi
   .text:00000001800B188F                 mov     rdx, r14
   .text:00000001800B1892                 mov     rcx, r12
-  .text:00000001800B1895                 call    qword ptr [rax+280h]
+  .text:00000001800B1895                 call    qword ptr [rax+280h] ; 280h = CNetworkGameServerBase_CheckPassword
   .text:00000001800B189B                 test    al, al
   .text:00000001800B189D                 jnz     short loc_1800B18FC
   .text:00000001800B189F                 mov     ecx, cs:dword_1808C87C0
@@ -1103,7 +1103,7 @@ procedure: |-
         0);
       return 0;
     }
-    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64, __int64, const char *))(*(_QWORD *)a1 + 640LL))(
+    if ( !(*(unsigned __int8 (__fastcall **)(__int64, __int64, __int64, const char *))(*(_QWORD *)a1 + 640LL))( // 640LL = 0x280 = CNetworkGameServerBase_CheckPassword
             a1,
             a3,
             a6,


### PR DESCRIPTION
## Summary
- Add `find-CNetworkGameServerBase_CheckPassword` (Pattern C, engine module): locates `CNetworkGameServerBase::CheckPassword`, a vfunc of `CNetworkGameServer_vtable`, via LLM_DECOMPILE of the predecessor `CNetworkGameServerBase_ConnectClient`.
- Annotate the CheckPassword vfunc call site in the existing `CNetworkGameServerBase_ConnectClient.{windows,linux}.yaml` reference files (both `disasm_code` and `procedure`), preserving prior `CNetworkGameServer_GetFreeClient` annotations.
- Add the `configs/14174.yaml` skill entry (expected_output `CheckPassword`; expected_input `ConnectClient` + `CNetworkGameServer_vtable`) and the `vfunc` symbol entry (alias `CNetworkGameServerBase::CheckPassword`).
- Resolved slots (against `CNetworkGameServer_vtable`): Windows vfunc_index 82 / vfunc_offset 0x290; Linux vfunc_index 87 / vfunc_offset 0x2b8.

## Validation
- scoped analyzer (`ida_analyze_bin.py -oldgamever none -modules engine -skill find-CNetworkGameServerBase_CheckPassword`): Failed: 0, Skipped: 0; both `CheckPassword.{windows,linux}.yaml` produced via the LLM_DECOMPILE path.
- non-MCP unittest suite: Ran 1064 tests, OK (skipped=3), 0 failures.
- candidate preparation: passed for `14174` (candidate SHA-256 `95a1813c97cb16b93a602612a1c0b577b6826edc1a06a0544ba03974de93e1f7`).
- C++ post-change validation: passed with runnable tests and zero failures (Compile failures 0; Invalid test items 0; Layout compares 14 / diffs 0; VTable compares 12 / diffs 0; Record layout compares 2 / diffs 0).
- candidate publication: passed; published `gamesymbols/14174.yaml` SHA-256 equals the validated candidate SHA-256.
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created (`chore(gamesymbols): publish 14174 snapshot`).

Note: the republished `gamesymbols/14174.yaml` also refreshes previously-stale entries for symbols already present on `main` (IGameSystem_SetName, CNetworkGameServerBase_FillServerInfo/IsChangelevelPending/IsHLTV, CServerSideClientBase_SendServerInfo) to current analysis values; C++ validation confirms zero layout/vtable/record differences.
