### PR TITLE
ci(pr-self-runner): rename validate job to pr-validate

### DIFF
--- a/.github/workflows/pr-self-runner.yml
+++ b/.github/workflows/pr-self-runner.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  validate:
+  pr-validate:
     if: >-
       github.event.action != 'closed' &&
       (github.repository == 'HLND2T/CS2_VibeSignatures' ||


### PR DESCRIPTION
Rename the PR self-runner validation job from `validate` to `pr-validate`.

## Why

Two pull_request workflows both produce a job named `validate`:
- `PR Self Runner Validation` (`.github/workflows/pr-self-runner.yml`)
- `Validate Generated Output PR` (`.github/workflows/validate-generated-output-pr.yml`)

The two jobs are mutually exclusive via `if:` conditions (self-runner skips bot gamesymbols publish PRs; the output validator only runs those). GitHub merges same-named checks into one required check that must *both* pass, so requiring `validate` would deadlock ordinary PRs (their self-runner validate passes, but the skipped bot-output validate would still be required).

Renaming the self-runner job to `pr-validate` gives each PR path its own check name, so both can be required independently.

## Next step (not in this PR)

After this merges to main, configure branch protection required status checks to `["pr-validate", "validate"]`. Skipped required checks report `skipped` and count as passing, so no PR path deadlocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)