### PR TITLE
feat(preprocessor): add find-CBaseEntity_ModifyOrAppendCriteria

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -6225,6 +6225,11 @@ modules:
           - CBaseEntity_UpdateOnRemove.{platform}.yaml
         expected_input:
           - CBaseEntity_vtable.{platform}.yaml
+      - name: find-CBaseEntity_ModifyOrAppendCriteria
+        expected_output:
+          - CBaseEntity_ModifyOrAppendCriteria.{platform}.yaml
+        expected_input:
+          - CBaseEntity_vtable.{platform}.yaml
       - name: find-CEntityInstance_OnRestore
         expected_output:
           - CEntityInstance_OnRestore.{platform}.yaml
@@ -9305,6 +9310,10 @@ modules:
         category: vfunc
         alias:
           - CBaseEntity::UpdateOnRemove
+      - name: CBaseEntity_ModifyOrAppendCriteria
+        category: vfunc
+        alias:
+          - CBaseEntity::ModifyOrAppendCriteria
       - name: CEntityInstance_OnRestore
         category: vfunc
         alias:

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:d767c691d249a7e579b5af0378cf78f45f9c5c2999d1c6ef3bb3a9c6a17bff48
-file_count: 3371
+config_sha256: sha256:8f944c604fc0425c7362ca85da626be6d5832ba53cac6951d358f6a096ab1cd4
+file_count: 3373
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -16482,6 +16482,24 @@ files:
     vfunc_offset: '0x548'
     vfunc_sig: FF 92 48 05 00 00 84 C0 0F 85 ?? ?? ?? ?? 8B 8B ?? ?? ?? ??
     vtable_name: CBaseEntity
+  server/CBaseEntity_ModifyOrAppendCriteria.linux.yaml:
+    func_name: CBaseEntity_ModifyOrAppendCriteria
+    func_rva: '0xd24650'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 49 89 F4 53 48 89 FB 48 83 EC ?? 48 8B 47 ?? 48 8B 50 ??
+    func_size: '0x287'
+    func_va: '0xd24650'
+    vfunc_index: 184
+    vfunc_offset: '0x5c0'
+    vtable_name: CBaseEntity_vtable
+  server/CBaseEntity_ModifyOrAppendCriteria.windows.yaml:
+    func_name: CBaseEntity_ModifyOrAppendCriteria
+    func_rva: '0x3cbb50'
+    func_sig: 48 89 5C 24 ?? 48 89 6C 24 ?? 56 57 41 54 41 56 41 57 48 83 EC ?? 48 8B 41 ??
+    func_size: '0x2c5'
+    func_va: '0x1803cbb50'
+    vfunc_index: 185
+    vfunc_offset: '0x5c8'
+    vtable_name: CBaseEntity_vtable
   server/CBaseEntity_NetworkStateChanged.linux.yaml:
     func_name: CBaseEntity_NetworkStateChanged
     func_rva: '0xa312d0'
@@ -43060,5 +43078,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-13T11:32:10Z'
+last_publish_time: '2026-08-13T12:57:54Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CBaseEntity_ModifyOrAppendCriteria.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_ModifyOrAppendCriteria.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_ModifyOrAppendCriteria skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBaseEntity_ModifyOrAppendCriteria",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBaseEntity_ModifyOrAppendCriteria",
+        "xref_strings": [
+            "FULLMATCH:targethealthfrac",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CBaseEntity_ModifyOrAppendCriteria", "CBaseEntity_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBaseEntity_ModifyOrAppendCriteria",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CBaseEntity_ModifyOrAppendCriteria` preprocessor (Pattern B — vfunc via xref string `FULLMATCH:targethealthfrac`), anchored on `CBaseEntity_vtable`.
- Registers `CBaseEntity_ModifyOrAppendCriteria` as a `vfunc` symbol (`CBaseEntity::ModifyOrAppendCriteria`) in `configs/14174.yaml`.

## Validation
- implementation-specific tests: `uv run ida_analyze_bin.py -debug` → Failed: 0; non-MCP unittest suite → 1085 tests OK.
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: 1 initial commit(s) ahead of `origin/main`; supplemental publication commit: created

Closes #715