### PR TITLE
CSource2Server_GetAllServerClasses

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -600,6 +600,11 @@ modules:
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
           - CNetworkGameServerBase_Shutdown.{platform}.yaml
+      - name: find-CSource2Server_GetAllServerClasses
+        expected_output:
+          - CSource2Server_GetAllServerClasses.{platform}.yaml
+        expected_input:
+          - CNetworkGameServer_Shutdown.{platform}.yaml
       - name: find-CNetworkGameServer_SpawnServer
         expected_output:
           - CNetworkGameServer_SpawnServer.{platform}.yaml
@@ -2443,6 +2448,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::Shutdown
+      - name: CSource2Server_GetAllServerClasses
+        category: vfunc
+        alias:
+          - CSource2Server::GetAllServerClasses
       - name: CNetworkGameServer_SpawnServer
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:f716b379f77603d975c07a97889be9a25ecc21384090b53427eee6ded9853dc1
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -12927,6 +12927,18 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
+  engine/CSource2Server_GetAllServerClasses.linux.yaml:
+    func_name: CSource2Server_GetAllServerClasses
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vfunc_sig: FF 90 E8 00 00 00 48 89 C2 48 8B 40 ?? 48 63 12 48 8D 0C D0
+    vtable_name: CSource2Server_vtable
+  engine/CSource2Server_GetAllServerClasses.windows.yaml:
+    func_name: CSource2Server_GetAllServerClasses
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vfunc_sig: FF 90 E8 00 00 00 48 8B 48 ??
+    vtable_name: CSource2Server_vtable
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -42784,5 +42796,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T16:16:09Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
@@ -34,7 +34,7 @@ FUNC_VTABLE_RELATIONS = [
     # concrete body lives in the server module, so no CSource2Server_vtable YAML is
     # consumed here. The vfunc_sig anchors on the vcall instruction inside the
     # engine predecessor CNetworkGameServer_Shutdown.
-    ("CSource2Server_GetAllServerClasses", "CSource2Server_vtable"),
+    ("CSource2Server_GetAllServerClasses", "CSource2Server"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [

--- a/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GetAllServerClasses skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GetAllServerClasses",
+]
+
+# CSource2Server::GetAllServerClasses is a vfunc whose concrete body lives in the
+# server module (libserver.so / server.dll). The engine predecessor
+# CNetworkGameServer_Shutdown reaches it through a register-indirect vcall on the
+# CSource2Server interface (g_pSource2Server): `call qword ptr [rax+0E8h]`. The
+# skill runs in the ENGINE module (where the predecessor is renamed/available) and
+# produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
+# matching the IGameTypes / CEngineServer_UnloadSpawnGroup offset pattern. The same
+# predecessor holds the vcall on both platforms.
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CSource2Server_GetAllServerClasses",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServer_Shutdown.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServer_Shutdown.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class) -- vtable_name is metadata only; CSource2Server's
+    # concrete body lives in the server module, so no CSource2Server_vtable YAML is
+    # consumed here. The vfunc_sig anchors on the vcall instruction inside the
+    # engine predecessor CNetworkGameServer_Shutdown.
+    ("CSource2Server_GetAllServerClasses", "CSource2Server_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "CSource2Server_GetAllServerClasses",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the engine predecessor CNetworkGameServer_Shutdown."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.linux.yaml
@@ -1,0 +1,72 @@
+func_name: CNetworkGameServer_Shutdown
+func_va: '0x5151a0'
+disasm_code: |-
+  .text:00000000005151A0                 push    rbp
+  .text:00000000005151A1                 mov     rbp, rsp
+  .text:00000000005151A4                 push    rbx
+  .text:00000000005151A5                 mov     rbx, rdi
+  .text:00000000005151A8                 sub     rsp, 8
+  .text:00000000005151AC                 call    sub_575B00
+  .text:00000000005151B1                 mov     rdi, rax
+  .text:00000000005151B4                 call    sub_5769C0
+  .text:00000000005151B9                 mov     rdi, rbx
+  .text:00000000005151BC                 call    CNetworkGameServerBase_Shutdown
+  .text:00000000005151C1                 lea     rax, g_pSource2Server
+  .text:00000000005151C8                 mov     rdi, [rax]
+  .text:00000000005151CB                 test    rdi, rdi
+  .text:00000000005151CE                 jz      short loc_515213
+  .text:00000000005151D0                 mov     rax, [rdi]
+  .text:00000000005151D3                 ; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:00000000005151D3                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:00000000005151D9                 mov     rdx, rax
+  .text:00000000005151DC                 mov     rax, [rax+8]
+  .text:00000000005151E0                 movsxd  rdx, dword ptr [rdx]
+  .text:00000000005151E3                 lea     rcx, [rax+rdx*8]
+  .text:00000000005151E7                 cmp     rcx, rax
+  .text:00000000005151EA                 jz      short loc_515213
+  .text:00000000005151EC                 nop     word ptr [rax+rax+00000000h]
+  .text:00000000005151F7                 nop     word ptr [rax+rax+00000000h]
+  .text:0000000000515200                 mov     rdx, [rax]
+  .text:0000000000515203                 add     rax, 8
+  .text:0000000000515207                 mov     dword ptr [rdx+2Ch], 0FFFFFFFFh
+  .text:000000000051520E                 cmp     rax, rcx
+  .text:0000000000515211                 jnz     short loc_515200
+  .text:0000000000515213                 mov     rdi, rbx
+  .text:0000000000515216                 call    sub_50AEE0
+  .text:000000000051521B                 lea     rdi, aDeactivatestea; "DeactivateSteamGameServer(start)"
+  .text:0000000000515222                 xor     eax, eax
+  .text:0000000000515224                 call    sub_2CA1C0
+  .text:0000000000515229                 mov     rdi, rbx
+  .text:000000000051522C                 call    sub_4F7A90
+  .text:0000000000515231                 lea     rdi, aDeactivatestea_0; "DeactivateSteamGameServer(finished)"
+  .text:0000000000515238                 xor     eax, eax
+  .text:000000000051523A                 call    sub_2CA1C0
+  .text:000000000051523F                 lea     rdi, qword_C6FA00
+  .text:0000000000515246                 mov     rbx, [rbp+var_8]
+  .text:000000000051524A                 leave
+  .text:000000000051524B                 jmp     sub_5570B0
+procedure: |-
+  __int64 __fastcall CNetworkGameServer_Shutdown(__int64 a1)
+  {
+    __int64 v1; // rax
+    int *v2; // rdx
+    __int64 *v3; // rax
+    __int64 *i; // rcx
+    __int64 v5; // rdx
+
+    v1 = sub_575B00();
+    sub_5769C0(v1);
+    CNetworkGameServerBase_Shutdown(a1);
+    if ( g_pSource2Server )
+    {
+      v2 = (int *)(*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+      v3 = *((__int64 **)v2 + 1);
+      for ( i = &v3[*v2]; v3 != i; *(_DWORD *)(v5 + 44) = -1 )
+        v5 = *v3++;
+    }
+    sub_50AEE0(a1);
+    sub_2CA1C0("DeactivateSteamGameServer(start)");
+    sub_4F7A90(a1);
+    sub_2CA1C0("DeactivateSteamGameServer(finished)");
+    return sub_5570B0(&qword_C6FA00);
+  }

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.windows.yaml
@@ -1,0 +1,188 @@
+func_name: CNetworkGameServer_Shutdown
+func_va: '0x18009c210'
+disasm_code: |-
+  .text:000000018009C210                 push    rbp
+  .text:000000018009C212                 sub     rsp, 20h
+  .text:000000018009C216                 cmp     cs:byte_1806129BC, 0
+  .text:000000018009C21D                 mov     [rsp+28h+arg_0], rbx
+  .text:000000018009C222                 mov     rbx, rcx
+  .text:000000018009C225                 mov     [rsp+28h+arg_10], rdi
+  .text:000000018009C22A                 jz      short loc_18009C241
+  .text:000000018009C22C                 xor     edx, edx
+  .text:000000018009C22E                 mov     cs:byte_1806129BC, 0
+  .text:000000018009C235                 lea     rcx, off_180612910
+  .text:000000018009C23C                 call    CSteam3Server_SendUpdatedServerDetails
+  .text:000000018009C241                 mov     rcx, rbx
+  .text:000000018009C244                 call    CNetworkGameServerBase_Shutdown
+  .text:000000018009C249                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009C250                 test    rcx, rcx
+  .text:000000018009C253                 jz      short loc_18009C283
+  .text:000000018009C255                 mov     rax, [rcx]
+  .text:000000018009C258                 ; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:000000018009C258                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:000000018009C25E                 mov     rcx, [rax+8]
+  .text:000000018009C262                 movsxd  rax, dword ptr [rax]
+  .text:000000018009C265                 lea     rdx, [rcx+rax*8]
+  .text:000000018009C269                 cmp     rcx, rdx
+  .text:000000018009C26C                 jz      short loc_18009C283
+  .text:000000018009C26E                 xchg    ax, ax
+  .text:000000018009C270                 mov     rax, [rcx]
+  .text:000000018009C273                 add     rcx, 8
+  .text:000000018009C277                 mov     dword ptr [rax+2Ch], 0FFFFFFFFh
+  .text:000000018009C27E                 cmp     rcx, rdx
+  .text:000000018009C281                 jnz     short loc_18009C270
+  .text:000000018009C283                 xor     ebp, ebp
+  .text:000000018009C285                 mov     [rsp+28h+arg_8], rsi
+  .text:000000018009C28A                 mov     edi, ebp
+  .text:000000018009C28C                 cmp     [rbx+2C0h], ebp
+  .text:000000018009C292                 jle     short loc_18009C2DC
+  .text:000000018009C294                 mov     esi, ebp
+  .text:000000018009C296                 nop     word ptr [rax+rax+00000000h]
+  .text:000000018009C2A0                 mov     rax, [rbx+2C8h]
+  .text:000000018009C2A7                 mov     rdx, rbx
+  .text:000000018009C2AA                 mov     rcx, [rsi+rax]
+  .text:000000018009C2AE                 mov     rax, [rcx]
+  .text:000000018009C2B1                 call    qword ptr [rax+8]
+  .text:000000018009C2B4                 mov     rax, [rbx+2C8h]
+  .text:000000018009C2BB                 mov     rcx, [rsi+rax]
+  .text:000000018009C2BF                 test    rcx, rcx
+  .text:000000018009C2C2                 jz      short loc_18009C2CE
+  .text:000000018009C2C4                 mov     rax, [rcx]
+  .text:000000018009C2C7                 mov     edx, 1
+  .text:000000018009C2CC                 call    qword ptr [rax]
+  .text:000000018009C2CE                 inc     edi
+  .text:000000018009C2D0                 add     rsi, 8
+  .text:000000018009C2D4                 cmp     edi, [rbx+2C0h]
+  .text:000000018009C2DA                 jl      short loc_18009C2A0
+  .text:000000018009C2DC                 mov     eax, [rbx+328h]
+  .text:000000018009C2E2                 mov     [rbx+2C0h], ebp
+  .text:000000018009C2E8                 test    eax, eax
+  .text:000000018009C2EA                 jnz     short loc_18009C32D
+  .text:000000018009C2EC                 mov     rdi, [rbx+318h]
+  .text:000000018009C2F3                 movsxd  rax, dword ptr [rbx+310h]
+  .text:000000018009C2FA                 lea     rsi, [rdi+rax*8]
+  .text:000000018009C2FE                 cmp     rdi, rsi
+  .text:000000018009C301                 jz      short loc_18009C327
+  .text:000000018009C303                 nop     dword ptr [rax+00h]
+  .text:000000018009C307                 nop     word ptr [rax+rax+00000000h]
+  .text:000000018009C310                 mov     r8d, [rdi+4]
+  .text:000000018009C314                 mov     rcx, rbx
+  .text:000000018009C317                 mov     edx, [rdi]
+  .text:000000018009C319                 call    CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal
+  .text:000000018009C31E                 add     rdi, 8
+  .text:000000018009C322                 cmp     rdi, rsi
+  .text:000000018009C325                 jnz     short loc_18009C310
+  .text:000000018009C327                 mov     [rbx+310h], ebp
+  .text:000000018009C32D                 lea     rcx, aDeactivatestea; "DeactivateSteamGameServer(start)"
+  .text:000000018009C334                 call    cs:COM_TimestampedLog
+  .text:000000018009C33A                 mov     rax, [rbx]
+  .text:000000018009C33D                 mov     rcx, rbx
+  .text:000000018009C340                 call    qword ptr [rax+178h]
+  .text:000000018009C346                 mov     rdi, [rsp+28h+arg_10]
+  .text:000000018009C34B                 mov     rsi, [rsp+28h+arg_8]
+  .text:000000018009C350                 test    al, al
+  .text:000000018009C352                 jz      short loc_18009C38E
+  .text:000000018009C354                 cmp     [rbx+2B8h], bpl
+  .text:000000018009C35B                 jnz     short loc_18009C38E
+  .text:000000018009C35D                 cmp     [rbx+2BAh], bpl
+  .text:000000018009C364                 jnz     short loc_18009C38E
+  .text:000000018009C366                 lea     rcx, off_180612910
+  .text:000000018009C36D                 mov     cs:qword_1809105D0, rbp
+  .text:000000018009C374                 call    sub_1800F85B0
+  .text:000000018009C379                 mov     rcx, cs:g_pSource2Server
+  .text:000000018009C380                 test    rcx, rcx
+  .text:000000018009C383                 jz      short loc_18009C38E
+  .text:000000018009C385                 mov     rax, [rcx]
+  .text:000000018009C388                 call    qword ptr [rax+150h]
+  .text:000000018009C38E                 lea     rcx, aDeactivatestea_0; "DeactivateSteamGameServer(finished)"
+  .text:000000018009C395                 call    cs:COM_TimestampedLog
+  .text:000000018009C39B                 cmp     qword ptr cs:xmmword_1808CCE00, rbp
+  .text:000000018009C3A2                 mov     rbx, [rsp+28h+arg_0]
+  .text:000000018009C3A7                 jz      short loc_18009C3D7
+  .text:000000018009C3A9                 lea     rdx, aLogFileClosed; "Log file closed\n"
+  .text:000000018009C3B0                 lea     rcx, qword_1808CCDD0
+  .text:000000018009C3B7                 call    sub_1800E2200
+  .text:000000018009C3BC                 mov     rcx, cs:g_pFileSystem
+  .text:000000018009C3C3                 mov     rdx, qword ptr cs:xmmword_1808CCE00
+  .text:000000018009C3CA                 mov     rax, [rcx]
+  .text:000000018009C3CD                 call    qword ptr [rax+70h]
+  .text:000000018009C3D0                 mov     qword ptr cs:xmmword_1808CCE00, rbp
+  .text:000000018009C3D7                 add     rsp, 20h
+  .text:000000018009C3DB                 pop     rbp
+  .text:000000018009C3DC                 retn
+procedure: |-
+  __int64 __fastcall CNetworkGameServer_Shutdown(__int64 a1)
+  {
+    int *v2; // rax
+    __int64 *v3; // rcx
+    __int64 *i; // rdx
+    __int64 v5; // rax
+    int v6; // edi
+    __int64 v7; // rsi
+    void (__fastcall ***v8)(_QWORD, __int64); // rcx
+    int v9; // eax
+    unsigned int *v10; // rdi
+    unsigned int *j; // rsi
+    __int64 result; // rax
+
+    if ( byte_1806129BC )
+    {
+      byte_1806129BC = 0;
+      CSteam3Server_SendUpdatedServerDetails(&off_180612910, 0);
+    }
+    CNetworkGameServerBase_Shutdown(a1);
+    if ( g_pSource2Server )
+    {
+      v2 = (int *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+      v3 = *((__int64 **)v2 + 1);
+      for ( i = &v3[*v2]; v3 != i; *(_DWORD *)(v5 + 44) = -1 )
+        v5 = *v3++;
+    }
+    v6 = 0;
+    if ( *(int *)(a1 + 704) > 0 )
+    {
+      v7 = 0;
+      do
+      {
+        (*(void (__fastcall **)(_QWORD, __int64))(**(_QWORD **)(v7 + *(_QWORD *)(a1 + 712)) + 8LL))(
+          *(_QWORD *)(v7 + *(_QWORD *)(a1 + 712)),
+          a1);
+        v8 = *(void (__fastcall ****)(_QWORD, __int64))(v7 + *(_QWORD *)(a1 + 712));
+        if ( v8 )
+          (**v8)(v8, 1);
+        ++v6;
+        v7 += 8;
+      }
+      while ( v6 < *(_DWORD *)(a1 + 704) );
+    }
+    v9 = *(_DWORD *)(a1 + 808);
+    *(_DWORD *)(a1 + 704) = 0;
+    if ( !v9 )
+    {
+      v10 = *(unsigned int **)(a1 + 792);
+      for ( j = &v10[2 * *(int *)(a1 + 784)]; v10 != j; v10 += 2 )
+        CNetworkGameServerBase_AsyncUnloadSpawnGroupInternal(a1, *v10, v10[1]);
+      *(_DWORD *)(a1 + 784) = 0;
+    }
+    COM_TimestampedLog("DeactivateSteamGameServer(start)");
+    if ( (*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 376LL))(a1) )
+    {
+      if ( !*(_BYTE *)(a1 + 696) && !*(_BYTE *)(a1 + 698) )
+      {
+        qword_1809105D0 = 0;
+        sub_1800F85B0(&off_180612910);
+        if ( g_pSource2Server )
+          (*(void (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 336LL))(g_pSource2Server);
+      }
+    }
+    result = COM_TimestampedLog("DeactivateSteamGameServer(finished)");
+    if ( (_QWORD)xmmword_1808CCE00 )
+    {
+      sub_1800E2200(&qword_1808CCDD0, "Log file closed\n");
+      result = (*(__int64 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pFileSystem + 112LL))(
+                 g_pFileSystem,
+                 xmmword_1808CCE00);
+      *(_QWORD *)&xmmword_1808CCE00 = 0;
+    }
+    return result;
+  }


### PR DESCRIPTION
## Summary
- Add `find-CSource2Server_GetAllServerClasses` (slim Pattern C, vfunc via LLM_DECOMPILE) locating `CSource2Server::GetAllServerClasses`, a vfunc of `CSource2Server_vtable` (server module), via a caller-anchored `vfunc_sig` on the register-indirect vcall `call qword ptr [rax+0E8h]` inside the engine predecessor `CNetworkGameServer_Shutdown`.
- Skill runs in the ENGINE module (where the predecessor is renamed/available) and outputs to `bin/14174/engine/`; `vtable_name: CSource2Server_vtable` is written as metadata only (no vtable YAML consumed), mirroring `find-CEngineServer_UnloadSpawnGroup`.
- Generate + hand-annotate `references/engine/CNetworkGameServer_Shutdown.{windows,linux}.yaml` at the GetAllServerClasses vcall site (offset 0xE8 = 232, slot index 29) in both `disasm_code` and `procedure`.
- Add `configs/14174.yaml` engine skill entry (`expected_input: CNetworkGameServer_Shutdown.{platform}.yaml`) and symbol entry (category vfunc, alias `CSource2Server::GetAllServerClasses`).

Result (both platforms): vfunc_index 29, vfunc_offset 0xe8. Windows vfunc_sig `FF 90 E8 00 00 00 48 8B 48 ??`; Linux vfunc_sig `FF 90 E8 00 00 00 48 89 C2 48 8B 40 ?? 48 63 12 48 8D 0C D0`.

## Validation
- scoped analyzer (`ida_analyze_bin.py -oldgamever none -modules engine -skill find-CSource2Server_GetAllServerClasses`): Successful 2, Failed 0, Skipped 0; both platforms produced via the LLM_DECOMPILE path.
- non-MCP unittest suite: 1064 tests, OK (skipped=3), 0 failures.
- candidate preparation: passed for `14174` (candidate SHA-256 `54eb4bfc01204f8ebc4ef085a6bebfbd224e9d1ecf37c0df3d6267ddff74233b`).
- C++ post-change validation: passed with runnable tests and zero failures (compile 0, invalid 0, layout diffs 0, vtable diffs 0, record diffs 0); dumped vtable confirms `[29] GetAllServerClasses`.
- candidate publication: passed; published `gamesymbols/14174.yaml` SHA-256 matches the validated candidate. Refreshed already-merged entries (all pre-existing on origin/main) are authorized/by-design given zero-diff C++ validation.
- existing committed branch: 1 initial commit ahead of `origin/main`; supplemental publication commit: created.