### PR TITLE
feat(binsync): push IDA symbols to remotes; drive init-gamebin from build workflow

### DIFF
--- a/.claude/skills/init-gamebin/SKILL.md
+++ b/.claude/skills/init-gamebin/SKILL.md
@@ -5,7 +5,7 @@ description: Initialize this repository's local game binaries and per-binary Bin
 
 # Initialize Game Binaries
 
-Use the bundled script as the only entry point for downloading, merging, depot fallback, and BinSync recovery setup.
+Use the repository-root script as the only entry point for downloading, merging, depot fallback, and BinSync recovery setup.
 Never overwrite an existing binary, substitute an unlisted version, or continue after a failed step. Delegate all symbol
 snapshot behavior to the project-level `$restore-from-snapshot` skill; do not call `gamesymbol_snapshot.py` or restore
 YAML locally in this skill.
@@ -16,7 +16,7 @@ YAML locally in this skill.
 2. If the user did not specify a version, run:
 
    ```powershell
-   uv run python .claude/skills/init-gamebin/scripts/init_gamebin.py versions
+   uv run init_gamebin.py versions
    ```
 
    Tell the user which entry is latest and ask: `Which GAMEVER do you want to initialize?`
@@ -28,7 +28,7 @@ YAML locally in this skill.
 Run from the owning repository root:
 
 ```powershell
-uv run python .claude/skills/init-gamebin/scripts/init_gamebin.py prepare <GAMEVER-or-latest>
+uv run init_gamebin.py prepare <GAMEVER-or-latest>
 ```
 
 The script checks existing binaries, downloads and non-overwritingly merges `gamebin-<GAMEVER>.7z` when needed, and uses

--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -218,27 +218,24 @@ jobs:
             --gamever "$env:GAMEVER" --bindir bin --github-output "$env:GITHUB_OUTPUT"
           if ($LASTEXITCODE -ne 0) { throw "Failed to prepare old-version signature baseline." }
 
-      - name: Check cached binaries
-        id: cache
+      - name: Initialize binaries and BinSync recovery
+        id: init-binaries
         shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.HLND2T_GH_TOKEN }}
         run: |
-          $PSNativeCommandUseErrorActionPreference = $false
-          uv run copy_depot_bin.py -gamever "$env:GAMEVER" -platform all-platform -config "$env:ANALYSIS_CONFIG" -checkonly
-          $code = $LASTEXITCODE
-          if ($code -eq 0) { "ready=true" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append; exit 0 }
-          if ($code -eq 1) { "ready=false" | Out-File $env:GITHUB_OUTPUT -Encoding utf8 -Append; exit 0 }
-          throw "copy_depot_bin.py -checkonly failed with exit code $code"
-
-      - name: Download and copy missing depot binaries
-        id: download-binaries
-        if: steps.cache.outputs.ready != 'true'
-        shell: pwsh
-        run: |
-          uv run download_depot.py -tag "$env:GAMEVER" -depotdir cs2_depot -config download.yaml -configyaml "$env:ANALYSIS_CONFIG" `
-            -username "$env:DEPOTDOWNLOADER_STEAM_USERNAME" -password "$env:DEPOTDOWNLOADER_STEAM_PASSWORD" -remember-password
-          if ($LASTEXITCODE -ne 0) { throw "download_depot.py failed with exit code $LASTEXITCODE" }
-          uv run copy_depot_bin.py -gamever "$env:GAMEVER" -platform all-platform -config "$env:ANALYSIS_CONFIG"
-          if ($LASTEXITCODE -ne 0) { throw "copy_depot_bin.py failed with exit code $LASTEXITCODE" }
+          gh auth setup-git
+          if ($LASTEXITCODE -ne 0) { throw "gh auth setup-git failed with exit code $LASTEXITCODE" }
+          $orgLogin = gh api /orgs/HLND2T --jq .login
+          if ($LASTEXITCODE -ne 0) {
+            throw "HLND2T_GH_TOKEN could not authenticate to the HLND2T organization (gh api /orgs/HLND2T exited $LASTEXITCODE). Verify the token is valid, not expired, and has access to the HLND2T organization."
+          }
+          if ($orgLogin.Trim() -ne "HLND2T") {
+            throw "HLND2T_GH_TOKEN authenticated to an unexpected organization: '$($orgLogin.Trim())' (expected HLND2T)."
+          }
+          Write-Host "HLND2T_GH_TOKEN authenticated to $($orgLogin.Trim())"
+          uv run init_gamebin.py prepare "$env:GAMEVER"
+          if ($LASTEXITCODE -ne 0) { throw "init_gamebin.py prepare failed with exit code $LASTEXITCODE" }
 
       - name: Analyze binaries with normal producer scheduling
         id: analyze

--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -252,6 +252,24 @@ jobs:
           uv run ida_analyze_bin.py @args
           if ($LASTEXITCODE -ne 0) { throw "ida_analyze_bin.py failed with exit code $LASTEXITCODE" }
 
+      - name: Push accumulated symbols to BinSync remotes
+        id: binsync-push
+        shell: pwsh
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.HLND2T_GH_TOKEN }}
+        run: |
+          gh auth setup-git
+          if ($LASTEXITCODE -ne 0) { Write-Warning "gh auth setup-git failed with exit code $LASTEXITCODE" }
+          $pythonExe = (Get-Command python -ErrorAction SilentlyContinue).Source
+          if ([string]::IsNullOrWhiteSpace($pythonExe)) {
+            Write-Warning "BinSync push skipped: no python on PATH"
+            exit 0
+          }
+          uv run python push_binsync_symbols.py "$env:GAMEVER" `
+            --python "$pythonExe" `
+            --headless-script "D:\binsync\examples\headless_force_push.py"
+
       - name: Build immutable symbol and gamedata candidates
         id: build-candidates
         shell: pwsh

--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -266,9 +266,7 @@ jobs:
             Write-Warning "BinSync push skipped: no python on PATH"
             exit 0
           }
-          uv run python push_binsync_symbols.py "$env:GAMEVER" `
-            --python "$pythonExe" `
-            --headless-script "D:\binsync\examples\headless_force_push.py"
+          uv run python push_binsync_symbols.py "$env:GAMEVER" --python "$pythonExe"
 
       - name: Build immutable symbol and gamedata candidates
         id: build-candidates

--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -257,38 +257,10 @@ jobs:
           "GAMEVER=$validationGamever" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           Write-Host "PR validation GAMEVER=$validationGamever (release GAMEVER=$env:PR_GAMEVER)"
 
-      - name: Prepare persisted depot link and PR bin copy
+      - name: Prepare PR bin copy
         id: prepare-bin
         shell: pwsh
         run: |
-          function Ensure-DirectoryLink {
-            param(
-              [Parameter(Mandatory=$true)][string]$LinkPath,
-              [Parameter(Mandatory=$true)][string]$TargetPath
-            )
-
-            if (-not (Test-Path -LiteralPath $TargetPath -PathType Container)) {
-              New-Item -ItemType Directory -Path $TargetPath -Force | Out-Null
-            }
-
-            if (Test-Path -LiteralPath $LinkPath) {
-              $item = Get-Item -LiteralPath $LinkPath -Force
-              if (-not ($item.Attributes -band [IO.FileAttributes]::ReparsePoint)) {
-                throw "$LinkPath exists but is not a directory junction or symlink."
-              }
-              $actualTarget = [string]$item.Target
-              if ([IO.Path]::GetFullPath($actualTarget) -ne [IO.Path]::GetFullPath($TargetPath)) {
-                throw "$LinkPath link target mismatch: $actualTarget"
-              }
-              return
-            }
-
-            cmd /c mklink /d "$LinkPath" "$TargetPath"
-            if ($LASTEXITCODE -ne 0) {
-              throw "Failed to create directory link $LinkPath -> $TargetPath"
-            }
-          }
-
           function Get-BinCopyExcludes {
             param(
               [Parameter(Mandatory=$true)][string]$IgnoreFile
@@ -332,15 +304,10 @@ jobs:
           }
 
           Set-Location $env:WORKSPACE
-          $depotTarget = Join-Path $env:PERSISTED_WORKSPACE "cs2_depot"
           $persistedBinRoot = Join-Path $env:PERSISTED_WORKSPACE "bin"
           $sourceBinGamever = Join-Path $persistedBinRoot $env:GAMEVER
           $workspaceBinRoot = Join-Path $env:WORKSPACE "bin"
           $targetBinGamever = Join-Path $workspaceBinRoot $env:GAMEVER
-
-          Ensure-DirectoryLink `
-            -LinkPath (Join-Path $env:WORKSPACE "cs2_depot") `
-            -TargetPath $depotTarget
 
           if (-not (Test-Path -LiteralPath $sourceBinGamever -PathType Container)) {
             throw "Persisted bin source for GAMEVER=$env:GAMEVER does not exist: $sourceBinGamever"

--- a/.serena/memories/pr-self-runner.md
+++ b/.serena/memories/pr-self-runner.md
@@ -36,7 +36,7 @@
 2. 非 closed 事件进入 `validate`。条件要求仓库在白名单、PR head 来自当前仓库，并排除两类 GitHub Actions bot PR：`bump-download/*` + `chore(download): Update manifest for `，以及 build workflow 创建、同时包含 validated snapshot 与生成 gamedata 的 `gamesymbols/*` + `chore(gamesymbols): add ` 输出 PR。相同排除条件也应用于 closed 事件的 `finalize-pr-workspace`。
 3. 在 `RUNNER_WORKSPACE/CS2_VibeSignatures-pr-<PR>` 创建隔离目录；每次验证先删除旧目录，再初始化 Git 仓库、抓取并 detached checkout `refs/pull/<PR>/merge`，同时初始化 submodules。
 4. 执行格式检查，并从 PR merge 结果的 `download.yaml` 最后一项读取 `GAMEVER`。
-5. 将 `cs2_depot` 链接到持久化 depot；要求 `PERSISTED_WORKSPACE/bin/<GAMEVER>` 已存在，按 `.stignore` 排除规则复制到真实的 PR 工作区 `bin`。本 workflow 不负责下载缺失二进制。
+5. 要求 `PERSISTED_WORKSPACE/bin/<GAMEVER>` 已存在，按 `.stignore` 排除规则复制到真实的 PR 工作区 `bin`。本 workflow 不链接 `cs2_depot`，也不负责下载缺失二进制。
 6. 以 `HEAD^1` 作为 PR base parent，提取 base `configs/<GAMEVER>.yaml`。若 base 已有同版本 snapshot，则直接提取；否则寻找 base 中排序后的最后一个 tracked snapshot，并使用其发布 commit 对应的 config；若完全没有 snapshot，则进入 bootstrap。
 7. 有 base snapshot 时先 `restore`。同版本场景运行 `invalidate`，依据 base/head config、snapshot 与 Git refs 只失效受影响结果；新版本场景保留旧版本结果供 signature 复用，但清空当前版本全部 YAML；bootstrap 场景直接从空的当前版本 YAML 开始重建。
 8. 运行 Python unit tests，再执行 IDA 分析。
@@ -54,7 +54,7 @@ D{"Finalization eligibility and Bot-PR exclusions pass?"}
 E["Prepare isolated PR workspace"]
 F["Fetch refs/pull/<PR>/merge and detached checkout"]
 G["Check formatting; read GAMEVER from download.yaml"]
-H["Link persistent depot; copy persisted bin/<GAMEVER> with .stignore exclusions"]
+H["Copy persisted bin/<GAMEVER> with .stignore exclusions"]
 I["Extract base config and snapshot from HEAD^1"]
 J{"Base has same-version snapshot?"}
 K["Restore same-version base; invalidate affected outputs"]
@@ -103,8 +103,8 @@ U --> V
 ## Dependencies
 - GitHub Actions `win64` environment，以及标签为 `self-hosted`, `windows`, `x64` 的 runner。
 - GitHub PR merge ref：`refs/pull/<PR>/merge`；workflow 仅有 `contents: read` 权限。
-- Secrets：必须有 `PERSISTED_WORKSPACE`；IDA 分析使用 `CS2VIBE_AGENT` 与 LLM 配置。Steam secrets 虽配置在 env 中，但当前 PR 流程没有 depot 下载步骤。
-- 持久化资源：`PERSISTED_WORKSPACE/cs2_depot`、`PERSISTED_WORKSPACE/bin/<GAMEVER>`、`PERSISTED_WORKSPACE/bin/.stignore`。
+- Secrets：必须有 `PERSISTED_WORKSPACE`；IDA 分析使用 `CS2VIBE_AGENT` 与 LLM 配置。PR 流程不链接 `cs2_depot`，也没有 depot 下载步骤。
+- 持久化资源：`PERSISTED_WORKSPACE/bin/<GAMEVER>`、`PERSISTED_WORKSPACE/bin/.stignore`。
 - 工具链：PowerShell、`git`、`robocopy`、`mklink`、`uv`、Python、IDA / idalib-mcp、LLM agent、Clang/C++。
 - 仓库数据：base/head `configs/<GAMEVER>.yaml`、`download.yaml`、base/head `gamesymbols/*.yaml`、submodules。
 - 相关 Serena memory：`mem:ida_analyze_bin`、`mem:update_gamedata`、`mem:run_cpp_tests`。
@@ -113,7 +113,7 @@ U --> V
 - concurrency group 为 `pr-self-runner-<repository>-<PR number>`，且 `cancel-in-progress: true`；同一 PR 的旧验证会被新提交取消。
 - fork PR 被跳过，因为流程需要受保护 secrets 和 self-hosted runner；特定 bot `bump-download/*` manifest PR，以及 build workflow 创建的 `gamesymbols/*` snapshot/gamedata 输出 PR，都会被 `validate` 与 `finalize-pr-workspace` 显式跳过。过滤器同时校验 Bot 身份、head 分支前缀和标题前缀，避免误伤普通人工 PR。
 - workflow 验证的是 GitHub 合成的 merge commit；`HEAD^1` 被当作 base parent，当前 `HEAD` 是合并结果。
-- PR 流程不会下载 depot；如果持久化 `bin/<GAMEVER>` 不存在，验证直接失败。因此正式 build/cache 准备是新版本 PR 验证的外部前置条件。
+- PR 流程不链接 `cs2_depot` 也不下载 depot；如果持久化 `bin/<GAMEVER>` 不存在，验证直接失败。因此正式 build/cache 准备是新版本 PR 验证的外部前置条件。
 - `.stignore` 解析只接受扁平文件名或目录名；注释、空行和否定规则被忽略，包含嵌套路径的 pattern 会被拒绝。
 - 实际候选是 compare、gamedata 和 C++ tests 的唯一 symbol source。PR workflow 不调用 `gamesymbol_candidate.py publish`，也不会把 PR 产生的 YAML 写回 `PERSISTED_WORKSPACE`。
 - PR head 必须包含与实际分析结果一致的 `gamesymbols/<GAMEVER>.yaml`；compare 失败会阻止后续验证。

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -43060,5 +43060,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-13T03:58:18Z'
+last_publish_time: '2026-08-13T11:32:10Z'
 schema_version: 5

--- a/headless_force_push.py
+++ b/headless_force_push.py
@@ -1,0 +1,289 @@
+"""
+Headless BinSync force push — a standalone, GUI-free way to push *every* Reverse
+Engineering Artifact currently present in an IDA database into a BinSync Git
+project.
+
+It is meant to run inside a **headless idalib** process (IDA 9+). idalib is a
+plain Python library, so you invoke this script with the ordinary ``python``
+interpreter of an environment that has ``idalib`` (``idapro``), ``binsync`` and
+``declib`` installed::
+
+    python examples/headless_force_push.py <binary> [options]
+
+--------------------------------------------------------------------------------
+Why not the GUI plugin?
+--------------------------------------------------------------------------------
+The BinSync IDA plugin (``BinsyncPlugin``) is a GUI plugin and is never loaded in
+headless idalib — ``PLUGIN_ENTRY`` bails out unless ``IDA_IS_INTERACTIVE`` is set.
+This module instead builds the same pieces the plugin would (a headless
+``declib`` IDA interface plus a ``BSController``) and drives ``force_push_*``
+directly. No Qt, no dialogs, no artifact watchers.
+
+--------------------------------------------------------------------------------
+Database ownership (important)
+--------------------------------------------------------------------------------
+idalib can only have one database open per process, and two processes cannot
+open the same ``.i64`` at once (IDA holds a ``.id0`` lock). Run this script in a
+*different* process than your analysis / MCP server, and only after that process
+has closed the database. declib's headless interface reopens the existing
+``<binary>.i64`` (or ``.idb``) next to the binary, so any renames / types /
+comments your analysis already persisted are picked up automatically.
+
+--------------------------------------------------------------------------------
+Sidecar config
+--------------------------------------------------------------------------------
+Connection details are read from ``<binary>.binsync.json`` in the same directory
+as the binary — the same schema consumed by the GUI auto-recover in
+``binsync/auto_recover.py``::
+
+    {
+        "user": "HZDEV",            // optional; fallback when the OS user can't be resolved
+        "remote": "https://...",    // clone source when the local repo is missing
+        "repo_path": null,          // optional; default is <binary>.bsproj
+        "expected_md5": "...",      // optional; skip when it mismatches the loaded binary's md5
+        "force_user": false         // optional; use "user" verbatim instead of the OS user
+    }
+
+Every value can be overridden on the command line (``--user``, ``--repo``,
+``--remote``) or with an explicit ``--sidecar`` path.
+
+--------------------------------------------------------------------------------
+Examples
+--------------------------------------------------------------------------------
+    # dry run: connect and print what would be pushed (no commit / push)
+    python headless_force_push.py D:/bins/client.dll
+
+    # actually commit + push everything
+    python headless_force_push.py D:/bins/client.dll --push
+
+    # also push full function headers (args + stack vars) — needs Hex-Rays
+    python headless_force_push.py D:/bins/client.dll --push --use-decompilation
+
+    # no sidecar: specify everything inline
+    python headless_force_push.py D:/bins/client.dll --push \\
+        --user HZDEV --repo D:/bins/client.dll.bsproj --remote https://github.com/me/proj.git
+
+Notes
+--------------------------------------------------------------------------------
+* Hex-Rays is usually unavailable headless; without ``--use-decompilation`` only
+  function names / return types plus comments are pushed (still a full "header"
+  push, but no arguments or stack variables).
+* Keep everything on the main thread: ``connect(..., single_thread=True)`` skips
+  BinSync's background worker threads so nothing else touches idalib off-thread.
+* Git must be installed and reachable (BinSync uses GitPython).
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import logging
+import pathlib
+
+_log = logging.getLogger("binsync.headless_force_push")
+
+try:
+    # declib's IDA interface is Qt-free when IDA_IS_INTERACTIVE is unset — which
+    # is exactly the headless idalib case. Do NOT use binsync's IDABSInterface
+    # here: that is the GUI plugin wrapper and imports Qt.
+    from declib.decompilers.ida.interface import IDAInterface
+    from binsync.controller import BSController
+    from binsync.core.client import ConnectionWarnings
+except ImportError as exc:  # pragma: no cover - only meaningful outside idalib
+    raise SystemExit(
+        "headless_force_push.py must run in an idalib (IDA 9+) environment with "
+        "binsync + declib installed.\n"
+        f"Import error: {exc}"
+    ) from exc
+
+
+BINSYNC_SIDECAR_SUFFIX = ".binsync.json"
+DEFAULT_REPO_SUFFIX = ".bsproj"
+
+
+def find_sidecar(binary_path: pathlib.Path) -> pathlib.Path:
+    """Path of the sidecar config for ``binary_path`` (``<binary>.binsync.json``)."""
+    return pathlib.Path(str(binary_path) + BINSYNC_SIDECAR_SUFFIX)
+
+
+class SidecarConfig:
+    """Parsed ``<binary>.binsync.json`` — mirrors ``binsync.auto_recover.AutoRecoverConfig``."""
+
+    __slots__ = ("binary_path", "sidecar_path", "user", "remote", "repo_path", "expected_md5", "force_user")
+
+    def __init__(self, binary_path: pathlib.Path, data: dict):
+        self.binary_path = binary_path
+        self.sidecar_path = find_sidecar(binary_path)
+        self.user = data.get("user")
+        self.remote = data.get("remote") or None
+        self.expected_md5 = data.get("expected_md5")
+        self.force_user = bool(data.get("force_user", False))
+
+        raw_repo = data.get("repo_path")
+        if raw_repo:
+            repo = pathlib.Path(raw_repo)
+            if not repo.is_absolute():
+                repo = binary_path.parent / repo
+            self.repo_path = repo
+        else:
+            # default mirrors the GUI auto-recover: <binary>.bsproj next to the binary
+            self.repo_path = binary_path.with_suffix(DEFAULT_REPO_SUFFIX)
+
+
+def resolve_user(cfg: SidecarConfig | None, cli_user: str | None) -> str:
+    """Resolve the BinSync user identity: CLI > sidecar force_user > OS user > sidecar > "user"."""
+    if cli_user:
+        return cli_user
+
+    if cfg is not None and cfg.force_user and cfg.user:
+        return cfg.user
+
+    try:
+        os_user = getpass.getuser()
+    except Exception:
+        os_user = None
+
+    return os_user or (cfg.user if cfg else None) or "user"
+
+
+def build_controller(binary_path: pathlib.Path) -> BSController:
+    """Build a headless BinSync controller on top of a headless IDA interface.
+
+    ``IDAInterface(headless=True, ...)`` calls ``idapro.open_database`` itself,
+    reopening the existing ``<binary>.i64`` when one is present.
+    """
+    deci = IDAInterface(headless=True, binary_path=str(binary_path))
+    return BSController(decompiler_interface=deci, headless=True)
+
+
+def connect_controller(controller: BSController, user: str, repo: pathlib.Path, remote: str | None) -> None:
+    """Connect to an existing project, or clone it from ``remote`` when missing.
+
+    ``single_thread=True`` keeps BinSync from spawning background worker threads
+    (idalib requires all IDA API access to happen on the main thread).
+    """
+    if repo.exists():
+        _log.info("Connecting to existing project %s as %s", repo, user)
+        warnings = controller.connect(user, str(repo), init_repo=False, remote_url=None, single_thread=True)
+    elif remote:
+        _log.info("Cloning %s from %s as %s", repo, remote, user)
+        warnings = controller.connect(user, str(repo), init_repo=False, remote_url=remote, single_thread=True)
+    else:
+        raise SystemExit(f"BinSync repo {repo} does not exist and no --remote / sidecar remote is set.")
+
+    if ConnectionWarnings.HASH_MISMATCH in warnings:
+        _log.warning("Repository binary hash does not match the loaded binary (md5 mismatch).")
+
+
+def collect_artifacts(controller: BSController) -> dict[str, list]:
+    """Enumerate every artifact type straight from the decompiler (not the BS State)."""
+    deci = controller.deci
+    return {
+        "functions": list(deci.functions.keys()),
+        "globals": list(deci.global_vars.keys()),
+        "types": list(deci.structs.keys()) + list(deci.enums.keys()) + list(deci.typedefs.keys()),
+        "segments": list(deci.segments.keys()),
+    }
+
+
+def force_push_all(controller: BSController, arts: dict[str, list], use_decompilation: bool = False) -> None:
+    """Force push every collected artifact in a single commit + push."""
+    controller.force_push_all(
+        arts["functions"],
+        arts["globals"],
+        arts["types"],
+        arts["segments"],
+        use_decompilation=use_decompilation,
+    )
+
+
+def print_summary(arts: dict[str, list]) -> None:
+    print("BinSync force push — collected artifacts:")
+    print(f"  functions : {len(arts['functions'])}")
+    print(f"  globals   : {len(arts['globals'])}")
+    print(f"  types     : {len(arts['types'])} (structs + enums + typedefs)")
+    print(f"  segments  : {len(arts['segments'])}")
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="headless_force_push.py",
+        description="Force push all IDA artifacts into a BinSync project (headless idalib).",
+    )
+    parser.add_argument("binary", help="Path to the original binary (used to open the DB and locate the sidecar).")
+    parser.add_argument("--push", action="store_true", help="Commit + push. Without this flag it is a dry run.")
+    parser.add_argument("--user", help="Override the BinSync user identity.")
+    parser.add_argument("--repo", help="Override the local BinSync repo path (default <binary>.bsproj).")
+    parser.add_argument("--remote", help="Override the remote URL to clone when the repo is missing.")
+    parser.add_argument("--sidecar", help="Explicit sidecar path (default <binary>.binsync.json).")
+    parser.add_argument(
+        "--use-decompilation",
+        action="store_true",
+        help="Also push function args + stack vars (requires Hex-Rays; usually unavailable headless).",
+    )
+    parser.add_argument(
+        "--ignore-md5",
+        action="store_true",
+        help="Skip the sidecar expected_md5 sanity check.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(name)s: %(message)s")
+
+    binary_path = pathlib.Path(args.binary).resolve()
+    if not binary_path.exists():
+        raise SystemExit(f"Binary not found: {binary_path}")
+
+    sidecar_path = pathlib.Path(args.sidecar) if args.sidecar else find_sidecar(binary_path)
+    cfg = None
+    if sidecar_path.exists():
+        try:
+            cfg = SidecarConfig(binary_path, json.loads(sidecar_path.read_text(encoding="utf-8")))
+        except (OSError, ValueError) as exc:
+            raise SystemExit(f"Failed to read sidecar {sidecar_path}: {exc}") from exc
+        _log.info("Loaded sidecar %s", sidecar_path)
+    else:
+        _log.info("No sidecar at %s; using command-line args only.", sidecar_path)
+
+    user = resolve_user(cfg, args.user)
+
+    if args.repo:
+        repo = pathlib.Path(args.repo)
+        if not repo.is_absolute():
+            repo = binary_path.parent / repo
+    elif cfg is not None:
+        repo = cfg.repo_path
+    else:
+        repo = binary_path.with_suffix(DEFAULT_REPO_SUFFIX)
+
+    remote = args.remote or (cfg.remote if cfg else None)
+
+    controller = build_controller(binary_path)
+
+    # optional md5 sanity check (mirrors binsync/auto_recover.py)
+    if cfg is not None and cfg.expected_md5 and not args.ignore_md5:
+        current_md5 = controller.deci.binary_hash
+        if current_md5 != cfg.expected_md5:
+            raise SystemExit(f"md5 mismatch for {binary_path.name}: expected {cfg.expected_md5}, got {current_md5}")
+
+    connect_controller(controller, user, repo, remote)
+
+    arts = collect_artifacts(controller)
+    print_summary(arts)
+
+    if not args.push:
+        _log.info("Dry run: nothing committed/pushed. Re-run with --push to apply.")
+    else:
+        force_push_all(controller, arts, use_decompilation=args.use_decompilation)
+        _log.info("Force push complete.")
+
+    controller.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/init_gamebin.py
+++ b/init_gamebin.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import requests
 import yaml
 
-REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+REPOSITORY_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(REPOSITORY_ROOT))
 
 from analysis_config import AnalysisConfigError, resolve_analysis_config  # noqa: E402
@@ -79,7 +79,7 @@ def run_command(command, cwd: Path, *, allowed=(0,), capture=False, label=None):
 
 def repository_root() -> Path:
     """Require execution from the repository that owns this project-level skill."""
-    expected = Path(__file__).resolve().parents[4]
+    expected = Path(__file__).resolve().parent
     result = run_command(["git", "rev-parse", "--show-toplevel"], expected, capture=True, label="git rev-parse")
     actual = Path(result.stdout.strip()).resolve()
     if actual != expected:

--- a/push_binsync_symbols.py
+++ b/push_binsync_symbols.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Push accumulated IDA symbols to every configured binary's BinSync remote.
+
+This is a best-effort, workflow-internal step: it resolves each configured
+Windows/Linux binary from the analysis config and force-pushes the IDA
+artifacts already persisted in that binary's ``.i64`` database. It never fails
+the surrounding workflow — a missing interpreter or an individual push failure
+is reported on stderr and the script still exits 0.
+"""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from init_gamebin import configured_binary_paths, resolve_analysis_config  # noqa: E402
+
+# Mirror the exact imports headless_force_push.py performs, so a passing probe
+# guarantees the push script can actually start in the same interpreter.
+CAPABILITY_PROBE = "import idapro, binsync.controller, declib.decompilers.ida.interface"
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gamever", help="Exact GAMEVER from download.yaml")
+    parser.add_argument("--python", required=True, help="Interpreter with idalib + binsync + declib")
+    parser.add_argument("--headless-script", required=True, help="Path to headless_force_push.py")
+    return parser.parse_args(argv)
+
+
+def probe_capability(python_exe: str) -> tuple[bool, str]:
+    """Return whether ``python_exe`` can import the push script's runtime deps."""
+    result = subprocess.run([python_exe, "-c", CAPABILITY_PROBE], capture_output=True, text=True, check=False)
+    if result.returncode == 0:
+        return True, ""
+    return False, (result.stderr or result.stdout).strip()
+
+
+def push_binary(python_exe: str, headless_script: str, binary_path: Path) -> int:
+    """Run headless_force_push.py for one binary in its own idalib process."""
+    return subprocess.run(
+        [python_exe, headless_script, str(binary_path), "--push"],
+        check=False,
+    ).returncode
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+
+    python_exe = shutil.which(args.python)
+    if not python_exe:
+        print(f"BinSync push skipped: python not found: {args.python}", file=sys.stderr)
+        return 0
+
+    if not Path(args.headless_script).is_file():
+        print(f"BinSync push skipped: headless script not found: {args.headless_script}", file=sys.stderr)
+        return 0
+
+    supported, detail = probe_capability(python_exe)
+    if not supported:
+        print(f"BinSync push skipped: {python_exe} lacks idalib/binsync/declib", file=sys.stderr)
+        if detail:
+            print(detail, file=sys.stderr)
+        return 0
+
+    config_path = resolve_analysis_config(args.gamever, repo_root=REPOSITORY_ROOT)
+    binaries = configured_binary_paths(REPOSITORY_ROOT, args.gamever, config_path)
+
+    pushed = 0
+    failed = 0
+    for binary_path in binaries:
+        code = push_binary(python_exe, args.headless_script, binary_path)
+        if code == 0:
+            pushed += 1
+        else:
+            failed += 1
+            print(f"BinSync push FAILED for {binary_path.name} (exit {code})", file=sys.stderr)
+
+    print(f"BinSync push done: {pushed} pushed, {failed} failed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/push_binsync_symbols.py
+++ b/push_binsync_symbols.py
@@ -28,7 +28,11 @@ def parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("gamever", help="Exact GAMEVER from download.yaml")
     parser.add_argument("--python", required=True, help="Interpreter with idalib + binsync + declib")
-    parser.add_argument("--headless-script", required=True, help="Path to headless_force_push.py")
+    parser.add_argument(
+        "--headless-script",
+        default=str(REPOSITORY_ROOT / "headless_force_push.py"),
+        help="Path to headless_force_push.py (defaults to the repo copy)",
+    )
     return parser.parse_args(argv)
 
 

--- a/tests/test_init_gamebin.py
+++ b/tests/test_init_gamebin.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
-SCRIPT = Path(".claude/skills/init-gamebin/scripts/init_gamebin.py")
+SCRIPT = Path("init_gamebin.py")
 SPEC = importlib.util.spec_from_file_location("init_gamebin", SCRIPT)
 init_gamebin = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -50,7 +50,7 @@ def git(cwd: Path, *arguments: str) -> subprocess.CompletedProcess:
 
 class TestInitGamebin(unittest.TestCase):
     def test_script_resolves_its_own_repository_root(self) -> None:
-        expected = SCRIPT.resolve().parents[4]
+        expected = SCRIPT.resolve().parent
         with patch.object(init_gamebin, "run_command", return_value=completed([], stdout=f"{expected}\n")):
             self.assertEqual(expected, init_gamebin.repository_root())
 
@@ -359,6 +359,7 @@ class TestInitGamebin(unittest.TestCase):
                 "set_remote_default_branch",
                 side_effect=lambda *_: events.append("default"),
             ),
+            patch.object(init_gamebin, "validate_sidecar", return_value=False),
             patch.object(
                 init_gamebin,
                 "write_sidecar_atomic",


### PR DESCRIPTION
## Summary
- Push persisted IDA symbols to BinSync remotes after analysis via a new `push_binsync_symbols.py` best-effort wrapper, wired in as a build workflow step that skips gracefully (exit 0) when idalib/binsync/declib or the headless script are unavailable.
- Vendor `headless_force_push.py` into the repo and default `push_binsync_symbols.py --headless-script` to it, so the BinSync push no longer depends on a machine-local `D:\binsync` checkout.
- Move `init_gamebin.py` to the repo root and drive it from `build-on-self-runner.yml`, replacing the cached-binaries and depot-copy steps; it now also initializes BinSync remotes, authenticated with `HLND2T_GH_TOKEN`.
- Drop the unused `cs2_depot` junction from the PR self-runner workflow and sync its Serena memory.

## Validation
- implementation-specific tests: none supplied by the caller; C++ layout validation below covers vtable/record changes
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (compile failures 0, invalid items 0, vtable/layout/record differences 0)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `4` initial commit(s) ahead of `origin/main`; supplemental publication commit: created