### PR TITLE
CSource2Server_GetActiveWorldName

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -1811,6 +1811,11 @@ modules:
         expected_input:
           - CLoopTypeClientServer_vtable.{platform}.yaml
           - CLoopTypeClientSimple_ActivateEngineServices.{platform}.yaml
+      - name: find-CSource2Server_GetActiveWorldName
+        expected_output:
+          - CSource2Server_GetActiveWorldName.{platform}.yaml
+        expected_input:
+          - CLoopTypeClientServer_ActivateLoop.{platform}.yaml
       - name: find-CLoopTypeClientServer_AllocateLoopMode
         expected_output:
           - CLoopTypeClientServer_AllocateLoopMode.{platform}.yaml
@@ -3279,6 +3284,10 @@ modules:
         category: vfunc
         alias:
           - CLoopTypeClientServer::ActivateLoop
+      - name: CSource2Server_GetActiveWorldName
+        category: vfunc
+        alias:
+          - CSource2Server::GetActiveWorldName
       - name: CLoopTypeClientServer_AllocateLoopMode
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:91e4343f7e16f4dde11e88575155b9cfd1b81cef6dbecd14b9f120b9d129c4d5
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -12927,6 +12927,18 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
+  engine/CSource2Server_GetActiveWorldName.linux.yaml:
+    func_name: CSource2Server_GetActiveWorldName
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vfunc_sig: FF 90 F0 00 00 00 48 89 C6 48 8B BB ?? ?? ?? ??
+    vtable_name: CSource2Server_vtable
+  engine/CSource2Server_GetActiveWorldName.windows.yaml:
+    func_name: CSource2Server_GetActiveWorldName
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vfunc_sig: FF 90 F0 00 00 00 48 8B F0 48 8B 9F ?? ?? ?? ??
+    vtable_name: CSource2Server_vtable
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -42784,5 +42796,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T16:48:37Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_GetActiveWorldName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_GetActiveWorldName",
+]
+
+# CSource2Server::GetActiveWorldName is a vfunc whose concrete body lives in the
+# server module (libserver.so / server.dll). The engine predecessor
+# CLoopTypeClientServer_ActivateLoop reaches it through a register-indirect vcall
+# on the CSource2Server interface (g_pSource2Server): `call qword ptr [rax+0F0h]`.
+# The skill runs in the ENGINE module (where the predecessor is renamed/available)
+# and produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
+# matching the CSource2Server_GetAllServerClasses offset pattern (GetActiveWorldName
+# is the vtable slot immediately after GetAllServerClasses at 0xE8). The same
+# predecessor holds the vcall on both platforms.
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CSource2Server_GetActiveWorldName",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CLoopTypeClientServer_ActivateLoop.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CLoopTypeClientServer_ActivateLoop.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class) -- vtable_name is metadata only; CSource2Server's
+    # concrete body lives in the server module, so no CSource2Server_vtable YAML is
+    # consumed here. The vfunc_sig anchors on the vcall instruction inside the
+    # engine predecessor CLoopTypeClientServer_ActivateLoop.
+    ("CSource2Server_GetActiveWorldName", "CSource2Server_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "CSource2Server_GetActiveWorldName",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the engine predecessor CLoopTypeClientServer_ActivateLoop."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
@@ -35,7 +35,7 @@ FUNC_VTABLE_RELATIONS = [
     # concrete body lives in the server module, so no CSource2Server_vtable YAML is
     # consumed here. The vfunc_sig anchors on the vcall instruction inside the
     # engine predecessor CLoopTypeClientServer_ActivateLoop.
-    ("CSource2Server_GetActiveWorldName", "CSource2Server_vtable"),
+    ("CSource2Server_GetActiveWorldName", "CSource2Server"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.linux.yaml
@@ -1,0 +1,100 @@
+func_name: CLoopTypeClientServer_ActivateLoop
+func_va: '0x38e6d0'
+disasm_code: |-
+  .text:000000000038E6D0                 push    rbp
+  .text:000000000038E6D1                 mov     rbp, rsp
+  .text:000000000038E6D4                 push    rbx
+  .text:000000000038E6D5                 mov     rbx, rdi
+  .text:000000000038E6D8                 sub     rsp, 8
+  .text:000000000038E6DC                 mov     rax, [rdi+0C8h]
+  .text:000000000038E6E3                 mov     rcx, [rdi+0B0h]
+  .text:000000000038E6EA                 mov     rdi, [rdi+98h]
+  .text:000000000038E6F1                 mov     cs:qword_9E5420, rax
+  .text:000000000038E6F8                 mov     qword ptr cs:xmmword_9E5410, rcx
+  .text:000000000038E6FF                 mov     qword ptr cs:xmmword_9E5410+8, rdi
+  .text:000000000038E706                 mov     rdi, rbx
+  .text:000000000038E709                 call    CLoopTypeClientSimple_ActivateEngineServices
+  .text:000000000038E70E                 call    sub_2C8260
+  .text:000000000038E713                 xor     eax, eax
+  .text:000000000038E715                 mov     qword ptr [rbx+80h], 0
+  .text:000000000038E720                 mov     [rbx+128h], ax
+  .text:000000000038E727                 lea     rax, g_pSource2Server
+  .text:000000000038E72E                 lea     rsi, aUnknown_0; "unknown"
+  .text:000000000038E735                 movsd   qword ptr [rbx+78h], xmm0
+  .text:000000000038E73A                 pxor    xmm0, xmm0
+  .text:000000000038E73E                 mov     qword ptr [rbx+0F0h], 0
+  .text:000000000038E749                 mov     dword ptr [rbx+0F8h], 0
+  .text:000000000038E753                 mov     rdi, [rax]
+  .text:000000000038E756                 mov     qword ptr [rbx+0E0h], 0
+  .text:000000000038E761                 mov     dword ptr [rbx+0E8h], 0
+  .text:000000000038E76B                 mov     qword ptr [rbx+100h], 0
+  .text:000000000038E776                 mov     dword ptr [rbx+108h], 0
+  .text:000000000038E780                 mov     dword ptr [rbx+0D8h], 0
+  .text:000000000038E78A                 mov     qword ptr [rbx+110h], 0
+  .text:000000000038E795                 mov     qword ptr [rbx+118h], 0
+  .text:000000000038E7A0                 mov     byte ptr [rbx+12Ah], 0
+  .text:000000000038E7A7                 movups  xmmword ptr [rbx+130h], xmm0
+  .text:000000000038E7AE                 test    rdi, rdi
+  .text:000000000038E7B1                 jz      short loc_38E7BF
+  .text:000000000038E7B3                 mov     rax, [rdi]
+  .text:000000000038E7B6                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+  .text:000000000038E7BC                 mov     rsi, rax
+  .text:000000000038E7BF                 mov     rdi, [rbx+178h]
+  .text:000000000038E7C6                 call    sub_37BE50
+  .text:000000000038E7CB                 lea     rax, g_pEngineServiceMgr
+  .text:000000000038E7D2                 mov     rdi, [rax]
+  .text:000000000038E7D5                 mov     rax, [rdi]
+  .text:000000000038E7D8                 call    qword ptr [rax+0F0h]
+  .text:000000000038E7DE                 pxor    xmm0, xmm0
+  .text:000000000038E7E2                 mov     edx, 1
+  .text:000000000038E7E7                 cvtsd2ss xmm0, qword ptr [rbx+118h]
+  .text:000000000038E7EF                 mov     rdi, rax
+  .text:000000000038E7F2                 mov     rax, [rax]
+  .text:000000000038E7F5                 xor     esi, esi
+  .text:000000000038E7F7                 mov     rbx, [rbp+var_8]
+  .text:000000000038E7FB                 mov     rax, [rax+20h]
+  .text:000000000038E7FF                 leave
+  .text:000000000038E800                 jmp     rax
+procedure: |-
+  __int64 __fastcall CLoopTypeClientServer_ActivateLoop(__int64 a1, __int64 a2, __int64 a3, double a4, double a5)
+  {
+    __int64 v6; // rax
+    __int64 v7; // rcx
+    __int64 v8; // rdi
+    double v9; // xmm0_8
+    const char *v10; // rsi
+    _QWORD *v11; // rdi
+    __int64 v12; // rax
+    float v13; // xmm0_4
+
+    v6 = *(_QWORD *)(a1 + 200);
+    v7 = *(_QWORD *)(a1 + 176);
+    v8 = *(_QWORD *)(a1 + 152);
+    qword_9E5420 = v6;
+    *(_QWORD *)&xmmword_9E5410 = v7;
+    *((_QWORD *)&xmmword_9E5410 + 1) = v8;
+    CLoopTypeClientSimple_ActivateEngineServices(a1, a2, a3);
+    v9 = sub_2C8260(a4, a5);
+    *(_QWORD *)(a1 + 128) = 0;
+    *(_WORD *)(a1 + 296) = 0;
+    v10 = "unknown";
+    *(double *)(a1 + 120) = v9;
+    *(_QWORD *)(a1 + 240) = 0;
+    *(_DWORD *)(a1 + 248) = 0;
+    v11 = g_pSource2Server;
+    *(_QWORD *)(a1 + 224) = 0;
+    *(_DWORD *)(a1 + 232) = 0;
+    *(_QWORD *)(a1 + 256) = 0;
+    *(_DWORD *)(a1 + 264) = 0;
+    *(_DWORD *)(a1 + 216) = 0;
+    *(_QWORD *)(a1 + 272) = 0;
+    *(_QWORD *)(a1 + 280) = 0;
+    *(_BYTE *)(a1 + 298) = 0;
+    *(_OWORD *)(a1 + 304) = 0;
+    if ( v11 )
+      v10 = (const char *)(*(__int64 (__fastcall **)(_QWORD *, const char *))(*v11 + 240LL))(v11, "unknown");// 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+    sub_37BE50(*(_QWORD *)(a1 + 376), v10);
+    v12 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pEngineServiceMgr + 240LL))(g_pEngineServiceMgr);
+    v13 = *(double *)(a1 + 280);
+    return (*(__int64 (__fastcall **)(__int64, _QWORD, __int64, float))(*(_QWORD *)v12 + 32LL))(v12, 0, 1, v13);
+  }

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.windows.yaml
@@ -1,0 +1,130 @@
+func_name: CLoopTypeClientServer_ActivateLoop
+func_va: '0x1802244b0'
+disasm_code: |-
+  .text:00000001802244B0                 mov     [rsp+arg_0], rbx
+  .text:00000001802244B5                 mov     [rsp+arg_8], rsi
+  .text:00000001802244BA                 push    rdi
+  .text:00000001802244BB                 sub     rsp, 30h
+  .text:00000001802244BF                 mov     r10, [rcx+0C8h]
+  .text:00000001802244C6                 mov     rdi, rcx
+  .text:00000001802244C9                 mov     r9, [rcx+0B0h]
+  .text:00000001802244D0                 mov     rax, [rcx+98h]
+  .text:00000001802244D7                 mov     qword ptr cs:xmmword_18090F4E0+8, rax
+  .text:00000001802244DE                 mov     qword ptr cs:xmmword_18090F4E0, r9
+  .text:00000001802244E5                 mov     cs:qword_18090F4F0, r10
+  .text:00000001802244EC                 call    CLoopTypeClientSimple_ActivateEngineServices
+  .text:00000001802244F1                 call    cs:Plat_FloatTime
+  .text:00000001802244F7                 mov     rcx, cs:g_pSource2Server
+  .text:00000001802244FE                 lea     rsi, aUnknown; "unknown"
+  .text:0000000180224505                 xor     eax, eax
+  .text:0000000180224507                 movsd   qword ptr [rdi+78h], xmm0
+  .text:000000018022450C                 mov     [rdi+0F0h], rax
+  .text:0000000180224513                 mov     [rdi+0F8h], eax
+  .text:0000000180224519                 mov     [rdi+0E0h], rax
+  .text:0000000180224520                 mov     [rdi+0E8h], eax
+  .text:0000000180224526                 mov     [rdi+100h], rax
+  .text:000000018022452D                 mov     [rdi+108h], eax
+  .text:0000000180224533                 mov     [rdi+118h], rax
+  .text:000000018022453A                 mov     [rdi+80h], rax
+  .text:0000000180224541                 mov     [rdi+0D8h], eax
+  .text:0000000180224547                 mov     [rdi+110h], rax
+  .text:000000018022454E                 mov     [rdi+128h], ax
+  .text:0000000180224555                 mov     [rdi+12Ah], al
+  .text:000000018022455B                 mov     [rdi+130h], rax
+  .text:0000000180224562                 mov     [rdi+138h], rax
+  .text:0000000180224569                 test    rcx, rcx
+  .text:000000018022456C                 jz      short loc_18022457A
+  .text:000000018022456E                 mov     rax, [rcx]
+  .text:0000000180224571                 ; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+  .text:0000000180224571                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+  .text:0000000180224577                 mov     rsi, rax
+  .text:000000018022457A                 mov     rbx, [rdi+178h]
+  .text:0000000180224581                 mov     rcx, rbx
+  .text:0000000180224584                 call    sub_18021F750
+  .text:0000000180224589                 mov     edx, [rbx+24h]
+  .text:000000018022458C                 test    edx, 3FFFFFFFh
+  .text:0000000180224592                 jbe     short loc_1802245A4
+  .text:0000000180224594                 lea     rcx, [rbx+28h]
+  .text:0000000180224598                 bt      edx, 1Eh
+  .text:000000018022459C                 jb      short loc_1802245A1
+  .text:000000018022459E                 mov     rcx, [rcx]
+  .text:00000001802245A1                 mov     byte ptr [rcx], 0
+  .text:00000001802245A4                 and     dword ptr [rbx+20h], 0C0000000h
+  .text:00000001802245AB                 lea     rcx, [rbx+20h]
+  .text:00000001802245AF                 mov     r9d, 0FFFFFFFFh
+  .text:00000001802245B5                 mov     [rsp+38h+var_18], 0
+  .text:00000001802245BA                 mov     r8, rsi
+  .text:00000001802245BD                 xor     edx, edx
+  .text:00000001802245BF                 call    cs:?Insert@CBufferString@@QEAAPEBDHPEBDH_N@Z; CBufferString::Insert(int,char const *,int,bool)
+  .text:00000001802245C5                 mov     rcx, cs:g_pEngineServiceMgr
+  .text:00000001802245CC                 mov     rax, [rcx]
+  .text:00000001802245CF                 call    qword ptr [rax+0F0h]
+  .text:00000001802245D5                 movsd   xmm2, qword ptr [rdi+118h]
+  .text:00000001802245DD                 mov     r9b, 1
+  .text:00000001802245E0                 cvtpd2ps xmm2, xmm2
+  .text:00000001802245E4                 xor     edx, edx
+  .text:00000001802245E6                 mov     rcx, rax
+  .text:00000001802245E9                 mov     r8, [rax]
+  .text:00000001802245EC                 mov     rbx, [rsp+38h+arg_0]
+  .text:00000001802245F1                 mov     rsi, [rsp+38h+arg_8]
+  .text:00000001802245F6                 add     rsp, 30h
+  .text:00000001802245FA                 pop     rdi
+  .text:00000001802245FB                 jmp     qword ptr [r8+20h]
+procedure: |-
+  __int64 __fastcall CLoopTypeClientServer_ActivateLoop(__int64 a1, __int64 a2, __int64 a3)
+  {
+    __int64 v3; // r10
+    __int64 v5; // r9
+    __int64 v6; // rdx
+    __int64 v7; // rcx
+    double v8; // xmm0_8
+    __int64 v9; // rcx
+    const char *v10; // rsi
+    __int64 v11; // rbx
+    int v12; // edx
+    _QWORD *v13; // rcx
+    _QWORD *v14; // rax
+    __int64 v15; // r9
+
+    v3 = *(_QWORD *)(a1 + 200);
+    v5 = *(_QWORD *)(a1 + 176);
+    *((_QWORD *)&xmmword_18090F4E0 + 1) = *(_QWORD *)(a1 + 152);
+    *(_QWORD *)&xmmword_18090F4E0 = v5;
+    qword_18090F4F0 = v3;
+    CLoopTypeClientSimple_ActivateEngineServices(a1, a2, a3);
+    v8 = Plat_FloatTime(v7, v6);
+    v9 = g_pSource2Server;
+    v10 = "unknown";
+    *(double *)(a1 + 120) = v8;
+    *(_QWORD *)(a1 + 240) = 0;
+    *(_DWORD *)(a1 + 248) = 0;
+    *(_QWORD *)(a1 + 224) = 0;
+    *(_DWORD *)(a1 + 232) = 0;
+    *(_QWORD *)(a1 + 256) = 0;
+    *(_DWORD *)(a1 + 264) = 0;
+    *(_QWORD *)(a1 + 280) = 0;
+    *(_QWORD *)(a1 + 128) = 0;
+    *(_DWORD *)(a1 + 216) = 0;
+    *(_QWORD *)(a1 + 272) = 0;
+    *(_WORD *)(a1 + 296) = 0;
+    *(_BYTE *)(a1 + 298) = 0;
+    *(_QWORD *)(a1 + 304) = 0;
+    *(_QWORD *)(a1 + 312) = 0;
+    if ( v9 )
+      v10 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v9 + 240LL))(v9);// 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+    v11 = *(_QWORD *)(a1 + 376);
+    sub_18021F750(v11);
+    v12 = *(_DWORD *)(v11 + 36);
+    if ( (v12 & 0x3FFFFFFF) != 0 )
+    {
+      v13 = (_QWORD *)(v11 + 40);
+      if ( (v12 & 0x40000000) == 0 )
+        v13 = (_QWORD *)*v13;
+      *(_BYTE *)v13 = 0;
+    }
+    *(_DWORD *)(v11 + 32) &= 0xC0000000;
+    CBufferString::Insert((CBufferString *)(v11 + 32), 0, v10, -1, 0);
+    v14 = (_QWORD *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pEngineServiceMgr + 240LL))(g_pEngineServiceMgr);
+    LOBYTE(v15) = 1;
+    return (*(__int64 (__fastcall **)(_QWORD *, _QWORD, _QWORD, __int64))(*v14 + 32LL))(v14, 0, *v14, v15);
+  }


### PR DESCRIPTION
## Summary
- Add `find-CSource2Server_GetActiveWorldName` (slim Pattern C, vfunc via LLM_DECOMPILE) in the engine module. `CSource2Server::GetActiveWorldName` is a vfunc of `CSource2Server_vtable` whose concrete body lives in the server module; the engine predecessor `CLoopTypeClientServer_ActivateLoop` reaches it through a register-indirect vcall on the `g_pSource2Server` interface (`call qword ptr [rax+0F0h]`), so the finder is engine-placed with a caller-anchored `vfunc_sig`.
- Add generated + hand-annotated engine reference YAMLs `references/engine/CLoopTypeClientServer_ActivateLoop.{windows,linux}.yaml` (vcall site annotated in both `disasm_code` and `procedure`).
- Add `configs/14174.yaml` engine skill entry (expected_output `CSource2Server_GetActiveWorldName`; expected_input `CLoopTypeClientServer_ActivateLoop`) and engine symbol entry (category vfunc, alias `CSource2Server::GetActiveWorldName`). `vtable_name = CSource2Server_vtable` is metadata only (no `CSource2Server_vtable` YAML consumed).
- Publish refreshed `gamesymbols/14174.yaml` snapshot (adds the new symbol; refreshes pre-existing already-merged entries per current-bin analysis).

## Validation
- scoped preprocessor run (`ida_analyze_bin.py -oldgamever none -modules engine -skill find-CSource2Server_GetActiveWorldName`): Successful 2, Failed 0, Skipped 0; both platforms via the LLM_DECOMPILE path (found_vcall at offset 0xF0). Result: vfunc_offset `0xf0`, vfunc_index `30` on both platforms; caller-anchored vfunc_sig windows `FF 90 F0 00 00 00 48 8B F0 48 8B 9F ?? ?? ?? ??`, linux `FF 90 F0 00 00 00 48 89 C6 48 8B BB ?? ?? ?? ??`.
- non-MCP unittest suite: Ran 1064 tests, OK (skipped 3), 0 failures.
- candidate preparation: passed for `14174`.
- C++ post-change validation: passed with runnable tests and zero failures (Layout 14/0, VTable 12/0, Record 2/0). `GetActiveWorldName` resolves at CSource2Server vtable index [30] with no layout/vfunc-mapping differences.
- candidate publication: passed; published SHA-256 matches the validated candidate.
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created.
