### PR TITLE
Gate PR self-runner behind manual approval

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -12,7 +12,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  approval:
+    name: Await PR approval
+    if: >-
+      github.event.action != 'closed' &&
+      (github.repository == 'HLND2T/CS2_VibeSignatures' ||
+       github.repository == 'hzqst/CS2_VibeSignatures') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !(github.event.pull_request.user.login == 'github-actions[bot]' &&
+        startsWith(github.event.pull_request.head.ref, 'bump-download/') &&
+        startsWith(github.event.pull_request.title, 'chore(download): Update manifest for ')) &&
+      !(github.event.pull_request.user.login == 'github-actions[bot]' &&
+        startsWith(github.event.pull_request.head.ref, 'gamesymbols/build/') &&
+        startsWith(github.event.pull_request.title, 'chore(gamesymbols): publish '))
+    environment:
+      name: pr-approval
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Approval granted
+        run: Write-Output 'PR approval received; starting validation.'
+
   validate:
+    needs: approval
     if: >-
       github.event.action != 'closed' &&
       (github.repository == 'HLND2T/CS2_VibeSignatures' ||


### PR DESCRIPTION
## Summary
- Add a `pr-approval` environment gate before PR validation starts.
- Keep the validation job on the existing `win64` environment for its secrets and self-hosted runner.
- Leave closed-PR workspace cleanup independent of the approval gate.

## Verification
- `actionlint .github/workflows/pr-self-runner.yml`
- YAML parse check
- `git diff --check`