### PR TITLE
CBasePlayerController_GetScriptDesc

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -8304,6 +8304,15 @@ modules:
         expected_input:
           - CEntityInstance_vtable.{platform}.yaml
           - CSceneEntity_GetScriptDesc.{platform}.yaml
+      - name: find-CBasePlayerController_GetScriptDescInternal
+        expected_output:
+          - CBasePlayerController_GetScriptDescInternal.{platform}.yaml
+      - name: find-CBasePlayerController_GetScriptDesc
+        expected_output:
+          - CBasePlayerController_GetScriptDesc.{platform}.yaml
+        expected_input:
+          - CBasePlayerController_GetScriptDescInternal.{platform}.yaml
+          - CBasePlayerController_vtable.{platform}.yaml
       - name: find-CEntityInstance_Precache
         expected_output:
           - CEntityInstance_Precache.{platform}.yaml

--- a/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDesc.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDesc.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_GetScriptDesc skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_GetScriptDesc",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerController_GetScriptDesc",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CBasePlayerController_GetScriptDescInternal"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CBasePlayerController_GetScriptDesc", "CBasePlayerController"),
+]
+
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_GetScriptDesc",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDesc.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDesc.py
@@ -23,7 +23,7 @@ FUNC_XREFS = [
 
 FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class)
-    ("CBasePlayerController_GetScriptDesc", "CBasePlayerController"),
+    ("CBasePlayerController_GetScriptDesc", "CBasePlayerController_vtable"),
 ]
 
 

--- a/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDescInternal.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerController_GetScriptDescInternal.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerController_GetScriptDescInternal skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CBasePlayerController_GetScriptDescInternal",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerController_GetScriptDescInternal",
+        "xref_strings": [
+            "The player controller entity.",
+        ],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CBasePlayerController_GetScriptDescInternal",
+        [
+            "func_name",
+            "func_sig",
+            "func_sig_allow_across_function_boundary:true",
+            "func_va",
+            "func_rva",
+            "func_size",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
/create-preprocessor-scripts create "find-CBasePlayerController_GetScriptDescInternal" by xref_strings "The player controller entity.".
CBasePlayerController_GetScriptDescInternal is a regular func.

/create-preprocessor-scripts create "find-CBasePlayerController_GetScriptDesc" by xref_funcs "CBasePlayerController_GetScriptDescInternal".
CBasePlayerController_GetScriptDesc is a vfunc of CBasePlayerController_vtable.
