### PR TITLE
CBasePlayerController_UpdateOnRemove

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -6626,6 +6626,12 @@ modules:
         expected_input:
           - CPlayerCommandQueue_ctor.{platform}.yaml
           - CBasePlayerController_vtable.{platform}.yaml
+      - name: find-CBasePlayerController_UpdateOnRemove
+        expected_output:
+          - CBasePlayerController_UpdateOnRemove.{platform}.yaml
+        expected_input:
+          - CBaseEntity_UpdateOnRemove.{platform}.yaml
+          - CBasePlayerController_vtable.{platform}.yaml
       - name: find-CBasePlayerController_SetConnectedState
         expected_output:
           - CBasePlayerController_SetConnectedState.{platform}.yaml
@@ -9776,6 +9782,10 @@ modules:
         category: vfunc
         alias:
           - CBasePlayerController::Connect
+      - name: CBasePlayerController_UpdateOnRemove
+        category: vfunc
+        alias:
+          - CBasePlayerController::UpdateOnRemove
       - name: CBasePlayerController_SetConnectedState
         category: func
         alias:

--- a/ida_preprocessor_scripts/find-CBasePlayerController_UpdateOnRemove.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_UpdateOnRemove.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_UpdateOnRemove skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_UpdateOnRemove",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerController_UpdateOnRemove",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CBaseEntity_UpdateOnRemove"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CBasePlayerController_UpdateOnRemove", "CBasePlayerController_vtable"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_UpdateOnRemove",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
/create-preprocessor-scripts create "find-CBaseEntity_UpdateOnRemove" by xref_strings "Warning: Deleting orphaned children of %s\n".
CBaseEntity_UpdateOnRemove is a vfunc of CBaseEntity_vtable.

/create-preprocessor-scripts create "find-CBasePlayerController_UpdateOnRemove" by xref_funcs "CBaseEntity_UpdateOnRemove".
CBasePlayerController_UpdateOnRemove is a vfunc of CBasePlayerController_vtable.
