### PR TITLE
CSource2GameEntities_PrepareForFullUpdate

### DIFF
--- a/configs/14174.yaml
+++ b/configs/14174.yaml
@@ -7474,6 +7474,13 @@ modules:
           - CSource2GameEntities_CheckTransmit.{platform}.yaml
         expected_input:
           - CSource2GameEntities_vtable.{platform}.yaml
+      - name: find-CSource2GameEntities_PrepareForFullUpdate
+        expected_output:
+          - CSource2GameEntities_PrepareForFullUpdate.{platform}.yaml
+        expected_input:
+          - UTIL_PlayerSlotToPlayerController.{platform}.yaml
+          - CSource2GameEntities_CheckTransmit.{platform}.yaml
+          - CSource2GameEntities_vtable.{platform}.yaml
       - name: find-CSource2GameEntities_ShouldClientReceiveStringTableUserData
         expected_output:
           - CSource2GameEntities_ShouldClientReceiveStringTableUserData.{platform}.yaml
@@ -10598,6 +10605,11 @@ modules:
           - ISource2GameEntities::CheckTransmit
           - ISource2GameEntities_CheckTransmit
           - CheckTransmit
+      - name: CSource2GameEntities_PrepareForFullUpdate
+        category: vfunc
+        alias:
+          - CSource2GameEntities::PrepareForFullUpdate
+          - ISource2GameEntities::PrepareForFullUpdate
       - name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
         category: vfunc
         alias:

--- a/gamedata/14174/CS2Fixes/gamedata/cs2fixes.jsonc
+++ b/gamedata/14174/CS2Fixes/gamedata/cs2fixes.jsonc
@@ -102,13 +102,6 @@
 			"windows": "40 55 53 56 57 41 54 48 8D 6C 24 ? 48 81 EC ? ? ? ? 4D 8B E0",
 			"linux": "55 66 0F EF C0 48 89 E5 41 57 41 56 41 55 49 89 FD 31 FF"
 		},
-		// Should be xref'd right above "flGravity", takes a float arg
-		"CBaseEntity::SetGravityScale":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 57 48 83 EC ? F3 0F 10 81 ? ? ? ? 48 8B F9 0F 29 74 24 ? 0F 28 F1 0F 2E C6 7A ? 74 ? BA ? ? ? ? 41 B8 ? ? ? ? 48 81 C1 ? ? ? ? E8 ? ? ? ? 48 8B CF F3 0F 11 B7 ? ? ? ? E8 ? ? ? ? 48 8B 5C 24 ? 0F 28 74 24 ? 48 83 C4 ? 5F C3 CC CC CC CC CC 48 89 5C 24 ?",
-			"linux": "55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 FB 48 81 EC ? ? ? ? 0F 2E 87 DC 06 ? ?"
-		},
 		// "Game System %s is defined twice!\n"
 		// Note that this signature points to the instruction with sm_pFirst which is the first qword referenced in the function.
 		"IGameSystem_InitAllSystems_pFirst":
@@ -193,29 +186,12 @@
 			"windows": "48 89 5C 24 ? 57 48 83 EC ? 48 8B DA 48 8B F9 48 85 C9 0F 84 ? ? ? ? 48 85 D2",
 			"linux": "48 85 FF 74 ? 55 48 89 E5 41 55 41 54 49 89 FC"
 		},
-		// Look for "SetEntityName", that will be the vscript binding definition
-		// Scroll a bit down and you'll find something like this (note the offset): *(_QWORD *)(v453 + 64) = sub_1807B0350;
-		// that function is just a jump to the one we want
-		"CEntityIdentity_SetEntityName":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 57 48 83 EC ? 48 8B D9 4C 8B C2",
-			"linux": "55 48 89 F2 48 89 E5 41 55 41 54 53"
-		},
 		// "Error - cannot add bots after game is over."
 		"BotNavIgnore":
 		{
 			"library": "server",
 			"windows": "0F 84 ? ? ? ? 80 B8 ? ? ? ? 00 0F 84 ? ? ? ? 80 3D ? ? ? ? 00 74 15",
 			"linux": "0F 84 ? ? ? ? 44 0F B6 B8 ? ? ? ? 45 84 FF 0F 84"
-		},
-		// next to "soundname", in windows it's the last referenced sub while in linux it's right after
-		// this is a vscript binding though so it may be removed in the future?
-		"CBaseEntity_EmitSoundParams":
-		{
-			"library": "server",
-			"windows": "48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 55 48 8B EC 48 81 EC ? ? ? ? 33 C0",
-			"linux": "48 B8 ? ? ? ? ? ? ? ? 55 0F 28 D0"
 		},
 		// "ParticleEffect", found in a function with 9 arguments
 		"DispatchParticleEffect":
@@ -416,12 +392,6 @@
 			"windows": 53,
 			"linux": 52
 		},
-		// String: "%s<%i><%s><%s>" ChangeTeam() CTMDBG..."
-		"CCSPlayerController_ChangeTeam":
-		{
-			"windows": 103,
-			"linux": 102
-		},
 		"CBaseEntity::Use":
 		{
 			"windows": 145,
@@ -446,18 +416,6 @@
 		{
 			"windows": 163,
 			"linux": 162
-		},
-		// For these two, look for the names, you'll find vscript bindings
-		// Scroll down to where the var + 64 gets set to a function, that calls the offset we want
-		"IsPlayerPawn":
-		{
-			"windows": 169,
-			"linux": 168
-		},
-		"IsPlayerController":
-		{
-			"windows": 170,
-			"linux": 169
 		},
 		"CollisionRulesChanged":
 		{

--- a/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
+++ b/gamedata/14174/modsharp-public/.asset/gamedata/server.games.jsonc
@@ -873,11 +873,6 @@
             "linux": "55 48 89 E5 41 57 41 56 45 89 CE 41 55 45 89 C5",
             "windows": "48 89 5C 24 ? 48 89 6C 24 ? 48 89 74 24 ? 57 48 83 EC ? 48 8B E9 49 8B F0 48 8B 0D"
         },
-        "SoundOpGameSystem::StopSoundEvent": {
-            "library": "server",
-            "linux": "8B 0E 85 C9 0F 84",
-            "windows": "48 89 5C 24 ? 48 89 6C 24 ? 56 48 83 EC ? 83 3A"
-        },
         "SoundOpGameSystem::StopSoundEventFilter": {
             "library": "server",
             "linux": "85 D2 74 ? 55 48 89 E5 41 57 41 56 4C 8D B7",

--- a/gamesymbols/14174.yaml
+++ b/gamesymbols/14174.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '6f5aa8c32e30d5369579f0e18bf97ec72e2076d3c06906efbfcc77f0c4111b80'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:78d5bc62c354ba4532f10670ee9d49ad7000d38b6ba7402939323ebef774bd56
-file_count: 3377
+config_sha256: sha256:39252eff4e26a6f27732d8aba51dd1e3fe7bf3ffce89e093e795e54d77aad068
+file_count: 3379
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -37789,6 +37789,24 @@ files:
     vfunc_index: 12
     vfunc_offset: '0x60'
     vtable_name: CSource2GameEntities
+  server/CSource2GameEntities_PrepareForFullUpdate.linux.yaml:
+    func_name: CSource2GameEntities_PrepareForFullUpdate
+    func_rva: '0x18d1eb0'
+    func_sig: 55 89 F7 48 89 E5 E8 85 ?? ?? ??
+    func_size: '0x22'
+    func_va: '0x18d1eb0'
+    vfunc_index: 14
+    vfunc_offset: '0x70'
+    vtable_name: CSource2GameEntities
+  server/CSource2GameEntities_PrepareForFullUpdate.windows.yaml:
+    func_name: CSource2GameEntities_PrepareForFullUpdate
+    func_rva: '0xd1d7b0'
+    func_sig: 48 83 EC ?? 8B CA E8 15 32 F2 ??
+    func_size: '0x26'
+    func_va: '0x180d1d7b0'
+    vfunc_index: 13
+    vfunc_offset: '0x68'
+    vtable_name: CSource2GameEntities
   server/CSource2GameEntities_ShouldClientReceiveStringTableUserData.linux.yaml:
     func_name: CSource2GameEntities_ShouldClientReceiveStringTableUserData
     func_rva: '0x18d4890'
@@ -43108,5 +43126,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14174'
-last_publish_time: '2026-08-13T13:34:42Z'
+last_publish_time: '2026-08-17T03:05:17Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CSource2GameEntities_PrepareForFullUpdate.py
+++ b/ida_preprocessor_scripts/find-CSource2GameEntities_PrepareForFullUpdate.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CSource2GameEntities_PrepareForFullUpdate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = [
+    "CSource2GameEntities_PrepareForFullUpdate",
+]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CSource2GameEntities_PrepareForFullUpdate",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["UTIL_PlayerSlotToPlayerController"],
+        # CheckTransmit is the sibling vfunc that also calls UTIL_PlayerSlotToPlayerController
+        "exclude_funcs": ["CSource2GameEntities_CheckTransmit"],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [
+    # (func_name, vtable_class)
+    ("CSource2GameEntities_PrepareForFullUpdate", "CSource2GameEntities"),
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    # (symbol_name, generate_yaml_fields)
+    (
+        "CSource2GameEntities_PrepareForFullUpdate",
+        [
+            "func_name",
+            "func_sig",
+            "func_va",
+            "func_rva",
+            "func_size",
+            "vtable_name",
+            "vfunc_offset",
+            "vfunc_index",
+        ],
+    ),
+]
+
+
+async def preprocess_skill(
+    session,
+    skill_name,
+    expected_outputs,
+    old_yaml_map,
+    new_binary_dir,
+    platform,
+    image_base,
+    debug=False,
+):
+    """Reuse previous gamever func_sig to locate target function(s) and write YAML."""
+    _ = skill_name
+
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `ida_preprocessor_scripts/find-CSource2GameEntities_PrepareForFullUpdate.py` to locate `CSource2GameEntities_PrepareForFullUpdate` via `xref_funcs` on `UTIL_PlayerSlotToPlayerController`, excluding `CSource2GameEntities_CheckTransmit`.
- Declare the `find-CSource2GameEntities_PrepareForFullUpdate` skill and the `CSource2GameEntities_PrepareForFullUpdate` symbol (`category: vfunc` of `CSource2GameEntities_vtable`) in `configs/14174.yaml`.
- Publish the resulting `14174` symbol snapshot and regenerated gamedata.

Original request:

```
/create-preprocessor-scripts create "find-CSource2GameEntities_PrepareForFullUpdate" by xref_funcs "UTIL_PlayerSlotToPlayerController" and exclude "CSource2GameEntities_CheckTransmit".
CSource2GameEntities_PrepareForFullUpdate is vfunc of CSource2GameEntities_vtable.
```

Resolved vtable slot: `CSource2GameEntities` index 14 / offset `0x70` on Linux, index 13 / offset `0x68` on Windows.

## Note on the gamedata diff
`gamedata/14174/` shows 47 unrelated deletions. These are **not** produced by this change. The CS2Fixes and modsharp-public generators download their templates live from upstream (`Source2ZE/CS2Fixes@dev`, `Kxnrl/modsharp-public@master`), and upstream removed these entries since the last publish on 2026-08-14: `CBaseEntity::SetGravityScale`, `CEntityIdentity_SetEntityName`, `CBaseEntity_EmitSoundParams`, `CCSPlayerController_ChangeTeam`, `IsPlayerController`, `IsPlayerPawn`, `SoundOpGameSystem::StopSoundEvent`. The corresponding symbol entries are byte-identical between `origin/main` and the validated candidate.

## Validation
- implementation-specific tests: `uv run python -m unittest discover -s tests` — `Ran 1120 tests`, `OK (skipped=3)`
- candidate preparation: passed for `14174`
- C++ post-change validation: passed with runnable tests and zero failures (compile failures 0, invalid test items 0, layout compares 14/0 differences, vtable compares 12/0 differences, record layout compares 2/0 differences)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit ahead of `origin/main`; supplemental publication commit: created
