### PR TITLE
CBasePlayerPawn_PhysicsSimulate

### DIFF
--- a/configs/14175.yaml
+++ b/configs/14175.yaml
@@ -6377,6 +6377,11 @@ modules:
           - CBasePlayerPawn_PrePhysicsSimulate.{platform}.yaml
         expected_input:
           - CBasePlayerPawn_vtable.{platform}.yaml
+      - name: find-CBasePlayerPawn_PhysicsSimulate
+        expected_output:
+          - CBasePlayerPawn_PhysicsSimulate.{platform}.yaml
+        expected_input:
+          - CBasePlayerPawn_vtable.{platform}.yaml
       - name: find-CBasePlayerPawn_OnTakeDamage-decompiles
         expected_output:
           - CBasePlayerPawn_OnTakeDamage_Alive.{platform}.yaml
@@ -9640,6 +9645,10 @@ modules:
         category: vfunc
         alias:
           - CBasePlayerPawn::PrePhysicsSimulate
+      - name: CBasePlayerPawn_PhysicsSimulate
+        category: vfunc
+        alias:
+          - CBasePlayerPawn::PhysicsSimulate
       - name: CCSPlayerPawn_vtable
         category: vtable
       - name: CCSPlayerPawnBase_vtable

--- a/gamesymbols/14175.yaml
+++ b/gamesymbols/14175.yaml
@@ -121,8 +121,8 @@ binaries:
       sha256: '40505bf09c2c0942a0abc8a48048b578baf585bc18abc197bde023225ce58dbb'
       size: 4592280
 config_digest_version: 2
-config_sha256: sha256:38e94f77f1b869e4b5e1b1b6c864a4a4d438f47245617e9df40dbef649ee59cd
-file_count: 3419
+config_sha256: sha256:a405a9993acdfc4cb20bddbfd1587ed46ad34086dd8da63831b7ea4995649fba
+file_count: 3421
 files:
   SDL3/SDL_GetMouse.windows.yaml:
     func_name: SDL_GetMouse
@@ -20101,6 +20101,24 @@ files:
     vfunc_sig: 48 FF A0 F0 07 00 00
     vfunc_sig_allow_across_function_boundary: true
     vtable_name: CBasePlayerPawn
+  server/CBasePlayerPawn_PhysicsSimulate.linux.yaml:
+    func_name: CBasePlayerPawn_PhysicsSimulate
+    func_rva: '0x15ef890'
+    func_sig: 55 48 89 E5 41 57 41 56 41 55 41 54 53 48 89 FB 48 81 EC ?? ?? ?? ?? 44 8B AF ?? ?? ?? ??
+    func_size: '0x6e8'
+    func_va: '0x15ef890'
+    vfunc_index: 158
+    vfunc_offset: '0x4f0'
+    vtable_name: CBasePlayerPawn_vtable
+  server/CBasePlayerPawn_PhysicsSimulate.windows.yaml:
+    func_name: CBasePlayerPawn_PhysicsSimulate
+    func_rva: '0xb05a60'
+    func_sig: 48 89 5C 24 ?? 48 89 74 24 ?? 55 57 41 54 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 8B 91 ?? ?? ?? ??
+    func_size: '0x4c2'
+    func_va: '0x180b05a60'
+    vfunc_index: 159
+    vfunc_offset: '0x4f8'
+    vtable_name: CBasePlayerPawn_vtable
   server/CBasePlayerPawn_PrePhysicsSimulate.linux.yaml:
     func_name: CBasePlayerPawn_PrePhysicsSimulate
     func_rva: '0x15c66f0'
@@ -44518,5 +44536,5 @@ files:
     vtable_symbol: ??_7CVPhys2World@@6B@
     vtable_va: '0x1803c57d0'
 game_version: '14175'
-last_publish_time: '2026-08-19T03:50:08Z'
+last_publish_time: '2026-08-19T07:05:36Z'
 schema_version: 5

--- a/ida_preprocessor_scripts/find-CBasePlayerPawn_PhysicsSimulate.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerPawn_PhysicsSimulate.py
@@ -8,7 +8,7 @@ TARGET_FUNCTION_NAMES = ["CBasePlayerPawn_PhysicsSimulate"]
 FUNC_XREFS = [
     {
         "func_name": "CBasePlayerPawn_PhysicsSimulate",
-        "xref_strings": ["FULLMATCH:CBasePlayerPawn_PhysicsSimulate"],
+        "xref_strings": ["FULLMATCH:PhysicsSimulate"],
         "xref_gvs": [],
         "xref_signatures": [],
         "xref_funcs": [],

--- a/ida_preprocessor_scripts/find-CBasePlayerPawn_PhysicsSimulate.py
+++ b/ida_preprocessor_scripts/find-CBasePlayerPawn_PhysicsSimulate.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Preprocess script for find-CBasePlayerPawn_PhysicsSimulate skill."""
+
+from ida_analyze_util import preprocess_common_skill
+
+TARGET_FUNCTION_NAMES = ["CBasePlayerPawn_PhysicsSimulate"]
+
+FUNC_XREFS = [
+    {
+        "func_name": "CBasePlayerPawn_PhysicsSimulate",
+        "xref_strings": ["FULLMATCH:CBasePlayerPawn_PhysicsSimulate"],
+        "xref_gvs": [],
+        "xref_signatures": [],
+        "xref_funcs": [],
+        "exclude_funcs": [],
+        "exclude_strings": [],
+        "exclude_gvs": [],
+        "exclude_signatures": [],
+    },
+]
+
+FUNC_VTABLE_RELATIONS = [("CBasePlayerPawn_PhysicsSimulate", "CBasePlayerPawn_vtable")]
+
+GENERATE_YAML_DESIRED_FIELDS = [
+    (
+        "CBasePlayerPawn_PhysicsSimulate",
+        ["func_name", "func_va", "func_rva", "func_size", "func_sig", "vtable_name", "vfunc_offset", "vfunc_index"],
+    ),
+]
+
+
+async def preprocess_skill(
+    session, skill_name, expected_outputs, old_yaml_map, new_binary_dir, platform, image_base, debug=False
+):
+    """Find the CBasePlayerPawn vfunc from its exact debug string."""
+    _ = skill_name
+    return await preprocess_common_skill(
+        session=session,
+        expected_outputs=expected_outputs,
+        old_yaml_map=old_yaml_map,
+        new_binary_dir=new_binary_dir,
+        platform=platform,
+        image_base=image_base,
+        func_names=TARGET_FUNCTION_NAMES,
+        func_xrefs=FUNC_XREFS,
+        func_vtable_relations=FUNC_VTABLE_RELATIONS,
+        generate_yaml_desired_fields=GENERATE_YAML_DESIRED_FIELDS,
+        debug=debug,
+    )


### PR DESCRIPTION
## Summary
- Add `find-CBasePlayerPawn_PhysicsSimulate` preprocessor — locates `CBasePlayerPawn_PhysicsSimulate` by `xref_strings` on `FULLMATCH:PhysicsSimulate`, resolved as a vfunc of `CBasePlayerPawn_vtable`.
- Register the skill and the symbol in `configs/14175.yaml` (`vfunc`, aliased to `CBasePlayerPawn::PhysicsSimulate`).

Resolved slots: linux index 158 (`0x4f0`), windows index 159 (`0x4f8`).

## Validation
- implementation-specific tests: none supplied by the caller beyond the standard gates
- candidate preparation: passed for `14175` (formatter clean, 3421 files, candidate `sha256:7f0b304d…75027bd2`)
- C++ post-change validation: passed with runnable tests and zero failures (16 layout compares, 14 vtable compares, 2 record-layout compares; 0 compile failures, 0 invalid test items, 0 differences)
- candidate publication: passed; published SHA-256 matches the validated candidate
- existing committed branch: `1` initial commit ahead of `origin/main` at invocation; supplemental publication commit: created

The published snapshot diff against `main` is exactly the two new `CBasePlayerPawn_PhysicsSimulate` entries plus the header (`file_count` 3419 → 3421, `config_sha256`, `last_publish_time`) — no unrelated entries were touched.

## Notes for reviewers
- The branch was based on a stale `main` (`b5e55c1f`). It has been merged up to `c82b0b5e`; without that, the rebuilt snapshot would have dropped 8 unrelated entries.
- `bin/14175/server/{CBaseModelEntity,CBreakable}_vtable.windows.yaml` locally produced `vtable_symbol: <Class>_vtable` instead of the mangled `??_7<Class>@@6B@` form that `main` carries. They were corrected at source before the candidate was rebuilt, so this PR does not re-introduce that drift.
- `gamedata/14175/cs2kz-metamod/gamedata/cs2kz-core.games.txt` is deliberately **not** included. The generator downloads the cs2kz template live, and upstream currently ships `DebugTriangle` `linux "56"`, which would have re-applied the exact change reverted in a048d41d. That file was restored to `main`'s state so the override survives. This will recur on every publish until the override is encoded somewhere the generator respects.
