### PR TITLE
CBaseEntity_OnSetDormant

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -8473,6 +8473,12 @@ modules:
           - CEntityInstance_OnSetDormant.{platform}.yaml
         expected_input:
           - CCSPlayerPawnBase_OnSetDormant.{platform}.yaml
+      - name: find-CBaseEntity_OnSetDormant
+        expected_output:
+          - CBaseEntity_OnSetDormant.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
+          - CEntityInstance_OnSetDormant.{platform}.yaml
       - name: find-CScriptedSequence_SynchronizeSequence
         expected_output:
           - CScriptedSequence_SynchronizeSequence.{platform}.yaml
@@ -10837,6 +10843,10 @@ modules:
         category: func
         alias:
           - CBaseEntity::ScriptGetAbsOrigin
+      - name: CBaseEntity_OnSetDormant
+        category: vfunc
+        alias:
+          - CBaseEntity::OnSetDormant
       - name: CBaseEntity_Precache
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:22b69af5d76e383979e436a6ac4fd68fdc1e366d2b7012e1948193eb104691cf
-file_count: 3361
+config_sha256: sha256:c3075121a5328d73f4764eef5c5f1bda2e6159f722ac877e5ea1278262dbdccf
+file_count: 3363
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -16516,6 +16516,24 @@ files:
     vfunc_index: 24
     vfunc_offset: '0xc0'
     vtable_name: CBaseEntity_vtable
+  server/CBaseEntity_OnSetDormant.linux.yaml:
+    func_name: CBaseEntity_OnSetDormant
+    func_rva: '0x1824250'
+    func_sig: 55 48 89 E5 41 54 41 89 D4 53 48 89 FB E8 ?? ?? ?? ?? 45 85 E4
+    func_size: '0x129'
+    func_va: '0x1824250'
+    vfunc_index: 16
+    vfunc_offset: '0x80'
+    vtable_name: CBaseEntity
+  server/CBaseEntity_OnSetDormant.windows.yaml:
+    func_name: CBaseEntity_OnSetDormant
+    func_rva: '0xc76a20'
+    func_sig: 40 55 53 57 48 8B EC 48 83 EC ?? 41 8B D8
+    func_size: '0x1f9'
+    func_va: '0x180c76a20'
+    vfunc_index: 15
+    vfunc_offset: '0x78'
+    vtable_name: CBaseEntity
   server/CBaseEntity_OnTakeDamage.linux.yaml:
     func_name: CBaseEntity_OnTakeDamage
     vfunc_index: 127
@@ -42988,5 +43006,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-12T16:09:24Z'
+last_publish_time: '2026-08-13T01:46:15Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CBaseEntity_OnSetDormant.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_OnSetDormant.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_OnSetDormant skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    ("CBaseEntity_OnSetDormant", "CBaseEntity", "CEntityInstance_OnSetDormant", True),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_OnSetDormant",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse old func_sig first; fallback to vtable index + generated signature when needed."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CBaseEntity_OnSetDormant` preprocessor that resolves `CBaseEntity::OnSetDormant` as a `CBaseEntity_vtable` vfunc, inheriting the slot from the `CEntityInstance_OnSetDormant` base vfunc via `INHERIT_VFUNCS` (the slot-only-anchor pattern) with `generate_func_sig` enabled.
- Declare the skill and the `CBaseEntity_OnSetDormant` vfunc symbol (alias `CBaseEntity::OnSetDormant`) in `configs/14174.yaml`.
- Publish the validated `14174` symbol snapshot containing both platform entries.

Resolved slots — linux `vfunc_index: 16` / `vfunc_offset: 0x80`, windows `vfunc_index: 15` / `vfunc_offset: 0x78` (the expected Itanium-ABI extra-destructor-slot offset).

Originating request:

```
/create-preprocessor-scripts create "find-CBaseEntity_OnSetDormant" by xref_funcs "CEntityInstance_OnSetDormant".
where CBaseEntity_OnSetDormant is vfunc of CBaseEntity_vtable.
```

## Validation
- candidate preparation: passed for `14174`; candidate SHA-256 `sha256:aeda9b297effd8873ce9a0b1464e21d7e19f17d832c268c4bcc4de8938ef4f0c`
- C++ post-change validation: passed with runnable tests and zero failures — compile failures 0, invalid test items 0, layout compares 14 (0 differing), vtable compares 12 (0 differing), record layout compares 2 (0 differing)
- candidate publication: passed; published snapshot SHA-256 matches the validated candidate
- snapshot drift check: the candidate differs from the previously published snapshot only by the two `CBaseEntity_OnSetDormant` entries plus `config_sha256`, `file_count` (3361 → 3363), and `last_publish_time` — no unrelated entries changed
- `gamedata/14174/` republished byte-identically (no tracked change)
- existing committed branch: 1 initial commit ahead of `origin/main`; supplemental publication commit: created

### Note on branch base
The branch was rebased onto current `origin/main` before validation. Its original base predated `bd8d997d fix(gamedata): bundle CS2FOW static template after upstream 403`, so candidate preparation could not complete on the stale base (the CS2FOW gitlab upstream now returns 403). The rebase is content-preserving: the pre- and post-rebase diffs for the two source files are byte-identical.
