### PR TITLE
CSource2Server_ShouldTimeoutClient

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -668,6 +668,11 @@ modules:
         expected_input:
           - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
           - CNetworkGameServerBase_vtable.{platform}.yaml
+      - name: find-CSource2Server_ShouldTimeoutClient
+        expected_output:
+          - CSource2Server_ShouldTimeoutClient.{platform}.yaml
+        expected_input:
+          - CNetworkGameServerBase_CheckTimeouts.{platform}.yaml
       - name: find-CNetworkGameServerBase_GetPassword
         expected_output:
           - CNetworkGameServerBase_GetPassword.{platform}.yaml
@@ -2483,6 +2488,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServerBase::IsHLTV
+      - name: CSource2Server_ShouldTimeoutClient
+        category: vfunc
+        alias:
+          - CSource2Server::ShouldTimeoutClient
       - name: CNetworkGameServerBase_GetPassword
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:15a4fc1b40851c656d8f4eb264efca86b1ddbd57d7d0658758e1b515ac5cdfc9
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -12927,6 +12927,18 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
+  engine/CSource2Server_ShouldTimeoutClient.linux.yaml:
+    func_name: CSource2Server_ShouldTimeoutClient
+    vfunc_index: 25
+    vfunc_offset: '0xc8'
+    vfunc_sig: 48 8B 92 C8 00 00 00
+    vtable_name: CSource2Server_vtable
+  engine/CSource2Server_ShouldTimeoutClient.windows.yaml:
+    func_name: CSource2Server_ShouldTimeoutClient
+    vfunc_index: 25
+    vfunc_offset: '0xc8'
+    vfunc_sig: 48 8B 98 C8 00 00 00
+    vtable_name: CSource2Server_vtable
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -42784,5 +42796,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T19:35:21Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/ida_preprocessor_scripts/find-CSource2Server_ShouldTimeoutClient.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_ShouldTimeoutClient.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2Server_ShouldTimeoutClient skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2Server_ShouldTimeoutClient",
+]
+
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "CSource2Server_ShouldTimeoutClient",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServerBase_CheckTimeouts.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServerBase_CheckTimeouts.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    ("CSource2Server_ShouldTimeoutClient", "CSource2Server_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CSource2Server_ShouldTimeoutClient",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.linux.yaml
@@ -60,7 +60,7 @@ disasm_code: |-
   .text:00000000004F9CE3                 mov     rdi, r15
   .text:00000000004F9CE6                 mov     [rbp-158h], rax
   .text:00000000004F9CED                 mov     rcx, [r15]
-  .text:00000000004F9CF0                 mov     rdx, [rdx+0C8h]
+  .text:00000000004F9CF0                 mov     rdx, [rdx+0C8h] ; 0C8h = CSource2Server_ShouldTimeoutClient
   .text:00000000004F9CF7                 mov     [rbp-150h], rdx
   .text:00000000004F9CFE                 call    qword ptr [rcx+0A0h]
   .text:00000000004F9D04                 mov     esi, [r14+48h]
@@ -307,7 +307,7 @@ procedure: |-
         if ( !(*(unsigned __int8 (__fastcall **)(__int64))(*(_QWORD *)a1 + 600LL))(a1) // 600LL = 0x258 = CNetworkGameServerBase_IsHLTV
           && g_pSource2Server
           && (v19 = g_pSource2Server,
-              v22 = *(unsigned __int8 (__fastcall **)(_QWORD *, _QWORD))(*g_pSource2Server + 200LL),
+              v22 = *(unsigned __int8 (__fastcall **)(_QWORD *, _QWORD))(*g_pSource2Server + 200LL),// 200LL = 0xC8 = CSource2Server_ShouldTimeoutClient
               (*(void (__fastcall **)(__int64))(*(_QWORD *)v7 + 160LL))(v7),
               v22(v19, v5[18])) )
         {

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServerBase_CheckTimeouts.windows.yaml
@@ -129,7 +129,7 @@ disasm_code: |-
   .text:00000001800AC096                 jz      loc_1800AC1AC
   .text:00000001800AC09C                 mov     rax, [rax]
   .text:00000001800AC09F                 mov     rcx, rsi
-  .text:00000001800AC0A2                 mov     rbx, [rax+0C8h]
+  .text:00000001800AC0A2                 mov     rbx, [rax+0C8h] ; 0C8h = CSource2Server_ShouldTimeoutClient
   .text:00000001800AC0A9                 mov     rax, [rsi]
   .text:00000001800AC0AC                 call    qword ptr [rax+0A0h]
   .text:00000001800AC0B2                 mov     edx, [rdi+48h]
@@ -357,7 +357,7 @@ procedure: |-
           {
             if ( g_pSource2Server )
             {
-              v19 = *(unsigned __int8 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Server + 200LL);
+              v19 = *(unsigned __int8 (__fastcall **)(__int64, _QWORD))(*(_QWORD *)g_pSource2Server + 200LL);// 200LL = 0xC8 = CSource2Server_ShouldTimeoutClient
               v1 = (*(double (__fastcall **)(__int64 *))(*v12 + 160))(v12);
               if ( v19(g_pSource2Server, *(unsigned int *)(v5 + 72)) )
               {


### PR DESCRIPTION
## Summary
- Add Pattern C (vfunc via LLM_DECOMPILE) preprocessor finder `find-CSource2Server_ShouldTimeoutClient` in the engine module. It resolves `CSource2Server::ShouldTimeoutClient` (a vfunc of `CSource2Server_vtable`) by decompiling the engine predecessor `CNetworkGameServerBase_CheckTimeouts` and identifying the register-indirect vtable call at slot offset `0xC8` on `g_pSource2Server`.
- Slim Pattern C output shape: `func_name, vfunc_sig, vfunc_offset, vfunc_index, vtable_name`. `vtable_name = CSource2Server_vtable` is metadata only (no `CSource2Server_vtable` `expected_input`; the class body lives in the server module).
- Add `configs/14174.yaml` engine skill entry (`expected_input: CNetworkGameServerBase_CheckTimeouts.{platform}.yaml`) and engine symbol entry (`category: vfunc`, alias `CSource2Server::ShouldTimeoutClient`).
- Hand-annotate both engine `CNetworkGameServerBase_CheckTimeouts.{windows,linux}.yaml` reference YAMLs at the `ShouldTimeoutClient` vcall site (`0xC8`) in both `disasm_code` and `procedure`, preserving the pre-existing `IsHLTV` annotations.

Resolved for both platforms: `vfunc_index 25`, `vfunc_offset 0xc8`; `vfunc_sig 48 8B 98 C8 00 00 00` (windows), `48 8B 92 C8 00 00 00` (linux).

## Validation
- implementation-specific tests: `ida_analyze_bin.py -oldgamever none -modules engine -skill find-CSource2Server_ShouldTimeoutClient` -> Successful 2, Failed 0, Skipped 0; both platform YAMLs produced via the LLM_DECOMPILE path. Non-MCP unittest suite: 1064 tests OK (skipped 3), 0 failures. C++ vtable dump confirms `[25] ShouldTimeoutClient`.
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (Compile 0, Layout diffs 0/14, VTable diffs 0/12, Record diffs 0/2)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit(s) ahead of `origin/main`; supplemental publication commit: created