### PR TITLE
feat(preprocessor): split Source2Server interface and implementation vfuncs

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -609,9 +609,9 @@ modules:
         expected_input:
           - CNetworkGameServer_vtable.{platform}.yaml
           - CNetworkGameServerBase_Shutdown.{platform}.yaml
-      - name: find-CSource2Server_GetAllServerClasses
+      - name: find-ISource2Server_GetAllServerClasses
         expected_output:
-          - CSource2Server_GetAllServerClasses.{platform}.yaml
+          - ISource2Server_GetAllServerClasses.{platform}.yaml
         expected_input:
           - CNetworkGameServer_Shutdown.{platform}.yaml
       - name: find-CNetworkGameServer_SpawnServer
@@ -1837,9 +1837,9 @@ modules:
         expected_input:
           - CLoopTypeClientServer_vtable.{platform}.yaml
           - CLoopTypeClientSimple_ActivateEngineServices.{platform}.yaml
-      - name: find-CSource2Server_GetActiveWorldName
+      - name: find-ISource2Server_GetActiveWorldName
         expected_output:
-          - CSource2Server_GetActiveWorldName.{platform}.yaml
+          - ISource2Server_GetActiveWorldName.{platform}.yaml
         expected_input:
           - CLoopTypeClientServer_ActivateLoop.{platform}.yaml
       - name: find-CLoopTypeClientServer_AllocateLoopMode
@@ -2486,10 +2486,10 @@ modules:
         category: vfunc
         alias:
           - CNetworkGameServer::Shutdown
-      - name: CSource2Server_GetAllServerClasses
+      - name: ISource2Server_GetAllServerClasses
         category: vfunc
         alias:
-          - CSource2Server::GetAllServerClasses
+          - ISource2Server::GetAllServerClasses
       - name: CNetworkGameServer_SpawnServer
         category: vfunc
         alias:
@@ -3330,10 +3330,10 @@ modules:
         category: vfunc
         alias:
           - CLoopTypeClientServer::ActivateLoop
-      - name: CSource2Server_GetActiveWorldName
+      - name: ISource2Server_GetActiveWorldName
         category: vfunc
         alias:
-          - CSource2Server::GetActiveWorldName
+          - ISource2Server::GetActiveWorldName
       - name: CLoopTypeClientServer_AllocateLoopMode
         category: vfunc
         alias:
@@ -6020,6 +6020,18 @@ modules:
       - name: find-CSource2Server_vtable
         expected_output:
           - CSource2Server_vtable.{platform}.yaml
+      - name: find-CSource2Server_GetAllServerClasses
+        expected_output:
+          - CSource2Server_GetAllServerClasses.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+          - ../engine/ISource2Server_GetAllServerClasses.{platform}.yaml
+      - name: find-CSource2Server_GetActiveWorldName
+        expected_output:
+          - CSource2Server_GetActiveWorldName.{platform}.yaml
+        expected_input:
+          - CSource2Server_vtable.{platform}.yaml
+          - ../engine/ISource2Server_GetActiveWorldName.{platform}.yaml
       - name: find-CUserMessageServerFrameTime_t_vtable
         expected_output:
           - CUserMessageServerFrameTime_t_vtable.{platform}.yaml
@@ -9019,6 +9031,14 @@ modules:
     symbols:
       - name: CSource2Server_vtable
         category: vtable
+      - name: CSource2Server_GetAllServerClasses
+        category: vfunc
+        alias:
+          - CSource2Server::GetAllServerClasses
+      - name: CSource2Server_GetActiveWorldName
+        category: vfunc
+        alias:
+          - CSource2Server::GetActiveWorldName
       - name: CUserMessageServerFrameTime_t_vtable
         category: vtable
       - name: CSource2Server_vtable2

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:660d19ae344885c323839332cbd246a319fa393ecae3cf1b9df5c868d7bf17f7
-file_count: 3345
+config_sha256: sha256:45855118d25e39ee8c3f8b1824ac4c2c49980dda7fa2d58f8576335dd923c010
+file_count: 3349
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -12975,30 +12975,6 @@ files:
     vtable_size: '0x278'
     vtable_symbol: ??_7CServerSideClient@@6B@
     vtable_va: '0x180543638'
-  engine/CSource2Server_GetActiveWorldName.linux.yaml:
-    func_name: CSource2Server_GetActiveWorldName
-    vfunc_index: 30
-    vfunc_offset: '0xf0'
-    vfunc_sig: FF 90 F0 00 00 00 48 89 C6 48 8B BB ?? ?? ?? ??
-    vtable_name: CSource2Server
-  engine/CSource2Server_GetActiveWorldName.windows.yaml:
-    func_name: CSource2Server_GetActiveWorldName
-    vfunc_index: 30
-    vfunc_offset: '0xf0'
-    vfunc_sig: FF 90 F0 00 00 00 48 8B F0 48 8B 9F ?? ?? ?? ??
-    vtable_name: CSource2Server
-  engine/CSource2Server_GetAllServerClasses.linux.yaml:
-    func_name: CSource2Server_GetAllServerClasses
-    vfunc_index: 29
-    vfunc_offset: '0xe8'
-    vfunc_sig: FF 90 E8 00 00 00 48 89 C2 48 8B 40 ?? 48 63 12 48 8D 0C D0
-    vtable_name: CSource2Server
-  engine/CSource2Server_GetAllServerClasses.windows.yaml:
-    func_name: CSource2Server_GetAllServerClasses
-    vfunc_index: 29
-    vfunc_offset: '0xe8'
-    vfunc_sig: FF 90 E8 00 00 00 48 8B 48 ??
-    vtable_name: CSource2Server
   engine/CSplitScreenService_AddSplitScreenUser.linux.yaml:
     func_name: CSplitScreenService_AddSplitScreenUser
     func_rva: '0x446280'
@@ -13641,6 +13617,30 @@ files:
     vfunc_offset: '0x98'
     vfunc_sig: FF 90 98 00 00 00 48 8D 0D ?? ?? ?? ??
     vtable_name: ISource2GameClients
+  engine/ISource2Server_GetActiveWorldName.linux.yaml:
+    func_name: ISource2Server_GetActiveWorldName
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vfunc_sig: FF 90 F0 00 00 00 48 89 C6 48 8B BB ?? ?? ?? ??
+    vtable_name: ISource2Server
+  engine/ISource2Server_GetActiveWorldName.windows.yaml:
+    func_name: ISource2Server_GetActiveWorldName
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vfunc_sig: FF 90 F0 00 00 00 48 8B F0 48 8B 9F ?? ?? ?? ??
+    vtable_name: ISource2Server
+  engine/ISource2Server_GetAllServerClasses.linux.yaml:
+    func_name: ISource2Server_GetAllServerClasses
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vfunc_sig: FF 90 E8 00 00 00 48 89 C2 48 8B 40 ?? 48 63 12 48 8D 0C D0
+    vtable_name: ISource2Server
+  engine/ISource2Server_GetAllServerClasses.windows.yaml:
+    func_name: ISource2Server_GetAllServerClasses
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vfunc_sig: FF 90 E8 00 00 00 48 8B 48 ??
+    vtable_name: ISource2Server
   engine/ISource2Server_PreWorldUpdate.linux.yaml:
     func_name: ISource2Server_PreWorldUpdate
     vfunc_index: 15
@@ -37820,6 +37820,42 @@ files:
     vfunc_index: 42
     vfunc_offset: '0x150'
     vtable_name: CSource2Server
+  server/CSource2Server_GetActiveWorldName.linux.yaml:
+    func_name: CSource2Server_GetActiveWorldName
+    func_rva: '0x18d1a70'
+    func_sig: 55 48 89 E5 53 48 83 EC ?? 48 8D 05 ?? ?? ?? ?? 48 8B 18
+    func_size: '0x3d'
+    func_va: '0x18d1a70'
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vtable_name: CSource2Server
+  server/CSource2Server_GetActiveWorldName.windows.yaml:
+    func_name: CSource2Server_GetActiveWorldName
+    func_rva: '0xd1b0c0'
+    func_sig: 48 83 EC ?? 48 8B 0D ?? ?? ?? ?? 48 85 C9 75 ?? 48 8D 05 ?? ?? ?? ??
+    func_size: '0x33'
+    func_va: '0x180d1b0c0'
+    vfunc_index: 30
+    vfunc_offset: '0xf0'
+    vtable_name: CSource2Server
+  server/CSource2Server_GetAllServerClasses.linux.yaml:
+    func_name: CSource2Server_GetAllServerClasses
+    func_rva: '0x18cf370'
+    func_sig: 48 8D 05 99 6E ?? ?? 48 8B 00
+    func_size: '0x17'
+    func_va: '0x18cf370'
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vtable_name: CSource2Server
+  server/CSource2Server_GetAllServerClasses.windows.yaml:
+    func_name: CSource2Server_GetAllServerClasses
+    func_rva: '0xd1b0a0'
+    func_sig: 48 8B 05 D9 8D ?? ?? 48 8B 88 E0 ?? ?? ??
+    func_size: '0x15'
+    func_va: '0x180d1b0a0'
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vtable_name: CSource2Server
   server/CSource2Server_GetEntityReport.linux.yaml:
     func_name: CSource2Server_GetEntityReport
     func_rva: '0x18e6fc0'
@@ -42856,5 +42892,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-12T11:05:59Z'
+last_publish_time: '2026-08-12T11:51:37Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetActiveWorldName.py
@@ -3,53 +3,28 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CSource2Server_GetActiveWorldName",
-]
-
-# CSource2Server::GetActiveWorldName is a vfunc whose concrete body lives in the
-# server module (libserver.so / server.dll). The engine predecessor
-# CLoopTypeClientServer_ActivateLoop reaches it through a register-indirect vcall
-# on the CSource2Server interface (g_pSource2Server): `call qword ptr [rax+0F0h]`.
-# The skill runs in the ENGINE module (where the predecessor is renamed/available)
-# and produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
-# matching the CSource2Server_GetAllServerClasses offset pattern (GetActiveWorldName
-# is the vtable slot immediately after GetAllServerClasses at 0xE8). The same
-# predecessor holds the vcall on both platforms.
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CSource2Server_GetActiveWorldName",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/engine/CLoopTypeClientServer_ActivateLoop.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CLoopTypeClientServer_ActivateLoop.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class) -- vtable_name is metadata only; CSource2Server's
-    # concrete body lives in the server module, so no CSource2Server_vtable YAML is
-    # consumed here. The vfunc_sig anchors on the vcall instruction inside the
-    # engine predecessor CLoopTypeClientServer_ActivateLoop.
-    ("CSource2Server_GetActiveWorldName", "CSource2Server"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CSource2Server_GetActiveWorldName",
+        "CSource2Server",
+        "../engine/ISource2Server_GetActiveWorldName",
+        True,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
-    # (symbol_name, generate_yaml_fields)
-    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
-    # vfunc_sig is MANDATORY for Pattern C.
     (
         "CSource2Server_GetActiveWorldName",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -63,11 +38,11 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the engine predecessor CLoopTypeClientServer_ActivateLoop."""
+    """Reuse an old signature or inherit the interface slot into CSource2Server."""
     _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -75,10 +50,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
+++ b/ida_preprocessor_scripts/find-CSource2Server_GetAllServerClasses.py
@@ -3,52 +3,28 @@
 
 from ida_analyze_util import preprocess_common_skill
 
-TARGET_FUNCTION_NAMES = [
-    "CSource2Server_GetAllServerClasses",
-]
-
-# CSource2Server::GetAllServerClasses is a vfunc whose concrete body lives in the
-# server module (libserver.so / server.dll). The engine predecessor
-# CNetworkGameServer_Shutdown reaches it through a register-indirect vcall on the
-# CSource2Server interface (g_pSource2Server): `call qword ptr [rax+0E8h]`. The
-# skill runs in the ENGINE module (where the predecessor is renamed/available) and
-# produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
-# matching the IGameTypes / CEngineServer_UnloadSpawnGroup offset pattern. The same
-# predecessor holds the vcall on both platforms.
-LLM_DECOMPILE = [
-    {
-        "symbol_name": "CSource2Server_GetAllServerClasses",
-        "prompt_path": "prompt/call_llm_decompile.md",
-        "reference_yaml_paths": [
-            "references/engine/CNetworkGameServer_Shutdown.{platform}.yaml",
-        ],
-        "expected_result_sections": ["found_vcall"],
-        "dependency_policy": {
-            "CNetworkGameServer_Shutdown.{platform}.yaml": "required",
-        },
-    },
-]
-
-FUNC_VTABLE_RELATIONS = [
-    # (func_name, vtable_class) -- vtable_name is metadata only; CSource2Server's
-    # concrete body lives in the server module, so no CSource2Server_vtable YAML is
-    # consumed here. The vfunc_sig anchors on the vcall instruction inside the
-    # engine predecessor CNetworkGameServer_Shutdown.
-    ("CSource2Server_GetAllServerClasses", "CSource2Server"),
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CSource2Server_GetAllServerClasses",
+        "CSource2Server",
+        "../engine/ISource2Server_GetAllServerClasses",
+        True,
+    ),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
-    # (symbol_name, generate_yaml_fields)
-    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
-    # vfunc_sig is MANDATORY for Pattern C.
     (
         "CSource2Server_GetAllServerClasses",
         [
             "func_name",
-            "vfunc_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
             "vfunc_offset",
             "vfunc_index",
-            "vtable_name",
         ],
     ),
 ]
@@ -62,11 +38,11 @@ async def preprocess_skill(
     new_binary_dir,
     platform,
     image_base,
-    llm_config=None,
     debug=False,
 ):
-    """Reuse previous gamever vfunc_sig to locate target; fallback to LLM_DECOMPILE of the engine predecessor CNetworkGameServer_Shutdown."""
+    """Reuse an old signature or inherit the interface slot into CSource2Server."""
     _ = skill_name
+
     return await preprocess_common_skill(
         session=session,
         expected_outputs=expected_outputs,
@@ -74,10 +50,7 @@ async def preprocess_skill(
         new_binary_dir=new_binary_dir,
         platform=platform,
         image_base=image_base,
-        func_names=TARGET_FUNCTION_NAMES,
-        func_vtable_relations=FUNC_VTABLE_RELATIONS,
-        llm_decompile_specs=LLM_DECOMPILE,
-        llm_config=llm_config,
+        inherit_vfuncs=INHERIT_VFUNCS,
         generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
         debug=debug,
     )

--- a/ida_preprocessor_scripts/find-ISource2Server_GetActiveWorldName.py
+++ b/ida_preprocessor_scripts/find-ISource2Server_GetActiveWorldName.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-ISource2Server_GetActiveWorldName skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2Server_GetActiveWorldName",
+]
+
+# ISource2Server::GetActiveWorldName is an abstract-interface vfunc. The engine
+# predecessor CLoopTypeClientServer_ActivateLoop reaches it through a
+# register-indirect vcall on g_pSource2Server: `call qword ptr [rax+0F0h]`.
+# The skill runs in the ENGINE module (where the predecessor is renamed/available)
+# and produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
+# matching the ISource2Server_GetAllServerClasses offset pattern (GetActiveWorldName
+# is the vtable slot immediately after GetAllServerClasses at 0xE8). The same
+# predecessor holds the vcall on both platforms.
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2Server_GetActiveWorldName",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CLoopTypeClientServer_ActivateLoop.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CLoopTypeClientServer_ActivateLoop.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class) -- vtable_name is metadata only; no
+    # ISource2Server_vtable YAML is consumed here. The vfunc_sig anchors on the
+    # vcall instruction inside the
+    # engine predecessor CLoopTypeClientServer_ActivateLoop.
+    ("ISource2Server_GetActiveWorldName", "ISource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "ISource2Server_GetActiveWorldName",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate the interface vfunc slot from CLoopTypeClientServer_ActivateLoop."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-ISource2Server_GetAllServerClasses.py
+++ b/ida_preprocessor_scripts/find-ISource2Server_GetAllServerClasses.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-ISource2Server_GetAllServerClasses skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "ISource2Server_GetAllServerClasses",
+]
+
+# ISource2Server::GetAllServerClasses is an abstract-interface vfunc. The engine
+# predecessor CNetworkGameServer_Shutdown reaches it through a register-indirect
+# vcall on g_pSource2Server: `call qword ptr [rax+0E8h]`. The
+# skill runs in the ENGINE module (where the predecessor is renamed/available) and
+# produces a caller-anchored vfunc_sig that anchors on that vcall instruction,
+# matching the IGameTypes / CEngineServer_UnloadSpawnGroup offset pattern. The same
+# predecessor holds the vcall on both platforms.
+LLM_DECOMPILE = [
+    {
+        "symbol_name": "ISource2Server_GetAllServerClasses",
+        "prompt_path": "prompt/call_llm_decompile.md",
+        "reference_yaml_paths": [
+            "references/engine/CNetworkGameServer_Shutdown.{platform}.yaml",
+        ],
+        "expected_result_sections": ["found_vcall"],
+        "dependency_policy": {
+            "CNetworkGameServer_Shutdown.{platform}.yaml": "required",
+        },
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class) -- vtable_name is metadata only; no
+    # ISource2Server_vtable YAML is consumed here. The vfunc_sig anchors on the
+    # vcall instruction inside the
+    # engine predecessor CNetworkGameServer_Shutdown.
+    ("ISource2Server_GetAllServerClasses", "ISource2Server"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    # Slim Pattern C: not a downstream predecessor, so func_va/rva/size omitted.
+    # vfunc_sig is MANDATORY for Pattern C.
+    (
+        "ISource2Server_GetAllServerClasses",
+        [
+            "func_name",
+            "vfunc_sig",
+            "vfunc_offset",
+            "vfunc_index",
+            "vtable_name",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    llm_config=None,
+    debug=False,
+):
+    """Locate the interface vfunc slot from CNetworkGameServer_Shutdown."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        llm_decompile_specs=LLM_DECOMPILE,
+        llm_config=llm_config,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.linux.yaml
@@ -37,7 +37,7 @@ disasm_code: |-
   .text:000000000038E7AE                 test    rdi, rdi
   .text:000000000038E7B1                 jz      short loc_38E7BF
   .text:000000000038E7B3                 mov     rax, [rdi]
-  .text:000000000038E7B6                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+  .text:000000000038E7B6                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = ISource2Server_GetActiveWorldName
   .text:000000000038E7BC                 mov     rsi, rax
   .text:000000000038E7BF                 mov     rdi, [rbx+178h]
   .text:000000000038E7C6                 call    sub_37BE50
@@ -92,7 +92,7 @@ procedure: |-
     *(_BYTE *)(a1 + 298) = 0;
     *(_OWORD *)(a1 + 304) = 0;
     if ( v11 )
-      v10 = (const char *)(*(__int64 (__fastcall **)(_QWORD *, const char *))(*v11 + 240LL))(v11, "unknown");// 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+      v10 = (const char *)(*(__int64 (__fastcall **)(_QWORD *, const char *))(*v11 + 240LL))(v11, "unknown");// 0x0F0 = 240LL = ISource2Server_GetActiveWorldName
     sub_37BE50(*(_QWORD *)(a1 + 376), v10);
     v12 = (*(__int64 (__fastcall **)(_QWORD *))(*g_pEngineServiceMgr + 240LL))(g_pEngineServiceMgr);
     v13 = *(double *)(a1 + 280);

--- a/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CLoopTypeClientServer_ActivateLoop.windows.yaml
@@ -35,8 +35,8 @@ disasm_code: |-
   .text:0000000180224569                 test    rcx, rcx
   .text:000000018022456C                 jz      short loc_18022457A
   .text:000000018022456E                 mov     rax, [rcx]
-  .text:0000000180224571                 ; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
-  .text:0000000180224571                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+  .text:0000000180224571                 ; 0x0F0 = 240LL = ISource2Server_GetActiveWorldName
+  .text:0000000180224571                 call    qword ptr [rax+0F0h]; 0x0F0 = 240LL = ISource2Server_GetActiveWorldName
   .text:0000000180224577                 mov     rsi, rax
   .text:000000018022457A                 mov     rbx, [rdi+178h]
   .text:0000000180224581                 mov     rcx, rbx
@@ -111,7 +111,7 @@ procedure: |-
     *(_QWORD *)(a1 + 304) = 0;
     *(_QWORD *)(a1 + 312) = 0;
     if ( v9 )
-      v10 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v9 + 240LL))(v9);// 0x0F0 = 240LL = CSource2Server_GetActiveWorldName
+      v10 = (const char *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)v9 + 240LL))(v9);// 0x0F0 = 240LL = ISource2Server_GetActiveWorldName
     v11 = *(_QWORD *)(a1 + 376);
     sub_18021F750(v11);
     v12 = *(_DWORD *)(v11 + 36);

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.linux.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.linux.yaml
@@ -16,8 +16,8 @@ disasm_code: |-
   .text:00000000005151CB                 test    rdi, rdi
   .text:00000000005151CE                 jz      short loc_515213
   .text:00000000005151D0                 mov     rax, [rdi]
-  .text:00000000005151D3                 ; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
-  .text:00000000005151D3                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:00000000005151D3                 ; 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
+  .text:00000000005151D3                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
   .text:00000000005151D9                 mov     rdx, rax
   .text:00000000005151DC                 mov     rax, [rax+8]
   .text:00000000005151E0                 movsxd  rdx, dword ptr [rdx]
@@ -59,7 +59,7 @@ procedure: |-
     CNetworkGameServerBase_Shutdown(a1);
     if ( g_pSource2Server )
     {
-      v2 = (int *)(*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+      v2 = (int *)(*(__int64 (__fastcall **)(_QWORD *))(*g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
       v3 = *((__int64 **)v2 + 1);
       for ( i = &v3[*v2]; v3 != i; *(_DWORD *)(v5 + 44) = -1 )
         v5 = *v3++;

--- a/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.windows.yaml
+++ b/ida_preprocessor_scripts/references/engine/CNetworkGameServer_Shutdown.windows.yaml
@@ -18,8 +18,8 @@ disasm_code: |-
   .text:000000018009C250                 test    rcx, rcx
   .text:000000018009C253                 jz      short loc_18009C283
   .text:000000018009C255                 mov     rax, [rcx]
-  .text:000000018009C258                 ; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
-  .text:000000018009C258                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+  .text:000000018009C258                 ; 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
+  .text:000000018009C258                 call    qword ptr [rax+0E8h]; 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
   .text:000000018009C25E                 mov     rcx, [rax+8]
   .text:000000018009C262                 movsxd  rax, dword ptr [rax]
   .text:000000018009C265                 lea     rdx, [rcx+rax*8]
@@ -133,7 +133,7 @@ procedure: |-
     CNetworkGameServerBase_Shutdown(a1);
     if ( g_pSource2Server )
     {
-      v2 = (int *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = CSource2Server_GetAllServerClasses
+      v2 = (int *)(*(__int64 (__fastcall **)(__int64))(*(_QWORD *)g_pSource2Server + 232LL))(g_pSource2Server);// 0x0E8 = 232LL = ISource2Server_GetAllServerClasses
       v3 = *((__int64 **)v2 + 1);
       for ( i = &v3[*v2]; v3 != i; *(_DWORD *)(v5 + 44) = -1 )
         v5 = *v3++;


### PR DESCRIPTION
## Summary
- Rename the engine call-site symbols to ISource2Server GetAllServerClasses and GetActiveWorldName interface vfuncs.
- Resolve the concrete CSource2Server overrides through inherited slots in CSource2Server_vtable and publish the 14174 snapshot.

## Validation
- preprocessor validation: uv run ida_analyze_bin.py -debug (Failed: 0)
- non-MCP unittests: 1064 tests passed (3 skipped)
- candidate preparation: passed for 14174
- C++ post-change validation: passed with 13 runnable tests and zero failures
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: 1 initial commit ahead of origin/main; supplemental publication commit: 6e4451a7