### PR TITLE
CGameEntitySystem_UpdateOnRemove

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7572,6 +7572,12 @@ modules:
         expected_input:
           - CEntitySystem_DestroyEntityImmediate.{platform}.yaml
           - CEntitySystem_vtable.{platform}.yaml
+      - name: find-CGameEntitySystem_UpdateOnRemove
+        expected_output:
+          - CGameEntitySystem_UpdateOnRemove.{platform}.yaml
+        expected_input:
+          - CEntitySystem_UpdateOnRemove.{platform}.yaml
+          - CGameEntitySystem_vtable.{platform}.yaml
       - name: find-CEntitySystem_OnRemoveEntity
         expected_output:
           - CEntitySystem_OnRemoveEntity.{platform}.yaml
@@ -11620,6 +11626,10 @@ modules:
         category: vfunc
         alias:
           - CEntitySystem::UpdateOnRemove
+      - name: CGameEntitySystem_UpdateOnRemove
+        category: vfunc
+        alias:
+          - CGameEntitySystem::UpdateOnRemove
       - name: ClientPrintToController
         category: func
         alias:

--- a/gamedata/14174/CS2Fixes/gamedata/cs2fixes.jsonc
+++ b/gamedata/14174/CS2Fixes/gamedata/cs2fixes.jsonc
@@ -102,13 +102,6 @@
 			"windows": "40 55 53 56 57 41 54 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4D 8B E0",
 			"linux": "55 66 0F EF C0 48 89 E5 41 57 41 56 41 55 49 89 FD 31 FF"
 		},
-		// Should be xref'd right above "flGravity", takes a float arg
-		"CBaseEntity::SetGravityScale":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 57 48 83 EC ? F3 0F 10 81 ? ? ? ? 48 8B F9 0F 29 74 24 ? 0F 28 F1 0F 2E C6 7A ? 74 ? BA ? ? ? ? 41 B8 ? ? ? ? 48 81 C1 ? ? ? ? E8 ? ? ? ? 48 8B CF F3 0F 11 B7 ? ? ? ? E8 ? ? ? ? 48 8B 5C 24 ? 0F 28 74 24 ? 48 83 C4 ? 5F C3 CC CC CC CC CC 48 89 5C 24 ?",
-			"linux": "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 FB 48 81 EC ? ? ? ? 0F 2E 87 DC 06 ? ?"
-		},
 		// "Game System %s is defined twice!\n"
 		// Note that this signature points to the instruction with sm_pFirst which is the first qword referenced in the function.
 		"IGameSystem_InitAllSystems_pFirst":
@@ -193,29 +186,12 @@
 			"windows": "48 89 5C 24 ? 57 48 83 EC ? 48 8B DA 48 8B F9 48 85 C9 0F 84 ? ? ? ? 48 85 D2",
 			"linux": "48 85 FF 74 ? 55 48 89 E5 41 55 41 54 49 89 FC"
 		},
-		// Look for "SetEntityName", that will be the vscript binding definition
-		// Scroll a bit down and you'll find something like this (note the offset): *(_QWORD *)(v453 + 64) = sub_1807B0350;
-		// that function is just a jump to the one we want
-		"CEntityIdentity_SetEntityName":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 4C 8B C2",
-			"linux": "55 48 89 F2 48 89 E5 41 55 41 54 53"
-		},
 		// "Error - cannot add bots after game is over."
 		"BotNavIgnore":
 		{
 			"library": "server",
 			"windows": "0F 84 ? ? ? ? 80 B8 ? ? ? ? 00 0F 84 ? ? ? ? 80 3D ? ? ? ? 00 74 15",
 			"linux": "0F 84 ? ? ? ? 44 0F B6 B8 ? ? ? ? 45 84 FF 0F 84"
-		},
-		// next to "soundname", in windows it's the last referenced sub while in linux it's right after
-		// this is a vscript binding though so it may be removed in the future?
-		"CBaseEntity_EmitSoundParams":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 55 48 8B EC 48 81 EC ? ? ? ? 33 C0",
-			"linux": "48 B8 ? ? ? ? ? ? ? ? 55 0F 28 D0"
 		},
 		// "ParticleEffect", found in a function with 9 arguments
 		"DispatchParticleEffect":
@@ -416,12 +392,6 @@
 			"windows": 53,
 			"linux": 52
 		},
-		// String: "%s<%i><%s><%s>" ChangeTeam() CTMDBG..."
-		"CCSPlayerController_ChangeTeam":
-		{
-			"windows": 103,
-			"linux": 102
-		},
 		"CBaseEntity::Use":
 		{
 			"windows": 145,
@@ -446,18 +416,6 @@
 		{
 			"windows": 163,
 			"linux": 162
-		},
-		// For these two, look for the names, you'll find vscript bindings
-		// Scroll down to where the var + 64 gets set to a function, that calls the offset we want
-		"IsPlayerPawn":
-		{
-			"windows": 169,
-			"linux": 168
-		},
-		"IsPlayerController":
-		{
-			"windows": 170,
-			"linux": 169
 		},
 		"CollisionRulesChanged":
 		{

--- a/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
+++ b/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
@@ -873,11 +873,6 @@
             "linux": "55 48 89 E5 41 57 41 56 45 89 CE 41 55 45 89 C5",
             "windows": "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B E9 49 8B F0 48 8B 0D"
         },
-        "SoundOpGameSystem::StopSoundEvent": {
-            "library": "server",
-            "linux": "8B 0E 85 C9 0F 84",
-            "windows": "48 89 5C 24 ? 48 89 6C 24 ? 56 48 83 EC ? 83 3A"
-        },
         "SoundOpGameSystem::StopSoundEventFilter": {
             "library": "server",
             "linux": "85 D2 74 ? 55 48 89 E5 41 57 41 56 4C 8D B7",

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:78d5bc62c354ba4532f10670ee9d49ad7000d38b6ba7402939323ebef774bd56
-file_count: 3377
+config_sha256: sha256:c040761f99d89c76e31c6e00a6c5cd4b7d915f0f67a548fa76290b2ce3c75a36
+file_count: 3379
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -29833,6 +29833,24 @@ files:
     vfunc_index: 19
     vfunc_offset: '0x98'
     vtable_name: CGameEntitySystem
+  server/CGameEntitySystem_UpdateOnRemove.linux.yaml:
+    func_name: CGameEntitySystem_UpdateOnRemove
+    func_rva: '0x16842f0'
+    func_sig: 55 48 89 E5 41 54 49 89 D4 53 89 F3
+    func_size: '0x29'
+    func_va: '0x16842f0'
+    vfunc_index: 24
+    vfunc_offset: '0xc0'
+    vtable_name: CGameEntitySystem
+  server/CGameEntitySystem_UpdateOnRemove.windows.yaml:
+    func_name: CGameEntitySystem_UpdateOnRemove
+    func_rva: '0xbc1300'
+    func_sig: 48 89 5C 24 ?? 57 48 83 EC ?? 49 8B D8 8B FA
+    func_size: '0x2f'
+    func_va: '0x180bc1300'
+    vfunc_index: 23
+    vfunc_offset: '0xb8'
+    vtable_name: CGameEntitySystem
   server/CGameEntitySystem_ctor.linux.yaml:
     func_name: CGameEntitySystem_ctor
     func_rva: '0x16a9e10'
@@ -43108,5 +43126,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-13T13:34:42Z'
+last_publish_time: '2026-08-17T03:00:26Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CGameEntitySystem_UpdateOnRemove.py
+++ b/ida_preprocessor_scripts/find-CGameEntitySystem_UpdateOnRemove.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CGameEntitySystem_UpdateOnRemove skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CGameEntitySystem_UpdateOnRemove",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CGameEntitySystem_UpdateOnRemove",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["CEntitySystem_UpdateOnRemove"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CGameEntitySystem_UpdateOnRemove", "CGameEntitySystem"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CGameEntitySystem_UpdateOnRemove",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `ida_preprocessor_scripts/find-CGameEntitySystem_UpdateOnRemove.py` to locate `CGameEntitySystem_UpdateOnRemove` via `xref_funcs` on `CEntitySystem_UpdateOnRemove`.
- Declare the `find-CGameEntitySystem_UpdateOnRemove` skill and the `CGameEntitySystem_UpdateOnRemove` symbol (`category: vfunc` of `CGameEntitySystem_vtable`) in `configs/14174.yaml`.
- Publish the resulting `14174` symbol snapshot and regenerated gamedata.

Original request:

```
/create-preprocessor-scripts create "find-CGameEntitySystem_UpdateOnRemove" by xref_funcs "CEntitySystem_UpdateOnRemove".
CGameEntitySystem_UpdateOnRemove is vfunc of CGameEntitySystem_vtable.
```

Resolved vtable slot: `CGameEntitySystem` index 24 / offset `0xc0` on Linux, index 23 / offset `0xb8` on Windows.

## Note on the gamedata diff
`gamedata/14174/` shows 47 unrelated deletions. These are **not** produced by this change. The CS2Fixes and modsharp-public generators download their templates live from upstream (`Source2ZE/CS2Fixes@dev`, `Kxnrl/modsharp-public@master`), and upstream removed these entries since the last publish on 2026-08-14: `CBaseEntity::SetGravityScale`, `CEntityIdentity_SetEntityName`, `CBaseEntity_EmitSoundParams`, `CCSPlayerController_ChangeTeam`, `IsPlayerController`, `IsPlayerPawn`, `SoundOpGameSystem::StopSoundEvent`. The corresponding symbol entries are byte-identical between `origin/main` and the validated candidate.

## Validation
- implementation-specific tests: `uv run python -m unittest discover -s tests` — `Ran 1120 tests`, `OK (skipped=3)`
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (compile failures 0, invalid test items 0, layout compares 14/0 differences, vtable compares 12/0 differences, record layout compares 2/0 differences)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created
