### PR TITLE
fix(gamedata): bundle CS2FOW static template after upstream 403

### DIFF
--- a/gamedata-generators/CS2FOW/gamedata.py
+++ b/gamedata-generators/CS2FOW/gamedata.py
@@ -12,12 +12,12 @@ GENERATOR_API_VERSION = 2
 
 GAMEDATA_PATH = "gamedata/cs2fow.games.txt"
 OUTPUT_PATHS = (GAMEDATA_PATH,)
-DOWNLOAD_SOURCES = [
-    (
-        "https://gitlab.com/karola3vax-group/cs2fow/-/raw/main/gamedata/cs2fow.games.txt?ref_type=heads",
-        GAMEDATA_PATH,
-    ),
-]
+# Upstream (gitlab.com/karola3vax-group/cs2fow) went private and now returns 403,
+# so seed the last-known-good template locally instead of downloading it. The
+# update() pass re-substitutes every value from the current snapshot, so the
+# emitted payload stays byte-identical to the previous published output.
+DOWNLOAD_SOURCES = []
+STATIC_SOURCES = (("templates/cs2fow.games.txt", GAMEDATA_PATH),)
 
 SUPPORTED_PLATFORMS = {"windows", "linux"}
 ASSIGNMENT_RE = re.compile(

--- a/gamedata-generators/CS2FOW/templates/cs2fow.games.txt
+++ b/gamedata-generators/CS2FOW/templates/cs2fow.games.txt
@@ -1,0 +1,49 @@
+// CS2FOW private runtime compatibility data.
+// Verified against the public CS2 app build 24537688 (1.41.7.4).
+// Unknown binaries fail open. Keep exactly one fingerprint per platform.
+
+// Exact server binaries (file size and CRC32).
+server_binary_size_windows=32818840
+server_binary_crc32_windows=1451045147
+server_binary_size_linux=40344184
+server_binary_crc32_linux=1097984287
+
+// CCheckTransmitInfo private layout.
+recipient_slot_offset_windows=576
+recipient_slot_offset_linux=576
+checktransmit_full_update_offset_windows=580
+checktransmit_full_update_offset_linux=580
+
+// GameResourceServiceServerV001 private layout in engine2.
+game_entity_system_offset_windows=88
+game_entity_system_offset_linux=80
+
+// Module-relative server function and vtable addresses.
+game_event_manager_vtable_rva_windows=24771832
+game_event_manager_vtable_rva_linux=38413048
+lookup_bone_rva_windows=11525088
+lookup_bone_rva_linux=22924928
+get_bone_transform_rva_windows=11465024
+get_bone_transform_rva_linux=22925488
+create_entity_by_name_rva_windows=12053024
+create_entity_by_name_rva_linux=23781248
+dispatch_spawn_rva_windows=12772832
+dispatch_spawn_rva_linux=24684864
+remove_entity_rva_windows=12312448
+remove_entity_rva_linux=23782048
+
+// CBaseEntity virtual function indexes used by temporary LOS debug beams.
+teleport_vtable_index_windows=163
+teleport_vtable_index_linux=162
+
+// CSmokeGrenadeProjectile::SmokeVolume private voxel layout.
+smoke_volume_offset_windows=2776
+smoke_volume_offset_linux=3504
+smoke_storage_offset_windows=112
+smoke_storage_offset_linux=112
+smoke_frame_offset_windows=236
+smoke_frame_offset_linux=236
+smoke_center_offset_windows=212
+smoke_center_offset_linux=212
+smoke_start_time_offset_windows=12
+smoke_start_time_offset_linux=12

--- a/tests/test_cs2fow_gamedata.py
+++ b/tests/test_cs2fow_gamedata.py
@@ -117,17 +117,18 @@ class TestCS2FOWGamedata(unittest.TestCase):
             if "=" in line
         }
 
-    def test_contract_declares_v2_remote_source_and_output(self) -> None:
+    def test_contract_declares_v2_static_source_and_output(self) -> None:
         self.assertEqual(2, self.contract.api_version)
         self.assertEqual(("gamedata/cs2fow.games.txt",), self.contract.output_paths)
+        self.assertEqual((), self.contract.download_sources)
         self.assertEqual(
             (
                 (
-                    "https://gitlab.com/karola3vax-group/cs2fow/-/raw/main/gamedata/cs2fow.games.txt?ref_type=heads",
+                    "templates/cs2fow.games.txt",
                     "gamedata/cs2fow.games.txt",
                 ),
             ),
-            self.contract.download_sources,
+            self.contract.static_sources,
         )
 
     def test_updates_all_assignments_and_preserves_formatting(self) -> None:


### PR DESCRIPTION
## Summary
- CS2FOW's upstream template host (`gitlab.com/karola3vax-group/cs2fow`) went private and now returns `403 Forbidden`, which hard-fails the gamedata download step for every candidate build on 14174.
- Drop the dead `DOWNLOAD_SOURCES` and seed the last-known-good `cs2fow.games.txt` locally via `STATIC_SOURCES` (`templates/cs2fow.games.txt`). The `update()` pass re-substitutes every value from the current snapshot, so the emitted payload stays byte-identical to the previous published output.
- Update the contract test to assert the v2 static-source / empty-download-source shape.

## Validation
- CS2FOW + update_gamedata unit tests: pass (`uv run python -m unittest tests.test_cs2fow_gamedata tests.test_update_gamedata`)
- candidate preparation: passed for `14174` (static template seeded: `CS2FOW/gamedata/cs2fow.games.txt`)
- C++ post-change validation: passed with runnable tests and zero failures (compile failures 0, invalid items 0, layout/vtable/record layout diffs 0)
- candidate publication: passed; published snapshot SHA-256 matches the validated candidate; the gamedata output was byte-identical and the snapshot required no change (publication no-op for the committed diff)
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: not needed because publication was a no-op
