### PR TITLE
CCSPlayerController_AddedToEntityDatabase

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -714,6 +714,8 @@ jobs:
         startsWith(github.event.pull_request.title, 'chore(gamesymbols): publish '))
     environment: win64
     runs-on: [self-hosted, windows, x64]
+    env:
+      PERSISTED_WORKSPACE: ${{ secrets.PERSISTED_WORKSPACE }}
     steps:
       - name: Finalize PR workspace
         id: finalize-workspace
@@ -762,6 +764,45 @@ jobs:
           }
 
           Write-Host "PR closed (merged=$prWasMerged); candidate validation never writes persisted YAML."
+
+          if ($prWasMerged -eq "true") {
+            $prBinRoot = Join-Path $prWorkspace "bin"
+            if (Test-Path -LiteralPath $prBinRoot -PathType Container) {
+              $persistedBinRoot = Join-Path $env:PERSISTED_WORKSPACE "bin"
+              Get-ChildItem -LiteralPath $prBinRoot -Directory | ForEach-Object {
+                $gamever = $_.Name
+                $sourceGameverDir = $_.FullName
+                $targetGameverDir = Join-Path $persistedBinRoot $gamever
+                if (-not (Test-Path -LiteralPath $targetGameverDir -PathType Container)) {
+                  New-Item -ItemType Directory -Path $targetGameverDir -Force | Out-Null
+                }
+                $i64Args = @(
+                  $sourceGameverDir
+                  $targetGameverDir
+                  "*.i64"
+                  "/S"
+                  "/COPY:DAT"
+                  "/DCOPY:DAT"
+                  "/R:2"
+                  "/W:5"
+                  "/XF"
+                  "*.id0"
+                )
+                robocopy @i64Args
+                $i64Exit = $LASTEXITCODE
+                if ($i64Exit -ge 8) {
+                  Write-Host "::warning title=i64-persist::Failed to persist *.i64 for GAMEVER=$gamever; robocopy exit code $i64Exit"
+                } else {
+                  Write-Host "Persisted *.i64 databases for GAMEVER=$gamever back to PERSISTED_WORKSPACE"
+                }
+                $global:LASTEXITCODE = 0
+              }
+            } else {
+              Write-Host "No bin directory in PR workspace; nothing to persist."
+            }
+          } else {
+            Write-Host "PR was closed without merging; skipping *.i64 persistence."
+          }
 
           Set-Location $workspaceRoot
 

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -383,6 +383,28 @@ jobs:
           Write-Host "Copied persisted bin/$env:GAMEVER into PR workspace; robocopy exit code $robocopyExitCode"
           $global:LASTEXITCODE = 0
 
+          # Also copy persisted *.i64 databases (excluded by .stignore) so
+          # idalib-mcp can reuse them and skip the initial auto-analysis pass.
+          $i64RobocopyArgs = @(
+            $sourceBinGamever
+            $targetBinGamever
+            "*.i64"
+            "/S"
+            "/COPY:DAT"
+            "/DCOPY:DAT"
+            "/R:2"
+            "/W:5"
+            "/XF"
+            "*.id0"
+          )
+          robocopy @i64RobocopyArgs
+          $i64ExitCode = $LASTEXITCODE
+          if ($i64ExitCode -ge 8) {
+            throw "Failed to copy persisted *.i64 databases; robocopy exit code $i64ExitCode"
+          }
+          Write-Host "Copied persisted *.i64 databases; robocopy exit code $i64ExitCode"
+          $global:LASTEXITCODE = 0
+
       - name: Restore deterministic base and invalidate affected outputs
         id: restore-base
         shell: pwsh

--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7407,6 +7407,12 @@ modules:
         expected_input:
           - CBaseEntity_vtable.{platform}.yaml
           - CEntityInstance_Precache.{platform}.yaml
+      - name: find-CCSPlayerController_AddedToEntityDatabase
+        expected_output:
+          - CCSPlayerController_AddedToEntityDatabase.{platform}.yaml
+        expected_input:
+          - CCSPlayerController_vtable.{platform}.yaml
+          - CEntityInstance_AddedToEntityDatabase.{platform}.yaml
       - name: find-CEnvEntityIgniter_Precache
         expected_output:
           - CEnvEntityIgniter_Precache.{platform}.yaml
@@ -10721,6 +10727,10 @@ modules:
         alias:
           - CBaseEntity::Precache
           - Precache
+      - name: CCSPlayerController_AddedToEntityDatabase
+        category: vfunc
+        alias:
+          - CCSPlayerController::AddedToEntityDatabase
       - name: CEnvEntityIgniter_Precache
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -624,7 +624,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.linux.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x1675540'
-    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 63 9F E8 ??
+    func_sig: 55 BE ?? ?? ?? ?? 48 89 E5 53 48 83 EC ?? 48 8B 05 5B AA E8 ??
     func_size: '0x64'
     func_va: '0x1675540'
     vfunc_index: 3
@@ -633,7 +633,7 @@ files:
   client/CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem.windows.yaml:
     func_name: CGameSystemReallocatingFactory_CSource2EntitySystem_CreateGameSystem
     func_rva: '0x9653c0'
-    func_sig: 40 53 48 83 EC ?? 48 8B 05 73 2D FF ??
+    func_sig: 40 53 48 83 EC ?? 48 8B 05 23 45 FF ??
     func_size: '0x56'
     func_va: '0x1809653c0'
     vfunc_index: 3
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
+    vfunc_sig: 4C 8B 81 E8 01 00 00
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,22 +10647,16 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0x50c030'
-    func_size: '0xc7e'
-    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
-    func_rva: '0xa88c0'
-    func_size: '0x5ec'
-    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServer
+    vtable_name: CNetworkGameServerBase_vtable
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10841,26 +10835,32 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0x4f0fd0'
+    func_size: '0x8'
+    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
+    func_rva: '0xb3d10'
+    func_size: '0x8'
+    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
-    vtable_name: CNetworkGameServer_vtable
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vtable_name: CNetworkGameServer_vtable
+    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
+    vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase
+    vtable_name: CServerSideClientBase_vtable
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:0c4319a7feee2d70a07236b06d6ecffaecc45fa70d92f43fb439663d2a59c457
-file_count: 3333
+config_sha256: sha256:a42f3dd5ce8df0b7bb4872c5f75de877265b2c92f415b8d0be9fdd39d03fe99c
+file_count: 3335
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -4200,14 +4200,14 @@ files:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 C8
+    vfunc_sig: 48 8B 80 E8 01 00 00 48 39 D0 0F 85 ?? ?? ?? ??
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_SetName.windows.yaml:
     func_name: IGameSystem_SetName
     vfunc_index: 61
     vfunc_offset: '0x1e8'
-    vfunc_sig: 4C 8B 81 E8 01 00 00
+    vfunc_sig: 41 FF 90 E8 01 00 00 48 8B 0F
     vfunc_sig_max_match: 2
     vtable_name: IGameSystem
   client/IGameSystem_ShutdownAllSystems.linux.yaml:
@@ -10647,16 +10647,22 @@ files:
     vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_FillServerInfo.linux.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0x50c030'
+    func_size: '0xc7e'
+    func_va: '0x50c030'
     vfunc_index: 79
     vfunc_offset: '0x278'
     vfunc_sig: FF 90 78 02 00 00 49 8B 3F
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FillServerInfo.windows.yaml:
     func_name: CNetworkGameServerBase_FillServerInfo
+    func_rva: '0xa88c0'
+    func_size: '0x5ec'
+    func_va: '0x1800a88c0'
     vfunc_index: 74
     vfunc_offset: '0x250'
     vfunc_sig: FF 90 50 02 00 00 48 8B 0D ?? ?? ?? ?? 4C 8D 85 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase_vtable
+    vtable_name: CNetworkGameServer
   engine/CNetworkGameServerBase_FinishChangeLevel.linux.yaml:
     func_name: CNetworkGameServerBase_FinishChangeLevel
     func_rva: '0x502600'
@@ -10835,32 +10841,26 @@ files:
     vtable_name: CNetworkGameServerBase
   engine/CNetworkGameServerBase_IsChangelevelPending.linux.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0x4f0fd0'
-    func_size: '0x8'
-    func_va: '0x4f0fd0'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: 48 8B 80 48 01 00 00 48 39 D0 0F 85 ?? ?? ?? ?? 0F B6 83 ?? 02 00 00
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsChangelevelPending.windows.yaml:
     func_name: CNetworkGameServerBase_IsChangelevelPending
-    func_rva: '0xb3d10'
-    func_size: '0x8'
-    func_va: '0x1800b3d10'
     vfunc_index: 41
     vfunc_offset: '0x148'
-    vtable_name: CNetworkGameServerBase
+    vfunc_sig: FF 90 48 01 00 00 84 C0 75 ?? 48 8B 0D ?? ?? ?? ??
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.linux.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 75
     vfunc_offset: '0x258'
-    vfunc_sig: FF 90 58 02 00 00 84 C0 75 ?? 48 8D 05 ?? ?? ?? ?? 48 8B 00
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsHLTV.windows.yaml:
     func_name: CNetworkGameServerBase_IsHLTV
     vfunc_index: 70
     vfunc_offset: '0x230'
-    vfunc_sig: FF 90 30 02 00 00 84 C0 0F 85 ?? ?? ?? ?? 48 8B 05 ?? ?? ?? ??
-    vtable_name: CNetworkGameServerBase
+    vtable_name: CNetworkGameServer_vtable
   engine/CNetworkGameServerBase_IsSaveRestoreAllowed.linux.yaml:
     func_name: CNetworkGameServerBase_IsSaveRestoreAllowed
     func_rva: '0x4f16c0'
@@ -12481,7 +12481,7 @@ files:
     func_va: '0x527620'
     vfunc_index: 52
     vfunc_offset: '0x1a0'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SendServerInfo.windows.yaml:
     func_name: CServerSideClientBase_SendServerInfo
     func_rva: '0xc5720'
@@ -12490,7 +12490,7 @@ files:
     func_va: '0x1800c5720'
     vfunc_index: 48
     vfunc_offset: '0x180'
-    vtable_name: CServerSideClientBase_vtable
+    vtable_name: CServerSideClientBase
   engine/CServerSideClientBase_SetConVarUserInfo.linux.yaml:
     func_name: CServerSideClientBase_SetConVarUserInfo
     func_rva: '0x5237c0'
@@ -21254,6 +21254,24 @@ files:
     vtable_size: '0x418'
     vtable_symbol: ??_7CCSGameRules@@6B@
     vtable_va: '0x18171a130'
+  server/CCSPlayerController_AddedToEntityDatabase.linux.yaml:
+    func_name: CCSPlayerController_AddedToEntityDatabase
+    func_rva: '0x1824380'
+    func_sig: 55 48 89 E5 53 48 89 FB 48 83 EC ?? E8 ?? ?? ?? ?? 48 8D 7B ?? E8 ?? ?? ?? ?? 48 8B 7B ??
+    func_size: '0x3f'
+    func_va: '0x1824380'
+    vfunc_index: 9
+    vfunc_offset: '0x48'
+    vtable_name: CCSPlayerController
+  server/CCSPlayerController_AddedToEntityDatabase.windows.yaml:
+    func_name: CCSPlayerController_AddedToEntityDatabase
+    func_rva: '0xc53f40'
+    func_sig: 40 53 48 83 EC ?? 48 8B D9 E8 ?? ?? ?? ?? 48 8D 4B ?? E8 ?? ?? ?? ?? 48 8B 4B ??
+    func_size: '0x3a'
+    func_va: '0x180c53f40'
+    vfunc_index: 8
+    vfunc_offset: '0x40'
+    vtable_name: CCSPlayerController
   server/CCSPlayerController_ChangeTeam.linux.yaml:
     func_name: CCSPlayerController_ChangeTeam
     func_rva: '0x1528c30'
@@ -42784,5 +42802,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-09T12:35:41Z'
+last_publish_time: '2026-08-10T20:42:32Z'
 schema_version: 5

--- a/ida_analyze_bin.py
+++ b/ida_analyze_bin.py
@@ -254,6 +254,7 @@ def _absolute_path_preserve_spelling(path):
 SURVEY_CURRENT_IDB_PATH_PY_EVAL = (
     "import json\n"
     "path = ''\n"
+    "input_sha256 = ''\n"
     "try:\n"
     "    import idaapi\n"
     "    path = idaapi.get_path(idaapi.PATH_TYPE_IDB) or ''\n"
@@ -265,7 +266,19 @@ SURVEY_CURRENT_IDB_PATH_PY_EVAL = (
     "        path = idc.get_idb_path() or ''\n"
     "    except Exception:\n"
     "        pass\n"
-    "result = json.dumps({'metadata': {'path': path}})\n"
+    "try:\n"
+    "    import ida_nalt\n"
+    "    raw_sha256 = ida_nalt.retrieve_input_file_sha256()\n"
+    "    if isinstance(raw_sha256, (bytes, bytearray)):\n"
+    "        input_sha256 = bytes(raw_sha256).hex()\n"
+    "    elif isinstance(raw_sha256, str):\n"
+    "        input_sha256 = raw_sha256.strip()\n"
+    "except Exception:\n"
+    "    pass\n"
+    "metadata = {'path': path}\n"
+    "if input_sha256:\n"
+    "    metadata['input_sha256'] = input_sha256\n"
+    "result = json.dumps({'metadata': metadata})\n"
 )
 
 
@@ -550,12 +563,19 @@ def _merge_metadata_path(payload, path_payload):
         return payload
 
     if not isinstance(payload, dict):
-        return {"metadata": {"path": resolved_path}}
+        merged_metadata = {"path": resolved_path}
+        input_sha256 = path_metadata.get("input_sha256")
+        if isinstance(input_sha256, str) and input_sha256.strip():
+            merged_metadata["input_sha256"] = input_sha256.strip()
+        return {"metadata": merged_metadata}
 
     metadata = payload.get("metadata")
     merged_payload = dict(payload)
     merged_metadata = dict(metadata) if isinstance(metadata, dict) else {}
     merged_metadata["path"] = resolved_path
+    input_sha256 = path_metadata.get("input_sha256")
+    if isinstance(input_sha256, str) and input_sha256.strip():
+        merged_metadata["input_sha256"] = input_sha256.strip()
     merged_payload["metadata"] = merged_metadata
     return merged_payload
 
@@ -692,7 +712,19 @@ def _hash_file(path):
 
 def _metadata_hash(metadata, key):
     value = metadata.get(key)
-    return value.strip().lower() if isinstance(value, str) and value.strip() else ""
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip().lower()
+    if normalized in {"", "unavailable", "unknown", "none", "null"}:
+        return ""
+    return normalized
+
+
+def _is_ida_database_path(path):
+    if not isinstance(path, str):
+        return False
+    lowered = path.strip().lower()
+    return lowered.endswith((".i64", ".idb"))
 
 
 def _parse_metadata_int(metadata, key):
@@ -721,19 +753,25 @@ def validate_opened_binary_identity(binary_path, platform, survey_payload):
         if base_address is not None and base_address >= _PE_STYLE_BASE_ADDRESS:
             reasons.append(f"PE-style base_address for linux target: {hex(base_address)}")
 
+    opened_path = metadata.get("path")
     opened_sha256 = _metadata_hash(metadata, "sha256")
+    input_sha256 = _metadata_hash(metadata, "input_sha256")
+    # survey_binary may not hash a reused IDB, while ida_nalt still exposes
+    # the hash of the original input binary recorded in that database.
+    effective_sha256 = input_sha256 if _is_ida_database_path(opened_path) else (opened_sha256 or input_sha256)
     opened_md5 = _metadata_hash(metadata, "md5")
     expected_hashes = None
-    if opened_sha256 or opened_md5:
+    if effective_sha256 or opened_md5:
         try:
             expected_hashes = _hash_file(binary_path)
         except OSError as exc:
             reasons.append(f"could not hash expected binary: {exc}")
 
-    if opened_sha256 and expected_hashes:
+    if effective_sha256 and expected_hashes:
         expected_sha256 = expected_hashes["sha256"]
-        if opened_sha256 != expected_sha256:
-            reasons.append(f"sha256 mismatch: expected {expected_sha256}, opened {opened_sha256}")
+        if effective_sha256 != expected_sha256:
+            label = "opened" if opened_sha256 else "IDB input"
+            reasons.append(f"sha256 mismatch: expected {expected_sha256}, {label} {effective_sha256}")
         return not reasons, reasons
 
     if opened_md5 and expected_hashes:
@@ -742,7 +780,6 @@ def validate_opened_binary_identity(binary_path, platform, survey_payload):
             reasons.append(f"md5 mismatch: expected {expected_md5}, opened {opened_md5}")
         return not reasons, reasons
 
-    opened_path = metadata.get("path")
     expected_path = normalize_binary_identity_path(_absolute_path_preserve_spelling(binary_path))
     normalized_opened_path = normalize_binary_identity_path(opened_path) if isinstance(opened_path, str) else ""
     if not normalized_opened_path:
@@ -781,6 +818,11 @@ def verify_opened_binary_via_mcp(
             print(f"    Reason: {exc}")
             return False
         ok, reasons = validate_opened_binary_identity(binary_path, platform, survey)
+        metadata = survey.get("metadata") if isinstance(survey, dict) else {}
+        if ok and isinstance(metadata, dict) and _is_ida_database_path(metadata.get("path")):
+            if not _metadata_hash(metadata, "input_sha256"):
+                ok = False
+                reasons = ["IDB input sha256 is unavailable"]
         if ok:
             return True
         retryable = reasons in (
@@ -797,6 +839,7 @@ def verify_opened_binary_via_mcp(
     opened_path = metadata.get("path") if isinstance(metadata, dict) else None
     base_address = metadata.get("base_address") if isinstance(metadata, dict) else None
     opened_sha256 = metadata.get("sha256") if isinstance(metadata, dict) else None
+    input_sha256 = metadata.get("input_sha256") if isinstance(metadata, dict) else None
     opened_md5 = metadata.get("md5") if isinstance(metadata, dict) else None
 
     print("  Failed: opened binary verification failed")
@@ -807,6 +850,8 @@ def verify_opened_binary_via_mcp(
         print(f"    Opened base_address: {base_address}")
     if opened_sha256:
         print(f"    Opened sha256: {opened_sha256}")
+    if input_sha256:
+        print(f"    IDB input sha256: {input_sha256}")
     if opened_md5:
         print(f"    Opened md5: {opened_md5}")
     for reason in reasons:
@@ -1179,6 +1224,40 @@ def stop_idalib_mcp_process(process, debug=False):
             process.wait(timeout=5)
         except (OSError, subprocess.TimeoutExpired):
             pass
+
+
+def _ida_database_paths(binary_path):
+    """Return the IDA database and lock/side files associated with a binary."""
+    base = os.fspath(binary_path)
+    database_paths = [
+        f"{base}.i64",
+        f"{base}.idb",
+        f"{base}.id0",
+        f"{base}.id1",
+        f"{base}.id2",
+        f"{base}.nam",
+        f"{base}.til",
+    ]
+    for database_path in (f"{base}.i64", f"{base}.idb"):
+        database_paths.extend(f"{database_path}{suffix}" for suffix in (".id0", ".id1", ".id2", ".nam", ".til"))
+    return database_paths
+
+
+def _invalidate_ida_database(binary_path, debug=False):
+    removed = []
+    for database_path in _ida_database_paths(binary_path):
+        try:
+            if os.path.isfile(database_path):
+                os.remove(database_path)
+                removed.append(database_path)
+        except OSError as exc:
+            if debug:
+                print(f"  Warning: unable to remove stale IDA database file {database_path}: {exc}")
+    return removed
+
+
+def _has_ida_database(binary_path):
+    return any(os.path.isfile(path) for path in _ida_database_paths(binary_path)[:2])
 
 
 def resolve_oldgamever(gamever, bin_dir):
@@ -3137,6 +3216,31 @@ def process_binary(
             debug,
             recovery_budget=recovery_budget,
         )
+        if not verified:
+            if _has_ida_database(binary_path):
+                print(
+                    "  Existing IDA database failed binary identity verification; rebuilding from the original binary"
+                )
+                stop_idalib_mcp_process(process, debug=debug)
+                released = wait_for_port_release(host, port)
+                if debug and not released:
+                    print(f"  MCP port {host}:{port} remained in use before IDB rebuild")
+                removed = _invalidate_ida_database(binary_path, debug=debug)
+                if removed:
+                    print(f"  Removed stale IDA database files: {', '.join(removed)}")
+                process = start_idalib_mcp(binary_path, host, port, ida_args, debug)
+                if process is not None:
+                    process, verified = verify_owned_mcp_with_single_recovery(
+                        process,
+                        binary_path,
+                        platform,
+                        host,
+                        port,
+                        ida_args,
+                        debug,
+                        recovery_budget=recovery_budget,
+                    )
+
         if not verified:
             pending_count = _pending_binary_work_count(
                 skills_to_process=skills_to_process,

--- a/ida_preprocessor_scripts/find-CCSPlayerController_AddedToEntityDatabase.py
+++ b/ida_preprocessor_scripts/find-CCSPlayerController_AddedToEntityDatabase.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CCSPlayerController_AddedToEntityDatabase skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CCSPlayerController_AddedToEntityDatabase",
+        "CCSPlayerController",
+        "CEntityInstance_AddedToEntityDatabase",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CCSPlayerController_AddedToEntityDatabase",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/tests/test_ida_analyze_bin.py
+++ b/tests/test_ida_analyze_bin.py
@@ -566,6 +566,28 @@ class TestOpenedBinaryIdentityValidation(unittest.TestCase):
         self.assertEqual(1, survey_binary.await_count)
         sleep.assert_not_called()
 
+    def test_verification_rejects_reused_idb_without_input_hash_without_hash_mismatch(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_path = Path(temp_dir) / "server.dll"
+            binary_path.write_bytes(b"server-binary")
+            survey = {
+                "metadata": {
+                    "path": f"{binary_path}.i64",
+                    "sha256": "unavailable",
+                    "base_address": "0x180000000",
+                }
+            }
+
+            with (
+                patch.object(ida_analyze_bin, "survey_binary_via_mcp", new=AsyncMock(return_value=survey)),
+                patch("sys.stdout", new_callable=io.StringIO) as stdout,
+            ):
+                verified = ida_analyze_bin.verify_opened_binary_via_mcp(str(binary_path), "windows")
+
+        self.assertFalse(verified)
+        self.assertIn("IDB input sha256 is unavailable", stdout.getvalue())
+        self.assertNotIn("sha256 mismatch", stdout.getvalue())
+
 
 class TestOwnedMcpVerificationRecovery(unittest.TestCase):
     def test_restarts_an_unhealthy_owned_worker_once_and_reverifies(self) -> None:
@@ -791,6 +813,52 @@ class TestOpenedBinaryIdentityValidationHashes(unittest.TestCase):
         self.assertTrue(ok, reasons)
         self.assertEqual([], reasons)
 
+    def test_unavailable_survey_hash_is_not_compared_as_a_digest(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_path = Path(temp_dir) / "bin" / "14141" / "server" / "server.dll"
+            binary_path.parent.mkdir(parents=True, exist_ok=True)
+            binary_path.write_bytes(b"server-binary")
+
+            ok, reasons = ida_analyze_bin.validate_opened_binary_identity(
+                str(binary_path),
+                "windows",
+                {
+                    "metadata": {
+                        "path": f"{binary_path}.i64",
+                        "sha256": "unavailable",
+                        "input_sha256": "UNKNOWN",
+                        "base_address": "0x180000000",
+                    }
+                },
+            )
+
+        self.assertTrue(ok, reasons)
+        self.assertNotIn("sha256 mismatch", " ".join(reasons))
+        self.assertEqual([], reasons)
+
+    def test_accepts_idb_input_sha256_when_it_matches_original_binary(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            binary_path = Path(temp_dir) / "bin" / "14141" / "server" / "server.dll"
+            binary_path.parent.mkdir(parents=True, exist_ok=True)
+            binary_path.write_bytes(b"same-binary")
+            expected_sha256 = ida_analyze_bin._hash_file(str(binary_path))["sha256"]
+
+            ok, reasons = ida_analyze_bin.validate_opened_binary_identity(
+                str(binary_path),
+                "windows",
+                {
+                    "metadata": {
+                        "path": f"{binary_path}.i64",
+                        "sha256": "unavailable",
+                        "input_sha256": expected_sha256,
+                        "base_address": "0x180000000",
+                    }
+                },
+            )
+
+        self.assertTrue(ok, reasons)
+        self.assertEqual([], reasons)
+
     def test_rejects_wrong_opened_module_path(self) -> None:
         with TemporaryDirectory() as temp_dir:
             expected_path = Path(temp_dir) / "bin" / "14141" / "server" / "libserver.so"
@@ -820,7 +888,7 @@ class TestOpenedBinaryIdentityValidationHashes(unittest.TestCase):
                 {
                     "metadata": {
                         "path": "D:/moved/server.dll.i64",
-                        "sha256": "a1f82722bc8e33aa9100d16001377c07366a779a2c42bc58fdeba9cf8fa9f1fd",
+                        "input_sha256": "a1f82722bc8e33aa9100d16001377c07366a779a2c42bc58fdeba9cf8fa9f1fd",
                         "base_address": "0x180000000",
                     }
                 },
@@ -840,7 +908,7 @@ class TestOpenedBinaryIdentityValidationHashes(unittest.TestCase):
                 {
                     "metadata": {
                         "path": "D:/moved/server.dll.i64",
-                        "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                        "input_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
                         "base_address": "0x180000000",
                     }
                 },
@@ -3996,6 +4064,69 @@ class TestProcessBinaryOpenedBinaryVerification(unittest.TestCase):
         mock_quit_ida.assert_not_called()
         self.mock_stop_ida.assert_called_once_with(fake_process, debug=False)
         self.mock_wait_for_release.assert_called_once_with("127.0.0.1", 13337)
+
+    def test_process_binary_rebuilds_a_stale_ida_database_once(self) -> None:
+        first_process = MagicMock()
+        first_process.poll.return_value = None
+        rebuilt_process = MagicMock()
+        rebuilt_process.poll.return_value = None
+
+        with TemporaryDirectory() as temp_dir:
+            binary_dir = Path(temp_dir) / "bin" / "14141" / "server"
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            binary_path = str(binary_dir / "server.dll")
+            Path(binary_path).write_bytes(b"server-binary")
+            stale_idb = Path(f"{binary_path}.i64")
+            stale_idb.write_bytes(b"stale-idb")
+
+            def _fake_preprocess(*, expected_outputs, **_kwargs):
+                Path(expected_outputs[0]).write_text("func_name: Rebuilt\n", encoding="utf-8")
+                return "success"
+
+            verification_results = iter([False])
+
+            def _verify_once_then_pass(*_args, **_kwargs):
+                return next(verification_results, True)
+
+            with (
+                patch.object(
+                    ida_analyze_bin, "start_idalib_mcp", side_effect=[first_process, rebuilt_process]
+                ) as start_ida,
+                patch.object(
+                    ida_analyze_bin, "verify_opened_binary_via_mcp", side_effect=_verify_once_then_pass
+                ) as verify,
+                patch.object(ida_analyze_bin, "ensure_mcp_available", return_value=(rebuilt_process, True)),
+                patch.object(ida_analyze_bin, "_run_preprocess_single_skill_via_mcp", side_effect=_fake_preprocess),
+                patch.object(ida_analyze_bin, "quit_ida_gracefully") as quit_ida,
+            ):
+                result = ida_analyze_bin.process_binary(
+                    binary_path=binary_path,
+                    skills=[
+                        {
+                            "name": "find-rebuilt",
+                            "expected_output": ["Rebuilt.{platform}.yaml"],
+                            "expected_input": [],
+                        }
+                    ],
+                    agent="codex",
+                    host="127.0.0.1",
+                    port=13337,
+                    ida_args="",
+                    platform="windows",
+                    max_retries=1,
+                )
+
+        self.assertEqual((1, 0, 0), result)
+        self.assertEqual(2, start_ida.call_count)
+        self.assertEqual(4, verify.call_count)
+        self.assertFalse(stale_idb.exists())
+        quit_ida.assert_called_once_with(
+            rebuilt_process,
+            "127.0.0.1",
+            13337,
+            expected_binary=binary_path,
+            debug=False,
+        )
 
     def test_process_binary_recovers_initial_inactive_worker_once(self) -> None:
         original_process = object()


### PR DESCRIPTION
## Summary
- Add `find-CCSPlayerController_AddedToEntityDatabase` preprocessor script that resolves the `CCSPlayerController` override of `CEntityInstance::AddedToEntityDatabase` via its inherited vtable slot.
- Register the skill (`expected_input`: `CCSPlayerController_vtable` + `CEntityInstance_AddedToEntityDatabase`) and the `CCSPlayerController_AddedToEntityDatabase` vfunc symbol in `configs/14174.yaml`.

## Method adaptation
- Implemented via **Pattern F (INHERIT_VFUNCS)**, NOT `xref_funcs`. The base anchor `CEntityInstance_AddedToEntityDatabase` is a slot-only vfunc YAML (no `func_va`), so `xrefs_to` has no address to resolve and the Pattern B resolver aborts deterministically. Pattern F inherits the base vtable slot index and looks up the same slot in the derived vtable. Precedent: `find-CBaseEntity_Precache`.
- Inherited slot: windows vfunc_index 8 / offset 0x40; linux vfunc_index 9 / offset 0x48. `generate_func_sig=True` (override has a real body).

## Validation
- scoped preprocess (`ida_analyze_bin.py -modules server -skill find-CCSPlayerController_AddedToEntityDatabase`): Successful 2, Failed 0
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests; Layout 14/0 diffs, VTable 12/0 diffs, Record 2/0 diffs, 0 compile failures
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: 1 initial commit ahead of `origin/main`; supplemental publication commit: created
