### PR TITLE
fix(release): require manual retry after failed automatic build

### DIFF
--- a/.github/workflows/build-on-self-runner.yml
+++ b/.github/workflows/build-on-self-runner.yml
@@ -57,6 +57,7 @@ jobs:
           $gamever = "${{ inputs.gamever || github.event.client_payload.gamever }}"
           $sourceSha = "${{ inputs.source_sha || github.event.client_payload.source_sha }}"
           $mode = "${{ inputs.mode || github.event.client_payload.mode }}"
+          $sourcePullRequest = "${{ github.event.client_payload.source_pull_request }}"
           $allowLegacyBootstrap = "${{ inputs.allow_legacy_bootstrap || github.event.client_payload.allow_legacy_bootstrap || 'false' }}".ToLowerInvariant()
           if ($allowLegacyBootstrap -notin @("true", "false")) {
             throw "allow_legacy_bootstrap must be true or false."
@@ -74,6 +75,27 @@ jobs:
             --source-sha "$sourceSha" `
             --mode "$mode" `
             --default-ref "origin/${{ github.event.repository.default_branch }}"
+          if ("${{ github.event_name }}" -eq "repository_dispatch") {
+            if ($sourcePullRequest -notmatch '^[1-9][0-9]*$') {
+              throw "repository_dispatch requires a numeric source_pull_request."
+            }
+            $pullJson = gh api "repos/${{ github.repository }}/pulls/$sourcePullRequest"
+            if ($LASTEXITCODE -ne 0) { throw "Failed to query source pull request #$sourcePullRequest." }
+            $pull = $pullJson | ConvertFrom-Json
+            if (-not $pull.merged_at) { throw "Source pull request #$sourcePullRequest is not merged." }
+            if ($pull.head.repo.full_name -ne "${{ github.repository }}") {
+              throw "Source pull request #$sourcePullRequest is not from the trusted repository."
+            }
+            if ($pull.base.ref -ne "${{ github.event.repository.default_branch }}") {
+              throw "Source pull request #$sourcePullRequest did not target the default branch."
+            }
+            if ($pull.head.ref -ne "bump-download/$gamever") {
+              throw "Source pull request #$sourcePullRequest is not the bump PR for $gamever."
+            }
+            if ($pull.merge_commit_sha -ne $sourceSha) {
+              throw "Source pull request #$sourcePullRequest merge SHA does not match source_sha."
+            }
+          }
           if ($mode -eq "republish") {
             gh release view "$gamever" --repo "${{ github.repository }}" > $null
             if ($LASTEXITCODE -ne 0) { throw "mode=republish requires Release $gamever to exist." }

--- a/.github/workflows/bump-download.yml
+++ b/.github/workflows/bump-download.yml
@@ -108,7 +108,7 @@ jobs:
         run: uv run bump_download.py -config download.yaml -configs-dir configs -depotdir cs2_depot -username "$env:DEPOTDOWNLOADER_STEAM_USERNAME" -password "$env:DEPOTDOWNLOADER_STEAM_PASSWORD" -remember-password -github-output "$env:GITHUB_OUTPUT"
 
       - name: Push bump branch
-        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.dispatch_build != 'true' && steps.duplicate.outputs.skip_pr != 'true'
+        if: steps.bump.outputs.updated == 'true' && steps.duplicate.outputs.skip_pr != 'true'
         id: branch
         shell: pwsh
         run: |
@@ -127,7 +127,7 @@ jobs:
 
       - name: Create or update bump pull request
         id: create-pr
-        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.dispatch_build != 'true' && steps.duplicate.outputs.skip_pr != 'true'
+        if: steps.bump.outputs.updated == 'true' && steps.duplicate.outputs.skip_pr != 'true'
         uses: actions/github-script@v7
         env:
           BUMP_TAG: ${{ steps.bump.outputs.tag }}
@@ -200,58 +200,3 @@ jobs:
             });
 
             core.notice(`Created bump pull request: ${pull.html_url}`);
-
-      - name: Dispatch build for an accepted config entry without a release tag
-        id: dispatch-existing
-        if: steps.bump.outputs.updated == 'true' && steps.bump.outputs.dispatch_build == 'true'
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          $tag = "${{ steps.bump.outputs.tag }}"
-          if ([string]::IsNullOrWhiteSpace($tag)) {
-            throw "steps.bump.outputs.tag is empty."
-          }
-
-          $headSha = git rev-parse origin/main
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to resolve HEAD."
-          }
-
-          $existingTag = git ls-remote --tags origin "refs/tags/$tag"
-          if ($LASTEXITCODE -ne 0) {
-            throw "Failed to query remote tag $tag."
-          }
-
-          if (-not [string]::IsNullOrWhiteSpace($existingTag)) {
-            throw "Tag $tag appeared before output promotion; refusing unsafe dispatch."
-          }
-
-          git cat-file -e "$headSha`:configs/$tag.yaml"
-          if ($LASTEXITCODE -ne 0) {
-            throw "Accepted GAMEVER $tag is missing configs/$tag.yaml at origin/main; refusing recovery dispatch."
-          }
-
-          $payload = @{
-            event_type = "build-on-self-runner"
-            client_payload = @{
-              gamever = $tag
-              source_sha = $headSha.Trim()
-              mode = "new"
-            }
-          } | ConvertTo-Json -Depth 5
-
-          $headers = @{
-            Authorization = "Bearer $env:GITHUB_TOKEN"
-            Accept = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
-          }
-
-          Invoke-RestMethod `
-            -Method Post `
-            -Uri "https://api.github.com/repos/${{ github.repository }}/dispatches" `
-            -Headers $headers `
-            -ContentType "application/json" `
-            -Body $payload
-
-          Write-Host "Dispatched mode=new build-on-self-runner for accepted config entry $tag."

--- a/bump_download.py
+++ b/bump_download.py
@@ -191,7 +191,6 @@ class BumpPlan:
     tag: str
     patch_version: str
     manifests: dict[str, str]
-    dispatch_build: bool = False
     analysis_config_source_gamever: str | None = None
     analysis_config_path: str | None = None
 
@@ -263,7 +262,6 @@ def write_github_output(
     output_path: Path | None,
     updated: bool,
     tag: str | None,
-    dispatch_build: bool = False,
     analysis_config_source_gamever: str | None = None,
     analysis_config_path: str | None = None,
 ) -> None:
@@ -277,8 +275,6 @@ def write_github_output(
         lines.append(f"analysis_config_source_gamever={analysis_config_source_gamever}")
     if updated and analysis_config_path:
         lines.append(f"analysis_config_path={analysis_config_path}")
-    if dispatch_build:
-        lines.append("dispatch_build=true")
     with output_path.open("a", encoding="utf-8") as handle:
         handle.write("\n".join(lines) + "\n")
 
@@ -458,28 +454,6 @@ def plan_download_entry(
     )
 
 
-def plan_missing_release_build(
-    downloads: list[dict[str, Any]],
-    patch_version: str,
-    manifests: dict[str, str],
-    configs_dir: Path | None = None,
-) -> BumpPlan | None:
-    """Dispatch a new-version build when config is accepted but its release tag is absent."""
-    no_update_plan = plan_download_entry(downloads, patch_version, manifests, configs_dir=configs_dir)
-    if no_update_plan.updated:
-        return None
-    if remote_tag_exists(no_update_plan.tag):
-        return None
-    return BumpPlan(
-        updated=True,
-        tag=no_update_plan.tag,
-        patch_version=patch_version,
-        manifests=manifests,
-        dispatch_build=True,
-        analysis_config_path=no_update_plan.analysis_config_path,
-    )
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Discover CS2 default-branch depot manifests and update download.yaml."
@@ -516,82 +490,65 @@ def run(args: argparse.Namespace) -> int:
 
     if args.dry_run:
         if not plan.updated:
-            dispatch_plan = plan_missing_release_build(downloads, patch_version, manifests, configs_dir=configs_dir)
-            if dispatch_plan is None:
-                print(f"No update for {patch_version}: {manifests}")
-                write_github_output(output_path, updated=False, tag=None)
-                return 0
-            plan = dispatch_plan
-            print(f"Would dispatch build for accepted tag {plan.tag}")
-            write_github_output(
-                output_path,
-                updated=True,
-                tag=plan.tag,
-                dispatch_build=True,
-                analysis_config_path=plan.analysis_config_path,
-            )
-        else:
-            print(
-                f"Would update download.yaml with tag {plan.tag}: {manifests}; "
-                f"seed {plan.analysis_config_source_gamever} -> {plan.analysis_config_path}"
-            )
-            write_github_output(
-                output_path,
-                updated=True,
-                tag=plan.tag,
-                analysis_config_source_gamever=plan.analysis_config_source_gamever,
-                analysis_config_path=plan.analysis_config_path,
-            )
-        return 0
-
-    if not plan.updated:
-        dispatch_plan = plan_missing_release_build(downloads, patch_version, manifests, configs_dir=configs_dir)
-        if dispatch_plan is None:
             print(f"No update for {patch_version}: {manifests}")
             write_github_output(output_path, updated=False, tag=None)
             return 0
-        plan = dispatch_plan
+        print(
+            f"Would update download.yaml with tag {plan.tag}: {manifests}; "
+            f"seed {plan.analysis_config_source_gamever} -> {plan.analysis_config_path}"
+        )
+        write_github_output(
+            output_path,
+            updated=True,
+            tag=plan.tag,
+            analysis_config_source_gamever=plan.analysis_config_source_gamever,
+            analysis_config_path=plan.analysis_config_path,
+        )
+        return 0
 
-    if not plan.dispatch_build:
-        ensure_clean_worktree()
-        if local_tag_exists(plan.tag) or remote_tag_exists(plan.tag):
-            raise BumpError(f"Tag already exists: {plan.tag}")
-        original_download = config_path.read_bytes()
-        target_path = None
-        target_existed = False
-        try:
-            append_download_entry(downloads, plan)
-            save_config(config_path, data)
-            if configs_dir is None:
-                create_commit(config_path, plan.patch_version)
-            else:
-                source_gamever = plan.analysis_config_source_gamever
-                if not source_gamever:
-                    raise BumpError("New download entry is missing analysis config seed metadata")
-                source_path, target_path = _config_seed_paths(configs_dir, source_gamever, plan.tag)
-                target_existed = target_path.exists()
-                target_path.write_bytes(source_path.read_bytes())
-                create_commit([config_path, target_path], plan.patch_version)
-        except Exception:
-            config_path.write_bytes(original_download)
-            if target_path is not None and not target_existed:
-                target_path.unlink(missing_ok=True)
-            staged_paths = [config_path, *([target_path] if target_path is not None else [])]
-            subprocess.run(
-                ["git", "restore", "--staged", "--", *(str(path) for path in staged_paths)],
-                check=False,
-                capture_output=True,
-            )
-            raise
+    if not plan.updated:
+        print(f"No update for {patch_version}: {manifests}")
+        write_github_output(output_path, updated=False, tag=None)
+        return 0
+
+    ensure_clean_worktree()
+    if local_tag_exists(plan.tag) or remote_tag_exists(plan.tag):
+        raise BumpError(f"Tag already exists: {plan.tag}")
+    original_download = config_path.read_bytes()
+    target_path = None
+    target_existed = False
+    try:
+        append_download_entry(downloads, plan)
+        save_config(config_path, data)
+        if configs_dir is None:
+            create_commit(config_path, plan.patch_version)
+        else:
+            source_gamever = plan.analysis_config_source_gamever
+            if not source_gamever:
+                raise BumpError("New download entry is missing analysis config seed metadata")
+            source_path, target_path = _config_seed_paths(configs_dir, source_gamever, plan.tag)
+            target_existed = target_path.exists()
+            target_path.write_bytes(source_path.read_bytes())
+            create_commit([config_path, target_path], plan.patch_version)
+    except Exception:
+        config_path.write_bytes(original_download)
+        if target_path is not None and not target_existed:
+            target_path.unlink(missing_ok=True)
+        staged_paths = [config_path, *([target_path] if target_path is not None else [])]
+        subprocess.run(
+            ["git", "restore", "--staged", "--", *(str(path) for path in staged_paths)],
+            check=False,
+            capture_output=True,
+        )
+        raise
     write_github_output(
         output_path,
         updated=True,
         tag=plan.tag,
-        dispatch_build=plan.dispatch_build,
         analysis_config_source_gamever=plan.analysis_config_source_gamever,
         analysis_config_path=plan.analysis_config_path,
     )
-    print(f"Prepared release build request {plan.tag} for {patch_version}")
+    print(f"Prepared download bump {plan.tag} for {patch_version}")
     return 0
 
 

--- a/memory/build-on-self-runner.md
+++ b/memory/build-on-self-runner.md
@@ -34,5 +34,6 @@ Preflight -> required reusable warm-cache producer -> consumer IDA identity chec
 - `stage-build` excludes `.i64`, legacy `.idb`, and all known IDA side files before building the private inventory. Promotion therefore removes any historical accepted IDB copies instead of duplicating the warm-cache payload.
 - Output PR paths remain exactly the requested snapshot, `gamedata/<GAMEVER>/**`, and release manifest.
 ## Callers
-- `repository_dispatch.types: [build-on-self-runner]`.
-- Machine-oriented `workflow_dispatch`.
+- `repository_dispatch.types: [build-on-self-runner]` only for a provenance-verified merged `bump-download/<GAMEVER>` PR.
+- Machine-oriented `workflow_dispatch` for explicit human-authorized retries and republishes.
+- Scheduled bump discovery never retries an accepted version whose release build failed; a failed automatic attempt requires explicit human dispatch.

--- a/tests/test_build_self_runner_workflow.py
+++ b/tests/test_build_self_runner_workflow.py
@@ -33,6 +33,16 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
         self.assertEqual("${{ needs.preflight.outputs.source_sha }}", warmup["with"]["source_sha"])
         self.assertEqual("inherit", warmup["secrets"])
 
+    def test_repository_dispatch_requires_merged_bump_pr_provenance(self) -> None:
+        preflight = workflow_job(self.build_workflow, "preflight")
+        resolve = steps_by_id(preflight)["resolve"]["run"]
+
+        self.assertIn('if ("${{ github.event_name }}" -eq "repository_dispatch")', resolve)
+        self.assertIn("repository_dispatch requires a numeric source_pull_request", resolve)
+        self.assertIn('gh api "repos/${{ github.repository }}/pulls/$sourcePullRequest"', resolve)
+        self.assertIn('$pull.head.ref -ne "bump-download/$gamever"', resolve)
+        self.assertIn("$pull.merge_commit_sha -ne $sourceSha", resolve)
+
     def test_fast_and_full_test_suites_run_before_analysis(self) -> None:
         tests_step = self.build_steps["test-suites"]
         run = tests_step["run"]
@@ -153,6 +163,8 @@ class TestBuildSelfRunnerWorkflow(unittest.TestCase):
         self.assertEqual({"contents": "write", "pull-requests": "write"}, bump["permissions"])
         self.assertIn("git fetch origin --prune --prune-tags --tags", bump_steps["sync-refs"]["run"])
         self.assertNotIn("git tag", "\n".join(str(step.get("run", "")) for step in bump_job["steps"]))
+        self.assertNotIn("dispatch-existing", bump_steps)
+        self.assertNotIn("dispatch_build", "\n".join(str(step.get("run", "")) for step in bump_job["steps"]))
 
         dispatch = load_workflow("tag-bump-after-merge.yml")
         dispatch_job = workflow_job(dispatch, "dispatch-build")

--- a/tests/test_bump_download.py
+++ b/tests/test_bump_download.py
@@ -474,18 +474,6 @@ class TestBumpDownload(unittest.TestCase):
                 output.read_text(encoding="utf-8"),
             )
 
-            dispatch_output = Path(tmp) / "dispatch_out.txt"
-            bump_download.write_github_output(
-                dispatch_output,
-                updated=True,
-                tag="14161",
-                dispatch_build=True,
-            )
-            self.assertEqual(
-                "updated=true\ntag=14161\ndispatch_build=true\n",
-                dispatch_output.read_text(encoding="utf-8"),
-            )
-
     @patch("bump_download.subprocess.run")
     def test_create_commit_does_not_create_a_release_tag(self, mock_run) -> None:
         bump_download.create_commit(
@@ -623,7 +611,7 @@ class TestBumpDownload(unittest.TestCase):
         "bump_download.discover_latest",
         return_value=("1.41.6.1", {"2347771": "11", "2347773": "22"}),
     )
-    def test_dry_run_existing_entry_checks_release_tag_for_recovery(
+    def test_dry_run_existing_entry_is_no_update_without_release_checks(
         self,
         _discover,
         commit,
@@ -632,6 +620,7 @@ class TestBumpDownload(unittest.TestCase):
     ) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             config = Path(tmp) / "download.yaml"
+            output = Path(tmp) / "github_output.txt"
             config.write_text(
                 "downloads:\n"
                 '  - tag: "14161"\n'
@@ -649,59 +638,17 @@ class TestBumpDownload(unittest.TestCase):
                 username=None,
                 password=None,
                 remember_password=False,
-                github_output=None,
+                github_output=str(output),
                 dry_run=True,
             )
 
             self.assertEqual(0, bump_download.run(args))
+            output_text = output.read_text(encoding="utf-8")
 
         commit.assert_not_called()
         local_tag_exists.assert_not_called()
-        remote_tag_exists.assert_called_once_with("14161")
-
-    @patch("bump_download.remote_tag_exists", return_value=False)
-    def test_missing_release_build_when_entry_exists_but_remote_tag_missing(self, _remote) -> None:
-        downloads = [
-            {
-                "tag": "14161",
-                "name": "1.41.6.1",
-                "manifests": {"2347771": "11", "2347773": "22"},
-            }
-        ]
-
-        plan = bump_download.plan_missing_release_build(
-            downloads,
-            patch_version="1.41.6.1",
-            manifests={"2347771": "11", "2347773": "22"},
-        )
-
-        self.assertIsNotNone(plan)
-        self.assertTrue(plan.updated)
-        self.assertTrue(plan.dispatch_build)
-        self.assertEqual("14161", plan.tag)
-
-    @patch("bump_download.subprocess.run")
-    def test_missing_release_build_raises_when_remote_check_fails(self, mock_run) -> None:
-        mock_run.return_value = bump_download.subprocess.CompletedProcess(
-            ["git", "ls-remote"],
-            128,
-            stdout="",
-            stderr="fatal: unable to access origin\n",
-        )
-        downloads = [
-            {
-                "tag": "14161",
-                "name": "1.41.6.1",
-                "manifests": {"2347771": "11", "2347773": "22"},
-            }
-        ]
-
-        with self.assertRaisesRegex(bump_download.BumpError, "fatal: unable to access origin"):
-            bump_download.plan_missing_release_build(
-                downloads,
-                patch_version="1.41.6.1",
-                manifests={"2347771": "11", "2347773": "22"},
-            )
+        remote_tag_exists.assert_not_called()
+        self.assertEqual("updated=false\n", output_text)
 
     @patch("bump_download.create_commit")
     @patch("bump_download.remote_tag_exists", return_value=False)
@@ -759,14 +706,16 @@ class TestBumpDownload(unittest.TestCase):
 
     @patch("bump_download.create_commit")
     @patch("bump_download.ensure_clean_worktree")
-    @patch("bump_download.remote_tag_exists", return_value=True)
+    @patch("bump_download.remote_tag_exists")
+    @patch("bump_download.local_tag_exists")
     @patch(
         "bump_download.discover_latest",
         return_value=("1.41.6.1", {"2347771": "11", "2347773": "22"}),
     )
-    def test_run_existing_entry_remote_tag_present_writes_no_update(
+    def test_run_existing_entry_is_no_update_without_release_checks(
         self,
         _discover,
+        local_tag_exists,
         remote_tag_exists,
         ensure_clean_worktree,
         create_commit,
@@ -799,57 +748,11 @@ class TestBumpDownload(unittest.TestCase):
             self.assertEqual(original_text, config.read_text(encoding="utf-8"))
             output_text = output.read_text(encoding="utf-8")
 
-        remote_tag_exists.assert_called_once_with("14161")
+        local_tag_exists.assert_not_called()
+        remote_tag_exists.assert_not_called()
         ensure_clean_worktree.assert_not_called()
         create_commit.assert_not_called()
         self.assertEqual("updated=false\n", output_text)
-
-    @patch("bump_download.create_commit")
-    @patch("bump_download.ensure_clean_worktree")
-    @patch("bump_download.remote_tag_exists", return_value=False)
-    @patch(
-        "bump_download.discover_latest",
-        return_value=("1.41.6.1", {"2347771": "11", "2347773": "22"}),
-    )
-    def test_run_missing_release_mode_dispatches_without_local_mutation(
-        self,
-        _discover,
-        remote_tag_exists,
-        ensure_clean_worktree,
-        create_commit,
-    ) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            config = Path(tmp) / "download.yaml"
-            output = Path(tmp) / "github_output.txt"
-            original_text = (
-                "downloads:\n"
-                '  - tag: "14161"\n'
-                "    name: 1.41.6.1\n"
-                "    manifests:\n"
-                '      "2347771": "11"\n'
-                '      "2347773": "22"\n'
-            )
-            config.write_text(original_text, encoding="utf-8")
-            args = argparse.Namespace(
-                config=str(config),
-                depotdir=str(Path(tmp) / "depot"),
-                app="730",
-                os="all-platform",
-                username=None,
-                password=None,
-                remember_password=False,
-                github_output=str(output),
-                dry_run=False,
-            )
-
-            self.assertEqual(0, bump_download.run(args))
-            self.assertEqual(original_text, config.read_text(encoding="utf-8"))
-            output_text = output.read_text(encoding="utf-8")
-
-        remote_tag_exists.assert_called_once_with("14161")
-        ensure_clean_worktree.assert_not_called()
-        create_commit.assert_not_called()
-        self.assertEqual("updated=true\ntag=14161\ndispatch_build=true\n", output_text)
 
     @patch("bump_download.parse_args", return_value=argparse.Namespace())
     def test_main_maps_known_errors_to_exit_codes(self, _parse_args) -> None:


### PR DESCRIPTION
## Summary
- stop scheduled Bump Download runs from redispatching accepted versions whose release tag is absent
- require repository-dispatched release builds to match a merged bump PR and its merge SHA
- keep explicit workflow dispatch as the human-authorized retry path

## Validation
- uv run python -m unittest tests.test_bump_download tests.test_build_self_runner_workflow: 56 passed
- uv run python tests/run_test_suite.py repository-contract -b --durations 30: 101 passed
- uv run python format_repo_files.py --check: passed