### PR TITLE
CBaseEntity_VPhysicsCollision

### DIFF
--- a/configs/14175.yaml
+++ b/configs/14175.yaml
@@ -7946,6 +7946,15 @@ modules:
       - name: find-CPhysicsGameSystem_ProcessContactEvents
         expected_output:
           - CPhysicsGameSystem_ProcessContactEvents.{platform}.yaml
+      - name: find-PlayImpactPhysicsDust
+        expected_output:
+          - PlayImpactPhysicsDust.{platform}.yaml
+      - name: find-CBaseEntity_VPhysicsCollision
+        expected_output:
+          - CBaseEntity_VPhysicsCollision.{platform}.yaml
+        expected_input:
+          - PlayImpactPhysicsDust.{platform}.yaml
+          - CBaseEntity_vtable.{platform}.yaml
       - name: find-CPhysicsGameSystem_ProcessContactEvents-decompiles
         expected_output:
           - IVPhys2World_GetTouchingList.{platform}.yaml
@@ -11379,6 +11388,12 @@ modules:
         category: func
         alias:
           - CPhysicsGameSystem::ProcessContactEvents
+      - name: PlayImpactPhysicsDust
+        category: func
+      - name: CBaseEntity_VPhysicsCollision
+        category: vfunc
+        alias:
+          - CBaseEntity::VPhysicsCollision
       - name: CBaseEntity_VPhysicsStartTouch
         category: func
         alias:

--- a/gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt
+++ b/gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt
@@ -350,7 +350,7 @@
 			"DebugTriangle"
 			{
 				"windows" "56"
-				"linux" "56"
+				"linux" "57"
 			}
 			"GetDebugOverlay"
 			{

--- a/gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt
+++ b/gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt
@@ -350,7 +350,7 @@
 			"DebugTriangle"
 			{
 				"windows" "56"
-				"linux" "57"
+				"linux" "56"
 			}
 			"GetDebugOverlay"
 			{

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '40505bf09c2c0942a0abc8a48048b578baf585bc18abc197bde023225ce58dbb'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:257869f67533914ade7858b2e92d39b781d1a32040d77ae2c329c7d4323d3b13
-file_count: 3411
+config_sha256: sha256:c5843e92ccaf70f565bbbe42ad4be94394b274c6829b5cd50a3c3ef385311180
+file_count: 3415
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -17748,6 +17748,24 @@ files:
     vfunc_index: 145
     vfunc_offset: '0x488'
     vtable_name: CBaseEntity
+  server/CBaseEntity_VPhysicsCollision.linux.yaml:
+    func_name: CBaseEntity_VPhysicsCollision
+    func_rva: '0x17c1f90'
+    func_sig: 55 48 89 E5 41 57 41 56 45 31 F6 41 55 41 54 53 48 83 EC ??
+    func_size: '0x1aa'
+    func_va: '0x17c1f90'
+    vfunc_index: 78
+    vfunc_offset: '0x270'
+    vtable_name: CBaseEntity_vtable
+  server/CBaseEntity_VPhysicsCollision.windows.yaml:
+    func_name: CBaseEntity_VPhysicsCollision
+    func_rva: '0xc8ad70'
+    func_sig: 40 53 55 56 57 48 83 EC ?? 85 D2
+    func_size: '0x1af'
+    func_va: '0x180c8ad70'
+    vfunc_index: 79
+    vfunc_offset: '0x278'
+    vtable_name: CBaseEntity_vtable
   server/CBaseEntity_VPhysicsEndTouch.linux.yaml:
     func_name: CBaseEntity_VPhysicsEndTouch
     func_rva: '0x195bb40'
@@ -19268,7 +19286,7 @@ files:
     vtable_numvfunc: 269
     vtable_rva: '0x1787338'
     vtable_size: '0x868'
-    vtable_symbol: ??_7CBaseModelEntity@@6B@
+    vtable_symbol: CBaseModelEntity_vtable
     vtable_va: '0x181787338'
   server/CBasePlayerController_Connect.linux.yaml:
     func_name: CBasePlayerController_Connect
@@ -22142,7 +22160,7 @@ files:
     vtable_numvfunc: 270
     vtable_rva: '0x1689bc8'
     vtable_size: '0x870'
-    vtable_symbol: ??_7CBreakable@@6B@
+    vtable_symbol: CBreakable_vtable
     vtable_va: '0x181689bc8'
   server/CBtActionCoordinatedBuy_Update.linux.yaml:
     func_name: CBtActionCoordinatedBuy_Update
@@ -42452,6 +42470,18 @@ files:
     func_sig: 48 85 C9 0F 84 1F ?? ?? ?? 48 89 5C 24 ??
     func_size: '0x129'
     func_va: '0x180dc3110'
+  server/PlayImpactPhysicsDust.linux.yaml:
+    func_name: PlayImpactPhysicsDust
+    func_rva: '0x1957040'
+    func_sig: F3 0F 10 05 ?? ?? ?? ?? 0F 2F 47 ??
+    func_size: '0x3e9'
+    func_va: '0x1957040'
+  server/PlayImpactPhysicsDust.windows.yaml:
+    func_name: PlayImpactPhysicsDust
+    func_rva: '0xd88570'
+    func_sig: 48 8B C4 48 89 58 ?? 57 48 81 EC ?? ?? ?? ?? F3 0F 10 05 ?? ?? ?? ?? 48 8B FA
+    func_size: '0x16e'
+    func_va: '0x180d88570'
   server/PolymorphicHelper_t__SetPolymorphicPointer.linux.yaml:
     func_name: PolymorphicHelper_t__SetPolymorphicPointer
     func_rva: '0x1309e60'
@@ -44452,5 +44482,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-18T06:54:43Z'
+last_publish_time: '2026-08-19T02:42:37Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CBaseEntity_VPhysicsCollision.py
+++ b/ida_preprocessor_scripts/find-CBaseEntity_VPhysicsCollision.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBaseEntity_VPhysicsCollision skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CBaseEntity_VPhysicsCollision"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBaseEntity_VPhysicsCollision",
+        "xref_strings": [],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": ["PlayImpactPhysicsDust"],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [("CBaseEntity_VPhysicsCollision", "CBaseEntity_vtable")]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CBaseEntity_VPhysicsCollision",
+        ["func_name", "func_va", "func_rva", "func_size", "func_sig", "vtable_name", "vfunc_offset", "vfunc_index"],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map, new_binary_dir, platform, image_base, debug=False
+):
+    """Find the CBaseEntity vfunc that calls PlayImpactPhysicsDust."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )

--- a/ida_preprocessor_scripts/find-PlayImpactPhysicsDust.py
+++ b/ida_preprocessor_scripts/find-PlayImpactPhysicsDust.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-PlayImpactPhysicsDust skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["PlayImpactPhysicsDust"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "PlayImpactPhysicsDust",
+        "xref_strings": ["impact_physics_dust.vpcf"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    ("PlayImpactPhysicsDust", ["func_name", "func_sig", "func_va", "func_rva", "func_size"]),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map, new_binary_dir, platform, image_base, debug=False
+):
+    """Find PlayImpactPhysicsDust from its particle-system resource string."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-PlayImpactPhysicsDust` preprocessor — locates `PlayImpactPhysicsDust` (regular func) by `xref_strings` on `"impact_physics_dust.vpcf"`.
- Add `find-CBaseEntity_VPhysicsCollision` preprocessor — locates `CBaseEntity_VPhysicsCollision` by `xref_funcs` on `PlayImpactPhysicsDust`, resolved as a vfunc of `CBaseEntity_vtable`.
- Register both skills and both symbols in `configs/14175.yaml` (`PlayImpactPhysicsDust` as `func`, `CBaseEntity_VPhysicsCollision` as `vfunc` aliased to `CBaseEntity::VPhysicsCollision`).

Resolved slots: `CBaseEntity_VPhysicsCollision` linux index 78 (`0x270`), windows index 79 (`0x278`).

## Validation
- implementation-specific tests: none supplied by the caller beyond the standard gates
- candidate preparation: passed for `14175` (formatter clean, 3415 files, candidate `sha256:e0e8e153…6563558`)
- C++ post-change validation: passed with runnable tests and zero failures (15 layout compares, 13 vtable compares, 2 record-layout compares; 0 compile failures, 0 invalid test items, 0 differences)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit(s) ahead of `origin/main`; supplemental publication commit: created

## Note on unrelated entries swept in by publication
Publication rebuilt the snapshot from the local `bin/14175` analysis output, which carries pre-existing drift on entries this change never touches. Reviewers may want to confirm these against CI's fresh analysis:

- `gamesymbols/14175.yaml`: `vtable_symbol` for `CBaseModelEntity` and `CBreakable` (windows) flips from the mangled `??_7…@@6B@` form to the `…_vtable` form.
- `gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt`: `DebugTriangle` linux `57` → `56`.
