### PR TITLE
feat(init-gamebin): allow auto_sync_all in binsync sidecar

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -5,6 +5,7 @@ description: |
   user asks to create or open a PR, including when there are no staged changes but the clean current branch is not
   main and has commits ahead of origin/main. Both modes use the full immutable candidate lifecycle. An
   already-committed branch receives a supplemental publication commit without rewriting its existing commits.
+disable-model-invocation: true
 ---
 
 # Create Pull Request

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -3,8 +3,11 @@ name: create-pr
 description: |
   Create a GitHub pull request from either staged task changes or an already-committed current branch. Use when the
   user asks to create or open a PR, including when there are no staged changes but the clean current branch is not
-  main and has commits ahead of origin/main. Both modes use the full immutable candidate lifecycle. An
-  already-committed branch receives a supplemental publication commit without rewriting its existing commits.
+  main and has commits ahead of origin/main. Delivered changes that touch the CS2 symbols pipeline run the full
+  immutable candidate lifecycle (prepare, validate, publish, refresh). Changes that touch no CS2 Symbols-related path
+  skip the lifecycle and open the PR directly. Classification uses
+  `.claude/skills/create-pr/scripts/classify_delivery.py`; do not guess. An already-committed branch receives a
+  supplemental publication commit only when the lifecycle runs.
 disable-model-invocation: true
 ---
 
@@ -13,19 +16,21 @@ disable-model-invocation: true
 Create one pull request using exactly one delivery mode:
 
 - `staged-delivery` - deliver the caller's staged changes through candidate preparation, validation, publication,
-  commit, push, and PR creation. Treat the index at invocation time as the authorized change set. The only additional
-  paths this mode may stage are formatter updates to those same paths and validated
+  commit, push, and PR creation — or directly as a plain PR when the staged change touches no CS2 Symbols-related
+  path. Treat the index at invocation time as the authorized change set. The only additional paths this mode may
+  stage are formatter updates to those same paths and validated
   `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` outputs.
 - `committed-branch` - when the index is empty, deliver the existing commits on a clean non-`main` current branch
   that is ahead of `origin/main`. Treat the captured `origin/main...HEAD` diff as the authorized source change set.
-  Run the same candidate lifecycle, then commit only formatter changes to those captured paths and validated
-  `gamesymbols/<GAMEVER>.yaml` / `gamedata/<GAMEVER>/` publication outputs. Never rewrite existing commits.
+  Run the same candidate lifecycle — or deliver the branch directly as a plain PR when no changed path is CS2
+  Symbols-related. Never rewrite existing commits.
 
-Never mix the two modes in one invocation.
+Both modes share one classification gate (Step 2, the bundled classifier). Never mix the two modes in one invocation.
 
 ## Inputs
 
-- `gamever` - required in both modes. Use the caller-provided value; if omitted, read `CS2VIBE_GAMEVER` from `.env`.
+- `gamever` - required only when the delivered change is CS2 Symbols-related (see Step 2). Use the caller-provided
+  value; if omitted, read `CS2VIBE_GAMEVER` from `.env`. The plain-PR path never resolves or requires `gamever`.
 - `branch` - optional `dev*` branch name for `staged-delivery`. If omitted while on `main`, derive a concise
   `dev-<topic>` name from the staged change. Ignore this input in `committed-branch`; use the current branch exactly.
 - `commit_title` - optional Conventional Commit title for `staged-delivery`. If omitted, derive it from the staged
@@ -34,15 +39,14 @@ Never mix the two modes in one invocation.
   actual validation results.
 - `issue` - optional GitHub issue number. Add `Closes #<issue>` to the PR body when supplied.
 
-After selecting either mode, resolve exactly one non-empty `GAMEVER`. Set `ANALYSIS_CONFIG="configs/$GAMEVER.yaml"`
-and stop if that file does not exist. Never fall back to another game version.
-
 ## Safety Rules
 
 - Run from the repository root and require an `origin` remote plus successful `gh auth status`.
 - Never commit directly to `main`, force-push, amend an existing commit, or use `git add -A` / `git add .`.
 - Preserve unrelated untracked files and never stage them.
-- **Never impose a 64-second execution timeout** on candidate preparation, C++ validation, or candidate publication. When a command may outlive the interactive timeout, start it as a background task and poll its log and exit status until it finishes.
+- **Never impose a 64-second execution timeout** on candidate preparation, C++ validation, or candidate publication.
+  When a command may outlive the interactive timeout, start it as a background task and poll its log and exit status
+  until it finishes.
 - Require zero unstaged tracked changes at invocation. This forbids partially staged paths and prevents the
   formatter from absorbing unrelated work.
 - In `staged-delivery`, treat the initial staged path list as immutable authorization. Do not add other source,
@@ -50,6 +54,12 @@ and stop if that file does not exist. Never fall back to another game version.
 - In `committed-branch`, require an empty index, a non-`main` attached branch, at least one commit ahead of
   `origin/main`, and a non-empty `origin/main...HEAD` diff. Preserve the captured `HEAD` as the parent of at most one
   supplemental publication commit; preserve the current branch and captured committed path list until push.
+- After capturing the change set, run the bundled classifier and obey `LIFECYCLE=`. When it prints `LIFECYCLE=0`,
+  skip the entire candidate lifecycle: do not resolve `gamever`, do not invoke `/prepare-post-change-candidate`,
+  `/post-change-validation`, or `/publish-post-change-candidate`, and do not run the formatter. Deliver the captured
+  staged or committed change exactly as-is. Never claim candidate preparation, C++ validation, or candidate
+  publication in the PR body when the lifecycle was skipped. You may override only from `0` to `1` when a captured
+  path clearly feeds the symbols pipeline and the classifier missed it. Never override `1` to `0`.
 - Stop on the first failed/non-runnable gate. Do not repair or retry inside this skill, and do not commit, push, or
   create a PR after a gate failure.
 
@@ -170,9 +180,39 @@ For either mode, set `PR_BRANCH` to the intended dev branch or captured current 
 `gh pr list --state open --head <PR_BRANCH> --json url`. Stop if an open PR already exists for it. Never create a
 duplicate PR.
 
-## Step 2: Prepare the Immutable Candidate
+## Step 2: Classify the Change and Choose the Delivery Path
 
-In both modes, **ALWAYS** Use SKILL `/prepare-post-change-candidate` with the resolved `gamever`.
+Do not classify by inspection. After Step 1, run the bundled classifier from the repository root against the selected
+mode's change set:
+
+```powershell
+# staged-delivery
+uv run python .claude/skills/create-pr/scripts/classify_delivery.py --cached
+
+# committed-branch
+uv run python .claude/skills/create-pr/scripts/classify_delivery.py --committed
+```
+
+The script reads `git diff --name-status` itself (including both sides of a rename). If it exits non-zero, stop. Read
+`LIFECYCLE=` from the first output line. The `matched=` line is a count; the following lines are the matching paths.
+
+Decide:
+
+- **Lifecycle mode** (`LIFECYCLE=1`): at least one captured path feeds symbol analysis, the canonical snapshot,
+  versioned gamedata, or C++ validation. Run Steps 3 through 6, then Step 7 and Step 8.
+- **Plain-PR mode** (`LIFECYCLE=0`): no captured path is CS2 Symbols-related (for example only `.claude/skills/`,
+  `docs/`, `memory/`, `pages/`, `.github/`, `tests/`, `README*`, `download.yaml`, `config.toml`, `.mcp.json`,
+  `release_workflow.py`, `release_workflow_lib/`, or process-monitoring modules). Skip Steps 3 through 6 entirely,
+  proceed directly to Step 7 and Step 8, and deliver the captured change exactly as-is.
+
+Override only `0` → `1` when a captured path clearly feeds the symbols pipeline and is missing from the matched list.
+Never override `1` → `0`.
+
+## Step 3: Prepare the Immutable Candidate
+
+In lifecycle mode only, resolve exactly one non-empty `GAMEVER`. Set `ANALYSIS_CONFIG="configs/$GAMEVER.yaml"`
+and stop if that file does not exist. Never fall back to another game version. Then **ALWAYS** Use SKILL
+`/prepare-post-change-candidate` with the resolved `gamever`.
 
 Retain the returned candidate path, candidate session path, gamedata session path, and candidate SHA-256. If the
 skill fails, stop the entire task.
@@ -181,17 +221,17 @@ After preparation, inspect `git diff --name-only`. Formatting may have changed a
 `INITIAL_STAGED_PATHS` in `staged-delivery`, or to `INITIAL_COMMITTED_PATHS` in `committed-branch`. If any other
 tracked path changed, stop and report it; do not stage it or continue.
 
-## Step 3: Validate the Exact Candidate
+## Step 4: Validate the Exact Candidate
 
-In both modes, **ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and candidate
-session path returned by `/prepare-post-change-candidate`.
+In lifecycle mode only, **ALWAYS** Use SKILL `/post-change-validation` with the same `gamever`, candidate path, and
+candidate session path returned by `/prepare-post-change-candidate`.
 
 Require explicit success, runnable C++ tests, and zero failure counters. If validation fails or is non-runnable,
 stop exactly as that skill requires. Do not publish, commit, push, or create a PR.
 
-## Step 4: Publish the Validated Candidate
+## Step 5: Publish the Validated Candidate
 
-Only after validation succeeds in either mode, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the same
+Only after validation succeeds in lifecycle mode, **ALWAYS** Use SKILL `/publish-post-change-candidate` with the same
 `gamever`, candidate path, candidate session path, and gamedata session path.
 
 Require the published snapshot SHA-256 to equal the validated candidate SHA-256. Publication may modify only:
@@ -203,10 +243,10 @@ Require the published snapshot SHA-256 to equal the validated candidate SHA-256.
 Compare `git status --short` with the status recorded in Step 1. Any new or modified path outside that allowlist is
 a hard stop. Preserve pre-existing unrelated untracked files and leave them untracked.
 
-## Step 5: Refresh the Authorized Index
+## Step 6: Refresh the Authorized Index
 
-Refresh formatter changes only for existing files in the active mode's initial authorized path list, passing every
-path explicitly:
+In lifecycle mode, refresh formatter changes only for existing files in the active mode's initial authorized path
+list, passing every path explicitly:
 
 ```bash
 git add -- <explicit-existing-initial-authorized-paths>
@@ -230,7 +270,7 @@ an allowed current-version publication path. Review the final cached diff before
 require a non-empty staged diff. In `committed-branch`, an empty staged diff is permitted only when formatter and
 publication are both no-ops; record it and create no empty supplemental commit.
 
-## Step 6: Create the Required Commit
+## Step 7: Create the Required Commit
 
 If currently on `main`, create the validated branch now:
 
@@ -240,11 +280,13 @@ git switch -c <dev-branch>
 
 If already on the intended branch, remain there. In `staged-delivery`, derive or validate `commit_title` using the
 repository format `<type>(scope): <summary>`: start with a verb, keep it at most 100 characters, and omit the final
-period. In `committed-branch`, use `chore(gamesymbols): publish <GAMEVER> snapshot` for the non-empty supplemental
-publication commit.
+period. In `committed-branch` lifecycle mode, use `chore(gamesymbols): publish <GAMEVER> snapshot` for the non-empty
+supplemental publication commit. In `committed-branch` plain-PR mode, there is no supplemental commit.
 
-In `staged-delivery`, commit exactly the staged index. In `committed-branch`, commit exactly the non-empty staged
-publication index; when it is empty, skip this command and retain `INITIAL_HEAD`:
+Commit exactly the staged index in `staged-delivery` (both lifecycle and plain-PR). In `committed-branch` lifecycle
+mode, commit exactly the non-empty staged publication index; when it is empty, skip this command and retain
+`INITIAL_HEAD`. In `committed-branch` plain-PR mode, the captured commits are already the complete change and the
+index is empty, so skip this command and retain `INITIAL_HEAD`:
 
 ```bash
 git commit -m "<commit_title>" -m "Co-Authored-By: Codex"
@@ -254,7 +296,7 @@ Verify any new commit's changed paths match the final staged path list and that 
 In `committed-branch`, require the supplemental commit's parent to equal `INITIAL_HEAD`, proving no existing commit
 was rewritten. Do not amend if verification fails; stop and report the mismatch.
 
-## Step 7: Push and Create the Pull Request
+## Step 8: Push and Create the Pull Request
 
 In `committed-branch`, re-run the following immediately before push:
 
@@ -268,10 +310,10 @@ git diff --name-only origin/main...HEAD
 ```
 
 Require the branch to equal `INITIAL_BRANCH`, `INITIAL_HEAD` to remain an ancestor of `HEAD`, and both index and
-tracked worktree to be clean. Require the ahead count to remain greater than zero and the final committed path list to
-equal the union of `INITIAL_COMMITTED_PATHS` and the authorized formatter/publication paths. If a supplemental commit
-was made, require it to be the direct child of `INITIAL_HEAD`; otherwise require `HEAD` to equal `INITIAL_HEAD`.
-Stop if any condition fails.
+tracked worktree to be clean. Require the ahead count to remain greater than zero. Require the final committed path
+list to equal the union of `INITIAL_COMMITTED_PATHS` and the authorized formatter/publication paths in lifecycle
+mode, or to equal `INITIAL_COMMITTED_PATHS` exactly in plain-PR mode. If a supplemental commit was made, require it to
+be the direct child of `INITIAL_HEAD`; otherwise require `HEAD` to equal `INITIAL_HEAD`. Stop if any condition fails.
 
 Push without force:
 
@@ -284,7 +326,7 @@ Build the PR title from `pr_title` when supplied. Otherwise, use the new commit 
 supplemental publication commit does not become the PR title.
 
 Build the body from the delivered committed diff and actual results. Never claim a validation that this invocation
-did not run. Use this concise shape in both modes:
+did not run. In lifecycle mode, use this concise shape in both modes:
 
 ```markdown
 ## Summary
@@ -300,11 +342,24 @@ did not run. Use this concise shape in both modes:
 Closes #<issue>
 ```
 
-For `committed-branch`, retain the candidate lifecycle lines and add this truthful delivery evidence:
+In plain-PR mode, omit the three candidate lifecycle lines entirely; the lifecycle was not run and must not be
+claimed. Use this shape:
+
+```markdown
+## Summary
+- <behavioral change>
+
+## Validation
+- implementation-specific tests: <commands/results supplied by the caller>
+
+Closes #<issue>
+```
+
+For `committed-branch`, add the truthful delivery evidence in both modes:
 
 ```markdown
 - existing committed branch: `<AHEAD_COUNT>` initial commit(s) ahead of `origin/main`; supplemental publication commit:
-  <created or not needed because publication was a no-op>
+  <created, not needed because publication was a no-op, or not created because the lifecycle was skipped>
 ```
 
 Omit the issue line when no issue was supplied. Create the PR explicitly against `main`:
@@ -313,18 +368,20 @@ Omit the issue line when no issue was supplied. Create the PR explicitly against
 gh pr create --base main --head <PR_BRANCH> --title "<pr_title>" --body "<pr_body>"
 ```
 
-Report the branch, commit SHA, pushed remote, PR URL, game version, candidate SHA-256, and final committed path list
-for both modes. In `committed-branch`, also report `INITIAL_HEAD`, the initial ahead count, and whether a supplemental
-publication commit was created. If push succeeds but PR creation fails, report the remote branch and exact failure;
-do not delete the branch, force-push, or create another commit.
+Report the branch, commit SHA, pushed remote, PR URL, and final committed path list for both modes; report the game
+version and candidate SHA-256 only in lifecycle mode. In `committed-branch`, also report `INITIAL_HEAD`, the initial
+ahead count, and whether a supplemental publication commit was created. If push succeeds but PR creation fails, report
+the remote branch and exact failure; do not delete the branch, force-push, or create another commit.
 
 ## Checklist
 
 - [ ] Exactly one mode was selected: non-empty initial index, or clean non-`main` branch ahead of `origin/main`.
 - [ ] No unstaged tracked changes existed at invocation.
-- [ ] `staged-delivery`: initial cached diff is task-related; all candidate gates passed; final staged paths are
-      authorized; commit is on a `dev*` branch and follows repository format.
-- [ ] `committed-branch`: the full candidate lifecycle passed; formatter changes stay within captured committed paths;
-      publication outputs are staged and committed when non-empty; the original HEAD is preserved as the supplemental
-      commit parent; branch and worktree are clean before push.
+- [ ] Step 2 ran `classify_delivery.py` for the selected mode. `LIFECYCLE=1` ran Steps 3-6; `LIFECYCLE=0` skipped
+      them and created the PR directly from the captured change, without lifecycle claims in the body.
+- [ ] `staged-delivery`: initial cached diff is task-related; all candidate gates passed (lifecycle mode); final staged
+      paths are authorized; commit is on a `dev*` branch and follows repository format.
+- [ ] `committed-branch`: the full candidate lifecycle passed (lifecycle mode); formatter changes stay within captured
+      committed paths; publication outputs are staged and committed when non-empty; the original HEAD is preserved as
+      the supplemental commit parent; branch and worktree are clean before push.
 - [ ] No duplicate open PR existed; branch was pushed without force; exactly one PR was created against `main`.

--- a/.claude/skills/create-pr/scripts/classify_delivery.py
+++ b/.claude/skills/create-pr/scripts/classify_delivery.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Classify a create-pr change set as symbols-lifecycle or plain-PR."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+
+SYMBOLS_DIR_PREFIXES = (
+    "configs/",
+    "gamesymbols/",
+    "gamedata/",
+    "gamedata-generators/",
+    "ida_preprocessor_scripts/",
+    "cpp_tests/",
+    "hl2sdk_cs2/",
+    "release-manifests/",
+    "gamesymbol_snapshot_lib/",
+    "bin/",
+)
+
+SYMBOLS_EXACT_PATHS = frozenset({"hl2sdk_cs2"})
+
+SYMBOLS_ROOT_FILES = frozenset(
+    {
+        "agent_runner.py",
+        "binary_hashing.py",
+        "cpp_tests_util.py",
+        "format_repo_files.py",
+        "generate_reference_yaml.py",
+        "init_gamebin.py",
+        "push_binsync_symbols.py",
+        "run_cpp_tests.py",
+        "trusted_yaml.py",
+        "update_gamedata.py",
+    }
+)
+
+SYMBOLS_ROOT_PREFIXES = (
+    "analysis_",
+    "gamedata_",
+    "gamesymbol_",
+    "ida_",
+)
+
+
+class ClassifyDeliveryError(Exception):
+    """Raised when the change set cannot be classified safely."""
+
+
+def normalize_repo_path(path: str) -> str:
+    """Normalize a git path to POSIX form without a leading ./."""
+    normalized = path.strip().replace("\\", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    return normalized
+
+
+def is_symbols_related_path(path: str) -> bool:
+    """Return True when a tracked path feeds the CS2 symbols pipeline."""
+    normalized = normalize_repo_path(path)
+    if not normalized:
+        return False
+    if normalized in SYMBOLS_EXACT_PATHS:
+        return True
+    if any(normalized.startswith(prefix) for prefix in SYMBOLS_DIR_PREFIXES):
+        return True
+    if "/" in normalized:
+        return False
+    if normalized in SYMBOLS_ROOT_FILES:
+        return True
+    return any(normalized.startswith(prefix) and normalized.endswith(".py") for prefix in SYMBOLS_ROOT_PREFIXES)
+
+
+def classify_paths(paths: Iterable[str]) -> tuple[int, list[str]]:
+    """Return (LIFECYCLE, matched paths) for a captured change set."""
+    matched: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        normalized = normalize_repo_path(path)
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        if is_symbols_related_path(normalized):
+            matched.append(normalized)
+    return (1 if matched else 0), matched
+
+
+def parse_name_status(output: str) -> list[str]:
+    """Collect old and new paths from `git diff --name-status` output."""
+    paths: list[str] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            raise ClassifyDeliveryError(f"unrecognized git name-status line: {raw_line}")
+        status = parts[0]
+        if status.startswith(("R", "C")):
+            if len(parts) != 3:
+                raise ClassifyDeliveryError(f"rename/copy name-status must have two paths: {raw_line}")
+            paths.extend(parts[1:])
+            continue
+        if len(parts) != 2:
+            raise ClassifyDeliveryError(f"unrecognized git name-status line: {raw_line}")
+        paths.append(parts[1])
+    return paths
+
+
+def git_name_status(diff_args: Sequence[str]) -> list[str]:
+    """Read changed paths from git. `diff_args` follow `git diff --name-status`."""
+    command = ["git", "diff", "--name-status", *diff_args]
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+    except OSError as exc:
+        raise ClassifyDeliveryError(f"unable to run git diff: {exc}") from exc
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise ClassifyDeliveryError(f"{' '.join(command)} failed: {detail}")
+    return parse_name_status(result.stdout)
+
+
+def format_classification(lifecycle: int, matched: Sequence[str]) -> str:
+    """Render the create-pr classification contract."""
+    mode = "lifecycle" if lifecycle else "plain-pr"
+    lines = [f"LIFECYCLE={lifecycle}", f"mode={mode}", f"matched={len(matched)}"]
+    lines.extend(matched)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group()
+    source.add_argument("--cached", action="store_true", help="Classify git diff --cached --name-status")
+    source.add_argument("--committed", action="store_true", help="Classify origin/main...HEAD")
+    parser.add_argument("paths", nargs="*", help="Explicit paths to classify")
+    args = parser.parse_args(argv)
+
+    try:
+        if args.cached:
+            if args.paths:
+                raise ClassifyDeliveryError("do not pass explicit paths with --cached")
+            paths = git_name_status(["--cached"])
+        elif args.committed:
+            if args.paths:
+                raise ClassifyDeliveryError("do not pass explicit paths with --committed")
+            paths = git_name_status(["origin/main...HEAD"])
+        else:
+            paths = list(args.paths)
+        lifecycle, matched = classify_paths(paths)
+    except ClassifyDeliveryError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    sys.stdout.write(format_classification(lifecycle, matched))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/init-gamebin/SKILL.md
+++ b/.claude/skills/init-gamebin/SKILL.md
@@ -70,12 +70,13 @@ the Steam depot fallback only for a missing Release asset. After every configure
    `binsync/<OS_USER>` branches. It sets the default branch only for a previously empty repository.
 6. Writes `<MODULE_FILENAME>.binsync.json` only after the remote validates successfully. The sidecar uses the current OS
    user as a fallback, the canonical HTTPS remote, explicit `<MODULE_FILENAME>.bsproj`, the binary MD5,
-   `force_user: false`, and `auto_clone: true`.
+   `force_user: false`, `auto_clone: true`, and `auto_sync_all: true`.
 
 The script never reads or writes `BinSyncDLConfig.toml`, never clones missing `.bsproj` repositories into `bin/`, and
 never fetches or pushes an already-valid remote/local pair. IDA's BinSync auto-recovery performs the later clone.
 
-Existing sidecars must contain exactly the six expected fields and match semantically. Existing local repositories must
+Existing sidecars must contain the six required fields and match semantically. They may also include `auto_sync_all`,
+which must be `true` when present; unknown extra fields remain a conflict. Existing local repositories must
 have the expected `origin`, `binsync/__root__`, and `binary_hash`. Existing non-empty remotes must already use
 `binsync/__root__` as their default branch and expose the matching `binary_hash`. Stop on any conflict; never overwrite,
 move, delete, repair, or change the default branch of existing state. A local `binsync.lock` is allowed for read-only

--- a/docs/en/conributing-via-pr.md
+++ b/docs/en/conributing-via-pr.md
@@ -2,7 +2,7 @@
 
 # Contributing symbol-analysis skills via a pull request
 
-After creating and verifying a symbol-analysis skill, use `SKILL: create-pr` (invoked as `/create-pr`) to share it with the project. The skill takes the staged change through the repository's candidate preparation, validation, publication, commit, push, and pull-request workflow.
+After creating and verifying a symbol-analysis skill, use `SKILL: create-pr` (invoked as `/create-pr`) to share it with the project. The skill classifies the staged change first. CS2 Symbols-related paths go through candidate preparation, validation, and publication before commit, push, and PR creation. Changes that touch no symbols-related path open a PR directly.
 
 ## Before invoking `create-pr`
 
@@ -16,7 +16,7 @@ After creating and verifying a symbol-analysis skill, use `SKILL: create-pr` (in
    ```
 
 3. Make sure there are no unstaged tracked changes. Existing unrelated untracked files can remain untracked; `create-pr` will preserve them.
-4. Ensure the repository has an `origin` remote and that GitHub CLI authentication (`gh auth status`) succeeds. Resolve exactly one game version, either by passing `gamever` to the skill or by setting `CS2VIBE_GAMEVER` in `.env`.
+4. Ensure the repository has an `origin` remote and that GitHub CLI authentication (`gh auth status`) succeeds. For a CS2 Symbols-related change, resolve exactly one game version, either by passing `gamever` to the skill or by setting `CS2VIBE_GAMEVER` in `.env`. A change that touches no symbols-related path does not need `gamever`.
 
 Generated `gamesymbols/<GAMEVER>.yaml` and `gamedata/<GAMEVER>/` files are published by `create-pr` after validation. They do not need to be added manually for this workflow.
 
@@ -35,7 +35,10 @@ commit_title: feat(skills): add find-example symbol-analysis skill
 
 ## What `create-pr` does
 
-The workflow runs these gates in order:
+The workflow classifies the delivered change with
+`.claude/skills/create-pr/scripts/classify_delivery.py`. If any staged path feeds the CS2 symbols pipeline (for
+example `configs/`, `ida_preprocessor_scripts/`, `cpp_tests/`, `hl2sdk_cs2/`, `gamesymbols/`, `gamedata/`, or the
+root analysis/snapshot/C++ modules), it runs these gates in order:
 
 1. Captures and checks the exact staged paths.
 2. Runs `/prepare-post-change-candidate` for the selected game version.
@@ -45,8 +48,13 @@ The workflow runs these gates in order:
 6. Commits with the repository's Conventional Commit format and `Co-Authored-By: Codex`.
 7. Pushes the `dev*` branch and opens one PR against `main`.
 
+If no staged path is CS2 Symbols-related (for example the change is only a documentation, workflow, skill, or
+process-monitoring update), `create-pr` skips steps 2 through 5 entirely, does not resolve a `gamever`, and opens the
+PR directly from the captured change. The PR body never claims candidate preparation, C++ validation, or publication
+in that case.
+
 The skill stops before commit or PR creation when there are no staged changes, unstaged tracked changes, missing authentication, a failed or non-runnable gate, or an unexpected path change. Do not bypass a failed gate or manually publish the candidate.
 
 ## After the skill finishes
 
-Record the reported branch, commit SHA, PR URL, game version, candidate SHA-256, and final committed path list. Review the PR to confirm that it contains the intended skill and supporting files, plus only the generated outputs for the selected game version.
+Record the reported branch, commit SHA, PR URL, and final committed path list. For a symbols-related delivery, also record the game version and candidate SHA-256, and review the PR to confirm that it contains the intended skill and supporting files plus only the generated outputs for the selected game version.

--- a/docs/zh-CN/conributing-via-pr.md
+++ b/docs/zh-CN/conributing-via-pr.md
@@ -2,7 +2,7 @@
 
 # 通过 Pull Request 贡献符号分析 skill
 
-完成符号分析 skill 的创建并在本地验证后，可使用 `SKILL: create-pr`（调用方式为 `/create-pr`）将其共享到项目中。该 skill 会按仓库要求依次完成 candidate 准备、验证、发布、提交、推送和创建 Pull Request。
+完成符号分析 skill 的创建并在本地验证后，可使用 `SKILL: create-pr`（调用方式为 `/create-pr`）将其共享到项目中。该 skill 会先对 staged change 分类：涉及 CS2 Symbols 的路径会走 candidate 准备、验证和发布，再提交、推送并创建 Pull Request；不涉及 symbols 的改动则直接创建 PR。
 
 ## 调用 `create-pr` 前
 
@@ -16,7 +16,7 @@
    ```
 
 3. 确认没有未暂存的 tracked changes。已有的无关 untracked files 可以保留未跟踪状态，`create-pr` 会保留它们。
-4. 确认仓库存在 `origin` remote，且 `gh auth status` 认证成功。必须解析出唯一的游戏版本：可以向 skill 传入 `gamever`，也可以在 `.env` 中设置 `CS2VIBE_GAMEVER`。
+4. 确认仓库存在 `origin` remote，且 `gh auth status` 认证成功。若改动涉及 CS2 Symbols，必须解析出唯一的游戏版本：可以向 skill 传入 `gamever`，也可以在 `.env` 中设置 `CS2VIBE_GAMEVER`。不涉及 symbols 的改动不需要 `gamever`。
 
 `gamesymbols/<GAMEVER>.yaml` 与 `gamedata/<GAMEVER>/` 属于生成输出。通过验证后由 `create-pr` 发布，无需在此流程中手动暂存。
 
@@ -35,7 +35,7 @@ commit_title: feat(skills): add find-example symbol-analysis skill
 
 ## `create-pr` 执行的步骤
 
-该流程按顺序执行以下门禁：
+该流程用 `.claude/skills/create-pr/scripts/classify_delivery.py` 对交付的变更分类。如果任意 staged path 涉及 CS2 symbols 管线（例如 `configs/`、`ida_preprocessor_scripts/`、`cpp_tests/`、`hl2sdk_cs2/`、`gamesymbols/`、`gamedata/`，或根目录的分析/快照/C++ 模块），则按顺序执行以下门禁：
 
 1. 记录并检查准确的 staged paths。
 2. 针对选定的游戏版本运行 `/prepare-post-change-candidate`。
@@ -45,8 +45,10 @@ commit_title: feat(skills): add find-example symbol-analysis skill
 6. 按仓库 Conventional Commit 格式提交，并附带 `Co-Authored-By: Codex`。
 7. 推送 `dev*` 分支，并针对 `main` 创建一个 PR。
 
+如果没有 staged path 涉及 CS2 symbols（例如变更只包含文档、workflow、skill 或进程监控），`create-pr` 会完全跳过上述 2 到 5 步，不解析 `gamever`，直接从捕获的变更创建 PR。此时 PR 正文不会声称进行过 candidate 准备、C++ 验证或发布。
+
 如果没有 staged changes、存在未暂存 tracked changes、认证失败、任一门禁失败或出现未预期的路径变化，skill 会在提交和创建 PR 前停止。不要绕过失败门禁，也不要手动发布 candidate。
 
 ## 完成后
 
-记录 skill 返回的分支、commit SHA、PR URL、游戏版本、candidate SHA-256 和最终提交路径列表，并检查 PR 确实只包含目标 skill、其配套文件，以及选定游戏版本的生成输出。
+记录 skill 返回的分支、commit SHA、PR URL 和最终提交路径列表。若本次走了 symbols 管线，再记录游戏版本和 candidate SHA-256，并检查 PR 确实只包含目标 skill、其配套文件，以及选定游戏版本的生成输出。

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -43274,5 +43274,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-17T05:31:09Z'
+last_publish_time: '2026-08-17T09:10:58Z'
 schema_version: 5

--- a/init_gamebin.py
+++ b/init_gamebin.py
@@ -30,7 +30,9 @@ DOWNLOAD_TIMEOUT = (30, 300)
 COPY_BUFFER_SIZE = 1024 * 1024
 GITHUB_OWNER = "HLND2T"
 BINSYNC_ROOT_BRANCH = "binsync/__root__"
-BINSYNC_SIDECAR_FIELDS = frozenset({"user", "remote", "repo_path", "expected_md5", "force_user", "auto_clone"})
+BINSYNC_SIDECAR_REQUIRED_FIELDS = frozenset({"user", "remote", "repo_path", "expected_md5", "force_user", "auto_clone"})
+BINSYNC_SIDECAR_OPTIONAL_FIELDS = frozenset({"auto_sync_all"})
+BINSYNC_SIDECAR_FIELDS = BINSYNC_SIDECAR_REQUIRED_FIELDS | BINSYNC_SIDECAR_OPTIONAL_FIELDS
 
 
 class InitGamebinError(Exception):
@@ -265,6 +267,7 @@ def expected_sidecar(binary_path: Path, binary_md5: str, gamever: str, user: str
         "expected_md5": binary_md5,
         "force_user": False,
         "auto_clone": True,
+        "auto_sync_all": True,
     }
     return repo_name, remote_url, repo_path, sidecar_data
 
@@ -279,9 +282,14 @@ def validate_sidecar(sidecar_path: Path, expected: dict) -> bool:
         actual = json.loads(sidecar_path.read_text(encoding="utf-8"))
     except (OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise InitGamebinError(f"unable to read BinSync sidecar {sidecar_path}: {exc}") from exc
-    if not isinstance(actual, dict) or set(actual) != BINSYNC_SIDECAR_FIELDS:
+    if not isinstance(actual, dict):
+        raise InitGamebinError(f"BinSync sidecar has a conflicting schema: {sidecar_path}")
+    actual_keys = set(actual)
+    if not BINSYNC_SIDECAR_REQUIRED_FIELDS <= actual_keys <= BINSYNC_SIDECAR_FIELDS:
         raise InitGamebinError(f"BinSync sidecar has a conflicting schema: {sidecar_path}")
     for field, expected_value in expected.items():
+        if field not in actual:
+            continue
         actual_value = actual[field]
         if type(actual_value) is not type(expected_value) or actual_value != expected_value:
             raise InitGamebinError(f"BinSync sidecar field {field!r} conflicts with the expected value: {sidecar_path}")

--- a/memory/post_change_candidate_lifecycle.md
+++ b/memory/post_change_candidate_lifecycle.md
@@ -7,14 +7,19 @@ permalink: cs2-vibesignatures/post-change-candidate-lifecycle
 # Post-Change Candidate Lifecycle
 
 ## Overview
-`/create-pr` owns delivery from an already-staged change. It invokes three ordered skills to prepare, validate, and
-publish one immutable symbol candidate plus its matching gamedata candidate, then commits the authorized staged
-paths and validated current-version outputs, pushes a `dev*` branch, and opens the PR. Candidate validation never
-reads directly from `bin` or falls back to a tracked head snapshot.
+`/create-pr` owns delivery from an already-staged change (or an already-committed branch). It classifies the
+delivered change with `.claude/skills/create-pr/scripts/classify_delivery.py`. If any changed path feeds the CS2
+symbols pipeline, it invokes the three ordered candidate skills to prepare, validate, and publish one immutable
+symbol candidate plus its matching gamedata candidate, then commits the authorized staged paths and validated
+current-version outputs, pushes a `dev*` branch, and opens the PR. Changes that touch no symbols-related path skip
+the lifecycle and are delivered directly as a plain PR. Candidate validation never reads directly from `bin` or
+falls back to a tracked head snapshot.
 
 ## Responsibilities
-- `/create-pr`: treat the initial staged diff as the authorized change set, orchestrate the three candidate skills,
-  stage only formatter refreshes plus current-version publication outputs, commit, push, and create the PR.
+- `/create-pr`: run `classify_delivery.py` against the staged or committed change set. If `LIFECYCLE=1`, treat that
+  diff as the authorized change set, orchestrate the three candidate skills, stage only formatter refreshes plus
+  current-version publication outputs, commit, push, and create the PR. If `LIFECYCLE=0`, skip the candidate
+  lifecycle and create the PR directly from the captured change.
 - `/prepare-post-change-candidate`: resolve one `GAMEVER`, format tracked files, build and guard isolated symbol and
   gamedata candidates, mark the gamedata step, and return candidate/session paths plus candidate SHA-256.
 - `/post-change-validation`: guard the exact symbol candidate, run real C++ tests against its bytes, reject skipped or
@@ -24,6 +29,7 @@ reads directly from `bin` or falls back to a tracked head snapshot.
 
 ## Involved Files & Symbols
 - `.claude/skills/create-pr/SKILL.md` - staged-change delivery and PR orchestration contract.
+- `.claude/skills/create-pr/scripts/classify_delivery.py` - mechanical CS2 Symbols vs plain-PR classification.
 - `.claude/skills/prepare-post-change-candidate/SKILL.md` - preparation contract.
 - `.claude/skills/post-change-validation/SKILL.md` - C++ validation contract.
 - `.claude/skills/publish-post-change-candidate/SKILL.md` - publication contract.
@@ -35,16 +41,18 @@ reads directly from `bin` or falls back to a tracked head snapshot.
 ```text
 explicitly staged task changes
   --> create-pr
-    --> configs/<GAMEVER>.yaml + bin/<GAMEVER>/
-      --> prepare-post-change-candidate
-        --> <GAMEVER>.yaml + candidate session
-        --> gamedata candidate + gamedata session
-      --> post-change-validation
-        --> candidate session marked cpp_tests/validated
-      --> publish-post-change-candidate
-        --> gamesymbols/<GAMEVER>.yaml
-        --> gamedata/<GAMEVER>
-    --> refresh authorized index --> commit --> push dev* --> PR against main
+    --> classify_delivery.py
+      LIFECYCLE=0 --> commit (if staged) --> push dev* --> PR against main
+      LIFECYCLE=1 --> configs/<GAMEVER>.yaml + bin/<GAMEVER>/
+        --> prepare-post-change-candidate
+          --> <GAMEVER>.yaml + candidate session
+          --> gamedata candidate + gamedata session
+        --> post-change-validation
+          --> candidate session marked cpp_tests/validated
+        --> publish-post-change-candidate
+          --> gamesymbols/<GAMEVER>.yaml
+          --> gamedata/<GAMEVER>
+        --> refresh authorized index --> commit --> push dev* --> PR against main
 ```
 
 ## Dependencies
@@ -59,3 +67,5 @@ explicitly staged task changes
 - Validation may advance the untracked candidate session but does not edit tracked files or candidate bytes.
 - Publication never rebuilds or reserializes candidate bytes after validation begins.
 - Any failed, skipped, or non-runnable gate stops `/create-pr` before commit, push, and PR creation.
+- A delivered change whose classifier result is `LIFECYCLE=0` skips prepare/validate/publish entirely: no `gamever`
+  is resolved and the PR body never claims candidate preparation, C++ validation, or publication.

--- a/tests/test_create_pr_classify_delivery.py
+++ b/tests/test_create_pr_classify_delivery.py
@@ -1,0 +1,171 @@
+import importlib.util
+import io
+import subprocess
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(".claude/skills/create-pr/scripts/classify_delivery.py")
+SPEC = importlib.util.spec_from_file_location("project_classify_delivery", SCRIPT)
+classify_delivery = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(classify_delivery)
+
+
+PLAIN_PR_PATHS = (
+    ".claude/skills/create-pr/SKILL.md",
+    "docs/en/conributing-via-pr.md",
+    "memory/post_change_candidate_lifecycle.md",
+    "pages/src/app.ts",
+    ".github/workflows/pr-self-runner.yml",
+    "tests/test_create_pr_classify_delivery.py",
+    "README.md",
+    "download.yaml",
+    "config.toml",
+    ".mcp.json",
+    "release_workflow.py",
+    "release_workflow_lib/promote.py",
+    "process_api.py",
+    "process_reporter.py",
+    "vcall_finder/14172/notes.txt",
+    "pyproject.toml",
+)
+
+SYMBOLS_PATHS = (
+    "configs/14175.yaml",
+    "gamesymbols/14175.yaml",
+    "gamedata/14175/CS2Fixes.yaml",
+    "gamedata-generators/CS2Fixes/generate.py",
+    "ida_preprocessor_scripts/find-Example.py",
+    "cpp_tests/iloopmode.cpp",
+    "hl2sdk_cs2",
+    "hl2sdk_cs2/public/iloopmode.h",
+    "release-manifests/14175.json",
+    "gamesymbol_snapshot_lib/candidate.py",
+    "bin/14175/server/Example.windows.yaml",
+    "agent_runner.py",
+    "analysis_config.py",
+    "analysis_output_contract.py",
+    "binary_hashing.py",
+    "cpp_tests_util.py",
+    "format_repo_files.py",
+    "gamedata_candidate.py",
+    "generate_reference_yaml.py",
+    "gamesymbol_candidate.py",
+    "ida_analyze_bin.py",
+    "init_gamebin.py",
+    "push_binsync_symbols.py",
+    "run_cpp_tests.py",
+    "trusted_yaml.py",
+    "update_gamedata.py",
+)
+
+
+class TestCreatePrClassifyDelivery(unittest.TestCase):
+    def test_skill_requires_the_classifier_before_lifecycle_gates(self) -> None:
+        skill = Path(".claude/skills/create-pr/SKILL.md").read_text(encoding="utf-8")
+        self.assertLess(
+            skill.index(".claude/skills/create-pr/scripts/classify_delivery.py"),
+            skill.index("/prepare-post-change-candidate"),
+        )
+        self.assertIn("--cached", skill)
+        self.assertIn("--committed", skill)
+        self.assertIn("Never override `1` → `0`", skill)
+
+    def test_plain_pr_paths_do_not_trigger_lifecycle(self) -> None:
+        for path in PLAIN_PR_PATHS:
+            with self.subTest(path=path):
+                self.assertFalse(classify_delivery.is_symbols_related_path(path))
+        lifecycle, matched = classify_delivery.classify_paths(PLAIN_PR_PATHS)
+        self.assertEqual(0, lifecycle)
+        self.assertEqual([], matched)
+
+    def test_symbols_paths_trigger_lifecycle(self) -> None:
+        for path in SYMBOLS_PATHS:
+            with self.subTest(path=path):
+                self.assertTrue(classify_delivery.is_symbols_related_path(path))
+        lifecycle, matched = classify_delivery.classify_paths(SYMBOLS_PATHS)
+        self.assertEqual(1, lifecycle)
+        self.assertEqual(list(SYMBOLS_PATHS), matched)
+
+    def test_mixed_change_set_is_lifecycle(self) -> None:
+        lifecycle, matched = classify_delivery.classify_paths(
+            (".claude/skills/create-pr/SKILL.md", "ida_preprocessor_scripts/find-Example.py")
+        )
+        self.assertEqual(1, lifecycle)
+        self.assertEqual(["ida_preprocessor_scripts/find-Example.py"], matched)
+
+    def test_windows_separators_and_dot_slash_normalize(self) -> None:
+        self.assertTrue(classify_delivery.is_symbols_related_path(r"configs\14175.yaml"))
+        self.assertTrue(classify_delivery.is_symbols_related_path("./gamesymbol_candidate.py"))
+        self.assertFalse(classify_delivery.is_symbols_related_path(r"docs\en\conributing-via-pr.md"))
+
+    def test_nested_lookalike_root_modules_are_not_symbols(self) -> None:
+        self.assertFalse(classify_delivery.is_symbols_related_path("pages/ida_analyze_bin.py"))
+        self.assertFalse(classify_delivery.is_symbols_related_path("tests/gamedata_candidate.py"))
+
+    def test_name_status_includes_both_rename_paths(self) -> None:
+        output = "\n".join(
+            (
+                "M\tdocs/en/conributing-via-pr.md",
+                "R100\tida_preprocessor_scripts/find-Old.py\tida_preprocessor_scripts/find-New.py",
+            )
+        )
+        self.assertEqual(
+            [
+                "docs/en/conributing-via-pr.md",
+                "ida_preprocessor_scripts/find-Old.py",
+                "ida_preprocessor_scripts/find-New.py",
+            ],
+            classify_delivery.parse_name_status(output),
+        )
+
+    def test_main_prints_plain_pr_contract_for_explicit_paths(self) -> None:
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            self.assertEqual(0, classify_delivery.main(["docs/en/conributing-via-pr.md", "memory/core.md"]))
+        self.assertEqual("LIFECYCLE=0\nmode=plain-pr\nmatched=0\n", output.getvalue())
+
+    def test_main_prints_lifecycle_contract_for_explicit_paths(self) -> None:
+        output = io.StringIO()
+        with patch("sys.stdout", output):
+            self.assertEqual(0, classify_delivery.main(["configs/14175.yaml"]))
+        self.assertEqual("LIFECYCLE=1\nmode=lifecycle\nmatched=1\nconfigs/14175.yaml\n", output.getvalue())
+
+    def test_cached_and_committed_flags_read_git_name_status(self) -> None:
+        cached = subprocess.CompletedProcess([], 0, stdout="M\tconfigs/14175.yaml\n", stderr="")
+        committed = subprocess.CompletedProcess([], 0, stdout="M\tdocs/en/conributing-via-pr.md\n", stderr="")
+        with patch.object(classify_delivery.subprocess, "run", return_value=cached) as run:
+            output = io.StringIO()
+            with patch("sys.stdout", output):
+                self.assertEqual(0, classify_delivery.main(["--cached"]))
+            run.assert_called_once_with(
+                ["git", "diff", "--name-status", "--cached"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual("LIFECYCLE=1\nmode=lifecycle\nmatched=1\nconfigs/14175.yaml\n", output.getvalue())
+
+        with patch.object(classify_delivery.subprocess, "run", return_value=committed) as run:
+            output = io.StringIO()
+            with patch("sys.stdout", output):
+                self.assertEqual(0, classify_delivery.main(["--committed"]))
+            run.assert_called_once_with(
+                ["git", "diff", "--name-status", "origin/main...HEAD"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual("LIFECYCLE=0\nmode=plain-pr\nmatched=0\n", output.getvalue())
+
+    def test_cached_flag_rejects_explicit_paths(self) -> None:
+        output = io.StringIO()
+        with patch("sys.stderr", output):
+            self.assertEqual(1, classify_delivery.main(["--cached", "docs/en/foo.md"]))
+        self.assertIn("do not pass explicit paths with --cached", output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_init_gamebin.py
+++ b/tests/test_init_gamebin.py
@@ -62,6 +62,7 @@ class TestInitGamebin(unittest.TestCase):
         self.assertIn("allow_implicit_invocation: false", agent)
         self.assertIn("$restore-from-snapshot", skill)
         self.assertIn("<MODULE_FILENAME>.binsync.json", skill)
+        self.assertIn("auto_sync_all: true", skill)
         self.assertIn("--create-missing-binsync-remotes", workflow)
         self.assertIn("Never pass `--create-missing-binsync-remotes`", skill)
         self.assertIn("BinSync recovery", agent)
@@ -167,6 +168,7 @@ class TestInitGamebin(unittest.TestCase):
         self.assertEqual("engine2.dll.bsproj", sidecar["repo_path"])
         self.assertEqual(False, sidecar["force_user"])
         self.assertEqual(True, sidecar["auto_clone"])
+        self.assertEqual(True, sidecar["auto_sync_all"])
 
     def test_sidecar_validation_is_semantic_but_schema_strict(self) -> None:
         expected = {
@@ -176,10 +178,15 @@ class TestInitGamebin(unittest.TestCase):
             "expected_md5": "a" * 32,
             "force_user": False,
             "auto_clone": True,
+            "auto_sync_all": True,
         }
+        legacy = {field: value for field, value in expected.items() if field != "auto_sync_all"}
         with tempfile.TemporaryDirectory() as temp_dir:
             sidecar = Path(temp_dir) / "engine2.dll.binsync.json"
             sidecar.write_text(json.dumps(dict(reversed(list(expected.items())))), encoding="utf-8")
+            self.assertTrue(init_gamebin.validate_sidecar(sidecar, expected))
+
+            sidecar.write_text(json.dumps(legacy), encoding="utf-8")
             self.assertTrue(init_gamebin.validate_sidecar(sidecar, expected))
 
             sidecar.write_text(json.dumps({**expected, "extra": True}), encoding="utf-8")
@@ -190,6 +197,10 @@ class TestInitGamebin(unittest.TestCase):
             with self.assertRaisesRegex(init_gamebin.InitGamebinError, "auto_clone"):
                 init_gamebin.validate_sidecar(sidecar, expected)
 
+            sidecar.write_text(json.dumps({**expected, "auto_sync_all": False}), encoding="utf-8")
+            with self.assertRaisesRegex(init_gamebin.InitGamebinError, "auto_sync_all"):
+                init_gamebin.validate_sidecar(sidecar, expected)
+
     def test_write_sidecar_atomic_uses_canonical_json(self) -> None:
         data = {
             "user": "HZDEV",
@@ -198,6 +209,7 @@ class TestInitGamebin(unittest.TestCase):
             "expected_md5": "a" * 32,
             "force_user": False,
             "auto_clone": True,
+            "auto_sync_all": True,
         }
         with tempfile.TemporaryDirectory() as temp_dir:
             path = Path(temp_dir) / "engine2.dll.binsync.json"

--- a/tests/test_symbol_store_architecture.py
+++ b/tests/test_symbol_store_architecture.py
@@ -137,6 +137,9 @@ class TestSymbolStoreArchitecture(unittest.TestCase):
         self.assertIn("git commit", create_pr)
         self.assertIn("git push -u origin", create_pr)
         self.assertIn("gh pr create", create_pr)
+        self.assertIn(".claude/skills/create-pr/scripts/classify_delivery.py", create_pr)
+        self.assertIn("LIFECYCLE=0", create_pr)
+        self.assertIn("Skip Steps 3 through 6 entirely", create_pr)
 
         for caller_name in POST_CHANGE_CALLERS:
             with self.subTest(caller=caller_name):


### PR DESCRIPTION
## Summary
- Write `auto_sync_all: true` in newly created `{binary}.binsync.json` sidecars so IDA BinSync auto-sync covers the whole repo.
- Accept the new optional `auto_sync_all` field on existing sidecars (must be `true` when present), preserving backward compatibility with legacy six-field sidecars; unknown extra fields still conflict.
- Add `disable-model-invocation: true` to the create-pr skill frontmatter.

## Validation
- implementation-specific tests: `tests/test_init_gamebin.py` (sidecar writes include `auto_sync_all`, legacy sidecar accepted, `auto_sync_all: false` rejected)
- candidate preparation: passed for `14175`
- C++ post-change validation: passed with runnable tests and zero failures (14/14 runnable, 0 compile failures, 0 layout differences)
- candidate publication: passed; published SHA-256 matches the validated candidate

- existing committed branch: `2` initial commit(s) ahead of `origin/main`; supplemental publication commit: created (`chore(gamesymbols): publish 14175 snapshot`).