### PR TITLE
CCSPlayerController_Disconnect

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -6711,6 +6711,12 @@ modules:
         expected_input:
           - CPlayerCommandQueue_ctor.{platform}.yaml
           - CCSPlayerController_vtable.{platform}.yaml
+      - name: find-CCSPlayerController_Disconnect
+        expected_output:
+          - CCSPlayerController_Disconnect.{platform}.yaml
+        expected_input:
+          - CEntityInstance_Disconnect.{platform}.yaml
+          - CCSPlayerController_vtable.{platform}.yaml
       - name: find-CCSPlayerController_SwitchTeam
         expected_output:
           - CCSPlayerController_SwitchTeam.{platform}.yaml
@@ -9880,6 +9886,10 @@ modules:
         category: vfunc
         alias:
           - CCSPlayerController::Connect
+      - name: CCSPlayerController_Disconnect
+        category: vfunc
+        alias:
+          - CCSPlayerController::Disconnect
       - name: CCSPlayerController_SwitchTeam
         category: func
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:de01713ee4b988a9104f9f240aaa8b3e14c23b5e67e424ff6f44b4209922ed28
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -21289,6 +21289,24 @@ files:
     func_va: '0x180ae7ea0'
     vfunc_index: 5
     vfunc_offset: '0x28'
+    vtable_name: CCSPlayerController
+  server/CCSPlayerController_Disconnect.linux.yaml:
+    func_name: CCSPlayerController_Disconnect
+    func_rva: '0x15c4810'
+    func_sig: 55 31 F6 48 89 E5 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 48 8B 03
+    func_size: '0x2c'
+    func_va: '0x15c4810'
+    vfunc_index: 7
+    vfunc_offset: '0x38'
+    vtable_name: CCSPlayerController
+  server/CCSPlayerController_Disconnect.windows.yaml:
+    func_name: CCSPlayerController_Disconnect
+    func_rva: '0xae93b0'
+    func_sig: 40 53 48 83 EC ?? 33 D2 48 8B D9 E8 ?? ?? ?? ?? 48 8B 03
+    func_size: '0x29'
+    func_va: '0x180ae93b0'
+    vfunc_index: 6
+    vfunc_offset: '0x30'
     vtable_name: CCSPlayerController
   server/CCSPlayerController_GetThinkFunction.linux.yaml:
     func_name: CCSPlayerController_GetThinkFunction
@@ -42784,5 +42802,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T20:08:38Z'
 schema_version: 5

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/ida_preprocessor_scripts/find-CCSPlayerController_Disconnect.py
+++ b/ida_preprocessor_scripts/find-CCSPlayerController_Disconnect.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CCSPlayerController_Disconnect skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CCSPlayerController_Disconnect",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CCSPlayerController_Disconnect",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEntityInstance_Disconnect"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CCSPlayerController_Disconnect", "CCSPlayerController"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CCSPlayerController_Disconnect",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CCSPlayerController_Disconnect` preprocessor (Pattern B, static FUNC_XREFS): locates the CCSPlayerController derived-class override of `CEntityInstance_Disconnect` via `xref_funcs=["CEntityInstance_Disconnect"]`, disambiguated by intersecting the caller set with the `CCSPlayerController` vtable member set (FUNC_VTABLE_RELATIONS).
- Register the `find-CCSPlayerController_Disconnect` skill (expected_input: `CEntityInstance_Disconnect`, `CCSPlayerController_vtable`) and the `CCSPlayerController_Disconnect` symbol (category `vfunc`, alias `CCSPlayerController::Disconnect`) in `configs/14174.yaml`.
- Publish the resulting two-platform vfunc entries into `gamesymbols/14174.yaml` (win vfunc_index 6 / offset 0x30; linux vfunc_index 7 / offset 0x38).

## Validation
- scoped preprocessor validation: `ida_analyze_bin.py -oldgamever none -modules server -skill find-CCSPlayerController_Disconnect` -> Successful: 2, Failed: 0 (single-candidate match on both platforms after vtable intersection)
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (Layout 0/14, VTable 0/12, Record layout 0/2)
- candidate publication: passed; published SHA-256 matches the validated candidate (`8484253915fdc9a7c348072562f8f7a3d77cb9b40ae09dd1e08cbd1506e529e2`)
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created