### PR TITLE
CEntityInstance_dtor

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7604,6 +7604,12 @@ modules:
           - CEntityInstance_vdtor.{platform}.yaml
         expected_input:
           - CBaseEntity_vdtor.{platform}.yaml
+      - name: find-CEntityInstance_dtor
+        expected_output:
+          - CEntityInstance_dtor.{platform}.yaml
+        expected_input:
+          - CEntityInstance_vtable.{platform}.yaml
+          - CEntityInstance_UpdateOnRemove.{platform}.yaml
       - name: find-CEntityInstance_Spawn
         expected_output:
           - CEntityInstance_Spawn.{platform}.yaml
@@ -9193,6 +9199,10 @@ modules:
         category: vfunc
         alias:
           - CEntityInstance::~CEntityInstance (virtual)
+      - name: CEntityInstance_dtor
+        category: func
+        alias:
+          - CEntityInstance::~CEntityInstance
       - name: CEntitySaveRestoreBlockHandler_vtable
         category: vtable
       - name: CEntitySaveRestoreBlockHandler_PreSave

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:07dd7881c3d8b6f3e041d8b6c059db118c7be6d7eee9a8f5bccfadcda78225da
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -26124,6 +26124,18 @@ files:
     func_sig: 40 53 48 83 EC ?? 48 83 79 ?? ?? 48 8B D9 0F 85 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ??
     func_size: '0xc5'
     func_va: '0x181244980'
+  server/CEntityInstance_dtor.linux.yaml:
+    func_name: CEntityInstance_dtor
+    func_rva: '0x21089c0'
+    func_sig: 55 48 8D 05 ?? ?? ?? ?? 48 89 E5 41 55 41 54 53 48 89 FB 48 83 EC ?? 4C 8B 67 ?? 48 89 07 4D 85 E4 74 ?? 41 80 7C 24 ?? ?? 0F 85 ?? ?? ?? ?? 41 0F B7 44 24 ?? 83 E8 ?? 66 41 89 44 24 ?? 66 85 C0 0F 8E ?? ?? ?? ?? 48 C7 43 ?? ?? ?? ?? ?? 48 8B 43 ?? 48 85 C0 74 ?? 48 8B 50 ?? 48 85 D2 74 ?? 48 8D 3D ?? ?? ?? ?? 48 89 DE E8 ?? ?? ?? ?? 48 8B 43 ?? 48 C7 40 ?? ?? ?? ?? ?? 48 8B 73 ?? 48 85 F6 74 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 38 48 85 FF 74 ?? 48 8B 07 48 8B 80 ?? ?? ?? ??
+    func_size: '0x12a'
+    func_va: '0x21089c0'
+  server/CEntityInstance_dtor.windows.yaml:
+    func_name: CEntityInstance_dtor
+    func_rva: '0x1242210'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC ?? 48 8B 79 ?? 48 8D 05 ?? ?? ?? ?? 33 F6
+    func_size: '0xeb'
+    func_va: '0x181242210'
   server/CEntityInstance_m_CScriptComponent.linux.yaml:
     member_name: m_CScriptComponent
     offset: '0x28'
@@ -42784,5 +42796,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T18:55:27Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/ida_preprocessor_scripts/find-CEntityInstance_dtor.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_dtor.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CEntityInstance_dtor skill."""
+
+import os
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CEntityInstance_dtor",
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CEntityInstance_dtor",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+def _read_vtable_va(yaml_path):
+    """Read vtable_va from a vtable YAML file, returning it as a hex string or None."""
+    try:
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+        if isinstance(data, dict):
+            va = data.get("vtable_va")
+            if va:
+                return str(va)
+    except Exception:
+        pass
+    return None
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML.
+
+    The "kv 0x%p Release refcount == %d\n" logging string is inlined into ~91
+    functions (via CEntitySystem_ReleaseKeyValues), so it cannot uniquely locate
+    the destructor on its own. The base-object destructor also writes the
+    CEntityInstance vtable pointer, so intersecting the string xref with an
+    xref to CEntityInstance_vtable narrows the result to the destructor. This
+    mirrors the sibling find-CBaseEntity_dtor, which also anchors on its vtable.
+    """
+    vtable_yaml_path = os.path.join(
+        new_binary_dir, f"CEntityInstance_vtable.{platform}.yaml"
+    )
+    vtable_va = _read_vtable_va(vtable_yaml_path)
+    if not vtable_va:
+        if debug:
+            print(
+                "    Preprocess: CEntityInstance_vtable vtable_va not found, "
+                "cannot resolve xref_gvs"
+            )
+        return False
+
+    # The CEntityInstance destructor writes the vtable pointer directly
+    # (`lea rax, CEntityInstance_vtable; mov [rcx], rax`), so the vtable's own
+    # VA is the data reference on both platforms (unlike CBaseEntity, whose
+    # Linux dtor references the _ZTV base).
+    xref_va = vtable_va
+
+    # The "kv 0x%p Release refcount == %d\n" log string is inlined into ~90
+    # functions (via CEntitySystem_ReleaseKeyValues), so intersect it with a
+    # reference to the CEntityInstance vtable to isolate the destructors. That
+    # intersection still contains the *deleting* destructor (the vtable slot 4
+    # entry on Windows / slot 5 D0 on Linux), which the prior failed attempt
+    # wrongly picked. Exclude it by its self-delete signature so only the
+    # base-object destructor remains, mirroring find-CBaseEntity_dtor.
+    #   Windows: scalar-deleting dtor tests the deleting flag then
+    #            `operator delete(this, 0x30)`: test sil,1 / jz / mov edx,48 /
+    #            mov rcx,rbx.
+    #   Linux:   D0 deleting dtor makes a `call [rax+0A8h]` virtual call before
+    #            tail-calling operator delete on `this`; the complete-object
+    #            destructor (D1, slot 4) instead ends in `jmp rax`.
+    if platform == "windows":
+        exclude_signatures = ["40 F6 C6 01 74 ?? BA 30 00 00 00 48 8B CB"]
+    else:
+        exclude_signatures = ["FF 90 A8 00 00 00"]
+
+    func_xrefs = [
+        {
+            "func_name": "CEntityInstance_dtor",
+            "xref_strings": ["kv 0x%p Release refcount == %d\n"],
+            "xref_gvs": [xref_va],
+            "xref_signatures": [],
+            "xref_funcs": [],
+            "exclude_funcs": ["CEntityInstance_UpdateOnRemove"],
+            "exclude_strings": [],
+            "exclude_gvs": [],
+            "exclude_signatures": exclude_signatures,
+        },
+    ]
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=func_xrefs,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CEntityInstance_dtor.py
+++ b/ida_preprocessor_scripts/find-CEntityInstance_dtor.py
@@ -62,16 +62,11 @@ async def preprocess_skill(
     xref to CEntityInstance_vtable narrows the result to the destructor. This
     mirrors the sibling find-CBaseEntity_dtor, which also anchors on its vtable.
     """
-    vtable_yaml_path = os.path.join(
-        new_binary_dir, f"CEntityInstance_vtable.{platform}.yaml"
-    )
+    vtable_yaml_path = os.path.join(new_binary_dir, f"CEntityInstance_vtable.{platform}.yaml")
     vtable_va = _read_vtable_va(vtable_yaml_path)
     if not vtable_va:
         if debug:
-            print(
-                "    Preprocess: CEntityInstance_vtable vtable_va not found, "
-                "cannot resolve xref_gvs"
-            )
+            print("    Preprocess: CEntityInstance_vtable vtable_va not found, cannot resolve xref_gvs")
         return False
 
     # The CEntityInstance destructor writes the vtable pointer directly


### PR DESCRIPTION
## Summary
- Add `find-CEntityInstance_dtor` preprocessor (Pattern A, regular function) that locates the base-object destructor `CEntityInstance::~CEntityInstance` and registers it as `category: func` (alias `CEntityInstance::~CEntityInstance`), mirroring `find-CBaseEntity_dtor`. The vtable-slot destructor remains owned solely by `CEntityInstance_vdtor`, so there is no vtable-index conflict.
- Discovery intersects the `"kv 0x%p Release refcount == %d\n"` log-string xref with a reference to `CEntityInstance_vtable` (the string alone is inlined into ~90 functions), then excludes `CEntityInstance_UpdateOnRemove` and the deleting destructor via a self-delete `exclude_signatures`. Resolves to `func_va` `0x181242210` (windows) / `0x21089c0` (linux).

## Validation
- preprocessor scoped run: `ida_analyze_bin.py -oldgamever none -modules server -skill find-CEntityInstance_dtor` -> Successful 2, Failed 0; both platform YAMLs produced as plain funcs (no vfunc fields)
- non-MCP unittest suite: Ran 1064 tests, OK (skipped=3), 0 failures
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (layout diffs 0, vtable diffs 0, record layout diffs 0, reference conflicts 0)
- candidate publication: passed; published SHA-256 matches the validated candidate (`bd1e0d1ff1328be53d32f5e021880450b653ac56b762a10d7149ab5ddb7d9248`)
- existing committed branch: 1 initial commit ahead of `origin/main`; supplemental publication commit: created
