### PR TITLE
fix(engine): split network server service vfunc ownership

### DIFF
--- a/configs/14175.yaml
+++ b/configs/14175.yaml
@@ -1291,6 +1291,21 @@ modules:
         expected_input:
           - CNetworkGameClientBase__ProcessNetworking.{platform}.yaml
           - CNetworkServerService_vtable.{platform}.yaml
+      - name: find-CNetworkServerService_SetGameSpawnGroupMgr
+        expected_output:
+          - CNetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+      - name: find-CNetworkServerService_AddServerPrerequisites
+        expected_output:
+          - CNetworkServerService_AddServerPrerequisites.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+      - name: find-CNetworkServerService_SetFinalSimulationTickThisFrame
+        expected_output:
+          - CNetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
       - name: find-CNetworkServerService_OnEventMapCallbacks-engine
         expected_output:
           - CNetworkServerService_OnServerAdvanceTick.{platform}.yaml
@@ -2988,6 +3003,18 @@ modules:
         category: vfunc
         alias:
           - INetworkServerService::IsServerRunning
+      - name: CNetworkServerService_SetGameSpawnGroupMgr
+        category: vfunc
+        alias:
+          - CNetworkServerService::SetGameSpawnGroupMgr
+      - name: CNetworkServerService_AddServerPrerequisites
+        category: vfunc
+        alias:
+          - CNetworkServerService::AddServerPrerequisites
+      - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+        category: vfunc
+        alias:
+          - CNetworkServerService::SetFinalSimulationTickThisFrame
       - name: CNetworkServerService_Init
         category: vfunc
         alias:
@@ -8691,9 +8718,9 @@ modules:
           - CLoopModeGame_LoopInitInternal.{platform}.yaml
       - name: find-CLoopModeGame_LoopInit-decompiles
         expected_output:
-          - CNetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
-          - CNetworkServerService_AddServerPrerequisites.{platform}.yaml
-          - CNetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
+          - INetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
+          - INetworkServerService_AddServerPrerequisites.{platform}.yaml
+          - INetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
         expected_input_windows:
           - CLoopModeGame_LoopInit.{platform}.yaml
         expected_input_linux:
@@ -11463,18 +11490,18 @@ modules:
         category: vfunc
         alias:
           - CEngineServer::UnloadSpawnGroup
-      - name: CNetworkServerService_SetGameSpawnGroupMgr
+      - name: INetworkServerService_SetGameSpawnGroupMgr
         category: vfunc
         alias:
-          - CNetworkServerService::SetGameSpawnGroupMgr
-      - name: CNetworkServerService_AddServerPrerequisites
+          - INetworkServerService::SetGameSpawnGroupMgr
+      - name: INetworkServerService_AddServerPrerequisites
         category: vfunc
         alias:
-          - CNetworkServerService::AddServerPrerequisites
-      - name: CNetworkServerService_SetFinalSimulationTickThisFrame
+          - INetworkServerService::AddServerPrerequisites
+      - name: INetworkServerService_SetFinalSimulationTickThisFrame
         category: vfunc
         alias:
-          - CNetworkServerService::SetFinalSimulationTickThisFrame
+          - INetworkServerService::SetFinalSimulationTickThisFrame
       - name: CSpawnGroupMgrGameSystem_GetSpawnGroups
         category: func
         alias:

--- a/configs/14175.yaml
+++ b/configs/14175.yaml
@@ -1291,21 +1291,6 @@ modules:
         expected_input:
           - CNetworkGameClientBase__ProcessNetworking.{platform}.yaml
           - CNetworkServerService_vtable.{platform}.yaml
-      - name: find-CNetworkServerService_SetGameSpawnGroupMgr
-        expected_output:
-          - CNetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
-        expected_input:
-          - CNetworkServerService_vtable.{platform}.yaml
-      - name: find-CNetworkServerService_AddServerPrerequisites
-        expected_output:
-          - CNetworkServerService_AddServerPrerequisites.{platform}.yaml
-        expected_input:
-          - CNetworkServerService_vtable.{platform}.yaml
-      - name: find-CNetworkServerService_SetFinalSimulationTickThisFrame
-        expected_output:
-          - CNetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
-        expected_input:
-          - CNetworkServerService_vtable.{platform}.yaml
       - name: find-CNetworkServerService_OnEventMapCallbacks-engine
         expected_output:
           - CNetworkServerService_OnServerAdvanceTick.{platform}.yaml
@@ -12436,6 +12421,24 @@ modules:
         expected_input:
           - CEngineClient_vtable.{platform}.yaml
           - ../client/IVEngineClient2_IsPlayingDemo.{platform}.yaml
+      - name: find-CNetworkServerService_SetGameSpawnGroupMgr
+        expected_output:
+          - CNetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+          - ../server/INetworkServerService_SetGameSpawnGroupMgr.{platform}.yaml
+      - name: find-CNetworkServerService_AddServerPrerequisites
+        expected_output:
+          - CNetworkServerService_AddServerPrerequisites.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+          - ../server/INetworkServerService_AddServerPrerequisites.{platform}.yaml
+      - name: find-CNetworkServerService_SetFinalSimulationTickThisFrame
+        expected_output:
+          - CNetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
+        expected_input:
+          - CNetworkServerService_vtable.{platform}.yaml
+          - ../server/INetworkServerService_SetFinalSimulationTickThisFrame.{platform}.yaml
       - name: find-INetworkGameClient_SendStringCmd
         expected_output:
           - INetworkGameClient_SendStringCmd.{platform}.yaml

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -121,7 +121,7 @@ binaries:
       sha256: '40505bf09c2c0942a0abc8a48048b578baf585bc18abc197bde023225ce58dbb'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:c8437f6d3605a01aef9bd6d4e6eeccf98f3cd44c86d89593d2022a77c20264f6
+config_sha256: sha256:b62b38a77e8cce04d81a540c732bddfab6576f23a622eb83fe388b87c08b10ae
 file_count: 3387
 files:
   SDL3/SDL_GetMouse.windows.yaml:
@@ -43190,5 +43190,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-15T12:04:06Z'
+last_publish_time: '2026-08-15T12:58:23Z'
 schema_version: 5

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '40505bf09c2c0942a0abc8a48048b578baf585bc18abc197bde023225ce58dbb'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:84639a8a122ceaad315863315b23f2411232a35b33304f126869c688fe8bdcbf
-file_count: 3381
+config_sha256: sha256:c8437f6d3605a01aef9bd6d4e6eeccf98f3cd44c86d89593d2022a77c20264f6
+file_count: 3387
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -11950,6 +11950,24 @@ files:
     vtable_size: '0x2a0'
     vtable_symbol: ??_7CNetworkGameServer@@6B@
     vtable_va: '0x18053e088'
+  engine/CNetworkServerService_AddServerPrerequisites.linux.yaml:
+    func_name: CNetworkServerService_AddServerPrerequisites
+    func_rva: '0x4062e0'
+    func_sig: 48 83 BF ?? ?? ?? ?? ?? 0F 84 ?? ?? ?? ?? 55 48 89 E5 41 57 49 89 D7
+    func_size: '0x111'
+    func_va: '0x4062e0'
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vtable_name: CNetworkServerService
+  engine/CNetworkServerService_AddServerPrerequisites.windows.yaml:
+    func_name: CNetworkServerService_AddServerPrerequisites
+    func_rva: '0x1dec90'
+    func_sig: 40 55 41 54 41 57 48 83 EC ?? 48 83 B9 ?? ?? ?? ?? ??
+    func_size: '0x160'
+    func_va: '0x1801dec90'
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vtable_name: CNetworkServerService
   engine/CNetworkServerService_DisconnectGameNow.linux.yaml:
     func_name: CNetworkServerService_DisconnectGameNow
     func_rva: '0x4135f0'
@@ -12130,6 +12148,42 @@ files:
     func_sig: 48 8B C4 55 53 56 41 56 48 8B EC 48 83 EC ?? 48 8B F2 4C 8B F1 45 85 C0 0F 85 18 ?? ?? ??
     func_size: '0xc7b'
     func_va: '0x1801dd590'
+  engine/CNetworkServerService_SetFinalSimulationTickThisFrame.linux.yaml:
+    func_name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    func_rva: '0x3fd7b0'
+    func_sig: 48 8B BF 50 01 ?? ?? 48 85 FF 74 0C 48 8B 07 FF A0 F8 ?? ?? ??
+    func_size: '0x56'
+    func_va: '0x3fd7b0'
+    vfunc_index: 33
+    vfunc_offset: '0x108'
+    vtable_name: CNetworkServerService
+  engine/CNetworkServerService_SetFinalSimulationTickThisFrame.windows.yaml:
+    func_name: CNetworkServerService_SetFinalSimulationTickThisFrame
+    func_rva: '0x1e14e0'
+    func_sig: 40 53 48 83 EC ?? 48 8B 89 ?? ?? ?? ?? 48 8B DA 48 85 C9 74 ?? 48 8B 01 FF 90 ?? ?? ?? ??
+    func_size: '0x54'
+    func_va: '0x1801e14e0'
+    vfunc_index: 32
+    vfunc_offset: '0x100'
+    vtable_name: CNetworkServerService
+  engine/CNetworkServerService_SetGameSpawnGroupMgr.linux.yaml:
+    func_name: CNetworkServerService_SetGameSpawnGroupMgr
+    func_rva: '0x3f7460'
+    func_sig: 48 8B BF 50 ?? ?? ?? 48 85 FF 74 0C 48 8B 07 FF 60 08
+    func_size: '0x19'
+    func_va: '0x3f7460'
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vtable_name: CNetworkServerService
+  engine/CNetworkServerService_SetGameSpawnGroupMgr.windows.yaml:
+    func_name: CNetworkServerService_SetGameSpawnGroupMgr
+    func_rva: '0x1dec50'
+    func_sig: 48 8B 89 50 ?? ?? ?? 48 85 C9 74 ?? 48 8B 01 48 FF 60 08
+    func_size: '0x14'
+    func_va: '0x1801dec50'
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vtable_name: CNetworkServerService
   engine/CNetworkServerService_StartupServer.linux.yaml:
     func_name: CNetworkServerService_StartupServer
     func_rva: '0x40bf10'
@@ -32876,42 +32930,6 @@ files:
     vtable_size: '0x28'
     vtable_symbol: ??_7CNetworkSerializerBindingBuildFilter@@6B@
     vtable_va: '0x1818a4468'
-  server/CNetworkServerService_AddServerPrerequisites.linux.yaml:
-    func_name: CNetworkServerService_AddServerPrerequisites
-    vfunc_index: 29
-    vfunc_offset: '0xe8'
-    vfunc_sig: FF 90 E8 00 00 00 4C 8B 6D ??
-    vtable_name: CNetworkServerService_vtable
-  server/CNetworkServerService_AddServerPrerequisites.windows.yaml:
-    func_name: CNetworkServerService_AddServerPrerequisites
-    vfunc_index: 28
-    vfunc_offset: '0xe0'
-    vfunc_sig: FF 90 E0 00 00 00 48 8B 5D ??
-    vtable_name: CNetworkServerService_vtable
-  server/CNetworkServerService_SetFinalSimulationTickThisFrame.linux.yaml:
-    func_name: CNetworkServerService_SetFinalSimulationTickThisFrame
-    vfunc_index: 33
-    vfunc_offset: '0x108'
-    vfunc_sig: FF 90 08 01 00 00 31 F6
-    vtable_name: CNetworkServerService_vtable
-  server/CNetworkServerService_SetFinalSimulationTickThisFrame.windows.yaml:
-    func_name: CNetworkServerService_SetFinalSimulationTickThisFrame
-    vfunc_index: 32
-    vfunc_offset: '0x100'
-    vfunc_sig: FF 90 00 01 00 00 48 8B C8
-    vtable_name: CNetworkServerService_vtable
-  server/CNetworkServerService_SetGameSpawnGroupMgr.linux.yaml:
-    func_name: CNetworkServerService_SetGameSpawnGroupMgr
-    vfunc_index: 28
-    vfunc_offset: '0xe0'
-    vfunc_sig: FF 90 E0 00 00 00 8B 95 ?? ?? ?? ??
-    vtable_name: CNetworkServerService_vtable
-  server/CNetworkServerService_SetGameSpawnGroupMgr.windows.yaml:
-    func_name: CNetworkServerService_SetGameSpawnGroupMgr
-    vfunc_index: 27
-    vfunc_offset: '0xd8'
-    vfunc_sig: FF 90 D8 00 00 00 33 DB
-    vtable_name: CNetworkServerService_vtable
   server/CNetworkTransmitComponent_StateChanged.linux.yaml:
     func_name: CNetworkTransmitComponent_StateChanged
     func_rva: '0xa9b6d0'
@@ -40980,6 +40998,42 @@ files:
     vfunc_offset: '0xa0'
     vfunc_sig: FF 90 A0 00 00 00 48 8B 0D ?? ?? ?? ?? 48 8D 15 ?? ?? ?? ??
     vtable_name: INetworkMessages
+  server/INetworkServerService_AddServerPrerequisites.linux.yaml:
+    func_name: INetworkServerService_AddServerPrerequisites
+    vfunc_index: 29
+    vfunc_offset: '0xe8'
+    vfunc_sig: FF 90 E8 00 00 00 4C 8B 6D ??
+    vtable_name: CNetworkServerService_vtable
+  server/INetworkServerService_AddServerPrerequisites.windows.yaml:
+    func_name: INetworkServerService_AddServerPrerequisites
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vfunc_sig: FF 90 E0 00 00 00 48 8B 5D ??
+    vtable_name: CNetworkServerService_vtable
+  server/INetworkServerService_SetFinalSimulationTickThisFrame.linux.yaml:
+    func_name: INetworkServerService_SetFinalSimulationTickThisFrame
+    vfunc_index: 33
+    vfunc_offset: '0x108'
+    vfunc_sig: FF 90 08 01 00 00 31 F6
+    vtable_name: CNetworkServerService_vtable
+  server/INetworkServerService_SetFinalSimulationTickThisFrame.windows.yaml:
+    func_name: INetworkServerService_SetFinalSimulationTickThisFrame
+    vfunc_index: 32
+    vfunc_offset: '0x100'
+    vfunc_sig: FF 90 00 01 00 00 48 8B C8
+    vtable_name: CNetworkServerService_vtable
+  server/INetworkServerService_SetGameSpawnGroupMgr.linux.yaml:
+    func_name: INetworkServerService_SetGameSpawnGroupMgr
+    vfunc_index: 28
+    vfunc_offset: '0xe0'
+    vfunc_sig: FF 90 E0 00 00 00 8B 95 ?? ?? ?? ??
+    vtable_name: CNetworkServerService_vtable
+  server/INetworkServerService_SetGameSpawnGroupMgr.windows.yaml:
+    func_name: INetworkServerService_SetGameSpawnGroupMgr
+    vfunc_index: 27
+    vfunc_offset: '0xd8'
+    vfunc_sig: FF 90 D8 00 00 00 33 DB
+    vtable_name: CNetworkServerService_vtable
   server/IVEngineServer2_GetAchievementMgr.linux.yaml:
     func_name: IVEngineServer2_GetAchievementMgr
     vfunc_index: 79
@@ -43136,5 +43190,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-15T09:22:21Z'
+last_publish_time: '2026-08-15T12:04:06Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CLoopModeGame_LoopInit-decompiles.py
+++ b/ida_preprocessor_scripts/find-CLoopModeGame_LoopInit-decompiles.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Preprocess script for find-CLoopModeGame_LoopInit-decompiles skill.
 
-Finds three CNetworkServerService virtual functions that are invoked on the
+Finds three INetworkServerService virtual functions that are invoked on the
 ``g_pNetworkServerService`` instance from inside CLoopModeGame::LoopInit:
 
-  * CNetworkServerService_SetGameSpawnGroupMgr
-  * CNetworkServerService_AddServerPrerequisites
-  * CNetworkServerService_SetFinalSimulationTickThisFrame
+  * INetworkServerService_SetGameSpawnGroupMgr
+  * INetworkServerService_AddServerPrerequisites
+  * INetworkServerService_SetFinalSimulationTickThisFrame
 
 They are discovered via LLM_DECOMPILE of the CLoopModeGame::LoopInit predecessor.
 The vcall to each lives in a different predecessor per platform: on Windows
@@ -16,9 +16,9 @@ separate CLoopModeGame::LoopInitInternal where the vcalls actually reside. The
 reference func_name drives which function is decompiled in the new binary, so
 each platform points at its own predecessor (mirrors find-CEngineServer_UnloadSpawnGroup).
 
-CNetworkServerService's concrete body lives in engine2.dll, so no
-CNetworkServerService_vtable YAML is consumed here -- ``vtable_name`` is metadata
-only. The vfunc_sig anchors on the vcall instruction inside the server
+The concrete CNetworkServerService body lives in engine2.dll, so no
+CNetworkServerService_vtable YAML is consumed here -- ``vtable_name`` is
+metadata only. The vfunc_sig anchors on the vcall instruction inside the server
 predecessor, matching the CEngineServer::UnloadSpawnGroup / IGameTypes offset
 pattern. Slim Pattern C: not a downstream predecessor, so func_va/rva/size are
 omitted; vfunc_sig is mandatory for Pattern C.
@@ -27,14 +27,14 @@ omitted; vfunc_sig is mandatory for Pattern C.
 from ida_analyze_util import preprocess_common_skill
 
 TARGET_FUNCTION_NAMES = [
-    "CNetworkServerService_SetGameSpawnGroupMgr",
-    "CNetworkServerService_AddServerPrerequisites",
-    "CNetworkServerService_SetFinalSimulationTickThisFrame",
+    "INetworkServerService_SetGameSpawnGroupMgr",
+    "INetworkServerService_AddServerPrerequisites",
+    "INetworkServerService_SetFinalSimulationTickThisFrame",
 ]
 
 LLM_DECOMPILE_WINDOWS = [
     {
-        "symbol_name": "CNetworkServerService_SetGameSpawnGroupMgr",
+        "symbol_name": "INetworkServerService_SetGameSpawnGroupMgr",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInit.{platform}.yaml",
@@ -45,7 +45,7 @@ LLM_DECOMPILE_WINDOWS = [
         },
     },
     {
-        "symbol_name": "CNetworkServerService_AddServerPrerequisites",
+        "symbol_name": "INetworkServerService_AddServerPrerequisites",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInit.{platform}.yaml",
@@ -56,7 +56,7 @@ LLM_DECOMPILE_WINDOWS = [
         },
     },
     {
-        "symbol_name": "CNetworkServerService_SetFinalSimulationTickThisFrame",
+        "symbol_name": "INetworkServerService_SetFinalSimulationTickThisFrame",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInit.{platform}.yaml",
@@ -70,7 +70,7 @@ LLM_DECOMPILE_WINDOWS = [
 
 LLM_DECOMPILE_LINUX = [
     {
-        "symbol_name": "CNetworkServerService_SetGameSpawnGroupMgr",
+        "symbol_name": "INetworkServerService_SetGameSpawnGroupMgr",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInitInternal.{platform}.yaml",
@@ -81,7 +81,7 @@ LLM_DECOMPILE_LINUX = [
         },
     },
     {
-        "symbol_name": "CNetworkServerService_AddServerPrerequisites",
+        "symbol_name": "INetworkServerService_AddServerPrerequisites",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInitInternal.{platform}.yaml",
@@ -92,7 +92,7 @@ LLM_DECOMPILE_LINUX = [
         },
     },
     {
-        "symbol_name": "CNetworkServerService_SetFinalSimulationTickThisFrame",
+        "symbol_name": "INetworkServerService_SetFinalSimulationTickThisFrame",
         "prompt_path": "prompt/call_llm_decompile.md",
         "reference_yaml_paths": [
             "references/server/CLoopModeGame_LoopInitInternal.{platform}.yaml",
@@ -108,9 +108,9 @@ FUNC_VTABLE_RELATIONS = [
     # (func_name, vtable_class) -- vtable_name is metadata only; the
     # CNetworkServerService body lives in engine2.dll, so no
     # CNetworkServerService_vtable YAML is consumed here.
-    ("CNetworkServerService_SetGameSpawnGroupMgr", "CNetworkServerService_vtable"),
-    ("CNetworkServerService_AddServerPrerequisites", "CNetworkServerService_vtable"),
-    ("CNetworkServerService_SetFinalSimulationTickThisFrame", "CNetworkServerService_vtable"),
+    ("INetworkServerService_SetGameSpawnGroupMgr", "CNetworkServerService_vtable"),
+    ("INetworkServerService_AddServerPrerequisites", "CNetworkServerService_vtable"),
+    ("INetworkServerService_SetFinalSimulationTickThisFrame", "CNetworkServerService_vtable"),
 ]
 
 GENERATE_YAML_DESIRED_FIELDS = [
@@ -120,7 +120,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
     # the predecessor with distinct forward context, so the caller-anchored
     # vfunc_sig is unique (default max_match).
     (
-        "CNetworkServerService_SetGameSpawnGroupMgr",
+        "INetworkServerService_SetGameSpawnGroupMgr",
         [
             "func_name",
             "vfunc_sig",
@@ -130,7 +130,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CNetworkServerService_AddServerPrerequisites",
+        "INetworkServerService_AddServerPrerequisites",
         [
             "func_name",
             "vfunc_sig",
@@ -140,7 +140,7 @@ GENERATE_YAML_DESIRED_FIELDS = [
         ],
     ),
     (
-        "CNetworkServerService_SetFinalSimulationTickThisFrame",
+        "INetworkServerService_SetFinalSimulationTickThisFrame",
         [
             "func_name",
             "vfunc_sig",

--- a/ida_preprocessor_scripts/find-CNetworkServerService_AddServerPrerequisites.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_AddServerPrerequisites.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_AddServerPrerequisites skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkServerService_AddServerPrerequisites",
+        "CNetworkServerService",
+        "../server/INetworkServerService_AddServerPrerequisites",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkServerService_AddServerPrerequisites",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the concrete vfunc from the inherited interface slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerService_SetFinalSimulationTickThisFrame.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_SetFinalSimulationTickThisFrame.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_SetFinalSimulationTickThisFrame skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkServerService_SetFinalSimulationTickThisFrame",
+        "CNetworkServerService",
+        "../server/INetworkServerService_SetFinalSimulationTickThisFrame",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkServerService_SetFinalSimulationTickThisFrame",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the concrete vfunc from the inherited interface slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-CNetworkServerService_SetGameSpawnGroupMgr.py
+++ b/ida_preprocessor_scripts/find-CNetworkServerService_SetGameSpawnGroupMgr.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CNetworkServerService_SetGameSpawnGroupMgr skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+INHERIT_VFUNCS = [
+    # (target_func_name, inherit_vtable_class, base_vfunc_name, generate_func_sig)
+    (
+        "CNetworkServerService_SetGameSpawnGroupMgr",
+        "CNetworkServerService",
+        "../server/INetworkServerService_SetGameSpawnGroupMgr",
+        True,
+    ),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CNetworkServerService_SetGameSpawnGroupMgr",
+        [
+            "func_name",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "func_sig",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Resolve the concrete vfunc from the inherited interface slot."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        inherit_vfuncs=INHERIT_VFUNCS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Rename the three server-side vcall artifacts to INetworkServerService symbols.
- Add engine CNetworkServerService INHERIT_VFUNCS preprocessors for the matching concrete vtable slots.
- Publish the validated 14175 symbol snapshot.

## Validation
- uv run python tests/run_test_suite.py unit -b --durations 30
- uv run run_cpp_tests.py -gamever 14175 -configyaml configs/14175.yaml -snapshot immutable candidate
- Candidate SHA-256: aec1dfad3902f8d9ac0bab0cdf79f8f21c22b4f9eb1487cfcad8efae251f990f